### PR TITLE
fix(sessions): cap remote fan-out stdout per peer (RUSH-2065)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2065.md
+++ b/apps/cli/.changelog/next/RUSH-2065.md
@@ -1,0 +1,12 @@
+- **Cross-machine `agents … --json` fan-out caps each peer's stdout at 16 MiB
+  instead of buffering it unbounded (RUSH-2065).** The shared fan-out
+  (`gatherRemoteAgentsJson`, behind `agents sessions --active`, `agents feed`, and
+  every other fleet-wide JSON sweep) streamed each peer's output into memory with
+  no ceiling, under one `Promise.all` — so a single peer returning a corrupt or
+  pathologically large payload could retain ~170 MB and OOM the whole sweep. Each
+  peer's capture now stops and SIGKILLs the connection once it would exceed the
+  ceiling, treating that box as unreachable (reported in `skipped`) so the rest of
+  the fleet still renders. The bound and the UTF-8-safe accumulator now live once
+  in `apps/cli/src/lib/ssh-exec.ts`, shared with the `agents sessions` browse
+  fan-out that already had the guard. Source: `apps/cli/src/lib/remote-agents-json.ts`,
+  `apps/cli/src/lib/ssh-exec.ts`, `apps/cli/src/lib/session/remote-list.ts`.

--- a/apps/cli/src/lib/remote-agents-json.test.ts
+++ b/apps/cli/src/lib/remote-agents-json.test.ts
@@ -1,13 +1,31 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'child_process';
+import { EventEmitter } from 'events';
 import { decodePowershell } from './hosts/remote-cmd.js';
 import {
+  captureBoundedStdout,
   gatherRemoteAgentsJson,
   parseRemoteAgentsJsonPayload,
   remoteAgentsJsonCommand,
+  type CapturableChild,
   type SshCaptureFn,
 } from './remote-agents-json.js';
+import { REMOTE_STDOUT_MAX_BYTES } from './ssh-exec.js';
 import { parseRemoteListPayload } from './session/remote-list.js';
+
+/**
+ * A fake `ssh` child: an EventEmitter for the process-level `error`/`close`
+ * events with a nested emitter standing in for `stdout`, recording every kill so
+ * a test can assert the capture aborted a runaway peer.
+ */
+class FakeChild extends EventEmitter implements CapturableChild {
+  readonly stdout = new EventEmitter();
+  readonly kills: Array<NodeJS.Signals | undefined> = [];
+  kill(signal?: NodeJS.Signals): boolean {
+    this.kills.push(signal);
+    return true;
+  }
+}
 
 describe('remoteAgentsJsonCommand', () => {
   it('guards a POSIX peer against recursive fan-out', () => {
@@ -37,6 +55,47 @@ describe('parseRemoteAgentsJsonPayload', () => {
     );
 
     expect(parsed).toEqual({ items: [], parseFailed: true });
+  });
+});
+
+describe('captureBoundedStdout per-peer stdout cap (RUSH-2065)', () => {
+  it('returns a clean sub-ceiling payload on a zero-exit close', async () => {
+    const child = new FakeChild();
+    const capture = captureBoundedStdout(child, { timeoutMs: 1_000 });
+    child.stdout.emit('data', Buffer.from('[{"id":"a"}]'));
+    child.emit('close', 0);
+    await expect(capture).resolves.toEqual({ code: 0, stdout: '[{"id":"a"}]' });
+    expect(child.kills).toEqual([]); // a well-behaved peer is never killed
+  });
+
+  it('SIGKILLs a peer that overflows the ceiling and settles it as unreachable', async () => {
+    const child = new FakeChild();
+    const capture = captureBoundedStdout(child, { timeoutMs: 5_000 });
+    // First chunk sits exactly at the ceiling (allowed); the next byte trips it.
+    child.stdout.emit('data', Buffer.alloc(REMOTE_STDOUT_MAX_BYTES, 0x20));
+    child.stdout.emit('data', Buffer.from('x'));
+    const result = await capture;
+    expect(result.code).toBeNull(); // overflow → treated as unreachable, not trusted
+    expect(child.kills).toEqual(['SIGKILL']);
+    // The buffer never grew past the ceiling (the tripping byte was dropped).
+    expect(Buffer.byteLength(result.stdout)).toBeLessThanOrEqual(REMOTE_STDOUT_MAX_BYTES);
+  });
+
+  it('does not corrupt a multi-byte code point split across chunks', async () => {
+    const child = new FakeChild();
+    const capture = captureBoundedStdout(child, { timeoutMs: 1_000 });
+    // '€' is 0xE2 0x82 0xAC — split it so a naive per-chunk toString() would mangle it.
+    child.stdout.emit('data', Buffer.from([0xe2, 0x82]));
+    child.stdout.emit('data', Buffer.from([0xac]));
+    child.emit('close', 0);
+    await expect(capture).resolves.toEqual({ code: 0, stdout: '€' });
+  });
+
+  it('settles null on a spawn error without killing', async () => {
+    const child = new FakeChild();
+    const capture = captureBoundedStdout(child, { timeoutMs: 1_000 });
+    child.emit('error', new Error('ENOENT'));
+    await expect(capture).resolves.toEqual({ code: null, stdout: '' });
   });
 });
 

--- a/apps/cli/src/lib/remote-agents-json.ts
+++ b/apps/cli/src/lib/remote-agents-json.ts
@@ -9,7 +9,14 @@
 import { spawn } from 'child_process';
 import { setMaxListeners } from 'node:events';
 import chalk from 'chalk';
-import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from './ssh-exec.js';
+import {
+  SSH_OPTS,
+  controlOpts,
+  assertValidSshTarget,
+  shellQuote,
+  REMOTE_STDOUT_MAX_BYTES,
+  RemoteUtf8Accumulator,
+} from './ssh-exec.js';
 import { sshTargetFor } from './devices/connect.js';
 import { resolveExplicitTargets } from './devices/resolve-target.js';
 import { loadDevices, isControlDevice, isDialableDevice, type DeviceProfile } from './devices/registry.js';
@@ -104,23 +111,46 @@ export function remoteAgentsJsonCommand(args: string[], noFanoutEnv: string, os?
   return `bash -lc ${shellQuote(inner)}`;
 }
 
-const sshCapture: SshCaptureFn = (target, remoteCmd, { timeoutMs, signal }) => {
-  assertValidSshTarget(target);
+/**
+ * The subset of a spawned `ssh` child this capture loop drives. Structural so a
+ * unit test can feed synthetic `data`/`close` events through a fake without a
+ * live SSH connection.
+ */
+export interface CapturableChild {
+  stdout: { on(event: 'data', listener: (chunk: Buffer) => void): unknown } | null;
+  on(event: 'error' | 'close', listener: (arg?: number | null) => void): unknown;
+  kill(signal?: NodeJS.Signals): unknown;
+}
+
+/**
+ * Stream one child's stdout into memory under a hard per-peer byte ceiling.
+ *
+ * A cross-machine fan-out awaits every peer's capture under one `Promise.all`,
+ * so an unbounded buffer means a single runaway peer (a corrupt or
+ * pathologically large payload) exhausts the caller's heap and takes the whole
+ * sweep down — RUSH-2065. Once the accumulated bytes would exceed
+ * {@link REMOTE_STDOUT_MAX_BYTES}, the child is SIGKILLed and the capture settles
+ * as `code: null` (unreachable) rather than trust a truncated body. A definitive
+ * early-exit `signal` SIGTERMs the child the same way, and the timer is the
+ * per-peer deadline.
+ */
+export function captureBoundedStdout(
+  child: CapturableChild,
+  { timeoutMs, signal }: { timeoutMs: number; signal?: AbortSignal },
+): Promise<{ code: number | null; stdout: string }> {
   return new Promise((resolve) => {
-    if (signal?.aborted) {
-      resolve({ code: null, stdout: '' });
-      return;
-    }
-    const args = [...SSH_OPTS, ...controlOpts(), target, remoteCmd];
-    const child = spawn('ssh', args, { stdio: ['ignore', 'pipe', 'ignore'] });
-    let stdout = '';
+    const decoded = new RemoteUtf8Accumulator();
+    let stdoutBytes = 0;
     let settled = false;
     const done = (code: number | null) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       signal?.removeEventListener('abort', onAbort);
-      resolve({ code, stdout });
+      // A killed/aborted capture never cleanly ends its decoder; return what
+      // decoded so far (the caller treats a non-zero code as unreachable and
+      // ignores stdout anyway).
+      resolve({ code, stdout: code === null ? decoded.current() : decoded.end() });
     };
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
@@ -130,10 +160,28 @@ const sshCapture: SshCaptureFn = (target, remoteCmd, { timeoutMs, signal }) => {
     // unreachable peer is not left running to its full timeout.
     const onAbort = () => { child.kill('SIGTERM'); done(null); };
     signal?.addEventListener('abort', onAbort, { once: true });
-    child.stdout.on('data', (data) => { stdout += data.toString(); });
+    child.stdout?.on('data', (data: Buffer) => {
+      // Over the ceiling, SIGKILL the child and treat it as unreachable rather
+      // than trust a partial payload — the RUSH-2065 OOM guard.
+      if (stdoutBytes + data.byteLength > REMOTE_STDOUT_MAX_BYTES) {
+        child.kill('SIGKILL');
+        done(null);
+        return;
+      }
+      stdoutBytes += data.byteLength;
+      decoded.write(data);
+    });
     child.on('error', () => done(null));
-    child.on('close', (code) => done(code));
+    child.on('close', (code) => done(code ?? null));
   });
+}
+
+const sshCapture: SshCaptureFn = (target, remoteCmd, { timeoutMs, signal }) => {
+  assertValidSshTarget(target);
+  if (signal?.aborted) return Promise.resolve({ code: null, stdout: '' });
+  const args = [...SSH_OPTS, ...controlOpts(), target, remoteCmd];
+  const child = spawn('ssh', args, { stdio: ['ignore', 'pipe', 'ignore'] });
+  return captureBoundedStdout(child, { timeoutMs, signal });
 };
 
 /** Query explicit hosts, or every registered online peer when hosts is omitted. */

--- a/apps/cli/src/lib/session/remote-list.ts
+++ b/apps/cli/src/lib/session/remote-list.ts
@@ -14,9 +14,15 @@
  * never fatal — one asleep laptop must not blank the list.
  */
 import { spawn } from 'child_process';
-import { StringDecoder } from 'string_decoder';
 import chalk from 'chalk';
-import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from '../ssh-exec.js';
+import {
+  SSH_OPTS,
+  controlOpts,
+  assertValidSshTarget,
+  shellQuote,
+  REMOTE_STDOUT_MAX_BYTES,
+  RemoteUtf8Accumulator,
+} from '../ssh-exec.js';
 import { sshTargetFor } from '../devices/connect.js';
 import { resolveExplicitTargetSet } from '../devices/resolve-target.js';
 import { loadDevices, isControlDevice, isDialableDevice, type DeviceProfile } from '../devices/registry.js';
@@ -48,31 +54,16 @@ import {
 } from './tool-calls.js';
 
 const REMOTE_TOOL_TIMEOUT_MS = 60_000;
-export const REMOTE_STDOUT_MAX_BYTES = 16 * 1024 * 1024;
+// The per-peer stdout ceiling and the UTF-8-safe accumulator live in ssh-exec.ts
+// (the shared SSH transport both this reader and the top-level `remote-agents-json`
+// fan-out import), so the bound is defined once. Re-exported here for the existing
+// consumers/tests that reach them through this module.
+export { REMOTE_STDOUT_MAX_BYTES, RemoteUtf8Accumulator } from '../ssh-exec.js';
 export const REMOTE_TOOL_AGGREGATE_MAX_BYTES = TOOL_QUERY_MAX_SERIALIZED_BYTES;
 
 export interface RemoteToolByteBudget {
   remainingBytes: number;
   exhausted: boolean;
-}
-
-/** Preserve UTF-8 code points when SSH splits them across stdout chunks. */
-export class RemoteUtf8Accumulator {
-  private readonly decoder = new StringDecoder('utf8');
-  private value = '';
-
-  write(chunk: Buffer): void {
-    this.value += this.decoder.write(chunk);
-  }
-
-  end(): string {
-    this.value += this.decoder.end();
-    return this.value;
-  }
-
-  current(): string {
-    return this.value;
-  }
 }
 
 /** Claim received bytes against one fleet-query budget before retaining them. */

--- a/apps/cli/src/lib/ssh-exec.ts
+++ b/apps/cli/src/lib/ssh-exec.ts
@@ -9,6 +9,7 @@
  */
 
 import { spawn, spawnSync } from 'child_process';
+import { StringDecoder } from 'string_decoder';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getCacheDir } from './state.js';
@@ -52,6 +53,43 @@ export const SSH_OPTS: readonly string[] = [
   '-o', 'ServerAliveInterval=15',
   '-o', 'ServerAliveCountMax=3',
 ];
+
+/**
+ * Hard ceiling on the stdout one peer may return before its capture is aborted.
+ * A cross-machine fan-out streams every peer's `agents … --json` into memory in
+ * parallel, so an unbounded buffer means one runaway peer (a corrupt or
+ * pathologically large payload) can exhaust the caller's heap and take the whole
+ * sweep down with it — RUSH-2065 observed ~170MB retained across a single
+ * `--active` gather. 16 MiB is far above any legitimate JSON listing yet small
+ * enough that N peers in flight stay bounded. A peer that overflows is treated as
+ * unreachable rather than trusted with partial output.
+ */
+export const REMOTE_STDOUT_MAX_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Accumulate SSH stdout as UTF-8 without corrupting a multi-byte code point that
+ * a chunk boundary splits — the streaming `on('data')` callbacks hand us raw
+ * `Buffer`s, and a naive `buf.toString()` per chunk mangles any character the
+ * kernel cut in half. `StringDecoder` holds the trailing partial bytes until the
+ * next chunk completes them.
+ */
+export class RemoteUtf8Accumulator {
+  private readonly decoder = new StringDecoder('utf8');
+  private value = '';
+
+  write(chunk: Buffer): void {
+    this.value += this.decoder.write(chunk);
+  }
+
+  end(): string {
+    this.value += this.decoder.end();
+    return this.value;
+  }
+
+  current(): string {
+    return this.value;
+  }
+}
 
 /**
  * OpenSSH connection-multiplexing options. The first connection to a host opens


### PR DESCRIPTION
**fix — no user-visible surface (reliability / memory-safety guard).** Caps per-peer stdout in the cross-machine JSON fan-out. Ticket: [RUSH-2065](https://linear.app/getrush/issue/RUSH-2065).

## The bug

`gatherRemoteAgentsJson` (`apps/cli/src/lib/remote-agents-json.ts`) is the shared fleet-wide fan-out behind `agents sessions --active`, `agents feed`, and every other cross-machine `agents … --json` sweep. Its `sshCapture` buffered each peer's stdout with **no ceiling**:

```ts
let stdout = '';
child.stdout.on('data', (data) => { stdout += data.toString(); });
```

Every peer runs concurrently under one `Promise.all` (`remote-agents-json.ts:194`), so a single box returning a corrupt or pathologically large payload retains its whole output in memory — ~170 MB observed on one `--active` gather — and can OOM the entire sweep. The naive per-chunk `toString()` also corrupts any UTF-8 code point an SSH chunk boundary splits.

## The fix

- **Per-peer 16 MiB ceiling.** Once a peer's accumulated stdout would exceed `REMOTE_STDOUT_MAX_BYTES`, its connection is SIGKILLed and the capture settles as `code: null` — the peer is treated as **unreachable** (surfaced in the result's `skipped` list) rather than trusted with a truncated body, so the rest of the fleet still renders.
- **UTF-8-safe accumulator** replaces `stdout += data.toString()`, fixing the latent split-code-point corruption.
- **Defined once.** The bound + accumulator move into `apps/cli/src/lib/ssh-exec.ts` — the shared SSH transport both this fan-out and the `agents sessions` browse fan-out (`session/remote-list.ts`) already import. `remote-list.ts` had this exact guard; importing *it* here would be circular (`remote-list.ts` imports `remote-agents-json.ts`), so the shared source is the lower-level `ssh-exec.ts`. No duplicated cap logic.
- **Testable.** The bounded-capture stream loop is extracted into `captureBoundedStdout`, so the overflow → kill → skip path is unit-tested with a synthetic child, no live SSH needed.

## Run result

New tests exercise the real cap path (sub-ceiling clean close, overflow SIGKILL + null, split-code-point integrity, spawn error). Full file green:

```
 RUN  v4.1.9  apps/cli
 ✓ src/lib/remote-agents-json.test.ts (11 tests)
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

`session/remote-list.test.ts` (whose real-SSH `sshCapture` cap tests still pass after the symbol move) and `tsc --noEmit` are also green.

Session transcript (confidential — private repo): `yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.218/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz-agents-cli/cd1ea000-26d8-4082-bad5-4c69d106f5d1.jsonl`
