### PR TITLE
fix(secrets): list DP pass must not skip biometry-ACL items (RUSH-2251)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2251-list-skips-biometry-acl-items.md
+++ b/apps/cli/.changelog/next/RUSH-2251-list-skips-biometry-acl-items.md
@@ -1,0 +1,14 @@
+- **`secrets list` no longer skips every biometry-ACL'd item, so `hold`/`always`-policy
+  bundles are readable again (RUSH-2251).** A regression first shipped in v1.22.10 added
+  `kSecUseAuthenticationUI: kSecUseAuthenticationUISkip` to the keychain helper's `list`
+  data-protection pass. `UISkip` makes `SecItemCopyMatching` silently omit every item
+  protected by a biometry access control — which is exactly the value items `set` writes —
+  so enumeration returned only the no-ACL metadata and `never`-policy items. Every consumer
+  that builds its keychain read set from that enumeration (`secrets exec`/`get`/`unlock`/
+  `view --reveal`/`export`, `agents run --secrets`, `ssh`, `browser`, `share`) then reported
+  the real secrets as `stored item '…' not found`, and `unlock` could not even warm the
+  broker to work around it. The DP pass is now attributes-only with **no** `kSecUseAuthenticationUI`
+  key: `kSecReturnAttributes` without `kSecReturnData` never evaluates the ACL, so it
+  neither prompts for Touch ID nor filters the ACL'd items out — restoring the design the
+  code comment already described. The RUSH-2233 timeout bound on that pass is unchanged.
+  Source: `apps/cli/src/lib/secrets/keychain-helper.swift`.

--- a/apps/cli/src/lib/secrets/__tests__/keychain-helper.test.ts
+++ b/apps/cli/src/lib/secrets/__tests__/keychain-helper.test.ts
@@ -204,7 +204,32 @@ describe('keychain-helper has / list still probe both keychains', () => {
     expect(block).toContain('for query in [fileQuery, dpQuery]');
     expect(block).toContain('if status == errSecInteractionNotAllowed { continue }');
     expect(block).toContain('kSecReturnAttributes');
-    expect(block).toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUISkip');
+  });
+
+  it('the list DP pass carries NO kSecUseAuthenticationUI key (RUSH-2251 regression)', () => {
+    // kSecUseAuthenticationUISkip on the DP enumeration silently omits every
+    // biometry-ACL item, so every hold/always-policy bundle enumerated zero value
+    // items and became unreadable (regression window: added 2e677937, removed
+    // b395fb54, RE-added bf79dc88 / v1.22.10). The DP pass MUST stay attributes-only
+    // with no UI key at all: kSecReturnAttributes without kSecReturnData never
+    // evaluates the ACL, so it neither prompts nor filters the ACL'd items out.
+    const block = caseBlock(helperSource(), 'list');
+    const fileQueryIdx = block.indexOf('let fileQuery: [CFString: Any] = [');
+    const dpDecl = 'let dpQuery: [CFString: Any] = [';
+    const dpQueryStart = block.indexOf(dpDecl);
+    // Search for the closing `]` past the opening bracket, so the `]` in the
+    // `[CFString: Any]` type annotation isn't matched as the end of the literal.
+    const dpQueryEnd = block.indexOf(']', dpQueryStart + dpDecl.length);
+    expect(fileQueryIdx, 'fileQuery literal present').toBeGreaterThanOrEqual(0);
+    expect(dpQueryStart, 'dpQuery literal present').toBeGreaterThan(fileQueryIdx);
+    expect(dpQueryEnd, 'dpQuery literal closes').toBeGreaterThan(dpQueryStart);
+    const dpQueryLiteral = block.slice(dpQueryStart, dpQueryEnd);
+    // The DP query literal must not set the UI key to any value (Skip or Fail).
+    expect(dpQueryLiteral).not.toContain('kSecUseAuthenticationUI');
+    // The file pass still uses UIFail — it is a legacy-keychain probe with no ACL.
+    expect(block).toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUIFail');
+    // The DP pass stays bounded (coreauthd may still be hit — RUSH-2233).
+    expect(block).toContain('boundedWait(listDataProtectionTimeout');
   });
 
   it('list-synced skips authentication UI while enumerating attributes', () => {

--- a/apps/cli/src/lib/secrets/keychain-helper.swift
+++ b/apps/cli/src/lib/secrets/keychain-helper.swift
@@ -491,15 +491,19 @@ case "list":
         kSecReturnAttributes: kCFBooleanTrue!,
         kSecUseDataProtectionKeychain: kCFBooleanTrue!,
         kSecAttrSynchronizable: kCFBooleanFalse!,
-        kSecUseAuthenticationUI: kSecUseAuthenticationUISkip,
     ]
-    // The DP pass hits LocalAuthentication/coreauthd even though it never
-    // evaluates an ACL, so a starved coreauthd leaves SecItemCopyMatching
-    // blocked with no deadline of its own — that is how helpers accumulate
-    // (RUSH-2233). Bound it and skip on timeout. Switching the pass to
-    // kSecUseAuthenticationUIFail would bound it too, but at the cost named at
-    // the top of this case: it drops every biometry-ACL item even when
-    // coreauthd is healthy.
+    // No kSecUseAuthenticationUI on the DP pass — attributes-only, exactly as the
+    // note at the top of this case requires. A UI key would bound the pass
+    // cheaply, but neither value is usable here: kSecUseAuthenticationUIFail errors
+    // out of the DP keychain wholesale, and kSecUseAuthenticationUISkip silently
+    // omits every biometry-ACL item — which is precisely the value items `list`
+    // exists to enumerate (RUSH-2251: with UISkip present, every hold/always-policy
+    // bundle enumerated zero value items and became unreadable). Omitting the key
+    // instead never evaluates an ACL (attributes without kSecReturnData), so it
+    // neither prompts nor filters. It does still hit LocalAuthentication/coreauthd,
+    // so a starved coreauthd could block SecItemCopyMatching with no deadline of
+    // its own (RUSH-2233) — the boundedWait below is its only bound, and skips the
+    // pass on timeout.
     var items: [[String: Any]] = []
     for query in [fileQuery, dpQuery] {
         var result: AnyObject?


### PR DESCRIPTION
**bugfix (secrets) — RUSH-2251.** Restores `secrets list` enumeration of biometry-ACL'd keychain items. Draft: source + regression test land here; the signed helper rebuild + macOS live verify are release-time / reviewer steps (no Mac in CI).

Linear: https://linear.app/getrush/issue/RUSH-2251

## What was broken

`kSecUseAuthenticationUISkip` on the keychain helper's `list` data-protection pass makes `SecItemCopyMatching` **silently omit every item protected by a biometry access control** — exactly the value items `set` writes via `buildBiometryAccessControl()`. Enumeration returned only the no-ACL metadata (`.m`) and `never`-policy items. Every consumer that builds its keychain read set from that enumeration (`secrets exec`/`get`/`unlock`/`view --reveal`/`export`, `agents run --secrets`, `ssh`, `browser`, `share`, …) then reported the real secrets as `stored item '…' not found`, and `unlock` couldn't even warm the broker to work around it. First shipped **v1.22.10**; the regression line was added (`2e677937`), removed (`b395fb54`), then re-added (`bf79dc88`).

## The fix (minimal)

Drop the UI key from the `list` DP query entirely — `apps/cli/src/lib/secrets/keychain-helper.swift`:

```diff
 let dpQuery: [CFString: Any] = [
     kSecClass: kSecClassGenericPassword,
     kSecMatchLimit: kSecMatchLimitAll,
     kSecReturnAttributes: kCFBooleanTrue!,
     kSecUseDataProtectionKeychain: kCFBooleanTrue!,
     kSecAttrSynchronizable: kCFBooleanFalse!,
-    kSecUseAuthenticationUI: kSecUseAuthenticationUISkip,
 ]
```

`kSecReturnAttributes` **without** `kSecReturnData` never evaluates the ACL — so the pass neither prompts for Touch ID **nor** filters ACL'd items out. This restores the design the case comment already described (`keychain-helper.swift:461-473`). Neither UI value was usable: `…Fail` errors out of the DP keychain wholesale, `…Skip` drops the biometry items — so the key is omitted and the **RUSH-2233 `boundedWait` timeout stays** as the pass's only bound (coreauthd can still be hit). No `index.ts`/broker/unlock-UX change — no extra Touch ID sheets.

## Regression guard

The existing source-guard test **pinned the buggy line** (`toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUISkip')`) — that's how it slipped through. Flipped into a guard asserting the `list` DP query carries **no** `kSecUseAuthenticationUI` key at all (`__tests__/keychain-helper.test.ts`). Verified it has teeth: re-injecting the `UISkip` line fails the test; removing it passes.

## Tests (run on this Linux box)

```
$ bunx vitest run src/lib/secrets/
 Test Files  39 passed | 1 skipped (40)
      Tests  606 passed | 14 skipped (620)

$ bunx vitest run src/lib/secrets/__tests__/keychain-helper.test.ts   # after re-injecting UISkip
 × the list DP pass carries NO kSecUseAuthenticationUI key (RUSH-2251 regression)
      Tests  1 failed | 24 passed (25)
```

CHANGELOG queued at `.changelog/next/RUSH-2251-list-skips-biometry-acl-items.md` (regen produces no `CHANGELOG.md` drift).

## macOS live verify still needed (reviewers)

The shipped `.app` is sha-pinned; a source-only change ships nothing until the helper is rebuilt + re-notarized and `scripts/Agents CLI.app.sha256` re-pinned — `release.sh` does this inside the tagged worktree, so it's not committed here. On a real Mac with hashing active + a `hold`-policy bundle: `listKeychainItems("agents-cli.secrets.<bundle>.")` returns the `.k.` items, and `agents secrets unlock <bundle>` succeeds with **exactly one** Touch ID sheet (the one-sheet invariant `bf79dc88` protected must still hold).

## Must not break

- One-sheet unlock invariant (no extra Touch ID prompts).
- RUSH-2233 timeout/skip on a starved coreauthd (`boundedWait` retained).
- `never`-policy + metadata items still enumerate (they never carried an ACL).

Do not merge — owner gate: human review + macOS verify first.
