### PR TITLE
feat(insights): split silent stalls by harness and model

### DIFF
--- a/apps/cli/.changelog/next/insights-stalls-by-model.md
+++ b/apps/cli/.changelog/next/insights-stalls-by-model.md
@@ -1,0 +1,5 @@
+- **`agents insights` splits silent stalls by harness and model.** The By-agent/account
+  table now shows per-group stall and resume-nudge counts (so laziness is visible without
+  `--json`). Stalls are also attributed to the model that last spoke
+  (`silentStallsByModel`, "Silent stalls by model" section). Extractor version 6.
+  Source: `apps/cli/src/lib/session/insights.ts`, `commands/insights.ts`.

--- a/apps/cli/src/commands/insights.ts
+++ b/apps/cli/src/commands/insights.ts
@@ -278,20 +278,35 @@ function renderReport(groups: GroupReport[], dim: GroupDim, meta: ReportMeta, ac
   }
 
   // Per-group table — the headline, and the thing no sibling command produces.
+  // Includes silent-stall counts so harness/account laziness is visible without --json.
   out.push('');
   out.push(chalk.bold(`By ${dim}`));
   const labelW = Math.min(
     Math.max(...groups.map((g) => stringWidth(g.label)), 5),
-    Math.max(20, terminalWidth() - 46),
+    Math.max(16, terminalWidth() - 58),
   );
   const sessW = Math.max(...groups.map((g) => String(g.sessions).length), 3);
+  const stallOf = (g: GroupReport): number =>
+    Object.entries(g.facets.frictionSignals)
+      .filter(([k]) => k.startsWith('silent stall:'))
+      .reduce((n, [, c]) => n + c, 0);
+  const resumeOf = (g: GroupReport): number =>
+    g.facets.correctionSignals['resume after silent stall'] ?? 0;
+  const stallW = Math.max(...groups.map((g) => String(stallOf(g)).length), 5);
+  out.push(chalk.gray(
+    `  ${padToWidth('', labelW)}  ${''.padStart(sessW)}       ` +
+    `${''.padStart(9)}  ${''.padStart(8)}  ${'stalls'.padStart(stallW)}  resume`,
+  ));
   for (const g of groups) {
     const cost = g.costUsd > 0 ? formatUsd(g.costUsd) : '—';
     const dur = g.durationMs > 0 ? formatDuration(g.durationMs) : '—';
+    const stalls = stallOf(g);
+    const resumes = resumeOf(g);
     out.push(
       `  ${padToWidth(truncateToWidth(g.label, labelW), labelW)}  ` +
       `${chalk.gray(String(g.sessions).padStart(sessW))} ${chalk.gray('sess')}  ` +
-      `${chalk.green(padToWidth(cost, 9))}  ${chalk.gray(dur)}`,
+      `${chalk.green(padToWidth(cost, 9))}  ${chalk.gray(padToWidth(dur, 8))}  ` +
+      `${chalk.cyan(String(stalls).padStart(stallW))}  ${chalk.cyan(String(resumes))}`,
     );
   }
 
@@ -302,6 +317,7 @@ function renderReport(groups: GroupReport[], dim: GroupDim, meta: ReportMeta, ac
   renderCounts('Top tools', topEntries(all.toolCounts, 8), out);
   renderCounts('Languages', topEntries(all.languages, 6), out);
   renderCounts('Models', topEntries(all.models, 6), out);
+  renderCounts('Silent stalls by model', topEntries(all.silentStallsByModel ?? {}, 8), out);
 
   // Friction — the section that earns the command.
   const gaps = all.responseGaps;
@@ -323,7 +339,7 @@ function renderReport(groups: GroupReport[], dim: GroupDim, meta: ReportMeta, ac
   }
   if (silentStalls > 0) {
     out.push(`  ${padToWidth('silent stalls', 18)}  ${chalk.cyan(String(silentStalls))}` +
-      chalk.gray('   agent idle ≥5m until you resumed'));
+      chalk.gray('   agent idle ≥5m until you resumed (also in By ' + dim + ' table)'));
   }
   if (resumeNudges > 0) {
     out.push(`  ${padToWidth('resume nudges', 18)}  ${chalk.cyan(String(resumeNudges))}` +

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -316,8 +316,8 @@ CREATE TABLE IF NOT EXISTS session_insights (
  * re-derives on the next `agents insights` instead of silently reporting stale
  * numbers alongside fresh ones. Same role as RESOURCE_INDEX_VERSION.
  */
-/** Bump when facet extraction changes so cached rows recompute (silent-stall v5). */
-export const INSIGHTS_EXTRACTOR_VERSION = 5;
+/** Bump when facet extraction changes so cached rows recompute (stalls-by-model v6). */
+export const INSIGHTS_EXTRACTOR_VERSION = 6;
 
 /** Raw row shape returned from the sessions table. */
 export interface SessionRow {

--- a/apps/cli/src/lib/session/insights.test.ts
+++ b/apps/cli/src/lib/session/insights.test.ts
@@ -149,6 +149,20 @@ describe('computeInsightFacets', () => {
     expect(f.responseGaps).toContain(120);
   });
 
+  it('attributes silent stalls to the model that last spoke (laziness split)', () => {
+    const f = computeInsightFacets([
+      userMsg(0, 'go'),
+      { type: 'usage', agent: 'claude', timestamp: at(5), model: 'claude-opus-4-8-20250514' } as SessionEvent,
+      asstMsg(10, 'working'),
+      userMsg(10 + 600, 'continue'),
+      { type: 'usage', agent: 'claude', timestamp: at(700), model: 'claude-sonnet-4-20250514' } as SessionEvent,
+      asstMsg(710, 'more'),
+      userMsg(710 + 1200, 'ok'),
+    ], 0);
+    expect(f.silentStallsByModel['opus-4-8']).toBe(1);
+    expect(f.silentStallsByModel['sonnet-4']).toBe(1);
+  });
+
   it('emits a high-priority action for resume-after-silent-stall patterns', () => {
     const facets = computeInsightFacets([
       userMsg(0, 'ship it'),

--- a/apps/cli/src/lib/session/insights.ts
+++ b/apps/cli/src/lib/session/insights.ts
@@ -86,6 +86,12 @@ export interface InsightFacets {
   toolCounts: Record<string, number>;
   /** Per-model assistant turn counts. `/insights` has no model dimension at all. */
   models: Record<string, number>;
+  /**
+   * Silent stalls attributed to the model that last spoke before the idle gap
+   * (from the nearest preceding `usage`/message model tag). Some models go
+   * quiet more often — this is the laziness split. Key = shortened model id.
+   */
+  silentStallsByModel: Record<string, number>;
   languages: Record<string, number>;
   /** Slash commands the user invoked, by name. */
   slashCommands: Record<string, number>;
@@ -139,7 +145,8 @@ export interface InsightFacets {
 
 function emptyFacets(): InsightFacets {
   return {
-    toolCounts: {}, models: {}, languages: {}, slashCommands: {}, errorCategories: {},
+    toolCounts: {}, models: {}, silentStallsByModel: {}, languages: {},
+    slashCommands: {}, errorCategories: {},
     interruptions: 0, responseGaps: [], gapsOverCeiling: 0,
     linesTouchedBefore: 0, linesTouchedAfter: 0, editingToolCalls: 0,
     filesCreated: 0, filesModified: 0, filesDeleted: 0, gitCommits: 0, gitPushes: 0,
@@ -237,6 +244,8 @@ export function computeInsightFacets(
   // ("continue", "keep going", or any later message after minutes of silence). This is
   // the inverse framing of reply latency: same timestamps, attributed to the agent.
   let lastAssistantTs: number | null = null;
+  /** Shortened model id of the last assistant activity (for stall attribution). */
+  let lastAssistantModel: string | null = null;
   let lastFailedTool: string | null = null;
 
   for (const e of events) {
@@ -251,7 +260,14 @@ export function computeInsightFacets(
       case 'usage':
         // shortenModel so the label matches `agents sessions <id>` and `insights mix`
         // rather than printing the raw id beside their shortened one.
-        if (e.model) bump(f.models, shortenModel(e.model));
+        if (e.model) {
+          const m = shortenModel(e.model);
+          bump(f.models, m);
+          // Usage rows are the reliable model tag for Claude turns; keep as
+          // "last model" even when the timestamp is missing so a following
+          // tool_use still attributes a stall correctly.
+          lastAssistantModel = m;
+        }
         break;
 
       case 'error':
@@ -268,6 +284,7 @@ export function computeInsightFacets(
       case 'message':
         if (e.role === 'assistant') {
           if (hasTs) lastAssistantTs = ts;
+          if (e.model) lastAssistantModel = shortenModel(e.model);
           break;
         }
         if (e.role !== 'user') break;
@@ -292,6 +309,7 @@ export function computeInsightFacets(
             // Agent silent stall: model stopped; session sat idle until this message.
             if (gap >= SILENT_STALL_SECONDS) {
               classifySilentStall(gap, e.content ?? '', f.frictionSignals, f.correctionSignals);
+              bump(f.silentStallsByModel, lastAssistantModel ?? 'unknown');
             }
           }
         }
@@ -302,6 +320,7 @@ export function computeInsightFacets(
       case 'tool_use': {
         if (e._local) break;
         if (hasTs) lastAssistantTs = ts;
+        if (e.model) lastAssistantModel = shortenModel(e.model);
         const args = e.args ?? {};
         const toolName = e.tool ?? '';
         if (/askuserquestion/i.test(toolName)) classifyAskStall(args, f.correctionSignals);
@@ -495,6 +514,7 @@ export function detectOverlap(spans: SessionSpan[]): OverlapReport {
 export function mergeFacets(into: InsightFacets, add: InsightFacets): void {
   for (const [k, v] of Object.entries(add.toolCounts)) bump(into.toolCounts, k, v);
   for (const [k, v] of Object.entries(add.models)) bump(into.models, k, v);
+  for (const [k, v] of Object.entries(add.silentStallsByModel ?? {})) bump(into.silentStallsByModel, k, v);
   for (const [k, v] of Object.entries(add.languages)) bump(into.languages, k, v);
   for (const [k, v] of Object.entries(add.slashCommands)) bump(into.slashCommands, k, v);
   for (const [k, v] of Object.entries(add.errorCategories)) bump(into.errorCategories, k, v);


### PR DESCRIPTION
**feat** — silent stalls split by harness (By agent table) and by model (`silentStallsByModel`).

## Why

Some models/harnesses go silent more than others. Fleet-wide stall totals hide that. This surfaces laziness per harness in the default table, and attributes each stall to the model that last spoke.

## What

| Surface | Change |
|---|---|
| By agent/account table | columns: stalls + resume nudges per group |
| Silent stalls by model | new count section (from last-speaking model tag) |
| JSON | `silentStallsByModel` on each group + facets |
| Extractor | v6 |

## Tests

```
bun run test -- src/lib/session/insights.test.ts
29 passed
```

Includes model-attribution unit test.

## Prior live proof (extractor v5, by agent, 7d local)

| Harness | sessions | silent stalls | resume nudges |
|---|---:|---:|---:|
| claude | 380 | 259 | 52 |
| codex | 129 | 35 | 6 |

(Installed PATH `agents` was still pre-feature — 0 stall keys until run from main build.)
