### PR TITLE
fix(agents): OpenClaw capability table lied about hooks:true (RUSH-2122)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2122-openclaw-hooks-honest.md
+++ b/apps/cli/.changelog/next/RUSH-2122-openclaw-hooks-honest.md
@@ -1,0 +1,14 @@
+- **OpenClaw's capability table no longer claims `hooks: true` with zero hooks
+  ever installed (RUSH-2122).** `registerHooksToSettings` has no `openclaw`
+  branch and silently returned `{ registered: [], errors: [] }` for it, so
+  `agents sync openclaw` reported success while installing nothing, and
+  `agents doctor` treated the agent as hooks-capable with no way to detect the
+  gap. OpenClaw only exposes a fixed set of internal, named hooks (e.g.
+  `boot-md`, which runs `BOOT.md` on gateway restart) — there is no general
+  event->shell-command registration surface an agents-cli `hooks.yaml`
+  manifest could target — so `capabilities.hooks` and `supportsHooks` now read
+  `false`, matching what the CLI can actually do. A new completeness test
+  (`hooks-capability-completeness.test.ts`) pins every `hooks: true` agent to a
+  real branch in `registerHooksToSettings` so a capability flip can never ship
+  again without a registrar behind it. Source: `apps/cli/src/lib/agents.ts`,
+  `apps/cli/src/lib/hooks-capability-completeness.test.ts`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -274,7 +274,7 @@ Antigravity CLI, Grok CLI, OpenCode — features target these six first.
 | ★ Grok CLI | `grok` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ≥0.2.111 |
 | ★ OpenCode | `opencode` | ≥0.3.130 | ✓ | ≥1.1.1 | ✓ | ✓ | ✓ | — | — |
 | Cursor | `cursor` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ≥2026.1.22 | — |
-| OpenClaw | `openclaw` | ✓ | ✓ | ✓ | ✓ | — | ✓ | ✓ | ✓ |
+| OpenClaw | `openclaw` | — | ✓ | ✓ | ✓ | — | ✓ | ✓ | ✓ |
 | Copilot | `copilot` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ≥0.0.353 | — |
 | Amp | `amp` | — | ✓ | — | ✓ | ✓ | — | — | — |
 | Kiro | `kiro` | ≥0.10 | ✓ | ≥2.8 | ✓ | ✓ | — | ≥1.23 | — |

--- a/apps/cli/src/lib/__tests__/capabilities.test.ts
+++ b/apps/cli/src/lib/__tests__/capabilities.test.ts
@@ -204,11 +204,14 @@ describe('isCapable()', () => {
 });
 
 describe('capableAgents()', () => {
-  it('includes claude/codex/openclaw for hooks and excludes hard-deprecated gemini', () => {
+  it('includes claude/codex for hooks, excludes openclaw (no registrar) and hard-deprecated gemini', () => {
     const agents = capableAgents('hooks');
     expect(agents).toContain('claude');
     expect(agents).toContain('codex');
-    expect(agents).toContain('openclaw');
+    // OpenClaw only exposes fixed internal hooks (e.g. boot-md), not a
+    // general event->shell-command registration surface, and
+    // registerHooksToSettings has no 'openclaw' branch — RUSH-2122.
+    expect(agents).not.toContain('openclaw');
     expect(agents).not.toContain('gemini');
   });
 

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -406,14 +406,22 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     instructionsFile: 'workspace/AGENTS.md', // Primary memory file (also has SOUL.md, IDENTITY.md, etc.)
     format: 'markdown',
     variableSyntax: '{{ARGUMENTS}}',
-    supportsHooks: true,
+    // hooks: NOT supported. OpenClaw only exposes a fixed set of internal,
+    // named hooks (e.g. `boot-md`, which runs BOOT.md on gateway restart) —
+    // there is no general event->shell-command registration surface (no
+    // PreToolUse/PostToolUse/UserPromptSubmit equivalent an agents-cli
+    // hooks.yaml manifest could target). registerHooksToSettings has no
+    // `openclaw` case and silently no-ops (RUSH-2122: capability claimed
+    // hooks:true with zero hooks ever installed). Flip back to `true` only
+    // alongside a real registerHooksForOpenClaw implementation.
+    supportsHooks: false,
     // allowlist: maps blanket (whole-tool) rules to ~/.openclaw/openclaw.json
     // tools.alsoAllow (allow) / tools.deny (deny). OpenClaw gates at tool
     // granularity only, so sub-command/path/domain patterns are skipped.
     // OpenClaw is self-updating (no pinned since), so `true` is correct.
     // Workflows sync as Lobster `.lobster` files under `.openclaw/workflows/`;
     // the Lobster tool runs them by receiving the file path as `pipeline`.
-    capabilities: { hooks: true, mcp: true, mcpHttp: false, mcpHeaders: false, allowlist: true, skills: true, commands: false, plugins: true, subagents: true, rules: { file: 'workspace/AGENTS.md' }, workflows: true, memory: true, modes: ['plan', 'edit', 'skip'], interactiveRepl: true },
+    capabilities: { hooks: false, mcp: true, mcpHttp: false, mcpHeaders: false, allowlist: true, skills: true, commands: false, plugins: true, subagents: true, rules: { file: 'workspace/AGENTS.md' }, workflows: true, memory: true, modes: ['plan', 'edit', 'skip'], interactiveRepl: true },
   },
   copilot: {
     id: 'copilot',

--- a/apps/cli/src/lib/hooks-capability-completeness.test.ts
+++ b/apps/cli/src/lib/hooks-capability-completeness.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Pins the hooks capability table to `registerHooksToSettings`'s actual
+ * per-agent branches so the two can never drift again the way they did for
+ * OpenClaw (RUSH-2122): `capabilities.hooks: true` with no `agentId ===
+ * 'openclaw'` case in the registrar, so `agents sync openclaw` silently
+ * installed zero hooks while `agents doctor` reported the agent as capable.
+ *
+ * This is a static source check, not a runtime one: each registrar writes to
+ * a different config shape (Claude-family settings.json, Codex's
+ * config.toml, OpenCode's generated plugin), so exercising every one through
+ * a real version home belongs to their own dedicated tests. What this test
+ * guarantees is narrower and load-bearing on its own — every agent whose
+ * capability table claims `hooks: true` has SOME branch in
+ * `registerHooksToSettings`, so a capability flip can never again ship with
+ * no registrar behind it.
+ */
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { capableAgents } from './capabilities.js';
+
+describe('hooks capability <-> registrar completeness', () => {
+  it('every hooks-capable agent has a branch in registerHooksToSettings', () => {
+    const hooksSource = fs.readFileSync(path.resolve(process.cwd(), 'src/lib/hooks.ts'), 'utf-8');
+    const start = hooksSource.indexOf('export function registerHooksToSettings');
+    expect(start).toBeGreaterThan(-1);
+    // The function's final `return { registered: [], errors: [] };` (the
+    // openclaw-shaped fallthrough) precedes the next top-level declaration —
+    // slice up to there so the search doesn't spill into per-agent registrar
+    // bodies that also mention `agentId` in comments.
+    const nextDecl = hooksSource.indexOf('\nconst OPENCODE_DIRECT_EVENT_MAP', start);
+    expect(nextDecl).toBeGreaterThan(start);
+    const registrarBody = hooksSource.slice(start, nextDecl);
+
+    const missing = capableAgents('hooks').filter(
+      (id) => !registrarBody.includes(`agentId === '${id}'`)
+    );
+
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What + type

**bugfix** — OpenClaw's capability table claimed `hooks: true` with zero hooks ever installed.

## Problem

`AGENTS.openclaw.capabilities.hooks` was `true` and `supportsHooks: true`, but `registerHooksToSettings` in `apps/cli/src/lib/hooks.ts` has no `agentId === 'openclaw'` branch — it falls through to the final `return { registered: [], errors: [] };`. Every `agents sync openclaw` silently installed zero hooks while reporting success, and `agents doctor` had no way to detect the gap since the capability table said it was supported.

Root cause: OpenClaw (`~/.openclaw/`) only exposes a **fixed set of internal, named hooks** (e.g. `boot-md`, which runs `BOOT.md` on gateway restart) — there is no general event→shell-command registration surface an agents-cli `hooks.yaml` manifest could target (confirmed against `~/.agents/skills/openclaw/SKILL.md`, the project's own OpenClaw reference).

## Fix

- `apps/cli/src/lib/agents.ts` — `capabilities.hooks: false`, `supportsHooks: false` for `openclaw`, with a comment explaining why and what it would take to flip back (a real `registerHooksForOpenClaw`).
- `apps/cli/AGENTS.md` (canonical; `CLAUDE.md` is a symlink) — harness capability snapshot table corrected (`hooks` column: ✓ → —).
- `apps/cli/src/lib/hooks-capability-completeness.test.ts` (new) — pins every agent whose capability table claims `hooks: true` to a real branch in `registerHooksToSettings`, so this exact class of bug (capability flips true with no registrar behind it) can't ship silently again.
- `apps/cli/src/lib/__tests__/capabilities.test.ts` — fixed an existing test that had hardcoded the buggy assumption (`capableAgents('hooks')` was asserted to contain `'openclaw'`).
- `.changelog/next/RUSH-2122-openclaw-hooks-honest.md` — user-visible changelog fragment.

## Test plan

Ran the affected suites directly (no mocking, real vitest/bun:test run):

```
$ bun test src/lib/agents.test.ts src/lib/hooks.test.ts src/lib/hooks-capability-completeness.test.ts \
    src/lib/__tests__/capabilities.test.ts src/lib/resource-inventory.test.ts src/lib/doctor-diff.test.ts \
    src/lib/versions.test.ts src/commands/hooks.test.ts src/commands/sync.test.ts src/lib/refresh.test.ts \
    src/lib/staleness

 348 pass
 0 fail
 1141 expect() calls
Ran 348 tests across 21 files. [73.15s]
```

`bunx tsc --noEmit` and `bun run build` both clean.

- [x] `hooks-capability-completeness.test.ts` fails if `capabilities.hooks: true` is set for an agent with no registrar branch (verified by construction — it was red against the pre-fix table before `agents.ts` was flipped).
- [x] Existing `capabilities.test.ts` now documents the honest state and would catch a regression back to a lying `true`.

No UI surface — this is a capability-table + registry-gated behavior correction, not a new visible feature; no screenshot applies.

Linear: https://linear.app/getrush/issue/RUSH-2122