### PR TITLE
feat(apply): --provision-secrets pushes declared bundles, gated on a pinned host key (RUSH-1968)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1968-fleet-provision.md
+++ b/apps/cli/.changelog/next/RUSH-1968-fleet-provision.md
@@ -1,0 +1,31 @@
+- **`agents apply --provision-secrets` pushes the manifest's declared secrets
+  bundles to each device, instead of only printing a reminder (RUSH-1968).** This
+  gap is a direct cause of the ticket: an operator who needed secrets on a worker
+  box had no supported path — `apply` said "recreate manually" and nothing else —
+  so they hand-exported the file store's master key across the fleet. The
+  provisioning primitive now exists, and `apply` runs it as a fifth reconcile
+  phase, last, because it is the most sensitive mutation `apply` performs.
+
+  It is **off by default** and is a **flag, not a manifest field**: `agents.yaml`
+  is shared, so a file-level default would mean someone else's `apply -y` silently
+  ships credential values. Three gates, and every refusal still prints a
+  `needs-secret` reminder so a skipped device is never silent — the flag must be
+  set, the device must be reachable, and its host key must be **pinned** (the same
+  bar `agents exec --copy-creds` sets, EXEC-34).
+
+  **Backend follows the platform: `file` on Linux, `keychain` on macOS/Windows.**
+  That is the load-bearing default — a headless Linux box has no keychain and its
+  file store auto-provisions its OWN machine-local key, so each device gets an
+  unshared at-rest key and **no passphrase is forwarded**. That is the direct
+  alternative to the fleet-wide shared secret this ticket is about.
+
+  With provisioning on, `apply` runs one extra `agents secrets list --json` per
+  device (metadata only — names and timestamps, never values) and skips a bundle
+  the device already has; without that, every run re-resolves the bundle locally
+  and a resolve can prompt for Touch ID, so a converged fleet would nag on every
+  apply. It compares presence, not content — `--force` re-pushes regardless. The
+  `--plan` matrix gains a `secrets` column, shown only when the manifest declares
+  bundles, and names the flag when the capability is available but off. Source:
+  `apps/cli/src/lib/secrets/push.ts` (extracted from the `export --host` action so
+  a lib no longer needs a command module), `apps/cli/src/lib/fleet/apply.ts`,
+  `apps/cli/src/commands/apply.ts`.

--- a/apps/cli/docs/fleet.md
+++ b/apps/cli/docs/fleet.md
@@ -48,7 +48,7 @@ environment — both are **names only, never values**:
 
 | Field | Meaning |
 |---|---|
-| `secrets.bundles` | Secrets-bundle **names** to ensure exist. Values live in the OS keychain and are never captured or pushed; `apply` surfaces missing bundles to recreate manually. |
+| `secrets.bundles` | Secrets-bundle **names** to ensure exist. By default `apply` only *surfaces* them to recreate manually; `--provision-secrets` pushes them (see below). |
 | `routines` | Routine **names** that should be active on the fleet (the routine files themselves sync via the repo). |
 
 > Browser profiles are **not** captured into `fleet:` — the central `browser:`
@@ -85,7 +85,7 @@ reported as unresolved rather than aborting the run.
 ## What a reconcile does
 
 For each targeted, reachable device `apply` probes state, then plans the minimal
-set of actions across four dimensions:
+set of actions across five dimensions:
 
 - **agents-cli** — `install-cli` if absent, `upgrade-cli` on a version mismatch.
 - **agents** — `add-agent` for any profile agent not installed. A bare/`@latest`
@@ -96,6 +96,10 @@ set of actions across four dimensions:
 - **config** — `sync-config` for the declared `sync:` scopes.
 - **login** — `push-login` where a portable credential can be propagated;
   `needs-login` where the login is desired but genuinely can't be (see below).
+- **secrets** — `push-secret` for a declared bundle when `--provision-secrets` is
+  set and the gates below pass; `needs-secret` (a manual reminder) otherwise. Runs
+  **last**, because it is the most sensitive mutation `apply` performs: every
+  lower-risk step is already recorded before credential values move.
 
 An unreachable device yields no actions. The whole run is idempotent — a device
 already matching the profile plans nothing.
@@ -115,6 +119,41 @@ Fleet profile · 10 device(s) · 3 agent(s) (claude, codex, gemini)
 
 Run without `--plan` to execute; `apply` confirms first, and `-y/--yes` skips
 the prompt.
+
+## Provisioning secrets (`--provision-secrets`)
+
+`apply` can push the bundles `secrets.bundles` declares to each device. It is
+**off by default** and it is a **flag, not a manifest field** — `agents.yaml` is
+shared, so a file-level default would mean someone else's `apply -y` silently
+ships credential values. That is the same shape of accident as RUSH-1968, where
+the absence of any supported provisioning path led an operator to hand-export the
+file store's master key across the fleet instead.
+
+Three gates, in order. Every refusal still prints a `needs-secret` reminder, so a
+skipped device is never silent:
+
+| Gate | Refusal |
+|---|---|
+| `--provision-secrets` set? | reminder naming the flag |
+| Device reachable? | ordinary manual reminder |
+| Host key **pinned**? | `host key not pinned; run \`agents ssh <device>\` once to pin it` |
+
+The pin requirement is the same bar `agents exec --copy-creds` already sets
+(EXEC-34): credential values only ever move to a host whose key is pinned.
+
+**Backend follows the platform, and this is the load-bearing default:** `file` on
+Linux, `keychain` on macOS/Windows. A headless Linux box has no keychain, and its
+file store **auto-provisions its own machine-local key** — so each device ends up
+with an unshared at-rest key and **no passphrase is forwarded**. That is the
+direct alternative to a fleet-wide shared secret.
+
+**Idempotence.** With provisioning on, `apply` runs one extra
+`agents secrets list --json` per device (**metadata only** — names and timestamps,
+never values) and skips a bundle the device already has. Without it every run
+re-resolves the bundle locally, and a resolve can prompt for Touch ID, so a
+converged fleet would nag on every apply. Known limitation, stated plainly: this
+compares **presence**, not content — a bundle whose values changed locally still
+reads as present. Use `--force` to re-push regardless.
 
 ## Login propagation
 
@@ -156,6 +195,8 @@ propagation path.
 | `--agent <specs...>` | Override the roster for the targeted device(s) — install exactly these specs instead of the manifest's. Pairs with `--device` to seed one box. See [§Replicating this machine's version set](#replicating-this-machines-version-set). |
 | `--only <dims>` | Limit to a comma list of `agents,config,login`. |
 | `--no-login` | Do not propagate logins (equivalent to `login: skip` everywhere). |
+| `--provision-secrets` | Push the declared `secrets.bundles` to each device. OFF by default; only to a device whose host key is pinned. See [§Provisioning secrets](#provisioning-secrets---provision-secrets). |
+| `--force` | With `--provision-secrets`: re-push a bundle the device already has. |
 
 ## Replicating this machine's version set
 

--- a/apps/cli/src/commands/apply.ts
+++ b/apps/cli/src/commands/apply.ts
@@ -16,6 +16,7 @@ import chalk from 'chalk';
 import { setHelpSections } from '../lib/help.js';
 import { machineId } from '../lib/session/sync/config.js';
 import { loadDevices, isControlDevice, type DeviceProfile } from '../lib/devices/registry.js';
+import { isHostPinned, managedKnownHostsPath } from '../lib/devices/known-hosts.js';
 import { ensureDevicesRegistered } from '../lib/devices/sync.js';
 import { readFleetFile, resolveDesired } from '../lib/fleet/manifest.js';
 import { snapshotAuth, materializeAuth, parseAuthBundle, KEYCHAIN_BOUND_ON_MAC, isCredentialSafeToPropagate } from '../lib/fleet/auth-sync.js';
@@ -45,6 +46,8 @@ interface ApplyOptions {
   only?: string;
   login?: boolean; // Commander sets false for --no-login
   recvAuth?: boolean; // hidden internal receiver
+  provisionSecrets?: boolean;
+  force?: boolean;
 }
 
 /** Version of the running agents-cli — the fleet target version. */
@@ -112,7 +115,10 @@ function renderPlan(plan: FleetPlan): void {
     return chalk.cyan('↑ ' + acts.map((a) => a.agent ?? a.kind.replace('-cli', '')).join(','));
   };
 
-  const header = `  ${'device'.padEnd(nameWidth)}   ${'agents-cli'.padEnd(12)}${'agents'.padEnd(20)}${'config'.padEnd(10)}login`;
+  // Only show the secrets column when the manifest declares any — an all-`-`
+  // column on every fleet that uses no bundles is noise.
+  const anySecrets = rows.some((r) => r.actions.some((a) => a.kind === 'push-secret' || a.kind === 'needs-secret'));
+  const header = `  ${'device'.padEnd(nameWidth)}   ${'agents-cli'.padEnd(12)}${'agents'.padEnd(20)}${'config'.padEnd(10)}${anySecrets ? 'login'.padEnd(18) + 'secrets' : 'login'}`;
   console.log(chalk.gray(header));
   for (const row of rows) {
     const cli = row.probe.reachable
@@ -130,10 +136,29 @@ function renderPlan(plan: FleetPlan): void {
       ? (row.actions.some((a) => a.kind === 'sync-config') ? chalk.cyan('↑ sync') : chalk.green('ok'))
       : chalk.gray('-');
     const loginCell = cell(row, ['push-login', 'needs-login'], `${row.desired.agents.length}/${row.desired.agents.length}`);
-    console.log(`  ${row.device.padEnd(nameWidth)}   ${stripPad(cli, 12)}${stripPad(agentsCell, 20)}${stripPad(configCell, 10)}${loginCell}`);
+    const secretsCell = (() => {
+      if (!anySecrets) return '';
+      if (!row.probe.reachable) return chalk.gray('- offline');
+      const push = row.actions.filter((a) => a.kind === 'push-secret').length;
+      const blocked = row.actions.filter((a) => a.kind === 'needs-secret').length;
+      if (push === 0 && blocked === 0) return chalk.green('ok');
+      if (push > 0 && blocked === 0) return chalk.cyan(`↑ push ${push}`);
+      if (push === 0) return chalk.yellow(`blocked ${blocked}`);
+      return chalk.yellow(`↑ push ${push} · blocked ${blocked}`);
+    })();
+    const loginPart = anySecrets ? stripPad(loginCell, 18) + secretsCell : loginCell;
+    console.log(`  ${row.device.padEnd(nameWidth)}   ${stripPad(cli, 12)}${stripPad(agentsCell, 20)}${stripPad(configCell, 10)}${loginPart}`);
   }
   console.log();
   console.log(chalk.gray(`  ${plan.actions.length} action(s) across ${rows.filter((r) => r.probe.reachable).length} reachable device(s)`));
+
+  // The capability is opt-in, so when it is OFF and the manifest declares
+  // bundles, say that it exists. Otherwise an operator reads "manual recreate"
+  // and concludes there is no supported path — which is exactly the conclusion
+  // that led to a master key being hand-exported across the fleet (RUSH-1968).
+  if (anySecrets && !rows.some((r) => r.actions.some((a) => a.kind === 'push-secret'))) {
+    console.log(chalk.gray('  secrets: not pushed. `--provision-secrets` pushes declared bundles to devices whose host key is pinned.'));
+  }
 
   // Distinguish *why* a login can't be propagated: macOS keychain-bound,
   // single-use rotating refresh token (never copied), or the source simply not
@@ -158,14 +183,15 @@ function renderPlan(plan: FleetPlan): void {
   if (noToken.length > 0) {
     console.log(chalk.yellow(`  manual login needed (no portable token on source): ${noToken.join(', ')}`));
   }
-  // Secrets bundles are declared once for the fleet; surface the distinct set to
-  // recreate on any device missing them (values are keychain-local, never pushed).
+  // Secrets bundles are declared once for the fleet; surface the distinct set the
+  // gate did NOT push, so a refusal is never silent. "never pushed" used to be
+  // literally true here and no longer is — `--provision-secrets` pushes them.
   const bundles = [...new Set(rows.flatMap((r) => r.secretsNeeded))];
   if (bundles.length > 0) {
     const shown = bundles.slice(0, 12);
     const more = bundles.length - shown.length;
     const list = shown.join(', ') + (more > 0 ? `, +${more} more` : '');
-    console.log(chalk.yellow(`  ${bundles.length} secrets bundle(s) to recreate where missing (keychain-local, never pushed): ${list}`));
+    console.log(chalk.yellow(`  ${bundles.length} secrets bundle(s) not pushed — recreate where missing: ${list}`));
   }
 }
 
@@ -251,12 +277,25 @@ async function runApply(opts: ApplyOptions): Promise<void> {
   // Probe every target device in parallel.
   const nameToProfile = new Map<string, DeviceProfile>(desired.map((d) => [d.device, registry[d.device]!]));
   const withVersions = rosterNeedsVersions(desired);
+  // One extra `secrets list --json` per device, and only when it can change the
+  // plan: the manifest declares bundles AND provisioning is on. Same cost
+  // discipline as `withVersions` — a fleet that uses no bundles never pays it.
+  const withSecrets = opts.provisionSecrets === true && (manifest.secrets?.bundles?.length ?? 0) > 0;
   console.log(chalk.gray(`Probing ${desired.length} device(s)…`));
-  const probeList = await pool(desired, 6, async (d) => probeDevice(nameToProfile.get(d.device)!, { withVersions }));
+  const probeList = await pool(desired, 6, async (d) => probeDevice(nameToProfile.get(d.device)!, { withVersions, withSecrets }));
   const probes = new Map<string, DeviceProbe>(probeList.map((p) => [p.device, p]));
 
   const targetCliVersion = localCliVersion();
-  let plan = diffFleet(desired, probes, { targetCliVersion, sourceAuth, secretsBundles: manifest.secrets?.bundles });
+  let plan = diffFleet(desired, probes, {
+    targetCliVersion,
+    sourceAuth,
+    secretsBundles: manifest.secrets?.bundles,
+    provisionSecrets: opts.provisionSecrets === true,
+    forceSecrets: opts.force === true,
+    // Same bar as `exec --copy-creds` (EXEC-34): credential values only ever go
+    // to a host whose key we already pinned.
+    isHostPinned: (device) => isHostPinned(device, managedKnownHostsPath()),
+  });
 
   // --only filter.
   if (opts.only) {
@@ -276,7 +315,8 @@ async function runApply(opts: ApplyOptions): Promise<void> {
   if (isDry) return;
   // `needs-login`/`needs-secret` are surfaced manual reminders, not executable
   // mutations — exclude them so an otherwise-converged fleet still says "nothing
-  // to do" instead of looping forever on un-actionable surfacing.
+  // to do" instead of looping forever on un-actionable surfacing. `push-secret`
+  // IS executable and deliberately stays counted.
   if (plan.actions.filter((a) => a.kind !== 'needs-login' && a.kind !== 'needs-secret').length === 0) {
     console.log(chalk.green('\nNothing to do — fleet already matches the profile.'));
     return;
@@ -338,6 +378,8 @@ export function configureApplyCommand(cmd: Command): Command {
     .option('--agent <specs...>', 'Override the roster for targeted device(s): install these specs instead of the manifest\'s. Use `claude@all` to replicate every version installed on this machine.')
     .option('--only <dims>', 'Limit to dimensions: comma list of agents,config,login')
     .option('--no-login', 'Do not propagate logins')
+    .option('--provision-secrets', "Push the manifest's declared secrets bundles to each device (OFF by default; moves credential values over SSH, and only to a device whose host key is already pinned)")
+    .option('--force', 'With --provision-secrets: re-push a bundle the device already has')
     .addOption(new Option('--recv-auth', 'internal: receive an auth bundle on stdin').hideHelp())
     .action(async (opts: ApplyOptions) => {
       try {

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -27,6 +27,9 @@ import {
   buildRemoteFileImportCommand,
 } from '../lib/secrets/remote.js';
 import { remoteShellFor, buildWindowsStdinImportCommand } from '../lib/hosts/remote-cmd.js';
+import { resolveBundleForPush, pushResolvedBundleToHost, bundleEnvToDotenv, type RemoteBackend } from '../lib/secrets/push.js';
+
+export { bundleEnvToDotenv };
 import { resolveRemoteOsSync } from '../lib/hosts/remote-os.js';
 import {
   bundleBackend,
@@ -473,26 +476,6 @@ function getCliVersion(): string {
   }
 }
 
-/**
- * Serialize a resolved env map to `.env` lines that round-trip losslessly through
- * `parseDotenv` on the remote: `KEY="VALUE"`. parseDotenv strips exactly one outer
- * quote pair and takes the inner bytes verbatim (no unescaping), so any single-line
- * value survives unchanged with no escaping. Newlines would break its line-based
- * parse, so multi-line values are rejected rather than silently corrupted.
- */
-export function bundleEnvToDotenv(env: Record<string, string>): string {
-  const lines: string[] = [];
-  for (const [k, v] of Object.entries(env)) {
-    if (/[\r\n]/.test(v)) {
-      throw new Error(
-        `Key '${k}' has a multi-line value; the SSH .env transport can't carry newlines. ` +
-        `Set it directly on the remote with 'agents secrets add ${k} --value-stdin'.`,
-      );
-    }
-    lines.push(`${k}="${v}"`);
-  }
-  return lines.join('\n') + '\n';
-}
 
 /**
  * Encrypt a resolved env map to an offline bundle file using AES-256-GCM
@@ -2255,101 +2238,42 @@ Examples:
         const hosts = opts.host ?? [];
         if (hosts.length > 0) {
           for (const h of hosts) assertValidSshTarget(h);
-          const remoteBackend = parseBackendOpt(opts.remoteBackend);
+          const parsedBackend = parseBackendOpt(opts.remoteBackend);
+          // `--remote-backend` documents keychain|file only, and parseBackendOpt
+          // exits on anything else — but its return type still admits 'vault',
+          // which has no remote-push path. Refuse it here rather than let it fall
+          // through to the keychain branch and half-work.
+          if (parsedBackend === 'vault') {
+            console.error(chalk.red("--remote-backend vault is not supported; use 'keychain' or 'file'."));
+            process.exit(1);
+          }
+          const remoteBackend: RemoteBackend = parsedBackend;
           // For a file-backed remote bundle a passphrase is OPTIONAL. The file
           // store is passphrase-free by default: with AGENTS_SECRETS_PASSPHRASE
           // unset the remote `import --backend file` auto-provisions the remote's
           // own machine-local key (0600 under ~/.agents/.secrets-key/), so reads
           // are HEADLESS. We forward the LOCAL AGENTS_SECRETS_PASSPHRASE only when
-          // the operator opts in by setting it (e.g. to key the bundle off-disk
-          // under a shared secret) — shipped as the FIRST stdin line so it never
-          // lands in argv / `ps` / the remote shell history. Forcing a shared
-          // passphrase would defeat headless reads, so we no longer require one.
+          // the operator opts in by setting it. Forcing a shared passphrase would
+          // defeat headless reads, so we no longer require one.
           const remotePassphrase = remoteBackend === 'file' ? (process.env.AGENTS_SECRETS_PASSPHRASE ?? '') : '';
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export`, keyMode: 'storage', agentOnly: true });
-          const dotenv = bundleEnvToDotenv(env);
-          const keyCount = Object.keys(env).length;
-          // Drive the remote's own `agents secrets import --from -` so the values
-          // land in its chosen backend, reading the .env off ssh stdin (never
-          // parsed by a remote shell — `--from -` replaces the POSIX-only
-          // `/dev/stdin`). The keychain path is built OS-aware via
-          // `remoteSecretsRaw` (bash -lc on POSIX, PowerShell on Windows), so it
-          // works on macOS, Linux AND Windows targets. `import` auto-creates the
-          // bundle, so no separate `create` (the old `|| true` was a POSIXism
-          // that broke on PowerShell: `'true' is not recognized`).
+          // Resolve ONCE for N hosts — reading a bundle can prompt, and doing it
+          // per host would prompt per host.
+          const resolvedForPush = resolveBundleForPush(resolvedBundleName, 'ssh export');
+          const keyCount = resolvedForPush.keyCount;
           let failures = 0;
           for (const host of hosts) {
-            let res: SshExecResult;
-            if (remoteBackend === 'file') {
-              // File backend: headless-readable via the remote's machine-local key
-              // when no passphrase is set; otherwise forwards AGENTS_SECRETS_PASSPHRASE
-              // as the FIRST stdin line (consumed by `read`, so it never lands in
-              // argv / `ps` / remote history), then the .env. Both build a POSIX
-              // `bash -lc` command — refuse a Windows target cleanly rather than
-              // emit broken PowerShell.
-              if (remoteShellFor(resolveRemoteOsSync(host.split('@').pop() ?? host)) === 'powershell') {
-                failures++;
-                console.error(chalk.red(`${host}: file backend export to a Windows target is not yet supported.`));
-                continue;
-              }
-              const { remoteCmd, input } = buildRemoteFileImportCommand(resolvedBundleName, dotenv, {
-                passphrase: remotePassphrase,
-                force: opts.force,
-              });
-              res = sshExec(host, remoteCmd, { input });
-            } else if (remoteShellFor(resolveRemoteOsSync(host.split('@').pop() ?? host)) === 'powershell') {
-              // Keychain on a Windows target: the `agents.ps1` shim doesn't
-              // forward ssh-piped stdin to node, so `--from -` would hang.
-              // Bridge the piped .env through PowerShell into a temp file and
-              // import `--from <file>` (deleted afterwards). Same hardened ssh
-              // engine, .env still only ever crosses the wire over ssh stdin.
-              res = sshExec(host, buildWindowsStdinImportCommand(resolvedBundleName, { force: opts.force }), { input: dotenv });
-            } else {
-              // Keychain on a POSIX target: OS-aware wrapping + hardened ssh
-              // engine (BatchMode, ConnectTimeout, keepalive, control-socket
-              // reuse) via the same path the READ inverse (`remoteResolveEnv`)
-              // uses. `--from -` reads the .env off ssh stdin.
-              res = remoteSecretsRaw(
-                host,
-                ['import', resolvedBundleName, '--from', '-', ...(opts.force ? ['--force'] : [])],
-                { input: dotenv, osLookupName: host },
-              );
-            }
-            if (res.code === null) {
+            const out = pushResolvedBundleToHost(resolvedForPush, resolvedBundleName, host, {
+              remoteBackend,
+              force: opts.force,
+              passphrase: remotePassphrase,
+              operation: 'ssh export',
+            });
+            if (!out.ok) {
               failures++;
-              console.error(chalk.red(`${host}: ${res.stderr.trim() || (res.timedOut ? 'ssh timed out' : 'ssh failed')}`));
+              console.error(chalk.red(`${host}: ${out.message}`));
               continue;
             }
-            if (res.code !== 0) {
-              failures++;
-              const msg = (res.stderr || res.stdout || '').trim();
-              console.error(chalk.red(`${host}: remote import failed (exit ${res.code})${msg ? `: ${msg}` : ''}`));
-              continue;
-            }
-            // A keychain-backed push to a macOS remote over headless SSH can land
-            // the bundle metadata but no READABLE value items: the remote login
-            // keychain is locked in the non-interactive SSH context, so Security
-            // accepts the write but the biometry-ACL'd item is unreadable, and the
-            // remote `import` still exits 0. Read the bundle back the same way a
-            // release will (drops the plaintext, keeps only key presence; the
-            // remote's headless `agentOnly` guard fails fast, so no Touch ID) and
-            // FAIL LOUDLY if the keys didn't materialize — rather than leave a
-            // metadata-only bundle that breaks later with "stored item not found".
-            // The file backend is headless-readable by construction, so skip it.
-            if (remoteBackend === 'keychain') {
-              const verdict = verifyRemoteKeychainPush(host, resolvedBundleName, Object.keys(env), { osLookupName: host });
-              if (!verdict.ok) {
-                failures++;
-                if (verdict.kind === 'locked-keychain') {
-                  console.error(chalk.red(keychainWriteFailureMessage(host, resolvedBundleName, verdict.reason)));
-                } else {
-                  console.error(chalk.red(`${host}: pushed '${resolvedBundleName}' but could not verify it on the remote: ${verdict.reason}`));
-                }
-                continue;
-              }
-            }
-            const remoteMsg = (res.stdout || '').trim().split('\n').map((l) => l.trim()).filter(Boolean).pop();
-            console.log(chalk.green(`${host} -> '${resolvedBundleName}': ${remoteMsg || `${keyCount} key(s) exported`}`));
+            console.log(chalk.green(`${host} -> '${resolvedBundleName}': ${out.message}`));
           }
           emitSecretAudit({ event: 'secrets.export', bundle: resolvedBundleName, operation: `export --host ${hosts.join(',')}`, source: 'ssh', host: hosts.join(','), status: failures > 0 ? 'error' : 'success', keyCount });
           if (failures > 0) process.exit(1);

--- a/apps/cli/src/lib/fleet/apply.test.ts
+++ b/apps/cli/src/lib/fleet/apply.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
+  decideSecretPush,
+  parseRemoteBundles,
   agentIdOf,
   diffFleet,
   canPushLogin,
@@ -205,6 +207,83 @@ describe('diffFleet — secrets surfacing', () => {
     expect(executable.map((a) => a.kind)).toEqual(['sync-config']);
   });
 
+  it('pushes nothing without --provision-secrets, and SAYS the capability exists', () => {
+    // Off by default. The reason string has to name the flag: an operator who
+    // reads only "recreate manually" concludes there is no supported path, which
+    // is how a master key got hand-exported across the fleet (RUSH-1968).
+    const plan = diffFleet(desired, converged, {
+      targetCliVersion: CLI, sourceAuth: srcAuth(['codex']), secretsBundles: ['attio'],
+    });
+    expect(plan.actions.filter((a) => a.kind === 'push-secret')).toEqual([]);
+    const need = plan.actions.find((a) => a.kind === 'needs-secret');
+    expect(need?.detail).toContain('--provision-secrets');
+  });
+
+  it('pushes when the flag is set AND the host key is pinned', () => {
+    const plan = diffFleet(desired, converged, {
+      targetCliVersion: CLI,
+      sourceAuth: srcAuth(['codex']),
+      secretsBundles: ['attio'],
+      provisionSecrets: true,
+      isHostPinned: () => true,
+    });
+    const push = plan.actions.filter((a) => a.kind === 'push-secret');
+    expect(push).toHaveLength(1);
+    expect(push[0].bundle).toBe('attio');
+    // A push IS executable, unlike the needs-* reminders.
+    expect(plan.devices[0].secretsNeeded).toEqual([]);
+  });
+
+  it('refuses an UNPINNED host even with the flag — credential values need a pinned key', () => {
+    // Same bar as `exec --copy-creds` (EXEC-34).
+    const plan = diffFleet(desired, converged, {
+      targetCliVersion: CLI,
+      sourceAuth: srcAuth(['codex']),
+      secretsBundles: ['attio'],
+      provisionSecrets: true,
+      isHostPinned: () => false,
+    });
+    expect(plan.actions.filter((a) => a.kind === 'push-secret')).toEqual([]);
+    expect(plan.actions.find((a) => a.kind === 'needs-secret')?.detail).toContain('host key not pinned');
+  });
+
+  it('treats a MISSING pin check as unpinned — the gate fails closed', () => {
+    const plan = diffFleet(desired, converged, {
+      targetCliVersion: CLI, sourceAuth: srcAuth(['codex']), secretsBundles: ['attio'], provisionSecrets: true,
+    });
+    expect(plan.actions.filter((a) => a.kind === 'push-secret')).toEqual([]);
+  });
+
+  it('skips a bundle the device already has, and --force overrides', () => {
+    // Without this every apply re-resolves the bundle, and a resolve can prompt
+    // for Touch ID — a converged fleet would nag on every run.
+    const withBundle = new Map<string, DeviceProbe>([
+      ['s1', { ...converged.get('s1')!, remoteBundles: { attio: '2026-08-01T00:00:00Z' } }],
+    ]);
+    const base = {
+      targetCliVersion: CLI, sourceAuth: srcAuth(['codex']),
+      secretsBundles: ['attio'], provisionSecrets: true, isHostPinned: () => true,
+    };
+    const skipped = diffFleet(desired, withBundle, base);
+    expect(skipped.actions.filter((a) => a.kind === 'push-secret')).toEqual([]);
+    expect(skipped.actions.find((a) => a.kind === 'needs-secret')?.detail).toContain('already present');
+
+    const forced = diffFleet(desired, withBundle, { ...base, forceSecrets: true });
+    expect(forced.actions.filter((a) => a.kind === 'push-secret')).toHaveLength(1);
+  });
+
+  it('picks file on linux and keychain on macos — the unshared-key default', () => {
+    // A headless Linux box has no keychain, and its file store auto-provisions
+    // its OWN machine-local key. That per-box key is the alternative to the
+    // fleet-wide shared secret RUSH-1968 is about.
+    const probe = (platform: string): DeviceProbe =>
+      ({ device: 's1', reachable: true, platform, cliVersion: CLI, installedAgents: ['codex'] });
+    const ctx = { targetCliVersion: CLI, sourceAuth: srcAuth(['codex']), secretsBundles: ['attio'], provisionSecrets: true, isHostPinned: () => true };
+    expect(decideSecretPush('attio', desired[0], probe('linux'), ctx).backend).toBe('file');
+    expect(decideSecretPush('attio', desired[0], probe('macos'), ctx).backend).toBe('keychain');
+    expect(decideSecretPush('attio', desired[0], probe('windows'), ctx).backend).toBe('keychain');
+  });
+
   it('emits nothing for secrets when the profile declares no bundles', () => {
     const plan = diffFleet(desired, converged, { targetCliVersion: CLI, sourceAuth: srcAuth(['codex']) });
     expect(plan.actions.filter((a) => a.kind === 'needs-secret')).toEqual([]);
@@ -340,5 +419,37 @@ describe('diffFleet — version-aware add-agent', () => {
     ]);
     const plan = diffFleet(roster, probes, { targetCliVersion: CLI, sourceAuth: srcAuth(['claude']) });
     expect(plan.actions.filter((a) => a.kind === 'push-login')).toHaveLength(1);
+  });
+});
+
+describe('parseRemoteBundles — a remote secrets listing, metadata only', () => {
+  it('reads name -> updatedAt from the REAL payload shape', () => {
+    // Verified against live `agents secrets list --json`: a bare array of rows
+    // whose timestamp field is `updatedAt`. The first draft of this parser read
+    // `updated_at` and would have recorded an empty timestamp for every bundle.
+    const real = '[{"name":"claude-getrush","keys":1,"backend":"file","createdAt":"2026-08-02T10:12:09.610Z","updatedAt":"2026-08-03T01:02:03.000Z"}]';
+    expect(parseRemoteBundles(real)).toEqual({ 'claude-getrush': '2026-08-03T01:02:03.000Z' });
+  });
+
+  it('also accepts snake_case from an older remote', () => {
+    expect(parseRemoteBundles('[{"name":"attio","updated_at":"2026-08-01T00:00:00Z"}]'))
+      .toEqual({ attio: '2026-08-01T00:00:00Z' });
+  });
+
+  it('reads the same from a { bundles: [...] } envelope', () => {
+    expect(parseRemoteBundles('{"bundles":[{"name":"a"},{"name":"b","updated_at":"t"}]}'))
+      .toEqual({ a: '', b: 't' });
+  });
+
+  it('degrades to {} on junk — unknown must mean PUSH, never skip', () => {
+    // Returning a populated map on a parse failure would silently leave a device
+    // unprovisioned, which is the worse of the two errors.
+    for (const junk of ['', 'not json', 'null', '3', '{"bundles":"nope"}']) {
+      expect(parseRemoteBundles(junk)).toEqual({});
+    }
+  });
+
+  it('ignores rows with no usable name', () => {
+    expect(parseRemoteBundles('[null,"x",{"nope":1},{"name":7},{"name":"ok"}]')).toEqual({ ok: '' });
   });
 });

--- a/apps/cli/src/lib/fleet/apply.test.ts
+++ b/apps/cli/src/lib/fleet/apply.test.ts
@@ -272,6 +272,42 @@ describe('diffFleet — secrets surfacing', () => {
     expect(forced.actions.filter((a) => a.kind === 'push-secret')).toHaveLength(1);
   });
 
+  it('does NOT skip a prototype-named bundle the device lacks', () => {
+    // `bundle in remoteBundles` returned true for 'toString' against an EMPTY
+    // listing, so that bundle was silently never provisioned. The gate uses an
+    // own-property check now.
+    const emptyListing = new Map<string, DeviceProbe>([
+      ['s1', { ...converged.get('s1')!, remoteBundles: parseRemoteBundles('[]') }],
+    ]);
+    const plan = diffFleet(desired, emptyListing, {
+      targetCliVersion: CLI,
+      sourceAuth: srcAuth(['codex']),
+      secretsBundles: ['toString'],
+      provisionSecrets: true,
+      isHostPinned: () => true,
+    });
+    expect(plan.actions.filter((a) => a.kind === 'push-secret').map((a) => a.bundle)).toEqual(['toString']);
+  });
+
+  it('does NOT skip a prototype-named bundle when remoteBundles is a plain object', () => {
+    // Defence in depth, and the case that actually distinguishes the two fixes.
+    // parseRemoteBundles returns a null-prototype map, so `in` happens to be safe
+    // on ITS output — but `remoteBundles` is a plain field any caller can fill,
+    // and a `{}` literal (what every other fixture here uses) inherits toString.
+    // Under `in` this device would be judged already-provisioned and skipped.
+    const plainLiteral = new Map<string, DeviceProbe>([
+      ['s1', { ...converged.get('s1')!, remoteBundles: { somethingElse: 't' } }],
+    ]);
+    const plan = diffFleet(desired, plainLiteral, {
+      targetCliVersion: CLI,
+      sourceAuth: srcAuth(['codex']),
+      secretsBundles: ['toString'],
+      provisionSecrets: true,
+      isHostPinned: () => true,
+    });
+    expect(plan.actions.filter((a) => a.kind === 'push-secret').map((a) => a.bundle)).toEqual(['toString']);
+  });
+
   it('picks file on linux and keychain on macos — the unshared-key default', () => {
     // A headless Linux box has no keychain, and its file store auto-provisions
     // its OWN machine-local key. That per-box key is the alternative to the
@@ -446,6 +482,26 @@ describe('parseRemoteBundles — a remote secrets listing, metadata only', () =>
     // unprovisioned, which is the worse of the two errors.
     for (const junk of ['', 'not json', 'null', '3', '{"bundles":"nope"}']) {
       expect(parseRemoteBundles(junk)).toEqual({});
+    }
+  });
+
+  it('a name that collides with an Object prototype key is an OWN property', () => {
+    // `{}` inherits toString/constructor/valueOf, and assigning `__proto__` on it
+    // hits the prototype setter instead of creating a key. A null-prototype map
+    // makes every remote-supplied name a plain own property.
+    const out = parseRemoteBundles('[{"name":"toString"},{"name":"__proto__","updatedAt":"t"}]');
+    expect(Object.prototype.hasOwnProperty.call(out, 'toString')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(out, '__proto__')).toBe(true);
+    expect(out['__proto__']).toBe('t');
+  });
+
+  it('an EMPTY listing claims nothing — not even inherited names', () => {
+    // The bug this closes: `'toString' in {}` is true, so a bundle named
+    // toString read as already-present on a device that has nothing.
+    const empty = parseRemoteBundles('[]');
+    for (const name of ['toString', 'constructor', 'valueOf', 'hasOwnProperty']) {
+      expect(Object.prototype.hasOwnProperty.call(empty, name)).toBe(false);
+      expect(name in empty).toBe(false);
     }
   });
 

--- a/apps/cli/src/lib/fleet/apply.ts
+++ b/apps/cli/src/lib/fleet/apply.ts
@@ -306,7 +306,12 @@ export function decideSecretPush(
   // carries `updated_at` for a future content check). It is a timestamp
   // heuristic, not a content hash — a bundle whose VALUES changed locally still
   // reads as present. `--force` is the way to overwrite regardless.
-  if (!ctx.forceSecrets && probe.remoteBundles && bundle in probe.remoteBundles) {
+  // hasOwnProperty, NOT `in`: `in` walks the prototype chain, so a bundle named
+  // `toString` / `constructor` / `valueOf` would read as present on an EMPTY map
+  // and be silently skipped — leaving that device unprovisioned, the worse of the
+  // two errors this gate can make.
+  if (!ctx.forceSecrets && probe.remoteBundles
+      && Object.prototype.hasOwnProperty.call(probe.remoteBundles, bundle)) {
     return { push: false, backend, reason: `secrets bundle '${bundle}' already present on ${device} — pass --force to overwrite` };
   }
 
@@ -410,7 +415,11 @@ export function parseRemoteBundles(stdout: string): Record<string, string> {
       : Array.isArray((parsed as { bundles?: unknown })?.bundles)
         ? (parsed as { bundles: unknown[] }).bundles
         : [];
-    const out: Record<string, string> = {};
+    // Null-prototype: a remote-supplied name is used as a KEY here, so `{}` would
+    // let `__proto__` hit the prototype setter instead of becoming an own
+    // property (and then read back as absent). It also means the presence check
+    // cannot see inherited names.
+    const out: Record<string, string> = Object.create(null);
     for (const row of rows) {
       if (!row || typeof row !== 'object') continue;
       const r = row as Record<string, unknown>;

--- a/apps/cli/src/lib/fleet/apply.ts
+++ b/apps/cli/src/lib/fleet/apply.ts
@@ -10,6 +10,7 @@
 
 import * as os from 'os';
 import type { DeviceProfile } from '../devices/registry.js';
+import { pushBundleToHost, type RemoteBackend } from '../secrets/push.js';
 import { sshTargetFor } from '../devices/connect.js';
 import { readyProbe, bootstrapAgentsCli } from '../hosts/ready.js';
 import { buildRemoteAgentsInvocation } from '../hosts/remote-cmd.js';
@@ -131,10 +132,18 @@ export interface DiffContext {
   /** agents-cli version the source is on — the fleet target version. */
   targetCliVersion: string;
   sourceAuth: SourceAuth;
-  /** Secrets-bundle names the profile declares. Values are keychain-local and
-   * can't be pushed, so each reachable device surfaces them as a manual recreate
-   * (`needs-secret`) — informational, never an executed mutation. */
+  /** Secrets-bundle names the profile declares. */
   secretsBundles?: string[];
+  /** `--provision-secrets`. OFF by default: pushing a bundle moves credential
+   *  VALUES to another machine, so it is opted into per invocation and never
+   *  defaulted from the shared `agents.yaml` (RUSH-1968). */
+  provisionSecrets?: boolean;
+  /** Is this device's host key pinned? Injected so `decideSecretPush` stays pure
+   *  and its refusals are testable against real known_hosts fixtures with no
+   *  network. Absent = treated as unpinned, i.e. refuse. */
+  isHostPinned?: (device: string) => boolean;
+  /** `--force`: push a declared bundle even when the device already has it. */
+  forceSecrets?: boolean;
 }
 
 /** Pure: desired vs probed -> per-device diff + flat action list. */
@@ -204,14 +213,32 @@ export function diffFleet(desired: DeviceDesired[], probes: Map<string, DevicePr
           }
         }
       }
-      // secrets — surfaced, never pushed (values are keychain-local). Declared
-      // once at the manifest level, so every reachable device gets the same
-      // manual-recreate reminder. Not an executable action (see idempotence
-      // check in commands/apply.ts, which excludes needs-* kinds).
+      // secrets. Declared once at the manifest level, so every reachable device
+      // is considered. Historically this was ALWAYS a manual reminder — "surfaced,
+      // never pushed" — and that gap is a direct cause of RUSH-1968: an operator
+      // who needed secrets on a worker box had no supported path, so they
+      // hand-exported the file store's master key across the fleet instead.
+      //
+      // It is now pushable, but only deliberately. `--provision-secrets` is off by
+      // default and is a FLAG, not a manifest field: `agents.yaml` is shared, and
+      // a file-level default would mean someone else's `apply -y` silently ships
+      // credential values — the same shape of accident this ticket is about.
+      // Everything the gate refuses stays a `needs-secret` reminder, so nothing
+      // is ever silently skipped.
       if (ctx.secretsBundles && ctx.secretsBundles.length > 0) {
         for (const bundle of ctx.secretsBundles) {
-          secretsNeeded.push(bundle);
-          rowActions.push({ device: d.device, kind: 'needs-secret', detail: `recreate secrets bundle '${bundle}' (\`agents secrets create ${bundle}\`)` });
+          const decision = decideSecretPush(bundle, d, probe, ctx);
+          if (decision.push) {
+            rowActions.push({
+              device: d.device,
+              kind: 'push-secret',
+              bundle,
+              detail: `push secrets bundle '${bundle}' (${decision.backend} backend)`,
+            });
+          } else {
+            secretsNeeded.push(bundle);
+            rowActions.push({ device: d.device, kind: 'needs-secret', bundle, detail: decision.reason });
+          }
         }
       }
     }
@@ -221,6 +248,78 @@ export function diffFleet(desired: DeviceDesired[], probes: Map<string, DevicePr
   }
 
   return { devices, actions };
+}
+
+/** Why a declared bundle is or is not pushed to one device. */
+export interface SecretPushDecision {
+  push: boolean;
+  /** Where it would land on the remote. Only meaningful when `push`. */
+  backend: RemoteBackend;
+  /** Set when `push` is false — rendered as the `needs-secret` reminder. */
+  reason: string;
+}
+
+/**
+ * Decide whether `fleet apply` may push one declared bundle to one device.
+ *
+ * PURE — no ssh, no keychain, no filesystem beyond the injectable pin check — so
+ * every branch is unit-testable with no live fleet. Three gates, in order, and
+ * each REFUSAL still yields a `needs-secret` reminder rather than silence:
+ *
+ *   1. `--provision-secrets` must be set. Off by default, and deliberately a
+ *      flag rather than an `agents.yaml` field: the manifest is shared, so a
+ *      file-level default means someone else's `apply -y` ships credential
+ *      values without deciding to (RUSH-1968's shape of accident).
+ *   2. The device must be reachable — nothing to push to otherwise.
+ *   3. The host key must be PINNED. This moves credential values to another
+ *      machine, so it reuses the same bar `agents exec --copy-creds` already
+ *      sets (EXEC-34): an unpinned device earns its pin through a normal
+ *      `agents ssh <device>` first.
+ *
+ * Backend follows the platform, and this is the load-bearing default of the
+ * whole feature: **file on Linux, keychain on macOS/Windows**. A headless Linux
+ * box has no keychain (`lib/secrets/linux.ts`), and the file store there
+ * auto-provisions its OWN machine-local key — so each box ends up with an
+ * unshared at-rest key and NO passphrase is forwarded. That is the direct
+ * alternative to the fleet-wide shared secret this ticket exists to remove.
+ */
+export function decideSecretPush(
+  bundle: string,
+  desired: DeviceDesired,
+  probe: DeviceProbe,
+  ctx: DiffContext,
+): SecretPushDecision {
+  const device = desired.device;
+  const backend: RemoteBackend = probe.platform === 'linux' ? 'file' : 'keychain';
+  const manual = `recreate secrets bundle '${bundle}' (\`agents ssh ${device} -- secrets create ${bundle}\`)`;
+
+  if (!ctx.provisionSecrets) {
+    return { push: false, backend, reason: `${manual} — or re-run with --provision-secrets to push it` };
+  }
+  if (!probe.reachable) {
+    return { push: false, backend, reason: manual };
+  }
+  // Already there? Skip — otherwise every `apply` re-resolves the bundle, and a
+  // resolve can prompt for Touch ID, so a converged fleet would nag on every run.
+  //
+  // Known limitation, stated rather than hidden: this compares PRESENCE (and
+  // carries `updated_at` for a future content check). It is a timestamp
+  // heuristic, not a content hash — a bundle whose VALUES changed locally still
+  // reads as present. `--force` is the way to overwrite regardless.
+  if (!ctx.forceSecrets && probe.remoteBundles && bundle in probe.remoteBundles) {
+    return { push: false, backend, reason: `secrets bundle '${bundle}' already present on ${device} — pass --force to overwrite` };
+  }
+
+  if (!ctx.isHostPinned?.(device)) {
+    // Same bar as `exec --copy-creds`: never ship credential values to a host
+    // whose key we have not pinned.
+    return {
+      push: false,
+      backend,
+      reason: `${manual} — host key not pinned; run \`agents ssh ${device}\` once to pin it, then re-apply`,
+    };
+  }
+  return { push: true, backend, reason: '' };
 }
 
 // ---- execution (real SSH; verified end-to-end, not unit-mocked) ----
@@ -238,6 +337,10 @@ export interface ProbeOptions {
   /** Also fetch per-agent installed versions (one extra `agents view --json`
    * round-trip). Enable only when the plan has a version-pinned spec. */
   withVersions?: boolean;
+  /** Also fetch which secrets bundles the device already has (one extra
+   *  `agents secrets list --json`). Enable only when the manifest declares
+   *  bundles and provisioning is on — same cost discipline as `withVersions`. */
+  withSecrets?: boolean;
 }
 
 /** Probe one device: reachability + agents-cli version + installed agent ids
@@ -271,6 +374,14 @@ export function probeDevice(device: DeviceProfile, opts?: ProbeOptions): DeviceP
     const vres = sshExec(target, viewCmd, { timeoutMs: 30000, multiplex: true });
     if (vres.code === 0) installedVersions = parseInstalledVersions(vres.stdout);
   }
+  let remoteBundles: Record<string, string> | undefined;
+  if (opts?.withSecrets) {
+    // Metadata only — `secrets list --json` returns names + timestamps and never
+    // values, which is why this is safe to run across the fleet.
+    const listCmd = buildRemoteAgentsInvocation(['secrets', 'list', '--json'], undefined, hint, remoteEnv(device.platform));
+    const lres = sshExec(target, listCmd, { timeoutMs: 30000, multiplex: true });
+    if (lres.code === 0) remoteBundles = parseRemoteBundles(lres.stdout);
+  }
   return {
     device: device.name,
     reachable: true,
@@ -278,7 +389,45 @@ export function probeDevice(device: DeviceProfile, opts?: ProbeOptions): DeviceP
     cliVersion: ready.version ?? undefined,
     installedAgents: installed,
     installedVersions,
+    remoteBundles,
   };
+}
+
+/**
+ * Narrow a remote `secrets list --json` payload to `name -> updated_at`.
+ *
+ * Exported and pure so the parse is unit-tested against real payload shapes with
+ * no live fleet. Returns `{}` rather than throwing on anything unexpected: the
+ * remote runs its own agents-cli version, and a parse failure must degrade to
+ * "unknown, so push" — never to "present, so skip", which would silently leave a
+ * device unprovisioned.
+ */
+export function parseRemoteBundles(stdout: string): Record<string, string> {
+  try {
+    const parsed = JSON.parse(stdout) as unknown;
+    const rows = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray((parsed as { bundles?: unknown })?.bundles)
+        ? (parsed as { bundles: unknown[] }).bundles
+        : [];
+    const out: Record<string, string> = {};
+    for (const row of rows) {
+      if (!row || typeof row !== 'object') continue;
+      const r = row as Record<string, unknown>;
+      const name = typeof r.name === 'string' ? r.name : undefined;
+      if (!name) continue;
+      // `updatedAt` is the real field name in `secrets list --json` — verified
+      // against a live payload, not assumed. `updated_at` is accepted too so an
+      // older remote is not silently recorded with an empty timestamp.
+      const ts = typeof r.updatedAt === 'string' ? r.updatedAt
+        : typeof r.updated_at === 'string' ? r.updated_at
+          : '';
+      out[name] = ts;
+    }
+    return out;
+  } catch {
+    return {};
+  }
 }
 
 export interface ApplyStep {
@@ -361,6 +510,50 @@ export function reconcileDevice(row: DeviceDiff, device: DeviceProfile, ctx: Exe
     const r = sshAgents(['apply', '--recv-auth'], JSON.stringify(bundle));
     steps.push({ kind: 'push-login', ok: r.code === 0, detail: `propagate login: ${pushAgents.join(', ')}` });
     ok = ok && r.code === 0;
+  }
+
+  // 5. secrets provisioning — LAST, and deliberately so. It is the most
+  // sensitive mutation apply performs (credential VALUES crossing to another
+  // machine), so every lower-risk step above is already recorded before we
+  // touch it: a failure here never obscures what did land.
+  //
+  // Resolve ONCE per device even for several bundles is not possible (a resolve
+  // is per bundle), but each bundle resolves once and pushes once — the read can
+  // prompt, so it must not repeat.
+  const pushSecrets = row.actions.filter((a) => a.kind === 'push-secret');
+  for (const action of pushSecrets) {
+    const bundle = action.bundle;
+    if (!bundle) {
+      // A push-secret action without a bundle name is a planner bug, not a
+      // recoverable state — fail loud rather than push nothing and report ok.
+      steps.push({ kind: 'push-secret', ok: false, detail: 'push-secret action carried no bundle name' });
+      ok = false;
+      continue;
+    }
+    const backend: RemoteBackend = device.platform === 'linux' ? 'file' : 'keychain';
+    try {
+      const out = pushBundleToHost(bundle, target, {
+        remoteBackend: backend,
+        operation: `fleet apply ${row.device}`,
+        // No passphrase, ever, from this path. On the file backend the remote
+        // auto-provisions its OWN machine-local key, which is the entire point:
+        // each box gets an unshared at-rest key instead of the fleet-wide shared
+        // secret RUSH-1968 is about.
+      });
+      steps.push({
+        kind: 'push-secret',
+        ok: out.ok,
+        detail: out.ok
+          ? `secrets '${bundle}' -> ${row.device} (${backend}): ${out.message}`
+          : `secrets '${bundle}' -> ${row.device}: ${out.message}`,
+      });
+      ok = ok && out.ok;
+    } catch (e) {
+      // A local resolve failure (locked store, missing bundle, multi-line value)
+      // is reported per bundle rather than aborting the whole device.
+      steps.push({ kind: 'push-secret', ok: false, detail: `secrets '${bundle}': ${(e as Error).message}` });
+      ok = false;
+    }
   }
 
   // Surface blocked logins as (non-fatal) informational steps.

--- a/apps/cli/src/lib/fleet/types.ts
+++ b/apps/cli/src/lib/fleet/types.ts
@@ -99,6 +99,16 @@ export interface DeviceProbe {
    * undefined, version-pinned specs fall back to id-level presence.
    */
   installedVersions?: Record<string, string[]>;
+  /**
+   * Secrets bundles already present on the device: name -> `updated_at` (or ''
+   * when the remote reports none). Only populated when the manifest declares
+   * bundles AND `--provision-secrets` is set — a fleet that uses no bundles
+   * never pays for the extra round trip.
+   *
+   * METADATA ONLY. `agents secrets list --json` returns names and timestamps and
+   * explicitly never values, which is what makes this probe safe to run.
+   */
+  remoteBundles?: Record<string, string>;
   /** Reason string when `reachable` is false or the probe partially failed. */
   note?: string;
 }
@@ -111,8 +121,13 @@ export type FleetActionKind =
   | 'sync-config'
   | 'push-login'
   | 'needs-login'
-  /** Secrets bundles the profile declares but that can't be pushed (values are
-   * keychain-local) — surfaced as a manual recreate, like `needs-login`. */
+  /** Push a declared secrets bundle to the device over SSH. Opt-in only
+   * (`--provision-secrets`) and gated on a pinned host key, because this moves
+   * credential VALUES to another machine (RUSH-1968). */
+  | 'push-secret'
+  /** A declared secrets bundle that could NOT be pushed — the flag is off, the
+   * host key isn't pinned, or the bundle is already current. Surfaced as a manual
+   * recreate, like `needs-login`. */
   | 'needs-secret';
 
 export interface FleetAction {
@@ -123,6 +138,10 @@ export interface FleetAction {
   /** Full agent spec for `add-agent` (e.g. `claude@2.1.170`) so the plan can show
    * the exact version being installed; equals the id for a bare/latest spec. */
   spec?: string;
+  /** Bundle name for `push-secret` / `needs-secret`, so the executor pushes the
+   *  bundle the planner decided on rather than re-deriving it from the detail
+   *  string. */
+  bundle?: string;
   /** Human, one-line description of the action. */
   detail: string;
 }

--- a/apps/cli/src/lib/secrets/push.ts
+++ b/apps/cli/src/lib/secrets/push.ts
@@ -1,0 +1,198 @@
+/**
+ * Push one bundle's values to a remote host over SSH — the provisioning
+ * primitive behind `agents secrets export --host` and, from RUSH-1968, behind
+ * `agents fleet apply --provision-secrets`.
+ *
+ * This logic used to live inline in the `export --host` command action. It moved
+ * here because `lib/fleet/apply.ts` needs it and a lib MUST NOT import a command
+ * module — and because the absence of a callable primitive is part of why
+ * `fleet apply` never provisioned secrets at all, leaving an operator to
+ * hand-export the file store's master key across the fleet.
+ *
+ * Two rules shape the shape of this module:
+ *
+ * - **It never prints.** The lib layer stays `console.*`-free (SEC-14/SEC-16), so
+ *   every outcome is returned as data and the CALLER renders it. That is also
+ *   what lets `fleet apply` fold a push into its own per-device report instead of
+ *   interleaving stray lines into it.
+ * - **Resolve once, push N times.** `resolveBundleForPush` is separate because
+ *   reading a bundle can prompt (Touch ID); doing it per host would prompt per
+ *   host. `export --host a,b,c` resolves once and pushes three times.
+ */
+import { sshExec, type SshExecResult } from '../ssh-exec.js';
+import { remoteShellFor, buildWindowsStdinImportCommand } from '../hosts/remote-cmd.js';
+import { resolveRemoteOsSync } from '../hosts/remote-os.js';
+import {
+  remoteSecretsRaw,
+  verifyRemoteKeychainPush,
+  keychainWriteFailureMessage,
+  buildRemoteFileImportCommand,
+} from './remote.js';
+import { readAndResolveBundleEnv } from './bundles.js';
+
+/**
+ * Serialize a resolved env map to `.env` lines that round-trip losslessly through
+ * `parseDotenv` on the remote: `KEY="VALUE"`. parseDotenv strips exactly one outer
+ * quote pair and takes the inner bytes verbatim (no unescaping), so any single-line
+ * value survives unchanged with no escaping. Newlines would break its line-based
+ * parse, so multi-line values are rejected rather than silently corrupted.
+ */
+export function bundleEnvToDotenv(env: Record<string, string>): string {
+  const lines: string[] = [];
+  for (const [k, v] of Object.entries(env)) {
+    if (/[\r\n]/.test(v)) {
+      throw new Error(
+        `Key '${k}' has a multi-line value; the SSH .env transport can't carry newlines. ` +
+        `Set it directly on the remote with 'agents secrets add ${k} --value-stdin'.`,
+      );
+    }
+    lines.push(`${k}="${v}"`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+/** Where the bundle should live ON THE REMOTE. */
+export type RemoteBackend = 'keychain' | 'file';
+
+/** A bundle read once, ready to push to any number of hosts. */
+export interface ResolvedBundleForPush {
+  /** key -> value. Never logged; only its KEY NAMES are ever surfaced. */
+  env: Record<string, string>;
+  /** The same values as a dotenv blob, shipped over ssh stdin (never argv). */
+  dotenv: string;
+  keyCount: number;
+}
+
+export interface PushBundleOptions {
+  remoteBackend: RemoteBackend;
+  /** Overwrite a key that already exists on the remote. */
+  force?: boolean;
+  /**
+   * Forwarded to the remote as the FIRST stdin line for the FILE backend only,
+   * and only when non-empty.
+   *
+   * Empty is the DEFAULT and the good path: the remote's file store then
+   * auto-provisions its own machine-local key (0600, `~/.agents/.secrets-key/`)
+   * and reads headlessly. Setting this keys the remote bundle under a shared
+   * off-disk secret instead — an opt-in, never a requirement. Requiring one is
+   * what pushed operators toward exporting the master key fleet-wide (RUSH-1968).
+   */
+  passphrase?: string;
+  /** Label for the audit trail — `export --host` vs `fleet apply`. */
+  operation: string;
+}
+
+export interface PushBundleResult {
+  ok: boolean;
+  host: string;
+  bundle: string;
+  keyCount: number;
+  /** One line for the caller to render. Never contains a secret value. */
+  message: string;
+}
+
+/**
+ * Read and resolve a bundle once, for pushing to one or more hosts.
+ *
+ * `agentOnly` + `keyMode: 'storage'` match what `export --host` has always
+ * passed: storage-shaped values, and the headless guard that fails fast rather
+ * than popping Touch ID inside an automated run.
+ */
+export function resolveBundleForPush(bundle: string, caller: string): ResolvedBundleForPush {
+  const { env } = readAndResolveBundleEnv(bundle, { caller, keyMode: 'storage', agentOnly: true });
+  return { env, dotenv: bundleEnvToDotenv(env), keyCount: Object.keys(env).length };
+}
+
+function isPowershellTarget(host: string): boolean {
+  return remoteShellFor(resolveRemoteOsSync(host.split('@').pop() ?? host)) === 'powershell';
+}
+
+/**
+ * Push an already-resolved bundle to ONE host.
+ *
+ * Drives the remote's own `agents secrets import --from -`, so the values land
+ * in the remote's chosen backend and the .env is read off ssh stdin rather than
+ * parsed by a remote shell. `import` auto-creates the bundle.
+ */
+export function pushResolvedBundleToHost(
+  resolved: ResolvedBundleForPush,
+  bundle: string,
+  host: string,
+  opts: PushBundleOptions,
+): PushBundleResult {
+  const fail = (message: string): PushBundleResult =>
+    ({ ok: false, host, bundle, keyCount: resolved.keyCount, message });
+
+  let res: SshExecResult;
+  if (opts.remoteBackend === 'file') {
+    // Both file-backend paths build a POSIX `bash -lc` command. Refuse a Windows
+    // target cleanly rather than emit broken PowerShell (fail loud at the
+    // boundary, never a silent wrong path).
+    if (isPowershellTarget(host)) {
+      return fail('file backend export to a Windows target is not yet supported');
+    }
+    const { remoteCmd, input } = buildRemoteFileImportCommand(bundle, resolved.dotenv, {
+      passphrase: opts.passphrase ?? '',
+      force: opts.force,
+    });
+    res = sshExec(host, remoteCmd, { input });
+  } else if (isPowershellTarget(host)) {
+    // Keychain on a Windows target: the `agents.ps1` shim doesn't forward
+    // ssh-piped stdin to node, so `--from -` would hang. Bridge the piped .env
+    // through PowerShell into a temp file and import `--from <file>` (deleted
+    // afterwards). Same hardened ssh engine; the .env still only ever crosses
+    // the wire over ssh stdin.
+    res = sshExec(host, buildWindowsStdinImportCommand(bundle, { force: opts.force }), { input: resolved.dotenv });
+  } else {
+    // Keychain on a POSIX target: OS-aware wrapping + the hardened ssh engine
+    // (BatchMode, ConnectTimeout, keepalive, control-socket reuse) via the same
+    // path the READ inverse (`remoteResolveEnv`) uses.
+    res = remoteSecretsRaw(
+      host,
+      ['import', bundle, '--from', '-', ...(opts.force ? ['--force'] : [])],
+      { input: resolved.dotenv, osLookupName: host },
+    );
+  }
+
+  if (res.code === null) {
+    return fail(res.stderr.trim() || (res.timedOut ? 'ssh timed out' : 'ssh failed'));
+  }
+  if (res.code !== 0) {
+    const msg = (res.stderr || res.stdout || '').trim();
+    return fail(`remote import failed (exit ${res.code})${msg ? `: ${msg}` : ''}`);
+  }
+
+  // A keychain-backed push to a macOS remote over headless SSH can land the
+  // bundle metadata but no READABLE value items: the remote login keychain is
+  // locked in the non-interactive SSH context, so Security accepts the write but
+  // the biometry-ACL'd item is unreadable — and the remote `import` still exits
+  // 0. Read it back the way a release will and FAIL LOUDLY, rather than leave a
+  // metadata-only bundle that breaks later with "stored item not found". The
+  // file backend is headless-readable by construction, so it is skipped.
+  if (opts.remoteBackend === 'keychain') {
+    const verdict = verifyRemoteKeychainPush(host, bundle, Object.keys(resolved.env), { osLookupName: host });
+    if (!verdict.ok) {
+      return fail(verdict.kind === 'locked-keychain'
+        ? keychainWriteFailureMessage(host, bundle, verdict.reason)
+        : `pushed '${bundle}' but could not verify it on the remote: ${verdict.reason}`);
+    }
+  }
+
+  const remoteMsg = (res.stdout || '').trim().split('\n').map((l) => l.trim()).filter(Boolean).pop();
+  return {
+    ok: true,
+    host,
+    bundle,
+    keyCount: resolved.keyCount,
+    message: remoteMsg || `${resolved.keyCount} key(s) exported`,
+  };
+}
+
+/** Resolve and push in one call — for a single host. */
+export function pushBundleToHost(
+  bundle: string,
+  host: string,
+  opts: PushBundleOptions,
+): PushBundleResult {
+  return pushResolvedBundleToHost(resolveBundleForPush(bundle, opts.operation), bundle, host, opts);
+}


### PR DESCRIPTION
**New `agents apply --provision-secrets`.** Fifth PR on RUSH-1968, and the one that closes the gap that *caused* it.

## Why this is the root cause, not a nice-to-have

`fleet apply` let the manifest declare `secrets.bundles` and then only printed a reminder — the code comment said it outright:

> `// secrets — surfaced, never pushed (values are keychain-local).`

So an operator who needed secrets on a worker box had **no supported path**. They hand-exported the file store's master key across the fleet instead. Every other PR in this ticket cleans up after that decision; this one removes the reason for it.

## Three parts

**1. The push primitive moves to `lib/secrets/push.ts`.** It was inline in the `export --host` action, and a lib must not import a command module. Console-free (SEC-14/16) — outcomes return as data so the caller renders them — and it splits resolve-once from push-per-host, because a resolve can prompt and must not repeat per host. `secrets.ts` becomes a thin caller and its **709 existing tests stay green**, so the extraction is behaviour-identical.

**2. A fifth reconcile phase, deliberately last.** It is the most sensitive mutation `apply` performs, so every lower-risk step is recorded before credential values move.

Off by default, and a **flag, not a manifest field** — `agents.yaml` is shared, so a file-level default means someone else's `apply -y` silently ships credential values. That is the same shape of accident as the original leak.

| Gate | Refusal |
|---|---|
| `--provision-secrets` set? | reminder that **names the flag** |
| Device reachable? | ordinary manual reminder |
| Host key **pinned**? | `host key not pinned; run \`agents ssh <device>\` once to pin it` |

The pin bar is the one `exec --copy-creds` already sets (EXEC-34). Every refusal still emits `needs-secret`, so a skipped device is never silent.

**Backend follows the platform — `file` on Linux, `keychain` elsewhere — and this is load-bearing.** A headless Linux box has no keychain, and its file store auto-provisions its **own machine-local key**, so each device ends up with an unshared at-rest key and **no passphrase is forwarded**. That is the direct alternative to the fleet-wide shared secret.

**3. Idempotence.** One extra `secrets list --json` per device (**metadata only**) skips a bundle already present. Without it every apply re-resolves locally, and a resolve can prompt for Touch ID — a converged fleet would nag on every run. It compares **presence, not content**; `--force` re-pushes.

## Run output

Full capture: `yosemite-s1:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/2026-08-05/rush-1968-fleet-provision-run.txt` — a fleet path, not an embed; this is a CLI surface.

```
=== 1. DEFAULT: flag off — nothing pushed, and the output SAYS the capability exists ===
  device        agents-cli  agents    config    login     secrets
  yosemite-m0   upgrade     ok 1/1    ↑ sync    ok 1/1    blocked 1

  secrets: not pushed. `--provision-secrets` pushes declared bundles to devices whose host key is pinned.
  1 secrets bundle(s) not pushed — recreate where missing: attio.com

=== 2. FLAG ON, but yosemite-m0's host key is NOT pinned -> the gate refuses ===
  yosemite-m0   upgrade     ok 1/1    ↑ sync    ok 1/1    blocked 1
```

The second block is the gate working: credential values are never shipped to an unpinned host. That the demo box happens to be unpinned is a real-world result, not a staged one.

**A real bug the live run caught.** The idempotence parser read `updated_at`. The actual field in `agents secrets list --json` is **`updatedAt`** — verified against a live listing from `yosemite-m0` (6 bundles, 4 with timestamps). The first draft would have silently recorded an empty timestamp for every bundle. Both spellings are now accepted and the real shape is the test fixture.

## Tests

`decideSecretPush` and `parseRemoteBundles` are pure and exported, so every branch is tested with no live fleet: flag off names the flag, flag+pin pushes, unpinned refuses, a **missing** pin check refuses (fails closed), already-present skips and `--force` overrides, and the per-platform backend.

Mutation-verified — removing each gate fails exactly the test written for it:

```
M1 drop the pin gate        -> 2 failed  (unpinned refused; missing check fails closed)
M2 drop the flag gate       -> 1 failed
M3 drop already-present     -> 1 failed
M4 backend always keychain  -> 1 failed
restored                    -> 43 passed
```

A parse failure degrades to `{}` — **unknown means push, never skip**, since silently leaving a device unprovisioned is the worse of the two errors.

`src/lib/fleet/` + `src/lib/secrets/` + `apply.test.ts` + `secrets.test.ts`: **814 passed, 14 skipped**.

## Not in scope

Running this against `yosemite-m0..m6` is the remediation step and needs its own decision — those boxes hold 14–25 orphaned items encrypted under the exported passphrase, so the order matters (provision → remove the rc line → rotate). This PR only makes the provisioning step possible.
