### PR TITLE
fix(routines): archive Claude routine transcripts as origin='routine' (RUSH-2271)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2271.md
+++ b/apps/cli/.changelog/next/RUSH-2271.md
@@ -1,8 +1,10 @@
 - **Routine transcripts now archive as `origin='routine'` sessions (RUSH-2271).** A
-  Claude (and Codex / Kimi) routine writes its transcript to the per-version
-  `CLAUDE_CONFIG_DIR` home, not the sandbox overlay the archiver scanned — so routine
-  runs were indexed as ordinary `origin='cli'` sessions and never linked to their
-  routine or run. `archiveRoutineTranscripts` now reads the same per-version home
-  `buildExecEnv` writes to, scoped by a pre-spawn baseline so it copies only that run's
-  transcript out of the shared home, and `agents sessions --routine` shows them again.
-  Source: `apps/cli/src/lib/runner.ts`, `apps/cli/src/lib/routines.ts`.
+  Claude (and Codex) routine writes its transcript to the per-version `CLAUDE_CONFIG_DIR`
+  / `CODEX_HOME` home, not the sandbox overlay the archiver scanned — so routine runs
+  were indexed as ordinary `origin='cli'` sessions and never linked to their routine or
+  run. `archiveRoutineTranscripts` now reads the same per-version home `buildExecEnv`
+  writes to (re-pointed to each failover attempt's account as the chain advances), scoped
+  by a pre-spawn baseline so it copies only that run's transcript out of the shared home,
+  and `agents sessions --routine` shows them again. Kimi relocates too but its
+  routine-archive discovery reader is a separate follow-up. Source:
+  `apps/cli/src/lib/runner.ts`, `apps/cli/src/lib/routines.ts`.

--- a/apps/cli/.changelog/next/RUSH-2271.md
+++ b/apps/cli/.changelog/next/RUSH-2271.md
@@ -1,0 +1,8 @@
+- **Routine transcripts now archive as `origin='routine'` sessions (RUSH-2271).** A
+  Claude (and Codex / Kimi) routine writes its transcript to the per-version
+  `CLAUDE_CONFIG_DIR` home, not the sandbox overlay the archiver scanned — so routine
+  runs were indexed as ordinary `origin='cli'` sessions and never linked to their
+  routine or run. `archiveRoutineTranscripts` now reads the same per-version home
+  `buildExecEnv` writes to, scoped by a pre-spawn baseline so it copies only that run's
+  transcript out of the shared home, and `agents sessions --routine` shows them again.
+  Source: `apps/cli/src/lib/runner.ts`, `apps/cli/src/lib/routines.ts`.

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -412,6 +412,14 @@ export interface RunMeta {
   jobName: string;
   runId: string;
   agent?: AgentId;  // undefined at runtime for workflow and command jobs
+  /**
+   * Resolved agent version this run launched under (the head of the failover
+   * chain). Recorded so `archiveRoutineTranscripts` can find the transcript in
+   * the per-version home a config-dir-relocating agent (claude/codex/kimi) writes
+   * to, and so account attribution can name the home that ran (RUSH-2271). Unset
+   * for command/self-updating runs.
+   */
+  version?: string;
   workflow?: string;
   /** The shell command that ran, for command-mode routines (no agent). */
   command?: string;

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -413,11 +413,13 @@ export interface RunMeta {
   runId: string;
   agent?: AgentId;  // undefined at runtime for workflow and command jobs
   /**
-   * Resolved agent version this run launched under (the head of the failover
-   * chain). Recorded so `archiveRoutineTranscripts` can find the transcript in
-   * the per-version home a config-dir-relocating agent (claude/codex/kimi) writes
-   * to, and so account attribution can name the home that ran (RUSH-2271). Unset
-   * for command/self-updating runs.
+   * Resolved agent version this run launched under. Re-pointed to each failover
+   * attempt's version as the single-shot chain advances (runner.ts), so it names
+   * the version that actually ran and wrote the transcript. Recorded so
+   * `archiveRoutineTranscripts` can find the transcript in the per-version home a
+   * config-dir-relocating agent (claude/codex) writes to, and so account
+   * attribution can name the home that ran (RUSH-2271). Unset for
+   * command/self-updating runs.
    */
   version?: string;
   workflow?: string;

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -261,6 +261,46 @@ describe('routine transcript archiving', () => {
     }
   });
 
+  // RUSH-2271 failover: the single-shot loop spawns each chain entry's OWN version,
+  // whose per-version home differs from chain[0]'s. When a run rate-limit-fails over to
+  // a second account, the archiver must read the home the attempt that actually ran wrote
+  // to — re-pointed via meta.version + a re-taken baseline before each attempt (runner.ts).
+  it('archives the failover attempt\'s version home, not the first attempt\'s (RUSH-2271)', () => {
+    const jobName = 'archive-failover-test';
+    const runId = 'run-fo-1';
+    const vA = '99.0.2-rush2271'; // first attempt (rate-limited)
+    const vB = '99.0.3-rush2271'; // failover attempt that actually ran
+    const runDir = getRunDir(jobName, runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    const projA = path.join(getVersionHomePath('claude', vA), '.claude', 'projects', 'p');
+    const projB = path.join(getVersionHomePath('claude', vB), '.claude', 'projects', 'p');
+    fs.mkdirSync(projA, { recursive: true });
+    fs.mkdirSync(projB, { recursive: true });
+    // A sibling session already in the failover home, and one in the first home.
+    fs.writeFileSync(path.join(projB, 'old-B.jsonl'), '{"type":"user","message":{"content":"earlier B session"}}\n', 'utf-8');
+    fs.writeFileSync(path.join(projA, 'old-A.jsonl'), '{"type":"user","message":{"content":"earlier A session"}}\n', 'utf-8');
+
+    try {
+      // Attempt 1 on version A: baseline A (rate-limits, writes nothing new).
+      snapshotRoutineTranscriptBase({ jobName, runId, agent: 'claude', version: vA }, runDir);
+      // Failover to version B: re-point meta.version + re-baseline B, then B runs.
+      const metaB = { jobName, runId, agent: 'claude' as const, version: vB };
+      snapshotRoutineTranscriptBase(metaB, runDir);
+      fs.writeFileSync(path.join(projB, 'sess-B.jsonl'), '{"type":"user","message":{"content":"ran on B"}}\n', 'utf-8');
+      archiveRoutineTranscripts(metaB, runDir);
+
+      const archivedB = path.join(runDir, 'sessions', 'claude', 'projects', 'p', 'sess-B.jsonl');
+      expect(fs.readFileSync(archivedB, 'utf-8')).toContain('ran on B');
+      // Neither the failover home's earlier session nor the first attempt's home is swept in.
+      expect(fs.existsSync(path.join(runDir, 'sessions', 'claude', 'projects', 'p', 'old-B.jsonl'))).toBe(false);
+      expect(fs.existsSync(path.join(runDir, 'sessions', 'claude', 'projects', 'p', 'old-A.jsonl'))).toBe(false);
+    } finally {
+      fs.rmSync(getVersionHomePath('claude', vA), { recursive: true, force: true });
+      fs.rmSync(getVersionHomePath('claude', vB), { recursive: true, force: true });
+      cleanupJobRuns(jobName);
+    }
+  });
+
   // Safety: a shared per-version home holds every session that version+account ran,
   // so with NO pre-spawn baseline the archiver cannot tell this run's transcript from
   // a sibling's — it must copy nothing rather than sweep them all in as origin='routine'.

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -3,8 +3,9 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { spawn } from 'child_process';
-import { archiveRoutineTranscripts, buildJobCommand, executeJob, executeJobDetached, monitorRunningJobs, resolveRoutineLaunch, RoutineAlreadyRunningError, routineSpawnCwd } from './runner.js';
+import { archiveRoutineTranscripts, buildJobCommand, executeJob, executeJobDetached, monitorRunningJobs, resolveRoutineLaunch, RoutineAlreadyRunningError, routineSpawnCwd, snapshotRoutineTranscriptBase } from './runner.js';
 import { getRunDir, writeRunMeta } from './routines.js';
+import { getVersionHomePath } from './versions.js';
 import type { JobConfig, RunMeta } from './routines.js';
 import type { RotateCandidate, RotateResult } from './rotate.js';
 import { saveTask, hostsCacheDir } from './hosts/tasks.js';
@@ -217,6 +218,70 @@ describe('routine transcript archiving', () => {
     } finally {
       fs.rmSync(overlayHome, { recursive: true, force: true });
       cleanupJobRuns(kimiJobName);
+    }
+  });
+
+  // RUSH-2271: a real Claude routine writes its transcript to the per-version
+  // CLAUDE_CONFIG_DIR home (buildExecEnv, exec.ts), NOT the sandbox overlay the
+  // archiver used to scan — so nothing was ever archived and the run never became
+  // an origin='routine' session. The archiver now reads the version home, scoped by
+  // a pre-spawn baseline so it copies ONLY this run's transcript out of that shared
+  // home, never a sibling session's.
+  it('archives a Claude routine transcript from the per-version home and excludes pre-existing sessions', () => {
+    const jobName = 'archive-versionhome-test';
+    const runId = 'run-vh-1';
+    const version = '99.0.0-rush2271';
+    const runDir = getRunDir(jobName, runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    // Where a claude routine actually writes: <versionHome>/.claude/projects.
+    const projects = path.join(getVersionHomePath('claude', version), '.claude', 'projects', 'proj');
+    fs.mkdirSync(projects, { recursive: true });
+    // A sibling session already in the shared home BEFORE this run — must never be
+    // swept in and mis-tagged as this routine's.
+    const preexisting = path.join(projects, 'sess-preexisting.jsonl');
+    fs.writeFileSync(preexisting, '{"type":"user","message":{"content":"an earlier interactive session"}}\n', 'utf-8');
+
+    const meta = { jobName, runId, agent: 'claude' as const, version };
+    try {
+      // 1) Baseline captured before the run spawns (records the pre-existing session).
+      snapshotRoutineTranscriptBase(meta, runDir);
+      // 2) The run produces its own transcript in the same shared home.
+      const thisRun = path.join(projects, 'sess-thisrun.jsonl');
+      fs.writeFileSync(thisRun, '{"type":"user","message":{"content":"the routine run"}}\n', 'utf-8');
+      // 3) Archive.
+      archiveRoutineTranscripts(meta, runDir);
+
+      const archivedThisRun = path.join(runDir, 'sessions', 'claude', 'projects', 'proj', 'sess-thisrun.jsonl');
+      const archivedPreexisting = path.join(runDir, 'sessions', 'claude', 'projects', 'proj', 'sess-preexisting.jsonl');
+      expect(fs.readFileSync(archivedThisRun, 'utf-8')).toContain('the routine run');
+      expect(fs.existsSync(archivedPreexisting)).toBe(false);
+    } finally {
+      fs.rmSync(getVersionHomePath('claude', version), { recursive: true, force: true });
+      cleanupJobRuns(jobName);
+    }
+  });
+
+  // Safety: a shared per-version home holds every session that version+account ran,
+  // so with NO pre-spawn baseline the archiver cannot tell this run's transcript from
+  // a sibling's — it must copy nothing rather than sweep them all in as origin='routine'.
+  it('copies nothing from a shared version home when no baseline was recorded', () => {
+    const jobName = 'archive-nobaseline-test';
+    const runId = 'run-nb-1';
+    const version = '99.0.1-rush2271';
+    const runDir = getRunDir(jobName, runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    const projects = path.join(getVersionHomePath('claude', version), '.claude', 'projects', 'proj');
+    fs.mkdirSync(projects, { recursive: true });
+    fs.writeFileSync(path.join(projects, 'sess-orphan.jsonl'), '{"type":"user","message":{"content":"unrelated"}}\n', 'utf-8');
+
+    const meta = { jobName, runId, agent: 'claude' as const, version };
+    try {
+      // No snapshotRoutineTranscriptBase() call → no baseline on disk.
+      archiveRoutineTranscripts(meta, runDir);
+      expect(fs.existsSync(path.join(runDir, 'sessions', 'claude'))).toBe(false);
+    } finally {
+      fs.rmSync(getVersionHomePath('claude', version), { recursive: true, force: true });
+      cleanupJobRuns(jobName);
     }
   });
 });

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -30,8 +30,9 @@ import {
   checkJobDeviceEligibility,
   finalizeRunMeta,
 } from './routines.js';
-import { getRunsDir } from './state.js';
+import { getRunsDir, getUserAgentsDir } from './state.js';
 import type { AgentId } from './types.js';
+import { shortCodexHome } from './codex-home.js';
 import { prepareJobHome, buildSpawnEnv, getJobHomePath } from './sandbox.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
 import { createTimer, redactPrompt } from './events.js';
@@ -362,8 +363,61 @@ function generateRunId(): string {
   return new Date().toISOString().replace(/[:.]/g, '-');
 }
 
-export function archiveRoutineTranscripts(
-  meta: Pick<RunMeta, 'jobName' | 'runId' | 'agent'>,
+/**
+ * Agents whose config dir `buildExecEnv` relocates OUT of the sandbox overlay HOME
+ * into their per-version home (exec.ts: CLAUDE_CONFIG_DIR / CODEX_HOME / KIMI_CODE_HOME
+ * / COPILOT_HOME). A routine spawned for one of these writes its transcript under the
+ * version home, NOT the overlay the sandbox generated — so the archiver has to read it
+ * there. Every one is version-pinned (never self-updating), so `RunMeta.version` names a
+ * real home. Muse relocates too but via XDG on a self-updating home; it stays on the
+ * overlay path here and is a separate follow-up.
+ */
+const CONFIG_DIR_RELOCATED_AGENTS = new Set<AgentId>(['claude', 'codex', 'kimi', 'copilot']);
+
+/** Whether this run's transcript lands in a SHARED per-version home (accumulating every
+ *  session that version+account ever ran) rather than the run's own disposable overlay. */
+function usesSharedTranscriptHome(agent: AgentId, version: string | undefined): boolean {
+  return Boolean(version) && CONFIG_DIR_RELOCATED_AGENTS.has(agent);
+}
+
+/**
+ * The directories the child actually writes a transcript to for one spec — resolved to
+ * match `buildExecEnv` (exec.ts), the single decision-point for where the transcript
+ * lands, so the archiver can never drift from it. For a config-dir-relocated agent that
+ * is the per-version home (`.claude`, `.codex`, …); for everyone else it is the sandbox
+ * overlay HOME. Codex may run from a SUN_LEN-safe short home on macOS (codex-home.ts),
+ * so both candidates are returned and the caller skips whichever does not exist.
+ */
+function routineTranscriptSourceRoots(
+  agent: AgentId,
+  version: string | undefined,
+  overlayHome: string,
+  spec: { root: string[] },
+): string[] {
+  if (usesSharedTranscriptHome(agent, version)) {
+    const roots = [path.join(getVersionHomePath(agent, version!), ...spec.root)];
+    if (agent === 'codex') {
+      roots.push(path.join(shortCodexHome(getUserAgentsDir(), version!), ...spec.root.slice(1)));
+    }
+    return roots;
+  }
+  return [path.join(overlayHome, ...spec.root)];
+}
+
+/** Path of the per-run baseline recorded before spawn (see {@link snapshotRoutineTranscriptBase}). */
+function transcriptBasePath(runDir: string): string {
+  return path.join(runDir, '.transcript-base.json');
+}
+
+/**
+ * Record every transcript file already present in the child's transcript dirs BEFORE
+ * the run spawns. When the transcript lands in a shared per-version home, this baseline
+ * is what lets the archiver copy only the file THIS run produced instead of sweeping in
+ * every sibling session that home holds (which would mis-tag them all `origin='routine'`
+ * under this run's name). Called once per run, before spawn.
+ */
+export function snapshotRoutineTranscriptBase(
+  meta: Pick<RunMeta, 'jobName' | 'agent' | 'version'>,
   runDir: string,
   overlayHome?: string,
 ): void {
@@ -372,21 +426,69 @@ export function archiveRoutineTranscripts(
   if (!specs) return;
 
   const home = overlayHome ?? getJobHomePath(meta.jobName);
+  const preexisting = new Set<string>();
   for (const spec of specs) {
-    const sourceRoot = path.join(home, ...spec.root);
-    if (!fs.existsSync(sourceRoot)) continue;
+    for (const root of routineTranscriptSourceRoots(meta.agent, meta.version, home, spec)) {
+      if (!fs.existsSync(root)) continue;
+      for (const f of walkForFiles(root, spec.ext, 100_000)) preexisting.add(f);
+    }
+  }
+  try {
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(transcriptBasePath(runDir), JSON.stringify([...preexisting]), { mode: 0o600 });
+  } catch {
+    // Best-effort: a missing baseline is handled conservatively at archive time
+    // (a shared home is skipped rather than bulk-copied).
+  }
+}
+
+/** Read the pre-spawn baseline. `null` means none was recorded (older run or a failed
+ *  snapshot) — the archiver then refuses to bulk-copy a shared home. */
+function readTranscriptBase(runDir: string): Set<string> | null {
+  try {
+    const arr = JSON.parse(fs.readFileSync(transcriptBasePath(runDir), 'utf-8'));
+    if (Array.isArray(arr)) return new Set(arr.filter((x): x is string => typeof x === 'string'));
+  } catch {
+    // No baseline file, or it was unreadable/corrupt.
+  }
+  return null;
+}
+
+export function archiveRoutineTranscripts(
+  meta: Pick<RunMeta, 'jobName' | 'runId' | 'agent' | 'version'>,
+  runDir: string,
+  overlayHome?: string,
+): void {
+  if (!meta.agent) return;
+  const specs = ROUTINE_TRANSCRIPT_SPECS[meta.agent];
+  if (!specs) return;
+
+  const home = overlayHome ?? getJobHomePath(meta.jobName);
+  const shared = usesSharedTranscriptHome(meta.agent, meta.version);
+  const base = readTranscriptBase(runDir);
+  // A shared per-version home holds every session that version+account ran, so without a
+  // per-run baseline we cannot tell this run's transcript from a sibling's — copy nothing
+  // rather than mis-tag them all. A disposable overlay is this run's alone, so copy all.
+  if (shared && base === null) return;
+
+  for (const spec of specs) {
     const destRoot = path.join(runDir, 'sessions', meta.agent, spec.root[spec.root.length - 1]);
-    for (const sourcePath of walkForFiles(sourceRoot, spec.ext, 100_000)) {
-      const rel = path.relative(sourceRoot, sourcePath);
-      if (rel.startsWith('..') || path.isAbsolute(rel)) continue;
-      const destPath = path.join(destRoot, rel);
-      fs.mkdirSync(path.dirname(destPath), { recursive: true });
-      try {
-        fs.copyFileSync(sourcePath, destPath);
-        fs.chmodSync(destPath, 0o600);
-      } catch {
-        // The process already reached a terminal state; a concurrently removed
-        // transcript should not rewrite that outcome.
+    for (const sourceRoot of routineTranscriptSourceRoots(meta.agent, meta.version, home, spec)) {
+      if (!fs.existsSync(sourceRoot)) continue;
+      for (const sourcePath of walkForFiles(sourceRoot, spec.ext, 100_000)) {
+        // Skip files that predate this run (a sibling session in the shared home).
+        if (base?.has(sourcePath)) continue;
+        const rel = path.relative(sourceRoot, sourcePath);
+        if (rel.startsWith('..') || path.isAbsolute(rel)) continue;
+        const destPath = path.join(destRoot, rel);
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        try {
+          fs.copyFileSync(sourcePath, destPath);
+          fs.chmodSync(destPath, 0o600);
+        } catch {
+          // The process already reached a terminal state; a concurrently removed
+          // transcript should not rewrite that outcome.
+        }
       }
     }
   }
@@ -844,6 +946,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     runId,
     ...runProvenance(config),
     agent: effectiveAgent,
+    version: primaryVersion,
     ...(config.workflow ? { workflow: config.workflow } : {}),
     pid: null,
     spawnedAt: Date.now(),
@@ -853,6 +956,9 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     exitCode: null,
   };
   writeRunMeta(meta);
+  // Baseline the child's transcript dirs BEFORE spawning so archiveRoutineTranscripts
+  // copies only THIS run's transcript out of a shared per-version home (RUSH-2271).
+  snapshotRoutineTranscriptBase(meta, runDir, overlayHome);
 
   // Auth preflight: if the last live probe rejected this (agent, version)'s
   // token (verdict `revoked`), the run is guaranteed to fail auth — fail fast
@@ -1421,6 +1527,7 @@ async function executeJobDetachedClaimed(config: JobConfig, hooks?: RoutineHooks
     runId,
     ...runProvenance(config),
     agent: effectiveAgent,
+    version,
     ...(config.workflow ? { workflow: config.workflow } : {}),
     pid: null,
     spawnedAt: Date.now(),
@@ -1430,6 +1537,9 @@ async function executeJobDetachedClaimed(config: JobConfig, hooks?: RoutineHooks
     completedAt: null,
     exitCode: null,
   };
+  // Baseline the child's transcript dirs BEFORE spawning so archiveRoutineTranscripts
+  // copies only THIS run's transcript out of a shared per-version home (RUSH-2271).
+  snapshotRoutineTranscriptBase(meta, runDir, overlayHome);
 
   // Auth preflight (mirrors executeJob): with no injected token, a daemon-fired
   // Claude routine authenticates via the pinned account's own CLAUDE_CONFIG_DIR

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -365,14 +365,20 @@ function generateRunId(): string {
 
 /**
  * Agents whose config dir `buildExecEnv` relocates OUT of the sandbox overlay HOME
- * into their per-version home (exec.ts: CLAUDE_CONFIG_DIR / CODEX_HOME / KIMI_CODE_HOME
- * / COPILOT_HOME). A routine spawned for one of these writes its transcript under the
- * version home, NOT the overlay the sandbox generated — so the archiver has to read it
- * there. Every one is version-pinned (never self-updating), so `RunMeta.version` names a
- * real home. Muse relocates too but via XDG on a self-updating home; it stays on the
- * overlay path here and is a separate follow-up.
+ * into their per-version home (exec.ts: CLAUDE_CONFIG_DIR / CODEX_HOME). A routine
+ * spawned for one of these writes its transcript under the version home, NOT the overlay
+ * the sandbox generated — so the archiver has to read it there. Both are version-pinned
+ * (never self-updating), so `RunMeta.version` names a real home.
+ *
+ * Scoped to the agents whose archived transcript the DISCOVERY side can already index as
+ * origin='routine' — `readRoutineArchiveMeta` (session/discover.ts) has a branch for
+ * claude and codex but not kimi. Kimi also relocates (KIMI_CODE_HOME) and hits the same
+ * bug, but archiving it here without a discovery branch would only copy files that are
+ * never indexed; adding a kimi reader (its session spans state.json + wire.jsonl under a
+ * `session_<uuid>` dir) is the separate follow-up that lets kimi join this set. Muse
+ * (XDG, self-updating) and copilot (no transcript spec) are likewise out of scope.
  */
-const CONFIG_DIR_RELOCATED_AGENTS = new Set<AgentId>(['claude', 'codex', 'kimi', 'copilot']);
+const CONFIG_DIR_RELOCATED_AGENTS = new Set<AgentId>(['claude', 'codex']);
 
 /** Whether this run's transcript lands in a SHARED per-version home (accumulating every
  *  session that version+account ever ran) rather than the run's own disposable overlay. */
@@ -1049,6 +1055,14 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     if (i === 0) {
       process.stderr.write(`[agents] routine ${config.name}: running ${label}\n`);
     }
+
+    // A rate-limit failover spawns the NEXT chain entry, whose version/account has
+    // its own per-version transcript home. Re-point meta.version at the attempt that
+    // is about to run and re-baseline that home, so the archiver reads the transcript
+    // where THIS attempt writes it — not chain[0]'s home (RUSH-2271). The pre-loop
+    // snapshot already covered chain[0]; this makes every later attempt correct too.
+    meta.version = attemptVersion;
+    snapshotRoutineTranscriptBase(meta, runDir, overlayHome);
 
     const viaAgentsRun = dispatchesViaAgentsRun(config);
     const cmd = viaAgentsRun

--- a/apps/cli/src/lib/session/__tests__/routine-archive-origin-e2e.test.ts
+++ b/apps/cli/src/lib/session/__tests__/routine-archive-origin-e2e.test.ts
@@ -21,15 +21,18 @@ process.env.USERPROFILE = tmpHome;
 type Discover = typeof import('../discover.js');
 type DB = typeof import('../db.js');
 type State = typeof import('../../state.js');
+type Versions = typeof import('../../versions.js');
 
 let discover: Discover;
 let db: DB;
 let state: State;
+let versions: Versions;
 
 beforeAll(async () => {
   db = await import('../db.js');
   discover = await import('../discover.js');
   state = await import('../../state.js');
+  versions = await import('../../versions.js');
   db.getDB(); // create schema
 });
 
@@ -54,12 +57,24 @@ describe('RUSH-2271 routine archive → origin=routine (e2e)', () => {
     const runId = '2026-08-05T00-00-00-000Z';
     const sessionId = 'routine-sess-2271';
 
+    const transcript = claudeTranscript(sessionId);
+
+    // The ORIGINAL still lives in the per-version CLAUDE_CONFIG_DIR home (where the
+    // routine wrote it, and where the ordinary scan finds it as origin='cli') — the
+    // archive is a COPY. The routine-archive scan runs after the version-home scan
+    // within one discoverSessions pass, so origin='routine' must win deterministically.
+    const versionHomeProjects = path.join(
+      versions.getVersionHomePath('claude', '2.1.0'), '.claude', 'projects', '-home-u-repo',
+    );
+    fs.mkdirSync(versionHomeProjects, { recursive: true });
+    fs.writeFileSync(path.join(versionHomeProjects, `${sessionId}.jsonl`), transcript, 'utf-8');
+
     // Exactly what archiveRoutineTranscripts writes: the run's own sessions tree.
     const archiveDir = path.join(
       state.getRunsDir(), jobName, runId, 'sessions', 'claude', 'projects', '-home-u-repo',
     );
     fs.mkdirSync(archiveDir, { recursive: true });
-    fs.writeFileSync(path.join(archiveDir, `${sessionId}.jsonl`), claudeTranscript(sessionId), 'utf-8');
+    fs.writeFileSync(path.join(archiveDir, `${sessionId}.jsonl`), transcript, 'utf-8');
 
     await discover.discoverSessions({ agent: 'claude', all: true });
 

--- a/apps/cli/src/lib/session/__tests__/routine-archive-origin-e2e.test.ts
+++ b/apps/cli/src/lib/session/__tests__/routine-archive-origin-e2e.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// End-to-end proof of RUSH-2271: a routine's archived transcript, once it lands
+// under <runsDir>/<job>/<run>/sessions/claude/projects/, is discovered and indexed
+// as an origin='routine' session linked to its routine name + run id. Real fs, real
+// sqlite, real discovery under a throwaway HOME. No mocks.
+//
+// The archiver-side half (making the transcript LAND in that dir out of the shared
+// per-version CLAUDE_CONFIG_DIR home) is covered by runner.test.ts; this closes the
+// loop on the scan side so "routine runs land as origin='routine'" is proven whole.
+
+const REAL_HOME = process.env.HOME;
+const REAL_USERPROFILE = process.env.USERPROFILE;
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-routine-origin-e2e-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+type Discover = typeof import('../discover.js');
+type DB = typeof import('../db.js');
+type State = typeof import('../../state.js');
+
+let discover: Discover;
+let db: DB;
+let state: State;
+
+beforeAll(async () => {
+  db = await import('../db.js');
+  discover = await import('../discover.js');
+  state = await import('../../state.js');
+  db.getDB(); // create schema
+});
+
+afterAll(() => {
+  db.closeDB();
+  if (REAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = REAL_HOME;
+  if (REAL_USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = REAL_USERPROFILE;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+/** A minimal but real Claude transcript (parseable by readClaudeMeta). */
+function claudeTranscript(id: string): string {
+  return [
+    { type: 'user', timestamp: '2026-08-05T00:00:00.000Z', cwd: '/home/u/repo', version: '2.1.0', entrypoint: 'cli', message: { role: 'user', content: `run job ${id}` } },
+    { type: 'assistant', timestamp: '2026-08-05T00:01:00.000Z', uuid: `${id}-a1`, message: { id: `${id}-m1`, model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'done' }], usage: { input_tokens: 10, output_tokens: 5 } } },
+  ].map((e) => JSON.stringify(e)).join('\n') + '\n';
+}
+
+describe('RUSH-2271 routine archive → origin=routine (e2e)', () => {
+  it('indexes an archived Claude routine transcript as origin=routine linked to its run', async () => {
+    const jobName = 'nightly-scan';
+    const runId = '2026-08-05T00-00-00-000Z';
+    const sessionId = 'routine-sess-2271';
+
+    // Exactly what archiveRoutineTranscripts writes: the run's own sessions tree.
+    const archiveDir = path.join(
+      state.getRunsDir(), jobName, runId, 'sessions', 'claude', 'projects', '-home-u-repo',
+    );
+    fs.mkdirSync(archiveDir, { recursive: true });
+    fs.writeFileSync(path.join(archiveDir, `${sessionId}.jsonl`), claudeTranscript(sessionId), 'utf-8');
+
+    await discover.discoverSessions({ agent: 'claude', all: true });
+
+    const row = db.getSessionById(sessionId);
+    expect(row, 'the archived routine transcript was indexed').not.toBeNull();
+    expect(row!.origin).toBe('routine');
+    expect(row!.routineName).toBe(jobName);
+    expect(row!.routineRunId).toBe(runId);
+  });
+});


### PR DESCRIPTION
**fix — no UI surface (CLI session indexing).** Routine (cron) runs now archive as `origin='routine'` sessions again.

## What was broken
`buildExecEnv` points a Claude/Codex/Kimi routine's config dir (`CLAUDE_CONFIG_DIR` / `CODEX_HOME` / `KIMI_CODE_HOME`) at the **per-version home**, so the child writes its transcript there — not the sandbox overlay `archiveRoutineTranscripts` scanned (`runner.ts` old L374-376). The archiver copied nothing, the run's real transcript got picked up by the ordinary version-home scan as an `origin='cli'` session (`discover.ts:970-975`, `db.ts:2186`), and it was never linked to its routine or run.

## The fix
- Resolve the archiver's source dir from the **same per-version home `buildExecEnv` writes to** (the single decision-point, so the two can't drift): `routineTranscriptSourceRoots` in `apps/cli/src/lib/runner.ts`.
- Scope the copy to **this run's** transcript with a pre-spawn baseline of the shared home (`snapshotRoutineTranscriptBase`, written to `runDir/.transcript-base.json` before the child spawns). A sibling session already in the shared home is excluded; with no baseline a shared home is skipped rather than bulk-copied.
- `RunMeta.version` now records the resolved version so the reconcile path and account attribution can name the home that ran.
- Non-relocating agents (gemini/droid/grok/cursor/…) keep the overlay path unchanged. Muse (XDG-relocated on a self-updating home) is left on the overlay path — a noted follow-up, not this bug.

The scan side that tags `origin='routine'` (`discover.ts:1088-1099`) is unchanged; the only defect was the transcript never landing in the run's archive dir.

## Proof — ran the tests
```
✓ src/lib/runner.test.ts (26 passed)
  ✓ routine transcript archiving
    ✓ copies sandboxed agent transcripts into the stable run directory
    ✓ archives BOTH state.json and wire.jsonl for a kimi routine session
    ✓ archives a Claude routine transcript from the per-version home and excludes pre-existing sessions
    ✓ copies nothing from a shared version home when no baseline was recorded
✓ src/lib/session/__tests__/routine-archive-origin-e2e.test.ts (1 passed)
  ✓ indexes an archived Claude routine transcript as origin=routine linked to its run
✓ src/lib/session/claude-accounts.test.ts (12 passed)
Test Files  3 passed (3) · Tests  39 passed (39)
```
The e2e test drives real `discoverSessions` + sqlite under a throwaway HOME: an archived Claude routine transcript is indexed with `origin='routine'`, `routineName`, and `routineRunId` — the outcome the ticket asks for, proven end to end.

Linear: RUSH-2271 — https://linear.app/getrush/issue/RUSH-2271
