### PR TITLE
feat(insights): detect agent silent stalls from message timestamps

### DIFF
--- a/.agents/commands/sessions-insights.md
+++ b/.agents/commands/sessions-insights.md
@@ -20,3 +20,19 @@ agents sessions insights --since 30d
 Forward any arguments to the command. Use repeated `--agent` flags to narrow the
 harnesses, `--json` for structured output, and `--narrative` only when the user
 explicitly wants coaching from aggregate counts. Never upload raw transcripts.
+
+## Required read on silent stalls
+
+When summarizing the report (or reading `--json`), **always check** friction /
+corrections for agent idle patterns:
+
+| Signal | Meaning |
+|---|---|
+| `silent stall: 5-15m` / `15-60m` / `1h+` | Assistant was last to speak; session sat idle that long before the next user message (timestamp gap ≥ 5m). The model stopped on its own. |
+| `resume after silent stall` | User's first message after a silent stall was a resume nudge (`continue`, `keep going`, `resume`, …). |
+| `continue / keep going` | User typed a continue-class correction (may or may not follow a long gap). |
+
+Call these out with counts in your summary. Do **not** reframe long gaps as "the
+user was slow" when silent-stall signals are present — the agent went silent and
+waited for a human ping. Recommend stop-gates, background CI watches, and finishing
+the delivery chain without idling.

--- a/apps/cli/.changelog/next/insights-silent-stalls.md
+++ b/apps/cli/.changelog/next/insights-silent-stalls.md
@@ -1,0 +1,9 @@
+- **`agents insights` detects agent silent stalls (model goes idle until you resume).**
+  When the assistant is last to speak and the next user message is ≥5 minutes later,
+  facets count duration-bucketed `silent stall: 5-15m` / `15-60m` / `1h+` friction
+  signals; resume nudges (`continue`, `keep going`, …) after that silence also count
+  as `resume after silent stall`. Report, actions, `--narrative`, and
+  `/sessions-insights` instruct models to call these out (not reframe as "user was
+  slow"). Extractor version bumped to 5 so cached facets recompute. Source:
+  `apps/cli/src/lib/session/insights.ts`, `commands/insights.ts`,
+  `docs/06-observability.md`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -1192,10 +1192,30 @@ agents insights --narrative                    # add a written read on the numbe
 |---|---|
 | By account | sessions, cost, duration per account (or per `--by` dimension) |
 | Top tools / Languages / Models | histograms by name, from transcript content |
-| Friction | interruptions, tool errors bucketed into classes, your own reply latency (p50/p90) |
+| Friction | interruptions, tool errors, gap until next user message (p50/p90), **agent silent stalls** (assistant last spoke, then ≥5m idle until you resumed — buckets 5-15m / 15-60m / 1h+), resume nudges ("continue" after a stall) |
 | What you changed | lines touched, files created/modified/deleted, git commits and pushes |
 | When you work | 24-slot local-time histogram of your messages |
 | Parallel sessions | overlapping pairs, and how many straddled two accounts |
+
+### Agent silent stalls (model goes quiet until you ping)
+
+A common failure mode: the assistant ends a turn while work remains, sits idle, and
+only resumes when you type "continue" / "keep going" later. Insights detects that from
+**timestamps**, not vibes:
+
+1. Take the last assistant event timestamp (message or tool_use).
+2. Take the next non-synthetic user message timestamp.
+3. If the gap is **≥ 5 minutes**, count a **silent stall** (bucketed by duration).
+4. If that user message is a resume nudge (`continue`, `keep going`, `resume`, …),
+   also count **resume after silent stall**.
+
+Gaps under 5 minutes stay normal turn-taking (and feed the p50/p90 "gap until next
+msg" line). Gaps over an hour are excluded from p50/p90 (you may have left the desk)
+but still count as `silent stall: 1h+` when the assistant was the last speaker.
+
+Actions and `--narrative` are instructed to call these out so the report drives
+anti-idle rules (stop gates, background watches, queue drain) rather than treating
+the human as the only resume signal.
 
 ### Two engines under one verb (not two top-level commands)
 

--- a/apps/cli/src/commands/insights.ts
+++ b/apps/cli/src/commands/insights.ts
@@ -305,14 +305,29 @@ function renderReport(groups: GroupReport[], dim: GroupDim, meta: ReportMeta, ac
 
   // Friction — the section that earns the command.
   const gaps = all.responseGaps;
+  const silentStalls = Object.entries(all.frictionSignals)
+    .filter(([k]) => k.startsWith('silent stall:'))
+    .reduce((n, [, c]) => n + c, 0);
+  const resumeNudges = all.correctionSignals['resume after silent stall'] ?? 0;
   out.push('');
   out.push(chalk.bold('Friction'));
   out.push(`  ${padToWidth('interruptions', 18)}  ${chalk.cyan(String(all.interruptions))}` +
     chalk.gray('   turns you cut short'));
   out.push(`  ${padToWidth('tool errors', 18)}  ${chalk.cyan(String(all.errorCount))}`);
   if (gaps.length > 0) {
-    out.push(`  ${padToWidth('your reply time', 18)}  ` +
-      chalk.cyan(`p50 ${Math.round(percentile(gaps, 50))}s`) + chalk.gray(` · p90 ${Math.round(percentile(gaps, 90))}s`));
+    // Same timestamps as silent stalls; this line is the distribution. Silent
+    // stalls (below) are the agent-attributed long gaps after the model stopped.
+    out.push(`  ${padToWidth('gap until next msg', 18)}  ` +
+      chalk.cyan(`p50 ${Math.round(percentile(gaps, 50))}s`) + chalk.gray(` · p90 ${Math.round(percentile(gaps, 90))}s`) +
+      chalk.gray('   after assistant last spoke'));
+  }
+  if (silentStalls > 0) {
+    out.push(`  ${padToWidth('silent stalls', 18)}  ${chalk.cyan(String(silentStalls))}` +
+      chalk.gray('   agent idle ≥5m until you resumed'));
+  }
+  if (resumeNudges > 0) {
+    out.push(`  ${padToWidth('resume nudges', 18)}  ${chalk.cyan(String(resumeNudges))}` +
+      chalk.gray('   "continue"/"keep going" after a silent stall'));
   }
   const errs = topEntries(all.errorCategories, 6);
   if (errs.length > 0) {
@@ -390,7 +405,9 @@ function renderReport(groups: GroupReport[], dim: GroupDim, meta: ReportMeta, ac
     out.push(chalk.yellow(`  ${meta.unreadable} transcripts could not be read; their behaviour is missing from these totals.`));
   }
   if (all.gapsOverCeiling > 0) {
-    out.push(chalk.gray(`  ${all.gapsOverCeiling} reply gaps over an hour excluded from the percentiles.`));
+    out.push(chalk.gray(
+      `  ${all.gapsOverCeiling} gaps over an hour excluded from p50/p90 (still counted as silent stall: 1h+ when the assistant last spoke).`,
+    ));
   }
   out.push('');
   out.push(chalk.gray('  `agents insights --by project` to see it per repo'));
@@ -422,6 +439,13 @@ async function renderNarrative(payload: unknown): Promise<void> {
     '2. What is costing you — split into the assistant\'s fault vs your own workflow.',
     '3. Quick wins — concrete, tied to a number in the data.',
     '4. Worth trying — one more ambitious workflow change.',
+    '',
+    'Silent stalls (required): if frictionSignals contain "silent stall: …" or',
+    'correctionSignals contain "resume after silent stall" / "continue / keep going",',
+    'call that out explicitly in section 2 or 3 with the counts. Those mean the model',
+    'stopped mid-session and sat idle until the human pinged it (timestamps: last',
+    'assistant event → next user message ≥ 5 minutes). Do not reframe them as the',
+    'user being slow unless the data only shows short reply gaps.',
     'Be specific and cite the numbers. No preamble, no flattery, no bullet padding.',
     '',
     JSON.stringify(payload),

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -316,7 +316,8 @@ CREATE TABLE IF NOT EXISTS session_insights (
  * re-derives on the next `agents insights` instead of silently reporting stale
  * numbers alongside fresh ones. Same role as RESOURCE_INDEX_VERSION.
  */
-export const INSIGHTS_EXTRACTOR_VERSION = 4;
+/** Bump when facet extraction changes so cached rows recompute (silent-stall v5). */
+export const INSIGHTS_EXTRACTOR_VERSION = 5;
 
 /** Raw row shape returned from the sessions table. */
 export interface SessionRow {

--- a/apps/cli/src/lib/session/insights.test.ts
+++ b/apps/cli/src/lib/session/insights.test.ts
@@ -165,6 +165,24 @@ describe('computeInsightFacets', () => {
     )).toBe(true);
   });
 
+  it('ignores synthetic user messages so stop-hook feedback does not end a silent stall', () => {
+    // Assistant at t=0; synthetic meta at t=600 (would look like a 10m gap); real
+    // "continue" at t=1200 (20m from assistant). Stall must be measured to the real
+    // human message, not the injected row.
+    const f = computeInsightFacets([
+      userMsg(0, 'build'),
+      asstMsg(1, 'working'),
+      {
+        type: 'message', agent: 'claude', timestamp: at(600), role: 'user',
+        content: 'Stop hook feedback: open PR still…', _synthetic: true,
+      } as SessionEvent,
+      userMsg(1200, 'continue'),
+    ], 0);
+    expect(f.frictionSignals['silent stall: 15-60m']).toBe(1);
+    expect(f.frictionSignals['silent stall: 5-15m']).toBeUndefined();
+    expect(f.correctionSignals['resume after silent stall']).toBe(1);
+  });
+
   it('rejects a negative gap from clock skew rather than counting it', () => {
     // Removing the old 2s floor removed the implicit negative guard with it; a real
     // corpus contained a gap of -8.662s from out-of-order record timestamps.

--- a/apps/cli/src/lib/session/insights.test.ts
+++ b/apps/cli/src/lib/session/insights.test.ts
@@ -123,6 +123,46 @@ describe('computeInsightFacets', () => {
     ], 0);
     expect(f.responseGaps).toEqual([60, 1]);
     expect(f.gapsOverCeiling).toBe(1);
+    // 2h idle after assistant still counts as a silent stall (1h+ bucket).
+    expect(f.frictionSignals['silent stall: 1h+']).toBe(1);
+  });
+
+  it('classifies agent silent stalls from timestamps (model idle until human resumes)', () => {
+    // Assistant stops at t=10; user "continue" at t=10+600 (10m later) → 5-15m stall + resume nudge.
+    // Assistant stops again; user arbitrary "ok next" after 20m → 15-60m stall, no resume nudge.
+    // Sub-threshold 2m gap is normal turn-taking — not a silent stall.
+    const f = computeInsightFacets([
+      userMsg(0, 'build it'),
+      asstMsg(10, 'working…'),
+      userMsg(10 + 600, 'continue'),
+      asstMsg(700, 'more work'),
+      userMsg(700 + 1200, 'ok next file'),
+      asstMsg(2000, 'done for now'),
+      userMsg(2000 + 120, 'small follow-up'),
+    ], 0);
+    expect(f.frictionSignals['silent stall: 5-15m']).toBe(1);
+    expect(f.frictionSignals['silent stall: 15-60m']).toBe(1);
+    expect(f.frictionSignals['silent stall: 1h+']).toBeUndefined();
+    expect(f.correctionSignals['resume after silent stall']).toBe(1);
+    expect(f.correctionSignals['continue / keep going']).toBe(1);
+    // 2m gap stays in reply-latency sample, not silent-stall friction.
+    expect(f.responseGaps).toContain(120);
+  });
+
+  it('emits a high-priority action for resume-after-silent-stall patterns', () => {
+    const facets = computeInsightFacets([
+      userMsg(0, 'ship it'),
+      asstMsg(5),
+      userMsg(5 + 900, 'keep going'),
+    ], 0);
+    const actions = buildInsightActions([{ id: 'bbbbbbbb-stall-sess', facets }]);
+    expect(actions.some((a) =>
+      a.action.includes('Never stop mid-task') && a.evidenceCount >= 1,
+    )).toBe(true);
+    expect(actions.some((a) =>
+      a.action.includes('Stop ending turns while work remains') ||
+      a.action.includes('Long idle after the assistant'),
+    )).toBe(true);
   });
 
   it('rejects a negative gap from clock skew rather than counting it', () => {

--- a/apps/cli/src/lib/session/insights.ts
+++ b/apps/cli/src/lib/session/insights.ts
@@ -52,15 +52,33 @@ const ERROR_CATEGORIES: ReadonlyArray<readonly [readonly string[], string]> = [
 ];
 
 /**
- * Gaps longer than this are someone leaving and coming back, not a reply latency.
- * Counted separately rather than silently dropped.
+ * Gaps longer than this leave the reply-latency percentiles (someone left for
+ * lunch / overnight). They still count as silent stalls when the assistant
+ * was the last speaker — the agent had already stopped before the user left.
  */
 const GAP_CEILING_SECONDS = 3600;
+
+/**
+ * Minimum quiet time after the assistant's last event before a user message
+ * is classified as an **agent silent stall**: the model went quiet on its own
+ * and sat idle until the human resumed. Shorter gaps are normal turn-taking.
+ * 5 minutes is long enough to exclude "user typing the next instruction" and
+ * short enough to catch "went silent mid-task until I said continue."
+ */
+export const SILENT_STALL_SECONDS = 300;
 
 /** Response-gap buckets, in ascending order. Upper bound is exclusive. */
 const GAP_BUCKETS: ReadonlyArray<readonly [string, number]> = [
   ['<10s', 10], ['10-30s', 30], ['30s-1m', 60], ['1-2m', 120],
   ['2-5m', 300], ['5-15m', 900], ['15-60m', Infinity],
+];
+
+/** Silent-stall duration buckets (agent idle after its last event). */
+const SILENT_STALL_BUCKETS: ReadonlyArray<readonly [string, number, number]> = [
+  // label, min inclusive, max exclusive (Infinity = open)
+  ['silent stall: 5-15m', 300, 900],
+  ['silent stall: 15-60m', 900, 3600],
+  ['silent stall: 1h+', 3600, Infinity],
 ];
 
 /** Behavioural facets of one session. Serialized as JSON into `session_insights`. */
@@ -209,9 +227,15 @@ export function computeInsightFacets(
   // reported p50 by 63% (143s against a true 88s), because fast replies are common and
   // dropping them all shifts the median right. A 0-second reply is a real reply.
   //
-  // The upper bound stays: past an hour the user went away and came back, which is not
-  // a reply latency. It censors 5.5% of gaps, and `gapsOverCeiling` reports how many so
-  // the number is never quietly truncated.
+  // The upper bound stays for *percentiles only*: past an hour the user often left the
+  // desk, which is not "reply latency." Those gaps still feed silent-stall classification
+  // (the agent had already stopped). `gapsOverCeiling` reports how many so percentiles
+  // are never quietly truncated.
+  //
+  // Silent stall (agent idle): when the gap after the assistant's last event is long
+  // enough that the model clearly stopped mid-session and waited for a human nudge
+  // ("continue", "keep going", or any later message after minutes of silence). This is
+  // the inverse framing of reply latency: same timestamps, attributed to the agent.
   let lastAssistantTs: number | null = null;
   let lastFailedTool: string | null = null;
 
@@ -261,6 +285,10 @@ export function computeInsightFacets(
             // this guard with it; a negative reply latency is not a data point.
             if (gap >= 0 && gap < GAP_CEILING_SECONDS) f.responseGaps.push(gap);
             else if (gap >= GAP_CEILING_SECONDS) f.gapsOverCeiling++;
+            // Agent silent stall: model stopped; session sat idle until this message.
+            if (gap >= SILENT_STALL_SECONDS) {
+              classifySilentStall(gap, e.content ?? '', f.frictionSignals, f.correctionSignals);
+            }
           }
         }
         lastAssistantTs = null;
@@ -321,6 +349,32 @@ const CORRECTION_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
   [/\b(?:check now|check again|try now|did it work)\b/i, 'check now'],
   [/\b(?:don'?t ask|just do it|run what)\b/i, "don't ask / just do it"],
 ];
+
+/** User text that is a pure resume nudge after the agent went silent. */
+const RESUME_NUDGE_PATTERN =
+  /\b(?:continue|keep going|don'?t stop|resume|pick up|you stopped|still there|wake up|hello\??|are you (?:there|stuck)|go on)\b/i;
+
+/**
+ * Classify a long quiet gap after the assistant's last event as an agent silent stall.
+ * Optionally also marks an explicit resume nudge ("continue", …) after that silence.
+ */
+export function classifySilentStall(
+  gapSeconds: number,
+  userText: string,
+  friction: Record<string, number>,
+  corrections: Record<string, number>,
+): void {
+  for (const [label, min, max] of SILENT_STALL_BUCKETS) {
+    if (gapSeconds >= min && gapSeconds < max) {
+      bump(friction, label);
+      break;
+    }
+  }
+  const normalized = userText.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  if (normalized && RESUME_NUDGE_PATTERN.test(normalized)) {
+    bump(corrections, 'resume after silent stall');
+  }
+}
 
 const AUTOMATION_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
   [/\bgh pr (?:checks|view|merge)\b/i, 'PR babysitting'],
@@ -502,6 +556,7 @@ export function buildInsightActions(sessions: SessionFacetEvidence[]): InsightAc
     action: string;
   }> = [
     { source: 'correctionSignals', label: 'continue / keep going', category: 'rule', action: 'Keep working through the delivery chain without waiting for another “continue”.' },
+    { source: 'correctionSignals', label: 'resume after silent stall', category: 'rule', action: 'Never stop mid-task waiting for a human ping — finish the current goal or park with an explicit blocker; keep driving CI/review/merge without going idle.' },
     { source: 'correctionSignals', label: 'approval repeated', category: 'rule', action: 'Treat the original build or ship request as authorization for routine follow-through.' },
     { source: 'correctionSignals', label: 'done end-to-end?', category: 'rule', action: 'Verify the user-visible outcome before declaring the task complete.' },
     { source: 'correctionSignals', label: 'did you merge?', category: 'automation', action: 'Automate PR review, CI watching, and merge-on-green as one durable workflow.' },
@@ -512,6 +567,9 @@ export function buildInsightActions(sessions: SessionFacetEvidence[]): InsightAc
     { source: 'correctionSignals', label: "Ask stall: what's next?", category: 'rule', action: 'Remove workflow-stall “what next?” prompts from agent guidance.' },
     { source: 'correctionSignals', label: 'Ask stall: merge / reconcile', category: 'skill', action: 'Encode the safe merge and reconcile path in the git workflow skill.' },
     { source: 'correctionSignals', label: 'Ask stall: direction / approach', category: 'rule', action: 'Let agents choose implementation details after scope is clear.' },
+    { source: 'frictionSignals', label: 'silent stall: 5-15m', category: 'rule', action: 'Stop ending turns while work remains open — after a tool batch, take the next step or schedule a real background wait that re-invokes you; do not sit idle until the user says continue.' },
+    { source: 'frictionSignals', label: 'silent stall: 15-60m', category: 'rule', action: 'Long idle after the assistant last spoke is an agent stop, not a user pause — drive open PRs/CI/todos to completion or name a true external blocker instead of going silent.' },
+    { source: 'frictionSignals', label: 'silent stall: 1h+', category: 'rule', action: 'Sessions that sit idle for an hour+ after the model stops are stranded work — use stop-gates, background watches, and queue drain so a human is not the only resume signal.' },
     { source: 'frictionSignals', label: 'blocked guard', category: 'product', action: 'Make guard failures return the safe next command and exact blocked operation.' },
     { source: 'frictionSignals', label: 'CI red loop', category: 'automation', action: 'Deduplicate CI watchers and turn repeated red checks into one stateful wait.' },
     { source: 'frictionSignals', label: 'merge conflict', category: 'skill', action: 'Standardize conflict diagnosis and fix-forward reconciliation.' },

--- a/apps/cli/src/lib/session/insights.ts
+++ b/apps/cli/src/lib/session/insights.ts
@@ -271,7 +271,11 @@ export function computeInsightFacets(
           break;
         }
         if (e.role !== 'user') break;
-        if (!e._synthetic) classifyCorrection(e.content ?? '', f.correctionSignals);
+        // Synthetic user rows (stop-hook feedback, injected meta) are not a human
+        // resume — skip correction/stall classification and leave lastAssistantTs so
+        // the next real user message still measures the full idle gap.
+        if (e._synthetic) break;
+        classifyCorrection(e.content ?? '', f.correctionSignals);
         if (hasTs) {
           // Local-time hour. parse.ts falls back to `new Date()` for a record with no
           // timestamp; those are indistinguishable here, but they are rare and would


### PR DESCRIPTION
**feat** — `agents insights` / `sessions insights` now classify **agent silent stalls** (model goes quiet mid-session until you resume).

## Problem

Models often stop on their own and sit idle until a human types "continue" / "keep going". That is visible in transcript timestamps (last assistant event to next user message) but was only partially covered: gaps fed "reply latency" framed as human slowness, and "continue" text was a separate correction signal without the gap.

## What landed

| Signal | How |
|---|---|
| `silent stall: 5-15m` / `15-60m` / `1h+` | Assistant last spoke; next user msg at least 5m later (timestamp gap) |
| `resume after silent stall` | That user msg is a resume nudge (continue, keep going, resume, ...) |
| Report lines | silent stalls + resume nudges counts; gap line relabeled "gap until next msg" |
| Actions | Rule actions for idle-until-pinged sessions |
| `--narrative` | Instructed to call out silent stalls with counts |
| `/sessions-insights` | Required read table for the same signals |

Extractor version **5** so cached facets recompute.

## Run result

```
$ bun run test -- src/lib/session/insights.test.ts src/commands/insights.test.ts
Test Files  2 passed (2)
     Tests  40 passed (40)
```

New unit tests: silent-stall buckets + resume nudge + action emission; existing gap ceiling test now expects `silent stall: 1h+`.

No UI surface — CLI report + docs.

## Docs / CHANGELOG

- `docs/06-observability.md` — Agent silent stalls section
- `.changelog/next/insights-silent-stalls.md`
- `.agents/commands/sessions-insights.md`
