### PR TITLE
perf(resources): drop the redundant readMeta in getActiveResourceProfile

### DIFF
--- a/apps/cli/.changelog/next/resource-profile-redundant-readmeta.md
+++ b/apps/cli/.changelog/next/resource-profile-redundant-readmeta.md
@@ -1,0 +1,12 @@
+- **Layered resource listing is ~40% faster.** `getActiveResourceProfile()` read
+  `agents.yaml` twice per call — once up front, then again inside
+  `getActiveResourceProfileName()` — and `listResources()` calls it once per
+  resolved resource, so a listing paid two memoized `readMeta()` round-trips
+  (`ensureAgentsDir()` plus four `stat`s each) for every entry. Reading it only
+  after the profile name is known drops one of them. Measured on `yosemite-s1`
+  against the real `~/.agents`: one pass over all eight resource kinds (135
+  entries) went 10.52 ms → 6.23 ms, and `agents doctor --json` spends ~243 ms in
+  this path across 95 listings. No behavior change — an active profile still
+  costs two reads, and the `ensureAgentsDir()` side effect is unchanged because
+  `getActiveResourceProfileName()` always reaches `readMeta()`. Source:
+  `apps/cli/src/lib/resource-profiles.ts`.

--- a/apps/cli/.changelog/next/resource-profile-redundant-readmeta.md
+++ b/apps/cli/.changelog/next/resource-profile-redundant-readmeta.md
@@ -6,7 +6,11 @@
   after the profile name is known drops one of them. Measured on `yosemite-s1`
   against the real `~/.agents`: one pass over all eight resource kinds (135
   entries) went 10.52 ms → 6.23 ms, and `agents doctor --json` spends ~243 ms in
-  this path across 95 listings. No behavior change — an active profile still
-  costs two reads, and the `ensureAgentsDir()` side effect is unchanged because
-  `getActiveResourceProfileName()` always reaches `readMeta()`. Source:
+  this path across 95 listings. No behavior change: the read count is never
+  higher on any path and is unchanged whenever a profile name resolves — the one
+  saved read is the up-front one that the `if (!name) return null;` guard now
+  skips. The `ensureAgentsDir()` side effect is unchanged because
+  `getActiveResourceProfileName()` always reaches `readMeta()`, via
+  `brand.ts` `listBrands()` when a brand is set and via
+  `resource-profiles.ts` otherwise. Source:
   `apps/cli/src/lib/resource-profiles.ts`.

--- a/apps/cli/src/lib/resource-profiles.ts
+++ b/apps/cli/src/lib/resource-profiles.ts
@@ -67,10 +67,9 @@ export function getActiveResourceProfileName(): string | null {
 }
 
 export function getActiveResourceProfile(): ActiveResourceProfile | null {
-  const meta = readMeta();
   const name = getActiveResourceProfileName();
   if (!name) return null;
-  const preset = meta.profiles?.presets?.[name];
+  const preset = readMeta().profiles?.presets?.[name];
   return preset ? { name, preset } : null;
 }
 


### PR DESCRIPTION
**perf, internal — one line, no behavior change, no user-visible surface change.** Removes a redundant `agents.yaml` read that `listResources()` paid once per resolved resource. No UI: the run evidence below is timing output, not a screenshot.

## What changed

`getActiveResourceProfile()` read meta twice — once up front, then again inside `getActiveResourceProfileName()`:

```
resource-profiles.ts:70   const meta = readMeta();                    <- read #1
resource-profiles.ts:71   const name = getActiveResourceProfileName();
resource-profiles.ts:66     return readMeta().profiles?.active ?? null  <- read #2
```

`readMeta()` is memoized (`state.ts:1130`), but a **cache hit still costs** `ensureAgentsDir()` (`state.ts:1125` — ~20 `existsSync` + 2 `chmodSync`) plus `currentMetaStamp()` (`state.ts:836` — 4 `stat`s). Measured: **0.024 ms per cache hit.**

`listResources()` calls `resourceIsActive()` once per entry (`resources.ts:320`), which reaches this function — so every listed resource paid 2 × 0.024 ms for a check that is a no-op when no profile is active.

The fix reads meta only after the profile name is known. When a profile **is** active the cost is unchanged (still two reads), and the `ensureAgentsDir()` side effect is preserved because `getActiveResourceProfileName()` always reaches `readMeta()` on both the branded (`brand.ts:70`) and unbranded (`resource-profiles.ts:66`) paths.

## Where the time actually goes

Attribution of `listResources('skills')` over a representative 4-layer fixture (project 9 / user 25 / system 22 / extra-repo 20 → 76 unique entries), 7 samples × 100 iterations:

| component | ms | share |
|---|---|---|
| whole call | 4.3957 | 100% |
| `n × isNameActiveInResourceProfile` | 3.8082 | **86.6%** |
| `getProjectAgentsDir` + `getEnabledExtraRepos` | 0.0345 | 0.8% |
| raw `readdirSync` × 4 layers | 0.0232 | 0.5% |

The filesystem work is 0.5%. The profile check is 86.6%.

## Run result

Three independent process runs each, `yosemite-s1`, `loadavg` 1m between 2.95 and 3.26 (20 cores):

| | baseline | patched | |
|---|---|---|---|
| `listResources('skills')`, 76 entries | 4.44 ms | **2.32 ms** | −47.7% |
| `isNameActiveInResourceProfile` | 0.0518 ms | **0.0267 ms** | −48.5% |
| `readMeta` (cache hit) | 0.0236 ms | 0.0236 ms | unchanged |

`readMeta` itself is unchanged, which confirms the saving is exactly one call.

Against the **real `~/.agents`** on this box, one warm pass over all eight resource kinds (135 entries): **10.52 ms → 6.23 ms (−40.7%)**.

## Is this path hot? Honest answer: no.

Counters compiled into `resources.ts`, driving the real CLI entrypoint against the real `~/.agents` (baseline):

| command | `listResources` | `resourceIsActive` | wall | share of wall |
|---|---|---|---|---|
| `agents view` | 1 call, 0.48 ms | 6 calls, 0.02 ms | 3.71 s | 0.013% |
| `agents inspect claude` | 3 calls, 5.17 ms | 50 calls, 4.07 ms | 1.45 s | 0.36% |
| `agents doctor --json` | 95 calls, 243.25 ms | 3078 calls, 214.01 ms | 59.22 s | 0.41% |

`resourceIsActive` is 79–88% of the resolution path on the real box, matching the 86.6% synthetic attribution — but the resolution path itself is at most 0.41% of any command's wall time. **No command becomes noticeably faster.** This lands because it is one line that deletes a redundant read with a measured 40–48% cut and zero behavior change, not because it unblocks anything.

## Tests

`resources.test.ts` + `resource-profiles.test.ts`: **10 passed**. These already cover the active-profile fall-through, i.e. the branch where `getActiveResourceProfile()` returns non-null. `tsc --noEmit` clean. No new test: this is a redundant-read removal with identical semantics on every branch, not new behavior.

Full suite, baseline `45963e92` checked out into a second worktree and run identically (this box is not the supported test env — `apps/cli/CLAUDE.md` says the laptop-safe path is `bun run test:remote` on a crabbox — so only the delta is meaningful):

```
baseline (45963e92)  Test Files  58 failed | 677 passed | 5 skipped (746)
                     Tests      333 failed | 9740 passed | 77 skipped (10283)
patched  (63e96c59)  Test Files  60 failed | 675 passed | 5 skipped (746)
                     Tests      335 failed | 9738 passed | 77 skipped (10283)
```

An earlier full patched run scored 58 / 333, identical to baseline. Diffing the failing-file lists, the only two that differ are `src/lib/session/active.tmux-identity.test.ts` and `src/lib/tmux/session.test.ts` — both drive real tmux servers. Re-run in isolation they **pass on the patched tree** (25/25 and 13/13) and **one fails on the baseline tree** (1 failed | 37 passed). They flip either way under load and touch nothing in this diff. CI on Linux is the real gate.

## Evidence

Full raw measurement log (every sample, every loadavg reading, the attribution, the command counters, the suite comparison): https://share.agents-cli.sh/muqsitnawaz/agents-cli-measurements-c20e2fb52c1512ed

## Not included, deliberately

No benchmark harness is committed. A wall-clock benchmark has no stable assertion to make on a shared CI runner, and the repo has no bench precedent or runner to hang it on — committing one would be a surface with no consumer. The probes stayed in gitignored `.agents/scratch/`; their output is the shared log above.

No Linear ticket: repo conventions skip one for a trivial fix, and this is a one-line reorder.

## Changelog

Queued as a fragment at `apps/cli/.changelog/next/resource-profile-redundant-readmeta.md`.
