### PR TITLE
feat(setup): add re-runnable onboarding hub (RUSH-1878)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ https://agents-cli.sh/demo.mp4
 
 ```bash
 npm install -g @phnx-labs/agents-cli   # or: curl -fsSL agi-cli.sh | sh
-agents setup                           # first-time setup -- config + pick your agents
+agents setup                           # first-time setup, or re-open the capability hub
+agents setup status                    # readiness for browser, computer, fleet, and more
 agents run claude "explain this repo"  # run any agent on your existing subscription
 ```
 
-`agents setup` is interactive and idempotent -- safe to re-run on a new machine. The `agi-cli.sh` one-liner installs this same canonical `@phnx-labs/agents-cli` package. Prefer bun? `bun install -g @phnx-labs/agents-cli` works too.
+`agents setup` is interactive and idempotent -- safe to re-run on any machine. Once core setup exists, it opens a status-aware menu for browser, computer, secrets, fleet, share, watchdog, and device preferences; each choice delegates to the same wizard available under `agents setup <capability>`. In CI or another non-TTY, bare setup prints the checklist without prompting. The `agi-cli.sh` one-liner installs this same canonical `@phnx-labs/agents-cli` package. Prefer bun? `bun install -g @phnx-labs/agents-cli` works too.
 
 Already installed? `agents upgrade` updates agents-cli itself to the latest version (`agents upgrade 1.2.3` for a specific version or dist-tag, `-y` to skip the confirm prompt). The command is `upgrade` on every platform -- there is no `agents update` (on macOS, `agents helper update` is a different command that reinstalls the keychain helper, not agents-cli).
 

--- a/apps/cli/.changelog/next/RUSH-1878.md
+++ b/apps/cli/.changelog/next/RUSH-1878.md
@@ -1,0 +1,1 @@
+- Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -17,6 +17,11 @@ module map, build, and release mechanics the README does not.
 > Phoenix Labs OSS · Apache-2.0. Repo-wide policy (conventions, code review, security)
 > lives in the root [AGENTS.md](../../AGENTS.md).
 
+`agents setup` is the re-runnable onboarding hub. It reports live readiness for
+core, browser, computer, secrets, fleet, share, watchdog, and preferences, then
+delegates each selected phase to its existing `agents setup <capability>` wizard.
+`agents setup status --json` is the non-interactive view of the same probes.
+
 ## Core design choices (read this first)
 
 Break these and downstream code drifts silently.

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -152,11 +152,13 @@ toward it depends on the consumer: Factory auto-launch counts device-wide
 running agents, while teams placement counts the team's own roster on the
 device (local teammates included); a capped device is excluded from auto-pick
 with a stated reason, and an all-capped pool fails loud. Setup asks instead of
-guessing: bare `agents setup` ends with a skippable preferences step (which
-machine you sit at → `interactive.host`; which browser agents drive here →
-`browser.profile`), `agents setup fleet` offers the interactive host after a
+guessing: bare `agents setup` opens a re-runnable capability hub with live
+ready/missing status for core, browser, computer, secrets, fleet, share,
+watchdog, and preferences. Selecting preferences runs the skippable questions
+(which machine you sit at → `interactive.host`; which browser agents drive here
+→ `browser.profile`), `agents setup fleet` offers the interactive host after a
 sync, and `agents setup browser` highlights the auto-detect winner in its
-picker.
+picker. `agents setup status --json` exposes the same probes to automation.
 
 **Hosts** — machines you dispatch agent work to. `agents hosts add` enrolls a
 target either from an existing `~/.ssh/config` stanza (connection details stay in

--- a/apps/cli/src/commands/setup-secrets.ts
+++ b/apps/cli/src/commands/setup-secrets.ts
@@ -39,7 +39,7 @@ function defaultBackendForPlatform(platform: NodeJS.Platform = process.platform)
   return platform === 'darwin' ? 'keychain' : 'file';
 }
 
-function setupSecretsPrefsPath(): string {
+export function setupSecretsPrefsPath(): string {
   return path.join(getHistoryDir(), 'setup', 'secrets.json');
 }
 

--- a/apps/cli/src/commands/setup.test.ts
+++ b/apps/cli/src/commands/setup.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { execFileSync } from 'child_process';
 
 // Isolate HOME before importing modules that capture path constants at import.
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-setup-test-'));
 process.env.HOME = TEST_HOME;
 
 const { Command } = await import('commander');
-const { registerSetupCommand } = await import('./setup.js');
+const { getSetupStatus, registerSetupCommand, runSetup, runSetupHub } = await import('./setup.js');
 const { listInstalledBrowsers } = await import('../lib/browser/chrome.js');
 
 describe('agents setup command group', () => {
@@ -18,7 +19,7 @@ describe('agents setup command group', () => {
     const setup = program.commands.find((c) => c.name() === 'setup');
     expect(setup).toBeDefined();
     const subs = setup!.commands.map((c) => c.name()).sort();
-    expect(subs).toEqual(['browser', 'computer', 'fleet', 'mine', 'secrets', 'share', 'watchdog']);
+    expect(subs).toEqual(['browser', 'computer', 'fleet', 'mine', 'secrets', 'share', 'status', 'watchdog']);
   });
 
   it('keeps the bare `setup` command with its force / no-system-repo flags', () => {
@@ -28,6 +29,50 @@ describe('agents setup command group', () => {
     const flags = setup.options.map((o) => o.long).sort();
     expect(flags).toContain('--force');
     expect(flags).toContain('--no-system-repo');
+  });
+
+  it('reports real ready/missing rows after core setup already exists', async () => {
+    const systemRepo = path.join(TEST_HOME, '.agents', '.system');
+    fs.mkdirSync(systemRepo, { recursive: true });
+    execFileSync('git', ['init', '--quiet'], { cwd: systemRepo });
+
+    const rows = await getSetupStatus();
+    expect(rows.find((row) => row.phase === 'core')).toMatchObject({ state: 'ready', detail: 'system repo ready' });
+    expect(rows.find((row) => row.phase === 'browser')?.state).toBe('missing');
+    expect(rows.find((row) => row.phase === 'computer')).toBeDefined();
+    expect(rows.map((row) => row.phase)).toEqual([
+      'core', 'browser', 'computer', 'secrets', 'fleet', 'share', 'watchdog', 'preferences',
+    ]);
+  });
+
+  it('re-enters the onboarding hub instead of returning when core is configured', async () => {
+    const systemRepo = path.join(TEST_HOME, '.agents', '.system');
+    fs.mkdirSync(systemRepo, { recursive: true });
+    execFileSync('git', ['init', '--quiet'], { cwd: systemRepo });
+    let hubRuns = 0;
+    await runSetup(new Command(), { runHub: async () => { hubRuns += 1; } });
+    expect(hubRuns).toBe(1);
+  });
+
+  it('re-enters the hub, runs a selected wizard seam, then refreshes status', async () => {
+    const selected: string[] = [];
+    let promptCount = 0;
+    await runSetupHub({
+      interactive: true,
+      selectPhase: async () => (promptCount++ === 0 ? 'browser' : 'exit'),
+      runPhase: async (phase) => { selected.push(phase); },
+    });
+    expect(selected).toEqual(['browser']);
+    expect(promptCount).toBe(2);
+  });
+
+  it('prints status and returns without prompting outside a TTY', async () => {
+    let selected = false;
+    await runSetupHub({
+      interactive: false,
+      selectPhase: async () => { selected = true; return 'exit'; },
+    });
+    expect(selected).toBe(false);
   });
 });
 

--- a/apps/cli/src/commands/setup.test.ts
+++ b/apps/cli/src/commands/setup.test.ts
@@ -81,6 +81,22 @@ describe('agents setup command group', () => {
     expect(rows.find((row) => row.phase === 'browser')).toMatchObject({ state: 'ready', detail: 'profile work' });
   });
 
+  it('reports a configured browser profile with a missing binary as unavailable', async () => {
+    const { updateProfile } = await import('../lib/browser/profiles.js');
+    await updateProfile({
+      name: 'work',
+      browser: 'custom',
+      binary: path.join(TEST_HOME, 'missing-browser'),
+      endpoints: ['cdp://127.0.0.1:9333'],
+      viewport: { width: 1280, height: 720 },
+    });
+    const rows = await getSetupStatus();
+    expect(rows.find((row) => row.phase === 'browser')).toMatchObject({
+      state: 'missing',
+      detail: 'profile work cannot launch here',
+    });
+  });
+
   it('prints status, returns without prompting, and exits nonzero for missing phases outside a TTY', async () => {
     let selected = false;
     try {

--- a/apps/cli/src/commands/setup.test.ts
+++ b/apps/cli/src/commands/setup.test.ts
@@ -66,13 +66,33 @@ describe('agents setup command group', () => {
     expect(promptCount).toBe(2);
   });
 
-  it('prints status and returns without prompting outside a TTY', async () => {
-    let selected = false;
-    await runSetupHub({
-      interactive: false,
-      selectPhase: async () => { selected = true; return 'exit'; },
+  it('uses the configured named browser profile for readiness', async () => {
+    const { createProfile } = await import('../lib/browser/profiles.js');
+    const { setConfigValue } = await import('../lib/device-config.js');
+    await createProfile({
+      name: 'work',
+      browser: 'custom',
+      binary: process.execPath,
+      endpoints: ['cdp://127.0.0.1:9333'],
+      viewport: { width: 1280, height: 720 },
     });
-    expect(selected).toBe(false);
+    setConfigValue('browser.profile', 'work');
+    const rows = await getSetupStatus();
+    expect(rows.find((row) => row.phase === 'browser')).toMatchObject({ state: 'ready', detail: 'profile work' });
+  });
+
+  it('prints status, returns without prompting, and exits nonzero for missing phases outside a TTY', async () => {
+    let selected = false;
+    try {
+      await runSetupHub({
+        interactive: false,
+        selectPhase: async () => { selected = true; return 'exit'; },
+      });
+      expect(selected).toBe(false);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = undefined;
+    }
   });
 });
 

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -29,7 +29,7 @@ import { registerSetupSecretsCommand } from './setup-secrets.js';
 import { registerSetupFleetCommand } from './setup-fleet.js';
 import { registerSetupWatchdogCommand, runWatchdogSetupWizard } from './setup-watchdog.js';
 import { runPreferencesStep } from './setup-preferences.js';
-import { getConfiguredDefaultProfileName, getProfile, DEFAULT_BROWSER_PROFILE_NAME } from '../lib/browser/profiles.js';
+import { getConfiguredDefaultProfileName, getProfile, isProfileLaunchableHere, DEFAULT_BROWSER_PROFILE_NAME } from '../lib/browser/profiles.js';
 import { listInstalledBrowsers } from '../lib/browser/chrome.js';
 import { probeComputerTrust } from './computer.js';
 import { readShareConfig } from '../lib/share/config.js';
@@ -290,6 +290,7 @@ export interface SetupStatusRow {
 export async function getSetupStatus(): Promise<SetupStatusRow[]> {
   const configuredBrowserProfile = getConfiguredDefaultProfileName();
   const browserProfile = await getProfile(configuredBrowserProfile ?? DEFAULT_BROWSER_PROFILE_NAME);
+  const browserReady = browserProfile !== null && isProfileLaunchableHere(browserProfile);
   const installedBrowsers = listInstalledBrowsers();
   const computerState = process.platform === 'darwin' ? (await probeComputerTrust() ? 'ready' : 'missing') : 'n/a';
   const devices = await loadDevices();
@@ -301,7 +302,7 @@ export async function getSetupStatus(): Promise<SetupStatusRow[]> {
   const defaultBrowser = getConfigValue('browser.profile').value;
   return [
     { phase: 'core', state: coreReady ? 'ready' : 'missing', detail: coreReady ? 'system repo ready' : 'system repo missing' },
-    { phase: 'browser', state: browserProfile ? 'ready' : 'missing', detail: browserProfile ? `profile ${browserProfile.name}` : installedBrowsers.length ? 'no default profile' : 'no supported browser found' },
+    { phase: 'browser', state: browserReady ? 'ready' : 'missing', detail: browserReady ? `profile ${browserProfile.name}` : browserProfile ? `profile ${browserProfile.name} cannot launch here` : installedBrowsers.length ? 'no default profile' : 'no supported browser found' },
     { phase: 'computer', state: computerState, detail: computerState === 'ready' ? 'helper trusted' : computerState === 'n/a' ? 'macOS local setup only' : 'helper not running or not trusted' },
     { phase: 'secrets', state: secretsReady ? 'ready' : 'missing', detail: secretsReady ? 'defaults chosen' : 'defaults not chosen' },
     { phase: 'fleet', state: Object.keys(devices).length ? 'ready' : 'missing', detail: Object.keys(devices).length ? `${Object.keys(devices).length} device${Object.keys(devices).length === 1 ? '' : 's'} registered` : 'no devices registered' },

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -29,7 +29,7 @@ import { registerSetupSecretsCommand } from './setup-secrets.js';
 import { registerSetupFleetCommand } from './setup-fleet.js';
 import { registerSetupWatchdogCommand, runWatchdogSetupWizard } from './setup-watchdog.js';
 import { runPreferencesStep } from './setup-preferences.js';
-import { getProfile, DEFAULT_BROWSER_PROFILE_NAME } from '../lib/browser/profiles.js';
+import { getConfiguredDefaultProfileName, getProfile, DEFAULT_BROWSER_PROFILE_NAME } from '../lib/browser/profiles.js';
 import { listInstalledBrowsers } from '../lib/browser/chrome.js';
 import { probeComputerTrust } from './computer.js';
 import { readShareConfig } from '../lib/share/config.js';
@@ -288,7 +288,8 @@ export interface SetupStatusRow {
 }
 
 export async function getSetupStatus(): Promise<SetupStatusRow[]> {
-  const browserProfile = await getProfile(DEFAULT_BROWSER_PROFILE_NAME);
+  const configuredBrowserProfile = getConfiguredDefaultProfileName();
+  const browserProfile = await getProfile(configuredBrowserProfile ?? DEFAULT_BROWSER_PROFILE_NAME);
   const installedBrowsers = listInstalledBrowsers();
   const computerState = process.platform === 'darwin' ? (await probeComputerTrust() ? 'ready' : 'missing') : 'n/a';
   const devices = await loadDevices();
@@ -336,7 +337,9 @@ export async function runSetupHub(deps: {
 } = {}): Promise<void> {
   const interactive = deps.interactive ?? isInteractiveTerminal();
   if (!interactive) {
-    renderSetupStatus(await getSetupStatus());
+    const rows = await getSetupStatus();
+    renderSetupStatus(rows);
+    if (rows.some((row) => row.state === 'missing')) process.exitCode = 1;
     return;
   }
   try {

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -29,6 +29,13 @@ import { registerSetupSecretsCommand } from './setup-secrets.js';
 import { registerSetupFleetCommand } from './setup-fleet.js';
 import { registerSetupWatchdogCommand, runWatchdogSetupWizard } from './setup-watchdog.js';
 import { runPreferencesStep } from './setup-preferences.js';
+import { getProfile, DEFAULT_BROWSER_PROFILE_NAME } from '../lib/browser/profiles.js';
+import { listInstalledBrowsers } from '../lib/browser/chrome.js';
+import { probeComputerTrust } from './computer.js';
+import { readShareConfig } from '../lib/share/config.js';
+import { loadDevices } from '../lib/devices/registry.js';
+import { getConfigValue } from '../lib/device-config.js';
+import { setupSecretsPrefsPath } from './setup-secrets.js';
 
 const HOME = os.homedir();
 
@@ -78,15 +85,21 @@ async function importAgent(agentId: AgentId, version: string): Promise<{ success
   }
 }
 
+interface RunSetupOptions {
+  force?: boolean;
+  suppressFooter?: boolean;
+  systemRepo?: boolean;
+  runHub?: () => Promise<void>;
+}
+
 /** First-run setup. Clones ~/.agents/.system/ from the system repo if needed. */
-export async function runSetup(program: Command, options: { force?: boolean; suppressFooter?: boolean; systemRepo?: boolean } = {}): Promise<void> {
+export async function runSetup(program: Command, options: RunSetupOptions = {}): Promise<void> {
   const agentsDir = getAgentsDir();
   const alreadyConfigured = isGitRepo(agentsDir);
 
   if (alreadyConfigured && !options.force) {
-    console.log(chalk.gray('~/.agents/.system/ is already set up.'));
-    console.log(chalk.gray('\nTo sync updates:      agents repo pull system'));
-    console.log(chalk.gray('To re-run setup:      agents setup --force'));
+    if (options.suppressFooter) return;
+    await (options.runHub ?? runSetupHub)();
     return;
   }
 
@@ -222,12 +235,7 @@ export async function runSetup(program: Command, options: { force?: boolean; sup
   // Fresh-machine hub: offer to set up the optional capabilities that need their
   // own guided flow. TTY-only and fully opt-in — a non-interactive `agents setup`
   // stops at the system-repo bootstrap above, unchanged.
-  await runSetupHub();
-
-  // Preferences step: the two questions that keep agents off the wrong machine —
-  // which box you sit at (interactive host) and which browser agents drive here.
-  // TTY-only, skippable, and writes the same keys as `agents devices …`.
-  await runPreferencesStep();
+  await (options.runHub ?? runSetupHub)();
 
   console.log(chalk.bold('\nSetup complete. Try:'));
   console.log(chalk.cyan('  agents view                 ') + chalk.gray(' # see what\'s installed'));
@@ -271,29 +279,89 @@ export async function ensureInitialized(program: Command): Promise<void> {
  * wizard. Never throws — a cancel or an optional wizard's error just skips the
  * rest and lets core setup complete.
  */
-async function runSetupHub(): Promise<void> {
-  if (!isInteractiveTerminal()) return;
+export type SetupPhase = 'browser' | 'computer' | 'share' | 'secrets' | 'fleet' | 'watchdog' | 'preferences';
+export type SetupStatusState = 'ready' | 'missing' | 'n/a';
+export interface SetupStatusRow {
+  phase: 'core' | SetupPhase;
+  state: SetupStatusState;
+  detail: string;
+}
+
+export async function getSetupStatus(): Promise<SetupStatusRow[]> {
+  const browserProfile = await getProfile(DEFAULT_BROWSER_PROFILE_NAME);
+  const installedBrowsers = listInstalledBrowsers();
+  const computerState = process.platform === 'darwin' ? (await probeComputerTrust() ? 'ready' : 'missing') : 'n/a';
+  const devices = await loadDevices();
+  const coreReady = isGitRepo(getAgentsDir());
+  const secretsReady = fs.existsSync(setupSecretsPrefsPath());
+  const shareConfig = readShareConfig();
+  const watchdogEnabled = getConfigValue('watchdog.enabled').value === true;
+  const interactiveHost = getConfigValue('interactive.host').value;
+  const defaultBrowser = getConfigValue('browser.profile').value;
+  return [
+    { phase: 'core', state: coreReady ? 'ready' : 'missing', detail: coreReady ? 'system repo ready' : 'system repo missing' },
+    { phase: 'browser', state: browserProfile ? 'ready' : 'missing', detail: browserProfile ? `profile ${browserProfile.name}` : installedBrowsers.length ? 'no default profile' : 'no supported browser found' },
+    { phase: 'computer', state: computerState, detail: computerState === 'ready' ? 'helper trusted' : computerState === 'n/a' ? 'macOS local setup only' : 'helper not running or not trusted' },
+    { phase: 'secrets', state: secretsReady ? 'ready' : 'missing', detail: secretsReady ? 'defaults chosen' : 'defaults not chosen' },
+    { phase: 'fleet', state: Object.keys(devices).length ? 'ready' : 'missing', detail: Object.keys(devices).length ? `${Object.keys(devices).length} device${Object.keys(devices).length === 1 ? '' : 's'} registered` : 'no devices registered' },
+    { phase: 'share', state: shareConfig ? 'ready' : 'missing', detail: shareConfig?.baseUrl ?? 'endpoint not configured' },
+    { phase: 'watchdog', state: watchdogEnabled ? 'ready' : 'missing', detail: watchdogEnabled ? 'enabled on this device' : 'disabled on this device' },
+    { phase: 'preferences', state: interactiveHost || defaultBrowser ? 'ready' : 'missing', detail: [interactiveHost && `host ${interactiveHost}`, defaultBrowser && `browser ${defaultBrowser}`].filter(Boolean).join(' · ') || 'interactive host and browser unset' },
+  ];
+}
+
+export function renderSetupStatus(rows: SetupStatusRow[]): void {
+  console.log(chalk.bold('\nagents setup — onboarding\n'));
+  for (const row of rows) {
+    const marker = row.state === 'ready' ? chalk.green('[x]') : row.state === 'n/a' ? chalk.gray('[-]') : chalk.yellow('[ ]');
+    const label = row.phase[0].toUpperCase() + row.phase.slice(1);
+    console.log(`  ${marker} ${label.padEnd(12)} ${chalk.gray(row.detail)}`);
+  }
+}
+
+async function runSetupPhase(phase: SetupPhase): Promise<void> {
+  if (phase === 'browser') await runBrowserWizard();
+  else if (phase === 'computer') await runComputerWizard();
+  else if (phase === 'share') await runShareWizard();
+  else if (phase === 'secrets') await import('./setup-secrets.js').then((m) => m.runSecretsSetupWizard());
+  else if (phase === 'fleet') await import('./setup-fleet.js').then((m) => m.runFleetSetupWizard());
+  else if (phase === 'watchdog') await runWatchdogSetupWizard();
+  else await runPreferencesStep();
+}
+
+export async function runSetupHub(deps: {
+  interactive?: boolean;
+  selectPhase?: (rows: SetupStatusRow[]) => Promise<SetupPhase | 'exit'>;
+  runPhase?: (phase: SetupPhase) => Promise<void>;
+} = {}): Promise<void> {
+  const interactive = deps.interactive ?? isInteractiveTerminal();
+  if (!interactive) {
+    renderSetupStatus(await getSetupStatus());
+    return;
+  }
   try {
-    const { checkbox } = await import('@inquirer/prompts');
-    const picks = await checkbox<'browser' | 'computer' | 'share' | 'secrets' | 'fleet' | 'watchdog'>({
-      message: 'Set up optional capabilities now? (space to select, enter to confirm)',
-      choices: [
-        { name: 'browser  — drive a real Chrome/Brave/Edge for web automation', value: 'browser' },
-        { name: 'computer — control native macOS apps (screenshot, click, type)', value: 'computer' },
-        { name: 'share    — publish shareable links (Cloudflare R2 + Worker)', value: 'share' },
-        { name: 'secrets  — choose storage defaults and import existing credentials', value: 'secrets' },
-        { name: 'fleet    — discover Tailscale devices and configure SSH access', value: 'fleet' },
-        { name: 'watchdog — resume stalled agent sessions on selected devices', value: 'watchdog' },
-      ],
-    });
-    for (const pick of picks) {
+    while (true) {
+      const rows = await getSetupStatus();
+      renderSetupStatus(rows);
+      let pick: SetupPhase | 'exit';
+      if (deps.selectPhase) {
+        pick = await deps.selectPhase(rows);
+      } else {
+        const { select } = await import('@inquirer/prompts');
+        pick = await select<SetupPhase | 'exit'>({
+          message: 'Choose a phase to configure',
+          choices: [
+            ...rows.filter((row): row is SetupStatusRow & { phase: SetupPhase } => row.phase !== 'core' && row.state !== 'n/a').map((row) => ({
+              name: `${row.state === 'ready' ? '[x]' : '[ ]'} ${row.phase.padEnd(12)} ${row.detail}`,
+              value: row.phase,
+            })),
+            { name: 'Exit setup', value: 'exit' as const },
+          ],
+        });
+      }
+      if (pick === 'exit') return;
       console.log();
-      if (pick === 'browser') await runBrowserWizard();
-      else if (pick === 'computer') await runComputerWizard();
-      else if (pick === 'share') await runShareWizard();
-      else if (pick === 'secrets') await import('./setup-secrets.js').then((m) => m.runSecretsSetupWizard());
-      else if (pick === 'fleet') await import('./setup-fleet.js').then((m) => m.runFleetSetupWizard());
-      else if (pick === 'watchdog') await runWatchdogSetupWizard();
+      await (deps.runPhase ?? runSetupPhase)(pick);
     }
   } catch (err) {
     if (isPromptCancelled(err)) return;
@@ -305,7 +373,7 @@ async function runSetupHub(): Promise<void> {
 export function registerSetupCommand(program: Command): void {
   const setupCmd = program
     .command('setup')
-    .description('First-time setup. Clones a config repo and installs agent CLIs.')
+    .description('Set up agents-cli, or re-open the capability onboarding hub.')
     .option('-f, --force', 'Re-run setup even if ~/.agents/.system/ already exists (use with caution)')
     .option('--no-system-repo', 'Skip cloning the system repo (you must populate ~/.agents/.system/ yourself)');
 
@@ -317,6 +385,15 @@ export function registerSetupCommand(program: Command): void {
   registerSetupSecretsCommand(setupCmd);
   registerSetupFleetCommand(setupCmd);
   registerSetupWatchdogCommand(setupCmd);
+  setupCmd.command('status')
+    .description('Show setup readiness for core, browser, computer, secrets, fleet, share, watchdog, and preferences.')
+    .option('--json', 'print machine-readable JSON')
+    .action(async (options: { json?: boolean }) => {
+      const rows = await getSetupStatus();
+      if (options.json) console.log(JSON.stringify(rows, null, 2));
+      else renderSetupStatus(rows);
+      if (rows.some((row) => row.state === 'missing')) process.exitCode = 1;
+    });
 
   setHelpSections(setupCmd, {
     examples: `
@@ -338,10 +415,8 @@ export function registerSetupCommand(program: Command): void {
       What it does:
         1. Clones the system repo into ~/.agents/.system/
         2. Imports any unmanaged agent installations it finds
-        3. On a TTY, offers to set up optional capabilities (browser/computer/share/secrets/fleet/watchdog)
-        4. On a TTY, asks preferences: which machine you sit at (interactive host)
-           and which browser agents drive here — both skippable, both the same
-           keys 'agents devices set-interactive' / 'browser profiles set-default' write
+        3. Opens a re-runnable capability menu with live ready/missing status
+        4. Delegates each selection to its existing setup wizard
 
       Capability setup can also be run any time on its own:
         agents setup browser    # detect a browser + create the default profile

--- a/apps/cli/src/lib/browser/profiles.ts
+++ b/apps/cli/src/lib/browser/profiles.ts
@@ -115,7 +115,7 @@ export async function getProfile(name: string): Promise<BrowserProfile | null> {
  * "Custom binary not found" failure) fails this check so the caller re-detects
  * for the current machine.
  */
-function isProfileLaunchableHere(profile: BrowserProfile): boolean {
+export function isProfileLaunchableHere(profile: BrowserProfile): boolean {
   const remote = Object.values(getEndpointPresets(profile)).some((preset) =>
     preset.target.startsWith('ssh://')
   );


### PR DESCRIPTION
Adds a re-runnable interactive onboarding hub for existing agents-cli installations.

## What changed

- Bare `agents setup` now opens the capability hub when core setup already exists instead of returning early.
- One live status source reports Core, Browser, Computer, Secrets, Fleet, Share, Watchdog, and Preferences as ready, missing, or not applicable.
- Selecting a phase delegates to its existing wizard, then refreshes the menu.
- Non-TTY bare setup prints the status table without prompting; `agents setup status --json` exposes the same probes and exits nonzero while required setup remains missing.
- Setup help, README, concepts documentation, component guidance, and the release queue are updated.

## Tracking

[RUSH-1878](https://linear.app/getrush/issue/RUSH-1878/agents-setup-consolidate-onboarding-into-one-command-group)

## Verification

- `bunx vitest run src/commands/setup.test.ts src/lib/browser/profiles.test.ts` — 63 tests passed.
- `bun run build` — TypeScript compilation passed.
- `scripts/verify-docs.sh` — passed.
- `node dist/index.js setup --help` — lists the status command and re-runnable hub workflow.
- `node dist/index.js setup status --json` — returned all eight live status rows and exit 1 for missing phases.
- Real `agents pty` run — opened the hub on an already-configured machine, displayed Browser and Computer together, entered the existing Browser wizard, declined changes, and returned to a refreshed hub.

PTY capture (fleet-local fallback because the configured share endpoint has no usable `share` credential on this host):

- `zion:/Users/muqsit/src/github.com/phnx-labs/agents-cli/.agents/artifacts/2026-08-05/rush-1878-setup-menu-pty.txt.png`
- `zion:/Users/muqsit/src/github.com/phnx-labs/agents-cli/.agents/artifacts/2026-08-05/rush-1878-setup-menu-pty.ansi`

The full local suite also ran (10,183 passed); 11 unrelated environment/live-state tests failed across model catalogs, owner notification wiring, an old-peer SSH probe, and interactive macOS Keychain access. The RUSH-1878 setup and browser-profile suites are green.

No raw session transcript is attached because this is a public repository.
