### PR TITLE
fix(hooks): TTL/stale recovery for the hook-cache single-flight lock (RUSH-2259)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2259.md
+++ b/apps/cli/.changelog/next/RUSH-2259.md
@@ -1,0 +1,7 @@
+- **Hook-cache background refresh recovers from an orphaned single-flight lock (RUSH-2259).**
+  The stale-while-revalidate lock (`<cache>.bg.lck`) was only released by the
+  background refresh's `EXIT` trap, so a hard kill (SIGKILL, OOM, reboot) that
+  skipped the trap orphaned the dir and every future refresh's `mkdir` failed —
+  permanently stalling background refresh while stale cache was served forever.
+  The shim now reclaims a lock older than a 5-minute TTL before acquiring, so a
+  dead lock self-heals on the next fire. Source: `apps/cli/src/lib/hooks/cache.ts`.

--- a/apps/cli/src/lib/hooks/cache-integration.test.ts
+++ b/apps/cli/src/lib/hooks/cache-integration.test.ts
@@ -206,6 +206,78 @@ echo "call=$count"
     expect(line.session_id).toBe('sess-guard');
   });
 
+  // RUSH-2259: an orphaned bg lockdir (from a refresh hard-killed before its
+  // EXIT trap ran) must not stop bg refresh forever. Poll for the detached
+  // child's effect since the shim returns before its bg refresh finishes.
+  function waitFor(pred: () => boolean, timeoutMs = 3000): boolean {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (pred()) return true;
+      execFileSync('bash', ['-c', 'sleep 0.05']);
+    }
+    return pred();
+  }
+
+  it('reclaims a stale bg lockdir and refreshes, instead of stalling forever', () => {
+    const shim = generateHookShim({
+      name: 'stale-lock-hook',
+      scriptPath,
+      cache: { ttl: 1, key: 'global', prefetch: 'background' },
+      paths,
+    });
+    const cacheFile = path.join(paths.cacheDir!, 'stale-lock-hook.out');
+    const lockDir = `${cacheFile}.bg.lck`;
+
+    // Populate the cache (call=1), then backdate it past ttl so the next fire
+    // takes the stale-while-revalidate (bg refresh) branch.
+    expect(runShim(shim, '{}').stdout.trim()).toBe('call=1');
+    const past = new Date(Date.now() - 5 * 60_000);
+    fs.utimesSync(cacheFile, past, past);
+
+    // Simulate the orphaned lock: a leftover dir from a bg refresh that was
+    // hard-killed before its trap removed it, backdated well past LOCK_TTL_SEC.
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.utimesSync(lockDir, past, past);
+
+    // Fire: serves stale (call=1) synchronously, and the bg child must reclaim
+    // the stale lock and refresh the cache to call=2.
+    const fire = runShim(shim, '{}');
+    expect(fire.stdout.trim()).toBe('call=1');
+
+    const refreshed = waitFor(() => {
+      try { return fs.readFileSync(cacheFile, 'utf-8').trim() === 'call=2'; }
+      catch { return false; }
+    });
+    expect(refreshed).toBe(true);
+    // The bg subshell's EXIT trap removes the lock it (re)acquired.
+    expect(waitFor(() => !fs.existsSync(lockDir))).toBe(true);
+  });
+
+  it('does NOT reclaim a fresh bg lockdir — a live refresh is left alone', () => {
+    const shim = generateHookShim({
+      name: 'fresh-lock-hook',
+      scriptPath,
+      cache: { ttl: 1, key: 'global', prefetch: 'background' },
+      paths,
+    });
+    const cacheFile = path.join(paths.cacheDir!, 'fresh-lock-hook.out');
+    const lockDir = `${cacheFile}.bg.lck`;
+
+    expect(runShim(shim, '{}').stdout.trim()).toBe('call=1');
+    const past = new Date(Date.now() - 5 * 60_000);
+    fs.utimesSync(cacheFile, past, past);
+
+    // A freshly-held lock (age ~0) stands in for an in-flight refresh: it must
+    // survive and the second refresh must be skipped, so the counter stays at 1.
+    fs.mkdirSync(lockDir, { recursive: true });
+
+    expect(runShim(shim, '{}').stdout.trim()).toBe('call=1');
+    // Give any (incorrectly-spawned) bg child a chance to advance the counter.
+    execFileSync('bash', ['-c', 'sleep 0.3']);
+    expect(fs.readFileSync(callCounterFile, 'utf-8').trim()).toBe('1');
+    expect(fs.existsSync(lockDir)).toBe(true);
+  });
+
   it('omits cwd/session_id from the perf-spool line when stdin carries neither', () => {
     const shim = generateHookShim({
       name: 'unattributed-hook',

--- a/apps/cli/src/lib/hooks/cache.test.ts
+++ b/apps/cli/src/lib/hooks/cache.test.ts
@@ -250,6 +250,24 @@ describe('generateHookShim', () => {
     expect(body).toMatch(/"exit":%d/);
   });
 
+  // Fix 4 (RUSH-2259): the bg lockdir has a TTL so an orphaned lock (bg refresh
+  // hard-killed before its EXIT trap) is reclaimed instead of stopping all
+  // future refresh permanently.
+  it('background-prefetch shim reclaims a stale bg lockdir before acquiring', () => {
+    const shim = generateHookShim({
+      name: 'bg-lock-ttl-test',
+      scriptPath: '/some/script.sh',
+      cache: { ttl: 60, key: 'global', prefetch: 'background' },
+      paths: testPaths,
+    });
+    const body = fs.readFileSync(shim, 'utf-8');
+    expect(body).toMatch(/LOCK_TTL_SEC=/);
+    // Guards the reclaim on the lock's own age, then removes it before mkdir.
+    expect(body).toMatch(/\[ -d "\$LOCK_DIR" \]/);
+    expect(body).toMatch(/_lock_age=/);
+    expect(body).toMatch(/\[ "\$_lock_age" -ge "\$LOCK_TTL_SEC" \] && rm -rf "\$LOCK_DIR"/);
+  });
+
   // Fix 2 (sync path): synchronous fetch also clears the FAIL_FILE sentinel on success
   it('synchronous-prefetch shim clears FAIL_FILE on a successful fetch', () => {
     const shim = generateHookShim({

--- a/apps/cli/src/lib/hooks/cache.ts
+++ b/apps/cli/src/lib/hooks/cache.ts
@@ -533,6 +533,21 @@ if [ "$CACHE_STATUS" = miss ]; then
     if [ "$_in_backoff" -eq 0 ]; then
       # Fix 1: lockdir — only one background refresh runs at a time.
       LOCK_DIR="$CACHE_FILE.bg.lck"
+      # Fix 4 (RUSH-2259): reclaim a stale lock. The lock is released by the bg
+      # subshell's EXIT trap, but a hard kill (SIGKILL, OOM, reboot) skips the
+      # trap and orphans the dir — after which every future mkdir fails and bg
+      # refresh stops FOREVER while stale cache is served indefinitely. The dir
+      # mtime is fixed at mkdir time (the refresh writes elsewhere), so its age
+      # is the time the lock has been held; treat a lock older than LOCK_TTL_SEC
+      # as abandoned and remove it before locking. LOCK_TTL_SEC is set well above
+      # any real hook runtime so a live refresh is never reclaimed out from under.
+      LOCK_TTL_SEC=300
+      if [ -d "$LOCK_DIR" ]; then
+        _lock_mtime=$("$PY" -c 'import os,sys; print(int(os.path.getmtime(sys.argv[1])))' "$LOCK_DIR" 2>/dev/null || echo 0)
+        _lock_now_s=$(date +%s)
+        _lock_age=$((_lock_now_s - \${_lock_mtime:-0}))
+        [ "$_lock_age" -ge "$LOCK_TTL_SEC" ] && rm -rf "$LOCK_DIR" 2>/dev/null
+      fi
       if mkdir "$LOCK_DIR" 2>/dev/null; then
         tmp="$CACHE_FILE.new.$$"
         # Fix 3: background subshell captures and logs its own real exit code.


### PR DESCRIPTION
**bug fix — no user-visible surface (generated hook-cache shim internals).** Follow-up to RUSH-2121.

## What was broken

The hook-cache stale-while-revalidate path (`prefetch: background`) prevents a thundering herd of background refreshes with an `mkdir` lockdir at `<cache>.bg.lck` (`apps/cli/src/lib/hooks/cache.ts:535`). The lock is released **only** by the background subshell's `trap ... EXIT` (`cache.ts:540`).

If that subshell is hard-killed before the trap runs — SIGKILL, OOM killer, machine reboot mid-refresh — the lock dir is orphaned. From then on **every** future `mkdir "$LOCK_DIR"` fails, so the background refresh branch is skipped on every fire. The cache file is never refreshed again while stale-while-revalidate keeps serving the stale content **indefinitely**. There was no TTL and no stale recovery: one dead process stopped all background refresh for that hook, permanently.

## The fix

Before acquiring the lock, reclaim it if its dir is older than `LOCK_TTL_SEC` (300s). The lockdir mtime is fixed at `mkdir` time (the refresh writes its tmp file elsewhere), so the dir's age is exactly how long the lock has been held. 300s sits well above any real hook runtime, so a genuinely in-flight refresh is never reclaimed out from under itself; an orphaned lock self-heals on the next fire. Mirrors the existing `FAIL_FILE` backoff already in this shim and the menubar `acquire` stale-lock self-heal.

## Proof — the test reproduces the bug

New **executable** integration test (`cache-integration.test.ts`) runs the real generated bash shim: it plants a backdated orphan lockdir, fires the shim, and asserts the bg child reclaims the lock and refreshes the cache (`call=1` then `call=2`). Against the pre-fix code it fails exactly as the bug predicts:

```
- true
+ false
   src/lib/hooks/cache-integration.test.ts:251:23
    251|       expect(refreshed).toBe(true);
 Test Files  1 failed (1)
      Tests  1 failed | 9 skipped (10)
```

With the fix, the whole cache suite is green (real bash execution, no mocking):

```
 Test Files  3 passed (3)
      Tests  60 passed (60)
```

A companion test asserts a **fresh** lock (age ~0, i.e. a live refresh) is left untouched and its refresh is skipped, plus a shim-body regex pin in `cache.test.ts`.

## Files
| File | Change |
|---|---|
| `apps/cli/src/lib/hooks/cache.ts` | stale-lock reclaim before locking in the bg-refresh branch |
| `apps/cli/src/lib/hooks/cache-integration.test.ts` | reproduces the bug (bash exec) + fresh-lock-left-alone |
| `apps/cli/src/lib/hooks/cache.test.ts` | shim-body regex pin |
| `apps/cli/.changelog/next/RUSH-2259.md` | changelog fragment |

Linear: https://linear.app/getrush/issue/RUSH-2259
