### PR TITLE
fix(sessions): keep dead rows out of active focus

### DIFF
--- a/apps/cli/.changelog/next/GH-2108-active-focus.md
+++ b/apps/cli/.changelog/next/GH-2108-active-focus.md
@@ -1,0 +1,6 @@
+---
+issue: 2108
+type: fixed
+---
+
+`agents sessions focus ... --active` now excludes closed and crashed registry rows; explicit lifecycle filters such as `--closed` and `--crashed` still select them. Per-device `latest` / `oldest` selectors also wait for the peer's filtered index result instead of widening to live rows whose version is unknown.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -692,7 +692,13 @@ unreachable still falls back to any age).
 
 On a TTY it opens the interactive browser seeded to running-only; `--json`,
 `--waiting`, and `--no-interactive` print the static grouped view instead. Both read
-the same gather, so they always agree on what is live.
+the same gather and the same running predicate, so they always agree on what is live.
+The registry retains terminally-dead rows for recovery, but bare `--active` excludes
+`closed`, `crashed`, and rows whose process is positively dead. Explicit lifecycle
+filters such as `--closed` and `--crashed` select those retained rows instead.
+Per-device `latest` / `oldest` selectors accept only rows returned by that device's
+version-filtered index query; an unindexed live row with no resolved version does not
+silently widen the picker.
 
 **Team lineage.** A teams teammate row carries the id of the **orchestrator** that
 spawned it — the session that ran `agents teams add`, captured from

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -561,6 +561,10 @@ SSH access (§7); rendering sessions that no harness produced.
   `sessions --active` (`commands/sessions-browser.ts` `BrowserFilter`,
   `collectSessionCandidates`, `applyFilters`; `commands/focus.ts` `focusAction`;
   tests `commands/sessions-browser.test.ts`, `commands/focus.test.ts`).
+  Bare `--active` MUST exclude terminally-dead rows retained by the live registry;
+  explicit `--closed` / `--crashed` filters MUST remain able to select those rows.
+  A per-device `latest` / `oldest` query MUST NOT admit an unindexed live row whose
+  version was not part of the peer's filtered result.
 - **SES-39 (MUST).** Focus MUST query tmux `#{pane_dead}` immediately before
   attach. A dead or missing pane MUST NOT attach. Session recovery MUST run on
   the origin device and MUST choose native resume only for the exact healthy

--- a/apps/cli/src/commands/focus.ts
+++ b/apps/cli/src/commands/focus.ts
@@ -25,6 +25,7 @@ import {
   filterSessionsByQuery,
   formatLiveStatusHeadline,
   formatPickerLabel,
+  isRunningLiveSession,
   pickerColumnsFor,
   resumeSessionInPlace,
   resolveSessionMetadataValue,
@@ -356,7 +357,7 @@ export async function focusAction(id: string | undefined, opts: FocusOptions): P
 
 /** A retained pane is not attachable merely because tmux can still display it. */
 export function isAttachableLiveSession(session: ActiveSession): boolean {
-  return session.pidAlive !== false && session.status !== 'closed' && session.status !== 'crashed';
+  return isRunningLiveSession(session);
 }
 
 const FOCUS_AGENT_SHORTHANDS = ['claude', 'codex', 'kimi', 'antigravity', 'grok', 'opencode'] as const;

--- a/apps/cli/src/commands/sessions-browser.test.ts
+++ b/apps/cli/src/commands/sessions-browser.test.ts
@@ -169,6 +169,31 @@ describe('applyFilters — shared browser/focus selection', () => {
     expect(result.map((session) => session.id)).toEqual(['orphan', 'working']);
   });
 
+  it('keeps retained dead rows out of bare --active while explicit lifecycle filters can select them', () => {
+    const rows = [row({ id: 'working' }), row({ id: 'closed' }), row({ id: 'crashed' })];
+    const live = new Map<string, ActiveSession>([
+      ['working', { context: 'terminal', kind: 'claude', status: 'running', pidAlive: true, sessionId: 'working' } as ActiveSession],
+      ['closed', { context: 'terminal', kind: 'claude', status: 'closed', pidAlive: false, sessionId: 'closed' } as ActiveSession],
+      ['crashed', { context: 'terminal', kind: 'claude', status: 'crashed', pidAlive: false, sessionId: 'crashed' } as ActiveSession],
+    ]);
+
+    expect(applyFilters(
+      rows,
+      live,
+      { ...base, running: true, projectScope: 'all' },
+      'zion',
+      new Set(),
+    ).map((session) => session.id)).toEqual(['working']);
+
+    expect(applyFilters(
+      rows,
+      live,
+      { ...base, running: true, statuses: ['closed', 'crashed'], projectScope: 'all' },
+      'zion',
+      new Set(),
+    ).map((session) => session.id)).toEqual(['closed', 'crashed']);
+  });
+
   it('does not treat a synced mirror as a peer-resolved latest result', () => {
     const rows = [
       row({ id: 'mirror', machine: 'yosemite-s0', version: '2.1.187' }),
@@ -450,6 +475,15 @@ describe('mergeLiveIntoPool — running is a SOURCE of rows, not an intersection
   it('leaves the pool untouched when nothing live is missing from it', () => {
     const rows = [row({ id: 'local-1' })];
     expect(mergeLiveIntoPool(rows, new Map(), 'zion')).toBe(rows);
+  });
+
+  it('does not widen a peer-resolved latest/oldest selector with unindexed live rows', () => {
+    const indexed = row({ id: 'indexed', machine: 'yosemite-s0', version: '2.1.219', _remote: true });
+    const unindexed = live({ sessionId: 'unindexed', machine: 'yosemite-s0', status: 'running' });
+    const liveIndex = indexLiveRows([unindexed], 'zion');
+
+    expect(mergeLiveIntoPool([indexed], liveIndex, 'zion', false)).toEqual([indexed]);
+    expect(mergeLiveIntoPool([indexed], liveIndex, 'zion', true).map((session) => session.id)).toContain('unindexed');
   });
 });
 

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -40,6 +40,7 @@ import {
   remoteHostsToDial,
   matchesTeam,
   formatLiveStatusHeadline,
+  isRunningLiveSession,
   matchesLiveStatus,
   parseAgentFilter,
   type LiveStatusFilter,
@@ -138,6 +139,8 @@ function poolCacheKey(f: BrowserFilter): string {
 
 /** Pool size when a team filter is active; one team's rows can sit anywhere. */
 const WHOLE_TEAM_POOL_LIMIT = 5000;
+/** A cold peer may need to resolve an installed-version alias and scan its index. */
+const BROWSER_PEER_TIMEOUT_MS = 30_000;
 
 /** Ordered window cycle for the `W` key. `undefined` = all time. */
 const WINDOW_CYCLE: (string | undefined)[] = [undefined, '1d', '7d', '30d'];
@@ -387,7 +390,9 @@ async function fetchRawPool(
       // --in-team itself, which a peer on an older build would reject as an
       // unknown option and fail the whole fan-out.
       const forwarded = remotePoolArgs(f, fixedFilters);
-      const remoteResult = await gatherRemoteList(forwarded, remoteHosts);
+      const remoteResult = await gatherRemoteList(forwarded, remoteHosts, {
+        timeoutMs: BROWSER_PEER_TIMEOUT_MS,
+      });
       unreachable = remoteResult.unreachable;
       if (remoteResult.sessions.length > 0) rows = mergeLocalFirst([...rows, ...remoteResult.sessions], self);
     } catch {
@@ -497,7 +502,12 @@ export function mergeLiveIntoPool(
   rows: SessionMeta[],
   live: Map<string, ActiveSession>,
   self: string,
+  includeUnindexed = true,
 ): SessionMeta[] {
+  // A latest/oldest selector is resolved by the peer's transcript query. A live
+  // row absent from that result has no proof it belongs to the resolved version,
+  // so callers using an alias fail closed instead of widening the selector.
+  if (!includeUnindexed) return rows;
   const known = new Set(rows.map((r) => r.id));
   const extra: SessionMeta[] = [];
   for (const [key, a] of live) {
@@ -561,7 +571,15 @@ export function applyFilters(
     const cwd = process.cwd();
     out = out.filter((r) => !!r.cwd && (r.cwd === cwd || r.cwd.startsWith(cwd + '/')));
   }
-  if (f.running) out = out.filter((r) => live.has(r.id));
+  // The live registry retains dead rows so explicit --closed/--crashed filters
+  // can recover them. Bare --active means currently active; a lifecycle filter
+  // intentionally replaces that default predicate with its exact status union.
+  if (f.running && f.statuses.length === 0) {
+    out = out.filter((r) => {
+      const active = live.get(r.id);
+      return !!active && isRunningLiveSession(active);
+    });
+  }
   if (f.statuses.length > 0) {
     out = out.filter((r) => {
       const active = live.get(r.id);
@@ -587,8 +605,9 @@ export async function collectSessionCandidates(
     const { sessions } = await gatherActiveSessions({ local: opts.local ?? false, hosts });
     liveById = indexLiveRows(sessions, self);
   }
+  const includeUnindexedLive = !filter.agent?.match(/@(latest|oldest)$/);
   const rows = filter.running || opts.includeLive
-    ? mergeLiveIntoPool(pool.rows, liveById, self)
+    ? mergeLiveIntoPool(pool.rows, liveById, self, includeUnindexedLive)
     : pool.rows;
   const sessions = applyFilters(rows, liveById, filter, self, listFavorites());
   return { sessions, liveById, self, unreachable: pool.unreachable };
@@ -700,7 +719,10 @@ export async function runSessionBrowser(
     if (live) liveCache = live;
     // Live sessions the transcript pool lacks become rows of their own, so the
     // running view lists every active session, not just the ones already indexed.
-    const rows = f.running && live ? mergeLiveIntoPool(pool.rows, live, self) : pool.rows;
+    const includeUnindexedLive = !f.agent?.match(/@(latest|oldest)$/);
+    const rows = f.running && live
+      ? mergeLiveIntoPool(pool.rows, live, self, includeUnindexedLive)
+      : pool.rows;
     agentsInPool = distinct(rows.map((r) => r.agent));
     devicesInPool = distinct(rows.map((r) => r.machine ?? self));
     // Both ends of the lineage seed the cycle: teams a row spawned, and teams a

--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -23,6 +23,7 @@ import {
   toolSearchFleetSortError,
   toolSearchForwardedArgs,
   matchesLiveStatus,
+  isRunningLiveSession,
   resolveSessionAgentName,
   requestedLiveStatuses,
 } from './sessions.js';
@@ -76,6 +77,14 @@ describe('live session status flags', () => {
     for (const status of ['idle', 'orphaned', 'crashed', 'closed', 'abandoned', 'queued', 'unknown'] as const) {
       expect(matchesLiveStatus(row({ status }), status)).toBe(true);
     }
+  });
+
+  it('distinguishes active rows from dead rows retained for recovery filters', () => {
+    expect(isRunningLiveSession(row({ status: 'running', pidAlive: true }))).toBe(true);
+    expect(isRunningLiveSession(row({ status: 'orphaned' }))).toBe(true);
+    expect(isRunningLiveSession(row({ status: 'closed', pidAlive: false }))).toBe(false);
+    expect(isRunningLiveSession(row({ status: 'crashed' }))).toBe(false);
+    expect(isRunningLiveSession(row({ status: 'abandoned', pidAlive: false }))).toBe(false);
   });
 
   it('routes aliases, unions, and the waiting exit gate through the real CLI', () => {
@@ -150,6 +159,12 @@ describe('live session status flags', () => {
       const waitingUnion = runAgents(['sessions', '--waiting', '--orphan', '--json', '--local'], cwd, tempHome);
       expect(waitingUnion.status).toBe(1);
       expect(JSON.parse(waitingUnion.stdout).map((row: ActiveSession) => row.sessionId)).toContain(liveSessionId);
+
+      const active = runAgents(['sessions', '--active', '--json', '--local'], cwd, tempHome);
+      expect(active.status, active.stderr).toBe(0);
+      const activeIds = JSON.parse(active.stdout).map((row: ActiveSession) => row.sessionId);
+      expect(activeIds).toContain(liveSessionId);
+      expect(activeIds).not.toContain(crashedSessionId);
     } finally {
       sleeper.kill('SIGTERM');
       fs.rmSync(tempHome, { recursive: true, force: true });

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -664,6 +664,20 @@ export function isAwaitingUser(s: ActiveSession): boolean {
   return s.status === 'input_required' || s.activity === 'waiting_input';
 }
 
+/**
+ * Whether a row belongs in an unqualified `--active` view.
+ *
+ * The live registry deliberately retains terminally-dead rows long enough for
+ * `--closed` / `--crashed` and recovery to find them. Presence in that registry
+ * therefore is not, by itself, evidence that a session is still active.
+ * Explicit lifecycle filters bypass this predicate and select those retained
+ * rows through {@link matchesLiveStatus} instead.
+ */
+export function isRunningLiveSession(s: ActiveSession): boolean {
+  if (s.status === 'closed' || s.status === 'crashed') return false;
+  return s.pidAlive !== false;
+}
+
 /** Width of the live status column — `crashed` is the longest word it renders. */
 const LIVE_STATUS_W = 8;
 
@@ -1439,7 +1453,7 @@ async function renderActiveSessions(
   // gate: exit non-zero when the union contains a session awaiting the user.
   const statusFiltered = opts.statuses?.length
     ? merged.filter((session) => opts.statuses!.some((status) => matchesLiveStatus(session, status)))
-    : merged;
+    : merged.filter(isRunningLiveSession);
   const sessions = statusFiltered;
 
   // Backfill agent version + ticket/PR/label/created onto the live rows from the

--- a/apps/cli/src/lib/session/remote-list.ts
+++ b/apps/cli/src/lib/session/remote-list.ts
@@ -260,6 +260,8 @@ export interface GatherRemoteListOptions {
    * know whether the match is unique or conflicting.
    */
   isDefinitive?: (session: SessionMeta, machine: string) => boolean;
+  /** Per-peer deadline for slower indexed browse queries. */
+  timeoutMs?: number;
 }
 
 export async function gatherRemoteList(
@@ -272,6 +274,7 @@ export async function gatherRemoteList(
     args: forwardedArgs,
     noFanoutEnv: NO_FANOUT_ENV,
     hosts,
+    timeoutMs: opts?.timeoutMs,
     earlyExit: opts?.isDefinitive ? { isDefinitive: opts.isDefinitive } : undefined,
     parse: (stdout, machine): RemoteAgentsJsonParseResult<SessionMeta> =>
       parseRemoteListPayload(stdout, machine, safeResolver),


### PR DESCRIPTION
Fixes the installed `agents sessions focus ... --active` picker for users recovering sessions across the fleet.

## What changed

- centralizes the definition of a currently active live session so retained `closed`, `crashed`, and dead-PID rows stay recoverable without leaking into bare `--active`
- preserves explicit lifecycle unions such as `--closed`, `--crashed`, and `--orphan`
- gives indexed remote picker queries enough time to complete on a cold peer
- prevents `@latest` / `@oldest` from widening to unindexed live rows whose version is unknown
- documents the shared filter contract and adds the release changelog fragment

## Installed reproduction and corrected result

![Installed 1.22.24 before and corrected dev build after](https://share.agents-cli.sh/muqsitnawaz/muqsit-1785988317041-d837e09f80b45765)

The left terminal is the installed 1.22.24 picker leaking `closed` rows and reporting a healthy peer as unreachable. The right terminal runs the installed dev package against the same peer and shows only working/idle/abandoned rows, with no false reachability warning.

## Verification

- `bunx vitest run src/commands/sessions.test.ts src/commands/sessions-browser.test.ts src/commands/focus.test.ts src/lib/session/remote-list.test.ts --reporter=verbose` — 189 passed
- `bunx tsc --noEmit` — passed
- `./scripts/build.sh --skip-tests` — passed; 1,292 files, 11,043 KB
- real PTY: `agents sessions focus claude@latest --device yosemite-s0 --active` — honest empty result, no false unreachable warning
- real PTY: `agents sessions focus claude --device yosemite-s0 --active` — picker contains no closed/crashed sessions

## Tracking

- Fixes #2108
- Follow-up to #2148 after installed-artifact PTY verification found the retained-row leak
