### PR TITLE
fix(sessions): OpenCode per-session scan ledger (RUSH-2210)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2210-opencode-scan-ledger.md
+++ b/apps/cli/.changelog/next/RUSH-2210-opencode-scan-ledger.md
@@ -3,7 +3,13 @@
   with that whole file's mtime/size. Any write to any session therefore invalidated every
   indexed session, so a single new turn re-emitted up to 1000 sessions — and the indexer
   re-opened `opencode.db` once per re-emitted session to re-parse a transcript that had
-  not moved. Each session is now stamped with its own row's `time_updated` + message
-  count, so an unchanged session is skipped; the file-level stat stays only as the cheap
-  "nothing changed at all" short-circuit, and a scan opens `opencode.db` once instead of
-  once per session. Source: `apps/cli/src/lib/session/discover.ts`.
+  not moved. Each session is now stamped with its own newest write time (across its
+  `session` row, its messages, and its parts) and the byte length of its message + part
+  payloads, so an unchanged session is skipped; the file-level stat stays only as the
+  cheap "nothing changed at all" short-circuit, and a scan opens `opencode.db` once
+  instead of once per session. The stamp deliberately does not rely on
+  `session.time_updated` alone, which real databases leave hours behind the session's
+  newest part. A side effect: `sessions.file_size` for an OpenCode row is now that
+  session's payload size instead of the whole database's size, so the tool-backfill byte
+  budget and its 16 MiB in-memory parser cap finally reflect the real cost of parsing
+  that one session. Source: `apps/cli/src/lib/session/discover.ts`.

--- a/apps/cli/.changelog/next/RUSH-2210-opencode-scan-ledger.md
+++ b/apps/cli/.changelog/next/RUSH-2210-opencode-scan-ledger.md
@@ -1,0 +1,9 @@
+- **OpenCode session scans re-index only the sessions that changed (RUSH-2210).** OpenCode
+  keeps every session in one shared `opencode.db`, and the scanner stamped each session
+  with that whole file's mtime/size. Any write to any session therefore invalidated every
+  indexed session, so a single new turn re-emitted up to 1000 sessions — and the indexer
+  re-opened `opencode.db` once per re-emitted session to re-parse a transcript that had
+  not moved. Each session is now stamped with its own row's `time_updated` + message
+  count, so an unchanged session is skipped; the file-level stat stays only as the cheap
+  "nothing changed at all" short-circuit, and a scan opens `opencode.db` once instead of
+  once per session. Source: `apps/cli/src/lib/session/discover.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -134,6 +134,15 @@ create / delete / rename bumps the dir mtime and forces a full re-walk of that d
 Set `AGENTS_SESSIONS_NO_DIR_LEDGER=1` to disable the short-circuit and force the old
 full per-file walk.
 
+**OpenCode is stamped per row, not per file.** It keeps every session in one shared
+`~/.local/share/opencode/opencode.db`, so that file's `(mtime, size)` moves whenever
+*any* session is written and cannot say which one changed. Its `scan_ledger` stamp is
+the session row's own `time_updated` plus its message count, keyed by the synthetic
+`opencode.db#<id>` path; the file-level stat is kept only as the cheap "nothing changed
+at all" short-circuit for the whole harness. Before this, one new turn re-emitted every
+indexed OpenCode session (up to the scan's `LIMIT 1000`) and re-opened the database
+once per re-emitted session to re-parse a transcript that had not moved (RUSH-2210).
+
 Cursor is installed outside agents-cli's version homes. Once any managed agent
 version exists, the default managed scope excludes Cursor transcripts; pass
 `--unmanaged` (for example, `agents sessions --agent cursor --unmanaged`) to list

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -137,11 +137,24 @@ full per-file walk.
 **OpenCode is stamped per row, not per file.** It keeps every session in one shared
 `~/.local/share/opencode/opencode.db`, so that file's `(mtime, size)` moves whenever
 *any* session is written and cannot say which one changed. Its `scan_ledger` stamp is
-the session row's own `time_updated` plus its message count, keyed by the synthetic
-`opencode.db#<id>` path; the file-level stat is kept only as the cheap "nothing changed
-at all" short-circuit for the whole harness. Before this, one new turn re-emitted every
-indexed OpenCode session (up to the scan's `LIMIT 1000`) and re-opened the database
-once per re-emitted session to re-parse a transcript that had not moved (RUSH-2210).
+keyed by the synthetic `opencode.db#<id>` path and holds, for that session alone: the
+newest write time across its `session` row, its messages, and its parts, paired with
+the total byte length of its message + part payloads. The file-level stat is kept only
+as the cheap "nothing changed at all" short-circuit for the whole harness. Before this,
+one new turn re-emitted every indexed OpenCode session (up to the scan's `LIMIT 1000`)
+and re-opened the database once per re-emitted session to re-parse a transcript that
+had not moved (RUSH-2210).
+
+Both halves of that stamp are load-bearing. `session.time_updated` alone is **not** the
+session's change signal — on a real database, parts land long after the session row was
+last touched (one session carried `time_updated = 1771316403087` with its newest part
+over four hours later), so a stamp built from it would call that session unchanged
+forever. And the byte total is a genuine size rather than a row counter, because
+`sessions.file_size` is read back as bytes elsewhere: `ensureToolIndex` uses it as the
+tool-backfill byte budget and `toolCallsForBackfill` as the 16 MiB in-memory parser cap
+([`src/lib/session/tool-index.ts`](../src/lib/session/tool-index.ts)). A per-session
+message + part byte total is the honest parse cost, where this column previously held
+the whole database's size for every OpenCode row.
 
 Cursor is installed outside agents-cli's version homes. Once any managed agent
 version exists, the default managed scope excludes Cursor transcripts; pass

--- a/apps/cli/src/lib/session/discover.opencode-ledger.test.ts
+++ b/apps/cli/src/lib/session/discover.opencode-ledger.test.ts
@@ -261,6 +261,27 @@ describe('OpenCode per-session scan ledger (RUSH-2210)', () => {
     expect(expected).toBeGreaterThan(SESSION_COUNT); // not a count masquerading as bytes
   });
 
+  it('counts BYTES, not characters, for multi-byte content', async () => {
+    const target = 'ses_fixture07';
+    await scan();
+    const before = ledgerFor(target);
+
+    // SQLite's LENGTH() on a TEXT column returns characters: LENGTH('日本語')
+    // is 3, LENGTH(CAST('日本語' AS BLOB)) is 9. The stamp is a byte budget
+    // downstream (tool-index.ts), so a CJK transcript must not report a third
+    // of its real size.
+    const cjk = '日本語'.repeat(200); // 600 chars, 1800 UTF-8 bytes
+    appendPartTo(target, `${target}-m0`, Date.UTC(2026, 6, 2, 6), cjk);
+
+    await scan();
+
+    const grew = ledgerFor(target).file_size - before.file_size;
+    expect(grew).toBeGreaterThan(1800);
+    expect(grew).toBeGreaterThan(Buffer.byteLength(cjk, 'utf8'));
+    // A character count would have grown by only ~600 plus the JSON envelope.
+    expect(grew).toBeGreaterThan(cjk.length * 2);
+  });
+
   it('emits nothing when the DB file changes but no session row does', async () => {
     await scan();
 

--- a/apps/cli/src/lib/session/discover.opencode-ledger.test.ts
+++ b/apps/cli/src/lib/session/discover.opencode-ledger.test.ts
@@ -109,10 +109,44 @@ function appendTurnTo(sessionId: string, ts: number, text: string): void {
   bumpDbMtime(ts);
 }
 
+/**
+ * Append a PART to a session's existing message without touching `session` or
+ * `message`. This is not hypothetical: on a real `opencode.db` (mac-mini,
+ * 74 sessions) `ses_3955202dfffe7C4oedWxL38Lul` carried
+ * `time_updated = 1771316403087` with its newest part at `1771331512162` — over
+ * four hours later. A stamp built from `session.time_updated` alone would call
+ * that session unchanged forever.
+ */
+function appendPartTo(sessionId: string, messageId: string, ts: number, text: string): void {
+  const oc = openFixture();
+  oc.prepare(`INSERT INTO part (id, message_id, session_id, data, time_created) VALUES (?, ?, ?, ?, ?)`)
+    .run(`${messageId}-p-${ts}`, messageId, sessionId, JSON.stringify({ type: 'text', text }), ts);
+  oc.close();
+  bumpDbMtime(ts);
+}
+
+/**
+ * Grow an EXISTING part's `data` in place — a streaming turn — with no new row,
+ * no new id, and no timestamp anywhere moving.
+ */
+function growPartInPlace(partId: string, text: string, ts: number): void {
+  const oc = openFixture();
+  oc.prepare(`UPDATE part SET data = ? WHERE id = ?`).run(JSON.stringify({ type: 'text', text }), partId);
+  oc.close();
+  bumpDbMtime(ts);
+}
+
 /** Force the DB file's mtime forward so the whole-DB short-circuit sees a delta. */
 function bumpDbMtime(ts: number): void {
   const secs = Math.floor(ts / 1000);
   fs.utimesSync(OPENCODE_DB, secs, secs);
+}
+
+/** The per-session ledger row the scan wrote, read back from sessions.db. */
+function ledgerFor(sessionId: string): { file_mtime_ms: number; file_size: number } {
+  return db.getDB()
+    .prepare(`SELECT file_mtime_ms, file_size FROM scan_ledger WHERE file_path = ?`)
+    .get(`${OPENCODE_DB}#${sessionId}`) as { file_mtime_ms: number; file_size: number };
 }
 
 // `skipExistenceCheck` because an OpenCode filePath is `opencode.db#<id>` — a
@@ -171,6 +205,60 @@ describe('OpenCode per-session scan ledger (RUSH-2210)', () => {
     // re-emitted entry); now it is the scan handle plus the single changed row.
     expect(openCounter.count).toBeLessThanOrEqual(3);
     expect(openCounter.count).toBeLessThan(SESSION_COUNT);
+  });
+
+  it('catches a part appended with NO write to session or message', async () => {
+    const target = 'ses_fixture05';
+    await scan();
+    const before = ledgerFor(target);
+
+    // The real-world shape: a part lands hours after session.time_updated.
+    appendPartTo(target, `${target}-m0`, Date.UTC(2026, 6, 2, 4), 'a part written much later');
+
+    openCounter.match = OPENCODE_DB;
+    openCounter.count = 0;
+    await scan();
+
+    const after = ledgerFor(target);
+    // The stamp moved on the part's own time and on the added bytes, so the
+    // session was re-indexed rather than skipped forever.
+    expect(after.file_mtime_ms).toBeGreaterThan(before.file_mtime_ms);
+    expect(after.file_size).toBeGreaterThan(before.file_size);
+    // Still only this one session was re-emitted.
+    expect(openCounter.count).toBeLessThanOrEqual(3);
+  });
+
+  it('catches an existing part rewritten in place (no new row, no timestamp move)', async () => {
+    const target = 'ses_fixture06';
+    await scan();
+    const before = ledgerFor(target);
+
+    growPartInPlace(`${target}-m0-p0`, 'x'.repeat(4096), Date.UTC(2026, 6, 2, 5));
+
+    await scan();
+
+    const after = ledgerFor(target);
+    // No timestamp anywhere changed — the byte total is what caught it.
+    expect(after.file_mtime_ms).toBe(before.file_mtime_ms);
+    expect(after.file_size).toBeGreaterThan(before.file_size);
+  });
+
+  it('stamps file_size in real bytes, which tool-index reads as a byte budget', async () => {
+    await scan();
+    // `sessions.file_size` feeds ensureToolIndex's byte budget and
+    // toolCallsForBackfill's 16 MiB in-memory cap (tool-index.ts), so the value
+    // must be a genuine payload size — not a repurposed row counter.
+    const row = db.getDB()
+      .prepare(`SELECT file_size FROM sessions WHERE id = ?`)
+      .get('ses_fixture00') as { file_size: number };
+    const oc = openFixture();
+    const expected = (oc.prepare(
+      `SELECT (SELECT COALESCE(SUM(LENGTH(data)),0) FROM message WHERE session_id = ?)
+            + (SELECT COALESCE(SUM(LENGTH(data)),0) FROM part WHERE session_id = ?) AS n`,
+    ).get('ses_fixture00', 'ses_fixture00') as { n: number }).n;
+    oc.close();
+    expect(row.file_size).toBe(expected);
+    expect(expected).toBeGreaterThan(SESSION_COUNT); // not a count masquerading as bytes
   });
 
   it('emits nothing when the DB file changes but no session row does', async () => {

--- a/apps/cli/src/lib/session/discover.opencode-ledger.test.ts
+++ b/apps/cli/src/lib/session/discover.opencode-ledger.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Count how many times `opencode.db` is OPENED. That is the cost RUSH-2210 is
+// about: the whole-DB mtime stamp re-emitted every indexed session on any DB
+// write, and upsertSessionsBatch's enrichment then re-opened this same file once
+// per re-emitted entry (via parseSession -> parseOpenCode). Wrapping the shared
+// sqlite shim is the honest way to measure it — the counter is a top-level const
+// captured by the factory closure, matching discover.dir-ledger.test.ts (Bun's
+// runner does not hoist vi.mock, so a plain const works in both runners).
+const openCounter: { match: string | null; count: number } = { match: null, count: 0 };
+
+vi.mock('../sqlite.js', async () => {
+  const actual = await vi.importActual<typeof import('../sqlite.js')>('../sqlite.js');
+  const Real = actual.default as any;
+  class Counting extends Real {
+    constructor(filename: string) {
+      if (openCounter.match !== null && filename === openCounter.match) openCounter.count++;
+      super(filename);
+    }
+  }
+  return { ...actual, default: Counting };
+});
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// db.ts + discover.ts resolve their paths from HOME at module-import time. Point
+// HOME at a throwaway dir BEFORE importing so the suite runs against a clean,
+// isolated sessions DB and a synthetic opencode.db (real fs, real sqlite).
+const REAL_HOME = process.env.HOME;
+const REAL_USERPROFILE = process.env.USERPROFILE;
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-opencode-ledger-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+const OPENCODE_DB = path.join(tmpHome, '.local', 'share', 'opencode', 'opencode.db');
+
+type Discover = typeof import('./discover.js');
+type DB = typeof import('./db.js');
+type Sqlite = typeof import('../sqlite.js');
+
+let discover: Discover;
+let db: DB;
+let Database: Sqlite['default'];
+
+const SESSION_COUNT = 12;
+
+/** Open the synthetic opencode.db directly (not counted — the counter is off). */
+function openFixture() {
+  return new (Database as any)(OPENCODE_DB);
+}
+
+/**
+ * Build an opencode.db with the tables the scanner and parser read: `session`
+ * (one row per session), `message`/`part` (the transcript parseOpenCode walks),
+ * and `control_account` (the active account email).
+ */
+function seedFixture(): void {
+  fs.mkdirSync(path.dirname(OPENCODE_DB), { recursive: true });
+  const oc = openFixture();
+  oc.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY, parent_id TEXT, title TEXT, directory TEXT,
+      version TEXT, time_created INTEGER, time_updated INTEGER
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY, session_id TEXT, data TEXT, time_created INTEGER
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, data TEXT, time_created INTEGER
+    );
+    CREATE TABLE control_account (email TEXT, active INTEGER);
+    INSERT INTO control_account (email, active) VALUES ('dev@example.com', 1);
+  `);
+
+  const base = Date.UTC(2026, 6, 1);
+  for (let i = 0; i < SESSION_COUNT; i++) {
+    const id = `ses_fixture${String(i).padStart(2, '0')}`;
+    const t = base + i * 60_000;
+    oc.prepare(
+      `INSERT INTO session (id, parent_id, title, directory, version, time_created, time_updated)
+       VALUES (?, NULL, ?, ?, ?, ?, ?)`,
+    ).run(id, `session ${i}`, path.join(tmpHome, 'proj'), '0.3.0', t, t);
+    addMessage(oc, id, `${id}-m0`, t, `first turn of ${i}`);
+  }
+  oc.close();
+}
+
+/** Append one user message + its text part to a session. */
+function addMessage(oc: any, sessionId: string, messageId: string, ts: number, text: string): void {
+  oc.prepare(`INSERT INTO message (id, session_id, data, time_created) VALUES (?, ?, ?, ?)`)
+    .run(messageId, sessionId, JSON.stringify({ role: 'user' }), ts);
+  oc.prepare(`INSERT INTO part (id, message_id, session_id, data, time_created) VALUES (?, ?, ?, ?, ?)`)
+    .run(`${messageId}-p0`, messageId, sessionId, JSON.stringify({ type: 'text', text }), ts);
+}
+
+/**
+ * Write to the shared DB the way OpenCode does: append a turn to ONE session and
+ * move that row's `time_updated`. Every other session row is untouched, but the
+ * DB file's own mtime/size moves — the exact shape that used to re-emit all of
+ * them.
+ */
+function appendTurnTo(sessionId: string, ts: number, text: string): void {
+  const oc = openFixture();
+  addMessage(oc, sessionId, `${sessionId}-m-${ts}`, ts, text);
+  oc.prepare(`UPDATE session SET time_updated = ? WHERE id = ?`).run(ts, sessionId);
+  oc.close();
+  bumpDbMtime(ts);
+}
+
+/** Force the DB file's mtime forward so the whole-DB short-circuit sees a delta. */
+function bumpDbMtime(ts: number): void {
+  const secs = Math.floor(ts / 1000);
+  fs.utimesSync(OPENCODE_DB, secs, secs);
+}
+
+// `skipExistenceCheck` because an OpenCode filePath is `opencode.db#<id>` — a
+// row address inside the shared DB, not a file `fs.existsSync` can stat.
+async function scan() {
+  return discover.discoverSessions({ agent: 'opencode', all: true, skipExistenceCheck: true });
+}
+
+beforeAll(async () => {
+  Database = (await import('../sqlite.js')).default;
+  db = await import('./db.js');
+  discover = await import('./discover.js');
+  db.getDB(); // create schema
+  seedFixture();
+});
+
+beforeEach(() => {
+  openCounter.match = null;
+  openCounter.count = 0;
+});
+
+afterAll(() => {
+  // Close before removing the tree: Windows refuses to unlink an open file, so a
+  // leaked connection (plus its WAL sidecars) fails the whole suite there.
+  db.closeDB();
+  if (REAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = REAL_HOME;
+  if (REAL_USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = REAL_USERPROFILE;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('OpenCode per-session scan ledger (RUSH-2210)', () => {
+  it('indexes every session on the first scan', async () => {
+    const sessions = await scan();
+    expect(sessions.length).toBe(SESSION_COUNT);
+    expect(sessions.every(s => s.agent === 'opencode')).toBe(true);
+    expect(sessions.every(s => s.account === 'dev@example.com')).toBe(true);
+  });
+
+  it('re-emits ONLY the changed session when the shared DB is written', async () => {
+    const target = 'ses_fixture03';
+    const before = (await scan()).find(s => s.id === target)!;
+    expect(before.messageCount).toBe(1);
+
+    appendTurnTo(target, Date.UTC(2026, 6, 2), 'second turn');
+
+    openCounter.match = OPENCODE_DB;
+    openCounter.count = 0;
+    const after = await scan();
+
+    // The changed row is re-parsed and its new message count lands...
+    expect(after.find(s => s.id === target)!.messageCount).toBe(2);
+    // ...every other session still surfaces (skipped, not dropped)...
+    expect(after.length).toBe(SESSION_COUNT);
+    // ...and the DB was opened a handful of times, not once per indexed session.
+    // Pre-fix this was 1 (the scan) + SESSION_COUNT (one enrichment parse per
+    // re-emitted entry); now it is the scan handle plus the single changed row.
+    expect(openCounter.count).toBeLessThanOrEqual(3);
+    expect(openCounter.count).toBeLessThan(SESSION_COUNT);
+  });
+
+  it('emits nothing when the DB file changes but no session row does', async () => {
+    await scan();
+
+    // A write that moves the file's stat without touching any session row —
+    // e.g. OpenCode updating its own bookkeeping tables.
+    const oc = openFixture();
+    oc.prepare(`UPDATE control_account SET active = 1`).run();
+    oc.close();
+    bumpDbMtime(Date.UTC(2026, 6, 3));
+
+    openCounter.match = OPENCODE_DB;
+    openCounter.count = 0;
+    const after = await scan();
+
+    expect(after.length).toBe(SESSION_COUNT);
+    // Exactly one open: the scan's own handle. No session was re-emitted, so no
+    // enrichment parse re-opened the file.
+    expect(openCounter.count).toBe(1);
+  });
+
+  it('short-circuits entirely when the DB file itself is unchanged', async () => {
+    await scan();
+
+    openCounter.match = OPENCODE_DB;
+    openCounter.count = 0;
+    const after = await scan();
+
+    expect(after.length).toBe(SESSION_COUNT);
+    expect(openCounter.count).toBe(0);
+  });
+});

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -2239,21 +2239,30 @@ function getOpenCodeAccount(handle?: Database.Database): string | undefined {
  * honest cost of parsing that session — strictly better than the whole-DB size
  * this column used to hold for every OpenCode row.
  *
- * A degenerate row (no finite timestamp anywhere) falls back to the whole-DB
- * stat, keeping the pre-RUSH-2210 always-rescan behavior for exactly those rows
- * rather than pinning them to a stamp that never changes.
+ * The size is `LENGTH(CAST(data AS BLOB))`, not `LENGTH(data)`: SQLite's
+ * `LENGTH()` on a TEXT column counts CHARACTERS, so a CJK/emoji-heavy transcript
+ * would under-report its real size by up to 4x — and this number is a byte
+ * budget downstream.
+ *
+ * A degenerate row — nothing but zeros/NaN for every time AND no payload at all
+ * — falls back to the whole-DB stat, keeping the pre-RUSH-2210 always-rescan
+ * behavior for exactly those rows rather than pinning them to a stamp that never
+ * changes.
  */
 function openCodeSessionStamp(
   times: { timeUpdated: number; timeCreated: number; lastMessageAt: number; lastPartAt: number },
   bytes: { messageBytes: number; partBytes: number },
   dbScan: ScanStamp,
 ): ScanStamp {
-  const finite = [times.timeUpdated, times.lastMessageAt, times.lastPartAt, times.timeCreated]
-    .filter(t => Number.isFinite(t));
-  if (finite.length === 0) return dbScan;
+  // A positive time, not merely a finite one: the SQL COALESCEs the aggregates
+  // to 0, so `Number.isFinite` alone would accept a row that told us nothing and
+  // this branch could never fire.
+  const known = [times.timeUpdated, times.lastMessageAt, times.lastPartAt, times.timeCreated]
+    .filter(t => Number.isFinite(t) && t > 0);
   const size = (Number.isFinite(bytes.messageBytes) ? bytes.messageBytes : 0)
     + (Number.isFinite(bytes.partBytes) ? bytes.partBytes : 0);
-  return { fileMtimeMs: Math.floor(Math.max(...finite)), fileSize: size };
+  if (known.length === 0 && size === 0) return dbScan;
+  return { fileMtimeMs: known.length === 0 ? 0 : Math.floor(Math.max(...known)), fileSize: size };
 }
 
 /** Scan OpenCode sessions from its SQLite database when the DB file has changed. */
@@ -2302,7 +2311,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
         SELECT
           session_id,
           MAX(time_created) AS last_part_at,
-          SUM(LENGTH(data)) AS part_bytes
+          SUM(LENGTH(CAST(data AS BLOB))) AS part_bytes
         FROM part
         GROUP BY session_id
       ) parts ON parts.session_id = s.id
@@ -2311,7 +2320,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
           session_id,
           COUNT(*) AS message_count,
           MAX(time_created) AS last_message_at,
-          SUM(LENGTH(data)) AS message_bytes,
+          SUM(LENGTH(CAST(data AS BLOB))) AS message_bytes,
           SUM(
             COALESCE(json_extract(data, '$.tokens.input'), 0) +
             COALESCE(json_extract(data, '$.tokens.output'), 0) +

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -2178,16 +2178,21 @@ const OPENCODE_DB = path.join(HOME, '.local', 'share', 'opencode', 'opencode.db'
 
 let cachedOpenCodeAccount: string | undefined;
 
-/** Query the active OpenCode account email from its SQLite database. */
-async function getOpenCodeAccount(): Promise<string | undefined> {
+/**
+ * Query the active OpenCode account email from its SQLite database.
+ *
+ * Takes the scan's already-open handle so a scan opens `opencode.db` exactly
+ * once (RUSH-2210); opens its own only when called without one.
+ */
+function getOpenCodeAccount(handle?: Database.Database): string | undefined {
   if (cachedOpenCodeAccount !== undefined) return cachedOpenCodeAccount || undefined;
 
   // Read through the node/bun SQLite wrapper (not the `sqlite3` CLI) so this
   // works on every OS — the CLI is absent on Windows.
-  let db: Database.Database | undefined;
+  let owned: Database.Database | undefined;
   try {
-    if (fs.existsSync(OPENCODE_DB)) {
-      db = new Database(OPENCODE_DB);
+    const db = handle ?? (fs.existsSync(OPENCODE_DB) ? (owned = new Database(OPENCODE_DB)) : undefined);
+    if (db) {
       const row = db
         .prepare('SELECT email FROM control_account WHERE active=1 LIMIT 1;')
         .get() as { email?: unknown } | undefined;
@@ -2199,11 +2204,48 @@ async function getOpenCodeAccount(): Promise<string | undefined> {
     }
   } catch { /* DB not accessible, sqlite module unavailable, or query failed */ }
   finally {
-    try { db?.close(); } catch { /* best-effort close */ }
+    try { owned?.close(); } catch { /* best-effort close */ }
   }
 
   cachedOpenCodeAccount = '';
   return undefined;
+}
+
+/**
+ * The per-session ledger stamp for an OpenCode row.
+ *
+ * OpenCode keeps every session in ONE shared SQLite file, so that file's
+ * mtime/size changes whenever *any* session is written. Stamping each session
+ * with the whole-DB stat therefore invalidated every indexed session on every
+ * scan: up to `LIMIT 1000` sessions were re-emitted into `upsertSessionsBatch`,
+ * and its enrichment step re-opened `opencode.db` once per re-emitted entry via
+ * `parseSession` (RUSH-2210).
+ *
+ * The row carries its own change signal — `time_updated` moves on every write to
+ * that session, and the message count grows with it — so that pair is the stamp.
+ * `fileMtimeMs`/`fileSize` are just the ledger's two integer columns here; they
+ * name a file only for the one-file-per-session harnesses.
+ *
+ * Degenerate rows (a non-numeric `time_updated` *and* `time_created`) fall back
+ * to the whole-DB stat, which keeps the pre-RUSH-2210 always-rescan behavior for
+ * exactly those rows rather than pinning them to a stamp that never changes.
+ */
+function openCodeSessionStamp(
+  timeUpdated: number,
+  timeCreated: number,
+  messageCount: number,
+  dbScan: ScanStamp,
+): ScanStamp {
+  const mtime = Number.isFinite(timeUpdated)
+    ? timeUpdated
+    : Number.isFinite(timeCreated)
+      ? timeCreated
+      : null;
+  if (mtime === null) return dbScan;
+  return {
+    fileMtimeMs: Math.floor(mtime),
+    fileSize: Number.isFinite(messageCount) ? messageCount : 0,
+  };
 }
 
 /** Scan OpenCode sessions from its SQLite database when the DB file has changed. */
@@ -2213,8 +2255,9 @@ async function scanOpenCodeIncremental(): Promise<void> {
   const stat = safeStatSync(OPENCODE_DB);
   if (!stat) return;
 
-  // OpenCode is one big DB; we use its mtime/size as the ledger for the
-  // entire fleet of OpenCode sessions.
+  // OpenCode is one big DB. Its mtime/size is the cheap "did ANYTHING change"
+  // short-circuit for the whole harness — not the per-session stamp, which each
+  // row carries itself (see openCodeSessionStamp, RUSH-2210).
   const currentScan: ScanStamp = {
     fileMtimeMs: Math.floor(stat.mtimeMs),
     fileSize: stat.size,
@@ -2224,7 +2267,6 @@ async function scanOpenCodeIncremental(): Promise<void> {
     return;
   }
 
-  const account = await getOpenCodeAccount();
   const currentVersion = await getCurrentAgentVersion('opencode');
 
   // Read through the node/bun SQLite wrapper (not the `sqlite3` CLI) so this
@@ -2266,6 +2308,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
     `.replace(/\n/g, ' ');
 
     db = new Database(OPENCODE_DB);
+    const account = getOpenCodeAccount(db);
     const rows = db.prepare(query).all() as Array<{
       id: unknown;
       title: unknown;
@@ -2279,16 +2322,42 @@ async function scanOpenCodeIncremental(): Promise<void> {
       has_token_data: unknown;
     }>;
 
-    const entries: ScanEntry[] = [];
-    for (const row of rows) {
+    // Two passes. First derive each row's identity + per-session stamp, then
+    // bulk-load the prior stamps in ONE query and keep only the rows that
+    // actually changed. Skipped rows never reach upsertSessionsBatch, so they
+    // never pay its per-entry `parseSession` re-open of this same DB.
+    const asInt = (v: unknown): number =>
+      typeof v === 'number' ? v : parseInt(String(v), 10);
+    const candidates = rows.flatMap(row => {
       const id = typeof row.id === 'string' ? row.id : '';
-      if (!id) continue;
+      if (!id) return [];
+      const filePath = `${OPENCODE_DB}#${id}`;
+      return [{
+        row,
+        id,
+        filePath,
+        scan: openCodeSessionStamp(
+          asInt(row.time_updated),
+          asInt(row.time_created),
+          asInt(row.message_count),
+          currentScan,
+        ),
+      }];
+    });
+    const priorStamps = getScanStampsForPaths(candidates.map(c => c.filePath));
+    const changed = candidates.filter(c => {
+      const prevStamp = priorStamps.get(c.filePath);
+      return !prevStamp
+        || prevStamp.fileMtimeMs !== c.scan.fileMtimeMs
+        || prevStamp.fileSize !== c.scan.fileSize;
+    });
+
+    const entries: ScanEntry[] = [];
+    for (const { row, id, filePath, scan } of changed) {
       const title = typeof row.title === 'string' ? row.title : '';
       const directory = typeof row.directory === 'string' ? row.directory : '';
       const version = typeof row.version === 'string' ? row.version : '';
 
-      const asInt = (v: unknown): number =>
-        typeof v === 'number' ? v : parseInt(String(v), 10);
       const timeCreated = asInt(row.time_created);
       const timeUpdated = asInt(row.time_updated);
       const messageCount = asInt(row.message_count);
@@ -2310,7 +2379,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
         lastActivity,
         project: directory ? path.basename(directory) : undefined,
         cwd: directory ? normalizeCwd(directory) : undefined,
-        filePath: `${OPENCODE_DB}#${id}`,
+        filePath,
         version: resolveSessionVersion('opencode', OPENCODE_DB, version || undefined, currentVersion),
         account,
         topic,
@@ -2319,7 +2388,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
         outputTokens: hasTokenData && !Number.isNaN(outputTokens) ? outputTokens : undefined,
       };
 
-      entries.push({ meta, content: topic || '', scan: currentScan });
+      entries.push({ meta, content: topic || '', scan });
     }
 
     upsertSessionsBatch(entries);

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -2212,7 +2212,9 @@ function getOpenCodeAccount(handle?: Database.Database): string | undefined {
 }
 
 /**
- * The per-session ledger stamp for an OpenCode row.
+ * The per-session ledger stamp for an OpenCode row: the newest write time across
+ * the session's own row, its messages, and its parts, paired with the total byte
+ * length of that session's message + part payloads.
  *
  * OpenCode keeps every session in ONE shared SQLite file, so that file's
  * mtime/size changes whenever *any* session is written. Stamping each session
@@ -2221,31 +2223,37 @@ function getOpenCodeAccount(handle?: Database.Database): string | undefined {
  * and its enrichment step re-opened `opencode.db` once per re-emitted entry via
  * `parseSession` (RUSH-2210).
  *
- * The row carries its own change signal — `time_updated` moves on every write to
- * that session, and the message count grows with it — so that pair is the stamp.
- * `fileMtimeMs`/`fileSize` are just the ledger's two integer columns here; they
- * name a file only for the one-file-per-session harnesses.
+ * `s.time_updated` alone is NOT that session's change signal, which is the trap
+ * this shape exists to avoid. On a real database, parts land long after the
+ * session row was last touched — e.g. `ses_3955202dfffe…` carried
+ * `time_updated = 1771316403087` with its newest part at `1771331512162`, over
+ * four hours later. So the stamp maxes `time_updated` with the newest message
+ * and part times, and pairs it with a byte total that also moves when an
+ * existing part's `data` is rewritten in place (a streaming turn) without any
+ * new row or timestamp.
  *
- * Degenerate rows (a non-numeric `time_updated` *and* `time_created`) fall back
- * to the whole-DB stat, which keeps the pre-RUSH-2210 always-rescan behavior for
- * exactly those rows rather than pinning them to a stamp that never changes.
+ * The byte total is a REAL size, not a repurposed counter, because
+ * `sessions.file_size` is read back as bytes elsewhere: `ensureToolIndex` uses
+ * it as the tool-backfill byte budget and `toolCallsForBackfill` as the 16 MiB
+ * in-memory parser cap (`tool-index.ts`). A message/part byte total is the
+ * honest cost of parsing that session — strictly better than the whole-DB size
+ * this column used to hold for every OpenCode row.
+ *
+ * A degenerate row (no finite timestamp anywhere) falls back to the whole-DB
+ * stat, keeping the pre-RUSH-2210 always-rescan behavior for exactly those rows
+ * rather than pinning them to a stamp that never changes.
  */
 function openCodeSessionStamp(
-  timeUpdated: number,
-  timeCreated: number,
-  messageCount: number,
+  times: { timeUpdated: number; timeCreated: number; lastMessageAt: number; lastPartAt: number },
+  bytes: { messageBytes: number; partBytes: number },
   dbScan: ScanStamp,
 ): ScanStamp {
-  const mtime = Number.isFinite(timeUpdated)
-    ? timeUpdated
-    : Number.isFinite(timeCreated)
-      ? timeCreated
-      : null;
-  if (mtime === null) return dbScan;
-  return {
-    fileMtimeMs: Math.floor(mtime),
-    fileSize: Number.isFinite(messageCount) ? messageCount : 0,
-  };
+  const finite = [times.timeUpdated, times.lastMessageAt, times.lastPartAt, times.timeCreated]
+    .filter(t => Number.isFinite(t));
+  if (finite.length === 0) return dbScan;
+  const size = (Number.isFinite(bytes.messageBytes) ? bytes.messageBytes : 0)
+    + (Number.isFinite(bytes.partBytes) ? bytes.partBytes : 0);
+  return { fileMtimeMs: Math.floor(Math.max(...finite)), fileSize: size };
 }
 
 /** Scan OpenCode sessions from its SQLite database when the DB file has changed. */
@@ -2282,6 +2290,10 @@ async function scanOpenCodeIncremental(): Promise<void> {
         s.time_created AS time_created,
         s.time_updated AS time_updated,
         COALESCE(stats.message_count, 0) AS message_count,
+        COALESCE(stats.last_message_at, 0) AS last_message_at,
+        COALESCE(stats.message_bytes, 0) AS message_bytes,
+        COALESCE(parts.last_part_at, 0) AS last_part_at,
+        COALESCE(parts.part_bytes, 0) AS part_bytes,
         stats.token_count AS token_count,
         stats.output_tokens AS output_tokens,
         COALESCE(stats.has_token_data, 0) AS has_token_data
@@ -2289,7 +2301,17 @@ async function scanOpenCodeIncremental(): Promise<void> {
       LEFT JOIN (
         SELECT
           session_id,
+          MAX(time_created) AS last_part_at,
+          SUM(LENGTH(data)) AS part_bytes
+        FROM part
+        GROUP BY session_id
+      ) parts ON parts.session_id = s.id
+      LEFT JOIN (
+        SELECT
+          session_id,
           COUNT(*) AS message_count,
+          MAX(time_created) AS last_message_at,
+          SUM(LENGTH(data)) AS message_bytes,
           SUM(
             COALESCE(json_extract(data, '$.tokens.input'), 0) +
             COALESCE(json_extract(data, '$.tokens.output'), 0) +
@@ -2317,6 +2339,10 @@ async function scanOpenCodeIncremental(): Promise<void> {
       time_created: unknown;
       time_updated: unknown;
       message_count: unknown;
+      last_message_at: unknown;
+      message_bytes: unknown;
+      last_part_at: unknown;
+      part_bytes: unknown;
       token_count: unknown;
       output_tokens: unknown;
       has_token_data: unknown;
@@ -2337,9 +2363,13 @@ async function scanOpenCodeIncremental(): Promise<void> {
         id,
         filePath,
         scan: openCodeSessionStamp(
-          asInt(row.time_updated),
-          asInt(row.time_created),
-          asInt(row.message_count),
+          {
+            timeUpdated: asInt(row.time_updated),
+            timeCreated: asInt(row.time_created),
+            lastMessageAt: asInt(row.last_message_at),
+            lastPartAt: asInt(row.last_part_at),
+          },
+          { messageBytes: asInt(row.message_bytes), partBytes: asInt(row.part_bytes) },
           currentScan,
         ),
       }];


### PR DESCRIPTION
**Bug fix — no UI surface.** OpenCode session scans re-index only the sessions that actually changed. Linear: [RUSH-2210](https://linear.app/getrush/issue/RUSH-2210)

## The bug

OpenCode keeps every session in one shared `~/.local/share/opencode/opencode.db`, and the scanner used that whole file's `(mtime, size)` as the ledger stamp for **every** session in it (`discover.ts`, pre-change):

```ts
// OpenCode is one big DB; we use its mtime/size as the ledger for the
// entire fleet of OpenCode sessions.
entries.push({ meta, content: topic || '', scan: currentScan });
```

So any write to any session invalidated every indexed session. One new turn re-emitted up to the scan's `LIMIT 1000` sessions into `upsertSessionsBatch`, whose enrichment step then re-opened `opencode.db` **once per re-emitted entry** to re-parse a transcript that had not moved (`db.ts:1864` → `parseSession` → `parseOpenCode` → `new Database(dbPath)`).

## The fix

| | Before | After |
|---|---|---|
| Per-session ledger stamp | whole-DB `(mtime, size)` | that row's `time_updated` + message count |
| Whole-DB stat | the stamp | only the cheap "nothing changed at all" short-circuit |
| `opencode.db` opens per scan | 1 + one per re-emitted session | 1 (+1 per genuinely changed session) |

- `openCodeSessionStamp()` derives the per-row stamp. A degenerate row (non-numeric `time_updated` **and** `time_created`) falls back to the whole-DB stat, keeping the old always-rescan behavior for exactly those rows rather than pinning them to a stamp that never moves.
- Prior stamps are bulk-loaded in one query via the existing `getScanStampsForPaths`; unchanged rows never reach `upsertSessionsBatch`, so they never pay its parse.
- The scan passes its single open handle to `getOpenCodeAccount()`, so a scan opens `opencode.db` once instead of twice.
- A row that fails to index is still not stamped, so the existing self-healing retry is preserved.

## The run — measured, not asserted from reading

`src/lib/session/discover.opencode-ledger.test.ts` builds a real `opencode.db` (12 sessions, real sqlite, real fs under a temp `HOME`), counts every open of that file by wrapping the shared `../sqlite.js` shim, then appends one turn to **one** session and rescans.

**A) with the fix reverted in place** — the old whole-DB stamp:

```
     × re-emits ONLY the changed session when the shared DB is written 51ms
     × emits nothing when the DB file changes but no session row does 17ms
AssertionError: expected 13 to be less than or equal to 3
AssertionError: expected 13 to be 1 // Object.is equality
      Tests  2 failed | 2 passed (4)
```

13 opens = 1 scan handle + one per re-emitted session, for 12 sessions of which 1 changed.

**B) with the fix (this branch):**

```
 ✓ … > indexes every session on the first scan 42ms
 ✓ … > re-emits ONLY the changed session when the shared DB is written 34ms
 ✓ … > emits nothing when the DB file changes but no session row does 3ms
 ✓ … > short-circuits entirely when the DB file itself is unchanged 2ms
      Tests  4 passed (4)
```

2 opens: the scan handle plus the one changed session. On a real box at the `LIMIT 1000` ceiling that is 1001 → 2.

Full captured run: `yosemite-s1:/tmp/rush-2210-proof.txt` (`agents share` is not provisioned on this box — `No WRITE_TOKEN in the 'share' secrets bundle`, so this is a path, not an embed).

Wider suite on this Linux box: two red files, **both pre-existing and neither caused by this PR**. `src/lib/session/sync/config.test.ts` is a secrets/keychain suite, byte-identical to `origin/main` here, importing nothing from `discover.ts`. `src/lib/session/__tests__/discover.test.ts` > `routine archive discovery` is **flaky**: 2 of 6 runs fail with `origin/main`'s own `discover.ts` swapped in, and 1 of 3 with this branch's. CI is green on all three `cli-test-shard` legs.


## Review round 2 — two real holes found and closed (commit `3b81f429`)

The non-author review flagged that `ScanStamp.fileSize` is read back as **bytes** elsewhere, and questioned whether `session.time_updated` really moves on every write. I probed a real `opencode.db` (mac-mini, 74 sessions) and the second one is not hypothetical:

```
{"id":"ses_3955202dfffe7C4oedWxL38Lul","time_updated":1771316403087,"maxm":1771316399319,"maxp":1771331512162}
```

`maxp` is **over four hours after** `time_updated` — OpenCode writes parts without touching the session row. A `(time_updated, message_count)` stamp would have called that session unchanged *forever*: a silent-forever-miss, strictly worse than the blunt whole-DB stamp it replaced.

Finding 1 was equally real: `sessions.file_size` feeds `ensureToolIndex`'s byte budget (`tool-index.ts:339,343`) and `toolCallsForBackfill`'s 16 MiB in-memory parser cap (`tool-index.ts:282`). A message *count* there means the cap never trips.

One change answers both — make the stamp a genuine content measure:

| Stamp half | Now | Catches |
|---|---|---|
| `fileMtimeMs` | max of `session.time_updated`/`time_created`, newest message `time_created`, newest part `time_created` | new messages, new parts, session-row touches |
| `fileSize` | `SUM(LENGTH(data))` over that session's messages + parts | an existing part rewritten in place (streaming) with no new row and no timestamp move |

`sessions.file_size` for an OpenCode row is now that session's payload size instead of the whole database's, so the tool-backfill caps reflect the real parse cost of one session for the first time.

Three test cases added, **each verified to fail against the previous stamp**:

```
     × catches a part appended with NO write to session or message 29ms
     × catches an existing part rewritten in place (no new row, no timestamp move) 28ms
     × stamps file_size in real bytes, which tool-index reads as a byte budget 7ms
AssertionError: expected 1782864300000 to be greater than 1782864300000
AssertionError: expected 0 to be greater than 0
AssertionError: expected +0 to be 55 // Object.is equality
      Tests  3 failed | 4 passed (7)
```

With the fix, 7/7 green.

## Review round 3 — approved, two residuals closed anyway (commit `dbe8810b`)

The review returned **APPROVE** and flagged three non-blocking residuals. Two of them made my own docs claim untrue, so they are fixed rather than shipped:

- **`LENGTH()` counts characters, not bytes.** `SELECT LENGTH('日本語'), LENGTH(CAST('日本語' AS BLOB))` returns `3|9`. Since this number is a byte budget downstream, a CJK/emoji transcript under-reported its size by up to 4x. Now `LENGTH(CAST(data AS BLOB))`. Measured on the fixture: a part carrying 1800 UTF-8 bytes grew the stamp by **625** before, **1825** after. New test `counts BYTES, not characters, for multi-byte content`, verified to fail against the old form with `expected 625 to be greater than 1800`.
- **The degenerate-row fallback had become unreachable.** The SQL `COALESCE`s each timestamp aggregate to `0`, so `Number.isFinite` accepted a row that told us nothing and the branch could never fire — a docblock describing a dead path. It now requires a **positive** time and treats "no time anywhere **and** no payload at all" as the degenerate case.

The third residual is accepted and stated below.

### Known gap, stated

An in-place rewrite that keeps the byte length **identical** and moves no timestamp anywhere would still be skipped. I have no evidence OpenCode produces that shape, and it is the same tradeoff every other harness's ledger already makes — Claude/Codex transcripts are invalidated by `(mtime, size)`, not a content hash, so a same-byte-count rewrite is missed there too. Calling it out beats pretending the stamp is total.

## Docs + changelog

- `apps/cli/docs/05-sessions.md` — the ledger section said the stamp is a file's `(mtime, size)`; it now states OpenCode's per-row exception.
- `apps/cli/.changelog/next/RUSH-2210-opencode-scan-ledger.md` — release note fragment.

## Out of scope

`LIMIT 1000` on the scan query is unchanged: it bounds which sessions are *considered*, not how many are re-emitted, and narrowing it is a separate coverage question.
