### PR TITLE
fix(release): isolate orchestration from caller checkout (RUSH-2263)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2263.md
+++ b/apps/cli/.changelog/next/RUSH-2263.md
@@ -1,0 +1,1 @@
+`scripts/release.sh` now runs orchestration in a fresh release-owned worktree, so a dirty shared checkout or feature branch no longer blocks or contaminates a release.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -405,9 +405,9 @@ Nothing from `apps/`, `native/`, or sibling `packages/` can leak into the tarbal
 
 ## Releasing
 
-**Self-routing, zero-config.** Run it from ANY fleet box with an empty
-environment — no variables to set, no Touch ID, no hand-moved credentials. Run
-from a clean, in-sync `main`:
+**Self-routing, zero-config.** Run it from ANY fleet box and ANY checkout state —
+no variables to set, no Touch ID, no hand-moved credentials, and no requirement
+that the caller be on a clean `main`:
 
 ```bash
 scripts/release.sh <version>          # dry-run: bump, type-check, tarball preview, detected state
@@ -419,12 +419,21 @@ each phase labeled with the box it runs on and a ✓/✗ result:
 
 | Work | Runs on | How it's chosen |
 |---|---|---|
-| Orchestrate: bump, changelog, PR, tag | the box you invoked it on | it's already there (git + gh only) |
-| CI / tests (Linux) | a **crabbox** (Hetzner Linux VM) | [`scripts/sandbox.sh`](scripts/sandbox.sh) selects an available box for this repo's `.crabbox.yaml` profile or warms a fresh one — **dynamic, never a hardcoded instance** |
+| Orchestrate: bump, changelog, PR, tag | a detached worktree on the box you invoked it on | fresh `origin/<default>` under `.agents/worktrees/release-v<version>-<pid>` |
+| CI / tests (Linux) | a **crabbox** workspace (Hetzner Linux VM) | [`scripts/sandbox.sh`](scripts/sandbox.sh) reclaims an available warm box and syncs into `~/workspaces/<repo>-<task>`; it warms capacity only when the shared pool has none — **dynamic, never a hardcoded or release-exclusive instance** |
 | Build, sign+notarize, npm publish, computer-helper | the **home base** | one hardcoded constant `RELEASE_HOME_BASE="mac-mini"` in `release.sh`; the script detects if it's already there (`scutil --get LocalHostName` / `hostname -s`), else reaches it over `ssh` |
 
 `mac-mini` is the only hardcoded machine name (it holds the Developer ID cert +
 npm publish rights). The crabbox is **not** hardcoded.
+
+**The caller checkout is never mutated or gated.** `release.sh` immediately
+fetches origin and re-enters the release from a detached, release-owned worktree
+at fresh `origin/<default>`. Version bumps, changelog folding, release-branch
+construction, CI orchestration, merging, and tagging happen there. The worktree
+is removed on every exit path, so a dirty shared `main`, an agent feature branch,
+or another branch already checking out `main` cannot block or contaminate a
+release. The isolated tree installs dependencies from its pinned lockfile; it
+does not borrow `node_modules` or staged files from the caller.
 
 **One releaser at a time — the lease.** Because the script runs from any box, two
 agents on two machines could enter it at once; they then clobber the same release

--- a/apps/cli/scripts/release-worktree.sh
+++ b/apps/cli/scripts/release-worktree.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run release orchestration from a fresh detached origin/<default> worktree.
+
+set -euo pipefail
+
+[[ $# -ge 2 ]] || { echo "usage: release-worktree.sh <repo-root> <release args...>" >&2; exit 2; }
+
+REPO_ROOT="$1"
+shift
+RELEASE_ARGS=("$@")
+TARGET=""
+for arg in "${RELEASE_ARGS[@]}"; do
+  [[ "$arg" == --* ]] || { TARGET="$arg"; break; }
+done
+[[ -n "$TARGET" ]] || { echo "error: release version is required" >&2; exit 2; }
+
+git -C "$REPO_ROOT" fetch --quiet origin
+DEFAULT_BRANCH="$(git -C "$REPO_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+[[ -n "$DEFAULT_BRANCH" ]] || DEFAULT_BRANCH="main"
+
+WORKTREE="$REPO_ROOT/.agents/worktrees/release-v$TARGET-$$"
+cleanup() {
+  git -C "$REPO_ROOT" worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+git -C "$REPO_ROOT" worktree add --quiet --detach "$WORKTREE" "origin/$DEFAULT_BRANCH" \
+  || { echo "error: could not create release worktree at $WORKTREE from origin/$DEFAULT_BRANCH" >&2; exit 1; }
+
+missing="$(git -C "$WORKTREE" status --short | awk '$1 == "D" || $2 == "D" { print $2 }')"
+if [[ -n "$missing" ]]; then
+  printf 'error: release worktree %s is incomplete; missing tracked files:\n%s\n' "$WORKTREE" "$missing" >&2
+  printf 'Remove only this isolated release worktree, then retry: %s\n' "$WORKTREE" >&2
+  exit 1
+fi
+
+cd "$WORKTREE/apps/cli"
+scripts/release.sh "${RELEASE_ARGS[@]}" --orchestration-phase

--- a/apps/cli/scripts/release-worktree.test.ts
+++ b/apps/cli/scripts/release-worktree.test.ts
@@ -1,0 +1,71 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SCRIPT = path.resolve(__dirname, 'release-worktree.sh');
+const roots: string[] = [];
+
+function git(cwd: string, ...args: string[]) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf-8' });
+  if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+  return result.stdout.trim();
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('release-worktree.sh', () => {
+  it('runs from clean origin/main while leaving dirty main and feature checkouts untouched', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'release-worktree-'));
+    roots.push(root);
+    const remote = path.join(root, 'remote.git');
+    const caller = path.join(root, 'caller');
+
+    git(root, 'init', '--bare', remote);
+    git(root, 'clone', remote, caller);
+    git(caller, 'config', 'user.name', 'Release Test');
+    git(caller, 'config', 'user.email', 'release-test@example.com');
+    fs.mkdirSync(path.join(caller, 'apps/cli/scripts'), { recursive: true });
+    fs.mkdirSync(path.join(caller, '.agents/worktrees'), { recursive: true });
+    fs.copyFileSync(SCRIPT, path.join(caller, 'apps/cli/scripts/release-worktree.sh'));
+    fs.writeFileSync(
+      path.join(caller, 'apps/cli/scripts/release.sh'),
+      '#!/usr/bin/env bash\nset -euo pipefail\n' +
+        'test "$(git rev-parse --abbrev-ref HEAD)" = HEAD\n' +
+        'test -z "$(git status --porcelain)"\n' +
+        'target=""\n' +
+        'for arg in "$@"; do [[ "$arg" == --* ]] || { target="$arg"; break; }; done\n' +
+        'printf "isolated:%s:%s\\n" "$target" "${*: -1}"\n',
+    );
+    fs.chmodSync(path.join(caller, 'apps/cli/scripts/release.sh'), 0o755);
+    git(caller, 'add', '.');
+    git(caller, 'commit', '-m', 'initial');
+    git(caller, 'branch', '-M', 'main');
+    git(caller, 'push', '-u', 'origin', 'main');
+    git(remote, 'symbolic-ref', 'HEAD', 'refs/heads/main');
+    git(caller, 'remote', 'set-head', 'origin', '--auto');
+    fs.writeFileSync(path.join(caller, 'dirty-main.txt'), 'shared main work in progress\n');
+    git(caller, 'worktree', 'add', '-b', 'feature', path.join(root, 'feature'), 'origin/main');
+    const feature = path.join(root, 'feature');
+    fs.writeFileSync(path.join(feature, 'dirty.txt'), 'caller work in progress\n');
+
+    const result = spawnSync(
+      'bash',
+      [path.join(feature, 'apps/cli/scripts/release-worktree.sh'), caller, '--skip-tests', '9.8.7'],
+      { cwd: feature, encoding: 'utf-8' },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('isolated:9.8.7:--orchestration-phase');
+    expect(fs.readFileSync(path.join(caller, 'dirty-main.txt'), 'utf-8')).toBe(
+      'shared main work in progress\n',
+    );
+    expect(fs.readFileSync(path.join(feature, 'dirty.txt'), 'utf-8')).toBe('caller work in progress\n');
+    expect(git(caller, 'status', '--porcelain')).toBe('?? dirty-main.txt');
+    expect(git(feature, 'status', '--porcelain')).toBe('?? dirty.txt');
+    expect(fs.readdirSync(path.join(caller, '.agents/worktrees'))).toEqual([]);
+  });
+});

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -7,7 +7,8 @@
 # (frozen at 1.19.x since v1.20.0).
 #
 # Three self-selected homes, no environment variables to set:
-#   - Orchestrate (bump, changelog, PR, tag): the box you invoke it on (git + gh).
+#   - Orchestrate (bump, changelog, PR, tag): a release-owned detached worktree
+#     on the box you invoke it on (git + gh), based on fresh origin/<default>.
 #   - CI / tests: a crabbox (dynamic Hetzner Linux VM) via scripts/sandbox.sh --
 #     never a hardcoded instance. Covers the Linux suite; the GH Actions matrix
 #     still covers the cross-platform (macOS/Windows) legs on the release PR.
@@ -104,6 +105,9 @@ YES=false
 # publish phase (build + sign + notarize + npm publish + computer-helper) against
 # an already-merged+tagged release. It is never something an operator passes.
 HOME_BASE_PHASE=false
+# --orchestration-phase is an INTERNAL marker added only by release-worktree.sh.
+# It prevents the release-owned checkout from recursively creating another one.
+ORCHESTRATION_PHASE=false
 TARGET=""
 for arg in "$@"; do
   case "$arg" in
@@ -111,6 +115,7 @@ for arg in "$@"; do
     --skip-tests) SKIP_TESTS=true ;;
     --yes|-y) YES=true ;;
     --home-base-phase) HOME_BASE_PHASE=true ;;
+    --orchestration-phase) ORCHESTRATION_PHASE=true ;;
     -h|--help) printf '%s\n' "usage: scripts/release.sh <version> [--apply] [--skip-tests] [--yes]"; exit 0 ;;
     --*) die "unknown flag: $arg" ;;
     *)
@@ -121,6 +126,18 @@ for arg in "$@"; do
 done
 [[ -n "$TARGET" ]] || die "usage: scripts/release.sh <version> [--apply]  (e.g. 1.14.2 --apply)"
 [[ "$TARGET" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be MAJOR.MINOR.PATCH (no pre-release tags)"
+
+# The caller's checkout is never the orchestration workspace. It may be a dirty
+# shared main checkout or an agent's feature worktree; either way, release-owned
+# isolation keeps unrelated work out of the release index and avoids contending
+# for the branch already checked out there. The internal home-base phase is
+# already inside its own tagged worktree and deliberately bypasses this hop.
+if ! $HOME_BASE_PHASE && ! $ORCHESTRATION_PHASE; then
+  CALLER_GIT_COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+    || die "release.sh must run from an agents-cli git checkout"
+  CALLER_REPO_ROOT="$(dirname "$CALLER_GIT_COMMON_DIR")"
+  exec scripts/release-worktree.sh "$CALLER_REPO_ROOT" "$@"
+fi
 
 if $APPLY; then
   bold "Mode: APPLY (real publish)"
@@ -283,27 +300,31 @@ fi
 # ----- Pre-flight -----
 command -v npm >/dev/null    || die "npm not found"
 command -v node >/dev/null   || die "node not found"
+command -v bun >/dev/null    || die "bun not found"
 command -v git >/dev/null    || die "git not found"
 command -v jq >/dev/null     || die "jq not found (brew install jq)"
 command -v gh >/dev/null      || die "gh (GitHub CLI) not found (brew install gh) -- needed to open + merge the release PR"
 gh auth status >/dev/null 2>&1 || die "gh is not authenticated -- run 'gh auth login'"
 
-# Working tree must be clean. This is load-bearing: the release commit is built
-# straight from the index via 'git write-tree' (see the apply phase), so a dirty
-# tree would smuggle unrelated changes into the release PR + published tarball.
-if [[ -n "$(git status --porcelain)" ]]; then
-  die "working tree is dirty -- commit or stash first"
-fi
-
-# Resolve the default branch dynamically; must be on it and in sync with origin.
+# Resolve the default branch dynamically. release-worktree.sh checked out this
+# fresh remote tip in a detached worktree, so the caller need not be on main and
+# its dirty files cannot enter the index used below.
 git fetch --quiet origin
 DEFAULT_BRANCH="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
 [[ -n "$DEFAULT_BRANCH" ]] || DEFAULT_BRANCH="main"
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-[[ "$BRANCH" == "$DEFAULT_BRANCH" ]] || die "not on $DEFAULT_BRANCH (on '$BRANCH') -- release runs from the default branch"
 BASE_SHA="$(git rev-parse HEAD)"
 REMOTE="$(git rev-parse "origin/$DEFAULT_BRANCH")"
-[[ "$BASE_SHA" == "$REMOTE" ]] || die "$DEFAULT_BRANCH is not in sync with origin/$DEFAULT_BRANCH (run 'git push' first)"
+[[ "$BASE_SHA" == "$REMOTE" ]] || die "release worktree is not at fresh origin/$DEFAULT_BRANCH -- recreate only this release worktree and retry"
+if [[ -n "$(git status --porcelain)" ]]; then
+  red "release worktree became dirty before orchestration; changed files:" >&2
+  git status --short >&2
+  die "release-owned worktree must stay clean -- inspect the listed files; do not stash or alter the caller checkout"
+fi
+
+# A clean clone/worktree has no node_modules. Install from the pinned lockfile in
+# this isolated tree rather than borrowing mutable dependencies from the caller.
+bun install --frozen-lockfile >/dev/null \
+  || die "dependency install failed in the isolated release worktree"
 
 # ----- npm auth: resolved ON the home base, never borrowed to the trigger box -----
 # The npm publish token lives only on the home base (mac-mini) and is resolved
@@ -456,8 +477,8 @@ read -r TMAJ TMIN TPAT <<< "$(parse_v "$TARGET")"
 
 # Which kind of bump is this? The arithmetic lives in scripts/validate-bump.sh
 # so it can be tested directly (scripts/validate-bump.test.ts) — reaching it
-# here requires a clean main, npm auth and gh auth first. It prints the bump
-# kind, or the accepted versions to stderr and exits 1.
+# here requires live npm and GitHub authentication. It prints the bump kind, or
+# the accepted versions to stderr and exits 1.
 PKG_JSON_VERSION="$(jq -r .version package.json)"
 if ! BUMP="$(scripts/validate-bump.sh "$PHNX_LATEST" "$PKG_JSON_VERSION" "$SWARMIFY_LATEST" "$TARGET")"; then
   exit 1
@@ -835,7 +856,7 @@ require_lease() { # $1 = what we are about to do
 PKG_BUMPED=false
 
 phase "Preflight + version validation complete" "$THIS_HOST"
-phase_ok "clean $DEFAULT_BRANCH, bump $BUMP ($PHNX_LATEST -> $TARGET), type check + tarball preview done"
+phase_ok "isolated origin/$DEFAULT_BRANCH, bump $BUMP ($PHNX_LATEST -> $TARGET), type check + tarball preview done"
 
 # ----- Short-circuit: already published -----
 # Registry is the source of truth. If the version is live, the release happened;

--- a/apps/cli/scripts/select-publish-commit.test.ts
+++ b/apps/cli/scripts/select-publish-commit.test.ts
@@ -6,7 +6,7 @@
  * untested tarball: when unrelated PRs merge during a release PR's CI window, the
  * squash-merge tree diverges from what CI tested, and release.sh must fall back to
  * the CI-tested release commit rather than the drifted merge. release.sh itself
- * cannot run in a test (it demands a clean main, npm + gh auth); extracting the
+ * cannot run hermetically in a test (it demands live npm + GitHub); extracting the
  * decision into select-publish-commit.sh is what makes this path testable — the
  * same reason validate-bump.sh exists.
  */

--- a/apps/cli/scripts/stuck-release.sh
+++ b/apps/cli/scripts/stuck-release.sh
@@ -10,8 +10,7 @@
 #
 # The arithmetic lives here rather than inline in release.sh so it can be tested
 # directly (scripts/stuck-release.test.ts) -- reaching it inside release.sh
-# requires a clean main, npm auth and gh auth first. Same split as
-# validate-bump.sh.
+# requires live npm and GitHub access first. Same split as validate-bump.sh.
 #
 # Usage:
 #   stuck-release.sh <registry-latest> < tags.txt

--- a/apps/cli/scripts/validate-bump.test.ts
+++ b/apps/cli/scripts/validate-bump.test.ts
@@ -3,8 +3,8 @@
  *
  * This is the only thing standing between a typo in the comparison chain and a
  * bad `latest` on npm: nothing else in CI runs `scripts/`, and `release.sh`
- * cannot be invoked in a test — it demands a clean main, npm auth and gh auth
- * long before it reaches the bump decision. Extracting the decision into
+ * cannot be invoked hermetically in a test — it demands live npm and GitHub
+ * access long before it reaches the bump decision. Extracting the decision into
  * `validate-bump.sh` is what makes the real code path testable here.
  */
 


### PR DESCRIPTION
Release automation fix: `scripts/release.sh` now re-enters from a fresh detached `origin/<default>` worktree before any dirty-sensitive phase.

## What changed

- Dirty shared `main` and feature checkouts no longer gate or contaminate release orchestration.
- The release worktree lives at `.agents/worktrees/release-v<version>-<pid>` and is removed on exit.
- A clean worktree installs pinned dependencies instead of borrowing caller `node_modules`.
- Existing `sandbox.sh` remains the only crabbox path and retains its shared warm-box `--reclaim` + `~/workspaces/...` behavior.
- Dirty-tree failures inside the owned worktree list changed files and never recommend stash.

## Before / after proof

Before, the script stopped at the caller checkout:

```text
error: working tree is dirty -- commit or stash first
error: not on main (on <feature>) -- release runs from the default branch
```

After, the real helper test creates a bare origin, a dirty shared `main`, and a dirty feature worktree, then invokes the release entry with flags before the version:

```text
$ bun run test -- scripts/release-worktree.test.ts scripts/release.test.ts scripts/stuck-release.test.ts scripts/validate-bump.test.ts scripts/select-publish-commit.test.ts scripts/release-lease.test.ts
Test Files  6 passed (6)
Tests  55 passed (55)
```

The regression asserts the child runs detached and clean at `origin/main`, both dirty caller files remain unchanged, and the release-owned worktree is removed.

No visual surface: this changes headless release orchestration only.

## Additional verification

- `bun install --frozen-lockfile` completed and ran the CLI build.
- `bash -n scripts/release.sh scripts/release-worktree.sh` passed.
- Shellcheck passed for the changed release path (existing documented suppressions only).
- `bun run test:remote` failed loud before provisioning: `HCLOUD_TOKEN is empty after secret resolution`. The local full suite then hit unrelated host-state failures in credentials/model/feed tests; the release-specific 55-test gate is green.

Ticket: https://linear.app/getrush/issue/RUSH-2263

Confidential session transcript omitted; local session evidence remains on yosemite-s0.