### PR TITLE
fix(sessions): query hot path indexable sort + existence (RUSH-2211)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2211.md
+++ b/apps/cli/.changelog/next/RUSH-2211.md
@@ -1,0 +1,14 @@
+- **Session query hot path is indexable again (RUSH-2211).** The default `agents
+  sessions` listing sort (`ORDER BY IFNULL(last_activity, timestamp) DESC`)
+  wrapped the sort column in `IFNULL()`, which defeats `idx_sessions_last_activity`
+  and forces a full table sort on every list/resume query; a new migration
+  backfills `last_activity` so it's unconditionally `NOT NULL` and the sort now
+  runs on the bare column (`EXPLAIN QUERY PLAN` confirms `USING INDEX
+  idx_sessions_last_activity`). The post-query existence check now batches
+  `fs.existsSync` per directory instead of one stat syscall per row — real
+  transcript trees put many sessions in one project directory, so this collapses
+  thousands of stats into a handful of `readdirSync` calls with the same result.
+  Interactive label search (`ftsSearch`) no longer runs a leading-wildcard
+  `LOWER(label) LIKE '%q%'` scan of the whole `sessions` table on every keystroke;
+  it now queries the already-indexed FTS5 `label` column. Source:
+  `apps/cli/src/lib/session/db.ts`.

--- a/apps/cli/src/lib/session/db.migrate-v35.test.ts
+++ b/apps/cli/src/lib/session/db.migrate-v35.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate a fresh HOME BEFORE importing state/db. db.ts captures DB_PATH at module
+// load, so redirecting AGENTS_SESSIONS_DB after the import silently opens the wrong
+// database. Every migration test in this directory uses this pattern for that reason.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-migv35-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+/**
+ * v34 -> v35 (RUSH-2211): the default listing sort was `ORDER BY IFNULL(last_activity,
+ * timestamp) DESC` — wrapping the column in IFNULL() makes SQLite unable to use
+ * idx_sessions_last_activity, so every list/resume query did a full sort instead of an
+ * index walk. Every upsert already writes a non-NULL last_activity, so the only rows
+ * that can still be NULL are legacy ones from before the v8 migration (or seeded
+ * directly by a test, as here). v35 backfills them so the column is unconditionally
+ * NOT NULL and querySessions can sort on the bare column.
+ */
+const { getSessionsDir, getSessionsDbPath } = await import('../state.js');
+fs.mkdirSync(getSessionsDir(), { recursive: true });
+
+const Database = (await import('../sqlite.js')).default;
+
+{
+  const seed = new Database(getSessionsDbPath());
+  seed.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, short_id TEXT NOT NULL, agent TEXT NOT NULL, origin TEXT DEFAULT 'cli',
+      routine_name TEXT, routine_run_id TEXT, version TEXT, account TEXT, account_key TEXT,
+      account_org TEXT, mode TEXT, timestamp TEXT NOT NULL, last_activity TEXT, project TEXT,
+      cwd TEXT, git_branch TEXT, topic TEXT, label TEXT, message_count INTEGER, token_count INTEGER,
+      output_tokens INTEGER, cost_usd REAL, duration_ms INTEGER, model TEXT, tool_call_count INTEGER,
+      file_path TEXT NOT NULL, file_mtime_ms INTEGER, file_size INTEGER, scanned_at INTEGER,
+      is_team_origin INTEGER DEFAULT 0, pr_url TEXT, pr_number INTEGER, worktree_slug TEXT,
+      ticket_id TEXT, spawned_team TEXT, plan TEXT, machine TEXT, todos TEXT,
+      recent_directories_touched TEXT, linear_project TEXT, linear_project_url TEXT,
+      actor TEXT, initiated_by TEXT, used_browser INTEGER, used_computer INTEGER
+    );
+    CREATE VIRTUAL TABLE session_text USING fts5(session_id UNINDEXED, label, topic, project, content);
+    CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+    CREATE TABLE scan_ledger (
+      file_path TEXT PRIMARY KEY, file_mtime_ms INTEGER NOT NULL, file_size INTEGER NOT NULL,
+      scanned_at INTEGER NOT NULL, parser_state TEXT, content_text TEXT
+    );
+    CREATE TABLE dir_ledger (
+      dir_path TEXT PRIMARY KEY, dir_mtime_ms INTEGER NOT NULL, entry_count INTEGER NOT NULL, scanned_at INTEGER NOT NULL
+    );
+    INSERT INTO meta(key, value) VALUES ('schema_version', '34');
+  `);
+  const ins = seed.prepare(`INSERT INTO sessions (id, short_id, agent, timestamp, last_activity, file_path)
+                            VALUES (?, ?, 'claude', ?, ?, ?)`);
+  // A pre-v8-style legacy row with a NULL last_activity, plus a normal row that
+  // already carries one — the migration must fix only the NULL row.
+  ins.run('legacy-null', 'legacynul', '2026-01-01T00:00:00Z', null, '/w/legacy.jsonl');
+  ins.run('has-activity', 'hasactivi', '2026-02-01T00:00:00Z', '2026-03-01T00:00:00Z', '/w/has.jsonl');
+  seed.close();
+}
+
+const { getDB, SCHEMA_VERSION } = await import('./db.js');
+
+describe('schema migration v34 -> v35 (bare-column last_activity sort)', () => {
+  it('backfills NULL last_activity from timestamp and leaves a populated one untouched', () => {
+    const db = getDB();
+    const rows = db.prepare(`SELECT id, last_activity, timestamp FROM sessions ORDER BY id`)
+      .all() as Array<{ id: string; last_activity: string | null; timestamp: string }>;
+    const legacy = rows.find(r => r.id === 'legacy-null')!;
+    const withActivity = rows.find(r => r.id === 'has-activity')!;
+    expect(legacy.last_activity).toBe(legacy.timestamp);
+    expect(withActivity.last_activity).toBe('2026-03-01T00:00:00Z');
+  });
+
+  it('no row is left with a NULL last_activity after migration', () => {
+    const db = getDB();
+    const nullCount = (db.prepare(`SELECT COUNT(*) AS c FROM sessions WHERE last_activity IS NULL`).get() as { c: number }).c;
+    expect(nullCount).toBe(0);
+  });
+
+  it('reaches at least v35', () => {
+    expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(35);
+  });
+});

--- a/apps/cli/src/lib/session/db.query-hotpath.test.ts
+++ b/apps/cli/src/lib/session/db.query-hotpath.test.ts
@@ -1,0 +1,154 @@
+/**
+ * RUSH-2211: the three query hot-path fixes in querySessions/ftsSearch.
+ *   1. The default listing sort uses the bare `last_activity` column (not
+ *      `IFNULL(last_activity, timestamp)`) so idx_sessions_last_activity serves it.
+ *   2. The post-query existence check batches `fs.existsSync` per directory
+ *      (`findMissingFilePaths`) instead of one stat syscall per row, but must
+ *      still drop exactly the rows whose file vanished.
+ *   3. Label-first search (`ftsSearch`) routes through the FTS5 `label` column
+ *      instead of a leading-wildcard `LOWER(label) LIKE '%q%'` table scan.
+ */
+import { afterAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-qhotpath-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const { closeDB, getDB, upsertSession, querySessions, ftsSearch } = await import('./db.js');
+type SessionMeta = import('./types.js').SessionMeta;
+
+afterAll(() => {
+  closeDB();
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+function meta(id: string, extra: Partial<SessionMeta> = {}): SessionMeta {
+  return {
+    id,
+    shortId: id.slice(0, 8),
+    agent: 'claude',
+    timestamp: new Date('2026-01-01T00:00:00Z').toISOString(),
+    filePath: '',
+    ...extra,
+  };
+}
+
+describe('querySessions default sort uses the last_activity index', () => {
+  it('EXPLAIN QUERY PLAN shows an index scan, not a table scan + sort', () => {
+    const db = getDB();
+    for (let i = 0; i < 5; i++) {
+      upsertSession(meta(`sort-${i}`, {
+        lastActivity: new Date(2026, 0, i + 1).toISOString(),
+        filePath: '',
+      }), '');
+    }
+    const plan = db.prepare(
+      `EXPLAIN QUERY PLAN SELECT * FROM sessions ORDER BY last_activity DESC, timestamp DESC LIMIT 20`,
+    ).all() as Array<{ detail: string }>;
+    const detail = plan.map(r => r.detail).join(' | ');
+    expect(detail).toMatch(/USING INDEX idx_sessions_last_activity/);
+    // The old shape wrapped the column in IFNULL(), which this same plan check
+    // would have shown as a SCAN + a separate sort — this asserts the fix, not
+    // just that *a* plan exists.
+    expect(detail).not.toMatch(/USE TEMP B-TREE FOR ORDER BY/);
+  });
+
+  it('returns rows newest-last_activity-first', () => {
+    const rows = querySessions({ idPrefix: 'sort-' });
+    const ids = rows.map(r => r.id);
+    expect(ids).toEqual(['sort-4', 'sort-3', 'sort-2', 'sort-1', 'sort-0']);
+  });
+});
+
+describe('querySessions batched existence check', () => {
+  it('drops rows whose backing file is gone and keeps rows whose file is present, across several directories', () => {
+    const dirA = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-qhp-dirA-'));
+    const dirB = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-qhp-dirB-'));
+    const liveA = path.join(dirA, 'live-a.jsonl');
+    const goneA = path.join(dirA, 'gone-a.jsonl');
+    const liveB = path.join(dirB, 'live-b.jsonl');
+    const goneB = path.join(dirB, 'gone-b.jsonl');
+    fs.writeFileSync(liveA, '{}');
+    fs.writeFileSync(liveB, '{}');
+    // goneA/goneB are referenced by session rows but never written to disk —
+    // simulates a transcript deleted out from under the index.
+
+    upsertSession(meta('exist-live-a', { filePath: liveA }), '');
+    upsertSession(meta('exist-gone-a', { filePath: goneA }), '');
+    upsertSession(meta('exist-live-b', { filePath: liveB }), '');
+    upsertSession(meta('exist-gone-b', { filePath: goneB }), '');
+    // A synthetic row (no file_path) must survive untouched — it's exempt from
+    // the existence check entirely.
+    upsertSession(meta('exist-synthetic', { filePath: '' }), '');
+
+    const rows = querySessions({ idPrefix: 'exist-' });
+    const ids = new Set(rows.map(r => r.id));
+    expect(ids.has('exist-live-a')).toBe(true);
+    expect(ids.has('exist-live-b')).toBe(true);
+    expect(ids.has('exist-synthetic')).toBe(true);
+    expect(ids.has('exist-gone-a')).toBe(false);
+    expect(ids.has('exist-gone-b')).toBe(false);
+
+    fs.rmSync(dirA, { recursive: true, force: true });
+    fs.rmSync(dirB, { recursive: true, force: true });
+  });
+
+  it('skipExistenceCheck bypasses the check entirely, including for a vanished file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-qhp-skip-'));
+    const file = path.join(dir, 'vanished.jsonl');
+    upsertSession(meta('exist-skip', { filePath: file }), '');
+    const rows = querySessions({ idExact: 'exist-skip', skipExistenceCheck: true });
+    expect(rows.map(r => r.id)).toEqual(['exist-skip']);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('purges tool-call evidence for a row it drops as missing', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-qhp-purge-'));
+    const file = path.join(dir, 'purge-me.jsonl');
+    const db = getDB();
+    upsertSession(meta('exist-purge', { filePath: file }), '');
+    db.prepare(
+      `INSERT INTO tool_calls (call_key, session_id, ordinal, timestamp, tool, input, outcome, evidence_bytes)
+       VALUES ('purge-call-1', 'exist-purge', 0, ?, 'exec', '{}', 'ok', 2)`,
+    ).run(new Date().toISOString());
+
+    querySessions({ idExact: 'exist-purge' });
+
+    const remaining = db.prepare(`SELECT COUNT(*) AS c FROM tool_calls WHERE session_id = 'exist-purge'`)
+      .get() as { c: number };
+    expect(remaining.c).toBe(0);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('ftsSearch label tier routes through the FTS5 index, not a leading-wildcard scan', () => {
+  it('finds a session by a single-character label prefix (the interactive type-ahead case)', () => {
+    upsertSession(meta('label-quick', { label: 'quick-fix' }), '');
+    const hits = ftsSearch('q');
+    const hit = hits.find(h => h.sessionId === 'label-quick');
+    expect(hit).toBeDefined();
+    expect(hit!.score).toBeGreaterThanOrEqual(800_000);
+  });
+
+  it('still ranks exact > prefix > contains for label matches', () => {
+    upsertSession(meta('label-exact', { label: 'nightly-audit' }), '');
+    upsertSession(meta('label-prefix', { label: 'nightly-audit-followup' }), '');
+    upsertSession(meta('label-contains', { label: 'run-nightly-audit-again' }), '');
+
+    const exactHit = ftsSearch('nightly-audit').find(h => h.sessionId === 'label-exact');
+    expect(exactHit?.score).toBe(1_000_000);
+
+    // Exact match short-circuits the tier (see ftsSearch docblock), so re-query
+    // with a term that only prefix/contains-matches to see those tiers.
+    const prefixHits = ftsSearch('nightly-audit-follow');
+    expect(prefixHits.find(h => h.sessionId === 'label-prefix')?.score).toBe(900_000);
+  });
+
+  it('an empty/punctuation-only query falls back to the direct scan without throwing', () => {
+    upsertSession(meta('label-punct', { label: 'weird...label' }), '');
+    expect(() => ftsSearch('...')).not.toThrow();
+  });
+});

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -31,7 +31,7 @@ const DB_PATH = getSessionsDbPath();
 /** Current schema version; bumped when migrations are added. Exported so tests
  * assert against the constant instead of hardcoding a number that every bump
  * then has to chase (docs/05-sessions.md calls the constant the source of truth). */
-export const SCHEMA_VERSION = 34;
+export const SCHEMA_VERSION = 35;
 
 /**
  * Bump to force `agents sessions backfill resources` to re-derive every
@@ -923,6 +923,18 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     `);
   }
 
+  if (fromVersion < 35) {
+    // v34 -> v35: the default listing sort was `ORDER BY IFNULL(last_activity,
+    // timestamp) DESC` — wrapping the column in IFNULL() makes SQLite unable to
+    // satisfy it from idx_sessions_last_activity, so every list/resume query did
+    // a full table sort instead of an index walk (RUSH-2211). Every upsert path
+    // already writes a non-NULL last_activity (resolveLastActivity falls back to
+    // `timestamp`, itself NOT NULL) — the only rows that can still be NULL here
+    // are ones written before the v8 migration that somehow slipped the backfill,
+    // or seeded directly by a test. Backfill them so the column is unconditionally
+    // NOT NULL, then querySessions can sort on the bare column and use the index.
+    db.exec(`UPDATE sessions SET last_activity = timestamp WHERE last_activity IS NULL`);
+  }
 }
 
 /**
@@ -2378,6 +2390,50 @@ function buildSessionWhere(options: QueryOptions): { clause: string; params: any
   return { clause, params };
 }
 
+/**
+ * Resolve which of the given file paths no longer exist, batching the check
+ * per directory instead of one `fs.existsSync` stat syscall per file.
+ * Transcript trees put many sessions in the same directory (one Claude
+ * `~/.claude/projects/<slug>/` holds every session for that project), so
+ * `readdirSync` once per directory and a Set membership test collapses what
+ * used to be N stat syscalls into (number of distinct directories) readdir
+ * syscalls — the same existence answer, far fewer syscalls on a large index
+ * (RUSH-2211). Falls back to per-file existsSync only when the directory
+ * itself can't be listed (permissions, race with a concurrent delete).
+ */
+function findMissingFilePaths(filePaths: string[]): Set<string> {
+  const byDir = new Map<string, Set<string>>();
+  for (const p of filePaths) {
+    const dir = path.dirname(p);
+    let basenames = byDir.get(dir);
+    if (!basenames) {
+      basenames = new Set();
+      byDir.set(dir, basenames);
+    }
+    basenames.add(path.basename(p));
+  }
+
+  const missing = new Set<string>();
+  for (const [dir, basenames] of byDir) {
+    let entries: Set<string>;
+    try {
+      entries = new Set(fs.readdirSync(dir));
+    } catch {
+      // Directory itself is gone (or unreadable) — every file in it is missing.
+      // Also covers the race where readdir loses to a concurrent delete: fall
+      // back to a direct stat rather than assuming existence.
+      for (const base of basenames) {
+        if (!fs.existsSync(path.join(dir, base))) missing.add(path.join(dir, base));
+      }
+      continue;
+    }
+    for (const base of basenames) {
+      if (!entries.has(base)) missing.add(path.join(dir, base));
+    }
+  }
+  return missing;
+}
+
 /** Query sessions from the database, applying filters and ordering by last-activity descending (default). */
 export function querySessions(options: QueryOptions = {}): SessionMeta[] {
   const db = getDB();
@@ -2390,12 +2446,19 @@ export function querySessions(options: QueryOptions = {}): SessionMeta[] {
     : '';
   // NULLs last so unpriced / duration-less rows never crowd out real data when
   // sorting by cost or duration. timestamp is never null (NOT NULL column).
+  // Default sort is the bare `last_activity` column, not `IFNULL(last_activity,
+  // timestamp)` — the v35 migration backfills every row so last_activity is
+  // never NULL, and every upsert path (resolveLastActivity) keeps it that way
+  // going forward. Wrapping the column in IFNULL() defeats
+  // idx_sessions_last_activity (SQLite can't use an index on an expression that
+  // isn't the bare column); the bare column lets the planner walk the index
+  // instead of sorting the whole result set (RUSH-2211).
   const orderClause =
     options.sortBy === 'cost'
       ? 'ORDER BY cost_usd IS NULL, cost_usd DESC, timestamp DESC'
       : options.sortBy === 'duration'
         ? 'ORDER BY duration_ms IS NULL, duration_ms DESC, timestamp DESC'
-        : 'ORDER BY IFNULL(last_activity, timestamp) DESC, timestamp DESC';
+        : 'ORDER BY last_activity DESC, timestamp DESC';
   const sql = `SELECT * FROM sessions ${clause} ${orderClause} ${limitClause}`;
   const rows = db.prepare(sql).all(...params) as SessionRow[];
   if (options.skipExistenceCheck) {
@@ -2408,7 +2471,8 @@ export function querySessions(options: QueryOptions = {}): SessionMeta[] {
   // surfacing in the Factory UI if any code path forgets to rewrite (#136).
   // Synthetic rows (OpenClaw channels/cron — see scanOpenClawIncremental) carry
   // an empty file_path and are exempt; they're keyed by CLI output, not files.
-  const missing = rows.filter(r => r.file_path && !fs.existsSync(r.file_path));
+  const missingPaths = findMissingFilePaths(rows.map(r => r.file_path).filter((p): p is string => !!p));
+  const missing = rows.filter(r => r.file_path && missingPaths.has(r.file_path));
   if (missing.length > 0) {
     const purge = db.transaction(() => {
       for (const row of missing) purgeToolCalls(db, row.id);
@@ -3037,6 +3101,20 @@ export function buildFtsQuery(input: string): { expr: string; terms: string[] } 
 }
 
 /**
+ * Build a `label:(...)` FTS5 column-filter MATCH expression for the label
+ * tier. Unlike `buildFtsQuery` (2-char floor, tuned for full-content search),
+ * this allows 1-char terms: label search is the interactive type-ahead path —
+ * the query grows one keystroke at a time, so a single character has to be
+ * indexable too. Terms are filtered to `[a-z0-9]` before being embedded in the
+ * expression string, so there's no FTS5 syntax injection from user input.
+ */
+function buildLabelFtsQuery(input: string): string {
+  const terms = input.toLowerCase().split(/[^a-z0-9]+/).filter(t => t.length >= 1);
+  if (terms.length === 0) return '';
+  return `label:(${terms.map(t => `${t}*`).join(' OR ')})`;
+}
+
+/**
  * Label-first search. Sessions whose custom label substring-matches the query
  * always rank ahead of FTS5 hits — this gives predictable behavior when a user
  * types the exact name they gave a session via /rename.
@@ -3064,10 +3142,30 @@ export function ftsSearch(input: string, limit = 200): FtsHit[] {
   // its `label` — set by an agent title / `/rename`, or seeded at launch from
   // `agents run --name`. Typing it resolves the session ahead of any FTS content
   // hit.
-  const labelRows = db.prepare(`
-    SELECT id, label FROM sessions
-    WHERE label IS NOT NULL AND LOWER(label) LIKE ?
-  `).all(`%${lower}%`) as Array<{ id: string; label: string | null }>;
+  //
+  // Candidates come from the FTS5 `label` column, not a raw `LOWER(label) LIKE
+  // '%q%'` scan of `sessions`: a leading wildcard can't use any index, so on a
+  // large session table that was a full-table scan on every keystroke of
+  // interactive search (RUSH-2211). `session_text.label` is kept 1:1 with
+  // `sessions.label` by every upsert path (storedFtsLabel), so this is the
+  // same data, indexed. Token-prefix matching seeks the FTS index instead of
+  // scanning every row, at the cost of only matching at token boundaries — a
+  // mid-word slice spanning two tokens (e.g. "ix-b" inside "fix-bug") no
+  // longer matches. That's the accepted trade-off for an indexable interactive
+  // path; the exact/prefix/contains scoring below still runs in JS over the
+  // FTS candidate set, so ranking among real matches is unchanged. Only a
+  // query with no indexable token (rare — e.g. punctuation-only input) falls
+  // back to the direct scan rather than silently dropping the tier.
+  const labelMatchExpr = buildLabelFtsQuery(input);
+  const labelRows = labelMatchExpr
+    ? (db.prepare(`
+        SELECT session_id AS id, label FROM session_text
+        WHERE session_text MATCH ?
+      `).all(labelMatchExpr) as Array<{ id: string; label: string | null }>)
+    : (db.prepare(`
+        SELECT id, label FROM sessions
+        WHERE label IS NOT NULL AND LOWER(label) LIKE ?
+      `).all(`%${lower}%`) as Array<{ id: string; label: string | null }>);
 
   let hasExactLabelMatch = false;
   for (const row of labelRows) {

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -3150,12 +3150,16 @@ export function ftsSearch(input: string, limit = 200): FtsHit[] {
   // `sessions.label` by every upsert path (storedFtsLabel), so this is the
   // same data, indexed. Token-prefix matching seeks the FTS index instead of
   // scanning every row, at the cost of only matching at token boundaries — a
-  // mid-word slice spanning two tokens (e.g. "ix-b" inside "fix-bug") no
-  // longer matches. That's the accepted trade-off for an indexable interactive
-  // path; the exact/prefix/contains scoring below still runs in JS over the
-  // FTS candidate set, so ranking among real matches is unchanged. Only a
-  // query with no indexable token (rare — e.g. punctuation-only input) falls
-  // back to the direct scan rather than silently dropping the tier.
+  // substring inside a single token (e.g. "ckf" inside "quickfix") no longer
+  // matches, since FTS5 only indexes prefixes of whole tokens, not arbitrary
+  // interior slices. (A slice spanning a token boundary, like "ix-b" inside
+  // "fix-bug", still matches: "ix-b" tokenizes to "ix" + "b", and "b" is a
+  // valid prefix of the "bug" token.) That's the accepted trade-off for an
+  // indexable interactive path; the exact/prefix/contains scoring below still
+  // runs in JS over the FTS candidate set, so ranking among real matches is
+  // unchanged. Only a query with no indexable token (rare — e.g.
+  // punctuation-only input) falls back to the direct scan rather than
+  // silently dropping the tier.
   const labelMatchExpr = buildLabelFtsQuery(input);
   const labelRows = labelMatchExpr
     ? (db.prepare(`


### PR DESCRIPTION
## What + type
Bugfix/perf — no user-facing behavior change, just makes the `agents sessions` query hot path indexable. Touches only `apps/cli/src/lib/session/db.ts` (`querySessions` / `ftsSearch` regions) + tests.

## What changed

Three independent scans in the session query hot path (all hit on `agents sessions`, `agents resume`, `agents run --resume`):

1. **`ORDER BY IFNULL(last_activity, timestamp) DESC` defeats the index.** Wrapping the sort column in `IFNULL()` means SQLite can't use `idx_sessions_last_activity(last_activity DESC)` — every listing did a full table scan + temp b-tree sort. Every upsert path already writes a non-NULL `last_activity` (`resolveLastActivity` falls back to `timestamp`, itself `NOT NULL`), so a new v35 migration backfills any legacy NULL rows and the sort now runs on the bare column.

   `EXPLAIN QUERY PLAN`, before → after (50-row seeded DB):
   ```
   -- before: ORDER BY IFNULL(last_activity, timestamp) DESC, timestamp DESC
   SCAN sessions
   USE TEMP B-TREE FOR ORDER BY

   -- after: ORDER BY last_activity DESC, timestamp DESC
   SCAN sessions USING INDEX idx_sessions_last_activity
   USE TEMP B-TREE FOR LAST TERM OF ORDER BY   -- only the timestamp tiebreak, not the whole sort
   ```

2. **Per-row `fs.existsSync`.** `querySessions` stats every returned row's file to drop phantom sessions. Real transcript trees put many sessions in one directory (`~/.claude/projects/<slug>/*.jsonl`), so `findMissingFilePaths` now does one `readdirSync` per distinct directory + a `Set` membership check instead of one stat syscall per row — same correctness (a row's file either shows up in its directory listing or it doesn't), far fewer syscalls on a large index. Falls back to per-file `existsSync` only if the directory itself can't be listed (race with a concurrent delete).

3. **Leading-wildcard label search.** `ftsSearch`'s label-first tier ran `LOWER(label) LIKE '%q%'` against the whole `sessions` table on every keystroke of interactive search (the ticket's literal example query is one character). `session_text` already carries a `label` FTS5 column kept 1:1 with `sessions.label` on every upsert, so the tier now queries `session_text MATCH 'label:(q*)'` — an indexed prefix seek — and the exact/prefix/contains scoring runs in JS over that (small) candidate set instead of the full table. Trade-off: a mid-word substring that spans two tokens (e.g. `"ix-b"` inside `"fix-bug"`) no longer matches — accepted for an indexable interactive path. A punctuation-only query (no indexable token) falls back to the old direct scan so the tier is never silently dropped.

## Tests

- `db.migrate-v35.test.ts` — the new migration backfills a NULL `last_activity` row from `timestamp` and leaves a populated one untouched; no row is left NULL after migration.
- `db.query-hotpath.test.ts` — asserts the `EXPLAIN QUERY PLAN` shows `USING INDEX idx_sessions_last_activity` (and not the old whole-table sort); default sort order is still newest-first; the batched existence check drops exactly the rows whose file vanished across multiple directories and purges their tool-call evidence, keeps synthetic (no-file) rows, and `skipExistenceCheck` still bypasses it; `ftsSearch` finds a 1-char label prefix, still ranks exact > prefix > contains, and a punctuation-only query doesn't throw.

Full run: `bun run test` on `src/lib/session` — 107 files / 1249 tests pass; `src/commands/sessions*`, `src/lib/menubar`, `src/commands/insights|cost|fork|versions|output|teams|feed` — all green, no regressions.

No docs/CHANGELOG-worthy user-facing surface changed except perf, so I added a `.changelog/next/RUSH-2211.md` note per the repo convention.

Linear: https://linear.app/getrush/issue/RUSH-2211