### PR TITLE
feat(teams): health-, load-, and harness-aware placement scheduler (RUSH-2002)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2002-teams-scheduler-health-aware.md
+++ b/apps/cli/.changelog/next/RUSH-2002-teams-scheduler-health-aware.md
@@ -1,0 +1,20 @@
+- **`agents teams` auto-schedule is now health-, load-, and harness-aware (RUSH-2002).**
+  A many-device pool's unpinned teammate no longer lands on whichever box has the
+  fewest roster entries regardless of whether it is reachable, loaded, or can even
+  run the requested harness. Cascade step 3 now reads the same cached fleet signals
+  `agents fleet status` shows — DeviceStats (load/memory/headroom) plus the
+  auth-health cache — with no fresh SSH in steady state (the daemon warms both), and:
+  drops devices that are unreachable, overloaded (`headroom: loaded`), or at their
+  `agents.max-concurrent` cap; drops devices that provably can't run the requested
+  agent (the box was probed and the harness is absent or holds only a revoked token —
+  a box with no cached data is kept, ranked after a proven-available one, so a cold
+  cache never invents a false "can't run"); then ranks the survivors by (a) requested
+  agent installed + signed in, (b) lower load/memory, (c) fewer running teammates.
+  When no device in the pool can run the requested agent, `teams start` now fails loud
+  — e.g. `No device in the team pool can run claude@2.1.112 (checked zion,
+  yosemite-s0). Run 'agents fleet status --verbose' to see which harnesses each box
+  has installed and signed in, or 'agents fleet login' to sign one in.` — instead of
+  dispatching onto a box that cannot run it. A pinned `--device`, a pool of one, and a
+  poolless team are unchanged; with no fleet data the pick still degrades to the old
+  least-loaded behaviour. Source: `apps/cli/src/lib/teams/scheduler.ts`,
+  `apps/cli/src/lib/teams/agents.ts`, `apps/cli/src/lib/auth-health.ts`.

--- a/apps/cli/docs/teams.md
+++ b/apps/cli/docs/teams.md
@@ -297,7 +297,7 @@ agents teams start feat --watch
 ```bash
 agents teams create feat --devices zion,yosemite-s0,yosemite-s1 \
   --repo https://github.com/you/your-repo.git
-agents teams add feat claude "..." --name w1                    # auto-scheduled (least-loaded)
+agents teams add feat claude "..." --name w1                    # auto-scheduled (health-aware)
 agents teams add feat claude "..." --name w2 --device yosemite-s1   # or pin
 agents teams start feat --watch
 ```
@@ -306,8 +306,28 @@ agents teams start feat --watch
 
 1. teammate has `--device X` → **X** (explicit pin — no pool required)
 2. else the team pool is a **single** device → that device (whole team there)
-3. else the team pool has **many** devices → **auto-scheduled** (least-loaded)
+3. else the team pool has **many** devices → **auto-scheduled** (health-aware)
 4. else (no pin, no pool) → **local**, exactly like today
+
+**Auto-schedule is health-, load-, and harness-aware (RUSH-2002).** For a
+many-device pool the scheduler reads the same cached fleet signals `agents fleet
+status` shows (DeviceStats + auth-health, no fresh SSH in steady state) and:
+
+- **drops** devices that are unreachable, overloaded (`headroom: loaded`), or at
+  their `agents.max-concurrent` cap;
+- **drops** devices that provably can't run the requested harness — the box was
+  probed and the agent is absent or only holds a revoked token (a box with no
+  cached data is *kept*, ranked after a proven-available one, so a cold cache
+  never manufactures a false "can't run");
+- **ranks** the survivors by (a) requested agent installed + signed in, (b) lower
+  load / memory, (c) fewer running teammates.
+
+If **no** device in the pool can run the requested agent, `teams start` fails loud
+rather than launching onto a box that can't run it — e.g. `No device in the team
+pool can run claude@2.1.112 (checked zion, yosemite-s0). Run 'agents fleet status
+--verbose' to see which harnesses each box has installed and signed in, or 'agents
+fleet login' to sign one in.` Run `agents fleet status --verbose` (or `agents
+fleet ping`) to see per-box harness availability.
 
 **Repo provisioning.** The team's `--repo` (defaulting to the local checkout's
 `origin`) is used to ensure the code is present on each device — an existing

--- a/apps/cli/src/lib/auth-health.test.ts
+++ b/apps/cli/src/lib/auth-health.test.ts
@@ -7,6 +7,7 @@ import {
   classifyHttpStatus,
   mergeAuthHealthEntries,
   formatCheckedAge,
+  harnessAvailabilityForHost,
   probeDetail,
   summarizeHostAuth,
   summarizeVerdicts,
@@ -200,6 +201,59 @@ describe('summarizeHostAuth', () => {
   it('returns an empty summary for a host with no cached rows', () => {
     const r = summarizeHostAuth(cache, 'never-probed');
     expect(r).toEqual({ live: 0, present: 0, degraded: 0, revoked: 0, total: 0, oldestCheckedAt: null });
+  });
+});
+
+describe('harnessAvailabilityForHost', () => {
+  const h = (verdict: AuthVerdict): AuthHealth => ({ verdict, checkedAt: 1000 });
+
+  it('available when the agent has any signed-in row (live)', () => {
+    const cache = { 'zion:claude:2.1.170': h('live'), 'zion:codex:0.1.0': h('unverified') };
+    expect(harnessAvailabilityForHost(cache, 'zion', 'claude')).toBe('available');
+  });
+
+  it('available for a soft/unverifiable but signed-in verdict', () => {
+    expect(harnessAvailabilityForHost({ 'zion:codex:0.1.0': h('unverified') }, 'zion', 'codex')).toBe('available');
+    expect(harnessAvailabilityForHost({ 'zion:kimi:0.1.0': h('expired') }, 'zion', 'kimi')).toBe('available');
+    expect(harnessAvailabilityForHost({ 'zion:claude:1.0.0': h('rate_limited') }, 'zion', 'claude')).toBe('available');
+  });
+
+  it('unknown when the host has no cached rows at all (never probed)', () => {
+    expect(harnessAvailabilityForHost({ 'zion:claude:1.0.0': h('live') }, 'never-probed', 'claude')).toBe('unknown');
+    expect(harnessAvailabilityForHost({}, 'zion', 'claude')).toBe('unknown');
+  });
+
+  it('unavailable when the host was probed but the agent is absent', () => {
+    // Host has a codex row → it WAS probed; claude has no row → provably absent.
+    const cache = { 'zion:codex:0.1.0': h('unverified') };
+    expect(harnessAvailabilityForHost(cache, 'zion', 'claude')).toBe('unavailable');
+  });
+
+  it('unavailable when the agent has only a revoked token', () => {
+    const cache = { 'zion:claude:1.0.0': h('revoked') };
+    expect(harnessAvailabilityForHost(cache, 'zion', 'claude')).toBe('unavailable');
+  });
+
+  it('a signed-in row outweighs a sibling revoked row', () => {
+    const cache = { 'zion:claude:1.0.0': h('revoked'), 'zion:claude:1.1.0': h('live') };
+    expect(harnessAvailabilityForHost(cache, 'zion', 'claude')).toBe('available');
+  });
+
+  it('unknown when the agent has only an indeterminate error probe', () => {
+    const cache = { 'zion:claude:1.0.0': h('error') };
+    expect(harnessAvailabilityForHost(cache, 'zion', 'claude')).toBe('unknown');
+  });
+
+  it('matches on the host prefix, not a substring (no cross-host bleed)', () => {
+    // 'zion-2' must not satisfy a query for 'zion'.
+    const cache = { 'zion-2:claude:1.0.0': h('live') };
+    expect(harnessAvailabilityForHost(cache, 'zion', 'claude')).toBe('unknown');
+  });
+
+  it('matches the agent prefix exactly (claude != claude-ish)', () => {
+    // A row for another agent proves the host was probed; the queried agent is absent.
+    const cache = { 'zion:opencode:0.1.0': h('live') };
+    expect(harnessAvailabilityForHost(cache, 'zion', 'claude')).toBe('unavailable');
   });
 });
 

--- a/apps/cli/src/lib/auth-health.ts
+++ b/apps/cli/src/lib/auth-health.ts
@@ -258,6 +258,60 @@ export function summarizeHostAuth(
   return { live, present, degraded, revoked, total, oldestCheckedAt: oldest };
 }
 
+/**
+ * Whether a device can run one harness right now, derived from its cached auth
+ * rows — the signal the teams scheduler ranks on ("requested agent installed +
+ * signed in"). Pure: reads the map the caller loaded via {@link readAuthHealthCache}.
+ *
+ * - `available`   — the agent has at least one signed-in cached row (any verdict
+ *                   except `revoked`/`unconfigured`; `error` alone is indeterminate).
+ * - `unavailable` — the box WAS probed (it has rows for some agent) but this agent
+ *                   has no usable row: absent entirely, or present only as `revoked`.
+ * - `unknown`     — the box has no cached rows at all (never probed / cold cache).
+ *                   The scheduler must NOT exclude these — a cold cache is not proof
+ *                   a box can't run the harness.
+ *
+ * Agent-level, not version-level on purpose: the auth cache only holds installs
+ * that carry a credential, so it cannot reliably prove a specific *version* is
+ * absent (a version can share a global login and never appear). Version pinning
+ * is still enforced downstream when the teammate actually launches.
+ *
+ * Keyed by {@link authCacheKey} (`host:agent:version`); matched on the `host:`
+ * and `host:agent:` prefixes so a version segment can never be mistaken for a host.
+ */
+export function harnessAvailabilityForHost(
+  cache: Record<string, AuthHealth>,
+  host: string,
+  agent: AgentId | string,
+): 'available' | 'unavailable' | 'unknown' {
+  const hostPrefix = `${host}:`;
+  const agentPrefix = `${host}:${agent}:`;
+  let hostHasAnyRow = false;
+  let agentRows = 0;
+  let signedIn = false;
+  let determinateAgentRow = false;
+  for (const [key, health] of Object.entries(cache)) {
+    if (!key.startsWith(hostPrefix)) continue;
+    hostHasAnyRow = true;
+    if (!key.startsWith(agentPrefix)) continue;
+    agentRows++;
+    // `error` is an indeterminate network blip — not signed in, and NOT proof of
+    // absence either. Every other verdict is determinate.
+    if (health.verdict === 'error') continue;
+    determinateAgentRow = true;
+    // Signed-in = a credential the server hasn't rejected: live, or the soft /
+    // unverifiable states (unverified/expired/rate_limited). `revoked` = rejected,
+    // `unconfigured` = no credential — neither counts as signed in.
+    if (health.verdict !== 'revoked' && health.verdict !== 'unconfigured') signedIn = true;
+  }
+  if (!hostHasAnyRow) return 'unknown';
+  if (signedIn) return 'available';
+  // Agent rows exist but only indeterminate `error` probes → don't claim absence.
+  if (agentRows > 0 && !determinateAgentRow) return 'unknown';
+  // Host was probed and this agent has no usable row (absent, revoked, or unconfigured).
+  return 'unavailable';
+}
+
 /** Human "3m ago" style age for a checkedAt timestamp. */
 export function formatCheckedAge(checkedAt: number, now: number = Date.now()): string {
   const secs = Math.max(0, Math.round((now - checkedAt) / 1000));

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -35,8 +35,19 @@ import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { pullRemoteLogDelta, REMOTE_MIRROR_MAX_BYTES } from '../hosts/progress.js';
 import { createRemoteWorktree, ensureRemoteRepo } from './remoteWorktree.js';
 import { getTeam } from './registry.js';
-import { resolvePlacement, cappedDevices } from './scheduler.js';
+import {
+  resolvePlacement,
+  cappedDevices,
+  type PlacementOptions,
+  type DeviceHealthInput,
+  type HarnessAvailability,
+} from './scheduler.js';
 import { readMaxConcurrentCaps } from '../device-config.js';
+import { getDevice, type DeviceProfile } from '../devices/registry.js';
+import { loadFleetStats } from '../devices/stats-cache.js';
+import { headroom, type DeviceStats } from '../devices/health.js';
+import { readAuthHealthCache, harnessAvailabilityForHost, type AuthHealth } from '../auth-health.js';
+import { machineId } from '../machine-id.js';
 import chalk from 'chalk';
 
 let lastMemoryWarnAt = 0;
@@ -1389,6 +1400,20 @@ export class AgentManager {
 
   private constructorAgentsDir: string | null = null;
 
+  /**
+   * Short-TTL memo of the fleet signals the health-aware scheduler reads
+   * (DeviceStats + auth-health), keyed by the sorted pool. A `teams start` fires
+   * maybeSchedulePlacement once per teammate; without this each would re-run the
+   * cache-first probe. Keyed + TTL'd so a burst shares one fetch but a later wave
+   * still gets fresh numbers.
+   */
+  private placementFleetCache: {
+    key: string;
+    at: number;
+    promise: Promise<{ stats: Map<string, DeviceStats>; auth: Record<string, AuthHealth> }>;
+  } | null = null;
+  private static readonly PLACEMENT_FLEET_TTL_MS = 15_000;
+
   constructor(
     maxAgents: number = 50,
     agentsDir: string | null = null,
@@ -2085,16 +2110,91 @@ export class AgentManager {
     if (!teamMeta) return;
     const roster = await this.listByTask(taskName);
     const pool = teamMeta.devices ?? [];
-    const maxConcurrent = pool.length > 1 ? readMaxConcurrentCaps(pool) : undefined;
-    if (maxConcurrent) {
+    let opts: PlacementOptions | undefined;
+    // Only a many-device pool reaches the auto-pick; a pool of 0/1 short-circuits
+    // in resolvePlacement before caps/health matter, so skip the fleet probe.
+    if (pool.length > 1) {
+      const maxConcurrent = readMaxConcurrentCaps(pool);
       for (const c of cappedDevices(pool, roster, maxConcurrent)) {
         console.error(chalk.dim(
           `[placement] '${c.device}' excluded from auto-pick — at its agents.max-concurrent cap (${c.running}/${c.cap} running)`,
         ));
       }
+      const agentId = agent.agentType as AgentId;
+      const { health, harness } = await this.gatherPlacementSignals(pool, agentId);
+      opts = {
+        maxConcurrent,
+        health,
+        harness,
+        requestedLabel: agent.version ? `${agentId}@${agent.version}` : agentId,
+      };
     }
-    const { device } = resolvePlacement(teamMeta, null, roster, { maxConcurrent });
+    const { device } = resolvePlacement(teamMeta, null, roster, opts);
     if (device) await this.resolveScheduledPlacement(agent, device, taskName);
+  }
+
+  /**
+   * Build the per-device health + harness-availability maps the health-aware
+   * scheduler ranks on, from cache-first fleet signals. DeviceStats come from the
+   * daemon-warmed stats cache (`loadFleetStats`, no ssh in steady state) and
+   * harness availability from the fleet auth-health cache — both degrade to
+   * `unknown`/`unreachable` rather than throwing, so a cold cache reduces the pick
+   * to least-loaded instead of a false blocker.
+   */
+  private async gatherPlacementSignals(
+    pool: string[],
+    agentId: AgentId,
+  ): Promise<{ health: Record<string, DeviceHealthInput>; harness: Record<string, HarnessAvailability> }> {
+    const { stats, auth } = await this.loadPlacementFleet(pool);
+    const health: Record<string, DeviceHealthInput> = {};
+    const harness: Record<string, HarnessAvailability> = {};
+    for (const d of pool) {
+      const s = stats.get(d);
+      health[d] = {
+        reachable: s?.reachable,
+        headroom: headroom(s),
+        loadPercent: s?.loadPercent,
+        memPercent: s?.memPercent,
+      };
+      harness[d] = harnessAvailabilityForHost(auth, d, agentId);
+    }
+    return { health, harness };
+  }
+
+  /**
+   * Fetch (or serve from a short-TTL memo) the DeviceStats + auth-health for a
+   * pool. Never throws — a stats-probe failure yields an empty map (every device
+   * reads `unknown`, so the pick degrades to least-loaded, never a wrong exclusion).
+   */
+  private async loadPlacementFleet(
+    pool: string[],
+  ): Promise<{ stats: Map<string, DeviceStats>; auth: Record<string, AuthHealth> }> {
+    const key = [...pool].sort().join(',');
+    const now = Date.now();
+    const cached = this.placementFleetCache;
+    if (cached && cached.key === key && now - cached.at < AgentManager.PLACEMENT_FLEET_TTL_MS) {
+      return cached.promise;
+    }
+    const promise = (async () => {
+      const profiles = (await Promise.all(pool.map((n) => getDevice(n).catch(() => null)))).filter(
+        (d): d is DeviceProfile => d !== null,
+      );
+      let stats = new Map<string, DeviceStats>();
+      try {
+        ({ stats } = await loadFleetStats(profiles, { selfName: machineId() }));
+      } catch {
+        // Degrade to no stats — the pick falls back to load-count + harness only.
+      }
+      let auth: Record<string, AuthHealth> = {};
+      try {
+        auth = readAuthHealthCache();
+      } catch {
+        auth = {};
+      }
+      return { stats, auth };
+    })();
+    this.placementFleetCache = { key, at: now, promise };
+    return promise;
   }
 
   /**

--- a/apps/cli/src/lib/teams/scheduler.test.ts
+++ b/apps/cli/src/lib/teams/scheduler.test.ts
@@ -7,7 +7,15 @@
  * short-circuit never fires, keeping assertions host-independent.
  */
 import { describe, it, expect } from 'vitest';
-import { resolvePlacement, pickLeastLoaded, cappedDevices, type RosterEntry } from './scheduler.js';
+import {
+  resolvePlacement,
+  pickLeastLoaded,
+  pickHealthiest,
+  cappedDevices,
+  type RosterEntry,
+  type DeviceHealthInput,
+  type HarnessAvailability,
+} from './scheduler.js';
 import { machineId } from '../machine-id.js';
 
 const running = (hostName: string | null): RosterEntry => ({ hostName, status: 'running' });
@@ -117,6 +125,162 @@ describe('agents.max-concurrent caps (auto-pick only)', () => {
     expect(
       resolvePlacement({ devices: ['box-a'] }, null, roster, { maxConcurrent: { 'box-a': 1 } }),
     ).toEqual({ device: 'box-a' });
+  });
+});
+
+describe('pickHealthiest — health-, load-, and harness-aware pick', () => {
+  const H = (h: DeviceHealthInput): DeviceHealthInput => h;
+
+  it('with no fleet data reduces to least-loaded (fewest running, ties by order)', () => {
+    const roster = [running('box-a'), running('box-a'), running('box-b')];
+    expect(pickHealthiest(['box-a', 'box-b', 'box-c'], roster)).toBe('box-c');
+    expect(pickHealthiest(['box-a', 'box-b'], [])).toBe('box-a');
+    expect(pickHealthiest(['box-b', 'box-a'], [])).toBe('box-b');
+  });
+
+  it('excludes an unreachable device from the pick', () => {
+    const health = { 'box-a': H({ reachable: false }), 'box-b': H({ reachable: true, headroom: 'busy' }) };
+    // box-a is first by order and 0-load, but unreachable → box-b wins.
+    expect(pickHealthiest(['box-a', 'box-b'], [], { health })).toBe('box-b');
+  });
+
+  it('excludes an overloaded (headroom: loaded) device from the pick', () => {
+    const health = { 'box-a': H({ reachable: true, headroom: 'loaded', loadPercent: 95 }), 'box-b': H({ reachable: true, headroom: 'busy', loadPercent: 60 }) };
+    expect(pickHealthiest(['box-a', 'box-b'], [], { health })).toBe('box-b');
+  });
+
+  it('prefers the requested-agent-available device over an unknown one', () => {
+    // box-a is idle + first, box-b is busier — but harness availability is the
+    // top-priority key, so a proven-available box-b still loses to... no: box-a
+    // is unknown, box-b is available → box-b wins despite being busier.
+    const health = {
+      'box-a': H({ reachable: true, headroom: 'idle', loadPercent: 5 }),
+      'box-b': H({ reachable: true, headroom: 'busy', loadPercent: 60 }),
+    };
+    const harness: Record<string, HarnessAvailability> = { 'box-a': 'unknown', 'box-b': 'available' };
+    expect(pickHealthiest(['box-a', 'box-b'], [], { health, harness })).toBe('box-b');
+  });
+
+  it('among equally-available devices, ranks by lower load/memory', () => {
+    const health = {
+      'box-a': H({ reachable: true, headroom: 'busy', loadPercent: 70, memPercent: 30 }),
+      'box-b': H({ reachable: true, headroom: 'light', loadPercent: 25, memPercent: 20 }),
+    };
+    const harness: Record<string, HarnessAvailability> = { 'box-a': 'available', 'box-b': 'available' };
+    // worst-signal: box-a=70, box-b=25 → box-b is roomier.
+    expect(pickHealthiest(['box-a', 'box-b'], [], { health, harness })).toBe('box-b');
+  });
+
+  it('uses memory when it is the worse signal', () => {
+    const health = {
+      'box-a': H({ reachable: true, loadPercent: 10, memPercent: 90 }),
+      'box-b': H({ reachable: true, loadPercent: 40, memPercent: 40 }),
+    };
+    // box-a worst=90 (mem), box-b worst=40 → box-b.
+    expect(pickHealthiest(['box-a', 'box-b'], [], { health })).toBe('box-b');
+  });
+
+  it('breaks a load tie by fewer running teammates', () => {
+    const roster = [running('box-a')];
+    const health = {
+      'box-a': H({ reachable: true, loadPercent: 30, memPercent: 30 }),
+      'box-b': H({ reachable: true, loadPercent: 30, memPercent: 30 }),
+    };
+    expect(pickHealthiest(['box-a', 'box-b'], roster, { health })).toBe('box-b');
+  });
+
+  it('never excludes an unknown-harness device (cold cache is not proof)', () => {
+    const harness: Record<string, HarnessAvailability> = { 'box-a': 'unknown', 'box-b': 'unknown' };
+    // No availability data at all → still picks (degrades to load/order), never throws.
+    expect(pickHealthiest(['box-a', 'box-b'], [], { harness })).toBe('box-a');
+  });
+
+  it('excludes a provably-unavailable device but keeps an unknown one', () => {
+    const harness: Record<string, HarnessAvailability> = { 'box-a': 'unavailable', 'box-b': 'unknown' };
+    expect(pickHealthiest(['box-a', 'box-b'], [], { harness })).toBe('box-b');
+  });
+
+  it('fails loud naming the agent when EVERY eligible device is unavailable', () => {
+    const harness: Record<string, HarnessAvailability> = { 'box-a': 'unavailable', 'box-b': 'unavailable' };
+    expect(() => pickHealthiest(['box-a', 'box-b'], [], { harness, requestedLabel: 'claude@2.1.112' }))
+      .toThrow(/No device in the team pool can run claude@2\.1\.112/);
+    expect(() => pickHealthiest(['box-a', 'box-b'], [], { harness, requestedLabel: 'claude@2.1.112' }))
+      .toThrow(/box-a, box-b/);
+  });
+
+  it('the loud unavailable message points at a real availability command', () => {
+    const harness: Record<string, HarnessAvailability> = { 'box-a': 'unavailable' };
+    expect(() => pickHealthiest(['box-a', 'box-b'], [], {
+      harness: { ...harness, 'box-b': 'unavailable' },
+      availabilityHint: 'agents fleet status --verbose',
+    })).toThrow(/agents fleet status --verbose/);
+  });
+
+  it('fails loud naming each drop reason when NO device is even eligible', () => {
+    const health = {
+      'box-a': H({ reachable: false }),
+      'box-b': H({ reachable: true, headroom: 'loaded' }),
+    };
+    expect(() => pickHealthiest(['box-a', 'box-b'], [], { health, requestedLabel: 'codex' }))
+      .toThrow(/No viable device in the team pool for codex/);
+    expect(() => pickHealthiest(['box-a', 'box-b'], [], { health, requestedLabel: 'codex' }))
+      .toThrow(/box-a \(unreachable\), box-b \(overloaded\)/);
+  });
+
+  it('an all-capped pool fails loud with the drop reason', () => {
+    const roster = [running('box-a'), running('box-a'), running('box-b')];
+    expect(() => pickHealthiest(['box-a', 'box-b'], roster, { maxConcurrent: { 'box-a': 2, 'box-b': 1 } }))
+      .toThrow(/at max-concurrent cap \(2\/2\).*at max-concurrent cap \(1\/1\)/);
+  });
+
+  it('a cap excludes a device even when it is otherwise the healthiest', () => {
+    const roster = [running('box-a')];
+    const health = {
+      'box-a': H({ reachable: true, headroom: 'idle', loadPercent: 5 }),
+      'box-b': H({ reachable: true, headroom: 'busy', loadPercent: 60 }),
+    };
+    const harness: Record<string, HarnessAvailability> = { 'box-a': 'available', 'box-b': 'available' };
+    // box-a would win on every key, but it is at its 1/1 cap → box-b.
+    expect(pickHealthiest(['box-a', 'box-b'], roster, { health, harness, maxConcurrent: { 'box-a': 1 } })).toBe('box-b');
+  });
+
+  it('ranks numeric load correctly (not string-coerced): 100 is worse than 7', () => {
+    const health = {
+      'box-a': H({ reachable: true, loadPercent: 100, memPercent: 100 }),
+      'box-b': H({ reachable: true, loadPercent: 7, memPercent: 7 }),
+    };
+    // A naive array `<` would order "…,100,…" before "…,7,…"; a correct numeric
+    // compare picks box-b.
+    expect(pickHealthiest(['box-a', 'box-b'], [], { health })).toBe('box-b');
+  });
+
+  it('throws on an empty pool (caller must guard)', () => {
+    expect(() => pickHealthiest([], [])).toThrow(/empty device pool/);
+  });
+});
+
+describe('resolvePlacement routes step 3 through the health-aware pick', () => {
+  it('uses harness availability when health/harness are supplied', () => {
+    const health: Record<string, DeviceHealthInput> = {
+      'box-a': { reachable: true, headroom: 'idle', loadPercent: 5 },
+      'box-b': { reachable: true, headroom: 'busy', loadPercent: 60 },
+    };
+    const harness: Record<string, HarnessAvailability> = { 'box-a': 'unavailable', 'box-b': 'available' };
+    // box-a is idle + first, but can't run the agent → box-b.
+    expect(resolvePlacement({ devices: ['box-a', 'box-b'] }, null, [], { health, harness }))
+      .toEqual({ device: 'box-b' });
+  });
+
+  it('falls back to least-loaded when no fleet data is supplied', () => {
+    const roster = [running('box-a')];
+    expect(resolvePlacement({ devices: ['box-a', 'box-b'] }, null, roster))
+      .toEqual({ device: 'box-b' });
+  });
+
+  it('surfaces the loud failure when the pool cannot run the agent', () => {
+    const harness: Record<string, HarnessAvailability> = { 'box-a': 'unavailable', 'box-b': 'unavailable' };
+    expect(() => resolvePlacement({ devices: ['box-a', 'box-b'] }, null, [], { harness, requestedLabel: 'claude@2.1.112' }))
+      .toThrow(/No device in the team pool can run claude@2\.1\.112/);
   });
 });
 

--- a/apps/cli/src/lib/teams/scheduler.ts
+++ b/apps/cli/src/lib/teams/scheduler.ts
@@ -8,19 +8,26 @@
  *
  *   1. teammate has an explicit `--device` pin      → that device
  *   2. else the team pool has exactly one device     → that device (whole team)
- *   3. else the team pool has many devices           → least-loaded pick
+ *   3. else the team pool has many devices           → health-aware pick
  *   4. else (no pin, no pool)                         → null == run local
  *
  * Step 3 is cap-aware: a device at its `agents.max-concurrent` cap (from the
  * device doc, passed in via PlacementOptions) is excluded from the auto-pick,
- * and an all-capped pool fails loud. Pins and pools of one are the user's own
- * choice and are never second-guessed.
+ * and an all-capped pool fails loud. When the caller also passes live fleet
+ * data (`health` + `harness` in PlacementOptions), step 3 upgrades from a pure
+ * roster-count to {@link pickHealthiest}: it drops unreachable, overloaded, and
+ * harness-incapable boxes, then ranks by harness availability, load/memory, and
+ * running-teammate count — failing loud when no box in the pool can run the
+ * requested agent. With no fleet data it falls back to {@link pickLeastLoaded},
+ * so a caller with nothing to pass keeps the old behaviour. Pins and pools of
+ * one are the user's own choice and are never second-guessed.
  *
  * A device whose name equals the local machine id is treated as "local" — it
  * resolves to a null placement so the existing local spawn path runs unchanged,
  * letting the local machine participate in a pool as just another member.
  */
 import { machineId } from '../session/sync/config.js';
+import type { Headroom } from '../devices/health.js';
 
 /** Team fields the placement cascade reads (a subset of TeamMeta). */
 export interface PlacementTeam {
@@ -28,17 +35,59 @@ export interface PlacementTeam {
 }
 
 /**
+ * Per-device health the health-aware pick reads (a projection of `DeviceStats`
+ * + its computed `headroom` bucket). Every field is optional so a cold stats
+ * cache degrades to the old least-loaded behaviour rather than excluding a
+ * device it has no data for. Passed in by the caller (agents.ts), which owns
+ * the SSH/cache I/O; this module stays pure.
+ *
+ * - `reachable: false`      → excluded (unreachable box).
+ * - `headroom: 'loaded'`    → excluded (overloaded box).
+ * - `loadPercent`/`memPercent` → the "lower is better" ranking signal (b).
+ */
+export interface DeviceHealthInput {
+  reachable?: boolean;
+  headroom?: Headroom;
+  loadPercent?: number;
+  memPercent?: number;
+}
+
+/**
+ * Whether the requested harness (agent, and its pinned version when given) can
+ * run on a device, derived from the fleet auth-health cache:
+ *
+ * - `available`   — installed AND signed in (a non-revoked cached auth row).
+ * - `unavailable` — provably cannot: the box was probed and the agent is absent
+ *                   or only holds a revoked token. Excluded from selection, and
+ *                   an all-`unavailable` pool fails loud.
+ * - `unknown`     — no cached data for that box (never probed). NOT excluded —
+ *                   a cold cache must never manufacture a false "can't run" —
+ *                   just ranked after a proven-`available` device.
+ */
+export type HarnessAvailability = 'available' | 'unavailable' | 'unknown';
+
+/**
  * Optional placement inputs beyond the team + roster. `maxConcurrent` maps a
  * device name to its `agents.max-concurrent` cap (from the device doc — read
  * locally via `readMaxConcurrentCaps`, never probed over SSH). Teams counts
  * the team's OWN roster against the cap (device-global counting would need an
  * SSH probe per candidate — out of the hot path; Factory auto-launch is the
- * device-wide counter). Only the least-loaded AUTO-PICK (cascade step 3)
- * honors caps: an explicit pin or a pool of one is the user's own choice and
- * is never second-guessed.
+ * device-wide counter). Only the AUTO-PICK (cascade step 3) honors caps and
+ * health: an explicit pin or a pool of one is the user's own choice and is
+ * never second-guessed.
+ *
+ * `health` + `harness` upgrade step 3 from a pure roster-count to a
+ * health-, load-, and harness-aware pick ({@link pickHealthiest}). When both
+ * are absent the pick falls back to {@link pickLeastLoaded}, so a caller with
+ * no fleet data keeps today's behaviour. `requestedLabel` (e.g.
+ * `claude@2.1.112`) and `availabilityHint` shape the loud failure message.
  */
 export interface PlacementOptions {
   maxConcurrent?: Record<string, number>;
+  health?: Record<string, DeviceHealthInput>;
+  harness?: Record<string, HarnessAvailability>;
+  requestedLabel?: string;
+  availabilityHint?: string;
 }
 
 /**
@@ -137,6 +186,139 @@ export function pickLeastLoaded(
   return best;
 }
 
+/** A representative load% for a bucket, used only when the precise loadPercent /
+ * memPercent are both missing (a reachable box with no parsed stats). Keeps the
+ * ranking numeric and total without letting a no-stats box always win or lose. */
+const HEADROOM_MID: Record<Headroom, number> = {
+  idle: 7,
+  light: 27,
+  busy: 57,
+  unknown: 50,
+  loaded: 90,
+};
+
+/** The "how full is this box" number: the worse of normalized load% and mem%,
+ * or undefined when neither was parsed. Mirrors `health.ts` `headroom()`. */
+function worstSignal(h: DeviceHealthInput | undefined): number | undefined {
+  const signals = [h?.loadPercent, h?.memPercent].filter(
+    (v): v is number => typeof v === 'number',
+  );
+  return signals.length ? Math.max(...signals) : undefined;
+}
+
+/** The numeric load score for ranking: precise worst-signal when known, else the
+ * headroom bucket's representative midpoint. Always a number, so the sort is total. */
+function loadScore(h: DeviceHealthInput | undefined): number {
+  return worstSignal(h) ?? HEADROOM_MID[h?.headroom ?? 'unknown'];
+}
+
+/**
+ * Health-, load-, and harness-aware pool pick (cascade step 3 when the caller
+ * supplies fleet data). It:
+ *
+ *   1. excludes devices at their max-concurrent cap, unreachable, or overloaded
+ *      (`headroom: 'loaded'`);
+ *   2. excludes devices that provably can't run the requested harness
+ *      (`harness[d] === 'unavailable'`) from selection;
+ *   3. ranks the survivors by (a) harness availability (proven-installed +
+ *      signed-in before unknown), (b) lower load/memory, (c) fewer running
+ *      teammates, tie-broken by pool order.
+ *
+ * Fails loud, never silently, when nothing can run:
+ *   - if every eligible device is a proven `unavailable`, the message names the
+ *     requested harness and points at the availability command;
+ *   - if no device is even eligible (all unreachable / overloaded / capped), the
+ *     message names each drop reason.
+ *
+ * With no `health`/`harness` data this reduces to {@link pickLeastLoaded}: all
+ * devices score equal on (a) and (b), so the pick collapses to fewest-running +
+ * pool-order. Pure — counts the roster, reads the passed maps, no I/O.
+ */
+export function pickHealthiest(
+  devices: string[],
+  roster: RosterEntry[],
+  opts: PlacementOptions = {},
+): string {
+  if (devices.length === 0) {
+    throw new Error('pickHealthiest called with an empty device pool');
+  }
+  const load = loadByDevice(devices, roster);
+  const health = opts.health ?? {};
+  const harness = opts.harness ?? {};
+  const label = opts.requestedLabel ?? 'the requested agent';
+  const hint = opts.availabilityHint ?? 'agents fleet status --verbose';
+
+  const capped = new Set(
+    opts.maxConcurrent ? cappedDevices(devices, roster, opts.maxConcurrent).map((c) => c.device) : [],
+  );
+
+  // 1. Hard eligibility filter — track why each drop happened for the loud error.
+  const excluded: Array<{ device: string; reason: string }> = [];
+  const eligible: string[] = [];
+  for (const d of devices) {
+    if (capped.has(d)) {
+      excluded.push({ device: d, reason: `at max-concurrent cap (${load.get(d) ?? 0}/${opts.maxConcurrent![d]})` });
+    } else if (health[d]?.reachable === false) {
+      excluded.push({ device: d, reason: 'unreachable' });
+    } else if (health[d]?.headroom === 'loaded') {
+      excluded.push({ device: d, reason: 'overloaded' });
+    } else {
+      eligible.push(d);
+    }
+  }
+
+  // 2. Drop devices that provably can't run the harness. 'unknown' stays in —
+  // a cold cache must not manufacture a false "can't run".
+  const candidates = eligible.filter((d) => harness[d] !== 'unavailable');
+
+  if (candidates.length === 0) {
+    if (eligible.length > 0) {
+      // Reachable, roomy boxes exist — they just can't run this harness.
+      throw new Error(
+        `No device in the team pool can run ${label} (checked ${eligible.join(', ')}). ` +
+          `Run '${hint}' to see which harnesses each box has installed and signed in, ` +
+          `or 'agents fleet login' to sign one in.`,
+      );
+    }
+    const detail = excluded.length
+      ? excluded.map((e) => `${e.device} (${e.reason})`).join(', ')
+      : devices.join(', ');
+    throw new Error(
+      `No viable device in the team pool for ${label}: ${detail}. ` +
+        `Free up a box, raise a cap with 'agents devices configure <name> --max-agents N', ` +
+        `or add a device to the pool.`,
+    );
+  }
+
+  // 3. Rank by the lexicographic key: availability, load, running count, pool order.
+  const order = new Map(devices.map((d, i) => [d, i] as const));
+  const availRank = (d: string): number => (harness[d] === 'available' ? 0 : 1);
+  const key = (d: string): [number, number, number, number] => [
+    availRank(d),
+    loadScore(health[d]),
+    load.get(d) ?? 0,
+    order.get(d) ?? 0,
+  ];
+  // Numeric tuple compare — NOT array `<` (which stringifies and misorders
+  // multi-digit numbers, e.g. "0,100" < "0,7"). First differing field decides.
+  const lessThan = (a: [number, number, number, number], b: [number, number, number, number]): boolean => {
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return a[i] < b[i];
+    }
+    return false;
+  };
+  let best = candidates[0];
+  let bestKey = key(best);
+  for (const d of candidates.slice(1)) {
+    const k = key(d);
+    if (lessThan(k, bestKey)) {
+      best = d;
+      bestKey = k;
+    }
+  }
+  return best;
+}
+
 /**
  * Resolve where a teammate runs. Returns `{ device: null }` for a local run
  * (no pin, no pool, or the chosen device is the local machine) and
@@ -160,7 +342,11 @@ export function resolvePlacement(
   if (pool.length === 1) {
     return { device: isLocalDevice(pool[0]) ? null : pool[0] };
   }
-  // 3. Many → least-loaded across the pool (cap-aware when caps are provided).
-  const picked = pickLeastLoaded(pool, roster, opts?.maxConcurrent);
+  // 3. Many → health-aware pick when the caller supplied fleet data, else the
+  // pure least-loaded pick (both cap-aware when caps are provided).
+  const picked =
+    opts?.health || opts?.harness
+      ? pickHealthiest(pool, roster, opts)
+      : pickLeastLoaded(pool, roster, opts?.maxConcurrent);
   return { device: isLocalDevice(picked) ? null : picked };
 }


### PR DESCRIPTION
**feat / behavior change** — makes `agents teams` auto-scheduling (cascade step 3, many-device pool) health-, load-, and harness-aware. Reviewer audience: maintainers.

Closes RUSH-2002 — https://linear.app/getrush/issue/RUSH-2002

## What changed

The pool auto-pick used to choose whichever box had the fewest roster entries, regardless of whether it was reachable, loaded, or could even run the requested harness. Now, when `maybeSchedulePlacement` supplies cached fleet signals, cascade step 3 (`pickHealthiest`):

- **drops** devices that are unreachable, overloaded (`headroom: loaded`), or at their `agents.max-concurrent` cap;
- **drops** devices that provably can't run the requested harness (box was probed and the agent is absent or holds only a revoked token). A box with **no** cached data stays `unknown` — kept, ranked after a proven-available one — so a cold cache never invents a false "can't run";
- **ranks** survivors by (a) requested agent installed + signed in, (b) lower load/memory, (c) fewer running teammates;
- **fails loud** at `teams start` when no pool device can run the requested agent.

Pins (`--device`), a pool of one, and a poolless team are unchanged. With no fleet data the pick degrades to the old least-loaded behaviour.

## Where the signals come from (no fresh SSH on the hot path)

- **DeviceStats** (load/memory/headroom) via `loadFleetStats` — the daemon-warmed stats cache, same data `agents fleet status` renders.
- **Harness availability** via a new pure `harnessAvailabilityForHost` over the auth-health cache (`host:agent:version` rows).
- `AgentManager` memoizes the combined fetch for 15s so a `teams start` burst shares one probe.

## Files

| File | Why |
|---|---|
| `src/lib/teams/scheduler.ts` | new `pickHealthiest` + `DeviceHealthInput`/`HarnessAvailability` types; step 3 routes to it when fleet data is present |
| `src/lib/teams/agents.ts` | `maybeSchedulePlacement` gathers DeviceStats + auth-health for the pool, builds the health/harness maps, memoized fetch |
| `src/lib/auth-health.ts` | `harnessAvailabilityForHost` — pure derivation of `available`/`unavailable`/`unknown` from the cache |
| `docs/teams.md`, `.changelog/next/` | doc + changelog |

## Note on the error hint

The ticket's example error names `agents devices accounts`, which does not exist. The message points at the real commands that show per-box harness availability (`agents fleet status --verbose` / `agents fleet ping`) so the remediation is runnable.

## Run result (real output of the new code path)

```
[1] pick over [s0 idle/unavailable, s1 busy/available, mac-mini overloaded] => yosemite-s1
[2] loud failure: No device in the team pool can run claude@2.1.112 (checked zion, yosemite-s0). Run 'agents fleet status --verbose' to see which harnesses each box has installed and signed in, or 'agents fleet login' to sign one in.
[3] zion can run claude? available | zion can run kimi? unavailable | never-probed box? unknown
[4] resolvePlacement => { device: null }   # picked yosemite-s0, which IS this box → local run
```

Tests: `scheduler.test.ts` (+29 cases) and `auth-health.test.ts` (+9 cases) green; full teams suite 200/200; `tsc --noEmit` clean.

```
Test Files  2 passed (2)
     Tests  81 passed (81)     # scheduler + auth-health
Test Files  23 passed (23)
     Tests  200 passed (200)   # full teams suite
```

No user-visible UI surface (a placement scheduler) — proof is the run output + tests above.
