### PR TITLE
feat(sessions): discover routine runs by name

### DIFF
--- a/apps/cli/.changelog/next/rush-1998-routine-session-discovery.md
+++ b/apps/cli/.changelog/next/rush-1998-routine-session-discovery.md
@@ -1,0 +1,1 @@
+- **Routine session discovery now supports an interactive picker and fuzzy names (RUSH-1998).** `agents sessions --routine` opens a routine picker on a TTY, `--routine <name>` accepts exact, substring, or unambiguous typo matches, and `--routines` is an alias for the same session filter.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -651,7 +651,9 @@ run metadata:
 ```
 
 Those archives are indexed by `agents sessions` with `origin: "routine"`,
-`routineName`, and `routineRunId`. Use `agents sessions --routine --all` to list
+`routineName`, and `routineRunId`. Use `agents sessions --routine --all` (or the
+`--routines` alias) to pick a routine interactively, or pass a fuzzy name such
+as `agents sessions --routine nightly-review --all`, to list
 them, or `agents sessions <run-id>` to render the existing session summary view
 for a specific routine run.
 

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -659,6 +659,8 @@ agents sessions --in-team redesign --teams
 
 # Show routine-run sessions, then open one by routine run id
 agents sessions --routine --all
+agents sessions --routine nightly-review --all
+agents sessions --routines --all      # alias; pick a routine interactively on a TTY
 agents sessions 2026-07-21T10-30-00-000Z
 
 # Sort the list by cost or duration (default: recent)

--- a/apps/cli/src/commands/__tests__/sessions-team-lineage.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-team-lineage.test.ts
@@ -9,7 +9,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { formatPickerLabel, hasNoBrowserDisqualifyingFlags, matchesTeam, resolveRoutineName, teamBadge } from '../sessions.js';
+import { filterSessionsByRoutine, formatPickerLabel, hasNoBrowserDisqualifyingFlags, matchesTeam, resolveRoutineName, teamBadge } from '../sessions.js';
+import { resolveSessionById } from '../../lib/session/discover.js';
 import { formatTeamLineage } from '../sessions-picker.js';
 import type { SessionMeta } from '../../lib/session/types.js';
 
@@ -77,6 +78,16 @@ describe('resolveRoutineName', () => {
   it('rejects missing and ambiguous selectors', () => {
     expect(resolveRoutineName('missing', names)).toBeNull();
     expect(resolveRoutineName('notes', ['release-notes', 'meeting-notes'])).toBeNull();
+  });
+
+  it('removes another routine before a positional session ID can resolve', async () => {
+    const wanted = meta({ id: 'wanted-id', shortId: 'wanted', origin: 'routine', routineName: 'nightly-review' });
+    const other = meta({ id: 'other-id', shortId: 'other', origin: 'routine', routineName: 'security-scan' });
+    const filtered = await filterSessionsByRoutine([wanted, other], 'nightly', false);
+
+    expect(filtered).not.toBeNull();
+    expect(resolveSessionById(filtered!, 'other-id')).toEqual([]);
+    expect(resolveSessionById(filtered!, 'wanted-id')).toEqual([wanted]);
   });
 });
 

--- a/apps/cli/src/commands/__tests__/sessions-team-lineage.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-team-lineage.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { formatPickerLabel, hasNoBrowserDisqualifyingFlags, matchesTeam, teamBadge } from '../sessions.js';
+import { formatPickerLabel, hasNoBrowserDisqualifyingFlags, matchesTeam, resolveRoutineName, teamBadge } from '../sessions.js';
 import { formatTeamLineage } from '../sessions-picker.js';
 import type { SessionMeta } from '../../lib/session/types.js';
 
@@ -62,6 +62,21 @@ describe('hasNoBrowserDisqualifyingFlags — which views the browser can represe
   it('one host qualifies; two do not, because `y` can only copy back one --device', () => {
     expect(hasNoBrowserDisqualifyingFlags({ host: ['zion'] }, undefined)).toBe(true);
     expect(hasNoBrowserDisqualifyingFlags({ host: ['zion', 'mac-mini'] }, undefined)).toBe(false);
+  });
+});
+
+describe('resolveRoutineName', () => {
+  const names = ['nightly-review', 'release-notes', 'security-scan'];
+
+  it('resolves exact, unique substring, and unambiguous typo matches', () => {
+    expect(resolveRoutineName('NIGHTLY-REVIEW', names)).toBe('nightly-review');
+    expect(resolveRoutineName('release', names)).toBe('release-notes');
+    expect(resolveRoutineName('securty-scan', names)).toBe('security-scan');
+  });
+
+  it('rejects missing and ambiguous selectors', () => {
+    expect(resolveRoutineName('missing', names)).toBeNull();
+    expect(resolveRoutineName('notes', ['release-notes', 'meeting-notes'])).toBeNull();
   });
 });
 

--- a/apps/cli/src/commands/__tests__/sessions-team-lineage.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-team-lineage.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { filterSessionsByRoutine, formatPickerLabel, hasNoBrowserDisqualifyingFlags, matchesTeam, resolveRoutineName, teamBadge } from '../sessions.js';
+import { applyScopeFilters, filterSessionsByRoutine, formatPickerLabel, hasNoBrowserDisqualifyingFlags, matchesTeam, resolveRoutineName, teamBadge } from '../sessions.js';
 import { resolveSessionById } from '../../lib/session/discover.js';
 import { formatTeamLineage } from '../sessions-picker.js';
 import type { SessionMeta } from '../../lib/session/types.js';
@@ -88,6 +88,9 @@ describe('resolveRoutineName', () => {
     expect(filtered).not.toBeNull();
     expect(resolveSessionById(filtered!, 'other-id')).toEqual([]);
     expect(resolveSessionById(filtered!, 'wanted-id')).toEqual([wanted]);
+    const globallyScoped = applyScopeFilters([wanted, other], { routine: 'nightly' });
+    expect(resolveSessionById(globallyScoped, 'other-id')).toEqual([]);
+    expect(resolveSessionById(globallyScoped, 'wanted-id')).toEqual([wanted]);
   });
 });
 

--- a/apps/cli/src/commands/sessions-lifecycle.test.ts
+++ b/apps/cli/src/commands/sessions-lifecycle.test.ts
@@ -47,3 +47,13 @@ describe('sessions team filter aliases', () => {
     expect(teams!.short).toBe('--team');
   });
 });
+
+describe('sessions routine discovery surface', () => {
+  it('registers --routines as an alias and accepts an optional routine name', () => {
+    const sessions = sessionsGroup();
+    const routine = sessions.options.find((option) => option.long === '--routine');
+    expect(routine).toBeDefined();
+    expect(routine!.short).toBe('--routines');
+    expect(routine!.optional).toBe(true);
+  });
+});

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1655,7 +1655,7 @@ async function selectRoutineName(names: readonly string[]): Promise<string | nul
   return picked?.item ?? null;
 }
 
-async function filterSessionsByRoutine(
+export async function filterSessionsByRoutine(
   sessions: SessionMeta[],
   routine: boolean | string,
   interactive: boolean,
@@ -2450,6 +2450,14 @@ async function sessionsAction(
       ? 0
       : countSessionsInScope({ ...scope, onlyTeamOrigin: true });
 
+    // A typed routine scope must apply before smart ID routing. Otherwise an ID
+    // from another routine resolves and renders before the routine filter below.
+    if (typeof options.routine === 'string') {
+      const filteredByRoutine = await filterSessionsByRoutine(sessions, options.routine, false);
+      if (!filteredByRoutine) return;
+      sessions = filteredByRoutine;
+    }
+
     // Smart ID routing: a bare query that resolves to one session renders
     // directly. If nothing matches in the scoped window and the query looks
     // like a session ID, widen to global scope (incl. Claude /resume history).
@@ -2473,7 +2481,7 @@ async function sessionsAction(
     }
 
     if (options.json) {
-      if (options.routine) {
+      if (options.routine === true) {
         const filteredByRoutine = await filterSessionsByRoutine(sessions, options.routine, false);
         if (!filteredByRoutine) return;
         sessions = filteredByRoutine;

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -2239,7 +2239,7 @@ async function sessionsAction(
   // When the user explicitly asks to render (via mode flag), resolve the
   // query globally so sessions outside the default cwd/30d window are found.
   if (wantsRender && searchQuery) {
-    await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, filter: filterOpts, redact: options.redact, local: options.local, hosts: options.host });
+    await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, routine: options.routine, filter: filterOpts, redact: options.redact, local: options.local, hosts: options.host });
     return;
   }
 
@@ -2475,7 +2475,7 @@ async function sessionsAction(
         return;
       }
       if (idMatches.length === 0 && looksLikeSessionId(searchQuery)) {
-        await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, filter: filterOpts, redact: options.redact, local: options.local, hosts: options.host });
+        await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, routine: options.routine, filter: filterOpts, redact: options.redact, local: options.local, hosts: options.host });
         return;
       }
     }
@@ -3958,9 +3958,9 @@ function scoreSessionQuery(session: SessionMeta, terms: string[]): number {
  * the project you specified AND elsewhere, producing an ambiguity error
  * even though the user already pointed at the correct scope.
  */
-function applyScopeFilters(
+export function applyScopeFilters(
   sessions: SessionMeta[],
-  scope: { agent?: string; project?: string },
+  scope: { agent?: string; project?: string; routine?: boolean | string },
 ): SessionMeta[] {
   let filtered = sessions;
 
@@ -3983,6 +3983,19 @@ function applyScopeFilters(
       if (wantVersion && s.version !== wantVersion) return false;
       return true;
     });
+  }
+
+  if (scope.routine) {
+    filtered = filtered.filter((session) => session.origin === 'routine');
+    if (typeof scope.routine === 'string') {
+      const names = [...new Set(
+        filtered.map((session) => session.routineName).filter((name): name is string => !!name),
+      )];
+      const selected = resolveRoutineName(scope.routine, names);
+      filtered = selected
+        ? filtered.filter((session) => session.routineName === selected)
+        : [];
+    }
   }
 
   return filtered;
@@ -4039,7 +4052,7 @@ async function renderArtifactsGlobal(
 async function renderOneSession(
   query: string,
   mode: ViewMode,
-  scope: { agent?: string; project?: string; filter: FilterOptions; redact?: boolean; local?: boolean; hosts?: string[] },
+  scope: { agent?: string; project?: string; routine?: boolean | string; filter: FilterOptions; redact?: boolean; local?: boolean; hosts?: string[] },
 ): Promise<void> {
   const spinner = ora().start();
   const tracker = createScanProgressTracker(FIND_VERBS, 'session', spinner);

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -49,6 +49,7 @@ import { renderMarkdown } from '../lib/markdown.js';
 import { AGENTS, colorAgent, resolveAgentName } from '../lib/agents.js';
 import { getShimsDir } from '../lib/state.js';
 import { fuzzyMatch, FUZZY_PRESETS } from '../lib/fuzzy.js';
+import { itemPicker } from '../lib/picker.js';
 import { resolveSessionAlias } from '../lib/session/actor-sidecar.js';
 import { resolveVersionAliasLoose } from '../lib/versions.js';
 import { getAgentsInvocation } from '../lib/daemon.js';
@@ -108,7 +109,7 @@ interface SessionFilterOptions {
   all?: boolean;
   teams?: boolean;
   inTeam?: string;
-  routine?: boolean;
+  routine?: boolean | string;
   since?: string;
   until?: string;
 }
@@ -1626,6 +1627,60 @@ export function hasNoBrowserDisqualifyingFlags(
   );
 }
 
+/** Resolve a typed routine selector by exact name, substring, or one unambiguous typo. */
+export function resolveRoutineName(query: string, names: readonly string[]): string | null {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return null;
+  const exact = names.find((name) => name.toLowerCase() === normalized);
+  if (exact) return exact;
+  const containing = names.filter((name) => name.toLowerCase().includes(normalized));
+  if (containing.length === 1) return containing[0];
+  return fuzzyMatch(query, names, FUZZY_PRESETS.dynamic);
+}
+
+async function selectRoutineName(names: readonly string[]): Promise<string | null> {
+  const picked = await itemPicker<string>({
+    message: 'Select a routine:',
+    items: [...names],
+    filter: (query) => {
+      const normalized = query.trim().toLowerCase();
+      if (!normalized) return [...names];
+      return names.filter((name) => name.toLowerCase().includes(normalized));
+    },
+    labelFor: (name) => name,
+    shortIdFor: (name) => name,
+    emptyMessage: 'No routines match.',
+    enterHint: 'show sessions',
+  });
+  return picked?.item ?? null;
+}
+
+async function filterSessionsByRoutine(
+  sessions: SessionMeta[],
+  routine: boolean | string,
+  interactive: boolean,
+): Promise<SessionMeta[] | null> {
+  const routineNames = [...new Set(
+    sessions.map((session) => session.routineName).filter((name): name is string => !!name),
+  )].sort((a, b) => a.localeCompare(b));
+  let selectedRoutine: string | null = null;
+  if (typeof routine === 'string') {
+    selectedRoutine = resolveRoutineName(routine, routineNames);
+    if (!selectedRoutine) {
+      console.error(chalk.red(`No routine matches "${routine}".`));
+      if (routineNames.length > 0) console.error(chalk.gray(`Available routines: ${routineNames.join(', ')}`));
+      process.exitCode = 1;
+      return null;
+    }
+  } else if (interactive) {
+    selectedRoutine = await selectRoutineName(routineNames);
+    if (!selectedRoutine) return null;
+  }
+  return selectedRoutine
+    ? sessions.filter((session) => session.routineName === selectedRoutine)
+    : sessions;
+}
+
 /** The canonical `ag sessions …` command for a set of flags — the twin of the
  * browser's `y` hotkey (see --print-cmd). Normalizes to the stable flag form. */
 function canonicalSessionsCommand(query: string | undefined, options: SessionsOptions): string {
@@ -1641,7 +1696,10 @@ function canonicalSessionsCommand(query: string | undefined, options: SessionsOp
   if (options.unknown) a.push('--unknown');
   if (options.teams) a.push('--teams');
   if (options.inTeam) a.push('--in-team', options.inTeam);
-  if (options.routine) a.push('--routine');
+  if (options.routine) {
+    a.push('--routine');
+    if (typeof options.routine === 'string') a.push(options.routine);
+  }
   if (options.agent) a.push('-a', options.agent);
   for (const h of options.host ?? []) a.push('--device', h);
   if (options.project) a.push('--project', options.project);
@@ -2415,6 +2473,11 @@ async function sessionsAction(
     }
 
     if (options.json) {
+      if (options.routine) {
+        const filteredByRoutine = await filterSessionsByRoutine(sessions, options.routine, false);
+        if (!filteredByRoutine) return;
+        sessions = filteredByRoutine;
+      }
       // An id-shaped query resolves by id ONLY — the same rule the render path
       // uses (resolveSessionQuery). Without this a `--json <uuid>` (as issued by
       // the fleet locate sweep, which runs `sessions <uuid> --json --local` on
@@ -2454,6 +2517,12 @@ async function sessionsAction(
       } finally {
         fanSpinner?.stop();
       }
+    }
+
+    if (options.routine) {
+      const filteredByRoutine = await filterSessionsByRoutine(sessions, options.routine, isInteractive);
+      if (!filteredByRoutine) return;
+      sessions = filteredByRoutine;
     }
 
     if (sessions.length === 0) {
@@ -4455,7 +4524,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--unmanaged', "Also show sessions from your own ~/.<agent> installs (hidden once agents-cli manages that agent)")
     .option('--team, --teams', 'Include team-spawned sessions (hidden by default)')
     .option('--in-team <name>', "Only this team: the session that spawned it plus (with --teams) its teammates. Spans every directory and all time, since a team's worktrees and history sit outside the default window.")
-    .option('--routine', 'Show only sessions archived from routine runs')
+    .option('--routines, --routine [name]', 'Show routine-run sessions; omit the name on a TTY to pick one interactively (fuzzy name matching)')
     .option('-p, --project <name>', 'Filter by project name (searches across all directories)')
     .option('--skill <name>', 'Only sessions that invoked this skill (matches a bare name or a namespaced plugin skill\'s short name, e.g. --skill design finds rush:design)')
     .option('--plugin <name>', 'Only sessions that used a skill/command owned by this plugin')
@@ -4545,6 +4614,7 @@ export function registerSessionsCommands(program: Command): void {
 
       # Show routine-run sessions and open one by routine run id
       agents sessions --routine --all
+      agents sessions --routine nightly-review --all
       agents sessions 2026-07-21T10-30-00-000Z
 
       # Export for analysis
@@ -4591,7 +4661,7 @@ export function registerSessionsCommands(program: Command): void {
       - --first and --last are mutually exclusive.
       - A filter flag (--include/--exclude/--first/--last) without --markdown/--json defaults to --markdown output.
       - --cloud sources from Rush Cloud captured runs instead of local disk.
-      - --routine shows only transcripts archived from routine run directories; routine rows also resolve by run id.
+      - --routine [name] shows transcripts archived from routine runs. On a TTY, omit the name to pick a routine; a name accepts exact, substring, or unambiguous typo matches. --routines is an alias. Routine rows also resolve by run id.
       - Without --teams, team-spawned sessions are hidden by default.
     `,
   });


### PR DESCRIPTION
Adds interactive and fuzzy routine-session discovery for CLI users.

## What changed

- `agents sessions --routine` opens a routine picker on a TTY; non-TTY keeps listing all routine sessions.
- `--routine <name>` resolves exact, unique substring, or unambiguous typo matches.
- `--routines` aliases `--routine`.
- Updates sessions/routines docs and queues the changelog fragment.

## Verification

No graphical surface: this is a terminal-only command change.

- `bun run build`
- 30 focused tests passed
- Live TTY run showed `Select a routine:` and selected `pr1730-cursor-default-e2e`
- Real indexed typo query returned `{"count":1,"names":["pr1730-cursor-default-e2e"]}`
- Real alias query returned `{"count":1,"names":["xtrack-cursor"]}`
- Full local suite: 10,219 passed; 17 host-state failures unrelated to this diff (locked Hetzner bundle, missing Rush CLI, host-global state). Clean CI is the merge gate.

## Tracking

- [RUSH-1998](https://linear.app/getrush/issue/RUSH-1998)