### PR TITLE
chore(browser): RUSH-2149 independent baseline benchmark + evidence

### DIFF
--- a/.agents/reports/2026-08-06/rush-2149-baseline.md
+++ b/.agents/reports/2026-08-06/rush-2149-baseline.md
@@ -1,0 +1,74 @@
+# RUSH-2149 — independent baseline (Claude, yosemite-s1)
+
+Captured 2026-08-05/06 before Codex's persistent-client fix (session `019fd53b`,
+still doing source inspection with `mq` at time of capture — no PR/branch yet).
+
+Script: `apps/cli/scripts/bench-browser-loop.sh` (this worktree, `rush-2149-bench` branch).
+n=5 per layer, median reported. All runs against a real, already-open browser task
+(`agents browser start --profile <p> --task rush2149-bench`) — no cold-start cost
+folded into the medians.
+
+## yosemite-s1 (this host, linux, load avg ~7-9) — no browser installed
+
+No CDP session possible here (headless box, no chrome/chromium/comet). Measured
+the CLI-boot layer only, which independently confirms the ticket's diagnosis that
+the fat is in **invocation**, not CDP:
+
+| Layer | Median (n=5) | Raw (ms) |
+| --- | --- | --- |
+| bare `node -e ""` | 19 ms | 19,18,19,19,19 |
+| `agents --version` | 97 ms | 97,92,91,108,115 |
+| `agents browser status` (**no daemon running** — error path) | 245 ms | 243,244,245,247,258 |
+
+Even with **zero CDP work and no daemon to talk to**, `browser status` still costs
+~245 ms — in the same band as the ticket's 226 ms "daemon IPC, no CDP work" figure.
+That's CLI boot (~97 ms) + the daemon-probe/IPC-connect path
+(`apps/cli/src/lib/browser/ipc.ts:53` `probeDaemon`, `:609` `sendIPCRequest`),
+independent of whether a daemon exists to answer. Confirms: the persistent-client
+fix needs to eliminate the boot, not just speed up CDP dispatch.
+
+## pinnacles (macos, load avg ~3, Comet daemon live) — clean baseline, closest to ticket conditions
+
+| Layer | Median (n=5) | Raw (ms) |
+| --- | --- | --- |
+| bare `node -e ""` | 42 ms | 42,42,44,43,41 |
+| `agents --version` | 143 ms | 140,139,143,146,146 |
+| `agents browser status` | 266 ms | 265,265,266,272,269 |
+| `agents browser screenshot` | 356 ms | 355,352,360,368,356 |
+| `agents browser click --at 10,10` | 368 ms | 363,368,381,358,369 |
+| **screenshot + click loop (2 CLI calls)** | **730 ms** | 740,730,735,717,711 |
+
+agents 1.22.20. Directly comparable in shape to the ticket's zion table (bare node
+39ms→42ms, `--version` 105ms→143ms, `status` 226ms→266ms) — same layer ordering,
+same conclusion, slightly higher absolute numbers (older CLI build + this box's
+baseline being naturally slower than zion idle).
+
+## zion (macos, load avg ~112-136 — heavily loaded during this run)
+
+| Layer | Median (n=5) | Raw (ms) |
+| --- | --- | --- |
+| bare `node -e ""` | 140 ms | 140,155,176,130,140 |
+| `agents --version` | 985 ms | 619,809,3636,2205,985 |
+| `agents browser status` | 1626 ms | 1908,2128,1626,1500,1464 |
+| `agents browser screenshot` | 1320 ms | 1912,1837,1320,839,605 |
+| `agents browser click --at 10,10` | 595 ms | 572,652,767,563,595 |
+| **screenshot + click loop (2 CLI calls)** | **909 ms** | 938,954,909,847,834 |
+
+zion is under real load right now (fleet snapshot at session start: 1058% CPU,
+confirmed by `uptime` load averages 112-136). Absolute numbers here are inflated
+by host contention, not representative of the ticket's original "warm, idle"
+measurement — kept for the record and because the after-fix run should also land
+on zion for an apples-to-apples same-host comparison, but **pinnacles is the more
+credible reference baseline** for the loop shape.
+
+## Takeaways for the fix
+
+1. Independently reproduces the ticket's core claim: `agents browser status` with
+   **no CDP work and (on yosemite-s1) no daemon at all** still costs ~245-266 ms —
+   confirms the fat is CLI boot + IPC/daemon-probe path, not the CDP op.
+2. The persistent-client fix should be benchmarked on the **same host** as its
+   baseline (host load swings the absolute numbers by 2-3x here); pinnacles
+   (idle, Comet daemon live) is the cleanest host available on this fleet right
+   now for a same-host before/after.
+3. Re-run `apps/cli/scripts/bench-browser-loop.sh` against Codex's branch on
+   pinnacles once a PR/branch exists, using the same `rush2149-bench` task.

--- a/apps/cli/scripts/bench-browser-loop.sh
+++ b/apps/cli/scripts/bench-browser-loop.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Independent A/B benchmark for RUSH-2149 — per-action Node CLI boot in the
+# `agents browser` loop. Reproduces the exact layer breakdown from the ticket
+# (bare node boot, CLI-only boot, status/screenshot/click round-trips, the
+# screenshot+click loop) so before/after runs are directly comparable.
+#
+# Usage:
+#   AGENTS_BROWSER_TASK=<task> ./bench-browser-loop.sh [n]
+#
+# Requires a live `agents browser` daemon with a session already open for
+# $AGENTS_BROWSER_TASK (`agents browser start --profile <p>` first). Prints
+# medians in the same layer table as the ticket. Not a CI benchmark — run by
+# hand against a warm daemon.
+
+set -uo pipefail
+
+N="${1:-5}"
+TASK="${AGENTS_BROWSER_TASK:-}"
+if [ -z "$TASK" ]; then
+  echo "AGENTS_BROWSER_TASK must be set to an open browser task (agents browser start --profile <p>)" >&2
+  exit 2
+fi
+
+AGENTS_BIN="$(command -v agents)"
+if [ -z "$AGENTS_BIN" ]; then
+  echo "agents not found on PATH" >&2
+  exit 2
+fi
+
+# median of N wall-clock ms for a shell command
+median_ms() {
+  local label="$1"; shift
+  local times=()
+  for i in $(seq 1 "$N"); do
+    local t0 t1
+    t0=$(date +%s%N)
+    "$@" >/dev/null 2>&1
+    t1=$(date +%s%N)
+    times+=( $(( (t1 - t0) / 1000000 )) )
+  done
+  local sorted
+  sorted=($(printf '%s\n' "${times[@]}" | sort -n))
+  local mid=$(( N / 2 ))
+  local med="${sorted[$mid]}"
+  printf '%-55s median=%4sms  all=[%s]\n' "$label" "$med" "$(IFS=,; echo "${times[*]}")"
+  echo "$med"
+}
+
+echo "Host: $(hostname)   agents $($AGENTS_BIN --version 2>/dev/null)   n=$N   task=$TASK"
+echo
+
+echo "-- layer breakdown (median of $N, ms) --"
+median_ms "bare node -e ''"                 node -e ""
+median_ms "agents --version"                "$AGENTS_BIN" --version
+median_ms "agents browser status"           "$AGENTS_BIN" browser status --task "$TASK"
+median_ms "agents browser screenshot"       "$AGENTS_BIN" browser screenshot --task "$TASK"
+median_ms "agents browser click --at 10,10" "$AGENTS_BIN" browser click --at 10,10 --task "$TASK"
+
+echo
+echo "-- screenshot + click loop (median of $N iterations) --"
+loop_times=()
+for i in $(seq 1 "$N"); do
+  t0=$(date +%s%N)
+  "$AGENTS_BIN" browser screenshot --task "$TASK" >/dev/null 2>&1
+  "$AGENTS_BIN" browser click --at 10,10 --task "$TASK" >/dev/null 2>&1
+  t1=$(date +%s%N)
+  loop_times+=( $(( (t1 - t0) / 1000000 )) )
+done
+sorted=($(printf '%s\n' "${loop_times[@]}" | sort -n))
+mid=$(( N / 2 ))
+printf '%-55s median=%4sms  all=[%s]\n' "screenshot+click loop (2 CLI calls)" "${sorted[$mid]}" "$(IFS=,; echo "${loop_times[*]}")"


### PR DESCRIPTION
**Type: evidence / benchmark harness (no production code change).**

Independent baseline for RUSH-2149 ("browser: eliminate per-action Node CLI boot
in the browser loop, ~431ms → ~60ms per screenshot+click"). Codex owns the
persistent-client implementation (session in progress); this PR carries the
before-fix numbers and the harness to re-run identically once that lands.

Ticket: https://linear.app/getrush/issue/RUSH-2149

## What's here

- `apps/cli/scripts/bench-browser-loop.sh` — n=5 median layer benchmark (bare
  node boot, `agents --version`, `browser status/screenshot/click`,
  screenshot+click loop), matching the ticket's own methodology so before/after
  runs are directly comparable.
- `.agents/reports/2026-08-06/rush-2149-baseline.md` — captured baseline across
  three hosts.

## Baseline (real run output)

**yosemite-s1** (no browser installed — CLI-boot layer only):

```
bare node -e ''                                         median=  19ms
agents --version                                        median=  97ms
agents browser status (no daemon running, error path)    median= 245ms
```

Even with **zero CDP work and no daemon to answer**, `browser status` still
costs ~245ms — independently confirms the ticket's claim that the fat is in
CLI boot + IPC/daemon-probe (`apps/cli/src/lib/browser/ipc.ts:53` `probeDaemon`,
`:609` `sendIPCRequest`), not the CDP op itself.

**pinnacles** (idle, load avg ~3, live Comet daemon — cleanest same-shape baseline):

```
bare node -e ''                                          median=  42ms
agents --version                                         median= 143ms
agents browser status                                    median= 266ms
agents browser screenshot                                median= 356ms
agents browser click --at 10,10                           median= 368ms
screenshot+click loop (2 CLI calls)                        median= 730ms
```

Same layer ordering and shape as the ticket's zion table (39→42ms bare node,
105→143ms `--version`, 226→266ms status) — different absolute numbers (older
CLI build, different idle baseline) but the same conclusion.

**zion** (heavily loaded at capture time, load avg 112-136 — kept for the record,
not the reference baseline): screenshot+click loop median 909ms. Absolute
numbers are load-inflated; noted in the report so the after-fix run isn't
mistaken for a regression if zion is quieter later.

## Next

Re-run `bench-browser-loop.sh` against Codex's branch (same host — pinnacles —
for apples-to-apples) once a PR/branch exists, post before/after table + verdict.
