### PR TITLE
perf(sessions): scan event logs once outside write txn for batch tool-usage (RUSH-2207)

### DIFF
--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -1321,6 +1321,70 @@ export function query(options: {
   return results;
 }
 
+/**
+ * Scan event logs once for a set of session IDs and return browser/computer
+ * usage flags for each. O(files) instead of O(N × files) — safe to call
+ * outside a SQLite write transaction.
+ */
+export function queryToolUsageForSessions(
+  sessionIds: ReadonlySet<string>,
+): Map<string, { usedBrowser: boolean; usedComputer: boolean }> {
+  const result = new Map<string, { usedBrowser: boolean; usedComputer: boolean }>();
+  if (sessionIds.size === 0) return result;
+
+  for (const id of sessionIds) {
+    result.set(id, { usedBrowser: false, usedComputer: false });
+  }
+
+  const BROWSER_EVENTS = new Set(['browser.navigate', 'browser.screenshot']);
+  const COMPUTER_EVENTS = new Set(['computer.action']);
+
+  eventsPath();
+  migrateLegacyEventLogs();
+  const files = listEventLogFiles().sort((a, b) =>
+    Number(b.currentActive) - Number(a.currentActive) || b.mtimeMs - a.mtimeMs || b.path.localeCompare(a.path)
+  );
+
+  let remaining = sessionIds.size * 2; // each session needs up to 2 flags set
+
+  for (const file of files) {
+    if (remaining <= 0) break;
+
+    let content: string;
+    if (file.gzip) {
+      try {
+        content = gunzipSync(fs.readFileSync(file.path)).toString('utf-8');
+      } catch {
+        continue;
+      }
+    } else {
+      content = fs.readFileSync(file.path, 'utf-8');
+    }
+
+    for (const line of content.trim().split('\n')) {
+      if (!line) continue;
+      try {
+        const record = JSON.parse(line) as EventRecord;
+        const sid = record.sessionId;
+        if (!sid || !result.has(sid)) continue;
+
+        const entry = result.get(sid)!;
+        if (BROWSER_EVENTS.has(record.event as string) && !entry.usedBrowser) {
+          entry.usedBrowser = true;
+          remaining--;
+        } else if (COMPUTER_EVENTS.has(record.event as string) && !entry.usedComputer) {
+          entry.usedComputer = true;
+          remaining--;
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+  }
+
+  return result;
+}
+
 // ─── Stats ────────────────────────────────────────────────────────────────────
 
 /**

--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -185,6 +185,41 @@ describe('usedBrowser/usedComputer — a scoped events-log read, not a transcrip
     expect(row.usedBrowser).toBeUndefined();
     expect(row.usedComputer).toBeUndefined();
   });
+
+  it('upsertSessionsBatch correctly flags multiple sessions in one call without scanning event logs inside the write transaction', () => {
+    // Three sessions in one batch: browser-only, computer-only, and neither.
+    // This exercises the pre-computed queryToolUsageForSessions path that runs
+    // outside the SQLite write transaction (RUSH-2207 fix).
+    emit('browser.navigate', { sessionId: 'batch-browser', profile: 'default', url: 'https://a.com' });
+    emit('computer.action', { sessionId: 'batch-computer', command: 'click', targetPid: 1 });
+    // 'batch-none' gets no events
+
+    const makeMeta = (id: string): SessionMeta => ({
+      id,
+      shortId: id.slice(0, 8),
+      agent: 'claude' as const,
+      timestamp: '2026-08-01T00:00:00Z',
+      filePath: emptyFile(id),
+    });
+
+    upsertSessionsBatch([
+      { meta: makeMeta('batch-browser'), content: '' },
+      { meta: makeMeta('batch-computer'), content: '' },
+      { meta: makeMeta('batch-none'), content: '' },
+    ]);
+
+    const browser = findSessionsById('batch-browser')[0];
+    expect(browser.usedBrowser).toBe(true);
+    expect(browser.usedComputer).toBe(false);
+
+    const computer = findSessionsById('batch-computer')[0];
+    expect(computer.usedBrowser).toBe(false);
+    expect(computer.usedComputer).toBe(true);
+
+    const none = findSessionsById('batch-none')[0];
+    expect(none.usedBrowser).toBe(false);
+    expect(none.usedComputer).toBe(false);
+  });
 });
 
 describe('session_resource_usage — skill/slash-command usage joined against real provenance (#12)', () => {

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -14,7 +14,7 @@ import type { SessionAgentId, SessionEvent, SessionMeta, SessionRunMode } from '
 import { parseSession } from './parse.js';
 import { extractRecentDirectoriesTouched, extractTodoProgressFromEvents } from './state.js';
 import { getSessionsDir, getSessionsDbPath } from '../state.js';
-import { query as queryEvents } from '../events.js';
+import { query as queryEvents, queryToolUsageForSessions } from '../events.js';
 import { machineForSessionFile } from './origin-machine.js';
 import { loadSessionActorIndex, readSessionActorRecord } from './actor-sidecar.js';
 import { toolCallsFromEvents, type IndexedToolCall } from './tool-calls.js';
@@ -1880,6 +1880,15 @@ export function upsertSessionsBatch(
   });
   const writtenEntries: typeof enrichedEntries = [];
 
+  // Pre-compute browser/computer usage for all sessions outside the write
+  // transaction. detectToolUsage scans all event log files (O(files) I/O
+  // per call) and holding the SQLite write lock during that scan is what
+  // causes the "DB locked" errors (RUSH-2006). One pass for the whole batch
+  // costs O(files) total instead of O(N × files) inside the lock.
+  const toolUsageBySession = queryToolUsageForSessions(
+    new Set(enrichedEntries.map(e => e.meta.id)),
+  );
+
   const txn = db.transaction((items: typeof entries) => {
     // Re-read the ledger now that we hold the write lock. Any file committed
     // by a concurrent process since our pre-scan is visible here.
@@ -1910,7 +1919,7 @@ export function upsertSessionsBatch(
       // back when the error escapes `fn`, so catching + skipping here leaves the txn valid
       // and committable. We deliberately do NOT stamp the ledger for a skipped row, so the
       // next scan re-tries it (self-healing once the underlying parser is fixed).
-      const toolUsage = detectToolUsage(meta.id);
+      const toolUsage = toolUsageBySession.get(meta.id) ?? { usedBrowser: false, usedComputer: false };
       // claude/codex skip enrichCachedSessionMeta above (preserving their
       // resumable-parse optimization) — write their pre-computed
       // skillsUsed/slashCommandsUsed (folded incrementally by discover.ts's


### PR DESCRIPTION
**perf — internal change, no CLI surface added or removed**

## What

`upsertSessionsBatch` called `detectToolUsage(sessionId)` **inside** the SQLite write transaction for every session in the batch. `detectToolUsage` calls `queryEvents` twice — once for `browser.*` events, once for `computer.action` — and each call scans **all** event-log JSONL files in O(files) while holding the write lock. With N sessions in a batch the cost was **O(2N × files) I/O inside the lock**, which is the direct cause of the "DB locked" contention reported in RUSH-2006.

## Fix

**`apps/cli/src/lib/events.ts`** — new export `queryToolUsageForSessions(sessionIds)`:
- Single pass over all event-log files for a **set** of session IDs
- Returns a `Map<sessionId, { usedBrowser, usedComputer }>` — O(files) total instead of O(2N × files)
- Early-exits once every session's two flags are resolved

**`apps/cli/src/lib/session/db.ts`** — `upsertSessionsBatch`:
- Adds `queryToolUsageForSessions` to the import from `'../events.js'`
- Calls it **before** `db.transaction(...)` for all enriched entries at once
- Replaces `detectToolUsage(meta.id)` inside the loop with a `Map` lookup (no I/O inside the write lock)

The single-session `upsertSession` path already called `detectToolUsage` outside its transaction and is unchanged.

## Before / after

| | Before | After |
|---|---|---|
| I/O inside write lock | O(2N × files) per batch | 0 |
| Total event-log scans per batch | 2N | 1 |

## Tests

All 51 tests pass. New test in `db.test.ts` covers `upsertSessionsBatch` with three sessions in one call — browser-only, computer-only, and neither — verifying all flags are correct.

```
bun test src/lib/session/__tests__/db.test.ts
 51 pass / 0 fail
```

Linear: https://linear.app/getrush/issue/RUSH-2207