### PR TITLE
fix(auth-health): probe once per account, not per version home (RUSH-2111)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2111.md
+++ b/apps/cli/.changelog/next/RUSH-2111.md
@@ -1,0 +1,10 @@
+- **Auth-health probes once per account, not once per version home (RUSH-2111).**
+  The daemon's every-3-minute auth-health refresh fanned `probeLocalFleetAuth`
+  over *every* installed version home at once, so a box with several Claude homes
+  signed into one account fired that many concurrent requests at the same
+  provider OAuth endpoint — racing its rate limit into a `429` that then parked
+  the whole box's usage reads behind a `Retry-After` penalty (`usage-backoff.ts`
+  survives that penalty; this removes its cause). Installs are now grouped by
+  account and the live probe runs once per (agent, account), fanning the one
+  verdict out to each home's per-version cache row. Homes with no resolvable
+  account are still probed individually. Source: `apps/cli/src/lib/auth-health.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.22.27
+
+- **Auth-health probes once per account, not once per version home (RUSH-2111).**
+  The daemon's every-3-minute auth-health refresh fanned `probeLocalFleetAuth`
+  over *every* installed version home at once, so a box with several Claude homes
+  signed into one account fired that many concurrent requests at the same provider
+  endpoint — racing its OAuth rate limit into a 429 that then parked the whole
+  box's usage reads behind a `Retry-After` penalty (`usage-backoff.ts` survives
+  that penalty; this removes its cause). Installs are now grouped by account and
+  the live probe runs once per (agent, account), fanning the one verdict out to
+  each home's cache row. Homes with no resolvable account are still probed
+  individually. Source: `apps/cli/src/lib/auth-health.ts`
+  (`groupFleetAuthInstalls`, `probeLocalFleetAuth`).
+
 ## 1.22.26
 
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## 1.22.27
-
-- **Auth-health probes once per account, not once per version home (RUSH-2111).**
-  The daemon's every-3-minute auth-health refresh fanned `probeLocalFleetAuth`
-  over *every* installed version home at once, so a box with several Claude homes
-  signed into one account fired that many concurrent requests at the same provider
-  endpoint — racing its OAuth rate limit into a 429 that then parked the whole
-  box's usage reads behind a `Retry-After` penalty (`usage-backoff.ts` survives
-  that penalty; this removes its cause). Installs are now grouped by account and
-  the live probe runs once per (agent, account), fanning the one verdict out to
-  each home's cache row. Homes with no resolvable account are still probed
-  individually. Source: `apps/cli/src/lib/auth-health.ts`
-  (`groupFleetAuthInstalls`, `probeLocalFleetAuth`).
-
 ## 1.22.26
 
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -1334,12 +1334,14 @@ a stable per-account key:
   are separate processes — one empty file per penalty, named
   `<agent>.<deadline>`, so concurrent writers cannot displace each other's
   deadline and a read simply takes the furthest one), and both
-  the usage fetch and the auth-health probe skip the network until it passes. The
-  daemon's 3-minute auth-health warm probes every installed version home in one
-  batch, so a box with several accounts could previously hold itself inside a
-  45-minute penalty window indefinitely and never refresh its cache — measured on
-  `yosemite-s1`, `retry-after: 2678` on all five accounts at once, with the
-  credentials reading healthy.
+  the usage fetch and the auth-health probe skip the network until it passes.
+  Backoff is the second layer; the first is that the daemon's 3-minute
+  auth-health warm now probes once per (network-probing agent, account) rather
+  than once per installed version home (`groupFleetAuthInstalls`, RUSH-2111), so
+  several homes signed into one account no longer fire concurrent same-account
+  requests that raced the rate limit in the first place — measured on
+  `yosemite-s1` before the fix, `retry-after: 2678` on all five accounts at once,
+  with the credentials reading healthy.
 - **A read that fails on the credential names the reason.** No readable
   credential, a locally-expired one, a rejected request, and a request that threw
   are distinct errors (`usageNoCredentialError` / `usageExpiredCredentialError` /

--- a/apps/cli/src/lib/auth-health.test.ts
+++ b/apps/cli/src/lib/auth-health.test.ts
@@ -5,6 +5,7 @@ import {
   authCacheKey,
   authCellColor,
   classifyHttpStatus,
+  groupFleetAuthInstalls,
   mergeAuthHealthEntries,
   formatCheckedAge,
   probeDetail,
@@ -16,6 +17,7 @@ import {
   verdictLabel,
   type AuthHealth,
   type AuthVerdict,
+  type FleetAuthInstall,
 } from './auth-health.js';
 
 describe('classifyHttpStatus', () => {
@@ -200,6 +202,67 @@ describe('summarizeHostAuth', () => {
   it('returns an empty summary for a host with no cached rows', () => {
     const r = summarizeHostAuth(cache, 'never-probed');
     expect(r).toEqual({ live: 0, present: 0, degraded: 0, revoked: 0, total: 0, oldestCheckedAt: null });
+  });
+});
+
+describe('groupFleetAuthInstalls — probe once per account (RUSH-2111)', () => {
+  const inst = (agent: string, version: string, account: string | undefined): FleetAuthInstall =>
+    ({ agent: agent as FleetAuthInstall['agent'], version, account });
+
+  it('collapses two homes on the SAME account into ONE probe group', () => {
+    const groups = groupFleetAuthInstalls([
+      inst('claude', '1.0.0', 'alice@example.com'),
+      inst('claude', '1.1.0', 'alice@example.com'),
+    ]);
+    // The whole point: two version homes, one live probe.
+    expect(groups).toHaveLength(1);
+    expect(groups[0].members.map((m) => m.version)).toEqual(['1.0.0', '1.1.0']);
+    // The representative is the first-seen home; every member rides its verdict.
+    expect(groups[0].probe.version).toBe('1.0.0');
+  });
+
+  it('keeps DIFFERENT accounts on the same agent as separate probes', () => {
+    const groups = groupFleetAuthInstalls([
+      inst('claude', '1.0.0', 'alice@example.com'),
+      inst('claude', '1.1.0', 'bob@example.com'),
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups.every((g) => g.members.length === 1)).toBe(true);
+  });
+
+  it('never merges the same account label across different agents', () => {
+    const groups = groupFleetAuthInstalls([
+      inst('claude', '1.0.0', 'shared@example.com'),
+      inst('kimi', '2.0.0', 'shared@example.com'),
+    ]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it('never merges installs with no resolvable account — each is its own group', () => {
+    const groups = groupFleetAuthInstalls([
+      inst('claude', '1.0.0', undefined),
+      inst('claude', '1.1.0', undefined),
+    ]);
+    // Can't prove they're the same account, so probe each (matches the old
+    // per-install behaviour for the un-labelable / unconfigured case).
+    expect(groups).toHaveLength(2);
+  });
+
+  it('deduplicates within an account while isolating the un-labelable ones', () => {
+    const groups = groupFleetAuthInstalls([
+      inst('claude', '1.0.0', 'alice@example.com'),
+      inst('claude', '1.1.0', 'alice@example.com'),
+      inst('claude', '1.2.0', undefined),
+      inst('claude', '1.3.0', 'bob@example.com'),
+    ]);
+    // alice(1 group of 2) + bob(1) + un-labelable(1) = 3 probes for 4 homes.
+    expect(groups).toHaveLength(3);
+    const alice = groups.find((g) => g.probe.account === 'alice@example.com');
+    expect(alice?.members.map((m) => m.version)).toEqual(['1.0.0', '1.1.0']);
+  });
+
+  it('returns no groups for no installs', () => {
+    expect(groupFleetAuthInstalls([])).toEqual([]);
   });
 });
 

--- a/apps/cli/src/lib/auth-health.test.ts
+++ b/apps/cli/src/lib/auth-health.test.ts
@@ -264,6 +264,27 @@ describe('groupFleetAuthInstalls — probe once per account (RUSH-2111)', () => 
   it('returns no groups for no installs', () => {
     expect(groupFleetAuthInstalls([])).toEqual([]);
   });
+
+  it('only merges installs the isMergeable predicate accepts', () => {
+    // The real caller passes `LIVE_PROBE_AGENTS.has(agent)`: claude merges (it can
+    // 429), cursor does not (a cheap local verdict with no rate limit — merging
+    // could silently override one home's signedIn state with another's).
+    const isLive = (i: FleetAuthInstall) => i.agent === 'claude';
+    const groups = groupFleetAuthInstalls(
+      [
+        inst('claude', '1.0.0', 'alice@example.com'),
+        inst('claude', '1.1.0', 'alice@example.com'),
+        inst('cursor', '2.0.0', 'alice@example.com'),
+        inst('cursor', '2.1.0', 'alice@example.com'),
+      ],
+      isLive,
+    );
+    // claude: 2 homes -> 1 group; cursor: 2 homes -> 2 groups (never merged).
+    expect(groups).toHaveLength(3);
+    const claude = groups.find((g) => g.probe.agent === 'claude');
+    expect(claude?.members).toHaveLength(2);
+    expect(groups.filter((g) => g.probe.agent === 'cursor').every((g) => g.members.length === 1)).toBe(true);
+  });
 });
 
 describe('formatCheckedAge', () => {

--- a/apps/cli/src/lib/auth-health.ts
+++ b/apps/cli/src/lib/auth-health.ts
@@ -383,33 +383,115 @@ export interface AuthProbeRow {
   health: AuthHealth;
 }
 
+/** One installed (agent, version) home, tagged with its resolved account label. */
+export interface FleetAuthInstall {
+  agent: AgentId;
+  version: string;
+  /** Human account label from {@link authAccountLabel}, or undefined when none resolves. */
+  account: string | undefined;
+}
+
 /**
- * Enumerate every installed (agent, version) on THIS host, probe each in
- * parallel, and return the rows (installs with no credential at all are
- * dropped). Shared by `agents fleet ping --local` and the daemon refresh.
+ * A set of installs that share one provider account and MUST be probed once.
+ * The live probe runs against `probe` (the representative home); every entry in
+ * `members` — the representative included — then receives that one verdict.
+ */
+export interface FleetAuthProbeGroup<T extends FleetAuthInstall> {
+  probe: T;
+  members: T[];
+}
+
+/**
+ * Collapse installs so a live auth probe fires ONCE per (agent, account) rather
+ * than once per version home.
+ *
+ * Several version homes signed into the same provider account share one OAuth
+ * rate limit, so probing each of them concurrently — which the daemon did every
+ * three minutes across every installed home (RUSH-2111) — raced that limit into
+ * a 429 storm that then parked the whole box behind a `Retry-After` penalty (the
+ * incident {@link file:./usage-backoff.ts} was written to survive; this removes
+ * its cause). Grouping by account means N homes on one account issue ONE request.
+ *
+ * Installs with no resolvable account label are never merged — we cannot prove
+ * two of them are the same account — so each becomes its own group keyed by
+ * version, preserving the old per-install probe for the un-labelable case
+ * (which is also the `unconfigured` case that gets dropped downstream). Pure: no
+ * fs, no network, so the dedup decision is unit-tested directly.
+ */
+export function groupFleetAuthInstalls<T extends FleetAuthInstall>(
+  installs: readonly T[],
+): FleetAuthProbeGroup<T>[] {
+  const groups = new Map<string, FleetAuthProbeGroup<T>>();
+  for (const inst of installs) {
+    // NUL separates the segments so an account label can never collide with the
+    // version fallback key (a version string cannot contain NUL).
+    const key = inst.account
+      ? `${inst.agent} acct:${inst.account}`
+      : `${inst.agent} ver:${inst.version}`;
+    const existing = groups.get(key);
+    if (existing) existing.members.push(inst);
+    else groups.set(key, { probe: inst, members: [inst] });
+  }
+  return [...groups.values()];
+}
+
+/**
+ * Enumerate every installed (agent, version) on THIS host and return one row per
+ * install (installs with no credential at all are dropped). Shared by
+ * `agents fleet ping --local` and the daemon refresh.
+ *
+ * The live network probe is deduped by account: homes sharing one provider
+ * account are probed ONCE and the verdict is fanned out to each home's row, so
+ * the daemon's every-3-minute refresh can no longer fire concurrent same-account
+ * requests and self-inflict a 429 (RUSH-2111). Each home still gets its own cache
+ * row (the cache key is per-version by design — see {@link authCacheKey}).
  */
 export async function probeLocalFleetAuth(opts?: {
   cliVersion?: string | null;
   agents?: readonly AgentId[];
 }): Promise<AuthProbeRow[]> {
   const agentIds = opts?.agents ?? ALL_AGENT_IDS;
-  const tasks: Promise<AuthProbeRow | null>[] = [];
+
+  interface LocalInstall extends FleetAuthInstall {
+    home: string;
+    info: AccountInfo | null;
+  }
+
+  // Enumerate every install, then resolve its account label. getAccountInfo is a
+  // local credential-file read (no network), so this fan-out is cheap and cannot
+  // contribute to the rate limit the probe grouping below exists to avoid.
+  const installs: LocalInstall[] = [];
   for (const agent of agentIds) {
     for (const version of listInstalledVersions(agent)) {
-      const home = getVersionHomePath(agent, version);
-      tasks.push(
-        (async (): Promise<AuthProbeRow | null> => {
-          const info = await getAccountInfo(agent, home).catch(() => null);
-          const health = await probeAuthHealth(agent, home, { cliVersion: opts?.cliVersion, info });
-          health.account = authAccountLabel(info);
-          if (health.verdict === 'unconfigured') return null;
-          return { agent, version, account: health.account, health };
-        })(),
-      );
+      installs.push({ agent, version, home: getVersionHomePath(agent, version), info: null, account: undefined });
     }
   }
-  const settled = await Promise.all(tasks);
-  return settled.filter((r): r is AuthProbeRow => r !== null);
+  await Promise.all(
+    installs.map(async (inst) => {
+      inst.info = await getAccountInfo(inst.agent, inst.home).catch(() => null);
+      inst.account = authAccountLabel(inst.info);
+    }),
+  );
+
+  // Probe once per (agent, account); fan the one verdict out to every home in the
+  // group. Groups run in parallel — they target distinct accounts, so there is no
+  // same-account concurrency left to trip the throttle.
+  const perGroup = await Promise.all(
+    groupFleetAuthInstalls(installs).map(async (group): Promise<AuthProbeRow[]> => {
+      const rep = group.probe;
+      const health = await probeAuthHealth(rep.agent, rep.home, { cliVersion: opts?.cliVersion, info: rep.info });
+      health.account = authAccountLabel(rep.info);
+      if (health.verdict === 'unconfigured') return [];
+      return group.members.map((inst) => ({
+        agent: inst.agent,
+        version: inst.version,
+        account: health.account,
+        // A distinct object per row so a later mutation of one can't bleed across.
+        health: { ...health },
+      }));
+    }),
+  );
+  return perGroup.flat();
 }
 
 /** Persist a host's probed rows into the cache (keyed by host+agent+version). */

--- a/apps/cli/src/lib/auth-health.ts
+++ b/apps/cli/src/lib/auth-health.ts
@@ -428,12 +428,11 @@ export function groupFleetAuthInstalls<T extends FleetAuthInstall>(
 ): FleetAuthProbeGroup<T>[] {
   const groups = new Map<string, FleetAuthProbeGroup<T>>();
   for (const inst of installs) {
-    // A NUL byte separates the segments so an account label (which may contain a
-    // space or a literal "ver:") can never collide with the version fallback key
-    // — a version string cannot contain a NUL.
+    // The `acct:` / `ver:` tokens make the two branches disjoint, so an account
+    // label can never collide with a version fallback key no matter its content.
     const key = inst.account && isMergeable(inst)
-      ? `${inst.agent} acct:${inst.account}`
-      : `${inst.agent} ver:${inst.version}`;
+      ? `${inst.agent} acct:${inst.account}`
+      : `${inst.agent} ver:${inst.version}`;
     const existing = groups.get(key);
     if (existing) existing.members.push(inst);
     else groups.set(key, { probe: inst, members: [inst] });

--- a/apps/cli/src/lib/auth-health.ts
+++ b/apps/cli/src/lib/auth-health.ts
@@ -412,20 +412,26 @@ export interface FleetAuthProbeGroup<T extends FleetAuthInstall> {
  * incident {@link file:./usage-backoff.ts} was written to survive; this removes
  * its cause). Grouping by account means N homes on one account issue ONE request.
  *
- * Installs with no resolvable account label are never merged — we cannot prove
- * two of them are the same account — so each becomes its own group keyed by
- * version, preserving the old per-install probe for the un-labelable case
- * (which is also the `unconfigured` case that gets dropped downstream). Pure: no
+ * `isMergeable` scopes the dedup to the installs it actually helps: only agents
+ * that make a network probe ({@link LIVE_PROBE_AGENTS}) can 429, so only they are
+ * merged. A best-effort agent (its verdict is a cheap local file read, no rate
+ * limit) is left per-install — collapsing it would gain nothing and could
+ * silently override one home's local `signedIn` verdict with another's. Installs
+ * with no resolvable account label, or that `isMergeable` rejects, are never
+ * merged: each becomes its own group keyed by version, preserving the old
+ * per-install probe (also the `unconfigured` case dropped downstream). Pure: no
  * fs, no network, so the dedup decision is unit-tested directly.
  */
 export function groupFleetAuthInstalls<T extends FleetAuthInstall>(
   installs: readonly T[],
+  isMergeable: (install: T) => boolean = () => true,
 ): FleetAuthProbeGroup<T>[] {
   const groups = new Map<string, FleetAuthProbeGroup<T>>();
   for (const inst of installs) {
-    // NUL separates the segments so an account label can never collide with the
-    // version fallback key (a version string cannot contain NUL).
-    const key = inst.account
+    // A NUL byte separates the segments so an account label (which may contain a
+    // space or a literal "ver:") can never collide with the version fallback key
+    // — a version string cannot contain a NUL.
+    const key = inst.account && isMergeable(inst)
       ? `${inst.agent} acct:${inst.account}`
       : `${inst.agent} ver:${inst.version}`;
     const existing = groups.get(key);
@@ -473,11 +479,12 @@ export async function probeLocalFleetAuth(opts?: {
     }),
   );
 
-  // Probe once per (agent, account); fan the one verdict out to every home in the
-  // group. Groups run in parallel — they target distinct accounts, so there is no
-  // same-account concurrency left to trip the throttle.
+  // Probe once per (agent, account) — but only for the network-probing agents
+  // that can actually 429; best-effort agents stay per-install (see
+  // groupFleetAuthInstalls). Groups run in parallel: they target distinct
+  // accounts, so no same-account concurrency is left to trip the throttle.
   const perGroup = await Promise.all(
-    groupFleetAuthInstalls(installs).map(async (group): Promise<AuthProbeRow[]> => {
+    groupFleetAuthInstalls(installs, (inst) => LIVE_PROBE_AGENTS.has(inst.agent)).map(async (group): Promise<AuthProbeRow[]> => {
       const rep = group.probe;
       const health = await probeAuthHealth(rep.agent, rep.home, { cliVersion: opts?.cliVersion, info: rep.info });
       health.account = authAccountLabel(rep.info);


### PR DESCRIPTION
**bug fix** — auth-health probe fan-out. No new surface; behavior change to a background probe.

## What & why

The daemon warms auth-health every 3 minutes and `probeLocalFleetAuth` fanned out over **every installed version home concurrently**. A box with several Claude homes signed into one account fired that many concurrent requests at the same provider OAuth endpoint per tick — racing its rate limit into a `429` that then parked the whole box's usage reads behind a `Retry-After` penalty. `usage-backoff.ts` (PR #1764) only *survives* that penalty; this removes its **cause**.

## Fix

- New pure `groupFleetAuthInstalls(installs)` — collapses installs by `(agent, account)`. Homes with no resolvable account label are never merged (each probed individually, as before — that's also the `unconfigured` case that gets dropped downstream).
- `probeLocalFleetAuth` now enumerates installs, resolves each account label (a local, non-networked read), then runs the **live probe once per group** and fans the one verdict out to each home's cache row.
- Each home still gets its own per-version cache row — `authCacheKey` is per-version by design; only the *network probe* is deduped.

No caller signature change (`ssh.ts`, `daemon.ts` unchanged).

## Proof — run against real installed homes on this box

```
Total installed homes: 19  ->  probe groups: 16
LIVE-probe homes (claude/kimi/droid): 12  ->  live probe groups: 9
  DEDUPED claude account=muqsit@getrush.ai: 3 homes -> 1 probe [2.1.181, 2.1.186, 2.1.222]
  DEDUPED claude account=muqsit@trp.so: 2 homes -> 1 probe [2.1.187, 2.1.221]
```

The 3 concurrent same-account probes per tick — the exact 429 trigger — are now 1.

## Tests

`apps/cli/src/lib/auth-health.test.ts` — 6 new cases for `groupFleetAuthInstalls` (same account → 1 group; different accounts / different agents → separate; un-labelable never merged; mixed; empty). Full file `38 passed`. `tsc --noEmit` clean.

Ticket: https://linear.app/getrush/issue/RUSH-2111