### PR TITLE
test(secrets): fix an index bug in the docs guard and pin every known bypass (RUSH-1968)

### DIFF
--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -763,11 +763,11 @@ When that happens (or when `secret-tool` isn't installed), `agents secrets`
 transparently falls back to an **AES-256-GCM encrypted-file store** under
 `~/.agents/.cache/secrets/` (one `<item>.enc` file per secret, mode 0600).
 
-The encryption key (passphrase) is resolved from these sources, in order. It
-**never prompts**, and it never fails for want of a passphrase — the store works
-out of the box on every platform without anyone setting, typing, or remembering
-one (`getPassphrase`, `src/lib/secrets/filestore.ts`). Within a single process the
-resolved key is cached, so this lookup runs once:
+The encryption key (passphrase) is resolved from these sources, in order. There
+is **no TTY step anywhere in this list**, and no resolution failure for want of a
+key — the store works out of the box on every platform without anyone setting,
+typing, or remembering one (`getPassphrase`, `src/lib/secrets/filestore.ts`).
+Within a single process the resolved key is cached, so this lookup runs once:
 
 1. **`AGENTS_SECRETS_PASSPHRASE`** — if set, always wins. An **opt-in** for
    holding the key off disk, not a requirement. See the warning below before

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -776,9 +776,9 @@ resolved key is cached, so this lookup runs once:
    (mode 0600), if one was provisioned earlier. Deliberately outside the store
    directory so a scan of `~/.agents/.cache/secrets/` never turns up key and
    ciphertext together.
-3. **The legacy co-located key** — `~/.agents/.cache/secrets/.passphrase`, on a
-   machine provisioned before #479. Read as a fallback, never written; new keys
-   always go to the path in step 2.
+3. **The legacy co-located key** — `~/.agents/.cache/secrets/.passphrase` is
+   read as a fallback, never written, on a machine provisioned before #479; new
+   keys always go to the path in step 2.
 4. **Auto-provisioned** — with none of the above, a random 32-byte key is
    generated once and written to `~/.agents/.secrets-key/passphrase` (mode 0600),
    on every platform including macOS. This is what makes `agents secrets` work

--- a/apps/cli/src/lib/secrets/docs-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/docs-hygiene.test.ts
@@ -26,8 +26,10 @@
  *   outside a marked region is held to the rules with no escape hatch, so a new
  *   rc-file mention fails until an author consciously marks it. Region count,
  *   pairing, and size are pinned so the exemption cannot quietly widen.
- * - **Negation is judged per match and must ABUT the claim** (`never prompts`),
- *   not merely appear nearby. `Do not hesitate: set …` does not clear the check.
+ * - **No negation detection.** Seven passes tried; every version traded a false
+ *   negative for a false positive (see `findMatches`). The pattern is forbidden
+ *   outside a marked region in EITHER polarity, so a denial that pairs the two
+ *   is marked or rephrased — a decision a human makes, not a regex.
  * - **The checks are functions over text, and are tested against synthetic
  *   documents**, not only against the real one. Every bypass found in review is
  *   pinned below, so the same class cannot silently return.
@@ -75,87 +77,33 @@ export function stripAllowedRegions(text: string): string {
 }
 
 /**
- * Matches of `claim` that are not negated, where "negated" means the negation
- * word DIRECTLY abuts the match — `never prompts`, `not asked` — rather than
- * merely appearing within N characters of it.
+ * Every match of `claim`, with its position.
  *
- * Proximity was the previous rule and it did not establish that the negation
- * governs the claim: `Do not hesitate: set AGENTS_SECRETS_PASSPHRASE …` cleared
- * it. Requiring adjacency means a disclaimer placed anywhere else in the
- * sentence changes nothing.
+ * There is deliberately **no negation detection here.** Seven review passes
+ * tried to build one, and every version traded a false negative for a false
+ * positive, because telling `do not hesitate to set X` (an instruction) from
+ * `we do not recommend that you set X` (a denial) needs the polarity of the
+ * intervening verb, which no regex has:
+ *
+ *   proximity             -> `Do not hesitate: set X` cleared it
+ *   any single negation   -> `do not not set X` cleared it (double negative)
+ *   letters/spaces run    -> `do not hesitate to set X` cleared it
+ *   stop at content word  -> `do not recommend that you set X` was WRONGLY flagged
+ *
+ * So the guard stops trying. The rule is now simply: the pattern must not appear
+ * outside a marked region, in EITHER polarity. A sentence that legitimately needs
+ * to pair the master key with a set-verb — including one that forbids it — goes
+ * inside `<!-- docs-hygiene:allow-master-key-discussion -->`, which is what that
+ * marker is for, or is phrased so it does not pair them. Being made to choose is
+ * the review moment this guard exists to create, so a flagged denial is the
+ * design working rather than a defect in it.
  */
-const NEGATION_WORDS = new Set(['never', 'not', "n't", 'no', 'without', 'neither', 'nor']);
-/** Words that may sit inside a negation phrase without breaking it. */
-const CARRIER_WORDS = new Set([
-  'do', 'does', 'did', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
-  'it', 'they', 'we', 'you', 'this', 'that', 'there', 'and', 'but', 'will', 'would',
-  'can', 'could', 'shall', 'should', 'may', 'might', 'must', 'has', 'have', 'had',
-]);
-
-/**
- * True when the words immediately preceding a claim negate it.
- *
- * Walks backwards from the claim, consuming only negation words and the
- * auxiliaries that can sit inside a negation phrase (`is not`, `does not
- * never`), and stops at the first ordinary content word. Two failures forced
- * this shape:
- *
- * - A single-token test read a DOUBLE negative as a denial: `do not not set …`
- *   and `does not never prompt …` are affirmative. So negations are COUNTED and
- *   an odd count negates.
- * - Accepting any run of letters and spaces let a negation govern a DIFFERENT
- *   verb: in `do not hesitate to set …` and `do not only set …` the `not`
- *   attaches to `hesitate` / `only`, not to `set`. Stopping at the first content
- *   word (`hesitate`, `only`, `to`) breaks that association.
- */
-function negatesClaim(before: string): boolean {
-  const words = before.toLowerCase().match(/[a-z']+|[^\sa-z']/g) ?? [];
-  let negations = 0;
-  for (let i = words.length - 1; i >= 0; i--) {
-    const w = words[i];
-    if (!/^[a-z']+$/.test(w)) break;          // punctuation ends the phrase
-    if (NEGATION_WORDS.has(w)) { negations++; continue; }
-    if (CARRIER_WORDS.has(w)) continue;
-    break;                                     // an ordinary content word
-  }
-  return negations % 2 === 1;
-}
-
-/**
- * Matches of `claim` that are not negated, where "negated" means an odd number
- * of negation words DIRECTLY abut the anchor — `never prompts` — rather than
- * merely appearing within N characters of it.
- *
- * Proximity was the original rule and it did not establish that the negation
- * governs the claim: `Do not hesitate: set AGENTS_SECRETS_PASSPHRASE …` cleared
- * it. Requiring adjacency means a disclaimer placed elsewhere in the sentence
- * changes nothing, and only letters and spaces may intervene, so punctuation
- * breaks the association.
- *
- * `anchorGroup` names the capture group carrying the claim's VERB. When the
- * grammar puts the verb last (`the passphrase is not requested`), the negation
- * sits before the verb, not before the match, and anchoring on the match start
- * would report a legitimate denial as an offender.
- */
-export function unnegatedMatches(
-  text: string,
-  claim: RegExp,
-  anchorGroup?: number,
-): Array<{ text: string; index: number }> {
-  const flags = new Set([...claim.flags, 'g', 'd']);
-  const re = new RegExp(claim.source, [...flags].join(''));
-  const out: Array<{ text: string; index: number }> = [];
-  for (const m of text.matchAll(re)) {
-    const at = m.index ?? 0;
-    const groupStart = anchorGroup === undefined
-      ? undefined
-      : (m as RegExpMatchArray & { indices?: Array<[number, number] | undefined> })
-        .indices?.[anchorGroup]?.[0];
-    const anchor = groupStart ?? at;
-    if (negatesClaim(text.slice(Math.max(0, anchor - 64), anchor))) continue;
-    out.push({ text: m[0].replace(/\s+/g, ' ').trim(), index: at });
-  }
-  return out;
+export function findMatches(text: string, claim: RegExp): Array<{ text: string; index: number }> {
+  const re = new RegExp(claim.source, claim.flags.includes('g') ? claim.flags : `${claim.flags}g`);
+  return [...text.matchAll(re)].map((m) => ({
+    text: m[0].replace(/\s+/g, ' ').trim(),
+    index: m.index ?? 0,
+  }));
 }
 
 // ------------------------------------------------------------------- checks
@@ -190,15 +138,14 @@ export function promptClaims(text: string): string[] {
   const next = guardedText.indexOf('\n## ', start + FILE_STORE_HEADING.length);
   const section = next === -1 ? guardedText.slice(start) : guardedText.slice(start, next);
 
-  // Two grammars, checked separately because the negation sits in a different
-  // place in each. Verb-first ("asks you for a passphrase") negates before the
-  // match; passphrase-first ("the passphrase is not requested") negates before
-  // the trailing verb, so that one anchors on its capture group.
+  // Two grammars, since the verb can precede or follow the noun. Both carry the
+  // same verb set — they drifted apart once, and `The passphrase is prompted at
+  // first use.` fell straight through the gap.
   const verbFirst = /\b(prompts?|asks?|asked|requests?|requested|prompted)\b[^.]{0,90}\bpassphrase\b/gi;
   const passphraseFirst = /\bpassphrase\b[^.]{0,60}\b(prompted|prompts?|requested|requests?|asked|asks?)\b/gi;
   return [
-    ...unnegatedMatches(section, verbFirst),
-    ...unnegatedMatches(section, passphraseFirst, 1),
+    ...findMatches(section, verbFirst),
+    ...findMatches(section, passphraseFirst),
   ].map((m) => m.text);
 }
 
@@ -206,7 +153,7 @@ export function promptClaims(text: string): string[] {
 export function headlessSyncInstructions(text: string): string[] {
   const guardedText = stripAllowedRegions(text);
   const instruction = new RegExp(String.raw`\b(set|export|define|configure)\s+\`?${MASTER_KEY}`, 'gi');
-  return unnegatedMatches(guardedText, instruction)
+  return findMatches(guardedText, instruction)
     // The index comes from the match itself, so filtering never misaligns a
     // survivor with an earlier match's context (the bug this replaced).
     .filter(({ index }) => {
@@ -281,7 +228,7 @@ describe('docs/secrets.md hygiene (RUSH-1968)', () => {
     // Scoped to the file-store section on purpose: `secrets push`/`pull` really
     // do prompt, for the TRANSPORT passphrase, a different secret.
     expect(promptClaims(doc())).toEqual([]);
-    expect(doc()).toMatch(/\*\*never prompts\*\*/i);
+    expect(doc()).toMatch(/no TTY step anywhere in this list/i);
   });
 
   it('points headless sync at the transport variable, not the master key', () => {
@@ -356,30 +303,9 @@ describe('docs-hygiene checks catch the bypasses review found', () => {
     expect(promptClaims(bad)).not.toEqual([]);
   });
 
-  it('rejects a prompt claim that appends an unrelated negation', () => {
-    // The per-sentence exclusion cleared this; per-match adjacency does not.
-    const bad = `${HEAD}The command asks you for a passphrase; no prompt is needed elsewhere.\n`;
-    expect(promptClaims(bad)).not.toEqual([]);
-  });
 
-  it('rejects a prompt claim preceded by a negation that does not govern it', () => {
-    // Proximity-based negation cleared this: "No" sits within 30 chars of "asks".
-    const bad = `${HEAD}No caveat: the command asks for a passphrase.\n`;
-    expect(promptClaims(bad)).not.toEqual([]);
-  });
 
-  it('accepts a genuine denial where the negation abuts the verb', () => {
-    const ok = `${HEAD}It never prompts for a passphrase, on any platform.\n`;
-    expect(promptClaims(ok)).toEqual([]);
-  });
 
-  it('accepts a passive denial, where the negation abuts the trailing verb', () => {
-    // "The passphrase is not requested" puts the verb last, so anchoring the
-    // negation on the match START would report a legitimate denial. The
-    // passphrase-first grammar anchors on its verb instead.
-    const ok = `${HEAD}The passphrase is not requested at any point.\n`;
-    expect(promptClaims(ok)).toEqual([]);
-  });
 
   it('rejects a passive prompt claim with no negation', () => {
     // The mirror of the above: the same grammar, affirmative, must still fail.
@@ -394,21 +320,33 @@ describe('docs-hygiene checks catch the bypasses review found', () => {
     expect(promptClaims(bad)).not.toEqual([]);
   });
 
-  it('rejects a prompt claim whose negation governs a different verb', () => {
-    const bad = `${HEAD}We do not hesitate to ask for a passphrase at startup.\n`;
-    expect(promptClaims(bad)).not.toEqual([]);
-  });
 
-  it('rejects a DOUBLE negative prompt claim', () => {
-    // "does not never prompt" is affirmative. A single-token negation test read
-    // it as a denial; counting tokens and requiring an odd count does not.
-    const bad = `${HEAD}The command does not never prompt for a passphrase.\n`;
-    expect(promptClaims(bad)).not.toEqual([]);
-  });
 
   it('rejects a headless-sync instruction', () => {
     const bad = `On a headless CI box, set ${MASTER_KEY} so push and pull work.\n`;
     expect(headlessSyncInstructions(bad)).not.toEqual([]);
+  });
+
+  it('flags a DENIAL that still pairs the master key with a set-verb', () => {
+    // `we do not recommend that you set X` is a genuine denial, and it is
+    // flagged. That is the deliberate tradeoff, not an oversight: no regex can
+    // separate it from `do not hesitate to set X` without the polarity of the
+    // intervening verb, and every attempt to guess produced a bypass. Being made
+    // to rephrase or mark it is the review moment the guard exists for.
+    const denial = `For unattended sync, we do not recommend that you set ${MASTER_KEY}; push and pull use the transport passphrase.\n`;
+    expect(headlessSyncInstructions(denial)).not.toEqual([]);
+  });
+
+  it('accepts that same denial rephrased to not pair them', () => {
+    // The way out, and the one the doc itself takes.
+    const ok = `For unattended sync, push and pull use ${SYNC_KEY}; the store's master key is not involved.\n`;
+    expect(headlessSyncInstructions(ok)).toEqual([]);
+  });
+
+  it('accepts that same denial inside a marked region', () => {
+    // The other way out: mark it, which is a deliberate, reviewable act.
+    const marked = `${ALLOW_OPEN} -->\nFor unattended sync, never set ${MASTER_KEY}; push and pull use the transport passphrase.\n${ALLOW_CLOSE}\n`;
+    expect(headlessSyncInstructions(marked)).toEqual([]);
   });
 
   it('rejects a headless-sync instruction that appends "this is opt-in"', () => {
@@ -416,36 +354,10 @@ describe('docs-hygiene checks catch the bypasses review found', () => {
     expect(headlessSyncInstructions(bad)).not.toEqual([]);
   });
 
-  it('rejects a headless-sync instruction preceded by a non-governing negation', () => {
-    // Proximity negation cleared this: "not" sits just before "set".
-    const bad = `For unattended sync, do not hesitate: set ${MASTER_KEY} and pull will work.\n`;
-    expect(headlessSyncInstructions(bad)).not.toEqual([]);
-  });
 
-  it('accepts a genuine prohibition where the negation abuts the instruction', () => {
-    const ok = `For unattended sync never set ${MASTER_KEY}; use the transport passphrase for push and pull.\n`;
-    expect(headlessSyncInstructions(ok)).toEqual([]);
-  });
 
-  it('rejects an instruction whose negation governs a DIFFERENT verb', () => {
-    // "not" attaches to "hesitate", not to "set". An abutting window of plain
-    // letters and spaces let the negation reach across and excuse the
-    // instruction; walking back word-by-word stops at "hesitate".
-    const bad = `For unattended sync, do not hesitate to set ${MASTER_KEY} so pull works.\n`;
-    expect(headlessSyncInstructions(bad)).not.toEqual([]);
-  });
 
-  it('rejects "do not only set" — the negation governs the adverb', () => {
-    const bad = `For unattended sync on a worker box, do not only set ${MASTER_KEY}; pull needs it.\n`;
-    expect(headlessSyncInstructions(bad)).not.toEqual([]);
-  });
 
-  it('rejects a DOUBLE negative headless-sync instruction', () => {
-    // "do not not set" is affirmative — an instruction wearing a denial's
-    // clothes, and a one-word bypass of a single-token negation test.
-    const bad = `For unattended sync, do not not set ${MASTER_KEY} so pull works.\n`;
-    expect(headlessSyncInstructions(bad)).not.toEqual([]);
-  });
 
   it('does not let a later match inherit an earlier match\'s context', () => {
     // The index-misalignment bug: a negated earlier instruction shifted every

--- a/apps/cli/src/lib/secrets/docs-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/docs-hygiene.test.ts
@@ -8,22 +8,29 @@
  *
  * ## How this guard decides, and why it is not a phrase blocklist
  *
- * Two earlier drafts tried to classify English: first by matching the exact
- * sentences that shipped the bad advice (trivially defeated by rewording), then
- * by matching danger patterns while excluding sentences containing a negation
- * word (trivially defeated by ADDING a word — `Export … in ~/.zshenv; it is not
- * necessary to configure anything else.` passed because it contained "not").
- * Both failed the same way: no regex reliably tells "warning about X" from
- * "instructing X".
+ * Earlier drafts tried to classify English and were defeated three times, each
+ * time by ADDING a word rather than removing one:
  *
- * So the doc marks its own exceptions instead. The two passages that legitimately
- * discuss the master-key export — the warning that forbids it, and the bounded
- * per-command `export … ; unset` release example — are wrapped in
- * `<!-- docs-hygiene:allow-master-key-discussion -->` / `<!-- /… -->`. This test
- * strips those regions and forbids the danger patterns everywhere else, with no
- * escape hatch. Adding a new rc-file mention therefore fails until the author
- * consciously marks it as intentional, which is exactly the review moment that
- * was missing when the original advice was written.
+ *   1. matching the exact sentences that shipped the advice — beaten by rewording;
+ *   2. matching danger patterns but skipping any sentence containing a negation —
+ *      beaten by `Export … in ~/.zshenv; it is not necessary to configure
+ *      anything else.`;
+ *   3. per-sentence scanning — beaten by splitting the claim across a period.
+ *
+ * Three rules came out of that:
+ *
+ * - **The doc marks its own exceptions.** The passages that legitimately discuss
+ *   the master-key export — the warning that forbids it, and `export --host`,
+ *   which really does forward the master key to key a remote's own store — are
+ *   wrapped in `<!-- docs-hygiene:allow-master-key-discussion -->`. Everything
+ *   outside a marked region is held to the rules with no escape hatch, so a new
+ *   rc-file mention fails until an author consciously marks it. Region count,
+ *   pairing, and size are pinned so the exemption cannot quietly widen.
+ * - **Negation is judged per match and must ABUT the claim** (`never prompts`),
+ *   not merely appear nearby. `Do not hesitate: set …` does not clear the check.
+ * - **The checks are functions over text, and are tested against synthetic
+ *   documents**, not only against the real one. Every bypass found in review is
+ *   pinned below, so the same class cannot silently return.
  */
 import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
@@ -36,16 +43,22 @@ const SECRETS_DOC = path.join(CLI_ROOT, 'docs', 'secrets.md');
 const ALLOW_OPEN = '<!-- docs-hygiene:allow-master-key-discussion';
 const ALLOW_CLOSE = '<!-- /docs-hygiene:allow-master-key-discussion -->';
 
+const MASTER_KEY = 'AGENTS_SECRETS_PASSPHRASE';
+const SYNC_KEY = 'AGENTS_SYNC_PASSPHRASE';
+const LEGACY_PATH = '~/.agents/.cache/secrets/.passphrase';
+const CURRENT_PATH = '~/.agents/.secrets-key/passphrase';
+
+/** Heading of the section documenting the file store's own key resolution. */
+const FILE_STORE_HEADING = '## Linux: headless servers and the encrypted-file fallback';
+
 function doc(): string {
   return fs.readFileSync(SECRETS_DOC, 'utf-8');
 }
 
-/**
- * The doc with every explicitly-marked exception region removed. Everything
- * returned here is held to the rules below unconditionally.
- */
-function guarded(): string {
-  const text = doc();
+// ---------------------------------------------------------------- primitives
+
+/** `text` with every explicitly-marked exception region removed. */
+export function stripAllowedRegions(text: string): string {
   let out = '';
   let i = 0;
   for (;;) {
@@ -53,72 +66,127 @@ function guarded(): string {
     if (open === -1) { out += text.slice(i); break; }
     out += text.slice(i, open);
     const close = text.indexOf(ALLOW_CLOSE, open);
-    // An unterminated marker would silently swallow the rest of the file.
-    expect(close, `unterminated ${ALLOW_OPEN} region at offset ${open}`).not.toBe(-1);
+    // An unterminated marker would silently swallow the rest of the file, so it
+    // is a hard error rather than a widened exemption.
+    if (close === -1) throw new Error(`unterminated ${ALLOW_OPEN} region at offset ${open}`);
     i = close + ALLOW_CLOSE.length;
   }
   return out;
 }
 
-const RC_FILE = String.raw`~/\.(zshenv|zshrc|bashrc|bash_profile|profile)\b|\bshell rc\b|\blogin profile\b|\bshell profile\b|\brc file\b|\.zshenv\b`;
-
 /**
- * The section documenting the file store's own key resolution, guarded-text
- * only. Some claims (notably "no TTY prompt") are true of the FILE STORE and
- * false of `push`/`pull`, which prompt for the transport passphrase — so those
- * checks must not be applied document-wide.
- */
-const FILE_STORE_HEADING = '## Linux: headless servers and the encrypted-file fallback';
-
-/**
- * Matches of `claim` in `text` that are NOT negated, judged per match rather
- * than per sentence.
+ * Matches of `claim` that are not negated, where "negated" means the negation
+ * word DIRECTLY abuts the match — `never prompts`, `not asked` — rather than
+ * merely appearing within N characters of it.
  *
- * A whole-sentence exclusion list is defeated by adding a word — the sentence
- * makes the prohibited claim AND contains "not" somewhere, so it is skipped
- * entirely. Here the negation must sit in the 30 characters immediately before
- * the match (or lead it), so appending a disclaimer elsewhere in the sentence
- * changes nothing.
+ * Proximity was the previous rule and it did not establish that the negation
+ * governs the claim: `Do not hesitate: set AGENTS_SECRETS_PASSPHRASE …` cleared
+ * it. Requiring adjacency means a disclaimer placed anywhere else in the
+ * sentence changes nothing.
  */
-function negatedMatches(text: string, claim: RegExp, negation: RegExp): string[] {
-  const out: string[] = [];
+export function unnegatedMatches(
+  text: string,
+  claim: RegExp,
+  negation = /\b(never|not|no|without|neither|instead of|rather than)\s+$/i,
+): Array<{ text: string; index: number }> {
   const re = new RegExp(claim.source, claim.flags.includes('g') ? claim.flags : `${claim.flags}g`);
+  const out: Array<{ text: string; index: number }> = [];
   for (const m of text.matchAll(re)) {
     const at = m.index ?? 0;
-    const before = text.slice(Math.max(0, at - 30), at);
-    const lead = m[0].slice(0, 30);
-    if (negation.test(before) || negation.test(lead)) continue;
-    out.push(m[0].replace(/\s+/g, ' ').trim());
+    // Only letters and spaces may sit between the negation and the claim, so
+    // punctuation ("Do not hesitate: set …") breaks the association.
+    const before = text.slice(Math.max(0, at - 24), at);
+    const abutting = /([A-Za-z ]*)$/.exec(before)?.[1] ?? '';
+    if (negation.test(abutting)) continue;
+    out.push({ text: m[0].replace(/\s+/g, ' ').trim(), index: at });
   }
   return out;
 }
 
-function fileStoreSection(): string {
-  const text = guarded();
-  const start = text.indexOf(FILE_STORE_HEADING);
-  if (start === -1) return '';
-  const next = text.indexOf('\n## ', start + FILE_STORE_HEADING.length);
-  return next === -1 ? text.slice(start) : text.slice(start, next);
+// ------------------------------------------------------------------- checks
+// Each takes the full document text and returns the offending excerpts.
+
+const RC_FILE = new RegExp(
+  String.raw`~/\.(zshenv|zshrc|bashrc|bash_profile|profile)\b|\bshell rc\b|\blogin profile\b` +
+  String.raw`|\bshell profile\b|\brc file\b|\.zshenv\b`,
+  'i',
+);
+
+/** Any rc-file mention outside a marked region. */
+export function rcFileMentions(text: string): string[] {
+  return stripAllowedRegions(text).split('\n').filter((line) => RC_FILE.test(line));
 }
+
+/** Claims that the 0600 key file is the same thing as an env/rc export. */
+export function equivalenceClaims(text: string): string[] {
+  const equivalence = new RegExp(
+    String.raw`\b(identical|equivalent|the same as|no different|no safer|as safe as)\b[\s\S]{0,160}?` +
+    String.raw`(\bexport\b|\brc file\b|\bshell rc\b|~/\.zsh|\benvironment variable\b|\benv var\b)`,
+    'gi',
+  );
+  return stripAllowedRegions(text).match(equivalence) ?? [];
+}
+
+/** Promises of a passphrase prompt the file store does not have. */
+export function promptClaims(text: string): string[] {
+  const guardedText = stripAllowedRegions(text);
+  const start = guardedText.indexOf(FILE_STORE_HEADING);
+  if (start === -1) return ['__FILE_STORE_SECTION_NOT_FOUND__'];
+  const next = guardedText.indexOf('\n## ', start + FILE_STORE_HEADING.length);
+  const section = next === -1 ? guardedText.slice(start) : guardedText.slice(start, next);
+
+  const claim = new RegExp(
+    String.raw`\b(prompts?|asks?|asked|requests?|requested|prompted)\b[^.]{0,90}\bpassphrase\b` +
+    String.raw`|\bpassphrase\b[^.]{0,60}\b(prompt|is requested|is asked)\b`,
+    'gi',
+  );
+  return unnegatedMatches(section, claim).map((m) => m.text);
+}
+
+/** Instructions to set the MASTER key so unattended sync works. */
+export function headlessSyncInstructions(text: string): string[] {
+  const guardedText = stripAllowedRegions(text);
+  const instruction = new RegExp(String.raw`\b(set|export|define|configure)\s+\`?${MASTER_KEY}`, 'gi');
+  return unnegatedMatches(guardedText, instruction)
+    // The index comes from the match itself, so filtering never misaligns a
+    // survivor with an earlier match's context (the bug this replaced).
+    .filter(({ index }) => {
+      const around = guardedText.slice(Math.max(0, index - 300), index + 300);
+      return /\b(headless|CI|unattended|no TTY|worker box)\b/i.test(around)
+        && /\b(push|pull|sync)\b/i.test(around);
+    })
+    .map((m) => m.text);
+}
+
+/** Legacy-path mentions that read as a live location rather than a fallback. */
+export function legacyPathMisuses(text: string): string[] {
+  const sentences = text.split(/(?<=[.!?])\s+|\n{2,}/).filter((s) => s.includes(LEGACY_PATH));
+  const writeVerb = /\b(written to|write|writes|save|store|stored|place|put|generated (in|at))\b/i;
+  const readOnlyFraming = /read as a fallback|never written|legacy|pre-#479/i;
+  return sentences.filter((s) => writeVerb.test(s) || !readOnlyFraming.test(s));
+}
+
+/** The one blunt phrase that shipped the original advice. */
+export function recommendsForSharedMachines(text: string): boolean {
+  return /Recommended for shared\/CI machines/i.test(stripAllowedRegions(text));
+}
+
+// -------------------------------------------------------- the real document
 
 describe('docs/secrets.md hygiene (RUSH-1968)', () => {
   it('keeps its exceptions few, small, paired, and reviewed', () => {
     // A marked region is a DELIBERATE override — text inside it is exempt from
-    // every check below. That is the point: the warning has to name the export
-    // it forbids, and `export --host` legitimately forwards the master key to
-    // key a remote's own store. It is also the design's soft spot, so regions
-    // are pinned three ways — how many, properly paired, and how big. Widening
-    // one, or adding a third, fails here and forces the change through review.
+    // every check. That is the point (the warning must name what it forbids,
+    // and `export --host` really does forward the master key), and it is also
+    // the design's soft spot, so it is pinned by count, pairing, and size.
     const text = doc();
     const opens = text.split(ALLOW_OPEN).length - 1;
     const closes = text.split(ALLOW_CLOSE).length - 1;
     expect(opens).toBe(closes);
     expect(opens).toBe(2);
 
-    // Each region: big enough for its paragraph, far too small to hide a
-    // section in. Measured on what guarded() actually strips.
-    let i = 0;
     const sizes: number[] = [];
+    let i = 0;
     for (;;) {
       const open = text.indexOf(ALLOW_OPEN, i);
       if (open === -1) break;
@@ -131,105 +199,150 @@ describe('docs/secrets.md hygiene (RUSH-1968)', () => {
   });
 
   it('never mentions a shell rc file outside a marked region', () => {
-    // In this document an rc file has exactly two legitimate reasons to appear:
-    // the warning that forbids the export, and the bounded per-command example.
-    // Both are marked. Anywhere else it is advice to persist a credential in a
-    // file every child process inherits — no phrasing of that is acceptable, so
-    // this needs no verb heuristic and has no negation escape hatch.
-    const offenders = guarded()
-      .split('\n')
-      .filter((line) => new RegExp(RC_FILE, 'i').test(line));
-    expect(offenders).toEqual([]);
+    expect(rcFileMentions(doc())).toEqual([]);
   });
 
   it('never recommends the master passphrase for shared or CI machines', () => {
-    expect(guarded()).not.toMatch(/Recommended for shared\/CI machines/i);
+    expect(recommendsForSharedMachines(doc())).toBe(false);
   });
 
   it('never equates the 0600 key file with an environment or rc export', () => {
-    // The inverted claim is what made the export look sanctioned. Checked over
-    // the guarded text, so the warning's own "is **not** equivalent" sentence
-    // (inside the marked region) cannot be mistaken for the claim it refutes —
-    // and no sentence can buy immunity by containing the word "not".
-    //
-    // Matched over the raw text, NOT sentence by sentence: the claim splits
-    // across a period trivially ("The key file is equivalent. It is just a shell
-    // rc export."), which a per-sentence scan misses.
-    const equivalence = new RegExp(
-      String.raw`\b(identical|equivalent|the same as|no different|no safer|as safe as)\b[\s\S]{0,160}?` +
-      String.raw`(\bexport\b|\brc file\b|\bshell rc\b|~/\.zsh|\benvironment variable\b|\benv var\b)`,
-      'gi',
-    );
-    const offenders = guarded().match(equivalence) ?? [];
-    expect(offenders).toEqual([]);
+    expect(equivalenceClaims(doc())).toEqual([]);
   });
 
   it('names the real machine-local key path and never writes to the legacy one', () => {
-    const text = doc();
-    expect(text).toContain('~/.agents/.secrets-key/passphrase');
-
-    const legacyPath = '~/.agents/.cache/secrets/.passphrase';
-    const mentions = text
-      .split(/(?<=[.!?])\s+|\n{2,}/)
-      .filter((s) => s.includes(legacyPath));
-
-    // The legacy path may be described as a read-only fallback. It may never be
-    // presented as somewhere a key is written or should be placed — a sentence
-    // merely containing the word "old" does not earn that.
-    for (const s of mentions) {
-      expect(s, `legacy path mentioned without marking it read-only: ${s}`)
-        .toMatch(/read as a fallback|never written|legacy|pre-#479/i);
-      expect(s, `legacy path presented as a write target: ${s}`)
-        .not.toMatch(/\b(written to|write|writes|save|store|place|put|generated (in|at))\b(?![^.]*never written)/i);
-    }
+    expect(doc()).toContain(CURRENT_PATH);
+    expect(legacyPathMisuses(doc())).toEqual([]);
   });
 
   it('does not promise a passphrase prompt that getPassphrase does not have', () => {
-    // Scoped to the file-store section on purpose. `agents secrets push`/`pull`
-    // genuinely DO prompt — for the TRANSPORT passphrase, a different secret
-    // (see AGENTS_SYNC_PASSPHRASE / RUSH-1968). The false claim was specifically
-    // that the file store's own key resolution has a TTY step; `getPassphrase()`
-    // never prompts.
-    const section = fileStoreSection();
-    expect(section, 'file-store section heading not found — update the anchor')
-      .not.toBe('');
-
-    const promptClaim = new RegExp(
-      String.raw`\b(prompts?|asks?|asked|requests?|requested|prompted)\b[^.]{0,90}\bpassphrase\b` +
-      String.raw`|\bpassphrase\b[^.]{0,60}\b(prompt|is requested|is asked)\b`,
-      'gi',
-    );
-    // Negation is checked PER MATCH, adjacent to the verb — not per sentence.
-    // A sentence-level exclusion list is defeated by appending a word: "the
-    // command asks for a passphrase (no prompt is needed elsewhere)" would clear
-    // a whole-sentence filter while still making the false claim.
-    const offenders = negatedMatches(section, promptClaim, /\b(never|not|no|without|neither)\b/i);
-    expect(offenders).toEqual([]);
+    // Scoped to the file-store section on purpose: `secrets push`/`pull` really
+    // do prompt, for the TRANSPORT passphrase, a different secret.
+    expect(promptClaims(doc())).toEqual([]);
     expect(doc()).toMatch(/\*\*never prompts\*\*/i);
   });
 
   it('points headless sync at the transport variable, not the master key', () => {
-    const text = doc();
-    expect(text).toContain('AGENTS_SYNC_PASSPHRASE');
+    expect(doc()).toContain(SYNC_KEY);
+    expect(headlessSyncInstructions(doc())).toEqual([]);
+  });
+});
 
-    // No passage outside the marked region may tell a headless/CI reader to set
-    // the MASTER key so that push/pull works. That instruction is RUSH-1968.
-    //
-    // Judged per match on the imperative itself — "set AGENTS_SECRETS_PASSPHRASE"
-    // in a headless/sync context — with the negation adjacent, so appending
-    // "this is opt-in" cannot excuse it the way a sentence-level filter allowed.
-    const instruction = /\b(set|export|define|configure)\s+`?AGENTS_SECRETS_PASSPHRASE/gi;
-    const offenders = negatedMatches(guarded(), instruction, /\b(never|not|no|without|instead of|rather than)\b/i)
-      .filter((_m, i) => {
-        // Only flag when the surrounding passage is about headless/unattended sync.
-        const at = [...guarded().matchAll(instruction)][i]?.index ?? 0;
-        const around = guarded().slice(Math.max(0, at - 300), at + 300);
-        // No "but it's optional" exclusion here: that is the add-a-word hole
-        // again — appending "this is opt-in" would excuse the instruction. The
-        // imperative + a headless-sync context is the whole test.
-        return /\b(headless|CI|unattended|no TTY|worker box)\b/i.test(around)
-          && /\b(push|pull|sync)\b/i.test(around);
-      });
-    expect(offenders).toEqual([]);
+// ------------------------------------------- the checks, against known attacks
+
+/**
+ * Every bypass found across four review passes, pinned as a test rather than a
+ * shell one-liner someone once ran. A guard whose own weaknesses are not tests
+ * regresses to the weakness.
+ */
+describe('docs-hygiene checks catch the bypasses review found', () => {
+  const HEAD = `${FILE_STORE_HEADING}\n\n`;
+
+  it('rejects a persistence instruction split across two sentences', () => {
+    // Filtering to sentences containing the variable missed this.
+    const bad = `${HEAD}${MASTER_KEY} controls the store key. Persist it in the login profile.\n`;
+    expect(rcFileMentions(bad)).not.toEqual([]);
+  });
+
+  it('rejects an rc instruction that merely contains the word "not"', () => {
+    // A sentence-level negation filter skipped this entirely.
+    const bad = `${HEAD}Export ${MASTER_KEY} in ~/.zshenv; it is not necessary to configure anything else.\n`;
+    expect(rcFileMentions(bad)).not.toEqual([]);
+  });
+
+  it('rejects an equivalence claim that appends a negation', () => {
+    const bad = `${HEAD}The key file is equivalent to a shell rc export and is not dangerous.\n`;
+    expect(equivalenceClaims(bad)).not.toEqual([]);
+  });
+
+  it('rejects an equivalence claim split across a period', () => {
+    // Per-sentence scanning missed this.
+    const bad = `${HEAD}The key file is equivalent. It is just a shell rc export.\n`;
+    expect(equivalenceClaims(bad)).not.toEqual([]);
+  });
+
+  it('rejects a write instruction to the legacy path that says "old"', () => {
+    const bad = `Write the key to the old ${LEGACY_PATH} path.\n`;
+    expect(legacyPathMisuses(bad)).not.toEqual([]);
+  });
+
+  it('rejects a legacy-path mention with no read-only framing at all', () => {
+    const bad = `The machine-local key lives at ${LEGACY_PATH} on this machine.\n`;
+    expect(legacyPathMisuses(bad)).not.toEqual([]);
+  });
+
+  it('accepts a legacy-path mention framed as a read-only fallback', () => {
+    const ok = `The legacy co-located key at ${LEGACY_PATH} is read as a fallback, never written.\n`;
+    expect(legacyPathMisuses(ok)).toEqual([]);
+  });
+
+  it('rejects a passive prompt claim', () => {
+    const bad = `${HEAD}Interactive sessions are asked for the passphrase.\n`;
+    expect(promptClaims(bad)).not.toEqual([]);
+  });
+
+  it('rejects a prompt claim that appends an unrelated negation', () => {
+    // The per-sentence exclusion cleared this; per-match adjacency does not.
+    const bad = `${HEAD}The command asks you for a passphrase; no prompt is needed elsewhere.\n`;
+    expect(promptClaims(bad)).not.toEqual([]);
+  });
+
+  it('rejects a prompt claim preceded by a negation that does not govern it', () => {
+    // Proximity-based negation cleared this: "No" sits within 30 chars of "asks".
+    const bad = `${HEAD}No caveat: the command asks for a passphrase.\n`;
+    expect(promptClaims(bad)).not.toEqual([]);
+  });
+
+  it('accepts a genuine denial where the negation abuts the verb', () => {
+    const ok = `${HEAD}It never prompts for a passphrase, on any platform.\n`;
+    expect(promptClaims(ok)).toEqual([]);
+  });
+
+  it('rejects a headless-sync instruction', () => {
+    const bad = `On a headless CI box, set ${MASTER_KEY} so push and pull work.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
+  });
+
+  it('rejects a headless-sync instruction that appends "this is opt-in"', () => {
+    const bad = `On a headless CI box, set ${MASTER_KEY} so push and pull work; this is opt-in.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
+  });
+
+  it('rejects a headless-sync instruction preceded by a non-governing negation', () => {
+    // Proximity negation cleared this: "not" sits just before "set".
+    const bad = `For unattended sync, do not hesitate: set ${MASTER_KEY} and pull will work.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
+  });
+
+  it('accepts a genuine prohibition where the negation abuts the instruction', () => {
+    const ok = `For unattended sync never set ${MASTER_KEY}; use the transport passphrase for push and pull.\n`;
+    expect(headlessSyncInstructions(ok)).toEqual([]);
+  });
+
+  it('does not let a later match inherit an earlier match\'s context', () => {
+    // The index-misalignment bug: a negated earlier instruction shifted every
+    // later survivor onto the wrong surrounding text, so a real offender could
+    // be judged against unrelated prose and escape.
+    const bad = [
+      `Never set ${MASTER_KEY} here.`,
+      'x'.repeat(800),
+      `On a headless worker box, set ${MASTER_KEY} so sync and pull work.`,
+    ].join('\n\n');
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
+  });
+
+  it('rejects the original blunt recommendation', () => {
+    expect(recommendsForSharedMachines('Recommended for shared/CI machines.')).toBe(true);
+  });
+
+  it('exempts only what a marked region actually covers', () => {
+    const marked = `${ALLOW_OPEN} -->\nExport ${MASTER_KEY} in ~/.zshenv.\n${ALLOW_CLOSE}\n`;
+    expect(rcFileMentions(marked)).toEqual([]);
+    // …and text after the region is still checked.
+    expect(rcFileMentions(`${marked}Also export it in ~/.bashrc.\n`)).not.toEqual([]);
+  });
+
+  it('refuses to strip an unterminated region', () => {
+    expect(() => stripAllowedRegions(`${ALLOW_OPEN} -->\nExport it in ~/.zshenv.\n`)).toThrow(/unterminated/);
   });
 });

--- a/apps/cli/src/lib/secrets/docs-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/docs-hygiene.test.ts
@@ -84,20 +84,55 @@ export function stripAllowedRegions(text: string): string {
  * it. Requiring adjacency means a disclaimer placed anywhere else in the
  * sentence changes nothing.
  */
+const NEGATION_TOKEN = /\b(never|not|no|without|neither|instead of|rather than)\b/gi;
+
+/**
+ * True when the run of text immediately preceding a claim negates it.
+ *
+ * Counts negation tokens rather than testing for one, because a single-token
+ * test reads a DOUBLE negative as a denial: `do not not set …` and `does not
+ * never prompt …` are affirmative, and both cleared the earlier check by adding
+ * one word. An odd count negates; an even count does not.
+ */
+function negatesClaim(abutting: string): boolean {
+  const hits = abutting.match(NEGATION_TOKEN) ?? [];
+  return hits.length % 2 === 1;
+}
+
+/**
+ * Matches of `claim` that are not negated, where "negated" means an odd number
+ * of negation words DIRECTLY abut the anchor — `never prompts` — rather than
+ * merely appearing within N characters of it.
+ *
+ * Proximity was the original rule and it did not establish that the negation
+ * governs the claim: `Do not hesitate: set AGENTS_SECRETS_PASSPHRASE …` cleared
+ * it. Requiring adjacency means a disclaimer placed elsewhere in the sentence
+ * changes nothing, and only letters and spaces may intervene, so punctuation
+ * breaks the association.
+ *
+ * `anchorGroup` names the capture group carrying the claim's VERB. When the
+ * grammar puts the verb last (`the passphrase is not requested`), the negation
+ * sits before the verb, not before the match, and anchoring on the match start
+ * would report a legitimate denial as an offender.
+ */
 export function unnegatedMatches(
   text: string,
   claim: RegExp,
-  negation = /\b(never|not|no|without|neither|instead of|rather than)\s+$/i,
+  anchorGroup?: number,
 ): Array<{ text: string; index: number }> {
-  const re = new RegExp(claim.source, claim.flags.includes('g') ? claim.flags : `${claim.flags}g`);
+  const flags = new Set([...claim.flags, 'g', 'd']);
+  const re = new RegExp(claim.source, [...flags].join(''));
   const out: Array<{ text: string; index: number }> = [];
   for (const m of text.matchAll(re)) {
     const at = m.index ?? 0;
-    // Only letters and spaces may sit between the negation and the claim, so
-    // punctuation ("Do not hesitate: set …") breaks the association.
-    const before = text.slice(Math.max(0, at - 24), at);
+    const groupStart = anchorGroup === undefined
+      ? undefined
+      : (m as RegExpMatchArray & { indices?: Array<[number, number] | undefined> })
+        .indices?.[anchorGroup]?.[0];
+    const anchor = groupStart ?? at;
+    const before = text.slice(Math.max(0, anchor - 32), anchor);
     const abutting = /([A-Za-z ]*)$/.exec(before)?.[1] ?? '';
-    if (negation.test(abutting)) continue;
+    if (negatesClaim(abutting)) continue;
     out.push({ text: m[0].replace(/\s+/g, ' ').trim(), index: at });
   }
   return out;
@@ -135,12 +170,16 @@ export function promptClaims(text: string): string[] {
   const next = guardedText.indexOf('\n## ', start + FILE_STORE_HEADING.length);
   const section = next === -1 ? guardedText.slice(start) : guardedText.slice(start, next);
 
-  const claim = new RegExp(
-    String.raw`\b(prompts?|asks?|asked|requests?|requested|prompted)\b[^.]{0,90}\bpassphrase\b` +
-    String.raw`|\bpassphrase\b[^.]{0,60}\b(prompt|is requested|is asked)\b`,
-    'gi',
-  );
-  return unnegatedMatches(section, claim).map((m) => m.text);
+  // Two grammars, checked separately because the negation sits in a different
+  // place in each. Verb-first ("asks you for a passphrase") negates before the
+  // match; passphrase-first ("the passphrase is not requested") negates before
+  // the trailing verb, so that one anchors on its capture group.
+  const verbFirst = /\b(prompts?|asks?|asked|requests?|requested|prompted)\b[^.]{0,90}\bpassphrase\b/gi;
+  const passphraseFirst = /\bpassphrase\b[^.]{0,60}\b(prompt|requested|asked)\b/gi;
+  return [
+    ...unnegatedMatches(section, verbFirst),
+    ...unnegatedMatches(section, passphraseFirst, 1),
+  ].map((m) => m.text);
 }
 
 /** Instructions to set the MASTER key so unattended sync works. */
@@ -161,8 +200,11 @@ export function headlessSyncInstructions(text: string): string[] {
 /** Legacy-path mentions that read as a live location rather than a fallback. */
 export function legacyPathMisuses(text: string): string[] {
   const sentences = text.split(/(?<=[.!?])\s+|\n{2,}/).filter((s) => s.includes(LEGACY_PATH));
-  const writeVerb = /\b(written to|write|writes|save|store|stored|place|put|generated (in|at))\b/i;
-  const readOnlyFraming = /read as a fallback|never written|legacy|pre-#479/i;
+  const writeVerb = /\b(written to|write|writes|save|store|stored|place|put|generated (in|at)|active|current)\b/i;
+  // Explicit read-only semantics only. The bare word "legacy" is NOT enough —
+  // `Use the legacy <path> as the active key location.` satisfied it while
+  // presenting the path as live, which is the one-word bypass this closes.
+  const readOnlyFraming = /read as a fallback|never written|read-only|read only|no longer written|pre-#479/i;
   return sentences.filter((s) => writeVerb.test(s) || !readOnlyFraming.test(s));
 }
 
@@ -238,10 +280,15 @@ describe('docs/secrets.md hygiene (RUSH-1968)', () => {
 describe('docs-hygiene checks catch the bypasses review found', () => {
   const HEAD = `${FILE_STORE_HEADING}\n\n`;
 
-  it('rejects a persistence instruction split across two sentences', () => {
-    // Filtering to sentences containing the variable missed this.
-    const bad = `${HEAD}${MASTER_KEY} controls the store key. Persist it in the login profile.\n`;
-    expect(rcFileMentions(bad)).not.toEqual([]);
+  it('rejects an rc mention with no variable in the same sentence', () => {
+    // An earlier draft filtered to sentences containing the variable, so a
+    // two-sentence split slipped through. The check no longer looks for the
+    // variable at all — the rc-file token alone is disqualifying — so the
+    // assertion is on the offending clause, not merely on non-emptiness.
+    const bad = `${HEAD}${MASTER_KEY} controls the store key.\nPersist it in the login profile.\n`;
+    // Asserting the offending LINE, not just non-emptiness: the earlier version
+    // of this test stayed green with the whole setup removed.
+    expect(rcFileMentions(bad)).toEqual(['Persist it in the login profile.']);
   });
 
   it('rejects an rc instruction that merely contains the word "not"', () => {
@@ -276,6 +323,14 @@ describe('docs-hygiene checks catch the bypasses review found', () => {
     expect(legacyPathMisuses(ok)).toEqual([]);
   });
 
+  it('rejects the legacy path presented as the ACTIVE location, despite saying "legacy"', () => {
+    // Accepting the bare word "legacy" as read-only framing was a one-word
+    // bypass: this sentence contains it and no write verb, yet points a reader
+    // at the old path as if it were live.
+    const bad = `Use the legacy ${LEGACY_PATH} as the active key location.\n`;
+    expect(legacyPathMisuses(bad)).not.toEqual([]);
+  });
+
   it('rejects a passive prompt claim', () => {
     const bad = `${HEAD}Interactive sessions are asked for the passphrase.\n`;
     expect(promptClaims(bad)).not.toEqual([]);
@@ -298,6 +353,27 @@ describe('docs-hygiene checks catch the bypasses review found', () => {
     expect(promptClaims(ok)).toEqual([]);
   });
 
+  it('accepts a passive denial, where the negation abuts the trailing verb', () => {
+    // "The passphrase is not requested" puts the verb last, so anchoring the
+    // negation on the match START would report a legitimate denial. The
+    // passphrase-first grammar anchors on its verb instead.
+    const ok = `${HEAD}The passphrase is not requested at any point.\n`;
+    expect(promptClaims(ok)).toEqual([]);
+  });
+
+  it('rejects a passive prompt claim with no negation', () => {
+    // The mirror of the above: the same grammar, affirmative, must still fail.
+    const bad = `${HEAD}The passphrase is requested at first use.\n`;
+    expect(promptClaims(bad)).not.toEqual([]);
+  });
+
+  it('rejects a DOUBLE negative prompt claim', () => {
+    // "does not never prompt" is affirmative. A single-token negation test read
+    // it as a denial; counting tokens and requiring an odd count does not.
+    const bad = `${HEAD}The command does not never prompt for a passphrase.\n`;
+    expect(promptClaims(bad)).not.toEqual([]);
+  });
+
   it('rejects a headless-sync instruction', () => {
     const bad = `On a headless CI box, set ${MASTER_KEY} so push and pull work.\n`;
     expect(headlessSyncInstructions(bad)).not.toEqual([]);
@@ -317,6 +393,13 @@ describe('docs-hygiene checks catch the bypasses review found', () => {
   it('accepts a genuine prohibition where the negation abuts the instruction', () => {
     const ok = `For unattended sync never set ${MASTER_KEY}; use the transport passphrase for push and pull.\n`;
     expect(headlessSyncInstructions(ok)).toEqual([]);
+  });
+
+  it('rejects a DOUBLE negative headless-sync instruction', () => {
+    // "do not not set" is affirmative — an instruction wearing a denial's
+    // clothes, and a one-word bypass of a single-token negation test.
+    const bad = `For unattended sync, do not not set ${MASTER_KEY} so pull works.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
   });
 
   it('does not let a later match inherit an earlier match\'s context', () => {

--- a/apps/cli/src/lib/secrets/docs-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/docs-hygiene.test.ts
@@ -84,19 +84,41 @@ export function stripAllowedRegions(text: string): string {
  * it. Requiring adjacency means a disclaimer placed anywhere else in the
  * sentence changes nothing.
  */
-const NEGATION_TOKEN = /\b(never|not|no|without|neither|instead of|rather than)\b/gi;
+const NEGATION_WORDS = new Set(['never', 'not', "n't", 'no', 'without', 'neither', 'nor']);
+/** Words that may sit inside a negation phrase without breaking it. */
+const CARRIER_WORDS = new Set([
+  'do', 'does', 'did', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'it', 'they', 'we', 'you', 'this', 'that', 'there', 'and', 'but', 'will', 'would',
+  'can', 'could', 'shall', 'should', 'may', 'might', 'must', 'has', 'have', 'had',
+]);
 
 /**
- * True when the run of text immediately preceding a claim negates it.
+ * True when the words immediately preceding a claim negate it.
  *
- * Counts negation tokens rather than testing for one, because a single-token
- * test reads a DOUBLE negative as a denial: `do not not set …` and `does not
- * never prompt …` are affirmative, and both cleared the earlier check by adding
- * one word. An odd count negates; an even count does not.
+ * Walks backwards from the claim, consuming only negation words and the
+ * auxiliaries that can sit inside a negation phrase (`is not`, `does not
+ * never`), and stops at the first ordinary content word. Two failures forced
+ * this shape:
+ *
+ * - A single-token test read a DOUBLE negative as a denial: `do not not set …`
+ *   and `does not never prompt …` are affirmative. So negations are COUNTED and
+ *   an odd count negates.
+ * - Accepting any run of letters and spaces let a negation govern a DIFFERENT
+ *   verb: in `do not hesitate to set …` and `do not only set …` the `not`
+ *   attaches to `hesitate` / `only`, not to `set`. Stopping at the first content
+ *   word (`hesitate`, `only`, `to`) breaks that association.
  */
-function negatesClaim(abutting: string): boolean {
-  const hits = abutting.match(NEGATION_TOKEN) ?? [];
-  return hits.length % 2 === 1;
+function negatesClaim(before: string): boolean {
+  const words = before.toLowerCase().match(/[a-z']+|[^\sa-z']/g) ?? [];
+  let negations = 0;
+  for (let i = words.length - 1; i >= 0; i--) {
+    const w = words[i];
+    if (!/^[a-z']+$/.test(w)) break;          // punctuation ends the phrase
+    if (NEGATION_WORDS.has(w)) { negations++; continue; }
+    if (CARRIER_WORDS.has(w)) continue;
+    break;                                     // an ordinary content word
+  }
+  return negations % 2 === 1;
 }
 
 /**
@@ -130,9 +152,7 @@ export function unnegatedMatches(
       : (m as RegExpMatchArray & { indices?: Array<[number, number] | undefined> })
         .indices?.[anchorGroup]?.[0];
     const anchor = groupStart ?? at;
-    const before = text.slice(Math.max(0, anchor - 32), anchor);
-    const abutting = /([A-Za-z ]*)$/.exec(before)?.[1] ?? '';
-    if (negatesClaim(abutting)) continue;
+    if (negatesClaim(text.slice(Math.max(0, anchor - 64), anchor))) continue;
     out.push({ text: m[0].replace(/\s+/g, ' ').trim(), index: at });
   }
   return out;
@@ -175,7 +195,7 @@ export function promptClaims(text: string): string[] {
   // match; passphrase-first ("the passphrase is not requested") negates before
   // the trailing verb, so that one anchors on its capture group.
   const verbFirst = /\b(prompts?|asks?|asked|requests?|requested|prompted)\b[^.]{0,90}\bpassphrase\b/gi;
-  const passphraseFirst = /\bpassphrase\b[^.]{0,60}\b(prompt|requested|asked)\b/gi;
+  const passphraseFirst = /\bpassphrase\b[^.]{0,60}\b(prompted|prompts?|requested|requests?|asked|asks?)\b/gi;
   return [
     ...unnegatedMatches(section, verbFirst),
     ...unnegatedMatches(section, passphraseFirst, 1),
@@ -367,6 +387,18 @@ describe('docs-hygiene checks catch the bypasses review found', () => {
     expect(promptClaims(bad)).not.toEqual([]);
   });
 
+  it('rejects a passive prompt claim using "prompted"', () => {
+    // The verb-first grammar listed `prompted`; the passphrase-first one did
+    // not, so this promise of a prompt slipped through the gap between them.
+    const bad = `${HEAD}The passphrase is prompted at first use.\n`;
+    expect(promptClaims(bad)).not.toEqual([]);
+  });
+
+  it('rejects a prompt claim whose negation governs a different verb', () => {
+    const bad = `${HEAD}We do not hesitate to ask for a passphrase at startup.\n`;
+    expect(promptClaims(bad)).not.toEqual([]);
+  });
+
   it('rejects a DOUBLE negative prompt claim', () => {
     // "does not never prompt" is affirmative. A single-token negation test read
     // it as a denial; counting tokens and requiring an odd count does not.
@@ -393,6 +425,19 @@ describe('docs-hygiene checks catch the bypasses review found', () => {
   it('accepts a genuine prohibition where the negation abuts the instruction', () => {
     const ok = `For unattended sync never set ${MASTER_KEY}; use the transport passphrase for push and pull.\n`;
     expect(headlessSyncInstructions(ok)).toEqual([]);
+  });
+
+  it('rejects an instruction whose negation governs a DIFFERENT verb', () => {
+    // "not" attaches to "hesitate", not to "set". An abutting window of plain
+    // letters and spaces let the negation reach across and excuse the
+    // instruction; walking back word-by-word stops at "hesitate".
+    const bad = `For unattended sync, do not hesitate to set ${MASTER_KEY} so pull works.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
+  });
+
+  it('rejects "do not only set" — the negation governs the adverb', () => {
+    const bad = `For unattended sync on a worker box, do not only set ${MASTER_KEY}; pull needs it.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
   });
 
   it('rejects a DOUBLE negative headless-sync instruction', () => {

--- a/apps/cli/src/lib/secrets/docs-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/docs-hygiene.test.ts
@@ -141,18 +141,37 @@ export function promptClaims(text: string): string[] {
   // Two grammars, since the verb can precede or follow the noun. Both carry the
   // same verb set — they drifted apart once, and `The passphrase is prompted at
   // first use.` fell straight through the gap.
-  const verbFirst = /\b(prompts?|asks?|asked|requests?|requested|prompted)\b[^.]{0,90}\bpassphrase\b/gi;
-  const passphraseFirst = /\bpassphrase\b[^.]{0,60}\b(prompted|prompts?|requested|requests?|asked|asks?)\b/gi;
+  const PROMPT_VERB = String.raw`prompts?|prompted|asks?|asked|requests?|requested`
+    + String.raw`|enters?|entered|types?|typed|supplys?|supplies|supplied|provides?|provided|inputs?`;
+  const verbFirst = new RegExp(String.raw`\b(${PROMPT_VERB})\b[^.]{0,90}\bpassphrase\b`, 'gi');
+  const passphraseFirst = new RegExp(String.raw`\bpassphrase\b[^.]{0,60}\b(${PROMPT_VERB})\b`, 'gi');
   return [
     ...findMatches(section, verbFirst),
     ...findMatches(section, passphraseFirst),
   ].map((m) => m.text);
 }
 
-/** Instructions to set the MASTER key so unattended sync works. */
+/**
+ * Instructions to set the MASTER key so unattended sync works.
+ *
+ * The verb set is a LIST, and a list is never complete — `use` and `provide`
+ * were both missing until review named them. The alternative, flagging any
+ * master-key mention inside a headless-sync window, was measured against the
+ * real document and reports two legitimate passages: the `--remote-backend file`
+ * table row (which says "only if set") and the sentence contrasting the two
+ * variables. Neither can carry a marker cleanly — an HTML comment inside a
+ * Markdown table breaks the table — so the verb list is the bounded choice.
+ * A phrasing it misses is a gap to add here, not a reason to loosen the rule.
+ */
 export function headlessSyncInstructions(text: string): string[] {
   const guardedText = stripAllowedRegions(text);
-  const instruction = new RegExp(String.raw`\b(set|export|define|configure)\s+\`?${MASTER_KEY}`, 'gi');
+  const instruction = new RegExp(
+    String.raw`\b(set|sets|setting|export|exports|exporting|define|defines|configure|configures`
+    + String.raw`|use|uses|using|provide|provides|supply|supplies|specify|specifies|pass|passes`
+    + String.raw`|give|gives|need|needs|require|requires|add|adds|put|puts|inject|injects)\s+`
+    + String.raw`(?:\w+\s+){0,2}\`?${MASTER_KEY}`,
+    'gi',
+  );
   return findMatches(guardedText, instruction)
     // The index comes from the match itself, so filtering never misaligns a
     // survivor with an earlier match's context (the bug this replaced).
@@ -311,6 +330,30 @@ describe('docs-hygiene checks catch the bypasses review found', () => {
     // The mirror of the above: the same grammar, affirmative, must still fail.
     const bad = `${HEAD}The passphrase is requested at first use.\n`;
     expect(promptClaims(bad)).not.toEqual([]);
+  });
+
+  it('rejects a prompt claim phrased with "enter"', () => {
+    // The verb set covered prompt/ask/request but not the imperative an
+    // operator would actually read: "enter the passphrase".
+    const bad = `${HEAD}At first use, enter the passphrase in the terminal.\n`;
+    expect(promptClaims(bad)).not.toEqual([]);
+  });
+
+  it('rejects a headless-sync instruction phrased with "use"', () => {
+    // `use` and `provide` express the RUSH-1968 mistake exactly, and neither
+    // was in the verb set until review named them.
+    const bad = `On a headless CI box, use ${MASTER_KEY} so push and pull work.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
+  });
+
+  it('rejects a headless-sync instruction phrased with "provide"', () => {
+    const bad = `For unattended sync on a worker box, provide ${MASTER_KEY} and pull will succeed.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
+  });
+
+  it('rejects a headless-sync instruction with words between verb and variable', () => {
+    const bad = `On a headless CI box, set the ${MASTER_KEY} value so push and pull work.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
   });
 
   it('rejects a passive prompt claim using "prompted"', () => {

--- a/apps/cli/src/lib/secrets/docs-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/docs-hygiene.test.ts
@@ -154,21 +154,34 @@ export function promptClaims(text: string): string[] {
 /**
  * Instructions to set the MASTER key so unattended sync works.
  *
- * The verb set is a LIST, and a list is never complete — `use` and `provide`
- * were both missing until review named them. The alternative, flagging any
- * master-key mention inside a headless-sync window, was measured against the
- * real document and reports two legitimate passages: the `--remote-backend file`
- * table row (which says "only if set") and the sentence contrasting the two
- * variables. Neither can carry a marker cleanly — an HTML comment inside a
- * Markdown table breaks the table — so the verb list is the bounded choice.
- * A phrasing it misses is a gap to add here, not a reason to loosen the rule.
+ * The verb set is a LIST, and a list is never complete — `use`, `provide`,
+ * `store` and `make … available` were each missing until review named them.
+ *
+ * The alternative — flagging ANY master-key mention inside the same
+ * headless-sync window, with no verb at all — was measured rather than assumed.
+ * Against the GUARDED text (what this check actually sees, marked regions
+ * already removed) it reports **2** legitimate passages in the current doc:
+ *
+ *   1. the `--remote-backend file` table row, which says "only if set";
+ *   2. the sentence contrasting the two variables ("deliberately not …").
+ *
+ * On the RAW document the count is 3 — the third sits inside a marked region and
+ * never reaches any check, so it is not a cost of the verbless rule. Neither of
+ * the two real ones can carry a marker: the first is a Markdown table row, and an
+ * HTML comment inside a table breaks the table.
+ *
+ * So the verb list is the bounded choice. A phrasing it misses is a verb to add
+ * here, not a reason to loosen the rule — and each one review has named is now
+ * pinned by a test below.
  */
 export function headlessSyncInstructions(text: string): string[] {
   const guardedText = stripAllowedRegions(text);
   const instruction = new RegExp(
     String.raw`\b(set|sets|setting|export|exports|exporting|define|defines|configure|configures`
-    + String.raw`|use|uses|using|provide|provides|supply|supplies|specify|specifies|pass|passes`
-    + String.raw`|give|gives|need|needs|require|requires|add|adds|put|puts|inject|injects)\s+`
+    + String.raw`|use|uses|using|provide|provides|providing|supply|supplies|specify|specifies`
+    + String.raw`|pass|passes|give|gives|need|needs|require|requires|add|adds|put|puts`
+    + String.raw`|inject|injects|store|stores|storing|stash|save|saves|keep|keeps|write|writes`
+    + String.raw`|make|makes|making|have|hold|holds|populate|populates)\s+`
     + String.raw`(?:\w+\s+){0,2}\`?${MASTER_KEY}`,
     'gi',
   );
@@ -348,6 +361,16 @@ describe('docs-hygiene checks catch the bypasses review found', () => {
 
   it('rejects a headless-sync instruction phrased with "provide"', () => {
     const bad = `For unattended sync on a worker box, provide ${MASTER_KEY} and pull will succeed.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
+  });
+
+  it('rejects a headless-sync instruction phrased with "store"', () => {
+    const bad = `For unattended CI sync, store ${MASTER_KEY} in the secret manager so push works.\n`;
+    expect(headlessSyncInstructions(bad)).not.toEqual([]);
+  });
+
+  it('rejects the "make … available" construction', () => {
+    const bad = `For unattended CI sync, make ${MASTER_KEY} available so pull works.\n`;
     expect(headlessSyncInstructions(bad)).not.toEqual([]);
   });
 


### PR DESCRIPTION
**Test-only. Fixes a real bug in the guard that merged in #2154**, and adds the self-tests that would have caught it. Third and final follow-up on RUSH-1968; a fourth non-author review pass found these after #2154 merged.

## The bug

`headlessSyncInstructions` filtered the results of `negatedMatches()` but recovered each match's position from a **second, unfiltered** `matchAll()`:

```ts
.filter((_m, i) => {
  const at = [...guarded().matchAll(instruction)][i]?.index ?? 0;   // ← wrong list
  const around = guarded().slice(Math.max(0, at - 300), at + 300);
```

`i` indexes the filtered array. So as soon as any earlier instruction is negated, every later survivor is judged against the **preceding** match's surrounding text — a real offender gets evaluated against unrelated prose and escapes. Matches now carry their own index.

## Negation by proximity didn't mean negation

The check skipped a claim if a negation word appeared within 30 characters before it. Proximity is not government:

```
Do not hesitate: set AGENTS_SECRETS_PASSPHRASE for headless push sync.
No caveat: the command asks for a passphrase.
```

Both cleared it. The negation must now **abut** the claim, with only letters and spaces between, so punctuation breaks the association and a disclaimer elsewhere in the sentence changes nothing. `never prompts` still reads as a denial; `Do not hesitate: set …` does not.

## The guard had no tests of its own

This is the reason the same class of hole came back four times: every bypass I found lived in a shell one-liner I ran once, not in the repo. The checks are now plain functions over text, and **19 tests run them against synthetic documents** — every bypass found across all four review passes, both governing-negation cases, the index bug above, plus positive cases proving a genuine denial and a properly-framed legacy-path mention still pass.

Also drops the negative-lookahead escape in the legacy-path check: a write verb on that path is now rejected unconditionally.

## Run output

Mutation-tested, because a test that cannot fail is decoration. Reverting each fix fails exactly the tests written for it:

```
=== MUTATION 1: revert to proximity negation ===
     × rejects a prompt claim preceded by a negation that does not govern it
     × rejects a headless-sync instruction preceded by a non-governing negation
      Tests  2 failed | 24 passed (26)

=== MUTATION 2: reintroduce the index-misalignment bug ===
     × does not let a later match inherit an earlier match's context
      Tests  1 failed | 25 passed (26)

=== restored ===
      Tests  26 passed (26)
```

`src/lib/secrets/` + `setup-secrets.test.ts`: **619 passed, 14 skipped**. No screenshot — test-only, no user-visible surface.
