### PR TITLE
feat(cloud): add Cursor Cloud Agents provider (RUSH-2228)

### DIFF
--- a/.agents/reports/2026-08-05/agents-run-cloud-flag-design.md
+++ b/.agents/reports/2026-08-05/agents-run-cloud-flag-design.md
@@ -31,7 +31,7 @@ both flags. There is no "cloud run on a host": placement is chosen once.
 and follow-up messaging across rush / codex / factory / antigravity / host,
 with agent auto-routing via the `cloudProvider` field on the agent registry.
 The alternative — appending each harness's native flag (`claude --cloud`,
-`codex exec --cloud`, `cursor-agent --cloud`) — was rejected: sessions would
+`codex exec --cloud`, or a nonexistent `cursor-agent --cloud`) — was rejected: sessions would
 live outside `agents cloud list/status/logs/cancel/message`, tracking would be
 uneven per vendor, and the flag would silently mean a different backend per
 agent.
@@ -42,7 +42,7 @@ agent.
 |---|---|---|
 | claude | `claude --cloud "<prompt>"` (hidden flag, docs 2026-08-04; Anthropic infra, claude.ai/code; needs claude.ai sub auth) | `rush` (unchanged by this spec) |
 | codex | `codex cloud exec` / `codex exec --cloud` | `codex` (provider already wraps the native CLI) |
-| cursor | `cursor-agent --cloud` (since 2026-03) | **none yet** — fails loud until a cursor provider lands (follow-up) |
+| cursor | Cursor Cloud Agents REST API (`api.cursor.com/v1`) | `cursor` (added by RUSH-2228) |
 | droid | Factory pods | `factory` |
 | antigravity | Gemini Managed Agents | `antigravity` |
 | kimi | none found (kimi-cli is local-only; kimi-agent-sdk is programmatic, not cloud) | unsupported — fail loud |
@@ -108,7 +108,7 @@ agents run <agent> [prompt] --cloud [--provider <id>] [--repo <owner/repo>]...
   has no headless Anthropic-hosted dispatch CLI") — `claude --cloud` now
   exists; record that routing to `rush` is deliberate (this doc).
 - Tests (real path, no mocks): registry routing for each capable agent
-  (claude→rush, codex→codex, droid→factory, antigravity→antigravity), the
+  (claude→rush, codex→codex, cursor→cursor, droid→factory, antigravity→antigravity), the
   unsupported-agent error, each placement-conflict rejection, `--where cloud`
   equivalence. Next to source per repo convention.
 - Docs: `apps/cli/docs/` run reference + `docs/00-concepts.md#placement`,
@@ -116,9 +116,8 @@ agents run <agent> [prompt] --cloud [--provider <id>] [--repo <owner/repo>]...
 
 ## Follow-ups (not in this spec)
 
-- **Cursor provider** wrapping `cursor-agent --cloud`, then
-  `cloudProvider: 'cursor'` on the cursor registry entry — capability flips to
-  supported only in the same PR as the real code path (repo rule).
+- **Cursor provider:** completed by RUSH-2228 through the Cursor Cloud Agents
+  REST API; no `cursor-agent --cloud` wrapper exists or is used.
 - **Kimi / Grok**: no native cloud exists for either; revisit if Moonshot or
   xAI ships one.
 - **Native claude provider** (`claude --cloud` → claude.ai/code) as an

--- a/README.md
+++ b/README.md
@@ -611,10 +611,10 @@ Team state is observable via `agents teams list --json` / `agents teams status -
 
 ## Cloud
 
-Some work shouldn't tie up your laptop. `agents cloud run` hands a task to a managed provider that clones the repo, plans, implements, tests, and opens a PR -- while your terminal stays free. A fifth provider, `host`, dispatches the same way onto machines you own: `agents cloud run "…" --host gpu-box` (tasks track in `agents cloud ps` and `agents hosts ps` alike).
+Some work shouldn't tie up your laptop. `agents cloud run` hands a task to a managed provider that clones the repo, plans, implements, tests, and opens a PR -- while your terminal stays free. The `host` provider dispatches the same way onto machines you own: `agents cloud run "…" --host gpu-box` (tasks track in `agents cloud ps` and `agents hosts ps` alike).
 
 <p align="center">
-  <img src="assets/cloud.svg" alt="agents cloud run dispatches one prompt to a managed provider (Rush, Codex, Factory, or Antigravity) that clones, plans, tests, and opens a pull request while you keep working" width="100%" />
+  <img src="assets/cloud.svg" alt="agents cloud run dispatches one prompt to a managed provider (Rush, Codex, Cursor, Factory, or Antigravity) that runs while you keep working" width="100%" />
 </p>
 
 ```bash
@@ -628,7 +628,7 @@ agents cloud message <id> "also update the changelog"  # steer it mid-run
 agents cloud cancel <id>
 ```
 
-Four managed backends behind one interface (`agents cloud providers`):
+Five managed backends behind one interface (`agents cloud providers`):
 
 | Provider | What runs | Notes |
 |---|---|---|
@@ -636,6 +636,7 @@ Four managed backends behind one interface (`agents cloud providers`):
 | `codex` | A pre-built Codex Cloud environment | Target it with `--env`. |
 | `factory` | `droid exec` on a cloud VM | Computer-use; pick the box with `--computer`. |
 | `antigravity` | Gemini managed agents | Antigravity harness in a remote sandbox. |
+| `cursor` | Cursor Cloud Agents | v1 REST API with repo, status, SSE, cancel, and follow-up runs. |
 
 Auto-routes each `--agent` to its native cloud, or pin the backend with `--provider`. Instead of dispatching now, register a run as an **event trigger** with `--on pull_request` (also `push`, `issue_comment`, `workflow_run`) -- it persists as a trigger-bound routine that fires on the event. `--json` on every subcommand for scripting.
 

--- a/apps/cli/.changelog/next/RUSH-2228-cursor-cloud.md
+++ b/apps/cli/.changelog/next/RUSH-2228-cursor-cloud.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+Add Cursor Cloud Agents as a native cloud provider so `agents run cursor --cloud` and `agents cloud run --agent cursor` dispatch through Cursor's v1 REST API, with status, streaming, cancellation, and follow-up runs.

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -226,8 +226,8 @@ one door:
 **Cloud placement.** `--cloud` routes the run to the agent's native vendor
 cloud through the provider registry — the same dispatch as `agents cloud run
 --agent <agent>`, tracked by `agents cloud list/status/logs/cancel/message`.
-Routing: claude→rush, codex→codex, droid→factory, antigravity→antigravity;
-`--provider` overrides. An agent with no native cloud (kimi, grok, cursor,
+Routing: claude→rush, codex→codex, cursor→cursor, droid→factory, antigravity→antigravity;
+`--provider` overrides. An agent with no native cloud (kimi, grok,
 opencode, …) fails loud unless `--provider` is given. Cloud tasks run in the
 provider's workspace on the provider's accounts, so local-run flags
 (`--loop`, `--resume`, `--secrets`, `--terminal`, `--cwd`, account strategy,

--- a/apps/cli/docs/cloud.md
+++ b/apps/cli/docs/cloud.md
@@ -5,10 +5,10 @@ Run agent tasks on remote infrastructure across multiple cloud backends, with un
 ## Overview
 
 `agents cloud` dispatches tasks to remote agent environments without requiring
-a local CLI session. **Each agent runs in its own cloud** — four providers ship
+a local CLI session. **Each agent runs in its own cloud** — five managed providers ship
 today: Rush Cloud (Claude against a GitHub repo → PR), Codex Cloud (pre-built
 Codex environments), Factory (Droid on a cloud Droid Computer), and Antigravity
-(Gemini Managed Agents). Pass `--agent` and the provider is auto-selected;
+(Gemini Managed Agents), plus Cursor Cloud Agents. Pass `--agent` and the provider is auto-selected;
 `--provider` overrides. Every dispatched task is tracked in a local SQLite store
 so `agents cloud list` shows the full history across all providers, and transient
 states (`queued`, `allocating`, `running`, `input_required`) are refreshed
@@ -29,6 +29,7 @@ in `~/.agents/agents.yaml` > `rush`.
 | `codex` | `codex` | `codex cloud exec` — first-class native CLI. |
 | `droid` | `factory` | Factory Droid Computer (cloud VM) via `droid computer ssh` + remote `droid exec`. |
 | `antigravity` | `antigravity` | Gemini Managed Agents Interactions API (remote sandbox). |
+| `cursor` | `cursor` | Cursor Cloud Agents v1 REST API (repo-backed or no-repo agent). |
 
 ### Dispatch from `agents run` — the `--cloud` placement
 
@@ -38,6 +39,7 @@ The same dispatch is a placement on `agents run`
 ```bash
 agents run claude "fix the flaky e2e" --cloud --repo acme/example
 agents run codex "add parser tests" --cloud --cloud-env env_a1b2c3
+agents run cursor "fix the flaky parser test" --cloud --repo acme/example
 agents run claude "…" --where cloud:codex   # one-door spelling (+ provider)
 ```
 
@@ -47,7 +49,7 @@ accepts `--provider`, `--repo` (repeatable), `--branch`, `--cloud-env` (run's
 `--env` stays the KEY=VAL passthrough), `--timeout`, `--model`, `--no-follow`,
 and `--json`; local-run flags (`--loop`, `--resume`, `--secrets`, `--terminal`,
 `--cwd`, account strategy, …) are rejected, not silently dropped. Agents with
-no native cloud (kimi, grok, cursor, opencode, …) fail loud with the capable
+no native cloud (kimi, grok, opencode, …) fail loud with the capable
 list unless `--provider` is given. Both surfaces call the shared dispatch core
 (`executeCloudDispatch` in `src/lib/cloud/dispatch.ts` via
 `src/commands/run-cloud.ts`), so tracking, streaming, and the budget
@@ -93,7 +95,7 @@ CLI (agents cloud run ...)
   │    reads cloud.default_provider  from ~/.agents/agents.yaml
   │    returns CloudProvider impl
   │
-  ├─ provider.dispatch(options)      rush.ts | codex.ts | factory.ts
+  ├─ provider.dispatch(options)      rush.ts | codex.ts | cursor.ts | factory.ts
   │    POST to remote API
   │    returns CloudTask { id, status, ... }
   │
@@ -110,7 +112,7 @@ agents cloud list
   └─ listStoredTasks({ provider, status, limit })
 
 agents cloud providers
-  └─ getAllProviders()                instantiate all three, report capabilities()
+  └─ getAllProviders()                instantiate every provider, report capabilities()
 ```
 
 ## Command Reference
@@ -130,8 +132,8 @@ agents cloud providers
 
 | Flag | Description |
 |---|---|
-| `--provider <id>` | Cloud backend: `rush`, `codex`, `factory` |
-| `--agent <name>` | Agent to run: `claude`, `codex`, `droid` |
+| `--provider <id>` | Cloud backend: `rush`, `codex`, `cursor`, `factory`, `antigravity`, `host` |
+| `--agent <name>` | Agent to run; native cloud routing includes `claude`, `codex`, `cursor`, `droid`, and `antigravity` |
 | `--repo <owner/repo>` | GitHub repository. Repeatable for multi-repo dispatch (Rush Cloud only) |
 | `--branch <name>` | Target git branch |
 | `-p, --prompt <text>` | Inline prompt (alternative to positional argument) |
@@ -170,7 +172,7 @@ agents cloud providers
 
 ## Providers
 
-Four providers are registered at startup (`src/lib/cloud/registry.ts`):
+Six providers, including the `host` machine backend, are registered at startup (`src/lib/cloud/registry.ts`):
 
 | ID | Name | Dispatch target | Multi-repo |
 |---|---|---|---|
@@ -178,6 +180,7 @@ Four providers are registered at startup (`src/lib/cloud/registry.ts`):
 | `codex` | Codex Cloud | Pre-built Codex environment (`--env`) | No — bundle the repos into the env |
 | `factory` | Factory (Droid) | Droid Computer (`--computer`) via relay SSH + `droid exec` | No |
 | `antigravity` | Antigravity (Gemini) | Gemini Managed Agents remote sandbox | No — raw sandbox, no repo → PR |
+| `cursor` | Cursor Cloud Agents | Cursor-hosted agent with optional GitHub repos | Yes — up to the API limit |
 
 The default provider is read from `cloud.default_provider` in
 `~/.agents/agents.yaml`. If unset, it falls back to `rush`. Note that an
@@ -197,6 +200,11 @@ API key comes from an `agents secrets` bundle named in
 `GOOGLE_API_KEY` in the env). It is a raw sandbox — no GitHub repo → PR; pass a
 repo and it routes you to `--provider rush` instead.
 
+**Cursor.** Talks directly to `https://api.cursor.com/v1`; it does not invoke
+`cursor-agent --cloud`. The API key comes from `CURSOR_API_KEY` in the
+`agents secrets` bundle named by `cloud.providers.cursor.secretsBundle`.
+Free-plan keys fail with a paid-plan requirement instead of a generic auth error.
+
 ### Provider configuration (`~/.agents/agents.yaml`)
 
 ```yaml
@@ -212,6 +220,8 @@ cloud:
     antigravity:
       secretsBundle: gemini.com   # agents secrets bundle holding GEMINI_API_KEY
       # model: antigravity-preview-05-2026   # optional managed-agent override
+    cursor:
+      secretsBundle: cursor    # agents secrets bundle holding CURSOR_API_KEY
 ```
 
 Rush Cloud uses the session token injected by `agents` — no separate config

--- a/apps/cli/src/commands/cloud.ts
+++ b/apps/cli/src/commands/cloud.ts
@@ -38,7 +38,7 @@ export function statusColor(status: string): (s: string) => string {
 export function registerCloudCommands(program: Command): void {
   const cloud = program
     .command('cloud', { hidden: true })
-    .description('Dispatch and manage cloud agent tasks across providers (Rush, Codex, Factory, Antigravity).')
+    .description('Dispatch and manage cloud agent tasks across providers (Rush, Codex, Cursor, Factory, Antigravity, Host).')
     .addHelpText('after', `
 Each agent runs in its own cloud. Pass --agent and the provider is auto-selected
 (claude→rush, codex→codex, cursor→cursor, droid→factory, antigravity→antigravity); --provider overrides.
@@ -46,6 +46,7 @@ Each agent runs in its own cloud. Pass --agent and the provider is auto-selected
 Providers:
   rush         Rush Cloud — Claude against a GitHub repo + branch → PR
   codex        Codex Cloud — runs in a pre-built Codex environment (--env)
+  cursor       Cursor Cloud Agents — v1 REST API, with optional GitHub repos
   factory      Factory Droid Computer — droid exec on a cloud VM (--computer)
   antigravity  Gemini Managed Agents — Antigravity harness in a remote sandbox
 
@@ -61,6 +62,9 @@ Examples:
 
   # Codex Cloud against a saved environment
   agents cloud run "add pytest fixtures for the new billing module" --provider codex --env env_a1b2c3 --agent codex --timeout 30m
+
+  # Cursor Cloud Agents against a GitHub repository
+  agents cloud run "fix the flaky parser test" --agent cursor --repo acme/example
 
   # Factory pod targeting a specific computer (Droid)
   agents cloud run "QA the new onboarding flow end-to-end" --provider factory --computer linux-vm-1 --agent droid
@@ -89,10 +93,10 @@ Examples:
     .command('run [prompt]')
     .description('Dispatch a task to a cloud agent.')
     .option('--provider <id>', 'Cloud backend: rush, codex, cursor, factory, antigravity, host (overrides agent auto-routing)')
-    .option('--agent <name>', 'Agent to run: claude, codex, droid, antigravity (auto-routes to its native cloud)')
+    .option('--agent <name>', 'Agent to run: claude, codex, cursor, droid, antigravity (auto-routes to its native cloud)')
     .option(
       '--repo <owner/repo>',
-      'GitHub repository. Repeatable for multi-repo dispatch (Rush Cloud only).',
+      'GitHub repository. Repeatable for multi-repo dispatch (Rush or Cursor Cloud).',
       (value: string, previous: string[] | undefined) => {
         const acc = Array.isArray(previous) ? previous : [];
         acc.push(value);

--- a/apps/cli/src/commands/cloud.ts
+++ b/apps/cli/src/commands/cloud.ts
@@ -41,7 +41,7 @@ export function registerCloudCommands(program: Command): void {
     .description('Dispatch and manage cloud agent tasks across providers (Rush, Codex, Factory, Antigravity).')
     .addHelpText('after', `
 Each agent runs in its own cloud. Pass --agent and the provider is auto-selected
-(claude→rush, codex→codex, droid→factory, antigravity→antigravity); --provider overrides.
+(claude→rush, codex→codex, cursor→cursor, droid→factory, antigravity→antigravity); --provider overrides.
 
 Providers:
   rush         Rush Cloud — Claude against a GitHub repo + branch → PR
@@ -88,7 +88,7 @@ Examples:
   cloud
     .command('run [prompt]')
     .description('Dispatch a task to a cloud agent.')
-    .option('--provider <id>', 'Cloud backend: rush, codex, factory, antigravity, host (overrides agent auto-routing)')
+    .option('--provider <id>', 'Cloud backend: rush, codex, cursor, factory, antigravity, host (overrides agent auto-routing)')
     .option('--agent <name>', 'Agent to run: claude, codex, droid, antigravity (auto-routes to its native cloud)')
     .option(
       '--repo <owner/repo>',

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -855,9 +855,9 @@ export function registerRunCommand(program: Command): void {
     .option('--no-tailscale', 'Force a public-IP lease even when a reuse context would default to Tailscale.')
     .option(
       '--cloud',
-      'Vendor cloud placement: dispatch to the agent\'s native cloud (claude→rush, codex→codex, droid→factory, antigravity→antigravity) and stream the result. Same dispatch as `agents cloud run --agent <agent>`; tracked by `agents cloud list/status/logs`. Same as --where cloud. Mutually exclusive with --host/--lease and local-run flags.',
+      'Vendor cloud placement: dispatch to the agent\'s native cloud (claude→rush, codex→codex, cursor→cursor, droid→factory, antigravity→antigravity) and stream the result. Same dispatch as `agents cloud run --agent <agent>`; tracked by `agents cloud list/status/logs`. Same as --where cloud. Mutually exclusive with --host/--lease and local-run flags.',
     )
-    .option('--provider <id>', 'With --cloud: override the agent\'s native cloud provider (rush | codex | factory | antigravity | host).')
+    .option('--provider <id>', 'With --cloud: override the agent\'s native cloud provider (rush | codex | cursor | factory | antigravity | host).')
     .option(
       '--repo <owner/repo>',
       'With --cloud: GitHub repository. Repeatable for multi-repo dispatch (Rush Cloud only).',

--- a/apps/cli/src/commands/run-cloud.test.ts
+++ b/apps/cli/src/commands/run-cloud.test.ts
@@ -16,7 +16,7 @@ import {
 
 describe('cloudCapableAgentIds', () => {
   it('is exactly the agents with a native cloudProvider in the registry', () => {
-    expect(cloudCapableAgentIds()).toEqual(['antigravity', 'claude', 'codex', 'droid']);
+    expect(cloudCapableAgentIds()).toEqual(['antigravity', 'claude', 'codex', 'cursor', 'droid']);
   });
 });
 
@@ -26,10 +26,11 @@ describe('resolveRunCloudProvider', () => {
     expect(resolveRunCloudProvider('codex').id).toBe('codex');
     expect(resolveRunCloudProvider('droid').id).toBe('factory');
     expect(resolveRunCloudProvider('antigravity').id).toBe('antigravity');
+    expect(resolveRunCloudProvider('cursor').id).toBe('cursor');
   });
 
   it('fails loud for agents with no native cloud, naming the capable set', () => {
-    for (const agent of ['kimi', 'grok', 'cursor', 'opencode']) {
+    for (const agent of ['kimi', 'grok', 'opencode']) {
       expect(() => resolveRunCloudProvider(agent)).toThrow(RunCloudError);
       expect(() => resolveRunCloudProvider(agent)).toThrow(/has no native cloud/);
       expect(() => resolveRunCloudProvider(agent)).toThrow(/claude/);

--- a/apps/cli/src/commands/run-cloud.ts
+++ b/apps/cli/src/commands/run-cloud.ts
@@ -101,7 +101,7 @@ export function resolveRunCloudProvider(agentId: string, explicitProvider?: stri
   if (!nativeProviderForAgent(agentId)) {
     throw new RunCloudError(
       `${agentId} has no native cloud. Cloud-capable agents: ${cloudCapableAgentIds().join(', ')}. ` +
-        `Override with --provider <id> (rush | codex | factory | antigravity | host).`,
+        `Override with --provider <id> (rush | codex | cursor | factory | antigravity | host).`,
     );
   }
   return resolveProvider(undefined, agentId);

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -301,6 +301,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     color: 'cyan',
     cliCommand: 'cursor-agent',
     npmPackage: '',
+    cloudProvider: 'cursor',
     installScript: 'curl https://cursor.com/install -fsS | bash && mv ~/.local/bin/agent ~/.local/bin/cursor-agent && grep -q "/.local/bin" ~/.zshrc || echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.zshrc',
     configDir: path.join(HOME, '.cursor'),
     commandsDir: path.join(HOME, '.cursor', 'commands'),

--- a/apps/cli/src/lib/cloud/agent-routing.test.ts
+++ b/apps/cli/src/lib/cloud/agent-routing.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { resolveProvider, nativeProviderForAgent } from './registry.js';
 
 describe('nativeProviderForAgent', () => {
-  it('maps the four agents to their own cloud', () => {
+  it('maps agents with native clouds', () => {
     expect(nativeProviderForAgent('claude')).toBe('rush');
     expect(nativeProviderForAgent('codex')).toBe('codex');
     expect(nativeProviderForAgent('droid')).toBe('factory');
     expect(nativeProviderForAgent('antigravity')).toBe('antigravity');
+    expect(nativeProviderForAgent('cursor')).toBe('cursor');
   });
 
   it('returns undefined for agents with no native cloud', () => {
     expect(nativeProviderForAgent('gemini')).toBeUndefined();
-    expect(nativeProviderForAgent('cursor')).toBeUndefined();
     expect(nativeProviderForAgent('not-an-agent')).toBeUndefined();
   });
 });
@@ -21,6 +21,7 @@ describe('resolveProvider precedence', () => {
     expect(resolveProvider(undefined, 'codex').id).toBe('codex');
     expect(resolveProvider(undefined, 'droid').id).toBe('factory');
     expect(resolveProvider(undefined, 'antigravity').id).toBe('antigravity');
+    expect(resolveProvider(undefined, 'cursor').id).toBe('cursor');
     expect(resolveProvider(undefined, 'claude').id).toBe('rush');
   });
 

--- a/apps/cli/src/lib/cloud/cursor.test.ts
+++ b/apps/cli/src/lib/cloud/cursor.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { CursorCloudProvider, buildCursorCreateBody, cursorApiError, parseCursorSseFrame, parseCursorTask } from './cursor.js';
+
+describe('Cursor Cloud request parsing', () => {
+  it('builds the documented v1 create body', () => {
+    expect(buildCursorCreateBody({
+      prompt: 'Fix the test',
+      repo: 'https://github.com/acme/app',
+      branch: 'main',
+      model: 'composer-2',
+    })).toEqual({
+      prompt: { text: 'Fix the test' },
+      model: { id: 'composer-2' },
+      repos: [{ url: 'https://github.com/acme/app', startingRef: 'main' }],
+      autoCreatePR: true,
+    });
+  });
+
+  it('maps a Cursor run to a CloudTask', () => {
+    expect(parseCursorTask({
+      id: 'bc-1', status: 'ACTIVE', createdAt: '2026-08-05T00:00:00Z', updatedAt: '2026-08-05T00:01:00Z',
+      repos: [{ url: 'https://github.com/acme/app' }],
+    }, {
+      id: 'run-1', agentId: 'bc-1', status: 'FINISHED', createdAt: '2026-08-05T00:00:00Z', updatedAt: '2026-08-05T00:02:00Z',
+      result: 'Fixed it', git: { branches: [{ repoUrl: 'github.com/acme/app', branch: 'cursor/fix', prUrl: 'https://github.com/acme/app/pull/1' }] },
+    }, 'Fix it')).toMatchObject({
+      id: 'bc-1', provider: 'cursor', status: 'completed', prompt: 'Fix it', repo: 'https://github.com/acme/app',
+      branch: 'cursor/fix', prUrl: 'https://github.com/acme/app/pull/1', summary: 'Fixed it',
+    });
+  });
+
+  it('parses status, text, tool, done, error, and unknown SSE frames', () => {
+    expect(parseCursorSseFrame('event: status\ndata: {"status":"RUNNING"}')).toMatchObject({ type: 'status', status: 'running' });
+    expect(parseCursorSseFrame('event: assistant\ndata: {"text":"hello"}')).toMatchObject({ type: 'text', content: 'hello' });
+    expect(parseCursorSseFrame('event: thinking\ndata: {"text":"considering"}')).toMatchObject({ type: 'thinking', content: 'considering' });
+    expect(parseCursorSseFrame('event: tool_call\ndata: {"name":"read_file","args":{"path":"a.ts"}}')).toMatchObject({ type: 'tool_use', tool: 'read_file' });
+    expect(parseCursorSseFrame('event: tool_call\ndata: {"name":"read_file","status":"completed","result":{"ok":true}}')).toMatchObject({ type: 'tool_result', tool: 'read_file' });
+    expect(parseCursorSseFrame('event: result\ndata: {"status":"FINISHED","text":"ok"}')).toMatchObject({ type: 'done', status: 'completed', summary: 'ok' });
+    expect(parseCursorSseFrame('event: error\ndata: {"message":"bad"}')).toMatchObject({ type: 'error', message: 'bad' });
+    expect(parseCursorSseFrame('event: future\ndata: value')).toMatchObject({ type: 'unknown', name: 'future', data: 'value' });
+  });
+});
+
+describe('Cursor Cloud API errors', () => {
+  it('distinguishes a free-plan key from invalid authentication', () => {
+    expect(cursorApiError('dispatch', 403, JSON.stringify({ error: { code: 'plan_required', message: 'Upgrade required' } })).message)
+      .toContain('requires a paid Cursor plan');
+    expect(cursorApiError('dispatch', 401, JSON.stringify({ error: { code: 'unauthorized', message: 'Bad key' } })).message)
+      .toContain('authentication failed');
+  });
+});
+
+describe('CursorCloudProvider auth', () => {
+  it('fails loud with the agents secrets command when no key is configured', async () => {
+    const old = process.env.CURSOR_API_KEY;
+    delete process.env.CURSOR_API_KEY;
+    try {
+      const provider = new CursorCloudProvider();
+      expect(provider.capabilities().available).toBe(false);
+      await expect(provider.dispatch({ prompt: 'test' })).rejects.toThrow('agents secrets add cursor CURSOR_API_KEY');
+    } finally {
+      if (old === undefined) delete process.env.CURSOR_API_KEY;
+      else process.env.CURSOR_API_KEY = old;
+    }
+  });
+});
+
+describe.skipIf(!process.env.CURSOR_API_KEY)('Cursor Cloud live API (skipped: CURSOR_API_KEY is not present)', () => {
+  it('lists agents through the real v1 API', async () => {
+    await expect(new CursorCloudProvider().list()).resolves.toBeInstanceOf(Array);
+  });
+});

--- a/apps/cli/src/lib/cloud/cursor.ts
+++ b/apps/cli/src/lib/cloud/cursor.ts
@@ -1,0 +1,265 @@
+/** Cursor Cloud Agents provider backed by the public v1 REST API. */
+
+import type {
+  CloudEvent,
+  CloudProvider,
+  CloudTask,
+  CloudTaskStatus,
+  DispatchOptions,
+  ProviderCapabilities,
+} from './types.js';
+import { normalizeProviderStatus, resolveDispatchRepos } from './types.js';
+import { readAndResolveBundleEnv } from '../secrets/bundles.js';
+
+export const CURSOR_API_BASE_URL = 'https://api.cursor.com/v1';
+const KEY_NAME = 'CURSOR_API_KEY';
+
+interface CursorAgent {
+  id: string;
+  name?: string;
+  status: 'ACTIVE' | 'ARCHIVED';
+  createdAt: string;
+  updatedAt: string;
+  latestRunId?: string;
+  repos?: Array<{ url: string; startingRef?: string; prUrl?: string }>;
+}
+
+interface CursorRun {
+  id: string;
+  agentId: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  result?: string;
+  git?: { branches?: Array<{ repoUrl: string; branch?: string; prUrl?: string }> };
+}
+
+interface CursorErrorBody {
+  error?: { code?: string; message?: string; helpUrl?: string } | string;
+}
+
+export interface CursorCreateBody {
+  prompt: { text: string; images?: Array<{ data: string; mimeType: string }> };
+  model?: { id: string };
+  repos?: Array<{ url: string; startingRef?: string }>;
+  autoCreatePR?: boolean;
+  envVars?: Record<string, string>;
+}
+
+/** Translate unified dispatch options into Cursor's documented v1 create shape. */
+export function buildCursorCreateBody(options: DispatchOptions): CursorCreateBody {
+  const repos = resolveDispatchRepos(options);
+  const body: CursorCreateBody = { prompt: { text: options.prompt } };
+  if (options.images?.length) {
+    body.prompt.images = options.images.map(({ data, mimeType }) => ({ data, mimeType }));
+  }
+  if (options.model) body.model = { id: options.model };
+  if (repos.length) {
+    body.repos = repos.map((url) => ({ url, ...(options.branch ? { startingRef: options.branch } : {}) }));
+    body.autoCreatePR = true;
+  }
+  if (options.env && Object.keys(options.env).length) body.envVars = options.env;
+  return body;
+}
+
+/** Map one Cursor agent/run pair into the provider-neutral task shape. */
+export function parseCursorTask(agent: CursorAgent, run: CursorRun, prompt = ''): CloudTask {
+  const branch = run.git?.branches?.[0];
+  return {
+    id: agent.id,
+    provider: 'cursor',
+    status: normalizeProviderStatus('cursor', run.status),
+    agent: 'cursor',
+    prompt: prompt || agent.name || '',
+    repo: agent.repos?.[0]?.url,
+    repos: agent.repos?.map((repo) => repo.url),
+    branch: branch?.branch,
+    prUrl: branch?.prUrl,
+    createdAt: agent.createdAt,
+    updatedAt: run.updatedAt,
+    summary: run.result,
+  };
+}
+
+/** Parse one complete SSE frame into a shared cloud event. */
+export function parseCursorSseFrame(frame: string): CloudEvent | undefined {
+  let eventName = 'message';
+  const data: string[] = [];
+  for (const line of frame.split(/\r?\n/)) {
+    if (line.startsWith('event:')) eventName = line.slice(6).trim();
+    else if (line.startsWith('data:')) data.push(line.slice(5).trimStart());
+  }
+  if (!data.length) return undefined;
+  const raw = data.join('\n');
+  let value: unknown = raw;
+  try { value = JSON.parse(raw); } catch { /* Cursor may send plain text. */ }
+  const obj = typeof value === 'object' && value !== null ? value as Record<string, unknown> : {};
+  const timestamp = typeof obj.timestamp === 'string' ? obj.timestamp : undefined;
+
+  if (eventName === 'status') {
+    const status = String(obj.status ?? obj.data ?? raw);
+    return { type: 'status', status: normalizeProviderStatus('cursor', status), timestamp };
+  }
+  if (eventName === 'assistant') {
+    return { type: 'text', content: String(obj.text ?? obj.content ?? obj.data ?? raw), timestamp };
+  }
+  if (eventName === 'thinking') {
+    return { type: 'thinking', content: String(obj.text ?? obj.content ?? obj.data ?? raw), timestamp };
+  }
+  if (eventName === 'tool_call') {
+    if (obj.status === 'completed') {
+      return { type: 'tool_result', tool: String(obj.name ?? 'tool'), output: obj.result ?? obj, timestamp };
+    }
+    return { type: 'tool_use', tool: String(obj.name ?? 'tool'), input: obj.args ?? obj, timestamp };
+  }
+  if (eventName === 'result' || eventName === 'done') {
+    const status = normalizeProviderStatus('cursor', String(obj.status ?? 'FINISHED'));
+    return { type: 'done', status, summary: typeof obj.text === 'string' ? obj.text : undefined, timestamp };
+  }
+  if (eventName === 'error') {
+    return { type: 'error', message: String(obj.message ?? raw), timestamp };
+  }
+  return { type: 'unknown', name: eventName, data: raw, timestamp };
+}
+
+/** Turn Cursor's structured API errors into actionable provider errors. */
+export function cursorApiError(action: string, status: number, text: string): Error {
+  let parsed: CursorErrorBody = {};
+  try { parsed = JSON.parse(text) as CursorErrorBody; } catch { /* preserve raw body */ }
+  const detail = typeof parsed.error === 'object' ? parsed.error : undefined;
+  const code = detail?.code;
+  const message = detail?.message ?? (typeof parsed.error === 'string' ? parsed.error : text.slice(0, 500));
+  if (code === 'plan_required') {
+    return new Error(`Cursor Cloud Agents requires a paid Cursor plan; this API key belongs to a plan without Cloud Agents access. ${message}`);
+  }
+  if (status === 401 || code === 'unauthorized' || code === 'api_key_not_found') {
+    return new Error(`Cursor Cloud authentication failed (${status}${code ? ` ${code}` : ''}). Check CURSOR_API_KEY in the configured agents secrets bundle. ${message}`);
+  }
+  return new Error(`Cursor Cloud ${action} failed (${status}${code ? ` ${code}` : ''}): ${message}`);
+}
+
+export class CursorCloudProvider implements CloudProvider {
+  id = 'cursor' as const;
+  name = 'Cursor Cloud Agents';
+  private secretsBundle?: string;
+
+  constructor(config?: { secretsBundle?: string }) {
+    this.secretsBundle = config?.secretsBundle;
+  }
+
+  private hasKeySource(): boolean {
+    return Boolean(this.secretsBundle || process.env[KEY_NAME]);
+  }
+
+  private resolveApiKey(): string {
+    if (this.secretsBundle) {
+      try {
+        const { env } = readAndResolveBundleEnv(this.secretsBundle, { caller: 'cloud:cursor', agentOnly: true });
+        if (env[KEY_NAME]) return env[KEY_NAME];
+        throw new Error(`Secrets bundle '${this.secretsBundle}' has no ${KEY_NAME}. Add one: agents secrets add ${this.secretsBundle} ${KEY_NAME}`);
+      } catch (err) {
+        throw new Error(`Could not read Cursor API key from bundle '${this.secretsBundle}': ${(err as Error).message}`);
+      }
+    }
+    if (process.env[KEY_NAME]) return process.env[KEY_NAME];
+    throw new Error(`Cursor cloud needs an API key. Set cloud.providers.cursor.secretsBundle in ~/.agents/agents.yaml after running: agents secrets add cursor ${KEY_NAME}`);
+  }
+
+  capabilities(): ProviderCapabilities {
+    const available = this.hasKeySource();
+    return {
+      available,
+      dispatch: available,
+      status: available,
+      list: available,
+      stream: available,
+      cancel: available,
+      message: available,
+      multiRepo: true,
+      skills: false,
+      images: true,
+    };
+  }
+
+  private async request(path: string, init?: RequestInit): Promise<Response> {
+    const apiKey = this.resolveApiKey();
+    let response: Response;
+    try {
+      response = await fetch(`${CURSOR_API_BASE_URL}${path}`, {
+        ...init,
+        headers: {
+          authorization: `Basic ${Buffer.from(`${apiKey}:`).toString('base64')}`,
+          ...(init?.body ? { 'content-type': 'application/json' } : {}),
+          ...init?.headers,
+        },
+      });
+    } catch (err) {
+      throw new Error(`Cursor Cloud request failed (network): ${(err as Error).message}`);
+    }
+    if (!response.ok) throw cursorApiError(init?.method ?? 'request', response.status, await response.text());
+    return response;
+  }
+
+  private async latestRun(agent: CursorAgent): Promise<CursorRun> {
+    if (!agent.latestRunId) throw new Error(`Cursor Cloud agent ${agent.id} has no runs.`);
+    return this.request(`/agents/${encodeURIComponent(agent.id)}/runs/${encodeURIComponent(agent.latestRunId)}`)
+      .then((response) => response.json() as Promise<CursorRun>);
+  }
+
+  async dispatch(options: DispatchOptions): Promise<CloudTask> {
+    const response = await this.request('/agents', { method: 'POST', body: JSON.stringify(buildCursorCreateBody(options)) });
+    const payload = await response.json() as { agent: CursorAgent; run: CursorRun };
+    return parseCursorTask(payload.agent, payload.run, options.prompt);
+  }
+
+  async status(taskId: string): Promise<CloudTask> {
+    const agent = await this.request(`/agents/${encodeURIComponent(taskId)}`).then((response) => response.json() as Promise<CursorAgent>);
+    return parseCursorTask(agent, await this.latestRun(agent));
+  }
+
+  async list(filter?: { status?: CloudTaskStatus }): Promise<CloudTask[]> {
+    const { items } = await this.request('/agents?limit=100').then((response) => response.json() as Promise<{ items: CursorAgent[] }>);
+    const tasks = await Promise.all(items.filter((agent) => agent.latestRunId).map(async (agent) => parseCursorTask(agent, await this.latestRun(agent))));
+    return filter?.status ? tasks.filter((task) => task.status === filter.status) : tasks;
+  }
+
+  async *stream(taskId: string): AsyncIterable<CloudEvent> {
+    const agent = await this.request(`/agents/${encodeURIComponent(taskId)}`).then((response) => response.json() as Promise<CursorAgent>);
+    if (!agent.latestRunId) throw new Error(`Cursor Cloud agent ${taskId} has no run to stream.`);
+    const response = await this.request(`/agents/${encodeURIComponent(taskId)}/runs/${encodeURIComponent(agent.latestRunId)}/stream`, {
+      headers: { accept: 'text/event-stream' },
+    });
+    if (!response.body) throw new Error(`Cursor Cloud stream for ${taskId} returned no response body.`);
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      buffer += decoder.decode(value, { stream: !done });
+      const frames = buffer.split(/\r?\n\r?\n/);
+      buffer = frames.pop() ?? '';
+      for (const frame of frames) {
+        const event = parseCursorSseFrame(frame);
+        if (event) yield event;
+      }
+      if (done) break;
+    }
+    if (buffer.trim()) {
+      const event = parseCursorSseFrame(buffer);
+      if (event) yield event;
+    }
+  }
+
+  async cancel(taskId: string): Promise<void> {
+    const agent = await this.request(`/agents/${encodeURIComponent(taskId)}`).then((response) => response.json() as Promise<CursorAgent>);
+    if (!agent.latestRunId) throw new Error(`Cursor Cloud agent ${taskId} has no run to cancel.`);
+    await this.request(`/agents/${encodeURIComponent(taskId)}/runs/${encodeURIComponent(agent.latestRunId)}/cancel`, { method: 'POST' });
+  }
+
+  async message(taskId: string, content: string): Promise<void> {
+    await this.request(`/agents/${encodeURIComponent(taskId)}/runs`, {
+      method: 'POST',
+      body: JSON.stringify({ prompt: { text: content } }),
+    });
+  }
+}

--- a/apps/cli/src/lib/cloud/registry.ts
+++ b/apps/cli/src/lib/cloud/registry.ts
@@ -14,6 +14,7 @@ import { RushCloudProvider } from './rush.js';
 import { CodexCloudProvider } from './codex.js';
 import { FactoryCloudProvider } from './factory.js';
 import { AntigravityCloudProvider } from './antigravity.js';
+import { CursorCloudProvider } from './cursor.js';
 import { HostCloudProvider } from './host.js';
 import { getUserAgentsDir } from '../state.js';
 import { AGENTS } from '../agents.js';
@@ -54,6 +55,7 @@ function initProviders(): void {
   providers.set('codex', new CodexCloudProvider(config.providers?.codex));
   providers.set('factory', new FactoryCloudProvider(config.providers?.factory));
   providers.set('antigravity', new AntigravityCloudProvider(config.providers?.antigravity));
+  providers.set('cursor', new CursorCloudProvider(config.providers?.cursor));
   // Your own machines (agents hosts / agents devices) over SSH. No agent
   // auto-routes here — it's always an explicit --provider host / --host choice.
   providers.set('host', new HostCloudProvider());

--- a/apps/cli/src/lib/cloud/types.test.ts
+++ b/apps/cli/src/lib/cloud/types.test.ts
@@ -114,4 +114,16 @@ describe('normalizeProviderStatus', () => {
       expect(normalizeProviderStatus('antigravity', undefined)).toBe('completed');
     });
   });
+
+  describe('cursor (v1 run statuses)', () => {
+    it('maps every documented run status', () => {
+      expect(normalizeProviderStatus('cursor', 'CREATING')).toBe('queued');
+      expect(normalizeProviderStatus('cursor', 'RUNNING')).toBe('running');
+      expect(normalizeProviderStatus('cursor', 'FINISHED')).toBe('completed');
+      expect(normalizeProviderStatus('cursor', 'ERROR')).toBe('failed');
+      expect(normalizeProviderStatus('cursor', 'EXPIRED')).toBe('failed');
+      expect(normalizeProviderStatus('cursor', 'CANCELLED')).toBe('cancelled');
+      expect(normalizeProviderStatus('cursor', 'future')).toBe('running');
+    });
+  });
 });

--- a/apps/cli/src/lib/cloud/types.ts
+++ b/apps/cli/src/lib/cloud/types.ts
@@ -16,13 +16,14 @@ import type { JobTrigger } from '../routines.js';
  *   - `codex`       — OpenAI Codex Cloud (`codex cloud exec`)
  *   - `factory`     — Factory Droid Computers (`droid computer ssh` + remote `droid exec`)
  *   - `antigravity` — Google Gemini Managed Agents (Interactions API)
+ *   - `cursor`      — Cursor Cloud Agents REST API
  *   - `host`        — a machine you own (`agents hosts` / `agents devices`), over SSH
  *
  * Agents route to their native cloud automatically (see `cloudProvider` in the
  * agent registry); `--provider` overrides. Nothing auto-routes to `host` — it
  * is always an explicit `--provider host` (or `--host <name>`) choice.
  */
-export type CloudProviderId = 'rush' | 'codex' | 'factory' | 'antigravity' | 'host';
+export type CloudProviderId = 'rush' | 'codex' | 'factory' | 'antigravity' | 'cursor' | 'host';
 
 /**
  * Lifecycle state of a cloud-dispatched task.
@@ -42,7 +43,7 @@ export type CloudTaskStatus =
   | 'cancelled';
 
 /** Cloud backends whose wire status is normalized by `normalizeProviderStatus`. */
-export type StatusNormalizingProvider = 'rush' | 'codex' | 'antigravity';
+export type StatusNormalizingProvider = 'rush' | 'codex' | 'antigravity' | 'cursor';
 
 /**
  * Normalize a provider's raw wire status into the canonical `CloudTaskStatus`.
@@ -73,6 +74,21 @@ export function normalizeProviderStatus(
       return normalizeCodexStatus(wireStatus ?? '');
     case 'antigravity':
       return normalizeAntigravityStatus(wireStatus);
+    case 'cursor':
+      return normalizeCursorStatus(wireStatus ?? '');
+  }
+}
+
+/** Cursor Cloud run status → canonical enum. Unknown non-terminal states remain running. */
+function normalizeCursorStatus(s: string): CloudTaskStatus {
+  switch (s.toUpperCase()) {
+    case 'CREATING': return 'queued';
+    case 'RUNNING': return 'running';
+    case 'FINISHED': return 'completed';
+    case 'ERROR':
+    case 'EXPIRED': return 'failed';
+    case 'CANCELLED': return 'cancelled';
+    default: return 'running';
   }
 }
 
@@ -364,6 +380,8 @@ export interface CloudProviderConfig {
    * environment. `model` overrides the default managed-agent id.
    */
   antigravity?: { secretsBundle?: string; model?: string };
+  /** Cursor Cloud Agents API. The API key remains in the named secrets bundle. */
+  cursor?: { secretsBundle?: string };
 }
 
 /** Top-level `cloud` section of agents.yaml. */


### PR DESCRIPTION
Adds the Cursor Cloud Agents REST API as a native cloud provider for Cursor users.

## What changed

- routes `agents run cursor --cloud` and `agents cloud run --agent cursor` to `https://api.cursor.com/v1`
- implements create, status, list, run-scoped SSE, cancel, and follow-up runs
- resolves `CURSOR_API_KEY` through a configured `agents secrets` bundle and distinguishes `plan_required` from invalid authentication
- updates routing tests, provider docs, README, and the next-version changelog

## Verification

No UI surface: this is an HTTP-backed CLI provider.

```text
Test Files  4 passed (4)
Tests       42 passed | 1 skipped (43)
```

The skipped test is the real Cursor v1 list call because this host has no `CURSOR_API_KEY`. Pure request/response/SSE parsers, missing-key behavior, free-plan errors, routing, and the full cloud suite are covered; the full cloud suite also passed 132 tests with the same one credential-gated skip.

```text
$ bun run build
$ tsc ...
exit 0
```

The canonical remote suite could not provision because the available `hetzner.com` secret is on hold and `HCLOUD_TOKEN` resolved empty. A local full-suite pass exposed and led to fixing the two stale Cursor routing assertions; unrelated host-state fixtures still failed outside this diff.

## Tracking

- [RUSH-2228](https://linear.app/getrush/issue/RUSH-2228/add-a-cursor-cloud-provider-cloud-agents-rest-api-so-cloud-works-for)
- Cursor API contract: https://cursor.com/docs/cloud-agent/api/endpoints