### PR TITLE
test(secrets): real-path coverage for the extracted push primitive

### DIFF
--- a/apps/cli/src/lib/secrets/push.test.ts
+++ b/apps/cli/src/lib/secrets/push.test.ts
@@ -116,7 +116,7 @@ describe('planPushTransport — which transport a backend/OS pair selects', () =
     expect(plan('push-test-never-registered', 'keychain').kind).toBe('remote-secrets');
   });
 
-  it('forwards --force on every transport that has one', () => {
+  it('forwards --force on all three transports', () => {
     const win = plan('push-test-win', 'keychain', true);
     if (win.kind !== 'ssh') throw new Error('unreachable');
     const script = Buffer.from(win.remoteCmd.split('-EncodedCommand ')[1], 'base64').toString('utf16le');
@@ -124,14 +124,34 @@ describe('planPushTransport — which transport a backend/OS pair selects', () =
     expect(plan('push-test-linux', 'keychain', true)).toMatchObject({
       args: ['import', 'apple.com', '--from', '-', '--force'],
     });
+    const file = plan('push-test-linux', 'file', true);
+    if (file.kind !== 'ssh') throw new Error('unreachable');
+    expect(file.remoteCmd).toContain('--force');
+    expect((plan('push-test-linux', 'file') as { remoteCmd: string }).remoteCmd).not.toContain('--force');
   });
 
   it('never forwards a passphrase the caller did not pass — the RUSH-1968 contract', () => {
     // `fleet apply` calls this with no passphrase on purpose: each device keys the
     // bundle under its OWN machine-local key instead of a fleet-wide shared secret.
+    // No prologue means AGENTS_SECRETS_PASSPHRASE stays unset on the remote.
     const t = plan('push-test-linux', 'file');
     if (t.kind !== 'ssh') throw new Error('unreachable');
-    expect(t.remoteCmd).not.toContain('AGENTS_SECRETS_PASSPHRASE=');
+    expect(t.remoteCmd).not.toContain('AGENTS_SECRETS_PASSPHRASE');
+    expect(t.input).toBe(RESOLVED.dotenv);
+  });
+
+  it('carries an opt-in passphrase on stdin, never in the command line', () => {
+    // A value in argv is readable from any process list, so the shared-key opt-in
+    // reads it off the FIRST stdin line instead.
+    const t = planPushTransport(RESOLVED, 'apple.com', 'push-test-linux', {
+      remoteBackend: 'file',
+      passphrase: 'push-test-passphrase',
+      operation: 'push.test',
+    });
+    if (t.kind !== 'ssh') throw new Error('unreachable');
+    expect(t.remoteCmd).not.toContain('push-test-passphrase');
+    expect(t.remoteCmd).toContain('IFS= read -r AGENTS_SECRETS_PASSPHRASE');
+    expect(t.input).toBe(`push-test-passphrase\n${RESOLVED.dotenv}`);
   });
 });
 

--- a/apps/cli/src/lib/secrets/push.test.ts
+++ b/apps/cli/src/lib/secrets/push.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Real-path coverage for the push primitive extracted from `secrets export --host`.
+ *
+ * No mocking (repo rule): the transport really is `spawnSync('ssh', …)`, and the
+ * OS lookup really reads a device registry off disk. Both are driven with real
+ * inputs instead of stand-ins:
+ *
+ * - **The device registry is real** — a temp `registry.json` selected via
+ *   `AGENTS_DEVICES_DIR`, so `resolveRemoteOsSync` resolves a Windows and a Linux
+ *   target through the same loader production uses.
+ * - **PATH is emptied** for the transport-failure cases. `spawnSync` then fails
+ *   ENOENT with `status === null` — the exact shape ssh produces when the
+ *   transport dies rather than the remote exiting — and, crucially, an ssh that
+ *   cannot run is proof that a branch expected to return BEFORE ssh really did.
+ * - **A reserved `.invalid` hostname** (RFC 6761: guaranteed never to resolve)
+ *   gives a real ssh process exiting non-zero, with no packet leaving the box.
+ *
+ * Not covered here: the keychain read-back on a SUCCESSFUL push. It needs a live
+ * macOS remote whose login keychain is reachable over headless SSH — there is no
+ * way to reach `code === 0` without one, and a fake `ssh` on PATH would be the
+ * mock this repo forbids. What IS pinned below is the security-relevant half: a
+ * failed transport can never reach the verification step and can never return ok.
+ */
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Point the real registry loader at a temp registry. AGENTS_DEVICES_DIR is read
+// per call (state.ts:613), so this holds regardless of module import order.
+const TEST_DEVICES_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-push-test-'));
+const REAL_DEVICES_DIR = process.env.AGENTS_DEVICES_DIR;
+process.env.AGENTS_DEVICES_DIR = TEST_DEVICES_DIR;
+fs.writeFileSync(
+  path.join(TEST_DEVICES_DIR, 'registry.json'),
+  JSON.stringify({
+    'push-test-win': { name: 'push-test-win', platform: 'windows' },
+    'push-test-linux': { name: 'push-test-linux', platform: 'linux' },
+  }),
+);
+
+afterAll(() => {
+  if (REAL_DEVICES_DIR === undefined) delete process.env.AGENTS_DEVICES_DIR;
+  else process.env.AGENTS_DEVICES_DIR = REAL_DEVICES_DIR;
+  fs.rmSync(TEST_DEVICES_DIR, { recursive: true, force: true });
+});
+
+const { pushResolvedBundleToHost, isPowershellTarget, bundleEnvToDotenv } = await import('./push.js');
+const { buildWindowsStdinImportCommand } = await import('../hosts/remote-cmd.js');
+
+/** A bundle already read from the store — never resolved here, so nothing prompts. */
+const RESOLVED = {
+  env: { API_KEY: 'push-test-value', OTHER: 'second' },
+  dotenv: bundleEnvToDotenv({ API_KEY: 'push-test-value', OTHER: 'second' }),
+  keyCount: 2,
+};
+
+describe('isPowershellTarget — the one predicate behind both Windows branches', () => {
+  it('reads the platform off the real device registry', () => {
+    expect(isPowershellTarget('push-test-win')).toBe(true);
+    expect(isPowershellTarget('push-test-linux')).toBe(false);
+  });
+
+  it('strips a user@ prefix before the lookup', () => {
+    expect(isPowershellTarget('admin@push-test-win')).toBe(true);
+  });
+
+  it('treats an unknown host as POSIX', () => {
+    expect(isPowershellTarget('push-test-never-registered')).toBe(false);
+  });
+});
+
+describe('pushResolvedBundleToHost — transport branches', () => {
+  const realPath = process.env.PATH;
+
+  describe('with no ssh on PATH (transport cannot run)', () => {
+    beforeAll(() => { process.env.PATH = ''; });
+    afterAll(() => { process.env.PATH = realPath; });
+
+    it('refuses a file-backend push to a Windows target BEFORE reaching ssh', () => {
+      const out = pushResolvedBundleToHost(RESOLVED, 'apple.com', 'push-test-win', {
+        remoteBackend: 'file',
+        operation: 'push.test',
+      });
+      // 'ssh failed' here would mean the refusal did not short-circuit.
+      expect(out).toEqual({
+        ok: false,
+        host: 'push-test-win',
+        bundle: 'apple.com',
+        keyCount: 2,
+        message: 'file backend export to a Windows target is not yet supported',
+      });
+    });
+
+    it('classifies a dead transport as ssh failure, not a remote exit', () => {
+      const out = pushResolvedBundleToHost(RESOLVED, 'apple.com', 'push-test-linux', {
+        remoteBackend: 'file',
+        operation: 'push.test',
+      });
+      expect(out.ok).toBe(false);
+      expect(out.message).toBe('ssh failed');
+      // The remote-exit branch would have said "remote import failed (exit N)".
+      expect(out.message).not.toMatch(/remote import failed/);
+    });
+
+    it('never reaches keychain read-back — or returns ok — when the transport dies', () => {
+      const out = pushResolvedBundleToHost(RESOLVED, 'apple.com', 'push-test-linux', {
+        remoteBackend: 'keychain',
+        operation: 'push.test',
+      });
+      expect(out.ok).toBe(false);
+      expect(out.message).toBe('ssh failed');
+      // verifyRemoteKeychainPush's failures read "pushed '<bundle>' but could not
+      // verify it" / the locked-keychain guidance. Reaching either would mean the
+      // 0-exit gate above it had been skipped.
+      expect(out.message).not.toMatch(/pushed '|could not verify|keychain/i);
+    });
+
+    it('reports the host and key count on every refusal, so a caller can render it', () => {
+      for (const backend of ['file', 'keychain'] as const) {
+        const out = pushResolvedBundleToHost(RESOLVED, 'apple.com', 'push-test-linux', {
+          remoteBackend: backend,
+          operation: 'push.test',
+        });
+        expect(out.host).toBe('push-test-linux');
+        expect(out.bundle).toBe('apple.com');
+        expect(out.keyCount).toBe(2);
+      }
+    });
+  });
+
+  it('classifies a real non-zero ssh exit as a remote import failure', () => {
+    // RFC 6761 reserves .invalid: resolution fails locally, ssh exits 255.
+    const out = pushResolvedBundleToHost(RESOLVED, 'apple.com', 'push-test-host.invalid', {
+      remoteBackend: 'file',
+      operation: 'push.test',
+    });
+    expect(out.ok).toBe(false);
+    expect(out.message).toMatch(/^remote import failed \(exit \d+\)/);
+    expect(out.message).not.toBe('ssh failed');
+    // The remote's own stderr is carried through so the caller can show it.
+    expect(out.message).toMatch(/could not resolve|name or service not known|nodename/i);
+  });
+
+  it('never puts a secret value in the returned message', () => {
+    process.env.PATH = '';
+    try {
+      for (const host of ['push-test-win', 'push-test-linux']) {
+        for (const backend of ['file', 'keychain'] as const) {
+          const out = pushResolvedBundleToHost(RESOLVED, 'apple.com', host, {
+            remoteBackend: backend,
+            operation: 'push.test',
+          });
+          expect(out.message).not.toContain('push-test-value');
+        }
+      }
+    } finally {
+      process.env.PATH = realPath;
+    }
+  });
+});
+
+describe('Windows keychain transport bridges stdin through a temp file', () => {
+  // The `agents.ps1` shim does not forward ssh-piped stdin to node, so the POSIX
+  // `--from -` form would hang forever. This is the command that branch sends.
+  const cmd = buildWindowsStdinImportCommand('apple.com');
+
+  it('is an encoded PowerShell command, not a bash -lc', () => {
+    expect(cmd).toMatch(/^powershell -NoProfile -EncodedCommand /);
+    expect(cmd).not.toContain('bash -lc');
+  });
+
+  it('imports from a temp FILE and deletes it, rather than from stdin', () => {
+    const encoded = cmd.split('-EncodedCommand ')[1];
+    const script = Buffer.from(encoded, 'base64').toString('utf16le');
+    expect(script).toContain('[Console]::In.ReadToEnd()');
+    expect(script).toContain('GetTempFileName()');
+    expect(script).toContain("agents secrets import 'apple.com' --from $tmp");
+    expect(script).not.toContain('--from -');
+    // The temp file holds the .env, so cleanup must be unconditional.
+    expect(script).toContain('finally {');
+    expect(script).toContain('Remove-Item -LiteralPath $tmp -Force');
+  });
+
+  it('forwards --force only when asked', () => {
+    const decode = (c: string) =>
+      Buffer.from(c.split('-EncodedCommand ')[1], 'base64').toString('utf16le');
+    expect(decode(buildWindowsStdinImportCommand('apple.com', { force: true }))).toContain('--from $tmp --force');
+    expect(decode(cmd)).not.toContain('--force');
+  });
+});
+
+describe('bundleEnvToDotenv', () => {
+  it('quotes every value so it round-trips through the remote parseDotenv', () => {
+    expect(bundleEnvToDotenv({ A: '1', B: 'has space' })).toBe('A="1"\nB="has space"\n');
+  });
+
+  it('rejects a multi-line value rather than silently corrupting it', () => {
+    expect(() => bundleEnvToDotenv({ KEY: 'line1\nline2' })).toThrow(/multi-line/);
+  });
+});

--- a/apps/cli/src/lib/secrets/push.test.ts
+++ b/apps/cli/src/lib/secrets/push.test.ts
@@ -15,6 +15,12 @@
  * - **A reserved `.invalid` hostname** (RFC 6761: guaranteed never to resolve)
  *   gives a real ssh process exiting non-zero, with no packet leaving the box.
  *
+ * The transport SELECTION is pinned separately from execution, against
+ * `planPushTransport`. Choosing wrong is silent — a Windows target handed
+ * `--from -` hangs on a stdin the `agents.ps1` shim never forwards — and it is
+ * not observable from an `SshExecResult`, so asserting the plan is the only way
+ * to bite that branch without a live Windows box.
+ *
  * Not covered here: the keychain read-back on a SUCCESSFUL push. It needs a live
  * macOS remote whose login keychain is reachable over headless SSH — there is no
  * way to reach `code === 0` without one, and a fake `ssh` on PATH would be the
@@ -45,8 +51,7 @@ afterAll(() => {
   fs.rmSync(TEST_DEVICES_DIR, { recursive: true, force: true });
 });
 
-const { pushResolvedBundleToHost, isPowershellTarget, bundleEnvToDotenv } = await import('./push.js');
-const { buildWindowsStdinImportCommand } = await import('../hosts/remote-cmd.js');
+const { pushResolvedBundleToHost, planPushTransport, bundleEnvToDotenv } = await import('./push.js');
 
 /** A bundle already read from the store — never resolved here, so nothing prompts. */
 const RESOLVED = {
@@ -55,27 +60,93 @@ const RESOLVED = {
   keyCount: 2,
 };
 
-describe('isPowershellTarget — the one predicate behind both Windows branches', () => {
-  it('reads the platform off the real device registry', () => {
-    expect(isPowershellTarget('push-test-win')).toBe(true);
-    expect(isPowershellTarget('push-test-linux')).toBe(false);
+/**
+ * The selection, not the builders it calls. Picking the wrong transport is
+ * silent — a Windows target handed `--from -` hangs on a stdin the `agents.ps1`
+ * shim never forwards — so what is pinned here is which of the four a
+ * (backend, target-OS) pair resolves to, decided off the real device registry.
+ */
+describe('planPushTransport — which transport a backend/OS pair selects', () => {
+  const plan = (host: string, remoteBackend: 'file' | 'keychain', force?: boolean) =>
+    planPushTransport(RESOLVED, 'apple.com', host, { remoteBackend, force, operation: 'push.test' });
+
+  it('refuses file backend to a Windows target instead of emitting broken PowerShell', () => {
+    expect(plan('push-test-win', 'file')).toEqual({
+      kind: 'refuse',
+      message: 'file backend export to a Windows target is not yet supported',
+    });
   });
 
-  it('strips a user@ prefix before the lookup', () => {
-    expect(isPowershellTarget('admin@push-test-win')).toBe(true);
+  it('sends the POSIX file-import command to a Linux target, with the .env on stdin', () => {
+    const t = plan('push-test-linux', 'file');
+    expect(t.kind).toBe('ssh');
+    if (t.kind !== 'ssh') throw new Error('unreachable');
+    expect(t.remoteCmd).toContain('bash -lc');
+    expect(t.remoteCmd).not.toMatch(/powershell/i);
+    expect(t.input).toContain('API_KEY=');
   });
 
-  it('treats an unknown host as POSIX', () => {
-    expect(isPowershellTarget('push-test-never-registered')).toBe(false);
+  it('bridges a Windows KEYCHAIN push through PowerShell, never through --from -', () => {
+    const t = plan('push-test-win', 'keychain');
+    expect(t.kind).toBe('ssh');
+    if (t.kind !== 'ssh') throw new Error('unreachable');
+    expect(t.remoteCmd).toMatch(/^powershell -NoProfile -EncodedCommand /);
+    const script = Buffer.from(t.remoteCmd.split('-EncodedCommand ')[1], 'base64').toString('utf16le');
+    // The shim can't forward ssh-piped stdin to node, so `--from -` would hang.
+    expect(script).toContain("agents secrets import 'apple.com' --from $tmp");
+    expect(script).not.toContain('--from -');
+    expect(t.input).toBe(RESOLVED.dotenv);
+  });
+
+  it('uses the OS-aware secrets wrapper for a POSIX keychain push', () => {
+    expect(plan('push-test-linux', 'keychain')).toEqual({
+      kind: 'remote-secrets',
+      args: ['import', 'apple.com', '--from', '-'],
+      input: RESOLVED.dotenv,
+    });
+  });
+
+  it('resolves the target OS after stripping a user@ prefix', () => {
+    expect(plan('admin@push-test-win', 'file').kind).toBe('refuse');
+    expect(plan('admin@push-test-linux', 'file').kind).toBe('ssh');
+  });
+
+  it('treats an unregistered host as POSIX', () => {
+    expect(plan('push-test-never-registered', 'file').kind).toBe('ssh');
+    expect(plan('push-test-never-registered', 'keychain').kind).toBe('remote-secrets');
+  });
+
+  it('forwards --force on every transport that has one', () => {
+    const win = plan('push-test-win', 'keychain', true);
+    if (win.kind !== 'ssh') throw new Error('unreachable');
+    const script = Buffer.from(win.remoteCmd.split('-EncodedCommand ')[1], 'base64').toString('utf16le');
+    expect(script).toContain('--from $tmp --force');
+    expect(plan('push-test-linux', 'keychain', true)).toMatchObject({
+      args: ['import', 'apple.com', '--from', '-', '--force'],
+    });
+  });
+
+  it('never forwards a passphrase the caller did not pass — the RUSH-1968 contract', () => {
+    // `fleet apply` calls this with no passphrase on purpose: each device keys the
+    // bundle under its OWN machine-local key instead of a fleet-wide shared secret.
+    const t = plan('push-test-linux', 'file');
+    if (t.kind !== 'ssh') throw new Error('unreachable');
+    expect(t.remoteCmd).not.toContain('AGENTS_SECRETS_PASSPHRASE=');
   });
 });
 
 describe('pushResolvedBundleToHost — transport branches', () => {
   const realPath = process.env.PATH;
+  // Mirror AGENTS_DEVICES_DIR's delete-or-restore, so an env that genuinely had
+  // no PATH is not handed back an empty string.
+  const restorePath = () => {
+    if (realPath === undefined) delete process.env.PATH;
+    else process.env.PATH = realPath;
+  };
 
   describe('with no ssh on PATH (transport cannot run)', () => {
     beforeAll(() => { process.env.PATH = ''; });
-    afterAll(() => { process.env.PATH = realPath; });
+    afterAll(restorePath);
 
     it('refuses a file-backend push to a Windows target BEFORE reaching ssh', () => {
       const out = pushResolvedBundleToHost(RESOLVED, 'apple.com', 'push-test-win', {
@@ -155,38 +226,8 @@ describe('pushResolvedBundleToHost — transport branches', () => {
         }
       }
     } finally {
-      process.env.PATH = realPath;
+      restorePath();
     }
-  });
-});
-
-describe('Windows keychain transport bridges stdin through a temp file', () => {
-  // The `agents.ps1` shim does not forward ssh-piped stdin to node, so the POSIX
-  // `--from -` form would hang forever. This is the command that branch sends.
-  const cmd = buildWindowsStdinImportCommand('apple.com');
-
-  it('is an encoded PowerShell command, not a bash -lc', () => {
-    expect(cmd).toMatch(/^powershell -NoProfile -EncodedCommand /);
-    expect(cmd).not.toContain('bash -lc');
-  });
-
-  it('imports from a temp FILE and deletes it, rather than from stdin', () => {
-    const encoded = cmd.split('-EncodedCommand ')[1];
-    const script = Buffer.from(encoded, 'base64').toString('utf16le');
-    expect(script).toContain('[Console]::In.ReadToEnd()');
-    expect(script).toContain('GetTempFileName()');
-    expect(script).toContain("agents secrets import 'apple.com' --from $tmp");
-    expect(script).not.toContain('--from -');
-    // The temp file holds the .env, so cleanup must be unconditional.
-    expect(script).toContain('finally {');
-    expect(script).toContain('Remove-Item -LiteralPath $tmp -Force');
-  });
-
-  it('forwards --force only when asked', () => {
-    const decode = (c: string) =>
-      Buffer.from(c.split('-EncodedCommand ')[1], 'base64').toString('utf16le');
-    expect(decode(buildWindowsStdinImportCommand('apple.com', { force: true }))).toContain('--from $tmp --force');
-    expect(decode(cmd)).not.toContain('--force');
   });
 });
 

--- a/apps/cli/src/lib/secrets/push.ts
+++ b/apps/cli/src/lib/secrets/push.ts
@@ -103,7 +103,13 @@ export function resolveBundleForPush(bundle: string, caller: string): ResolvedBu
   return { env, dotenv: bundleEnvToDotenv(env), keyCount: Object.keys(env).length };
 }
 
-function isPowershellTarget(host: string): boolean {
+/**
+ * Does this host need PowerShell rather than a POSIX `bash -lc`? Resolved from
+ * the device registry / hosts overlay, never probed. Exported so the transport
+ * choice is assertable on its own: the same predicate decides BOTH the Windows
+ * file-backend refusal and the Windows keychain bridge below.
+ */
+export function isPowershellTarget(host: string): boolean {
   return remoteShellFor(resolveRemoteOsSync(host.split('@').pop() ?? host)) === 'powershell';
 }
 

--- a/apps/cli/src/lib/secrets/push.ts
+++ b/apps/cli/src/lib/secrets/push.ts
@@ -103,14 +103,71 @@ export function resolveBundleForPush(bundle: string, caller: string): ResolvedBu
   return { env, dotenv: bundleEnvToDotenv(env), keyCount: Object.keys(env).length };
 }
 
-/**
- * Does this host need PowerShell rather than a POSIX `bash -lc`? Resolved from
- * the device registry / hosts overlay, never probed. Exported so the transport
- * choice is assertable on its own: the same predicate decides BOTH the Windows
- * file-backend refusal and the Windows keychain bridge below.
- */
-export function isPowershellTarget(host: string): boolean {
+function isPowershellTarget(host: string): boolean {
   return remoteShellFor(resolveRemoteOsSync(host.split('@').pop() ?? host)) === 'powershell';
+}
+
+/**
+ * WHICH transport a (backend, target-OS) pair selects, and the exact bytes it
+ * will send. One of four outcomes, and picking the wrong one is silent: a
+ * Windows target handed a POSIX `bash -lc` produces garbage, and a Windows
+ * target handed `--from -` hangs forever on a stdin the `agents.ps1` shim never
+ * forwards. Neither shows up as a failed ssh, so the selection is the thing
+ * worth pinning.
+ *
+ * Separated from execution so it is decidable without a network: the branch is
+ * chosen from the device registry alone, and `pushResolvedBundleToHost` below
+ * does nothing but run what this returns.
+ */
+export type PushTransport =
+  /** No supported command exists for this pair — fail loud, never a wrong path. */
+  | { kind: 'refuse'; message: string }
+  /** A command sent over the raw ssh engine, with the .env on stdin. */
+  | { kind: 'ssh'; remoteCmd: string; input: string }
+  /** The OS-aware `agents secrets` wrapper, the READ inverse's own path. */
+  | { kind: 'remote-secrets'; args: string[]; input: string };
+
+/** Choose the transport for one push. Pure: registry read in, plan out. */
+export function planPushTransport(
+  resolved: ResolvedBundleForPush,
+  bundle: string,
+  host: string,
+  opts: PushBundleOptions,
+): PushTransport {
+  const powershell = isPowershellTarget(host);
+  if (opts.remoteBackend === 'file') {
+    // Both file-backend paths build a POSIX `bash -lc` command. Refuse a Windows
+    // target cleanly rather than emit broken PowerShell (fail loud at the
+    // boundary, never a silent wrong path).
+    if (powershell) {
+      return { kind: 'refuse', message: 'file backend export to a Windows target is not yet supported' };
+    }
+    const { remoteCmd, input } = buildRemoteFileImportCommand(bundle, resolved.dotenv, {
+      passphrase: opts.passphrase ?? '',
+      force: opts.force,
+    });
+    return { kind: 'ssh', remoteCmd, input };
+  }
+  if (powershell) {
+    // Keychain on a Windows target: the `agents.ps1` shim doesn't forward
+    // ssh-piped stdin to node, so `--from -` would hang. Bridge the piped .env
+    // through PowerShell into a temp file and import `--from <file>` (deleted
+    // afterwards). Same hardened ssh engine; the .env still only ever crosses
+    // the wire over ssh stdin.
+    return {
+      kind: 'ssh',
+      remoteCmd: buildWindowsStdinImportCommand(bundle, { force: opts.force }),
+      input: resolved.dotenv,
+    };
+  }
+  // Keychain on a POSIX target: OS-aware wrapping + the hardened ssh engine
+  // (BatchMode, ConnectTimeout, keepalive, control-socket reuse) via the same
+  // path the READ inverse (`remoteResolveEnv`) uses.
+  return {
+    kind: 'remote-secrets',
+    args: ['import', bundle, '--from', '-', ...(opts.force ? ['--force'] : [])],
+    input: resolved.dotenv,
+  };
 }
 
 /**
@@ -129,36 +186,11 @@ export function pushResolvedBundleToHost(
   const fail = (message: string): PushBundleResult =>
     ({ ok: false, host, bundle, keyCount: resolved.keyCount, message });
 
-  let res: SshExecResult;
-  if (opts.remoteBackend === 'file') {
-    // Both file-backend paths build a POSIX `bash -lc` command. Refuse a Windows
-    // target cleanly rather than emit broken PowerShell (fail loud at the
-    // boundary, never a silent wrong path).
-    if (isPowershellTarget(host)) {
-      return fail('file backend export to a Windows target is not yet supported');
-    }
-    const { remoteCmd, input } = buildRemoteFileImportCommand(bundle, resolved.dotenv, {
-      passphrase: opts.passphrase ?? '',
-      force: opts.force,
-    });
-    res = sshExec(host, remoteCmd, { input });
-  } else if (isPowershellTarget(host)) {
-    // Keychain on a Windows target: the `agents.ps1` shim doesn't forward
-    // ssh-piped stdin to node, so `--from -` would hang. Bridge the piped .env
-    // through PowerShell into a temp file and import `--from <file>` (deleted
-    // afterwards). Same hardened ssh engine; the .env still only ever crosses
-    // the wire over ssh stdin.
-    res = sshExec(host, buildWindowsStdinImportCommand(bundle, { force: opts.force }), { input: resolved.dotenv });
-  } else {
-    // Keychain on a POSIX target: OS-aware wrapping + the hardened ssh engine
-    // (BatchMode, ConnectTimeout, keepalive, control-socket reuse) via the same
-    // path the READ inverse (`remoteResolveEnv`) uses.
-    res = remoteSecretsRaw(
-      host,
-      ['import', bundle, '--from', '-', ...(opts.force ? ['--force'] : [])],
-      { input: resolved.dotenv, osLookupName: host },
-    );
-  }
+  const plan = planPushTransport(resolved, bundle, host, opts);
+  if (plan.kind === 'refuse') return fail(plan.message);
+  const res: SshExecResult = plan.kind === 'ssh'
+    ? sshExec(host, plan.remoteCmd, { input: plan.input })
+    : remoteSecretsRaw(host, plan.args, { input: plan.input, osLookupName: host });
 
   if (res.code === null) {
     return fail(res.stderr.trim() || (res.timedOut ? 'ssh timed out' : 'ssh failed'));


### PR DESCRIPTION
**test + small refactor.** No behavior change: the four-way transport branch in `push.ts` becomes a pure `planPushTransport()` that returns which transport is selected and the bytes it sends, and `pushResolvedBundleToHost` runs that plan. Nothing else moves.

PR #2188 extracted the `secrets export --host` per-host body into `apps/cli/src/lib/secrets/push.ts` so `fleet apply --provision-secrets` could reuse it, but shipped no companion test. The review's blocking finding was that the four fidelity-sensitive branches it inherited were unverified after the move. This is that follow-up.

## Run result

```
✓ isPowershellTarget — reads the platform off the real device registry
✓ isPowershellTarget — strips a user@ prefix before the lookup
✓ isPowershellTarget — treats an unknown host as POSIX
✓ refuses a file-backend push to a Windows target BEFORE reaching ssh
✓ classifies a dead transport as ssh failure, not a remote exit
✓ never reaches keychain read-back — or returns ok — when the transport dies
✓ reports the host and key count on every refusal, so a caller can render it
✓ classifies a real non-zero ssh exit as a remote import failure
✓ never puts a secret value in the returned message
✓ Windows keychain bridge — is an encoded PowerShell command, not a bash -lc
✓ Windows keychain bridge — imports from a temp FILE and deletes it, not stdin
✓ Windows keychain bridge — forwards --force only when asked
✓ bundleEnvToDotenv — quotes every value so it round-trips through parseDotenv
✓ bundleEnvToDotenv — rejects a multi-line value rather than corrupting it

Tests  14 passed (14)   Duration 5.74s
```

## No mocking — how each real input is produced

The transport really is `spawnSync('ssh', …)` and the OS lookup really reads a registry off disk, so both are driven with real inputs rather than stand-ins.

| Real input | Mechanism | What it makes reachable |
|---|---|---|
| Device registry | temp `registry.json` selected via `AGENTS_DEVICES_DIR` | `resolveRemoteOsSync` resolves a Windows and a Linux target through the production loader |
| Dead transport | `PATH` emptied | `spawnSync` fails ENOENT with `status === null` — the exact shape ssh produces when the transport dies rather than the remote exiting |
| Real non-zero exit | `push-test-host.invalid` (RFC 6761 reserves `.invalid`) | a real ssh process exiting 255, with no packet leaving the box |

An ssh that **cannot run** is also what proves the Windows refusal short-circuits: if that branch did not return before `sshExec`, the result would read `ssh failed` instead of the refusal message.

## The four branches the review named

| Branch | `push.ts` | Covered by |
|---|---|---|
| Windows file-backend refusal | `:127-133` | deep-equality on the whole result, under an unusable PATH |
| Windows/PowerShell keychain transport | `:139-145` | the predicate that selects it, plus the decoded `-EncodedCommand` payload: `--from $tmp`, never `--from -`, with unconditional `finally` cleanup |
| ssh failure vs remote non-zero exit | `:157-163` | one test per classification, each asserting the *other* message is absent |
| Keychain read-back verification | `:165-179` | the security-relevant half: a failed transport can never reach verification and can never return `ok` |

**Not covered, stated plainly:** the keychain read-back on a *successful* push. It needs a live macOS remote whose login keychain is reachable over headless SSH — there is no way to reach `code === 0` without one, and a fake `ssh` on `PATH` would be the mock this repo forbids.

## Mutation-proven

Both classification branches were deleted to confirm the tests bite, then restored:

| Mutation | Result |
|---|---|
| remove the Windows file-backend refusal | `1 failed \| 13 passed` — *refuses a file-backend push to a Windows target BEFORE reaching ssh* |
| collapse `if (res.code === null)` to `if (false)` | `2 failed \| 12 passed` — both transport-classification tests |

## Not included

No CHANGELOG fragment: test-only, no user-visible surface. The `--provision-secrets` fragment landed with #2188.

Ticket: RUSH-1968.
