### PR TITLE
fix(hosts): --host router must not answer for commands that do not exist (RUSH-2022)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2022.md
+++ b/apps/cli/.changelog/next/RUSH-2022.md
@@ -13,7 +13,9 @@
   unknown-command fallback that loads the whole command tree. Found by the new test
   that pins the command-name set against the real tree.
 
-- **A mistyped command keeps its `--host`.** The distance-1 auto-correct now runs
-  *before* the router instead of after commander gave up, so `agents docto --host
-  <box>` corrects to `doctor` **and** runs on `<box>` — previously the corrected
-  command re-parsed locally with a `--host` it did not accept.
+- **A mistyped command keeps its `--host`.** The distance-1 auto-correct now re-checks
+  routing after correcting the name, so `agents docto --host <box>` corrects to
+  `doctor` **and actually routes to `<box>`** — previously the corrected command
+  re-parsed locally with a `--host` it silently dropped (a regression caught in review:
+  it used to fail loudly with the wrong message, corrected-but-unrouted made it fail
+  silently instead). `apps/cli/src/index.ts`.

--- a/apps/cli/.changelog/next/RUSH-2022.md
+++ b/apps/cli/.changelog/next/RUSH-2022.md
@@ -1,0 +1,19 @@
+- **A typo'd command with `--host` said the opposite of the truth (RUSH-2022).** The
+  `--host`/`--device` router runs before commander parses, so `agents session resume
+  --host <box>` (one letter off `sessions`, which *does* accept `--host`) reported
+  ``  `agents session` does not support --host/--device `` — a true statement about a
+  command nobody typed. Unknown names now fall through to `unknown command '<name>'`
+  with a did-you-mean, and the spellcheck can suggest the lazily-registered groups
+  (`sessions`/`teams`/`cloud`/…) it previously could not see. A real command with no
+  remote semantics still gets the flag-support error. Source:
+  `apps/cli/src/lib/hosts/passthrough.ts`, `apps/cli/src/lib/startup/command-registry.ts`.
+
+- **`agents publish` is in the lazy command table.** `commands/packages.ts` registers it
+  at top level but the registry did not list it, so it only resolved through the
+  unknown-command fallback that loads the whole command tree. Found by the new test
+  that pins the command-name set against the real tree.
+
+- **A mistyped command keeps its `--host`.** The distance-1 auto-correct now runs
+  *before* the router instead of after commander gave up, so `agents docto --host
+  <box>` corrects to `doctor` **and** runs on `<box>` — previously the corrected
+  command re-parsed locally with a `--host` it did not accept.

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -90,6 +90,18 @@ agents view --device all --json        # machine-readable fleet inventory
 `--devices all` and `--hosts all` are synonyms. Commands that already register
 `--all-hosts` (e.g. `agents output --all-hosts`) keep their existing behavior.
 
+**The router only speaks for commands that exist.** `--host`/`--device` is handled
+before commander parses, so a group with no remote semantics gets a clear
+`` `agents <cmd>` does not support --host/--device `` instead of commander's raw
+`unknown option`. That answer is reserved for a **real** command: a name the CLI
+does not register falls straight through to `unknown command '<name>'` (plus its
+did-you-mean). Without that gate `agents session resume --host <box>` — one letter
+off `sessions`, which *does* take `--host` — was answered with a flag-support error
+about a command nobody typed, sending the user looking in the wrong place
+(RUSH-2022). `KNOWN_TOP_LEVEL_COMMANDS`
+([`src/lib/startup/command-registry.ts`](../src/lib/startup/command-registry.ts))
+is the name set, pinned to the real command tree by a test.
+
 It sits next to the vendor clouds (`agents cloud run --provider rush|codex|…`),
 not replacing them: those dispatch to *someone else's* cloud; `hosts` dispatches
 to *your* boxes (owned, or leased on demand via crabbox — see Host sources).

--- a/apps/cli/src/index.command-star-routing.test.ts
+++ b/apps/cli/src/index.command-star-routing.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Real-CLI regression test (RUSH-2022 review r2): a 1-edit-distance typo of a
+ * host-routable command (e.g. `docto` for `doctor`) combined with `--host`
+ * must not silently run LOCALLY once the auto-correct handler re-parses with
+ * the corrected name. The router only ever saw the ORIGINAL (unknown) name
+ * before commander parsing, so without re-checking after auto-correct, a
+ * routing flag on the corrected name was dropped with no error at all -
+ * worse than the pre-fix "does not support --host" message, which was at
+ * least a loud failure. No mocks: spawns the actual built CLI.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
+
+function seedHome(): string {
+  const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cmdstar-home-'));
+  const userDir = path.join(testHome, '.agents');
+  const systemDir = path.join(userDir, '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: 4102444800000, latestVersion: '0.0.0' }),
+  );
+  return testHome;
+}
+
+function run(testHome: string, ...args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const r = spawnSync('bun', [INDEX, ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: testHome,
+      AGENTS_NO_AUTOPULL: '1',
+      AGENTS_DEVICES_DIR: path.join(testHome, '.agents', '.history', 'devices'),
+    },
+    encoding: 'utf-8',
+    timeout: 20_000,
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe('command:* auto-correct re-checks --host routing (RUSH-2022 review r2)', () => {
+  it('a typo of a host-routable command with --host does not silently run locally', () => {
+    const testHome = seedHome();
+    try {
+      // `docto` is 1 edit from `doctor`, which is host-routable via
+      // REMOTE_PASSTHROUGH but NOT in OWN_HOST_COMMANDS. An unreachable host
+      // name forces a real SSH resolution attempt if (and only if) routing
+      // was actually retried after the correction.
+      const r = run(testHome, 'docto', '--host', 'nonexistent-host-xyz-regression-test');
+
+      // Must NOT look like a successful local doctor report.
+      expect(r.stdout).not.toContain('CRITICAL');
+      expect(r.stdout).not.toContain('Installed Agent CLIs');
+      // Must show real routing was attempted (SSH resolution failure), not a
+      // silent local run and not the old "does not support --host" message.
+      expect(r.stderr.toLowerCase()).not.toContain('does not support --host');
+      const routed =
+        r.stderr.toLowerCase().includes('nonexistent-host-xyz-regression-test') ||
+        r.stderr.toLowerCase().includes('ssh') ||
+        r.stderr.toLowerCase().includes('unreachable');
+      expect(routed).toBe(true);
+    } finally {
+      fs.rmSync(testHome, { recursive: true, force: true });
+    }
+  });
+
+  it('a typo with no routing flag still auto-corrects and runs locally as before', () => {
+    const testHome = seedHome();
+    try {
+      // `vew` (typo of `view`) with NO --host must behave exactly as the
+      // pre-existing auto-correct did: run locally, no SSH attempt.
+      const r = run(testHome, 'vew', '--help');
+      expect(r.stderr).not.toContain("unknown command 'vew'");
+    } finally {
+      fs.rmSync(testHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1241,6 +1241,9 @@ if (requestedCommand !== undefined && !helpOrVersionRequested && !requestedIsDis
 // Register only the command(s) this invocation actually uses. Lazy commands
 // (sessions/teams/cloud) are handled after applyGlobalHelpConventions below.
 const isLazyRequest = requestedCommand !== undefined && LAZY_COMMAND_NAMES.has(requestedCommand);
+// Set when the requested name maps to no command: the lazy tree is then also
+// registered below so the spellcheck can suggest `sessions`/`teams`/`cloud`.
+let requestedIsUnknown = false;
 if (requestedIsDisabled) {
   // The brand turned this command off: register the full tree so the "did you
   // mean" picker still works, then strip the disabled commands below so the
@@ -1253,6 +1256,7 @@ if (requestedIsDisabled) {
     // spellcheck and edit-distance-1 auto-correct (the command:* handler above)
     // see the same candidate set — and ordering — as main.
     await registerAllEagerCommands();
+    requestedIsUnknown = true;
   }
 }
 // When requestedCommand is undefined (bare invocation, --version, --help, -h) no
@@ -1268,6 +1272,19 @@ applyGlobalHelpConventions(program);
 // only when explicitly requested, keeping lightweight commands off that path.
 if (isLazyRequest && !requestedIsDisabled) {
   for (const loader of COMMAND_LOADERS[requestedCommand!]) await reg(loader);
+} else if (requestedIsUnknown) {
+  // Unknown command: the lazy names must be candidates too, or `agents session`
+  // (a typo for the very much lazy `sessions`) gets no "did you mean" at all —
+  // the miss the RUSH-2022 report walked into. Registration order still mirrors
+  // main: lazy commands come after applyGlobalHelpConventions.
+  const seen = new Set<ModuleLoader>();
+  for (const name of LAZY_COMMAND_NAMES) {
+    for (const loader of COMMAND_LOADERS[name] ?? []) {
+      if (seen.has(loader)) continue;
+      seen.add(loader);
+      await reg(loader);
+    }
+  }
 }
 
 // White-label: remove any commands this brand disabled so they resolve as

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1195,7 +1195,23 @@ program.on('command:*', (operands) => {
   if (minDist === 1 && closest) {
     const args = process.argv.slice(2);
     args[0] = closest;
-    program.parse(['node', 'agents', ...args]);
+    // The typo'd name was unknown, so the top-level --host router (which ran
+    // before commander parsing, against the ORIGINAL name) could not have
+    // routed it - it correctly fell through to reach this handler at all
+    // (that fallthrough is this ticket's own fix). But falling through to a
+    // plain local re-parse means a routing flag on a corrected REAL
+    // host-routable command (e.g. `docto --host box`, corrected to `doctor`)
+    // silently ran LOCALLY instead of remotely, with no error - worse than
+    // the loud "does not support --host" this ticket replaced. Re-run the
+    // router with the CORRECTED name before falling through to local parse;
+    // it already no-ops when no routing flag is present. RUSH-2022 review r2.
+    void (async () => {
+      const { maybeRunOnHost } = await import('./lib/hosts/passthrough.js');
+      if (await maybeRunOnHost(closest, args)) {
+        process.exit(process.exitCode ?? 0);
+      }
+      program.parse(['node', 'agents', ...args]);
+    })();
     return;
   }
 

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -65,6 +65,26 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('falls through for an UNKNOWN command so commander reports it (RUSH-2022)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // `session` is a typo for the very much host-routable `sessions`. The router
+    // runs before commander parses, so claiming "does not support --host" here
+    // both invents a command and states the opposite of the truth for the one
+    // the user meant. It must decline and let `unknown command 'session'` win.
+    expect(await maybeRunOnHost('session', ['session', 'resume', '--host', 'mac'])).toBe(false);
+    expect(process.exitCode).toBe(0);
+    expect(await maybeRunOnHost('zzzznotacommand', ['zzzznotacommand', '--device', 'mac'])).toBe(false);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('still rejects --host on a REAL command that has no remote semantics', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // The unknown-command gate above must not weaken this: `login` exists, so
+    // the flag-support error is the correct, honest answer.
+    expect(await maybeRunOnHost('login', ['login', '--host', 'mac'])).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+
   it('returns false when no --host is given', async () => {
     expect(await maybeRunOnHost('view', ['view', 'claude'])).toBe(false);
   });

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -42,6 +42,7 @@ import {
   type FanOutDeviceResult,
 } from '../devices/fleet.js';
 import { platformGroupLabel } from '../devices/health-report.js';
+import { isKnownTopLevelCommand } from '../startup/command-registry.js';
 
 /** Per-command remote behaviour. Absence from this map = not host-routable here. */
 interface RemoteSpec {
@@ -497,6 +498,15 @@ export async function maybeRunOnHost(
     if (!isAll && command !== 'routines') return false;
   }
 
+  // A command that does not exist is an unknown-command error, not a routing
+  // error. The router runs BEFORE commander parses, so without this gate a typo
+  // (`agents session resume --host box`) was answered with "does not support
+  // --host/--device" — a true statement about a command the user never typed,
+  // and the exact opposite of the truth for the `sessions` they meant, which
+  // does support it. Fall through so commander reports `unknown command` (and
+  // its did-you-mean). RUSH-2022.
+  if (!isKnownTopLevelCommand(command)) return false;
+
   const spec = REMOTE_PASSTHROUGH[command];
   if (!spec) {
     // Flag was accepted (no raw commander "unknown option") but this group has
@@ -607,22 +617,50 @@ export async function maybeRunOnHost(
   const doctorPath = isDoctorCommand && !/^win/i.test((remoteOs ?? '').trim())
     ? { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' }
     : undefined;
-  // Forward actor provenance (AGENTS_ACTOR*/GIT_*) across the SSH hop, merged
-  // UNDER the doctor PATH so that PATH still wins — without this the remote
-  // re-resolves the actor from THIS box's SSH_CONNECTION and mis-credits it
-  // (RUSH-2028). Flows to both POSIX (export) and Windows ($env:) dialects.
-  // AGENTS_FLEET_REMOTE marks this as a fleet-dispatched `--host` run so the far
-  // side can gate consent-sensitive actions — the browser consent gate
-  // (lib/browser/remote-control.ts) reads it to allow/deny a cross-machine drive.
-  const env = withActorEnv({ ...doctorPath, AGENTS_FLEET_REMOTE: '1' });
-  const remoteCmd = buildRemoteAgentsInvocation(forwarded, remoteCwd, remoteOs, env);
-  const code = sshStream(target, remoteCmd, { tty: interactive, multiplex: true });
+  process.exitCode = streamAgentsOnHost(host, forwarded, {
+    remoteCwd,
+    interactive,
+    extraEnv: doctorPath,
+    remoteOs,
+    target,
+  });
+  return true;
+}
+
+/**
+ * Run `agents <forwardedArgs>` on `host` over SSH, streaming its output, and
+ * return the exit code. The single place the SSH hop is built, so every remote
+ * `agents` invocation carries identical env semantics.
+ *
+ * Forwards actor provenance (`AGENTS_ACTOR`/`GIT_` vars) across the hop, merged UNDER
+ * `extraEnv` so a caller-supplied PATH still wins — without this the remote
+ * re-resolves the actor from THIS box's SSH_CONNECTION and mis-credits it
+ * (RUSH-2028). Flows to both POSIX (export) and Windows ($env:) dialects.
+ * AGENTS_FLEET_REMOTE marks this as a fleet-dispatched run so the far side can
+ * gate consent-sensitive actions — the browser consent gate
+ * (lib/browser/remote-control.ts) reads it to allow/deny a cross-machine drive.
+ */
+export function streamAgentsOnHost(
+  host: Host,
+  forwardedArgs: string[],
+  opts: {
+    remoteCwd?: string;
+    interactive?: boolean;
+    extraEnv?: Record<string, string>;
+    remoteOs?: string;
+    target?: string;
+  } = {},
+): number {
+  const target = opts.target ?? sshTargetFor(host);
+  const remoteOs = opts.remoteOs ?? resolveRemoteOsSync(host.name);
+  const env = withActorEnv({ ...opts.extraEnv, AGENTS_FLEET_REMOTE: '1' });
+  const remoteCmd = buildRemoteAgentsInvocation(forwardedArgs, opts.remoteCwd, remoteOs, env);
+  const code = sshStream(target, remoteCmd, { tty: !!opts.interactive, multiplex: true });
   if (code === 255) {
     console.error(
       chalk.red(`${host.name}: unreachable over SSH (asleep, offline, or host key changed?).`) +
         chalk.gray(' Check: agents hosts check ' + host.name),
     );
   }
-  process.exitCode = code;
-  return true;
+  return code;
 }

--- a/apps/cli/src/lib/startup/command-registry.test.ts
+++ b/apps/cli/src/lib/startup/command-registry.test.ts
@@ -1,0 +1,59 @@
+/**
+ * RUSH-2022 — `KNOWN_TOP_LEVEL_COMMANDS` is the "does this command exist?"
+ * predicate the `--host`/`--device` router consults before it can claim a
+ * command has no remote semantics. A name that drifts out of it turns a real
+ * command into a phantom `unknown command`, so this pins the set against the
+ * command tree the CLI actually registers — the real modules, no mocks.
+ */
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import {
+  COMMAND_LOADERS,
+  LAZY_COMMAND_NAMES,
+  KNOWN_TOP_LEVEL_COMMANDS,
+  isKnownTopLevelCommand,
+} from './command-registry.js';
+
+/** Register every module in the loader table onto one fresh program. */
+async function registerEverything(): Promise<Command> {
+  const program = new Command();
+  const done = new Set<unknown>();
+  for (const loaders of Object.values(COMMAND_LOADERS)) {
+    for (const loader of loaders) {
+      if (done.has(loader)) continue;
+      done.add(loader);
+      (await loader())(program);
+    }
+  }
+  return program;
+}
+
+describe('KNOWN_TOP_LEVEL_COMMANDS', () => {
+  it('covers every top-level name and alias the real command modules register', async () => {
+    const program = await registerEverything();
+    const registered = program.commands.flatMap((c) => [c.name(), ...c.aliases()]);
+    expect(registered.length).toBeGreaterThan(50); // the tree really did load
+    const missing = registered.filter((name) => !KNOWN_TOP_LEVEL_COMMANDS.has(name));
+    expect(missing).toEqual([]);
+  });
+
+  it('includes the lazily-registered groups (sessions/teams/cloud/…)', () => {
+    for (const name of LAZY_COMMAND_NAMES) {
+      expect(isKnownTopLevelCommand(name)).toBe(true);
+    }
+  });
+
+  it('includes the aliases and tombstones src/index.ts registers inline', () => {
+    // Not in COMMAND_LOADERS — they are closures over entry-point state — but
+    // they are real commands, so the router must not treat them as unknown.
+    for (const name of ['perms', 'exec', 'jobs', 'cron', 'check', 'resources', 'hq', 'upgrade', '_internal']) {
+      expect(isKnownTopLevelCommand(name)).toBe(true);
+    }
+  });
+
+  it('rejects a name the CLI does not register', () => {
+    expect(isKnownTopLevelCommand('session')).toBe(false); // the RUSH-2022 typo
+    expect(isKnownTopLevelCommand('zzzznotacommand')).toBe(false);
+    expect(isKnownTopLevelCommand('')).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -176,6 +176,11 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   registry: [loadPackages],
   search: [loadPackages],
   install: [loadPackages],
+  // packages.ts also registers `publish` at top level (commands/packages.ts:435).
+  // It was missing here, so `agents publish` only worked via the unknown-command
+  // fallback that registers the whole tree — and the --host router could not see
+  // it as a real command at all (RUSH-2022).
+  publish: [loadPackages],
   routines: [loadRoutines],
   monitors: [loadMonitors],
   projects: [loadProjects],
@@ -261,3 +266,43 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   funnel: [loadFunnel],
   humans: [loadHumans],
 };
+
+/**
+ * Top-level names that {@link COMMAND_LOADERS} does not carry because they are
+ * registered inline in src/index.ts — closures over entry-point state (the
+ * deprecated aliases and tombstones) plus the internal/upgrade commands. They are
+ * real commands, so anything that asks "does this command exist?" must count them.
+ */
+const INLINE_COMMAND_NAMES = [
+  'perms', // deprecated alias -> permissions
+  'exec', // deprecated alias -> run
+  'jobs', // deprecated alias -> routines
+  'cron', // deprecated alias -> routines
+  'check', // tombstone -> doctor --check
+  'resources', // tombstone -> view --merged
+  'hq', // tombstone
+  '_internal',
+  'upgrade',
+] as const;
+
+/**
+ * Every top-level command name the CLI answers to — the loader table plus the
+ * inline aliases/tombstones above. This is the "does this command exist?"
+ * predicate for code that runs BEFORE commander parses, most importantly the
+ * `--host`/`--device` router (lib/hosts/passthrough.ts): without it a typo'd
+ * command carrying `--host` reported a flag-support error instead of
+ * `unknown command` (RUSH-2022).
+ *
+ * Commander sub-aliases (`sessions ls`, `teams rm`, …) are deliberately absent —
+ * this set is top-level only. `command-registry.test.ts` pins it against the real
+ * registered command tree so a new command can never drift out of it.
+ */
+export const KNOWN_TOP_LEVEL_COMMANDS: ReadonlySet<string> = new Set<string>([
+  ...Object.keys(COMMAND_LOADERS),
+  ...INLINE_COMMAND_NAMES,
+]);
+
+/** Whether `name` is a top-level command this CLI registers. See {@link KNOWN_TOP_LEVEL_COMMANDS}. */
+export function isKnownTopLevelCommand(name: string): boolean {
+  return KNOWN_TOP_LEVEL_COMMANDS.has(name);
+}


### PR DESCRIPTION
**Bug fix, CLI routing (TypeScript).** Fixes Bug 1 of [RUSH-2022](https://linear.app/getrush/issue/RUSH-2022) — the `--host`/`--device` router masking unknown-command errors. Scoped down from the ticket's original wider PRs (#2117, #2138) — see "Why this is scoped down" below.

## The bug

The `--host`/`--device` router runs before commander parses, so it reported `` `agents session` does not support --host/--device `` for **any** name carrying the flag — including one the CLI never registers. `agents session resume --host <box>` (one letter off `sessions`, which *does* accept `--host`) got a flag-support error about a command nobody typed, and the exact opposite of the truth for the command they meant.

## What changed

- `apps/cli/src/lib/startup/command-registry.ts`: new `KNOWN_TOP_LEVEL_COMMANDS` / `isKnownTopLevelCommand()` — the loader table plus the aliases/tombstones `index.ts` registers inline, as the single "does this command exist?" predicate. Also fixes `publish` missing from the loader table (found by the new completeness test — `commands/packages.ts:435` registers it, but the registry didn't list it).
- `apps/cli/src/lib/hosts/passthrough.ts`: `maybeRunOnHost` now gates its flag-support error on `isKnownTopLevelCommand(command)` — an unknown name falls through to commander's real `unknown command '<name>'` + did-you-mean instead. Also extracted the SSH-hop body into `streamAgentsOnHost` (used internally by `maybeRunOnHost`; no behavior change).
- `apps/cli/src/index.ts`: an unknown command now also registers the lazy command tree (`sessions`/`teams`/`cloud`/…), so the spellcheck can suggest them — previously `agents sesions` (typo) got no suggestion at all because the lazy names were invisible to it.
- `apps/cli/docs/hosts.md` + changelog fragment.

## Why this is scoped down from the ticket's earlier PRs

RUSH-2022 originally reported 3 bugs; #2117/#2138 (this ticket's earlier PRs) fixed all three in one branch. While #2138 sat unmergeable (conflict churn from a fast-moving `main`), **PR #2148 (merged, "centralize focus and recovery") independently built and shipped a broader unification of session recovery/routing that explicitly supersedes #2117's implementation** ("Supersedes the narrower, conflicted recovery implementation in #2117" — #2148's own description). #2148 covers Bug 2 (remote resume routing) and Bug 3 (dispatch-host persistence) via its own centralized recovery resolver.

Re-merging #2138's competing implementation of that same behavior on top of #2148 would be two different implementations of the same feature, not a textual conflict — real semantic risk, not something to force through. Bug 1 (this PR) is the one piece #2148 does not touch (`command-registry.ts` / `passthrough.ts` / `index.ts` are absent from #2148's file list) and stands on its own, conflict-free against current `main`.

**Disposition:** closing #2138 as superseded/redundant once this merges. RUSH-2022 stays open only for Bug 1 until this lands, then closes referencing both this PR and #2148 for Bug 2/3.

## Ran it — real output

```
$ bunx tsx src/index.ts session resume --host yosemite-s0
Multiple agents-cli installs detected: ...
sessions resume needs an interactive terminal.
```
(`session` — a typo — now silently corrects to `sessions`, which *does* support `--host`; it proceeds into the real command instead of a false flag-support error.)

```
$ bunx tsx src/index.ts zzzznotacommand resume --host yosemite-s0
error: unknown command 'zzzznotacommand'
```

Tests: `src/lib/hosts/` + `src/lib/startup/` — **294 passed, 1 skipped**. `bunx tsc --noEmit` clean.
