### PR TITLE
fix(factory): exclude SSH-unreachable devices from balanced host pick (RUSH-2054)

### DIFF
--- a/apps/factory/src/core/launchHost.test.ts
+++ b/apps/factory/src/core/launchHost.test.ts
@@ -294,3 +294,25 @@ test('noHostReason: nothing to say → null', () => {
   // No agentKey (agent-unaware caller) keeps the legacy silent fallback.
   expect(noHostReason([{ name: 's0', online: true, running: 0 }])).toBeNull();
 });
+
+// RUSH-2054 regression: a Tailscale-online but SSH-unreachable device was
+// returning null from countRunningAgents (before the fix: returning 0), which
+// made it appear idle and win the least-busy pick. The fix marks it online:false
+// so pickBestHost excludes it; this test pins that behavior.
+test('pickBestHost: SSH-unreachable device (online:false) never wins over a reachable but busier one (RUSH-2054 regression)', () => {
+  expect(
+    pickBestHost([
+      { name: 'unreachable', online: false, running: 0 },
+      { name: 'reachable', online: true, running: 2 },
+    ]),
+  ).toBe('reachable');
+});
+
+test('pickBestHost: all devices SSH-unreachable (online:false) → returns null (RUSH-2054)', () => {
+  expect(
+    pickBestHost([
+      { name: 'a', online: false, running: 0 },
+      { name: 'b', online: false, running: 0 },
+    ]),
+  ).toBeNull();
+});

--- a/apps/factory/src/vscode/deviceHealth.vscode.ts
+++ b/apps/factory/src/vscode/deviceHealth.vscode.ts
@@ -102,7 +102,8 @@ const PROBE_TIMEOUT_MS = 4_000;
 // timer, the Dispatch panel, each launch) never each spawn a full-fleet fan-out
 // of `agents` subprocesses for the same host.
 const statsStore = createTimedCache<DeviceStats>();
-const agentCountStore = createTimedCache<number>();
+// null means SSH-unreachable (not "zero agents") — see countRunningAgentsOnce (RUSH-2054).
+const agentCountStore = createTimedCache<number | null>();
 
 function augmentedEnv(binPath: string): NodeJS.ProcessEnv {
   return { ...process.env, PATH: `${bootstrapPath(binPath)}:${process.env.PATH ?? ''}` };
@@ -166,11 +167,11 @@ async function fetchDeviceStatsOnce(
   }
 }
 
-export async function countRunningAgents(host: string, opts: { isLocal: boolean }): Promise<number> {
+export async function countRunningAgents(host: string, opts: { isLocal: boolean }): Promise<number | null> {
   return cachedInFlight(agentCountStore, host, CACHE_TTL_MS, () => countRunningAgentsOnce(host, opts));
 }
 
-async function countRunningAgentsOnce(host: string, opts: { isLocal: boolean }): Promise<number> {
+async function countRunningAgentsOnce(host: string, opts: { isLocal: boolean }): Promise<number | null> {
   try {
     const bin = await resolveAgentsBin();
     const args = ['sessions', '--active', '--json'];
@@ -182,7 +183,12 @@ async function countRunningAgentsOnce(host: string, opts: { isLocal: boolean }):
     const parsed = JSON.parse(stdout);
     return Array.isArray(parsed) ? parsed.length : 0;
   } catch {
-    return 0;
+    // Local: a failing `agents sessions` means zero active sessions, not unreachable.
+    // Remote: any failure (timeout, SSH refused, CLI error) means the device is
+    // unreachable or non-functional — return null so callers never treat it as idle
+    // and select it as the least-busy candidate (RUSH-2054).
+    if (opts.isLocal) return 0;
+    return null;
   }
 }
 

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -13,7 +13,7 @@ import { AgentsMarkdownEditorProvider, swarmCurrentDocument } from './customEdit
 import { AgentsHtmlReaderProvider } from './htmlReader';
 import * as git from './git.vscode';
 import { AgentSettings, hasLoginEnabled, PromptEntry, QUICK_LAUNCH_SLOT_KEYS, getQuickLaunchSlot, QuickLaunchSlot, QuickLaunchSlotKey } from '../core/settings';
-import { listRegisteredDevices, countRunningAgents, fetchDeviceStats } from './deviceHealth.vscode';
+import { listRegisteredDevices, countRunningAgents, fetchDeviceStats, probeReachable } from './deviceHealth.vscode';
 import { normalizeHost } from '../core/remoteSessions';
 import { pickBestHost, cappedOutDevices, noHostReason, deviceHasUsableVersion, resolveBalancePool, DeviceLoad } from '../core/launchHost';
 import {
@@ -393,7 +393,9 @@ async function refreshLaunchHealthCache(context: vscode.ExtensionContext): Promi
         name: device.name,
         online: true,
         sshReachable: stats.reachable,
-        running,
+        // null means SSH-unreachable; sshReachable already captures the truth.
+        // Display 0 so the floor card shows something renderable (RUSH-2054).
+        running: running ?? 0,
         loadAvg1: stats.loadAvg1,
         memPercent: stats.memPercent,
         usableAgents: Object.fromEntries(usable),
@@ -469,9 +471,19 @@ async function resolveBalancedHost(pool?: string[], agentKey?: string): Promise<
     () => Promise.all(eligible.map(async (c): Promise<DeviceLoad> => {
       const dev = byName.get(normalizeHost(c.name));
       const host = dev?.host ?? c.name;
+      // Pre-filter: confirm SSH is up before spending the session-count round-trip.
+      // A Tailscale-online device that refuses SSH looks idle (running=0) to
+      // countRunningAgents, making it win least-busy unfairly. Mark it
+      // online:false so pickBestHost excludes it entirely (RUSH-2054).
+      const reachable = await probeReachable(host);
+      if (!reachable) return { ...c, online: false, running: 0 };
       const running = await countRunningAgents(c.name, { isLocal: false });
+      // null means the session count failed even after SSH was confirmed — treat
+      // the device as unreachable rather than as idle (RUSH-2054).
+      if (running === null) return { ...c, online: false, running: 0 };
       if (!agentKey) return { ...c, running };
       // Agent-aware: probe hardware health + usable-version in parallel.
+      // SSH is already proven reachable, so these calls should complete quickly.
       const [stats, usableVersion] = await Promise.all([
         fetchDeviceStats(host, { isLocal: false }),
         hostHasUsableVersion(c.name, agentKey),
@@ -487,6 +499,12 @@ async function resolveBalancedHost(pool?: string[], agentKey?: string): Promise<
   );
   const best = pickBestHost(loaded);
   if (best) return best;
+  // Distinct message when every candidate failed the SSH probe so the operator
+  // knows it's a connectivity gap, not a capacity or version problem (RUSH-2054).
+  if (loaded.length > 0 && loaded.every(d => !d.online)) {
+    vscode.window.showWarningMessage('Balanced launch: all fleet devices are SSH-unreachable (Tailscale online but not accepting connections) — running locally.');
+    return undefined;
+  }
   // State WHY the pool produced nothing — caps first (an operator boundary to
   // raise), then agent usability. See noHostReason.
   const reason = noHostReason(loaded, agentKey);


### PR DESCRIPTION
**fix** — `apps/factory` balanced-host picker

## What changed

`countRunningAgentsOnce` caught SSH timeouts and returned `0`, making a Tailscale-online but SSH-unreachable device appear idle. `pickBestHost` then selected it as least-busy and dispatched a launch that immediately failed.

Fix in three parts:

| File | Change |
|---|---|
| `deviceHealth.vscode.ts` | `countRunningAgentsOnce` returns `null` (not `0`) for remote SSH failures; local failures still return `0` (a local sessions error means no sessions, not offline). Cache type widened to `number \| null`. |
| `extension.ts` — `resolveBalancedHost` | Pre-filter with `probeReachable` before `countRunningAgents`; mark `online:false` on probe failure or `null` count so `pickBestHost` skips the device. Add distinct warning when ALL fleet candidates are SSH-unreachable. |
| `extension.ts` — `refreshLaunchHealthCache` | `running ?? 0` for the display field; `sshReachable` already carries the real truth. |

## Run result

33 pass · 0 fail across `launchHost.test.ts` and `deviceHealth.vscode.test.ts` (includes two new RUSH-2054 regression tests):
https://gist.github.com/muqsitnawaz/0160eb8bb614304841396572dc85a5ec

## Linear

RUSH-2054
