### PR TITLE
fix(release): detect a release lease holder killed from outside (RUSH-2274)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2274-release-lease-dead-holder.md
+++ b/apps/cli/.changelog/next/RUSH-2274-release-lease-dead-holder.md
@@ -1,0 +1,11 @@
+- **Release lease detects a holder killed from outside (RUSH-2274).** An externally
+  killed release (SIGKILL, a severed ssh, a rebooted box) left its lease on `origin`
+  and `scripts/release-lease.sh status` read `held` for up to the 30-minute TTL with
+  nothing actually releasing. The lease now records the holding `host`, `pid`, and
+  that pid's start time, and `status` reports `holder-alive=yes|no|unknown`. A holder
+  that is provably gone is reclaimed by the next `claim` immediately instead of
+  waiting out the TTL, and a new `release-lease.sh clear` drops such a lease without
+  starting a release. A live holder is never taken at any age, an unprobeable one
+  (another box, or a lease from an older release) still falls back to the TTL, and a
+  reused pid or an unreaped zombie counts as dead rather than as a live release.
+  Source: `apps/cli/scripts/release-lease.sh`, `apps/cli/scripts/release.sh`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -450,11 +450,12 @@ of the first's, so git's rejection *is* the failed lock acquisition: no polling,
 second service.
 
 ```bash
-scripts/release-lease.sh status     # unheld | held version=… holder=… age=…min
+scripts/release-lease.sh status     # unheld | held version=… holder=… age=…min holder-alive=yes|no|unknown
 scripts/release-lease.sh claim <v>  # 0 = acquired, 1 = someone else is releasing
 scripts/release-lease.sh renew      # prove this run is still alive
 scripts/release-lease.sh verify     # 0 = still ours; fails CLOSED on any doubt
 scripts/release-lease.sh release    # drop the lease this checkout claimed
+scripts/release-lease.sh clear      # drop a lease with no live holder (any checkout)
 ```
 
 `release.sh` claims it right after the confirmation (before the first mutation)
@@ -481,6 +482,32 @@ together:
 A lease abandoned by a killed run stops being renewed, so it becomes reclaimable
 after `RELEASE_LEASE_TTL` minutes (default 30); reclaiming names the dead holder
 rather than silently overwriting it.
+
+**An externally killed run is detected, not just waited out (RUSH-2274).** The TTL
+alone made a killed release indistinguishable from a healthy long one: for up to 30
+minutes `status` read `held` while nothing was releasing. So the lease also records
+**which process** holds it — `host`, `pid`, and that pid's start time — and
+`claim`/`clear`/`status` probe it, reporting `holder-alive=yes|no|unknown`:
+
+| Probe | When | What it licenses |
+|---|---|---|
+| `dead` | we are on the holder's box and that process is gone | reclaim **immediately**, no TTL wait |
+| `alive` | the recorded pid runs here with the recorded start time | **never** taken, at any age — stop that release instead |
+| `unknown` | the holder is another box, or the lease predates these fields | the TTL, exactly as before |
+
+`release.sh` exports `RELEASE_LEASE_HOLDER_PID=$$` so the recorded pid is the
+orchestrating release, not the 10-minutely `renew` shell (whose `$$` is dead a
+second later — recording that would make every renewed lease read as abandoned).
+A lease with no recorded pid stays `unknown`, so a missing export degrades to the
+old TTL behaviour rather than to "instantly reclaimable". The start time is what
+makes `dead` safe to act on: a recycled pid would otherwise read as a live release
+forever. A **zombie** counts as dead — a SIGKILLed release whose parent never
+reaped it is still listed by `ps`, which is precisely the case this detects.
+
+`scripts/release-lease.sh clear` drops such a lease without starting a release —
+the operator's unwedge path, since `release` only drops a lease *this checkout*
+claimed. It shares one predicate with `claim`, so it can never take a live holder's
+lease either.
 
 **Finish a stuck release before cutting a new one.** `release.sh` refuses to start
 when an older `v*` tag exists that npm never received, and prints the re-run that

--- a/apps/cli/scripts/release-lease.sh
+++ b/apps/cli/scripts/release-lease.sh
@@ -72,12 +72,9 @@ yellow(){ printf '\033[33m%s\033[0m\n' "$*"; }
 gray()  { printf '\033[2m%s\033[0m\n'  "$*"; }
 die()   { red "error: $*"; exit 2; }
 
-# Describe the holder for a human reading a stuck lease: a real box and, when the
-# releaser is an agent, a real session. This is DIAGNOSTIC text only -- ownership
-# is decided by the lease token below, never by matching this string. A release
-# spans several invocations (claim, then a resumed run that finishes a merged PR),
-# so anything process-scoped like $$ would make a lease undroppable by its own
-# owner on the second invocation.
+# This box's name, the way the fleet knows it. Recorded as the lease's `host` and
+# compared against it, so the liveness probe only ever reads the process table of
+# the machine that actually holds the lease.
 local_host() {
   if [[ "$(uname)" == "Darwin" ]]; then
     scutil --get LocalHostName 2>/dev/null || hostname -s
@@ -92,10 +89,18 @@ local_host() {
 # THAT would make every renewed lease look abandoned. Unset (a hand-run claim)
 # means no pid is recorded at all and liveness stays `unknown`: a missing export
 # must degrade to today's TTL behaviour, never to "instantly reclaimable".
+#
+# This pid decides LIVENESS ONLY, never ownership. Ownership stays the lease
+# token below, because a release spans several invocations (claim, then a resumed
+# run that finishes a merged PR) and a process-scoped owner would make a lease
+# undroppable by its own owner on the second invocation.
 holder_pid() { printf '%s' "${RELEASE_LEASE_HOLDER_PID:-}"; }
 
-# The pid segment is present only when a release process was declared, so the
-# human string never points at a shell that was already gone when it was written.
+# Describe the holder for a human reading a stuck lease: a real box and, when the
+# releaser is an agent, a real session. DIAGNOSTIC text only -- never matched to
+# decide anything. The pid segment appears only when a release process was
+# declared, so the string never points at a shell that was already gone when it
+# was written.
 holder_desc() {
   printf '%s%s%s' "$(local_host)" \
     "${RELEASE_LEASE_HOLDER_PID:+/pid-$RELEASE_LEASE_HOLDER_PID}" \

--- a/apps/cli/scripts/release-lease.sh
+++ b/apps/cli/scripts/release-lease.sh
@@ -18,17 +18,38 @@
 #   release-lease.sh renew                            # refresh our lease's timestamp
 #   release-lease.sh verify                           # 0 = we still hold it, 1 = we do NOT
 #   release-lease.sh release                          # drop the lease we hold
+#   release-lease.sh clear [--ttl-min N]              # drop a lease with no live holder
 #   release-lease.sh status                           # print the current holder, if any
 #
 # Env:
-#   RELEASE_LEASE_REF   override the ref (tests point this at a scratch ref)
-#   RELEASE_LEASE_TTL   minutes before an unrenewed lease is reclaimable (30)
+#   RELEASE_LEASE_REF          override the ref (tests point this at a scratch ref)
+#   RELEASE_LEASE_TTL          minutes before an unrenewed lease is reclaimable (30)
+#   RELEASE_LEASE_HOLDER_PID   pid of the release process this lease belongs to
 #
 # A lease older than the TTL is reclaimable: a release that dies without running
 # its trap (SIGKILL, a severed ssh, a rebooted box) must not wedge the pipeline
 # forever. Reclaiming is itself a compare-and-swap (--force-with-lease pinned to
 # the exact stale sha), so two agents reclaiming at once still yield one winner,
 # and the stale holder is always logged rather than silently overwritten.
+#
+# The TTL alone is a slow answer to an externally killed run: for up to 30
+# minutes `status` reads `held` while nothing is releasing, and the operator has
+# no way to tell that apart from a healthy long release. So the lease also
+# records WHICH process holds it -- `host`, `pid`, and that pid's start time --
+# and `claim`/`clear`/`status` probe it:
+#
+#   alive    the recorded pid is running on THIS box, same start time
+#   dead     we are on the holder's box and that process is gone
+#   unknown  the holder is another box, or the lease predates these fields
+#
+# A `dead` holder is reclaimable immediately -- no TTL wait -- because nothing
+# can still be releasing. `unknown` falls back to the TTL, so a holder we cannot
+# probe is treated exactly as before. `alive` is NEVER taken, at any age: a live
+# holder is the collision this script exists to prevent, so the answer there is
+# to stop that process, not to steal its lease. The pid start time is what makes
+# `dead` safe to act on -- after a reboot a recycled pid would otherwise read as
+# alive, and a recycled pid belonging to something else would read as a live
+# release forever.
 #
 # The TTL must NOT be read as "how long a release takes" -- it is "how long since
 # the holder last proved it was alive". A real release routinely outlives any
@@ -57,14 +78,27 @@ die()   { red "error: $*"; exit 2; }
 # spans several invocations (claim, then a resumed run that finishes a merged PR),
 # so anything process-scoped like $$ would make a lease undroppable by its own
 # owner on the second invocation.
-holder_desc() {
-  local host
+local_host() {
   if [[ "$(uname)" == "Darwin" ]]; then
-    host="$(scutil --get LocalHostName 2>/dev/null || hostname -s)"
+    scutil --get LocalHostName 2>/dev/null || hostname -s
   else
-    host="$(hostname -s 2>/dev/null || hostname)"
+    hostname -s 2>/dev/null || hostname
   fi
-  printf '%s/pid-%s%s' "$host" "$$" \
+}
+
+# The process whose death means this release is dead. release.sh exports its own
+# pid, so a lease survives the short-lived `renew` invocations that rotate it --
+# each of those is a fresh shell whose $$ is dead a second later, and recording
+# THAT would make every renewed lease look abandoned. Unset (a hand-run claim)
+# means no pid is recorded at all and liveness stays `unknown`: a missing export
+# must degrade to today's TTL behaviour, never to "instantly reclaimable".
+holder_pid() { printf '%s' "${RELEASE_LEASE_HOLDER_PID:-}"; }
+
+# The pid segment is present only when a release process was declared, so the
+# human string never points at a shell that was already gone when it was written.
+holder_desc() {
+  printf '%s%s%s' "$(local_host)" \
+    "${RELEASE_LEASE_HOLDER_PID:+/pid-$RELEASE_LEASE_HOLDER_PID}" \
     "${AGENTS_SESSION_ID:+/session-$AGENTS_SESSION_ID}"
 }
 
@@ -114,21 +148,100 @@ lease_age_min() { # $1 = sha
   echo $(( (now - when) / 60 ))
 }
 
+# ── Holder liveness ─────────────────────────────────────────────────────────
+# `ps -p` rather than `kill -0`: kill(2) also fails with EPERM for a live process
+# owned by another user, and reading that as "dead" would steal a lease from a
+# running release. `ps -p <pid> -o pid=` answers existence regardless of owner.
+#
+# Presence in the table is not life, though: a SIGKILLed release whose parent has
+# not reaped it stays listed as a zombie, and that is precisely the case this
+# whole feature is about. A zombie has already exited -- only its exit status is
+# parked -- so it counts as dead. An unreadable state degrades to alive, keeping
+# every uncertainty on the never-steal side.
+pid_alive() { # $1 = pid
+  ps -p "$1" -o pid= >/dev/null 2>&1 || return 1
+  local state
+  state="$(ps -p "$1" -o stat= 2>/dev/null | tr -d '[:space:]')"
+  [[ "$state" != Z* ]]
+}
+
+# The pid's start time, squeezed to a single space-free token so it survives the
+# "key: value" commit-message parser (`lease_field` splits on ": ", which the
+# colons inside a clock time never produce). Empty when ps cannot answer.
+pid_start_stamp() { # $1 = pid
+  ps -p "$1" -o lstart= 2>/dev/null | tr -s '[:space:]' '_' | sed 's/^_//; s/_$//'
+}
+
+# alive | dead | unknown — see the header block for what each one licenses.
+holder_liveness() { # $1 = sha
+  local host pid started running
+  host="$(lease_field "$1" host)"
+  pid="$(lease_field "$1" pid)"
+  # A lease with no recorded process (an older release.sh, or a hand-run claim)
+  # is unprobeable, not dead.
+  [[ -n "$host" && "$pid" =~ ^[0-9]+$ ]] || { printf 'unknown'; return; }
+  # Only the holder's own box can see the holder's process table.
+  [[ "$host" == "$(local_host)" ]] || { printf 'unknown'; return; }
+  pid_alive "$pid" || { printf 'dead'; return; }
+  # The pid exists — but a reboot or ordinary pid recycling can hand that number
+  # to an unrelated process, which would read as a live release forever.
+  started="$(lease_field "$1" started)"
+  running="$(pid_start_stamp "$pid")"
+  if [[ -n "$started" && -n "$running" && "$started" != "$running" ]]; then
+    printf 'dead'
+    return
+  fi
+  printf 'alive'
+}
+
+# Why a held lease may be taken over: "dead" (its holder is provably gone),
+# "stale" (unrenewed past the TTL), or "" (leave it alone). One predicate for
+# both `claim` and `clear`, so neither can grow its own weaker rule.
+reclaim_reason() { # $1 = sha, $2 = ttl-min
+  case "$(holder_liveness "$1")" in
+    alive) printf '' ;;
+    dead)  printf 'dead' ;;
+    *)     [[ "$(lease_age_min "$1")" -ge "$2" ]] && printf 'stale' || printf '' ;;
+  esac
+}
+
 describe_lease() { # $1 = sha
-  local v h a
+  local v h a l
   v="$(lease_field "$1" version)"; h="$(lease_field "$1" holder)"; a="$(lease_age_min "$1")"
-  printf 'version=%s holder=%s age=%smin' "${v:-?}" "${h:-?}" "$a"
+  case "$(holder_liveness "$1")" in
+    alive) l=yes ;;
+    dead)  l=no ;;
+    *)     l=unknown ;;
+  esac
+  printf 'version=%s holder=%s age=%smin holder-alive=%s' "${v:-?}" "${h:-?}" "$a" "$l"
 }
 
 # Build the orphan lease commit. No parents is what makes every claim a
 # non-fast-forward against any existing lease, which is the whole mechanism.
 make_lease_commit() { # $1 = version
-  local tree msg
+  local tree msg pid
   tree="$(git hash-object -t tree /dev/null)"
   msg="release lease
 
 version: $1
 holder: $(holder_desc)
+host: $(local_host)"
+  # `pid` + `started` are what make a dead holder detectable. They are written
+  # only when the caller declared the release process, and `started` only when
+  # ps can read it -- a half-recorded holder must degrade to `unknown`, not to a
+  # guess. `renew` rebuilds this message, so both stay current across rotations.
+  pid="$(holder_pid)"
+  if [[ -n "$pid" ]]; then
+    msg="$msg
+pid: $pid"
+    local started
+    started="$(pid_start_stamp "$pid")"
+    if [[ -n "$started" ]]; then
+      msg="$msg
+started: $started"
+    fi
+  fi
+  msg="$msg
 claimed: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
   git commit-tree "$tree" -m "$msg"
 }
@@ -173,15 +286,25 @@ cmd_claim() {
 
   fetch_lease || true
   age="$(lease_age_min "$held")"
-  if [[ "$age" -lt "$ttl" ]]; then
+  local reason
+  reason="$(reclaim_reason "$held" "$ttl")"
+  if [[ -z "$reason" ]]; then
     red "release already in flight -- not starting a competing one"
     gray "  lease: $(describe_lease "$held")"
-    gray "  it expires (becomes reclaimable) after ${ttl}min; watch that release instead of racing it"
+    if [[ "$(holder_liveness "$held")" == "alive" ]]; then
+      gray "  its holder process is still running on this box; stop that release before claiming"
+    else
+      gray "  it expires (becomes reclaimable) after ${ttl}min; watch that release instead of racing it"
+    fi
     return 1
   fi
 
-  yellow "reclaiming a stale release lease (${age}min old, TTL ${ttl}min)"
-  yellow "  stale holder: $(describe_lease "$held")"
+  if [[ "$reason" == "dead" ]]; then
+    yellow "reclaiming a release lease whose holder is gone (${age}min old, no live process)"
+  else
+    yellow "reclaiming a stale release lease (${age}min old, TTL ${ttl}min)"
+  fi
+  yellow "  previous holder: $(describe_lease "$held")"
   # CAS the delete against the exact sha we inspected, so two agents reclaiming
   # the same stale lease still produce one winner.
   if ! git push --quiet --force-with-lease="$LEASE_REF:$held" origin ":$LEASE_REF" 2>/dev/null; then
@@ -276,6 +399,55 @@ cmd_release() {
   gray "release lease dropped"
 }
 
+# Drop a lease nobody is holding, WITHOUT starting a release. This is the answer
+# to the shape that wedged the pipeline: an external kill (SIGKILL, a severed
+# ssh, a rebooted box) leaves the lease on origin, `status` reads `held`, and
+# there is no process left to finish the release or run the drop. `release`
+# cannot help -- it only drops a lease THIS checkout claimed. Same predicate as
+# `claim`, so this can never take a lease off a live holder either.
+cmd_clear() {
+  local ttl="$DEFAULT_TTL_MIN"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --ttl-min) ttl="${2:?--ttl-min needs a value}"; shift 2 ;;
+      *) die "unknown flag: $1" ;;
+    esac
+  done
+
+  local held reason
+  held="$(remote_lease_sha)"
+  if [[ -z "$held" ]]; then
+    gray "no release lease to clear"
+    return 0
+  fi
+  fetch_lease || true
+  reason="$(reclaim_reason "$held" "$ttl")"
+  if [[ -z "$reason" ]]; then
+    red "refusing to clear a lease that may still be held"
+    gray "  lease: $(describe_lease "$held")"
+    if [[ "$(holder_liveness "$held")" == "alive" ]]; then
+      gray "  its holder process is still running on this box; stop that release first"
+    else
+      gray "  it becomes clearable after ${ttl}min without a renewal"
+    fi
+    return 1
+  fi
+
+  # CAS against the exact sha we inspected: two operators clearing at once, or a
+  # holder that came back and renewed between the read and the push, must not
+  # lose to a blind delete.
+  if ! git push --quiet --force-with-lease="$LEASE_REF:$held" origin ":$LEASE_REF" 2>/dev/null; then
+    red "could not clear the release lease -- it changed under us; re-read status and retry"
+    return 1
+  fi
+  green "cleared a release lease with no live holder ($reason)"
+  gray "  was: $(describe_lease "$held")"
+  # If it happened to be ours, forget the token too, so a later `release` in this
+  # checkout does not think it still owns something.
+  if owned_token "$held"; then clear_token; fi
+  return 0
+}
+
 cmd_status() {
   local held
   held="$(remote_lease_sha)"
@@ -285,6 +457,11 @@ cmd_status() {
   fi
   fetch_lease || true
   echo "held $(describe_lease "$held")"
+  # Say what to DO about a holder that is provably gone. Without this the
+  # operator reads `held` and waits out a TTL for a release that already died.
+  if [[ "$(holder_liveness "$held")" == "dead" ]]; then
+    gray "  the holder process is gone -- drop it with: $(basename "$0") clear"
+  fi
 }
 
 case "${1:-}" in
@@ -292,7 +469,10 @@ case "${1:-}" in
   renew)   shift; cmd_renew "$@" ;;
   verify)  shift; cmd_verify "$@" ;;
   release) shift; cmd_release "$@" ;;
+  clear)   shift; cmd_clear "$@" ;;
   status)  shift; cmd_status "$@" ;;
-  -h|--help|"") sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  # The whole header block, however long it grows -- a hardcoded line range
+  # silently truncated the help mid-sentence every time the block was extended.
+  -h|--help|"") sed -n '2,/^[^#]/p' "$0" | sed '$d; s/^# \{0,1\}//'; exit 0 ;;
   *) die "unknown subcommand: $1" ;;
 esac

--- a/apps/cli/scripts/release-lease.test.ts
+++ b/apps/cli/scripts/release-lease.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { spawn, spawnSync } from 'child_process';
+import { spawn, spawnSync, type ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -57,6 +57,34 @@ function leaseAsync(cwd: string, args: string[]) {
   });
 }
 
+/** The kernel's state letter for a pid, as `ps` reports it ('' when unlisted). */
+function procState(pid: number): string {
+  return spawnSync('ps', ['-p', String(pid), '-o', 'stat='], { encoding: 'utf-8' }).stdout.trim();
+}
+
+/** Long-lived parents of the zombies below; torn down with each temp root. */
+const zombieParents: ChildProcess[] = [];
+
+/**
+ * A real, unreaped zombie: a bash that backgrounds a short `sleep` and then
+ * blocks without waiting on it, so the exited child sits in the process table
+ * with nothing to collect it. That is exactly the shape a SIGKILLed release.sh
+ * leaves behind, and `ps -p <pid>` still lists it.
+ */
+function spawnZombie(): number {
+  const pidFile = path.join(root, `zombie-${zombieParents.length}.pid`);
+  const parent = spawn('bash', ['-c', `sleep 0.2 & echo $! > "${pidFile}"; sleep 60`], { stdio: 'ignore' });
+  zombieParents.push(parent);
+  for (let i = 0; i < 200; i++) {
+    if (fs.existsSync(pidFile)) {
+      const pid = Number(fs.readFileSync(pidFile, 'utf-8').trim());
+      if (pid && procState(pid).startsWith('Z')) return pid;
+    }
+    spawnSync('sleep', ['0.05']);
+  }
+  throw new Error('no zombie appeared');
+}
+
 /** A clone that behaves like a distinct release box. */
 function makeBox(name: string) {
   const dir = path.join(root, name);
@@ -84,11 +112,19 @@ function plantStaleLease(
   cwd: string,
   version: string,
   ageMin: number,
-  opts: { force?: boolean } = {},
+  opts: { force?: boolean; host?: string; pid?: number; started?: string } = {},
 ) {
   const when = new Date(Date.now() - ageMin * 60_000).toISOString();
   const tree = git(cwd, 'hash-object', '-t', 'tree', '/dev/null');
-  const msg = `release lease\n\nversion: ${version}\nholder: dead-box/pid-1\nclaimed: ${when}\n`;
+  const holder = opts.host ? `${opts.host}/pid-${opts.pid ?? 1}` : 'dead-box/pid-1';
+  const fields = [`version: ${version}`, `holder: ${holder}`];
+  // Only a lease that names a probeable process gets liveness detection; the
+  // default (no host/pid) is the pre-RUSH-2274 shape, which must still work.
+  if (opts.host) fields.push(`host: ${opts.host}`);
+  if (opts.pid !== undefined) fields.push(`pid: ${opts.pid}`);
+  if (opts.started) fields.push(`started: ${opts.started}`);
+  fields.push(`claimed: ${when}`);
+  const msg = `release lease\n\n${fields.join('\n')}\n`;
   const r = spawnSync('git', ['commit-tree', tree, '-m', msg], {
     cwd,
     encoding: 'utf-8',
@@ -122,6 +158,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  for (const p of zombieParents.splice(0)) p.kill('SIGKILL');
   fs.rmSync(root, { recursive: true, force: true });
 });
 
@@ -349,5 +386,179 @@ describe('release-lease: status', () => {
     const s = lease(boxB, ['status']);
     expect(s.stdout).toContain('held');
     expect(s.stdout).toContain('version=1.20.82');
+  });
+});
+
+/**
+ * RUSH-2274: an externally killed release (SIGKILL, a severed ssh, a rebooted
+ * box) never reaches its trap, so its lease stays on origin. Before this, the
+ * only cure was the TTL: for up to 30 minutes `status` read `held` while nothing
+ * was releasing, and nothing distinguished that from a healthy long release.
+ *
+ * These tests use REAL processes — a spawned `sleep` stands in for the release
+ * run, and killing it is the external kill. Faking liveness would prove nothing,
+ * since the whole mechanism is a live `ps` probe.
+ */
+describe('release-lease: a killed holder must not wedge the pipeline', () => {
+  const victims: ChildProcess[] = [];
+
+  /** A real, live process to stand in for a running release.sh. */
+  function spawnVictim(): ChildProcess {
+    const p = spawn('sleep', ['300'], { stdio: 'ignore' });
+    victims.push(p);
+    return p;
+  }
+
+  /** Kill it the way an external SIGKILL would, and wait until it is really gone. */
+  async function killVictim(p: ChildProcess): Promise<void> {
+    const exited = new Promise<void>((resolve) => p.once('exit', () => resolve()));
+    p.kill('SIGKILL');
+    await exited;
+  }
+
+  /** The host string the script itself stamps, so tests never guess it. */
+  function thisHost(): string {
+    lease(boxA, ['claim', '0.0.0'], { RELEASE_LEASE_HOLDER_PID: String(process.pid) });
+    const host = currentHolder(boxA).split('/')[0];
+    lease(boxA, ['release']);
+    expect(host).not.toBe('');
+    return host;
+  }
+
+  /** The pid start stamp exactly as the script records it. */
+  function startStamp(pid: number): string {
+    const r = spawnSync('bash', ['-c', `ps -p ${pid} -o lstart= | tr -s '[:space:]' '_' | sed 's/^_//; s/_$//'`], {
+      encoding: 'utf-8',
+    });
+    return r.stdout.trim();
+  }
+
+  afterEach(() => {
+    for (const p of victims.splice(0)) p.kill('SIGKILL');
+  });
+
+  it('status says the holder is alive, then says it is gone once killed', async () => {
+    const victim = spawnVictim();
+    lease(boxA, ['claim', '1.20.82'], { RELEASE_LEASE_HOLDER_PID: String(victim.pid) });
+
+    expect(lease(boxA, ['status']).stdout).toContain('holder-alive=yes');
+
+    await killVictim(victim);
+
+    const dead = lease(boxA, ['status']);
+    expect(dead.stdout).toContain('holder-alive=no');
+    // Saying "held" without saying what to do is the original complaint.
+    expect(dead.stdout).toContain('clear');
+  });
+
+  it('reclaims a killed holder immediately, without waiting out the TTL', async () => {
+    const victim = spawnVictim();
+    lease(boxA, ['claim', '1.20.82'], { RELEASE_LEASE_HOLDER_PID: String(victim.pid) });
+    await killVictim(victim);
+
+    // Age 0 against a 45-minute TTL: only liveness can unblock this.
+    const again = lease(boxA, ['claim', '1.20.83', '--ttl-min', '45']);
+    expect(again.status).toBe(0);
+    expect(again.stdout).toContain('holder is gone');
+    expect(lease(boxA, ['verify']).status).toBe(0);
+  });
+
+  it('counts an unreaped zombie holder as dead, not as a live release', () => {
+    // A SIGKILLed release whose parent never reaps it stays LISTED in the
+    // process table. `ps -p` alone reads that as alive, so the lease would
+    // survive the very kill this feature exists to survive.
+    const pid = spawnZombie();
+    expect(procState(pid)).toMatch(/^Z/);
+
+    plantStaleLease(boxA, '1.20.82', 0, { host: thisHost(), pid });
+    const b = lease(boxA, ['claim', '1.20.83', '--ttl-min', '45']);
+    expect(b.status).toBe(0);
+    expect(b.stdout).toContain('holder is gone');
+  });
+
+  it('never force-steals a live holder, even long past the TTL', () => {
+    const pid = spawnVictim().pid!;
+    plantStaleLease(boxA, '1.20.82', 90, { host: thisHost(), pid, started: startStamp(pid) });
+
+    const b = lease(boxA, ['claim', '1.20.83', '--ttl-min', '45']);
+    expect(b.status).toBe(1);
+    expect(b.stderr).toContain('release already in flight');
+    expect(b.stdout).toContain('still running on this box');
+  });
+
+  it('treats a recycled pid as dead, not as a live release', () => {
+    // A reboot (or ordinary pid recycling) can hand the recorded number to an
+    // unrelated process. Without the start-time guard that reads as `alive`
+    // forever, which would wedge the pipeline harder than the TTL ever did.
+    const pid = spawnVictim().pid!;
+    plantStaleLease(boxA, '1.20.82', 0, { host: thisHost(), pid, started: 'Mon_Jan_1_00:00:00_1990' });
+
+    const b = lease(boxA, ['claim', '1.20.83', '--ttl-min', '45']);
+    expect(b.status).toBe(0);
+    expect(b.stdout).toContain('holder is gone');
+  });
+
+  it('will not probe a holder on another box — the TTL still governs there', () => {
+    // pid 1 is alive on every box, but it is not OUR pid 1. Guessing either way
+    // would be wrong, so an unprobeable holder must behave exactly as before.
+    plantStaleLease(boxA, '1.20.82', 5, { host: 'some-other-box', pid: 1 });
+    const fresh = lease(boxA, ['claim', '1.20.83', '--ttl-min', '45']);
+    expect(fresh.status).toBe(1);
+    expect(fresh.stdout).toContain('holder-alive=unknown');
+
+    plantStaleLease(boxA, '1.20.82', 90, { host: 'some-other-box', pid: 1, force: true });
+    const stale = lease(boxA, ['claim', '1.20.84', '--ttl-min', '45']);
+    expect(stale.status).toBe(0);
+    expect(stale.stdout).toContain('reclaiming a stale release lease');
+  });
+
+  it('keeps the release process as the holder across a renew', () => {
+    // The trap: `renew` runs in a fresh shell every 10 minutes. Recording THAT
+    // shell would stamp every renewed lease with an already-dead pid, so every
+    // healthy long release would read as abandoned.
+    const env = { RELEASE_LEASE_HOLDER_PID: String(spawnVictim().pid) };
+    lease(boxA, ['claim', '1.20.82'], env);
+    expect(lease(boxA, ['renew'], env).status).toBe(0);
+
+    expect(lease(boxA, ['status']).stdout).toContain('holder-alive=yes');
+    expect(lease(boxB, ['claim', '1.20.83', '--ttl-min', '45']).status).toBe(1);
+  });
+});
+
+describe('release-lease: clear', () => {
+  it('drops a lease whose holder was killed, without starting a release', async () => {
+    const p = spawn('sleep', ['300'], { stdio: 'ignore' });
+    lease(boxA, ['claim', '1.20.82'], { RELEASE_LEASE_HOLDER_PID: String(p.pid) });
+    const exited = new Promise<void>((resolve) => p.once('exit', () => resolve()));
+    p.kill('SIGKILL');
+    await exited;
+
+    // A second checkout on the holder's box never claimed anything, so `release`
+    // cannot help it — that is the gap `clear` fills for an operator unwedging
+    // the pipeline after the run that held it was killed.
+    expect(lease(boxB, ['release']).stdout).toContain('no release lease to drop');
+
+    const cleared = lease(boxB, ['clear']);
+    expect(cleared.status).toBe(0);
+    expect(cleared.stdout).toContain('no live holder');
+    expect(lease(boxB, ['status']).stdout.trim()).toBe('unheld');
+  });
+
+  it('refuses to clear a lease that may still be held', () => {
+    // No recorded holder at all: unprobeable and fresh, so clearing it could
+    // hand the pipeline to a second releaser while the first is publishing.
+    plantStaleLease(boxA, '1.20.82', 5);
+    const r = lease(boxB, ['clear', '--ttl-min', '45']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('refusing to clear');
+    expect(lease(boxB, ['status']).stdout).toContain('version=1.20.82');
+  });
+
+  it('clears a long-stale lease and is a no-op when nothing is held', () => {
+    expect(lease(boxA, ['clear']).stdout).toContain('no release lease to clear');
+
+    plantStaleLease(boxA, '1.20.82', 90);
+    expect(lease(boxB, ['clear', '--ttl-min', '45']).status).toBe(0);
+    expect(lease(boxB, ['status']).stdout.trim()).toBe('unheld');
   });
 });

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -825,6 +825,16 @@ fi
 # the version was left merged but unshipped.
 #
 # Released by cleanup_all's trap on EVERY exit path, success or failure.
+#
+# Declare THIS process as the lease holder. A run killed externally never reaches
+# the trap, and the lease then outlives it: without a recorded pid the only cure
+# is waiting out the TTL, during which `status` reads `held` with nothing
+# releasing. With it, the next claim (or `release-lease.sh clear`) on this box
+# sees the holder is gone and reclaims immediately. It must be the orchestrating
+# release.sh pid, not $$ inside the lease script -- the background renewer runs
+# release-lease.sh in a fresh shell every 10 minutes, and recording that shell
+# would stamp every renewed lease with an already-dead pid.
+export RELEASE_LEASE_HOLDER_PID=$$
 LEASE_HELD=false
 if ! scripts/release-lease.sh claim "$TARGET"; then
   die "another release is in flight -- watch it instead of racing it (scripts/release-lease.sh status)"


### PR DESCRIPTION
**Fix** — an externally killed release left its lease on `origin`, and `release-lease.sh status` read `held` for up to the 30-minute TTL with nothing actually releasing. Closes [RUSH-2274](https://linear.app/getrush/issue/RUSH-2274/release-lease-survives-an-external-kill-status-says-held-with-no-live).

## The run

![RUSH-2274 release lease dead-holder detection: real run + test suite](https://share.agents-cli.sh/muqsitnawaz/rush-2274-lease-dead-holder-lease-demo-92fbf487ad6caaf1)

A real release lease against a real git remote: claim, `kill -9` the holder, then `status` / `clear` / `claim`. Bottom half is `scripts/release-lease.test.ts`, 29/29.

## What changed

The lease commit now records **which process** holds it — `host`, `pid`, and that pid's start time — and `claim` / `clear` / `status` probe it:

| Probe | When | What it licenses |
|---|---|---|
| `dead` | we are on the holder's box and that process is gone | reclaim **immediately**, no TTL wait |
| `alive` | the recorded pid runs here with the recorded start time | **never** taken, at any age — stop that release instead |
| `unknown` | the holder is another box, or a lease from an older `release.sh` | the TTL, exactly as today |

- `status` reports `holder-alive=yes|no|unknown` and, when the holder is gone, names the command that drops it.
- **`release-lease.sh clear`** drops a dead-holder lease *without* starting a release — `release` only drops a lease the current checkout claimed, so an operator on a wedged pipeline had nothing to run. One predicate (`reclaim_reason`) backs both `claim` and `clear`, so neither can grow a weaker rule.
- `release.sh` exports `RELEASE_LEASE_HOLDER_PID=$$` — the orchestrating process, not the 10-minutely `renew` shell whose `$$` is dead a second later.

### No force-steal, by construction

- `alive` is never taken. The refusal names the live pid and says to stop that release.
- A lease with **no recorded pid** (older `release.sh`, or a hand-run `claim`) stays `unknown` — a missing export degrades to today's TTL, never to "instantly reclaimable".
- Another box's holder is never guessed at — no probe, so the TTL governs.
- Every reclaim is still CAS-pinned (`--force-with-lease` on the exact inspected sha).

### Two false-alive traps the tests caught

- **Zombie.** A SIGKILLed release whose parent never reaped it is still listed by `ps -p` — precisely the case being detected. `pid_alive` reads `ps -o stat=` and counts `Z*` as dead. (`ps -p`, not `kill -0`: kill(2) also fails EPERM for a live process owned by another user, and reading *that* as dead would steal a running release's lease.)
- **Recycled pid.** After a reboot the recorded number can belong to something else, which would read as a live release forever. The start-time stamp is what makes `dead` safe to act on.

## Tests

`scripts/release-lease.test.ts` — real git remotes, real processes, no mocking. A spawned `sleep` is the release run and killing it is the external kill; the zombie case is a genuine unreaped child. 8 new cases: alive→gone status, immediate reclaim, zombie-as-dead, live-holder-never-stolen-past-TTL, recycled-pid-as-dead, other-box-still-TTL, holder-survives-a-renew, plus `clear` (drops dead / refuses maybe-held / no-op).

## Docs

`apps/cli/AGENTS.md` §Releasing gets the probe table, `clear`, and the holder-pid rule. CHANGELOG fragment at `apps/cli/.changelog/next/RUSH-2274-release-lease-dead-holder.md`.

**Companion-repo audit:** none needed — this touches the release scripts, not a core `agents` command group, and nothing in `phnx-labs/.agents-system` invokes `release-lease.sh`.

**Drive-by:** `--help` printed a hardcoded line range and truncated mid-sentence whenever the header block grew; it now prints the whole block.
