### PR TITLE
perf(sessions): incremental tool index + FTS optimize (RUSH-2208)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2208-incremental-tool-index.md
+++ b/apps/cli/.changelog/next/RUSH-2208-incremental-tool-index.md
@@ -1,0 +1,21 @@
+- **`agents sessions backfill tools` reads a growing transcript incrementally, and
+  the search index compacts itself (RUSH-2208).** Incremental discovery already
+  appended tool calls for a Claude/Codex session that grew; the backfill did not.
+  Every `ensureToolIndex` pass re-read the transcript from byte 0 and deleted the
+  session's stored evidence to rewrite it, so a session backfilled N times cost N
+  full parses of an ever-larger file — measured on a 4.5 MiB, 4000-call transcript
+  that grew by 20 calls: 344 ms and 4020 calls re-parsed, now 12 ms and 20 calls.
+  Schema v36 adds a resume point to `tool_scan_ledger` (`parsed_offset`, the byte
+  just past the last complete record consumed, and `parser_state`, the collector
+  snapshot at that offset), so a transcript that only grew is read from where the
+  last pass stopped and merged into what is already stored; the batch byte budget
+  now counts the bytes a pass actually reads rather than the file's size, so one
+  bounded batch covers far more growing sessions. A different extractor version, a
+  mismatched ledger path, a file shorter than what was parsed, or an unreadable
+  snapshot still re-reads the whole file. Two related fixes ride along:
+  `tool_call_text` rows are addressed by the `rowid` of the call they describe
+  instead of the UNINDEXED `call_key`, which made every delete a full scan of the
+  FTS index, and the scan path now runs a bounded, threshold-gated FTS `'merge'`
+  after each batch of writes, so index health no longer depends on someone running
+  `agents sessions optimize` by hand. Source: `apps/cli/src/lib/session/tool-index.ts`,
+  `apps/cli/src/lib/session/tool-store.ts`, `apps/cli/src/lib/session/db.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **`agents sessions backfill tools` reads a growing transcript incrementally, and the search index compacts itself (RUSH-2208).** Incremental discovery already appended tool calls for a Claude/Codex session that grew; the backfill did not. Every `ensureToolIndex` pass re-read the transcript from byte 0 and deleted the session's stored evidence to rewrite it, so a session backfilled N times cost N full parses of an ever-larger file. Schema v36 adds a resume point to `tool_scan_ledger` (`parsed_offset` + `parser_state`), so a transcript that only grew is read from where the last pass stopped and merged into what is already stored; the batch byte budget now counts the bytes a pass actually reads rather than the file's size, so one bounded batch covers far more growing sessions. A different extractor version, a mismatched ledger path, a file shorter than what was parsed, or an unreadable snapshot still re-reads the whole file. Two related fixes ride along: `tool_call_text` rows are addressed by the `rowid` of the call they describe instead of the UNINDEXED `call_key`, which made every delete a full scan of the FTS index, and the scan path now runs a bounded, threshold-gated FTS `'merge'` after each batch of writes, so index health no longer depends on someone running `agents sessions optimize` by hand. Source: `apps/cli/src/lib/session/tool-index.ts`, `apps/cli/src/lib/session/tool-store.ts`, `apps/cli/src/lib/session/db.ts`.
+
 ## 1.22.25
 
 ---

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **`agents sessions backfill tools` reads a growing transcript incrementally, and the search index compacts itself (RUSH-2208).** Incremental discovery already appended tool calls for a Claude/Codex session that grew; the backfill did not. Every `ensureToolIndex` pass re-read the transcript from byte 0 and deleted the session's stored evidence to rewrite it, so a session backfilled N times cost N full parses of an ever-larger file. Schema v36 adds a resume point to `tool_scan_ledger` (`parsed_offset` + `parser_state`), so a transcript that only grew is read from where the last pass stopped and merged into what is already stored; the batch byte budget now counts the bytes a pass actually reads rather than the file's size, so one bounded batch covers far more growing sessions. A different extractor version, a mismatched ledger path, a file shorter than what was parsed, or an unreadable snapshot still re-reads the whole file. Two related fixes ride along: `tool_call_text` rows are addressed by the `rowid` of the call they describe instead of the UNINDEXED `call_key`, which made every delete a full scan of the FTS index, and the scan path now runs a bounded, threshold-gated FTS `'merge'` after each batch of writes, so index health no longer depends on someone running `agents sessions optimize` by hand. Source: `apps/cli/src/lib/session/tool-index.ts`, `apps/cli/src/lib/session/tool-store.ts`, `apps/cli/src/lib/session/db.ts`.
-
 ## 1.22.25
 
 ---

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -353,6 +353,25 @@ rows are rebuilt explicitly without forcing ordinary session history to reparse.
 The ledger is keyed by session id; its source path is retained for maintenance,
 not resolved or checked during a query.
 
+Schema v36 makes the **backfill** side of that lifecycle incremental too.
+Incremental discovery already appended (`toolIndexMode: 'append'`, `discover.ts`),
+carrying its own continuation in `scan_ledger.parser_state`; `ensureToolIndex`
+did not, so every `agents sessions backfill tools` pass re-read the transcript
+from byte 0 and deleted the session's evidence to rewrite it. `tool_scan_ledger`
+now carries its own resume point — `parsed_offset` (the byte just past the last
+complete record consumed) and `parser_state` (the collector snapshot at that
+offset) — so a transcript that only grew is read from where the last pass stopped
+and merged with `mode: 'append'`. A discovery-driven write records no resume point
+of its own and clears the columns, which is correct: it keeps the tool ledger's
+stamp current, so the next backfill pass finds nothing to do at all. The resume point is refused, and the whole file
+re-read, on a different extractor version, a ledger source path that does not
+match, or a file shorter than what was already parsed. Harnesses parsed whole into
+memory record no resume point and remain full replaces. The same migration rebuilds
+`tool_call_text` so each row sits at the `rowid` of the `tool_calls` row it
+describes: its `call_key` is UNINDEXED, so the previous `DELETE ... WHERE call_key
+= ?` scanned the whole FTS index once per call. Neither ledger is wiped — existing
+sessions re-read once, record a resume point, and are incremental after that.
+
 Schema v33 adds `account_key` / `account_org` and `idx_sessions_account_key`. Its
 migration also leaves `scan_ledger` alone: attribution derives from `file_path` and
 `version`, both already stored, so existing rows are repaired in place with no
@@ -1424,4 +1443,4 @@ fan-out specifically.
 - `agents sessions <id> --artifacts` — list files created/modified in a session
 - `agents teams status` — session state for team-coordinated runs
 - `agents cloud logs <id>` — for remote cloud dispatches (different subsystem)
-- `agents sessions optimize` — compact the FTS5 search index (`tool_call_text` / `session_text`) when it has bloated from repeated re-indexing, which slows or hangs `agents sessions`. FTS5 appends a segment per insert and never self-merges the scanner's delete+insert churn; this runs `'optimize'` to merge segments + purge tombstones, non-destructively. Reclaimed space frees as reusable pages (VACUUM with the daemon stopped returns it to disk). Wireable to a weekly routine so the index never re-bloats.
+- `agents sessions optimize` — compact the FTS5 search index (`tool_call_text` / `session_text`) in one full pass. FTS5 appends a segment per insert and leaves a tombstone per delete; this runs `'optimize'` to merge every segment + purge tombstones, non-destructively. Reclaimed space frees as reusable pages (VACUUM with the daemon stopped returns it to disk). Since 1.22.25 the scan path also compacts on its own — after a batch of writes it runs a bounded incremental `'merge'` (`maintainSessionSearchIndex`), gated on a segment-count threshold so a healthy index costs nothing — so this command is the manual, unbounded catch-up for an index that already bloated, not the only thing standing between the DB and gigabytes of unmerged segments.

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -503,6 +503,27 @@ SSH access (§7); rendering sessions that no harness produced.
   persistence MUST use ledger byte totals and read only changed ordinals
   (`lib/session/db.ts`; `lib/session/tool-store.ts`; `lib/session/tool-index.ts`;
   `commands/sessions-backfill.ts`; `commands/sessions.ts`).
+- **SES-42 (MUST).** An `ensureToolIndex` pass over a Claude/Codex transcript that
+  only grew MUST read only the bytes appended since the last pass (incremental
+  discovery already appends via `toolIndexMode`; this is the backfill side).
+  Schema v36's `tool_scan_ledger`
+  carries a resume point — `parsed_offset`, the byte just past the last complete
+  record consumed, and `parser_state`, the collector snapshot at that offset — and
+  the scan MUST resume there and persist with `mode: 'append'`, leaving the
+  session's already-stored call rows in place. The resume point MUST be refused,
+  and the whole file re-read, when the extractor version differs, no resume point
+  is recorded, the ledger's source path does not match, or the file is shorter
+  than what was already parsed. A record with no trailing newline MUST be indexed
+  but MUST NOT advance `parsed_offset`, so re-reading it next scan re-derives the
+  same ordinals rather than duplicating the call. Harnesses parsed whole into
+  memory record no resume point and stay full replaces.
+  Every `tool_call_text` row MUST be addressed by the `rowid` of the `tool_calls`
+  row it describes; its `call_key` is UNINDEXED, so a `call_key` predicate scans
+  the entire index once per call.
+  The scan path MUST also perform bounded, threshold-gated FTS compaction
+  (`maintainSessionSearchIndex`) so index health does not depend on a human
+  running `agents sessions optimize`
+  (`lib/session/tool-index.ts`; `lib/session/tool-store.ts`; `lib/session/db.ts`).
 - **SES-35 (MUST).** Fleet tool search MUST cap each peer's stdout at 16 MiB,
   query at most six peers concurrently, and subtract the exact encoded local
   envelope plus 64 KiB of coordinator headroom from the 15 MiB aggregate receive

--- a/apps/cli/src/lib/session/__tests__/db.migrations.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.migrations.test.ts
@@ -279,7 +279,12 @@ describe('tool ledger session identity migration (v29)', () => {
 
     const reopened = getDB();
     expect((reopened.prepare(`PRAGMA table_info(tool_scan_ledger)`).all() as Array<{ name: string }>).map((column) => column.name))
-      .toEqual(['session_id', 'file_path', 'file_mtime_ms', 'file_size', 'extractor_version', 'indexed_at', 'call_count', 'evidence_bytes']);
+      .toEqual([
+        'session_id', 'file_path', 'file_mtime_ms', 'file_size', 'extractor_version', 'indexed_at',
+        'call_count', 'evidence_bytes',
+        // v36 resume point for the incremental tool scan.
+        'parser_state', 'parsed_offset',
+      ]);
     expect(reopened.prepare(`SELECT count(*) AS n FROM tool_scan_ledger`).get()).toEqual({ n: 0 });
     expect(reopened.prepare(`SELECT count(*) AS n FROM scan_ledger WHERE file_path = ?`).get('/tmp/session-ledger/session.jsonl'))
       .toEqual({ n: 1 });

--- a/apps/cli/src/lib/session/db.migrate-v36.test.ts
+++ b/apps/cli/src/lib/session/db.migrate-v36.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate a fresh HOME BEFORE importing state/db. db.ts captures DB_PATH at module
+// load (db.ts:29), so redirecting it after the import silently opens the wrong
+// database. Every migration test in this directory uses this pattern.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-migv36-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+/**
+ * v35 -> v36: the tool index becomes incremental, and its FTS rows become
+ * addressable.
+ *
+ * Two things have to be true afterwards. `tool_scan_ledger` must carry the
+ * resume columns (NULL on existing rows, which reads as "re-read this one once
+ * from byte 0"), and every `tool_call_text` row must sit at the rowid of the
+ * `tool_calls` row it describes — the pre-v36 rows were inserted with
+ * FTS5-assigned rowids and could only be reached through the UNINDEXED
+ * `call_key`, i.e. a full index scan per delete.
+ *
+ * The rebuild must also stay non-destructive: `tool_calls` is the source of
+ * truth and is untouched, the searchable text survives, and neither ledger is
+ * wiped (the contract the other migration tests here assert).
+ */
+const { getSessionsDir, getSessionsDbPath } = await import('../state.js');
+fs.mkdirSync(getSessionsDir(), { recursive: true });
+
+const Database = (await import('../sqlite.js')).default;
+
+const CALLS = [
+  { key: 'sess-a:0', session: 'sess-a', ordinal: 0, input: 'git rebase origin/main' },
+  { key: 'sess-a:1', session: 'sess-a', ordinal: 1, input: 'gh pr checks 2208' },
+  { key: 'sess-b:0', session: 'sess-b', ordinal: 0, input: 'rg needle-in-evidence' },
+];
+
+{
+  const seed = new Database(getSessionsDbPath());
+  seed.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, short_id TEXT NOT NULL, agent TEXT NOT NULL, origin TEXT DEFAULT 'cli',
+      routine_name TEXT, routine_run_id TEXT, version TEXT, account TEXT, account_key TEXT,
+      account_org TEXT, mode TEXT, timestamp TEXT NOT NULL, last_activity TEXT, project TEXT,
+      cwd TEXT, git_branch TEXT, topic TEXT, label TEXT, message_count INTEGER, token_count INTEGER,
+      output_tokens INTEGER, cost_usd REAL, duration_ms INTEGER, model TEXT, tool_call_count INTEGER,
+      file_path TEXT NOT NULL, file_mtime_ms INTEGER, file_size INTEGER, scanned_at INTEGER,
+      is_team_origin INTEGER DEFAULT 0, pr_url TEXT, pr_number INTEGER, worktree_slug TEXT,
+      ticket_id TEXT, spawned_team TEXT, plan TEXT, machine TEXT, todos TEXT,
+      recent_directories_touched TEXT, linear_project TEXT, linear_project_url TEXT,
+      actor TEXT, initiated_by TEXT, used_browser INTEGER, used_computer INTEGER
+    );
+    CREATE TABLE dir_ledger (
+      dir_path TEXT PRIMARY KEY, dir_mtime_ms INTEGER NOT NULL, entry_count INTEGER NOT NULL,
+      scanned_at INTEGER NOT NULL
+    );
+    CREATE VIRTUAL TABLE session_text USING fts5(session_id UNINDEXED, label, topic, project, content);
+    CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+    CREATE TABLE scan_ledger (
+      file_path TEXT PRIMARY KEY, file_mtime_ms INTEGER NOT NULL, file_size INTEGER NOT NULL,
+      scanned_at INTEGER NOT NULL, parser_state TEXT, content_text TEXT
+    );
+    CREATE TABLE tool_calls (
+      call_key TEXT PRIMARY KEY, session_id TEXT NOT NULL, ordinal INTEGER NOT NULL,
+      source_call_id TEXT, timestamp TEXT NOT NULL, tool TEXT NOT NULL, input TEXT NOT NULL,
+      outcome TEXT NOT NULL, exit_code INTEGER, status_code INTEGER, error_code TEXT,
+      output TEXT, error TEXT, parse_error TEXT, evidence_bytes INTEGER NOT NULL,
+      UNIQUE(session_id, ordinal)
+    );
+    CREATE VIRTUAL TABLE tool_call_text USING fts5(
+      call_key UNINDEXED, tool, input, output, error, tokenize = 'trigram'
+    );
+    CREATE TABLE tool_scan_ledger (
+      session_id TEXT PRIMARY KEY, file_path TEXT NOT NULL UNIQUE, file_mtime_ms INTEGER NOT NULL,
+      file_size INTEGER NOT NULL, extractor_version INTEGER NOT NULL, indexed_at INTEGER NOT NULL,
+      call_count INTEGER NOT NULL, evidence_bytes INTEGER NOT NULL
+    );
+    INSERT INTO meta(key, value) VALUES ('schema_version', '35');
+  `);
+  const call = seed.prepare(`
+    INSERT INTO tool_calls (call_key, session_id, ordinal, timestamp, tool, input, outcome, evidence_bytes)
+    VALUES (?, ?, ?, '2026-08-03T00:00:00Z', 'Bash', ?, 'unknown', 64)
+  `);
+  const text = seed.prepare(`INSERT INTO tool_call_text (call_key, tool, input, output, error) VALUES (?, 'Bash', ?, '', '')`);
+  // Insert the text rows in a different order than the calls, so a passing rowid
+  // assertion cannot be an accident of both tables counting from 1 in step.
+  for (const row of CALLS) call.run(row.key, row.session, row.ordinal, row.input);
+  for (const row of [...CALLS].reverse()) text.run(row.key, row.input);
+  seed.prepare(`INSERT INTO scan_ledger VALUES ('/w/a.jsonl', 1, 2, 3, NULL, NULL)`).run();
+  seed.prepare(`
+    INSERT INTO tool_scan_ledger VALUES ('sess-a', '/w/a.jsonl', 1, 2, 9, 3, 2, 128)
+  `).run();
+  seed.close();
+}
+
+const { getDB, SCHEMA_VERSION } = await import('./db.js');
+
+describe('schema migration v35 -> v36 (incremental tool index)', () => {
+  it('adds the resume columns as NULL, leaving both ledgers warm', () => {
+    const db = getDB();
+    expect(db.prepare(`SELECT session_id, call_count, parser_state, parsed_offset FROM tool_scan_ledger`).get())
+      .toEqual({ session_id: 'sess-a', call_count: 2, parser_state: null, parsed_offset: null });
+    expect(db.prepare(`SELECT count(*) AS n FROM scan_ledger`).get()).toEqual({ n: 1 });
+  });
+
+  it('rebuilds tool_call_text at the rowid of the call each row describes', () => {
+    const db = getDB();
+    const mismatched = db.prepare(`
+      SELECT t.call_key FROM tool_call_text t
+      LEFT JOIN tool_calls c ON c.rowid = t.rowid
+      WHERE c.call_key IS NULL OR c.call_key <> t.call_key
+    `).all();
+    expect(mismatched).toEqual([]);
+    expect(db.prepare(`SELECT count(*) AS n FROM tool_call_text`).get()).toEqual({ n: CALLS.length });
+  });
+
+  it('keeps every call searchable and every tool_calls row intact', () => {
+    const db = getDB();
+    expect(db.prepare(`SELECT count(*) AS n FROM tool_calls`).get()).toEqual({ n: CALLS.length });
+    expect(db.prepare(`
+      SELECT call_key FROM tool_call_text WHERE tool_call_text MATCH '"needle-in-evidence"'
+    `).all()).toEqual([{ call_key: 'sess-b:0' }]);
+  });
+
+  it('reaches at least v36', () => {
+    expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(36);
+  });
+});

--- a/apps/cli/src/lib/session/db.optimize.test.ts
+++ b/apps/cli/src/lib/session/db.optimize.test.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-optimize-'));
 process.env.HOME = TEST_HOME;
 
-const { closeDB, getDB, optimizeSessionSearchIndex } = await import('./db.js');
+const { closeDB, getDB, maintainSessionSearchIndex, optimizeSessionSearchIndex } = await import('./db.js');
 
 afterAll(() => {
   closeDB();
@@ -56,5 +56,40 @@ describe('optimizeSessionSearchIndex', () => {
 
     // session_text was optimized too (empty here) without error.
     expect(results.some((r) => r.table === 'session_text')).toBe(true);
+  });
+});
+
+describe('maintainSessionSearchIndex', () => {
+  it('leaves a small index alone and merges one past the threshold', () => {
+    const db = getDB();
+    const segments = (): number =>
+      (db.prepare(`SELECT count(*) AS n FROM tool_call_text_data`).get() as { n: number }).n;
+    const insert = db.prepare(
+      `INSERT INTO tool_call_text(call_key, tool, input, output, error) VALUES (?, 'exec', ?, ?, '')`,
+    );
+
+    // Under the threshold this must be a no-op: paying merge work on every scan
+    // of a healthy index is the reason the automatic path did not exist before.
+    expect(maintainSessionSearchIndex(db, { segmentThreshold: segments() + 1 })).toEqual([]);
+
+    // The scanner's churn: one transaction per write, so one segment per write,
+    // plus a tombstone per delete.
+    for (let i = 0; i < 200; i++) insert.run(`m${i}`, `input ${i}`, `maintained body ${i}`);
+    const doomed = db.prepare(
+      `SELECT rowid FROM tool_call_text WHERE call_key LIKE 'm%' ORDER BY rowid LIMIT 100`,
+    ).all() as Array<{ rowid: number }>;
+    const del = db.prepare(`DELETE FROM tool_call_text WHERE rowid = ?`);
+    for (const { rowid } of doomed) del.run(rowid);
+
+    const before = segments();
+    const merged = maintainSessionSearchIndex(db, { segmentThreshold: before, mergePages: 1000 });
+    const tool = merged.find((result) => result.table === 'tool_call_text');
+    expect(tool).toBeDefined();
+    expect(tool!.segmentsAfter).toBeLessThan(tool!.segmentsBefore);
+
+    // Non-destructive, exactly like the full optimize: content stays searchable.
+    expect(db.prepare(
+      `SELECT count(*) AS n FROM tool_call_text WHERE tool_call_text MATCH 'maintained'`,
+    ).get()).toEqual({ n: 100 });
   });
 });

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -31,7 +31,7 @@ const DB_PATH = getSessionsDbPath();
 /** Current schema version; bumped when migrations are added. Exported so tests
  * assert against the constant instead of hardcoding a number that every bump
  * then has to chase (docs/05-sessions.md calls the constant the source of truth). */
-export const SCHEMA_VERSION = 35;
+export const SCHEMA_VERSION = 36;
 
 /**
  * Bump to force `agents sessions backfill resources` to re-derive every
@@ -211,6 +211,12 @@ CREATE TABLE IF NOT EXISTS tool_program_occurrences (
 CREATE INDEX IF NOT EXISTS idx_tool_program_occurrences_program
   ON tool_program_occurrences(program, call_key);
 
+-- Derived search index over tool_calls. call_key is UNINDEXED -- it is carried
+-- for display, NOT for lookup: an FTS5 table has no index on an ordinary column,
+-- so DELETE ... WHERE call_key = ? scans the whole index once per call, which is
+-- quadratic in a session's call count. Every write here therefore addresses a
+-- row by rowid, mirroring the tool_calls.rowid of the call it describes, so a
+-- delete is a single rowid seek (tool-store.ts persistToolCalls/deleteSessionCalls).
 CREATE VIRTUAL TABLE IF NOT EXISTS tool_call_text USING fts5(
   call_key UNINDEXED,
   tool,
@@ -231,7 +237,15 @@ CREATE TABLE IF NOT EXISTS tool_scan_ledger (
   extractor_version INTEGER NOT NULL,
   indexed_at INTEGER NOT NULL,
   call_count INTEGER NOT NULL,
-  evidence_bytes INTEGER NOT NULL
+  evidence_bytes INTEGER NOT NULL,
+  -- Resume point for the incremental tool scan. parsed_offset is the byte
+  -- offset just past the last COMPLETE newline-terminated record consumed, and
+  -- parser_state is the serialized ToolCallCollector snapshot at that offset
+  -- (next ordinal + still-unresolved calls). Together they let the next scan of
+  -- a session that only grew read the appended bytes instead of the whole file.
+  -- NULL means "no resume point" — the next scan re-reads from byte 0.
+  parser_state TEXT,
+  parsed_offset INTEGER
 );
 
 -- Skill/slash-command usage per session (#12), computed from a session's
@@ -935,6 +949,46 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     // NOT NULL, then querySessions can sort on the bare column and use the index.
     db.exec(`UPDATE sessions SET last_activity = timestamp WHERE last_activity IS NULL`);
   }
+
+  if (fromVersion < 36) {
+    // v35 -> v36: make the tool index incremental, and stop paying a full FTS
+    // scan per deleted call.
+    //
+    // (a) tool_scan_ledger gains a resume point (parser_state + parsed_offset).
+    //     Existing rows get NULLs, which read as "no resume point": the next
+    //     scan of each session re-reads it once from byte 0 and records a resume
+    //     point, so every scan after that is incremental. No ledger is wiped.
+    //
+    // (b) tool_call_text is rebuilt so its rowid mirrors tool_calls.rowid. The
+    //     old rows were inserted with FTS5-assigned rowids and are only
+    //     addressable by the UNINDEXED call_key, i.e. a full index scan per
+    //     delete. There is no ALTER for that, and the rowids cannot be repaired
+    //     in place, so the table is dropped and repopulated from tool_calls --
+    //     the same non-destructive derived-table rebuild v27 did (the source of
+    //     truth is tool_calls, which is untouched). The rebuild also lands the
+    //     content as one merged segment, which is the compaction
+    //     optimizeSessionSearchIndex would otherwise have to do afterwards.
+    const ledgerCols = new Set(
+      (db.prepare(`PRAGMA table_info(tool_scan_ledger)`).all() as Array<{ name: string }>)
+        .map((column) => column.name),
+    );
+    if (!ledgerCols.has('parser_state')) db.exec(`ALTER TABLE tool_scan_ledger ADD COLUMN parser_state TEXT`);
+    if (!ledgerCols.has('parsed_offset')) db.exec(`ALTER TABLE tool_scan_ledger ADD COLUMN parsed_offset INTEGER`);
+    db.exec(`
+      DROP TABLE IF EXISTS tool_call_text;
+      CREATE VIRTUAL TABLE tool_call_text USING fts5(
+        call_key UNINDEXED,
+        tool,
+        input,
+        output,
+        error,
+        tokenize = 'trigram'
+      );
+      INSERT INTO tool_call_text (rowid, call_key, tool, input, output, error)
+      SELECT rowid, call_key, tool, input, coalesce(output, ''), coalesce(error, '')
+      FROM tool_calls;
+    `);
+  }
 }
 
 /**
@@ -1128,6 +1182,55 @@ export function optimizeSessionSearchIndex(): FtsOptimizeResult[] {
     db.prepare(`INSERT INTO ${table}(${table}) VALUES('optimize')`).run();
     return { table, segmentsBefore, segmentsAfter: segments(table) };
   });
+}
+
+/**
+ * Segment count above which a scan pays for a slice of merge work. Below it the
+ * index is small enough that querying it is not the bottleneck and merging is
+ * pure overhead on every scan.
+ */
+const FTS_MAINTENANCE_SEGMENT_THRESHOLD = 512;
+
+/**
+ * Page budget for one incremental merge. FTS5's `'merge'` command does at most
+ * this much work and returns — it is not `'optimize'`, which merges the whole
+ * index in one unbounded pass. That bound is why this can run on the scan path:
+ * the cost per scan is fixed, and repeated scans converge the index instead of
+ * one scan stalling on a multi-gigabyte compaction.
+ */
+const FTS_MAINTENANCE_MERGE_PAGES = 64;
+
+/**
+ * Keep the FTS indexes from degrading on the normal scan path.
+ *
+ * `optimizeSessionSearchIndex` is the full, unbounded compaction behind
+ * `agents sessions optimize`. Leaving it as the ONLY compaction meant the index
+ * degraded until a human happened to run that command, which is how
+ * `tool_call_text_data` reached gigabytes for tens of MB of content. This is the
+ * automatic counterpart: bounded, threshold-gated, and safe to call after every
+ * batch of writes. Non-destructive — merging never changes what is searchable.
+ *
+ * Returns one result per table it actually merged (empty when every table is
+ * under the threshold, which is the common case on a warm index).
+ */
+export function maintainSessionSearchIndex(
+  db: Database.Database = getDB(),
+  options: { segmentThreshold?: number; mergePages?: number } = {},
+): FtsOptimizeResult[] {
+  const threshold = options.segmentThreshold ?? FTS_MAINTENANCE_SEGMENT_THRESHOLD;
+  const pages = options.mergePages ?? FTS_MAINTENANCE_MERGE_PAGES;
+  // Hardcoded literals — never interpolate caller input into an identifier.
+  const tables = ['tool_call_text', 'session_text'];
+  const segments = (table: string): number =>
+    (db.prepare(`SELECT count(*) AS n FROM ${table}_data`).get() as { n: number }).n;
+  const results: FtsOptimizeResult[] = [];
+  for (const table of tables) {
+    const segmentsBefore = segments(table);
+    if (segmentsBefore < threshold) continue;
+    db.prepare(`INSERT INTO ${table}(${table}, rank) VALUES('merge', ?)`).run(pages);
+    results.push({ table, segmentsBefore, segmentsAfter: segments(table) });
+  }
+  return results;
 }
 
 // ---------------------------------------------------------------------------
@@ -2034,11 +2137,17 @@ export function upsertSessionsBatch(
     const toolScan = entry.toolScan ?? entry.scan;
     if (!toolScan || !entry.toolCalls) continue;
     try {
-      persistToolCalls(db, entry.meta, entry.toolCalls, toolScan, entry.toolIndexMode ?? 'replace');
+      persistToolCalls(db, entry.meta, entry.toolCalls, toolScan, { mode: entry.toolIndexMode ?? 'replace' });
     } catch {
       // Boundary is intentionally retryable via tool_scan_ledger.
     }
   }
+  // Every batch appends FTS segments (session_text always, tool_call_text for the
+  // harnesses indexed above). Pay a bounded slice of the merge here so the
+  // scan path keeps its own index healthy instead of leaving all compaction to
+  // the manual `agents sessions optimize` (RUSH-2208). Threshold-gated, so a
+  // small index costs two counts and nothing else.
+  maintainSessionSearchIndex(db);
 }
 
 /**

--- a/apps/cli/src/lib/session/tool-index.incremental.test.ts
+++ b/apps/cli/src/lib/session/tool-index.incremental.test.ts
@@ -1,0 +1,215 @@
+/**
+ * The tool index reads a growing transcript incrementally (RUSH-2208).
+ *
+ * A live session's transcript only ever gets longer, but every scan used to
+ * re-read it from byte 0 and delete + reinsert the whole session's evidence, so
+ * indexing a session that was scanned N times cost N full parses of an
+ * ever-larger file. These tests pin the resume path: which bytes are actually
+ * read, that the calls already stored survive, and the cases that must still
+ * fall back to a full re-read.
+ */
+import { afterAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-tool-incremental-'));
+process.env.HOME = TEST_HOME;
+
+const { closeDB, getDB, upsertSession } = await import('./db.js');
+const { ensureToolIndex } = await import('./tool-index.js');
+type SessionMeta = import('./types.js').SessionMeta;
+
+afterAll(() => {
+  closeDB();
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+/** One completed Claude tool call: the tool_use and its tool_result. */
+function callRecords(id: string, command: string, result: string): string {
+  return [
+    { type: 'assistant', timestamp: '2026-08-03T00:00:00Z', message: { content: [
+      { type: 'tool_use', id, name: 'Bash', input: { command } },
+    ] } },
+    { type: 'user', timestamp: '2026-08-03T00:00:01Z', message: { content: [
+      { type: 'tool_result', tool_use_id: id, content: result },
+    ] } },
+  ].map((line) => JSON.stringify(line)).join('\n') + '\n';
+}
+
+function claudeSession(name: string, body: string): SessionMeta {
+  const filePath = path.join(TEST_HOME, `${name}.jsonl`);
+  fs.writeFileSync(filePath, body);
+  const meta = {
+    id: `${name}-session`, shortId: name.slice(0, 8), agent: 'claude',
+    timestamp: '2026-08-03T00:00:00Z', filePath, machine: 'test-box',
+  } as SessionMeta;
+  upsertSession(meta, name);
+  return meta;
+}
+
+function ledger(sessionId: string) {
+  return getDB().prepare(`
+    SELECT call_count, file_size, parsed_offset, parser_state
+    FROM tool_scan_ledger WHERE session_id = ?
+  `).get(sessionId) as {
+    call_count: number;
+    file_size: number;
+    parsed_offset: number | null;
+    parser_state: string | null;
+  };
+}
+
+function storedCalls(sessionId: string) {
+  return getDB().prepare(`
+    SELECT ordinal, source_call_id, input, rowid FROM tool_calls
+    WHERE session_id = ? ORDER BY ordinal
+  `).all(sessionId) as Array<{ ordinal: number; source_call_id: string; input: string; rowid: number }>;
+}
+
+/**
+ * Overwrite text in the already-parsed prefix, in place and at the same byte
+ * length so later offsets still line up. Nothing writes a transcript this way —
+ * it is a probe. A scan that re-read the prefix picks the new text up; a scan
+ * that resumed past it cannot, which is what makes "only the tail was read" an
+ * observable fact rather than an inference from row counts.
+ */
+function mutatePrefix(session: SessionMeta, from: string, to: string): void {
+  expect(Buffer.byteLength(to)).toBe(Buffer.byteLength(from));
+  const body = fs.readFileSync(session.filePath, 'utf8');
+  expect(body).toContain(from);
+  fs.writeFileSync(session.filePath, body.replace(from, to));
+}
+
+describe('incremental tool index', () => {
+  it('reads only the appended bytes and keeps the calls already stored', async () => {
+    const session = claudeSession('growing', callRecords('first-call', 'git status', 'clean'));
+
+    const first = await ensureToolIndex([session], { verifySourceStamps: true });
+    expect(first).toMatchObject({ indexedFiles: 1, indexedCalls: 1 });
+    const afterFirst = ledger(session.id);
+    const firstSize = fs.statSync(session.filePath).size;
+    expect(afterFirst.parsed_offset).toBe(firstSize);
+    expect(afterFirst.parser_state).not.toBeNull();
+    const before = storedCalls(session.id);
+
+    mutatePrefix(session, 'git status', 'git st4tus');
+    fs.appendFileSync(session.filePath, callRecords('second-call', 'gh pr view', 'open'));
+    await ensureToolIndex([session], { verifySourceStamps: true });
+
+    // The whole point: the second scan started past everything it had already
+    // parsed, so the doctored prefix never reached it.
+    expect(storedCalls(session.id)[0].input).toContain('git status');
+    expect(storedCalls(session.id).map((row) => [row.ordinal, row.source_call_id])).toEqual([
+      [0, 'first-call'],
+      [1, 'second-call'],
+    ]);
+    // The first call's row was never deleted and reinserted.
+    expect(storedCalls(session.id)[0]).toEqual(before[0]);
+    const afterSecond = ledger(session.id);
+    expect(afterSecond.call_count).toBe(2);
+    expect(afterSecond.parsed_offset).toBe(fs.statSync(session.filePath).size);
+  });
+
+  it('accounts for every byte of a transcript larger than one read chunk', async () => {
+    // The stream reads in 64 KiB chunks, so records straddle chunk boundaries.
+    // Counting only the bytes a record contributed to the chunk that ENDED it
+    // silently loses the part carried in from the previous chunk: measured, a
+    // 4.8 MB transcript came up 22,888 bytes short, and the resume point then
+    // re-read (and re-derived) the tail of every split record on the next scan.
+    // A single-chunk fixture cannot catch this — hence the size here.
+    const body = Array.from({ length: 400 }, (_, i) =>
+      callRecords(`bulk-${i}`, `git log --oneline -${i} # ${'x'.repeat(400)}`, `ok ${'y'.repeat(400)}`)).join('');
+    const session = claudeSession('multi-chunk', body);
+    expect(fs.statSync(session.filePath).size).toBeGreaterThan(64 * 1024);
+
+    await ensureToolIndex([session], { verifySourceStamps: true });
+
+    expect(ledger(session.id).parsed_offset).toBe(fs.statSync(session.filePath).size);
+    expect(ledger(session.id).call_count).toBe(400);
+  });
+
+  it('correlates a result that lands in a later append with its earlier call', async () => {
+    const session = claudeSession('split-call', JSON.stringify({
+      type: 'assistant', timestamp: '2026-08-03T00:00:00Z', message: { content: [
+        { type: 'tool_use', id: 'pending-call', name: 'Bash', input: { command: 'sleep 30' } },
+      ] },
+    }) + '\n');
+
+    await ensureToolIndex([session], { verifySourceStamps: true });
+    expect(storedCalls(session.id).map((row) => row.ordinal)).toEqual([0]);
+
+    // The result arrives in the appended bytes. Only the resumed collector's
+    // restored pending map can pair it with the call from the earlier chunk.
+    fs.appendFileSync(session.filePath, JSON.stringify({
+      type: 'user', timestamp: '2026-08-03T00:00:31Z', message: { content: [
+        { type: 'tool_result', tool_use_id: 'pending-call', content: 'slept' },
+      ] },
+    }) + '\n');
+    await ensureToolIndex([session], { verifySourceStamps: true });
+
+    const calls = getDB().prepare(`SELECT ordinal, outcome, output FROM tool_calls WHERE session_id = ?`)
+      .all(session.id) as Array<{ ordinal: number; outcome: string; output: string | null }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].ordinal).toBe(0);
+    expect(calls[0].output).toContain('slept');
+  });
+
+  it('re-reads from the start when the transcript was rewritten shorter', async () => {
+    const session = claudeSession(
+      'rewritten',
+      callRecords('a-call', 'git status', 'clean') + callRecords('b-call', 'gh pr view', 'open'),
+    );
+    await ensureToolIndex([session], { verifySourceStamps: true });
+    expect(ledger(session.id).call_count).toBe(2);
+
+    // Shorter means the stored prefix no longer describes this file, so the
+    // resume point must be refused rather than applied to different bytes.
+    fs.writeFileSync(session.filePath, callRecords('c-call', 'ls', 'ok'));
+    await ensureToolIndex([session], { verifySourceStamps: true });
+
+    expect(storedCalls(session.id).map((row) => row.source_call_id)).toEqual(['c-call']);
+  });
+
+  it('re-reads from the start when the extractor version moved on', async () => {
+    const session = claudeSession('stale-extractor', callRecords('old-call', 'git status', 'clean'));
+    await ensureToolIndex([session], { verifySourceStamps: true });
+
+    getDB().prepare(`UPDATE tool_scan_ledger SET extractor_version = extractor_version - 1 WHERE session_id = ?`)
+      .run(session.id);
+    mutatePrefix(session, 'git status', 'git st4tus');
+    fs.appendFileSync(session.filePath, callRecords('new-call', 'gh pr view', 'open'));
+    await ensureToolIndex([session], { verifySourceStamps: true });
+
+    // A resume point written by a different extractor is refused, so the whole
+    // file is re-read -- and the doctored prefix proves it was.
+    expect(storedCalls(session.id)[0].input).toContain('git st4tus');
+    expect(storedCalls(session.id).map((row) => row.source_call_id)).toEqual(['old-call', 'new-call']);
+  });
+
+  it('re-derives the same ordinals for a record that had no trailing newline', async () => {
+    const unterminated = JSON.stringify({
+      type: 'assistant', timestamp: '2026-08-03T00:00:00Z', message: { content: [
+        { type: 'tool_use', id: 'tail-call', name: 'Bash', input: { command: 'git status' } },
+      ] },
+    });
+    const session = claudeSession('unterminated', callRecords('head-call', 'ls', 'ok') + unterminated);
+    const prefixSize = Buffer.byteLength(callRecords('head-call', 'ls', 'ok'));
+
+    await ensureToolIndex([session], { verifySourceStamps: true });
+    // The half-written record is indexed, but the resume point stops before it.
+    expect(storedCalls(session.id).map((row) => row.source_call_id)).toEqual(['head-call', 'tail-call']);
+    expect(ledger(session.id).parsed_offset).toBe(prefixSize);
+
+    // Completing that record and appending another must not mint a second
+    // ordinal for the record the previous scan already indexed.
+    fs.appendFileSync(session.filePath, '\n' + callRecords('after-call', 'gh pr view', 'open'));
+    await ensureToolIndex([session], { verifySourceStamps: true });
+
+    expect(storedCalls(session.id).map((row) => [row.ordinal, row.source_call_id])).toEqual([
+      [0, 'head-call'],
+      [1, 'tail-call'],
+      [2, 'after-call'],
+    ]);
+  });
+});

--- a/apps/cli/src/lib/session/tool-index.ts
+++ b/apps/cli/src/lib/session/tool-index.ts
@@ -1,12 +1,13 @@
 import * as fs from 'fs';
 import { StringDecoder } from 'string_decoder';
 import type Database from '../sqlite.js';
-import { getDB } from './db.js';
+import { getDB, maintainSessionSearchIndex } from './db.js';
 import { parseSession } from './parse.js';
 import {
   TOOL_INDEX_VERSION,
   TOOL_INDEX_LIMIT_ORDINAL,
   ToolCallCollector,
+  type ToolCallCollectorSnapshot,
   collectClaudeToolCalls,
   collectCodexToolCalls,
   toolCallEvidenceBytes,
@@ -15,9 +16,11 @@ import {
 } from './tool-calls.js';
 import type { SessionMeta } from './types.js';
 import {
+  canonicalToolLedgerPath,
   persistToolCalls,
   purgeToolCalls,
   toolEvidenceSourcePath,
+  type ToolScanResumePoint,
 } from './tool-store.js';
 
 const BACKFILL_MAX_FILES = 25;
@@ -138,23 +141,83 @@ interface StoredCallRow {
   parse_error: string | null;
 }
 
+interface ToolLedgerRow {
+  file_path: string;
+  file_mtime_ms: number;
+  file_size: number;
+  extractor_version: number;
+  parsed_offset: number | null;
+}
+
+/**
+ * The ledger columns every candidate session is judged on. Deliberately NOT
+ * `parser_state`: this runs once per session in the scan's warm path, and that
+ * column holds a serialized collector snapshot that can reach a megabyte. It is
+ * read separately, only for the sessions that turn out to need indexing.
+ */
+function readToolLedger(db: Database.Database, sessionId: string): ToolLedgerRow | undefined {
+  return db.prepare(`
+    SELECT file_path, file_mtime_ms, file_size, extractor_version, parsed_offset
+    FROM tool_scan_ledger WHERE session_id = ?
+  `).get(sessionId) as ToolLedgerRow | undefined;
+}
+
+function readToolParserState(db: Database.Database, sessionId: string): string | null {
+  const row = db.prepare(`SELECT parser_state FROM tool_scan_ledger WHERE session_id = ?`)
+    .get(sessionId) as { parser_state: string | null } | undefined;
+  return row?.parser_state ?? null;
+}
+
 function needsIndex(
-  db: Database.Database,
-  sessionId: string,
+  row: ToolLedgerRow | undefined,
   stamp: { fileMtimeMs: number; fileSize: number },
 ): boolean {
-  const row = db.prepare(`
-    SELECT file_mtime_ms, file_size, extractor_version
-    FROM tool_scan_ledger WHERE session_id = ?
-  `).get(sessionId) as {
-    file_mtime_ms: number;
-    file_size: number;
-    extractor_version: number;
-  } | undefined;
   return !row
     || row.file_mtime_ms !== stamp.fileMtimeMs
     || row.file_size !== stamp.fileSize
     || row.extractor_version !== TOOL_INDEX_VERSION;
+}
+
+/**
+ * Where to start reading a session whose transcript changed.
+ *
+ * A live session's transcript is append-only, so re-reading it from byte 0 on
+ * every scan re-parses the entire history to discover the handful of records
+ * that are new — the cost that makes a large session's tool index quadratic in
+ * the number of scans. When the ledger carries a resume point that the current
+ * file still agrees with, the scan reads only the appended bytes and merges the
+ * result (`append`); anything else re-reads the whole file (`replace`).
+ *
+ * Each check below rejects a case where the stored prefix may no longer describe
+ * the file: a harness the streaming parser cannot resume, a different extractor,
+ * no recorded resume point, a source path the ledger row does not describe, a
+ * file that shrank below what was already parsed (a rewrite or truncation, not
+ * an append), or a snapshot that does not read back.
+ */
+function planToolScan(
+  db: Database.Database,
+  sessionId: string,
+  row: ToolLedgerRow | undefined,
+  sourcePath: string,
+  stamp: { fileMtimeMs: number; fileSize: number },
+  resumable: boolean,
+): { mode: 'replace' | 'append'; startOffset: number; snapshot?: ToolCallCollectorSnapshot } {
+  const full = { mode: 'replace' as const, startOffset: 0 };
+  if (!resumable || !row) return full;
+  if (row.extractor_version !== TOOL_INDEX_VERSION) return full;
+  if (row.parsed_offset === null) return full;
+  if (row.file_path !== canonicalToolLedgerPath(sourcePath)) return full;
+  if (stamp.fileSize < row.file_size || stamp.fileSize < row.parsed_offset) return full;
+  const parserState = readToolParserState(db, sessionId);
+  if (parserState === null) return full;
+  let snapshot: ToolCallCollectorSnapshot;
+  try {
+    snapshot = JSON.parse(parserState) as ToolCallCollectorSnapshot;
+  } catch {
+    return full;
+  }
+  if (snapshot?.v !== 1 || !Number.isSafeInteger(snapshot.nextOrdinal)) return full;
+  return { mode: 'append', startOffset: row.parsed_offset, snapshot };
 }
 
 /** Read index completeness from SQLite only; never stat or parse transcripts. */
@@ -203,15 +266,37 @@ function backfillLimitCall(session: SessionMeta, reason: string): IndexedToolCal
   };
 }
 
+/**
+ * One parse of a transcript: the calls to persist, plus where a later scan may
+ * resume. `resume` is null when the parse could not be trusted to have covered
+ * its whole prefix — the next scan then re-reads from byte 0.
+ */
+interface ToolParseResult {
+  calls: IndexedToolCall[];
+  resume: ToolScanResumePoint | null;
+}
+
 /** Stream Claude/Codex JSONL without ever retaining an oversized record. */
-async function streamJsonlToolCalls(session: SessionMeta): Promise<IndexedToolCall[]> {
-  const collector = new ToolCallCollector();
-  const stream = fs.createReadStream(session.filePath, { highWaterMark: 64 * 1024 });
+async function streamJsonlToolCalls(
+  session: SessionMeta,
+  from: { startOffset: number; snapshot?: ToolCallCollectorSnapshot } = { startOffset: 0 },
+): Promise<ToolParseResult> {
+  const collector = new ToolCallCollector(from.snapshot);
+  const stream = fs.createReadStream(session.filePath, {
+    highWaterMark: 64 * 1024,
+    start: from.startOffset,
+  });
   const decoder = new StringDecoder('utf8');
   let pending = '';
   let pendingBytes = 0;
   let droppingOversizedLine = false;
   let skippedOversizedLine = false;
+  // Byte offset just past the last complete record applied. Only a complete,
+  // newline-terminated record advances it, so resuming here can never re-apply a
+  // record (which would mint a second ordinal for it) nor skip a partial tail.
+  let parsedOffset = from.startOffset;
+  /** Bytes of the record currently being assembled, across chunk boundaries. */
+  let lineBytes = 0;
 
   const applyLine = (line: string): void => {
     if (!line.trim()) return;
@@ -231,8 +316,14 @@ async function streamJsonlToolCalls(session: SessionMeta): Promise<IndexedToolCa
       const newline = text.indexOf('\n', start);
       const end = newline >= 0 ? newline : text.length;
       const segment = text.slice(start, end);
+      const segmentBytes = Buffer.byteLength(segment);
+      // Counted outside the drop guard and across chunk boundaries: this is the
+      // record's true size on disk, which is what the resume offset is measured
+      // in. `pendingBytes` cannot stand in for it — that one resets when an
+      // oversized record is dropped, and a record split over two 64 KiB reads
+      // would lose the part carried in from the previous chunk.
+      lineBytes += segmentBytes;
       if (!droppingOversizedLine) {
-        const segmentBytes = Buffer.byteLength(segment);
         if (pendingBytes + segmentBytes <= BACKFILL_MAX_JSONL_RECORD_BYTES) {
           pending += segment;
           pendingBytes += segmentBytes;
@@ -245,6 +336,8 @@ async function streamJsonlToolCalls(session: SessionMeta): Promise<IndexedToolCa
       }
       if (newline < 0) break;
       if (!droppingOversizedLine) applyLine(pending);
+      parsedOffset += lineBytes + 1; // + the newline itself
+      lineBytes = 0;
       pending = '';
       pendingBytes = 0;
       droppingOversizedLine = false;
@@ -254,6 +347,17 @@ async function streamJsonlToolCalls(session: SessionMeta): Promise<IndexedToolCa
 
   for await (const chunk of stream) consume(decoder.write(chunk as Buffer));
   consume(decoder.end());
+
+  // Snapshot BEFORE the unterminated trailing record, and pair it with an offset
+  // that stops short of that record. The writer may be mid-append, so the record
+  // is indexed now (its evidence is real) but is re-read by the next scan — which
+  // resumes with the same next-ordinal and so re-derives the same ordinals,
+  // making the re-read an idempotent upsert rather than a duplicate.
+  const resume = skippedOversizedLine
+    // A dropped oversized record left the ordinals and the pending map out of
+    // step with the file; nothing here can be resumed from.
+    ? null
+    : { parserState: JSON.stringify(collector.snapshot()), parsedOffset };
   if (!droppingOversizedLine && pending.length > 0) applyLine(pending);
 
   const calls = collector.drainChanged();
@@ -263,29 +367,44 @@ async function streamJsonlToolCalls(session: SessionMeta): Promise<IndexedToolCa
       'At least one JSONL record exceeded the 1 MiB tool-backfill parser limit.',
     ));
   }
-  return calls;
+  return { calls, resume };
+}
+
+/** True for the harnesses whose transcript the streaming parser can resume. */
+function isResumableToolSource(agent: string): boolean {
+  return agent === 'claude' || agent === 'codex';
 }
 
 async function toolCallsForBackfill(
   session: SessionMeta,
   sourceBytes: number,
-): Promise<IndexedToolCall[]> {
-  if (session.agent === 'claude' || session.agent === 'codex') {
+  from: { startOffset: number; snapshot?: ToolCallCollectorSnapshot } = { startOffset: 0 },
+): Promise<ToolParseResult> {
+  if (isResumableToolSource(session.agent)) {
     if (sourceBytes > BACKFILL_MAX_STREAM_SOURCE_BYTES) {
-      return [backfillLimitCall(
-        session,
-        'Transcript exceeds the 64 MiB safe streaming tool-backfill limit.',
-      )];
+      return {
+        calls: [backfillLimitCall(
+          session,
+          'Transcript exceeds the 64 MiB safe streaming tool-backfill limit.',
+        )],
+        resume: null,
+      };
     }
-    return streamJsonlToolCalls(session);
+    return streamJsonlToolCalls(session, from);
   }
   if (sourceBytes > BACKFILL_MAX_IN_MEMORY_SOURCE_BYTES) {
-    return [backfillLimitCall(
-      session,
-      'Transcript exceeds the 16 MiB safe in-memory tool-backfill parser limit.',
-    )];
+    return {
+      calls: [backfillLimitCall(
+        session,
+        'Transcript exceeds the 16 MiB safe in-memory tool-backfill parser limit.',
+      )],
+      resume: null,
+    };
   }
-  return toolCallsFromEvents(parseSession(session.filePath, session.agent));
+  // Every other harness is parsed whole into memory by parseSession, which
+  // exposes no byte offset to resume from — so these stay full replaces and
+  // record no resume point, rather than storing one this path cannot honour.
+  return { calls: toolCallsFromEvents(parseSession(session.filePath, session.agent)), resume: null };
 }
 
 /**
@@ -299,12 +418,19 @@ export async function ensureToolIndex(
   const maxFiles = limits.maxFiles ?? BACKFILL_MAX_FILES;
   const maxBytes = limits.maxBytes ?? BACKFILL_MAX_BYTES;
   const db = getDB();
-  const pending: Array<{ session: SessionMeta; stamp: { fileMtimeMs: number; fileSize: number } }> = [];
+  const pending: Array<{
+    session: SessionMeta;
+    stamp: { fileMtimeMs: number; fileSize: number };
+    plan: ReturnType<typeof planToolScan>;
+    /** Bytes this scan will actually read — the whole file, or just the tail. */
+    readBytes: number;
+  }> = [];
   let skippedFiles = 0;
 
   for (const session of sessions) {
     if (!session.filePath) continue;
     const sourcePath = toolEvidenceSourcePath(session.filePath, session.agent);
+    const ledger = readToolLedger(db, session.id);
     const mustStatSource = limits.verifySourceStamps || sourcePath !== session.filePath;
     const indexed = !mustStatSource
       ? db.prepare(`
@@ -324,7 +450,14 @@ export async function ensureToolIndex(
         continue;
       }
     }
-    if (needsIndex(db, session.id, stamp)) pending.push({ session, stamp });
+    if (!needsIndex(ledger, stamp)) continue;
+    const plan = planToolScan(db, session.id, ledger, sourcePath, stamp, isResumableToolSource(session.agent));
+    pending.push({
+      session,
+      stamp,
+      plan,
+      readBytes: Math.max(0, stamp.fileSize - plan.startOffset),
+    });
   }
 
   let indexedFiles = 0;
@@ -336,18 +469,25 @@ export async function ensureToolIndex(
     // The byte budget is a batch boundary, not a correctness boundary. Admit
     // one oversized transcript by itself so it can never wedge the ledger or
     // silently disappear from results; the next invocation resumes afterward.
-    if (attemptedFiles > 0 && consumedBytes + item.stamp.fileSize > maxBytes) break;
+    // Budgeted on the bytes this scan reads, not the file's size: a resumed
+    // session costs only its appended tail, so a batch can cover far more
+    // growing sessions than it could when every one was re-read whole.
+    if (attemptedFiles > 0 && consumedBytes + item.readBytes > maxBytes) break;
     attemptedFiles++;
-    consumedBytes += item.stamp.fileSize;
+    consumedBytes += item.readBytes;
     try {
-      const calls = await toolCallsForBackfill(item.session, item.stamp.fileSize);
-      persistToolCalls(db, item.session, calls, item.stamp);
+      const { calls, resume } = await toolCallsForBackfill(item.session, item.stamp.fileSize, item.plan);
+      persistToolCalls(db, item.session, calls, item.stamp, { mode: item.plan.mode, resume });
       indexedFiles++;
       indexedCalls += calls.length;
     } catch {
       skippedFiles++;
     }
   }
+  // The scan just wrote a batch of FTS segments; pay a bounded slice of the
+  // merge they need so the index converges here instead of degrading until
+  // someone runs `agents sessions optimize` by hand (RUSH-2208).
+  if (indexedFiles > 0) maintainSessionSearchIndex(db);
 
   const remainingFiles = Math.max(0, pending.length - attemptedFiles);
   const limitedSessionIds = new Set<string>();

--- a/apps/cli/src/lib/session/tool-store.test.ts
+++ b/apps/cli/src/lib/session/tool-store.test.ts
@@ -32,12 +32,12 @@ describe('persistToolCalls', () => {
         { program: 'git', role: 'effective' },
       ],
       input: 'git status', outcome: 'unknown',
-    }], stamp, 'replace');
+    }], stamp, { mode: 'replace' });
     persistToolCalls(db, session, [{
       ordinal: 0, timestamp: session.timestamp, tool: 'exec_command', programs: ['git'],
       programOccurrences: [{ program: 'git', role: 'effective' }],
       input: 'git status', outcome: 'error', error: 'failed',
-    }], stamp, 'append');
+    }], stamp, { mode: 'append' });
 
     expect(db.prepare(`SELECT outcome, error FROM tool_calls WHERE session_id = ?`).get(session.id))
       .toEqual({ outcome: 'error', error: 'failed' });
@@ -49,6 +49,90 @@ describe('persistToolCalls', () => {
       { occurrence_ordinal: 0, program: 'git', role: 'effective' },
     ]);
     expect((db.prepare(`SELECT call_count FROM tool_scan_ledger`).get() as { call_count: number }).call_count).toBe(1);
+  });
+
+  it('keeps prior evidence on append and drops it on replace', () => {
+    const db = getDB();
+    const filePath = path.join(TEST_HOME, 'append-vs-replace.jsonl');
+    fs.writeFileSync(filePath, '{}\n');
+    const session = {
+      id: 'append-vs-replace', shortId: 'append-v', agent: 'claude',
+      timestamp: '2026-08-03T00:00:00Z', filePath,
+    } as SessionMeta;
+    const call = (ordinal: number, input: string) => ({
+      ordinal, timestamp: session.timestamp, tool: 'Bash', programs: ['git'],
+      programOccurrences: [{ program: 'git', role: 'effective' as const }],
+      input, outcome: 'unknown' as const,
+    });
+    const stamp = () => {
+      const stat = fs.statSync(filePath);
+      return { fileMtimeMs: stat.mtimeMs, fileSize: stat.size };
+    };
+    const rowids = () => db.prepare(`SELECT rowid FROM tool_calls WHERE session_id = ? ORDER BY ordinal`)
+      .all(session.id) as Array<{ rowid: number }>;
+    const inputs = () => (db.prepare(`SELECT input FROM tool_calls WHERE session_id = ? ORDER BY ordinal`)
+      .all(session.id) as Array<{ input: string }>).map((row) => row.input);
+
+    persistToolCalls(db, session, [call(0, 'git status'), call(1, 'git diff')], stamp(), {
+      mode: 'replace',
+      resume: { parserState: '{"v":1,"nextOrdinal":2,"pending":[]}', parsedOffset: 3 },
+    });
+    const beforeRowids = rowids();
+    fs.appendFileSync(filePath, '{}\n');
+
+    // The transcript grew, so the scan indexes only the new call. The two calls
+    // already stored keep their rows -- this is the delete-everything-and-reparse
+    // that RUSH-2208 is about, and the rowids prove they were never rewritten.
+    persistToolCalls(db, session, [call(2, 'git log')], stamp(), {
+      mode: 'append',
+      resume: { parserState: '{"v":1,"nextOrdinal":3,"pending":[]}', parsedOffset: 6 },
+    });
+
+    expect(inputs()).toEqual(['git status', 'git diff', 'git log']);
+    expect(rowids().slice(0, 2)).toEqual(beforeRowids);
+    expect(db.prepare(`SELECT call_count, parsed_offset FROM tool_scan_ledger WHERE session_id = ?`).get(session.id))
+      .toEqual({ call_count: 3, parsed_offset: 6 });
+    // Every stored call is still searchable through the rowid-addressed FTS rows.
+    expect(db.prepare(`
+      SELECT count(*) AS n FROM tool_call_text
+      WHERE rowid IN (SELECT rowid FROM tool_calls WHERE session_id = ?)
+    `).get(session.id)).toEqual({ n: 3 });
+
+    // A replace with no resume point clears the session's evidence and the
+    // resume point with it, so the next scan starts from byte 0.
+    persistToolCalls(db, session, [call(0, 'git fetch')], stamp(), { mode: 'replace' });
+
+    expect(inputs()).toEqual(['git fetch']);
+    expect(db.prepare(`SELECT call_count, parser_state, parsed_offset FROM tool_scan_ledger WHERE session_id = ?`)
+      .get(session.id)).toEqual({ call_count: 1, parser_state: null, parsed_offset: null });
+    expect(db.prepare(`
+      SELECT count(*) AS n FROM tool_call_text
+      WHERE rowid IN (SELECT rowid FROM tool_calls WHERE session_id = ?)
+    `).get(session.id)).toEqual({ n: 1 });
+  });
+
+  it('leaves no orphaned search rows when a session is replaced', () => {
+    const db = getDB();
+    const filePath = path.join(TEST_HOME, 'fts-orphans.jsonl');
+    fs.writeFileSync(filePath, '{}\n');
+    const session = {
+      id: 'fts-orphans', shortId: 'fts-orph', agent: 'claude',
+      timestamp: '2026-08-03T00:00:00Z', filePath,
+    } as SessionMeta;
+    const stat = fs.statSync(filePath);
+    const stamp = { fileMtimeMs: stat.mtimeMs, fileSize: stat.size };
+    const before = (db.prepare(`SELECT count(*) AS n FROM tool_call_text`).get() as { n: number }).n;
+    persistToolCalls(db, session, [0, 1, 2].map((ordinal) => ({
+      ordinal, timestamp: session.timestamp, tool: 'Bash', programs: ['rg'],
+      programOccurrences: [{ program: 'rg', role: 'effective' as const }],
+      input: `rg orphan-probe-${ordinal}`, outcome: 'unknown' as const,
+    })), stamp, { mode: 'replace' });
+
+    persistToolCalls(db, session, [], stamp, { mode: 'replace' });
+
+    expect(db.prepare(`SELECT count(*) AS n FROM tool_call_text`).get()).toEqual({ n: before });
+    expect(db.prepare(`SELECT count(*) AS n FROM tool_call_text WHERE tool_call_text MATCH '"orphan-probe"'`).get())
+      .toEqual({ n: 0 });
   });
 
   it('stores an explicit terminal record when a session reaches its evidence budget', () => {
@@ -64,7 +148,7 @@ describe('persistToolCalls', () => {
       ordinal: 0, timestamp: session.timestamp, tool: 'exec_command', programs: ['git'],
       programOccurrences: [{ program: 'git', role: 'effective' }],
       input: `git status ${'x'.repeat(200)}`, outcome: 'unknown',
-    }], { fileMtimeMs: stat.mtimeMs, fileSize: stat.size }, 'replace', 256);
+    }], { fileMtimeMs: stat.mtimeMs, fileSize: stat.size }, { mode: 'replace', maxSessionBytes: 256 });
 
     expect(db.prepare(`SELECT tool, parse_error FROM tool_calls WHERE session_id = ?`).all(session.id))
       .toEqual([{ tool: 'index_limit', parse_error: 'Additional tool calls were not indexed for this session.' }]);
@@ -92,7 +176,7 @@ describe('persistToolCalls', () => {
     fs.appendFileSync(filePath, '{}\n');
     const second = fs.statSync(filePath);
 
-    persistToolCalls(db, session, [], { fileMtimeMs: second.mtimeMs, fileSize: second.size }, 'append');
+    persistToolCalls(db, session, [], { fileMtimeMs: second.mtimeMs, fileSize: second.size }, { mode: 'append' });
 
     expect(db.prepare(`SELECT call_count, evidence_bytes FROM tool_scan_ledger WHERE file_path = ?`).get(filePath)).toEqual(before);
     expect(db.prepare(`SELECT count(*) AS n FROM tool_calls WHERE session_id = ?`).get(session.id)).toEqual({ n: 1 });

--- a/apps/cli/src/lib/session/tool-store.ts
+++ b/apps/cli/src/lib/session/tool-store.ts
@@ -38,11 +38,17 @@ export function toolEvidenceSourcePath(filePath: string, agent: string): string 
 }
 
 function deleteSessionCalls(db: Database.Database, sessionId: string): void {
-  const keys = db.prepare(`SELECT call_key FROM tool_calls WHERE session_id = ?`).all(sessionId) as Array<{ call_key: string }>;
-  for (const { call_key } of keys) {
-    db.prepare(`DELETE FROM tool_call_programs WHERE call_key = ?`).run(call_key);
-    db.prepare(`DELETE FROM tool_program_occurrences WHERE call_key = ?`).run(call_key);
-    db.prepare(`DELETE FROM tool_call_text WHERE call_key = ?`).run(call_key);
+  const rows = db.prepare(`SELECT rowid, call_key FROM tool_calls WHERE session_id = ?`)
+    .all(sessionId) as Array<{ rowid: number; call_key: string }>;
+  const deletePrograms = db.prepare(`DELETE FROM tool_call_programs WHERE call_key = ?`);
+  const deleteOccurrences = db.prepare(`DELETE FROM tool_program_occurrences WHERE call_key = ?`);
+  // Addressed by rowid, never by the UNINDEXED call_key — see the tool_call_text
+  // schema comment in db.ts. A call_key predicate scans the whole FTS index.
+  const deleteText = db.prepare(`DELETE FROM tool_call_text WHERE rowid = ?`);
+  for (const { rowid, call_key } of rows) {
+    deletePrograms.run(call_key);
+    deleteOccurrences.run(call_key);
+    deleteText.run(rowid);
   }
   db.prepare(`DELETE FROM tool_calls WHERE session_id = ?`).run(sessionId);
 }
@@ -80,15 +86,43 @@ export function purgeMissingToolCallsInDirectory(
   return purged;
 }
 
-/** Persist one parser batch and its file stamp atomically. */
+/** The resume point a later incremental scan starts from. */
+export interface ToolScanResumePoint {
+  /** Serialized ToolCallCollector snapshot at `parsedOffset`. */
+  parserState: string;
+  /** Byte offset just past the last complete record consumed. */
+  parsedOffset: number;
+}
+
+export interface PersistToolCallsOptions {
+  /**
+   * `replace` drops the session's stored evidence first — correct for a parse
+   * that started at byte 0. `append` merges the batch into what is already
+   * stored and requires an existing ledger row; use it only for a parse that
+   * resumed from that row's `parsedOffset`.
+   */
+  mode?: 'replace' | 'append';
+  /**
+   * Where a later scan may resume. Omitted (or null) clears any stored resume
+   * point, which forces the next scan of this session to re-read from byte 0 —
+   * the correct outcome whenever the parse could not cover the whole prefix
+   * (an oversized record, a size-capped transcript, a non-streaming harness).
+   */
+  resume?: ToolScanResumePoint | null;
+  maxSessionBytes?: number;
+}
+
+/** Persist one parser batch, its file stamp, and its resume point atomically. */
 export function persistToolCalls(
   db: Database.Database,
   session: SessionMeta,
   calls: IndexedToolCall[],
   sourceStamp: { fileMtimeMs: number; fileSize: number },
-  mode: 'replace' | 'append' = 'replace',
-  maxSessionBytes = TOOL_SESSION_EVIDENCE_MAX_BYTES,
+  options: PersistToolCallsOptions = {},
 ): void {
+  const mode = options.mode ?? 'replace';
+  const maxSessionBytes = options.maxSessionBytes ?? TOOL_SESSION_EVIDENCE_MAX_BYTES;
+  const resume = options.resume ?? null;
   const sourcePath = toolEvidenceSourcePath(session.filePath, session.agent);
   const insertCall = db.prepare(`
     INSERT INTO tool_calls (
@@ -115,16 +149,19 @@ export function persistToolCalls(
     INSERT INTO tool_program_occurrences (call_key, occurrence_ordinal, program, role)
     VALUES (?, ?, ?, ?)
   `);
-  const insertText = db.prepare(`INSERT INTO tool_call_text (call_key, tool, input, output, error) VALUES (?, ?, ?, ?, ?)`);
+  // tool_call_text rows are addressed by the rowid of the tool_calls row they
+  // describe (db.ts schema comment): its UNINDEXED call_key cannot be seeked.
+  const insertText = db.prepare(`INSERT INTO tool_call_text (rowid, call_key, tool, input, output, error) VALUES (?, ?, ?, ?, ?, ?)`);
+  const callRowid = db.prepare(`SELECT rowid FROM tool_calls WHERE call_key = ?`);
   const deletePrograms = db.prepare(`DELETE FROM tool_call_programs WHERE call_key = ?`);
   const deleteOccurrences = db.prepare(`DELETE FROM tool_program_occurrences WHERE call_key = ?`);
-  const deleteText = db.prepare(`DELETE FROM tool_call_text WHERE call_key = ?`);
+  const deleteText = db.prepare(`DELETE FROM tool_call_text WHERE rowid = ?`);
   const deleteCall = db.prepare(`DELETE FROM tool_calls WHERE call_key = ?`);
   const writeLedger = db.prepare(`
     INSERT INTO tool_scan_ledger (
       session_id, file_path, file_mtime_ms, file_size, extractor_version, indexed_at, call_count,
-      evidence_bytes
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      evidence_bytes, parser_state, parsed_offset
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(session_id) DO UPDATE SET
       file_path = excluded.file_path,
       file_mtime_ms = excluded.file_mtime_ms,
@@ -132,7 +169,9 @@ export function persistToolCalls(
       extractor_version = excluded.extractor_version,
       indexed_at = excluded.indexed_at,
       call_count = excluded.call_count,
-      evidence_bytes = excluded.evidence_bytes
+      evidence_bytes = excluded.evidence_bytes,
+      parser_state = excluded.parser_state,
+      parsed_offset = excluded.parsed_offset
   `);
 
   const txn = db.transaction(() => {
@@ -151,6 +190,7 @@ export function persistToolCalls(
       writeLedger.run(
         session.id, ledgerPath, sourceStamp.fileMtimeMs, sourceStamp.fileSize, TOOL_INDEX_VERSION, Date.now(),
         priorLedger!.call_count, priorLedger!.evidence_bytes,
+        resume?.parserState ?? null, resume?.parsedOffset ?? null,
       );
       return;
     }
@@ -162,9 +202,10 @@ export function persistToolCalls(
     const priorLimit = mode === 'append'
       ? existingSize.get(session.id, TOOL_INDEX_LIMIT_ORDINAL) as { evidence_bytes: number } | undefined
       : undefined;
+    const limitRow = callRowid.get(limitKey) as { rowid: number } | undefined;
     deletePrograms.run(limitKey);
     deleteOccurrences.run(limitKey);
-    deleteText.run(limitKey);
+    if (limitRow) deleteText.run(limitRow.rowid);
     deleteCall.run(limitKey);
 
     const existingRows = mode === 'append'
@@ -222,18 +263,22 @@ export function persistToolCalls(
         call.statusCode ?? null, call.errorCode ?? null, call.output ?? null,
         call.error ?? null, call.parseError ?? null, toolCallEvidenceBytes(call),
       );
+      // The upsert above preserves the rowid of a call it updated, so this is
+      // the same rowid the existing text row (if any) was written under.
+      const { rowid } = callRowid.get(key) as { rowid: number };
       deletePrograms.run(key);
       deleteOccurrences.run(key);
-      deleteText.run(key);
+      deleteText.run(rowid);
       for (const program of call.programs) insertProgram.run(key, program);
       call.programOccurrences.forEach((occurrence, occurrenceOrdinal) => {
         insertOccurrence.run(key, occurrenceOrdinal, occurrence.program, occurrence.role);
       });
-      insertText.run(key, call.tool, call.input, call.output ?? '', call.error ?? '');
+      insertText.run(rowid, key, call.tool, call.input, call.output ?? '', call.error ?? '');
     }
     writeLedger.run(
       session.id, ledgerPath, sourceStamp.fileMtimeMs, sourceStamp.fileSize,
       TOOL_INDEX_VERSION, Date.now(), count, storedBytes,
+      resume?.parserState ?? null, resume?.parsedOffset ?? null,
     );
   });
   txn();


### PR DESCRIPTION
**perf + bugfix** — `agents sessions backfill tools` now reads a growing transcript incrementally, and the FTS index compacts itself. Linear: [RUSH-2208](https://linear.app/getrush/issue/RUSH-2208)

## What was wrong

Incremental **discovery** already appended tool calls for a Claude/Codex session that grew (`toolIndexMode: 'append'`, `discover.ts:1472,1756`). The **backfill** side did not: every `ensureToolIndex` pass re-read the transcript from byte 0 and deleted the session's stored evidence to rewrite it, so a session backfilled N times cost N full parses of an ever-larger file. `ToolCallCollector` already had the snapshot/resume API for exactly this (`tool-calls.ts:389,473`); nothing reached it.

Two related defects, both in the same write path:

| | Before | After |
|---|---|---|
| FTS delete | `DELETE FROM tool_call_text WHERE call_key = ?` — `call_key` is UNINDEXED, so a full index scan **per call** | delete by `rowid`, mirroring `tool_calls.rowid` — one seek |
| FTS compaction | only `agents sessions optimize`, run by hand | bounded, threshold-gated `'merge'` on the scan path |

## Run result

Real `ensureToolIndex` (what `sessions backfill tools` calls) over a 4.5 MiB / 4000-call Claude transcript that grew by 20 calls. `BEFORE` is the same code with the v35 resume point cleared, i.e. exactly what every pass did:

```
cold pass (nothing indexed yet — must read the whole file)
  read: 297 ms, indexedCalls=4000, complete=true
  ledger: {"call_count":4000,"file_size":4747596,"parsed_offset":4747596}  <- resume point == file size

appended 20 calls -> 4.55 MiB

AFTER (v35 resume point present): reads only the appended tail
  read: 12 ms, indexedCalls=20, complete=true
  ledger: {"call_count":4020,"file_size":4771436,"parsed_offset":4771436}

BEFORE (resume point cleared — what every pass did): re-reads from byte 0
  read: 344 ms, indexedCalls=4020, complete=true

speedup on a 4.9 MiB session that grew by 20 calls: 28.4x (344 ms -> 12 ms)
appended call is searchable: 1 hit -> "git log --oneline -90019 ###############"
```

Full run output: https://share.agents-cli.sh/gitconfig-user/muqsit-r2208-run-output-0b22ad9d9926fef5

No UI surface — this is an indexing path; the run above is the proof.

## How the resume point works

`tool_scan_ledger` gains `parsed_offset` (the byte just past the last **complete** record consumed) and `parser_state` (the collector snapshot at that offset). `planToolScan` refuses it — and re-reads the whole file — on a different extractor version, a missing resume point, a ledger source path that does not match, a file shorter than what was already parsed, or a snapshot that does not read back. A record with no trailing newline is indexed but does **not** advance `parsed_offset`, so re-reading it next pass re-derives the same ordinals (an idempotent upsert, not a duplicate call). Harnesses parsed whole into memory record no resume point and stay full replaces. The batch byte budget now counts the bytes a pass actually reads, so one bounded batch covers far more growing sessions.

## Migration (v34 → v35)

Adds the two ledger columns as NULL (existing sessions re-read once, then go incremental) and rebuilds `tool_call_text` from `tool_calls` so its rowids align. Non-destructive: `tool_calls` is the source of truth and is untouched, neither ledger is wiped, and the rebuild lands the content as one merged segment.

## Tests

- `tool-index.incremental.test.ts` (new) — resume reads only the appended bytes (proved by doctoring the already-parsed prefix in place: a resumed pass cannot see it, a full re-read can), a result landing in a later append still pairs with its earlier call, byte accounting across 64 KiB read chunks, and each disqualifier falling back to a full re-read.
- `tool-store.test.ts` — append keeps prior rows and their rowids; replace clears them and their FTS rows, leaving no orphans.
- `db.migrate-v35.test.ts` (new) — rowid alignment, warm ledgers, content still searchable.
- `db.optimize.test.ts` — the automatic merge is a no-op under the threshold and non-destructive above it.

Full suite from `apps/cli`: 13 files / 33 tests fail identically on `origin/main` (`sync/config.test.ts` and friends — keychain-dependent on this Linux box); nothing in this diff fails.

## Caught during verification

The first cut of the byte accounting counted only the bytes a record contributed to the chunk that *ended* it, silently losing the part carried in from the previous 64 KiB read — a 4.8 MB transcript came up 22,888 bytes short. Small fixtures could not catch it, so `accounts for every byte of a transcript larger than one read chunk` now pins it.

## Follow-up (not in this PR)

A discovery-driven write records no resume point and clears the columns. That is correct — it keeps the tool ledger's stamp current, so the next backfill finds nothing to do — but wiring discovery to publish its own offset into the tool ledger would let the two paths share one resume point. That lives in `discover.ts`, which RUSH-2209 is editing.
