### PR TITLE
feat(sessions): multi-harness action insights (RUSH-2280)

### DIFF
--- a/.agents/commands/sessions-insights.md
+++ b/.agents/commands/sessions-insights.md
@@ -1,0 +1,22 @@
+---
+description: Analyze recent sessions across harnesses and return evidence-backed actions
+agents:
+  - claude
+  - codex
+  - gemini
+  - cursor
+  - opencode
+  - grok
+  - kimi
+  - droid
+---
+
+Run the deterministic local sessions analysis and summarize its action list.
+
+```bash
+agents sessions insights --since 30d
+```
+
+Forward any arguments to the command. Use repeated `--agent` flags to narrow the
+harnesses, `--json` for structured output, and `--narrative` only when the user
+explicitly wants coaching from aggregate counts. Never upload raw transcripts.

--- a/README.md
+++ b/README.md
@@ -288,7 +288,15 @@ agents sessions backfill tools --fleet
 agents sessions stats
 agents sessions stats --zero            # only the never-invoked (dead weight)
 agents sessions backfill resources      # fold historical sessions into the usage index
+
+# Friction, owner corrections, repeated recipes, and ranked actions across harnesses
+agents sessions insights --since 30d
+agents sessions insights --agent claude --agent codex --json
+# Top-level alias
+agents insights --since 7d
 ```
+
+`sessions insights` is deterministic and offline by default. It caches per-session facets, compares harnesses, and emits an actions table with evidence counts plus shortened sample session ids. `--narrative` is opt-in and receives aggregates only, never raw transcripts. The installed `/sessions-insights` slash command invokes the same CLI source of truth.
 
 Interactive picker when you're in a terminal. Structured output (`--json`, `--markdown`, filtered by role or turn count) when piped.
 

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -315,7 +315,7 @@ src/
     monitors/          # `agents monitors` — event-triggered watchers (source→condition→action); native state-diff store; MonitorEngine runs in the daemon beside the cron scheduler. See docs/10-monitors.md
     projects.ts        # `agents projects` — named multi-repo project defs (~/.agents/projects/*.yaml) layered above the --project convention (resolveProjectRef in project-root.ts); project-status.ts rolls live sessions + merged PRs + artifacts into the progress card. Beta-gated. See docs/11-projects.md
     migrate.ts         # One-shot idempotent migrations
-    session/           # `agents sessions` READER — discovery/parse/render of agent transcripts; also `migrate-targets.ts` (the `sessions migrate` target scorer); `db.ts` `queryResourceUsageStats`/`backfillResourceUsage` back `agents sessions stats` + `sessions backfill resources` (skill/command usage rollup, session_resource_usage + resource_scan_ledger); `claude-accounts.ts` attributes each Claude transcript to the account that produced it (account_key) and `insights.ts` extracts the behavioural facets behind `agents insights` (session_insights cache)
+    session/           # `agents sessions` READER — discovery/parse/render of agent transcripts; also `migrate-targets.ts` (the `sessions migrate` target scorer); `db.ts` `queryResourceUsageStats`/`backfillResourceUsage` back `agents sessions stats` + `sessions backfill resources` (skill/command usage rollup, session_resource_usage + resource_scan_ledger); `claude-accounts.ts` attributes each Claude transcript to the account that produced it (account_key) and `insights.ts` extracts the cached multi-harness friction/correction/automation facets behind `agents sessions insights` (`agents insights` alias)
     terminal/          # Terminal launch engine — tab/split in iTerm/Ghostty/tmux/Terminal.app, local or --host;
                        #   preferred.ts resolves WHICH terminal for a GUI caller (from live sessions' host app)
     cloud/             # Provider registry (Rush / Codex / Factory / Antigravity)
@@ -750,7 +750,8 @@ bug; fix the drift. It uses RFC-2119 MUST/SHOULD language, cites the implementin
   clauses match distinct calls, tool queries never parse transcripts, and exact
   static program counts retain repeated sites with wrapper/effective roles;
   versioned tool envelopes do not replace the list/detail JSON contracts
-  (SES-31..SES-37, SES-IF-4a); `agents sessions stats` emits its own versioned
+  (SES-31..SES-37, SES-IF-4a); `agents sessions insights` emits aggregate-only
+  actions and keeps `agents insights` as its top-level alias (SES-IF-4c); `agents sessions stats` emits its own versioned
   `sessions-stats` rollup of skill/command usage and never the list/detail shape
   (SES-IF-4b); `agents sessions
   export --encrypt` seals every transcript

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 1.22.24
 
+- **`agents sessions insights` turns multi-harness session history into an action list
+  (RUSH-2280).** The existing `agents insights` command is now also nested under the
+  sessions noun, accepts repeatable `--agent` filters, and reports deterministic offline
+  friction/thrash, owner corrections, automatable repeats, harness split, and ranked
+  rule/skill/automation/product actions with evidence counts and shortened sample session
+  ids. `/sessions-insights` is a thin agent entry over the same CLI implementation;
+  `--narrative` remains opt-in and receives aggregate data only. Source:
+  `apps/cli/src/commands/insights.ts`, `apps/cli/src/lib/session/insights.ts`,
+  `.agents/commands/sessions-insights.md`.
+
 - **`agents sessions focus` recovers dead panes and shares the sessions browser's selectors (GH-2108).** A retained tmux `remain-on-exit` pane is probed through `#{pane_dead}` immediately before attach, so dead or missing panes no longer open a `Pane is dead` screen. `focus` accepts session ids, topic/path searches, `agent@version` selectors (including per-device `latest`/`oldest`), device, project/time, team/routine, skill/plugin, favorites, and the complete live-state union. Focus, resume, attach, and `run --resume` now use one recovery decision on the origin device: a healthy exact origin performs native resume; otherwise balanced selection chooses a healthy version of the same harness and sends `/continue <id>` to read the indexed transcript, including transcripts retained under version trash. Host-dispatched rows persist the dispatch host as their origin, and `attach` routes its detach-record cleanup there before resuming. No usable same-harness version fails with the device, origin version, and account-health reason. Source: `apps/cli/src/commands/focus.ts`, `apps/cli/src/commands/sessions-browser.ts`, `apps/cli/src/lib/session/recovery.ts`.
 
 - **`agents secrets setup` no longer tells you to set `AGENTS_SECRETS_PASSPHRASE`, and

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -1198,6 +1198,23 @@ session's `from â†’ to`, mode, move-vs-copy, and status; a session that hops Aâ†
 three lines, its lineage. Source: `src/commands/sessions-migrate.ts`,
 `src/lib/session/migrate-targets.ts`, `src/lib/session/migrations.ts`.
 
+## Cross-harness workflow insights
+
+`agents sessions insights` analyzes the last 30 days by default across every indexed
+session-capable harness. The existing `agents insights` spelling is an alias. Repeat
+`--agent` to compare a subset, use the standard `--host`/`--device` routing flags for a
+specific machine, and use `--json` for the structured report.
+
+The deterministic report runs offline and includes friction/thrash, owner corrections,
+automatable command recipes, the harness split, and a ranked actions table. Facets are
+cached in `session_insights` and invalidated by transcript mtime/size. Sample evidence is
+limited to shortened session ids; transcript text, credentials, and local paths are not
+included. `--narrative` is explicitly opt-in and sends only the aggregate report to the
+coach process.
+
+Agents can invoke the same source of truth through `/sessions-insights`; the slash entry
+is a thin command wrapper, not a second analyzer.
+
 ## Skill/plugin/slash-command usage (`session_resource_usage`)
 
 A separate table, `session_resource_usage(session_id, kind, name, plugin,

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -663,6 +663,12 @@ The command surface (bare `sessions [query]`, `tail`, `sync`, `resume`, `focus`,
   a transcript already current at `RESOURCE_INDEX_VERSION`
   (`commands/sessions-stats.ts`; `commands/sessions-backfill.ts`;
   `lib/session/db.ts` `queryResourceUsageStats`/`backfillResourceUsage`).
+- **SES-IF-4c (MUST).** `sessions insights` and top-level `insights` MUST invoke
+  the same implementation. The default report MUST be deterministic and offline,
+  MUST include friction, corrections, automatable repeats, harness split, and ranked
+  evidence-backed actions, and MUST NOT emit raw transcript text or full local paths.
+  `--agent` MUST be repeatable. `--narrative` MAY call a coach only with aggregate
+  report data (`commands/insights.ts`; `lib/session/insights.ts`).
 
 #### 4.3 stdout / stderr / exit discipline
 

--- a/apps/cli/src/commands/insights.test.ts
+++ b/apps/cli/src/commands/insights.test.ts
@@ -110,6 +110,28 @@ async function runInsights(args: string[]): Promise<string> {
   return chunks.join('\n');
 }
 
+async function runNestedInsights(args: string[]): Promise<string> {
+  const { Command } = await import('commander');
+  const { registerSessionsInsightsCommand } = await import('./insights.js');
+  const program = new Command();
+  program.exitOverride();
+  const sessions = program.command('sessions')
+    .option('--json')
+    .option('--since <time>')
+    .option('--agent <id>');
+  registerSessionsInsightsCommand(sessions);
+
+  const chunks: string[] = [];
+  const origLog = console.log;
+  console.log = (...a: unknown[]) => { chunks.push(a.map(String).join(' ')); };
+  try {
+    await program.parseAsync(['node', 'agents', 'sessions', 'insights', ...args]);
+  } finally {
+    console.log = origLog;
+  }
+  return chunks.join('\n');
+}
+
 describe('agents insights', () => {
   it('splits the report by the account that produced each session', async () => {
     const payload = JSON.parse(await runInsights(['--json', '--since', 'all']));
@@ -170,6 +192,13 @@ describe('agents insights', () => {
   it('lets an explicit --since win over --all rather than contradicting it', async () => {
     const both = JSON.parse(await runInsights(['--json', '--all', '--since', '30d']));
     expect(both.window.since).toBe('30d');
+  });
+
+  it('nests under sessions, inherits overlapping parent flags, and emits actions', async () => {
+    const payload = JSON.parse(await runNestedInsights(['--json', '--since', 'all', '--agent', 'claude']));
+    expect(payload.window.since).toBeNull();
+    expect(payload.harnesses).toEqual([{ name: 'claude', count: 3 }]);
+    expect(payload.actions).toBeInstanceOf(Array);
   });
 
   it('filters to one account with --account', async () => {

--- a/apps/cli/src/commands/insights.test.ts
+++ b/apps/cli/src/commands/insights.test.ts
@@ -246,4 +246,22 @@ describe('agents insights', () => {
     expect(after.facets).toBe(before.facets);          // same input, same answer
     expect(after.computed_at).toBeGreaterThanOrEqual(before.computed_at);
   });
+
+  it('recomputes facets written by the previous extractor version', async () => {
+    const { getDB, INSIGHTS_EXTRACTOR_VERSION } = await import('../lib/session/db.js');
+    await runInsights(['--json', '--since', 'all']);
+    const db = getDB();
+    const id = 'aaaaaaaa-0000-0000-0000-00000000000a';
+    db.prepare(`UPDATE session_insights SET extractor_version = ? WHERE session_id = ?`)
+      .run(INSIGHTS_EXTRACTOR_VERSION - 1, id);
+
+    await runInsights(['--json', '--since', 'all']);
+
+    const row = db.prepare(`SELECT extractor_version, facets FROM session_insights WHERE session_id = ?`)
+      .get(id) as { extractor_version: number; facets: string };
+    expect(row.extractor_version).toBe(INSIGHTS_EXTRACTOR_VERSION);
+    expect(JSON.parse(row.facets)).toMatchObject({
+      frictionSignals: {}, correctionSignals: {}, automationSignals: {},
+    });
+  });
 });

--- a/apps/cli/src/commands/insights.ts
+++ b/apps/cli/src/commands/insights.ts
@@ -54,7 +54,9 @@ import {
   percentile,
   bucketGaps,
   topEntries,
+  buildInsightActions,
   type InsightFacets,
+  type InsightAction,
   type SessionSpan,
 } from '../lib/session/insights.js';
 import { formatUsd } from '../lib/pricing/index.js';
@@ -69,11 +71,24 @@ interface InsightsOptions {
   since?: string;
   all?: boolean;
   account?: string;
-  agent?: string;
+  agent?: string[];
   by?: string;
   refresh?: boolean;
   narrative?: boolean;
   minMessages?: string;
+}
+
+function collectAgent(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+function agentsFromArgv(argv: string[]): string[] {
+  const values: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--agent' && argv[i + 1]) values.push(argv[++i]);
+    else if (argv[i].startsWith('--agent=')) values.push(argv[i].slice('--agent='.length));
+  }
+  return values;
 }
 
 /** One reported group — an account by default, else an agent/project/day. */
@@ -244,7 +259,7 @@ function renderHours(hours: number[], out: string[]): void {
   out.push(`  ${chalk.gray('0h'.padEnd(6))}${chalk.gray('6h'.padEnd(6))}${chalk.gray('12h'.padEnd(6))}${chalk.gray('18h'.padEnd(5))}${chalk.gray('23h')}`);
 }
 
-function renderReport(groups: GroupReport[], dim: GroupDim, meta: ReportMeta): void {
+function renderReport(groups: GroupReport[], dim: GroupDim, meta: ReportMeta, actions: InsightAction[], harnesses: Array<{ name: string; count: number }>): void {
   const out: string[] = [];
   const scope = meta.since ? `last ${meta.since}` : 'all time';
   out.push(chalk.bold('Insights') + chalk.gray(`  ${scope} · ${meta.analyzed} of ${meta.scanned} sessions`));
@@ -296,6 +311,23 @@ function renderReport(groups: GroupReport[], dim: GroupDim, meta: ReportMeta): v
   const errs = topEntries(all.errorCategories, 6);
   if (errs.length > 0) {
     for (const e of errs) out.push(`    ${chalk.gray('·')} ${padToWidth(e.name, 16)} ${chalk.gray(String(e.count))}`);
+  }
+
+  renderCounts('Friction / thrash', topEntries(all.frictionSignals, 10), out);
+  renderCounts('Dissatisfaction / corrections', topEntries(all.correctionSignals, 10), out);
+  renderCounts('Automatable repeats', topEntries(all.automationSignals, 10), out);
+  renderCounts('Harness split', harnesses, out);
+
+  out.push('');
+  out.push(chalk.bold('Actions'));
+  if (actions.length === 0) {
+    out.push(chalk.gray('  No repeated action pattern met the evidence threshold in this window.'));
+  } else {
+    out.push(chalk.gray('  pri     category    evidence  sample sessions  action'));
+    for (const action of actions.slice(0, 12)) {
+      out.push(`  ${padToWidth(action.priority, 7)} ${padToWidth(action.category, 11)} ` +
+        `${String(action.evidenceCount).padStart(8)}  ${padToWidth(action.sampleSessionIds.join(', '), 25)} ${action.action}`);
+    }
   }
 
   // Output
@@ -431,11 +463,11 @@ async function insightsAction(options: InsightsOptions): Promise<void> {
   if (options.refresh) clearSessionInsights();
 
   const filter: QueryOptions = { sinceMs };
-  if (options.agent) filter.agent = options.agent as QueryOptions['agent'];
   const scanned = querySessions(filter);
 
   const wanted = options.account?.toLowerCase();
   const inScope = scanned.filter((m) => {
+    if (options.agent?.length && !options.agent.includes(m.agent)) return false;
     if (!wanted) return true;
     return [m.accountKey, m.account, m.accountOrg]
       .some((v) => v?.toLowerCase().includes(wanted));
@@ -461,6 +493,15 @@ async function insightsAction(options: InsightsOptions): Promise<void> {
   });
   const overlap = detectOverlap(spans);
   const groups = buildGroups(substantive, facetsById, dim);
+  const evidence = substantive.flatMap((m) => {
+    const facets = facetsById.get(m.id);
+    return facets ? [{ id: m.id, facets }] : [];
+  });
+  const actions = buildInsightActions(evidence);
+  const harnesses = topEntries(substantive.reduce<Record<string, number>>((counts, row) => {
+    counts[row.agent] = (counts[row.agent] ?? 0) + 1;
+    return counts;
+  }, {}), 20);
 
   if (options.json) {
     const payload = {
@@ -473,6 +514,8 @@ async function insightsAction(options: InsightsOptions): Promise<void> {
       minMessages,
       by: dim,
       overlap,
+      actions,
+      harnesses,
       groups: groups.map((g) => ({
         key: g.key,
         label: g.label,
@@ -501,7 +544,7 @@ async function insightsAction(options: InsightsOptions): Promise<void> {
     unreadable,
     minMessages,
     overlap,
-  });
+  }, actions, harnesses);
 
   if (options.narrative) {
     await renderNarrative(groups.map((g) => ({
@@ -517,20 +560,31 @@ async function insightsAction(options: InsightsOptions): Promise<void> {
   }
 }
 
-export function registerInsightsCommand(program: Command): void {
-  const cmd = addHostOption(program.command('insights'))
-    .description('How you work — tools, friction, and rhythm, split by the account that did the work')
+function configureInsightsCommand(cmd: Command): void {
+  addHostOption(cmd)
+    .description('Analyze friction, corrections, repeated work, and actions across session harnesses')
     .option('--json', 'Output the full report as JSON')
     .option('--since <time>', 'Window: 7d, 4w, 3mo, an ISO date, or "all" (default 30d)')
     .option('--all', 'Every session ever indexed. Alias for --since all')
     .option('--by <dimension>', 'Group by: account (default), agent, project, or day')
     .option('--account <match>', 'Only sessions whose account key, email, or org contains this')
-    .option('--agent <id>', 'Only one harness (claude, codex, droid, …)')
+    .option('--agent <id>', 'Only these harnesses; repeat for more than one', collectAgent, [])
     .option('--min-messages <n>', 'Skip sessions under this many messages, both roles counted (default 2)')
     .option('--refresh', 'Discard cached facets and re-read every transcript')
     .option('--narrative', 'Add a written read on the numbers via a headless `claude -p`')
     .action(async (options: InsightsOptions) => {
-      await insightsAction(options);
+      const inherited = cmd.parent?.name() === 'sessions'
+        ? cmd.parent.opts() as Record<string, unknown>
+        : {};
+      const inheritedAgent = typeof inherited.agent === 'string' ? [inherited.agent] : [];
+      const rawAgents = agentsFromArgv(process.argv.slice(2));
+      await insightsAction({
+        ...inherited,
+        ...options,
+        agent: rawAgents.length > 0 ? rawAgents : [...inheritedAgent, ...(options.agent ?? [])],
+        json: options.json ?? inherited.json as boolean | undefined,
+        since: options.since ?? inherited.since as string | undefined,
+      });
     });
 
   setHelpSections(cmd, {
@@ -545,7 +599,7 @@ export function registerInsightsCommand(program: Command): void {
       agents insights --account "Turing Labs" --all
 
       # Machine-readable, for a dashboard or a slash command
-      agents insights --json
+      agents sessions insights --agent claude --agent codex --json
 
       # Add a written read on what to change
       agents insights --narrative
@@ -557,10 +611,18 @@ export function registerInsightsCommand(program: Command): void {
       The first run parses every in-scope transcript and caches the result; later runs
       re-read only files that changed. \`--refresh\` forces a full re-read.
 
-      Account attribution is Claude-only today. Sessions from other harnesses group
-      under \`unattributed:<agent>\`.
+      \`agents insights\` is the top-level alias of \`agents sessions insights\`.
+      Repeat \`--agent\` to compare several harnesses in one report.
 
       Everything except \`--narrative\` is local and makes no network calls.
     `,
   });
+}
+
+export function registerInsightsCommand(program: Command): void {
+  configureInsightsCommand(program.command('insights'));
+}
+
+export function registerSessionsInsightsCommand(sessions: Command): void {
+  configureInsightsCommand(sessions.command('insights'));
 }

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -78,6 +78,7 @@ import { registerSessionsImportCommand } from './sessions-import.js';
 import { registerSessionsMigrateCommand, registerSessionsMigrationsCommand } from './sessions-migrate.js';
 import { registerSessionsBackfillCommand } from './sessions-backfill.js';
 import { registerSessionsStatsCommand } from './sessions-stats.js';
+import { registerSessionsInsightsCommand } from './insights.js';
 import { registerSessionsOptimizeCommand } from './sessions-optimize.js';
 import { runBrowserSessions } from '../lib/browser/sessions-list.js';
 import {
@@ -4596,6 +4597,7 @@ export function registerSessionsCommands(program: Command): void {
   registerSessionsMigrationsCommand(sessionsCmd);
   registerSessionsBackfillCommand(sessionsCmd);
   registerSessionsStatsCommand(sessionsCmd);
+  registerSessionsInsightsCommand(sessionsCmd);
   registerSessionsOptimizeCommand(sessionsCmd);
 
   // Observe-umbrella alias (Phase 3): roster → sessions --active.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -445,7 +445,7 @@ Credentials and profiles:
 Diagnostics:
   doctor [agent[@version]]        Diagnose CLI availability, sync status, and resource divergence; --check for the CI drift gate
   usage [agent]                   Show rate-limit and quota usage per agent
-  insights                        How you work — tools, friction, rhythm, split by Claude account
+  insights                        Session friction, corrections, repeated work, and ranked actions
   perf                            Latency rollups (hooks, commands, runs) from the disposable perf warehouse
 
 Config sync:

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -302,7 +302,7 @@ CREATE TABLE IF NOT EXISTS session_insights (
  * re-derives on the next `agents insights` instead of silently reporting stale
  * numbers alongside fresh ones. Same role as RESOURCE_INDEX_VERSION.
  */
-export const INSIGHTS_EXTRACTOR_VERSION = 3;
+export const INSIGHTS_EXTRACTOR_VERSION = 4;
 
 /** Raw row shape returned from the sessions table. */
 export interface SessionRow {

--- a/apps/cli/src/lib/session/insights.test.ts
+++ b/apps/cli/src/lib/session/insights.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
 import {
   computeInsightFacets,
   detectOverlap,
@@ -13,6 +15,7 @@ import {
   topEntries,
   mergeFacets,
   newFacetAccumulator,
+  buildInsightActions,
   type SessionSpan,
 } from './insights.js';
 import type { SessionEvent } from './types.js';
@@ -273,5 +276,34 @@ describe('topEntries', () => {
       { name: 'a', count: 2 },
       { name: 'b', count: 2 },
     ]);
+  });
+});
+
+describe('actions-forward analysis', () => {
+  it('classifies corrections, AskUserQuestion stalls, failed loops, and repeatable recipes', () => {
+    const fixture = JSON.parse(fs.readFileSync(
+      path.join(import.meta.dirname, 'testdata', 'insights-actions.json'), 'utf8',
+    )) as SessionEvent[];
+    const facets = computeInsightFacets(fixture, 0);
+
+    expect(facets.correctionSignals).toMatchObject({
+      'continue / keep going': 1,
+      'Ask stall: release / ship / deploy': 1,
+    });
+    expect(facets.frictionSignals).toMatchObject({
+      'CI red loop': 2,
+      'failed tool loop: exec_command': 1,
+    });
+    expect(facets.automationSignals['PR babysitting']).toBe(1);
+  });
+
+  it('emits deterministic actions with bounded, redacted session identifiers', () => {
+    const facets = computeInsightFacets([userMsg(0, 'did you merge?')], 0);
+    const actions = buildInsightActions([{ id: 'aaaaaaaa-secret-tail', facets }]);
+    expect(actions).toEqual([expect.objectContaining({
+      category: 'automation',
+      evidenceCount: 1,
+      sampleSessionIds: ['aaaaaaaa'],
+    })]);
   });
 });

--- a/apps/cli/src/lib/session/insights.ts
+++ b/apps/cli/src/lib/session/insights.ts
@@ -113,6 +113,10 @@ export interface InsightFacets {
   assistantTurns: number;
   toolCount: number;
   errorCount: number;
+  /** Deterministic evidence buckets used by the actions-forward report. */
+  frictionSignals: Record<string, number>;
+  correctionSignals: Record<string, number>;
+  automationSignals: Record<string, number>;
 }
 
 function emptyFacets(): InsightFacets {
@@ -124,6 +128,7 @@ function emptyFacets(): InsightFacets {
     shellCommandsSeen: 0,
     messageHours: new Array(24).fill(0), userTurns: 0, assistantTurns: 0,
     toolCount: 0, errorCount: 0,
+    frictionSignals: {}, correctionSignals: {}, automationSignals: {},
   };
 }
 
@@ -208,6 +213,7 @@ export function computeInsightFacets(
   // a reply latency. It censors 5.5% of gaps, and `gapsOverCeiling` reports how many so
   // the number is never quietly truncated.
   let lastAssistantTs: number | null = null;
+  let lastFailedTool: string | null = null;
 
   for (const e of events) {
     const ts = new Date(e.timestamp).getTime();
@@ -226,6 +232,13 @@ export function computeInsightFacets(
 
       case 'error':
         bump(f.errorCategories, categorizeError(e.content ?? e.output ?? ''));
+        if (e.tool && e.tool === lastFailedTool) bump(f.frictionSignals, `failed tool loop: ${e.tool}`);
+        lastFailedTool = e.tool ?? null;
+        classifyFriction(e.content ?? e.output ?? '', f.frictionSignals);
+        break;
+
+      case 'tool_result':
+        if (e.success !== false && e.outcome !== 'error') lastFailedTool = null;
         break;
 
       case 'message':
@@ -234,6 +247,7 @@ export function computeInsightFacets(
           break;
         }
         if (e.role !== 'user') break;
+        if (!e._synthetic) classifyCorrection(e.content ?? '', f.correctionSignals);
         if (hasTs) {
           // Local-time hour. parse.ts falls back to `new Date()` for a record with no
           // timestamp; those are indistinguishable here, but they are rare and would
@@ -258,6 +272,7 @@ export function computeInsightFacets(
         if (hasTs) lastAssistantTs = ts;
         const args = e.args ?? {};
         const toolName = e.tool ?? '';
+        if (/askuserquestion/i.test(toolName)) classifyAskStall(args, f.correctionSignals);
         // Keyed on the SHARED cross-harness vocabulary, not Claude's literals. Keying
         // on 'Edit'|'MultiEdit'|'Write' meant codex (whose vocabulary is exec /
         // exec_command / write_stdin) reported 5,197 tool calls and exactly zero lines
@@ -278,6 +293,7 @@ export function computeInsightFacets(
           f.shellCommandsSeen++;
           f.gitCommits += countGitOp(e.command, 'commit');
           f.gitPushes += countGitOp(e.command, 'push');
+          classifyAutomation(e.command, f.automationSignals);
         }
         break;
       }
@@ -288,6 +304,57 @@ export function computeInsightFacets(
   }
 
   return f;
+}
+
+const FRICTION_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/blocked by|guard(?:rail)? (?:blocked|denied)|permission denied/i, 'blocked guard'],
+  [/\b(?:ci|check|workflow)\b.*\b(?:red|fail(?:ed|ure)?)\b|\b(?:red|failed)\b.*\bci\b/i, 'CI red loop'],
+  [/merge conflict|conflict in |CONFLICT \(/i, 'merge conflict'],
+];
+
+const CORRECTION_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\b(?:continue|keep going|don'?t stop)\b/i, 'continue / keep going'],
+  [/\b(?:yes|go ahead|do it|merge it)\b/i, 'approval repeated'],
+  [/\b(?:are we done|done end.to.end|what(?:'s| is) left)\b/i, 'done end-to-end?'],
+  [/\b(?:did you merge|merged\??)\b/i, 'did you merge?'],
+  [/\bwhat(?:'s| is) next\??\b/i, "what's next?"],
+  [/\b(?:check now|check again|try now|did it work)\b/i, 'check now'],
+  [/\b(?:don'?t ask|just do it|run what)\b/i, "don't ask / just do it"],
+];
+
+const AUTOMATION_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\bgh pr (?:checks|view|merge)\b/i, 'PR babysitting'],
+  [/\bagents secrets (?:list|exec|unlock|export)\b/i, 'secrets unlock dance'],
+  [/\bgit (?:fetch|rebase|merge|push)\b/i, 'git reconcile recipe'],
+  [/\b(?:scp|rsync|agents ssh)\b/i, 'fleet file transfer'],
+  [/\b(?:release\.sh|deploy\.sh|npm publish)\b/i, 'release / deploy recipe'],
+];
+
+function classifyFriction(text: string, counts: Record<string, number>): void {
+  for (const [pattern, label] of FRICTION_PATTERNS) if (pattern.test(text)) bump(counts, label);
+}
+
+function classifyCorrection(text: string, counts: Record<string, number>): void {
+  const normalized = text.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  for (const [pattern, label] of CORRECTION_PATTERNS) if (pattern.test(normalized)) bump(counts, label);
+}
+
+function classifyAskStall(args: Record<string, unknown>, counts: Record<string, number>): void {
+  const text = JSON.stringify(args).toLowerCase();
+  const categories: ReadonlyArray<readonly [RegExp, string]> = [
+    [/release|ship|deploy|publish/, 'Ask stall: release / ship / deploy'],
+    [/what'?s next|next step|next move/, "Ask stall: what's next?"],
+    [/merge|reconcile|rebase/, 'Ask stall: merge / reconcile'],
+    [/direction|approach|implementation/, 'Ask stall: direction / approach'],
+  ];
+  for (const [pattern, label] of categories) {
+    if (pattern.test(text)) { bump(counts, label); return; }
+  }
+  bump(counts, 'AskUserQuestion');
+}
+
+function classifyAutomation(command: string, counts: Record<string, number>): void {
+  for (const [pattern, label] of AUTOMATION_PATTERNS) if (pattern.test(command)) bump(counts, label);
 }
 
 /** Percentile of a numeric sample, nearest-rank. Returns 0 for an empty sample. */
@@ -373,6 +440,9 @@ export function mergeFacets(into: InsightFacets, add: InsightFacets): void {
   for (const [k, v] of Object.entries(add.languages)) bump(into.languages, k, v);
   for (const [k, v] of Object.entries(add.slashCommands)) bump(into.slashCommands, k, v);
   for (const [k, v] of Object.entries(add.errorCategories)) bump(into.errorCategories, k, v);
+  for (const [k, v] of Object.entries(add.frictionSignals ?? {})) bump(into.frictionSignals, k, v);
+  for (const [k, v] of Object.entries(add.correctionSignals ?? {})) bump(into.correctionSignals, k, v);
+  for (const [k, v] of Object.entries(add.automationSignals ?? {})) bump(into.automationSignals, k, v);
   into.interruptions += add.interruptions;
   into.responseGaps.push(...add.responseGaps);
   into.gapsOverCeiling += add.gapsOverCeiling;
@@ -406,4 +476,89 @@ export function topEntries(
     .map(([name, count]) => ({ name, count }))
     .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
     .slice(0, limit);
+}
+
+export type InsightActionCategory = 'rule' | 'skill' | 'automation' | 'product';
+
+export interface InsightAction {
+  priority: 'high' | 'medium' | 'low';
+  category: InsightActionCategory;
+  action: string;
+  evidenceCount: number;
+  sampleSessionIds: string[];
+}
+
+export interface SessionFacetEvidence {
+  id: string;
+  facets: InsightFacets;
+}
+
+/** Build a stable, evidence-backed action list without exposing transcript text. */
+export function buildInsightActions(sessions: SessionFacetEvidence[]): InsightAction[] {
+  const specs: Array<{
+    source: keyof Pick<InsightFacets, 'frictionSignals' | 'correctionSignals' | 'automationSignals'>;
+    label: string;
+    category: InsightActionCategory;
+    action: string;
+  }> = [
+    { source: 'correctionSignals', label: 'continue / keep going', category: 'rule', action: 'Keep working through the delivery chain without waiting for another “continue”.' },
+    { source: 'correctionSignals', label: 'approval repeated', category: 'rule', action: 'Treat the original build or ship request as authorization for routine follow-through.' },
+    { source: 'correctionSignals', label: 'done end-to-end?', category: 'rule', action: 'Verify the user-visible outcome before declaring the task complete.' },
+    { source: 'correctionSignals', label: 'did you merge?', category: 'automation', action: 'Automate PR review, CI watching, and merge-on-green as one durable workflow.' },
+    { source: 'correctionSignals', label: "what's next?", category: 'rule', action: 'State and execute the next in-scope step instead of asking the owner to steer implementation.' },
+    { source: 'correctionSignals', label: 'check now', category: 'automation', action: 'Add bounded status polling with a terminal success or failure signal.' },
+    { source: 'correctionSignals', label: "don't ask / just do it", category: 'rule', action: 'Reserve questions for genuine product or scope choices.' },
+    { source: 'correctionSignals', label: 'Ask stall: release / ship / deploy', category: 'skill', action: 'Teach release workflows to carry publish, tag, rollout, and live verification as one chain.' },
+    { source: 'correctionSignals', label: "Ask stall: what's next?", category: 'rule', action: 'Remove workflow-stall “what next?” prompts from agent guidance.' },
+    { source: 'correctionSignals', label: 'Ask stall: merge / reconcile', category: 'skill', action: 'Encode the safe merge and reconcile path in the git workflow skill.' },
+    { source: 'correctionSignals', label: 'Ask stall: direction / approach', category: 'rule', action: 'Let agents choose implementation details after scope is clear.' },
+    { source: 'frictionSignals', label: 'blocked guard', category: 'product', action: 'Make guard failures return the safe next command and exact blocked operation.' },
+    { source: 'frictionSignals', label: 'CI red loop', category: 'automation', action: 'Deduplicate CI watchers and turn repeated red checks into one stateful wait.' },
+    { source: 'frictionSignals', label: 'merge conflict', category: 'skill', action: 'Standardize conflict diagnosis and fix-forward reconciliation.' },
+    { source: 'automationSignals', label: 'PR babysitting', category: 'automation', action: 'Bundle PR checks, review collection, comment handling, and merge-on-green.' },
+    { source: 'automationSignals', label: 'secrets unlock dance', category: 'product', action: 'Provide one headless secrets-backed command path for repeated credential operations.' },
+    { source: 'automationSignals', label: 'git reconcile recipe', category: 'skill', action: 'Promote repeated git reconciliation commands into the canonical workflow.' },
+    { source: 'automationSignals', label: 'fleet file transfer', category: 'product', action: 'Add a first-class fleet file transfer command with host/path validation.' },
+    { source: 'automationSignals', label: 'release / deploy recipe', category: 'automation', action: 'Turn repeated release shell recipes into a checked-in release script.' },
+  ];
+
+  const actions: InsightAction[] = [];
+  for (const spec of specs) {
+    let evidenceCount = 0;
+    const ids: string[] = [];
+    for (const session of sessions) {
+      const count = session.facets[spec.source]?.[spec.label] ?? 0;
+      if (count <= 0) continue;
+      evidenceCount += count;
+      if (ids.length < 3) ids.push(session.id.slice(0, 8));
+    }
+    if (evidenceCount === 0) continue;
+    actions.push({
+      priority: evidenceCount >= 10 ? 'high' : evidenceCount >= 3 ? 'medium' : 'low',
+      category: spec.category,
+      action: spec.action,
+      evidenceCount,
+      sampleSessionIds: ids,
+    });
+  }
+  let failedLoopCount = 0;
+  const failedLoopIds: string[] = [];
+  for (const session of sessions) {
+    const count = Object.entries(session.facets.frictionSignals ?? {})
+      .filter(([label]) => label.startsWith('failed tool loop:'))
+      .reduce((sum, [, value]) => sum + value, 0);
+    if (count <= 0) continue;
+    failedLoopCount += count;
+    if (failedLoopIds.length < 3) failedLoopIds.push(session.id.slice(0, 8));
+  }
+  if (failedLoopCount > 0) {
+    actions.push({
+      priority: failedLoopCount >= 10 ? 'high' : failedLoopCount >= 3 ? 'medium' : 'low',
+      category: 'automation',
+      action: 'Detect repeated failures of the same tool and stop the retry loop with a different recovery path.',
+      evidenceCount: failedLoopCount,
+      sampleSessionIds: failedLoopIds,
+    });
+  }
+  return actions.sort((a, b) => b.evidenceCount - a.evidenceCount || a.action.localeCompare(b.action));
 }

--- a/apps/cli/src/lib/session/testdata/insights-actions.json
+++ b/apps/cli/src/lib/session/testdata/insights-actions.json
@@ -1,0 +1,7 @@
+[
+  {"type":"message","agent":"codex","timestamp":"2026-07-01T12:00:00.000Z","role":"user","content":"continue, keep going"},
+  {"type":"tool_use","agent":"codex","timestamp":"2026-07-01T12:00:01.000Z","tool":"AskUserQuestion","args":{"header":"release","question":"Should I publish and deploy?"}},
+  {"type":"tool_use","agent":"codex","timestamp":"2026-07-01T12:00:02.000Z","tool":"exec_command","args":{"cmd":"gh pr checks 42 --watch"},"command":"gh pr checks 42 --watch"},
+  {"type":"error","agent":"codex","timestamp":"2026-07-01T12:00:03.000Z","tool":"exec_command","content":"CI check failed: red"},
+  {"type":"error","agent":"codex","timestamp":"2026-07-01T12:00:04.000Z","tool":"exec_command","content":"CI check failed: red"}
+]


### PR DESCRIPTION
Adds a deterministic, actions-forward session-history analysis for agents-cli users.

## What changed

- `agents sessions insights` and the aligned top-level `agents insights` alias
- repeatable `--agent`, standard host/device routing, JSON, cached offline facets, aggregate-only narrative mode
- friction/thrash, correction nudges, AskUserQuestion stalls, automatable repeats, harness split, and ranked actions
- `/sessions-insights` thin command entry
- docs, normative sessions contract, CHANGELOG, fixture-backed tests

## Verification

No UI surface: this is a CLI/report change.

```text
Test Files  2 passed (2)
Tests       37 passed (37)
```

- `bun run build` passed
- `git diff --check` passed
- A real 7-day multi-harness run completed against the local session index; its private aggregate payload was not uploaded to this public repository.
- Full local suite executed; unrelated environment-sensitive failures remain in usage credential detection, crabbox secret access, live model catalog, owner-delivery config, and one routine archive timing test.
- Canonical `test:remote` could not start because this host had no decryptable `HCLOUD_TOKEN`.

## Tracking

- [RUSH-2280](https://linear.app/getrush/issue/RUSH-2280)

Public repository: session transcript and private session-derived metrics omitted.