### PR TITLE
perf(sessions): single-parse upsert for non-resumable harnesses (RUSH-2209)

### DIFF
--- a/apps/cli/src/lib/session/__tests__/parse-cursor.test.ts
+++ b/apps/cli/src/lib/session/__tests__/parse-cursor.test.ts
@@ -102,6 +102,7 @@ describe('Cursor session parsing and discovery metadata', () => {
       activeForm: 'Summarize the commands',
     });
     expect(result!.content).toBe('Inspect the public CLI documentation and summarize the session commands.');
+    expect(result!.events).toEqual(parseCursor(transcriptPath));
   });
 
   test('indexes transcript-only archives without inventing cwd or title', () => {

--- a/apps/cli/src/lib/session/db.reparse.test.ts
+++ b/apps/cli/src/lib/session/db.reparse.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { SessionEvent, SessionMeta } from './types.js';
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-db-reparse-'));
+process.env.HOME = testHome;
+process.env.USERPROFILE = testHome;
+
+const db = await import('./db.js');
+
+afterAll(() => {
+  db.closeDB();
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  fs.rmSync(testHome, { recursive: true, force: true });
+});
+
+describe('upsertSessionsBatch scanner event reuse', () => {
+  it('indexes scanner-produced events without reopening the transcript', () => {
+    const missingTranscript = path.join(testHome, '.cursor', 'missing.jsonl');
+    const meta: SessionMeta = {
+      id: 'cursor-single-parse',
+      shortId: 'cursor-s',
+      agent: 'cursor',
+      timestamp: '2026-08-05T00:00:00.000Z',
+      cwd: '/tmp/project',
+      filePath: missingTranscript,
+      messageCount: 2,
+    };
+    const events: SessionEvent[] = [
+      {
+        type: 'tool_use',
+        agent: 'cursor',
+        timestamp: '2026-08-05T00:00:01.000Z',
+        tool: 'TodoWrite',
+        args: { todos: [{ content: 'Avoid the second parse', status: 'in_progress' }] },
+      },
+    ];
+
+    db.upsertSessionsBatch([{
+      meta,
+      content: 'single parse',
+      scan: { fileMtimeMs: 1, fileSize: 1 },
+      events,
+    }]);
+
+    expect(fs.existsSync(missingTranscript)).toBe(false);
+    expect(db.getSessionById(meta.id)?.todos).toMatchObject({
+      done: 0,
+      total: 1,
+      activeForm: 'Avoid the second parse',
+    });
+    expect((db.getDB().prepare(
+      'SELECT count(*) AS count FROM tool_calls WHERE session_id = ?',
+    ).get(meta.id) as { count: number }).count).toBe(1);
+  });
+});

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -1807,6 +1807,7 @@ export function upsertSessionsBatch(
     scan?: ScanStamp;
     parserState?: string;
     contentText?: string;
+    events?: SessionEvent[];
     toolCalls?: IndexedToolCall[];
     toolScan?: ScanStamp;
     toolIndexMode?: 'replace' | 'append';
@@ -1859,9 +1860,10 @@ export function upsertSessionsBatch(
             const stat = fs.statSync(toolSourcePath);
             return { fileMtimeMs: stat.mtimeMs, fileSize: stat.size };
           })();
-      // Non-resumable harnesses already parse here for todos/recent dirs. Derive
-      // the tool index from those same in-memory events: no second file read.
-      const events = parseSession(entry.meta.filePath, entry.meta.agent);
+      // Some non-resumable scanners already normalized the transcript while
+      // deriving metadata. Reuse those events; scanners that only read summary
+      // metadata fall back to exactly one normalized parse here.
+      const events = entry.events ?? parseSession(entry.meta.filePath, entry.meta.agent);
       writeResourceUsage(entry.meta.id, events, entry.meta.cwd);
       return {
         ...entry,
@@ -1872,6 +1874,8 @@ export function upsertSessionsBatch(
         },
         toolCalls: toolCallsFromEvents(events),
         toolScan,
+        // These are complete event arrays, not an appended tail. Append would
+        // duplicate existing evidence even when persistToolCalls supports it.
         toolIndexMode: 'replace' as const,
       };
     } catch {

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -308,6 +308,8 @@ interface ScanEntry {
   meta: SessionMeta;
   content: string;
   scan: ScanStamp;
+  /** Normalized events already produced while scanning; avoids reopening the transcript in the DB sink. */
+  events?: SessionEvent[];
   /**
    * Serialized {@link ClaudeParserState} continuation to persist in
    * scan_ledger.parser_state (Claude only). Carries the offset + accumulator so
@@ -1105,6 +1107,7 @@ async function readRoutineArchiveMeta(
 ): Promise<{
   meta: SessionMeta;
   content: string;
+  events?: SessionEvent[];
   toolCalls?: IndexedToolCall[];
   toolIndexMode?: 'replace' | 'append';
 } | null> {
@@ -1169,6 +1172,7 @@ async function scanRoutineArchivesIncremental(
         meta: result.meta,
         content: result.content,
         scan,
+        events: result.events,
         toolCalls: result.toolCalls,
         toolIndexMode: result.toolIndexMode,
       });
@@ -2117,7 +2121,7 @@ async function scanAntigravityIncremental(onProgress?: (p: ScanProgress) => void
       const result = readAntigravityMeta(filePath, currentVersion);
       if (result && !seen.has(result.meta.id)) {
         seen.add(result.meta.id);
-        entries.push({ meta: result.meta, content: result.content, scan });
+        entries.push({ meta: result.meta, content: result.content, scan, events: result.events });
       } else {
         touched.push({ filePath, scan });
       }
@@ -2136,7 +2140,7 @@ async function scanAntigravityIncremental(onProgress?: (p: ScanProgress) => void
 function readAntigravityMeta(
   filePath: string,
   currentVersion?: string,
-): { meta: SessionMeta; content: string } | null {
+): { meta: SessionMeta; content: string; events: SessionEvent[] } | null {
   const sessionId = path.basename(filePath).replace(/\.db$/, '');
   if (!sessionId) return null;
 
@@ -2167,7 +2171,7 @@ function readAntigravityMeta(
     topic: topic ? topic.slice(0, 120) : undefined,
     messageCount: events.length,
   };
-  return { meta, content: contentParts.join('\n') };
+  return { meta, content: contentParts.join('\n'), events };
 }
 
 // ---------------------------------------------------------------------------
@@ -4729,7 +4733,7 @@ async function scanCursorIncremental(onProgress?: (p: ScanProgress) => void): Pr
       const result = readCursorMeta(filePath, currentVersion);
       if (result && !seen.has(result.meta.id)) {
         seen.add(result.meta.id);
-        entries.push({ meta: result.meta, content: result.content, scan });
+        entries.push({ meta: result.meta, content: result.content, scan, events: result.events });
       } else {
         touched.push({ filePath, scan });
       }
@@ -4788,7 +4792,7 @@ function readCursorChatMeta(filePath: string, sessionId: string): any | undefine
 export function readCursorMeta(
   filePath: string,
   currentVersion?: string,
-): { meta: SessionMeta; content: string } | null {
+): { meta: SessionMeta; content: string; events: SessionEvent[] } | null {
   const sessionId = path.basename(filePath).replace(/\.jsonl$/, '');
   if (!sessionId || path.basename(path.dirname(filePath)) !== sessionId) return null;
 
@@ -4830,7 +4834,7 @@ export function readCursorMeta(
     todos: extractTodoProgressFromEvents(events),
   };
 
-  return { meta, content: userTexts.join('\n') };
+  return { meta, content: userTexts.join('\n'), events };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Threads normalized Cursor and Antigravity events from discovery into `upsertSessionsBatch`.
- Reuses scanner-produced events for todos, recent directories, resource usage, and tool evidence instead of reopening the transcript.
- Keeps `replace` mode because these scanners provide complete event arrays; append would duplicate stored calls.

## Verification

No UI surface: session-indexing performance fix.

Actual run: `bunx vitest run src/lib/session/db.reparse.test.ts src/lib/session/__tests__/parse-cursor.test.ts src/lib/session/discover.opencode-ledger.test.ts` -> 3 files passed, 14 tests passed.

The regression test indexes scanner-produced events from a deliberately nonexistent transcript path, proving `upsertSessionsBatch` does not reread the file.

## Tracking

- [RUSH-2209](https://linear.app/getrush/issue/RUSH-2209)
- Depends on #2187 landing before merge.