### PR TITLE
fix(menubar): prefer newest helper owner

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 1.22.26
 
-- **The newest signed agents-cli installation now owns the menu-bar helper (#2210).** A newer release takes over immediately even during the legacy ownership cooldown, while an older installation can no longer replace a newer helper and equal-version installations keep the existing owner stable. Missing-helper, Developer-ID repair, missing-owner, and unversioned legacy recovery paths are unchanged.
-
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 
 - **`agents apply --provision-secrets` pushes the manifest's declared secrets

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.22.26
 
+- **The newest signed agents-cli installation now owns the menu-bar helper (#2210).** A newer release takes over immediately even during the legacy ownership cooldown, while an older installation can no longer replace a newer helper and equal-version installations keep the existing owner stable. Missing-helper, Developer-ID repair, missing-owner, and unversioned legacy recovery paths are unchanged.
+
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 
 - **`agents apply --provision-secrets` pushes the manifest's declared secrets

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -202,6 +202,8 @@ describe('mayInstallMenubarHelper', () => {
   const base = {
     helperExecMissing: false,
     needsDevIdHeal: false,
+    installedVersion: null,
+    currentVersion: null,
     msSinceLastHeal: 60_000,
     cooldownMs: HOUR,
     sourceIsDeveloperId: true,
@@ -224,13 +226,45 @@ describe('mayInstallMenubarHelper', () => {
     })).toBe(true);
   });
 
-  it('lets another install take over once the owner is gone from disk', () => {
+  it('lets a newer signed release take over inside the cooldown', () => {
     expect(mayInstallMenubarHelper({
-      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: false,
+      ...base, plistEntry: nvm, activeEntry: brew, ownerEntryExists: true,
+      installedVersion: '1.22.5', currentVersion: '1.22.25',
     })).toBe(true);
   });
 
-  it('lets a foreign install take over after the cooldown, so nobody is stranded', () => {
+  it('never lets an older release reclaim a newer helper', () => {
+    expect(mayInstallMenubarHelper({
+      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
+      installedVersion: '1.22.25', currentVersion: '1.22.5',
+      msSinceLastHeal: HOUR + 1,
+    })).toBe(false);
+  });
+
+  it('never lets an older release reinstall through a formerly owner-shaped entry', () => {
+    expect(mayInstallMenubarHelper({
+      ...base, plistEntry: nvm, activeEntry: nvm, ownerEntryExists: true,
+      installedVersion: '1.22.25', currentVersion: '1.22.5',
+      msSinceLastHeal: HOUR + 1,
+    })).toBe(false);
+  });
+
+  it('keeps the existing owner stable for an equal-version foreign install', () => {
+    expect(mayInstallMenubarHelper({
+      ...base, plistEntry: nvm, activeEntry: brew, ownerEntryExists: true,
+      installedVersion: '1.22.25', currentVersion: '1.22.25',
+      msSinceLastHeal: HOUR + 1,
+    })).toBe(false);
+  });
+
+  it('lets another install take over once the owner is gone from disk', () => {
+    expect(mayInstallMenubarHelper({
+      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: false,
+      installedVersion: '1.22.25', currentVersion: '1.22.5',
+    })).toBe(true);
+  });
+
+  it('lets a foreign install take over after the cooldown in unversioned legacy state', () => {
     // The stuck state a pure ownership rule creates: a stale-but-present install
     // (an old nvm node dir nobody runs) owns the plist while the user's daily
     // driver upgrades. Refusing forever would freeze the menu bar at whatever the
@@ -254,6 +288,7 @@ describe('mayInstallMenubarHelper', () => {
     expect(mayInstallMenubarHelper({
       ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
       helperExecMissing: true,
+      installedVersion: '1.22.25', currentVersion: '1.22.5',
     })).toBe(true);
   });
 
@@ -262,6 +297,7 @@ describe('mayInstallMenubarHelper', () => {
     expect(mayInstallMenubarHelper({
       ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
       needsDevIdHeal: true,
+      installedVersion: '1.22.25', currentVersion: '1.22.5',
     })).toBe(true);
   });
 
@@ -288,6 +324,7 @@ describe('mayInstallMenubarHelper', () => {
   it('adopts a plist that records no owner yet (older install)', () => {
     expect(mayInstallMenubarHelper({
       ...base, plistEntry: null, activeEntry: brew, ownerEntryExists: false,
+      installedVersion: '1.22.25', currentVersion: '1.22.5',
     })).toBe(true);
   });
 

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -24,6 +24,7 @@ import { sleepSync } from '../fs-atomic.js';
 import { getRuntimeStateDir, getHelpersDir } from '../state.js';
 import { getCliVersion, resolveAgentsBin, resolveInstalledLayout } from '../version.js';
 import { copyAppBundle, withInstallLock } from '../app-bundle-install.js';
+import { compareVersions } from '../agent-spec/primitives.js';
 
 const APP_BUNDLE_NAME = 'MenubarHelper.app';
 const INSTALL_DIR_NAME = 'agents-cli';
@@ -499,12 +500,11 @@ export function disableMenubarService(): void {
  * different CDHashes. Any digest gate therefore reports "changed" for exactly
  * the skew case it was meant to exempt.
  *
- * So ownership decides instead: the plist's `AGENTS_ENTRY` names the owner, and
- * only the owner may reinstall. A non-owner takes over only once the recorded
- * owner is gone from disk, which is what makes the rule converge — a dead
- * install cannot hold the helper hostage, and a live one cannot be fought over.
- * A same-install upgrade keeps its entry path, so `npm update` still installs
- * the new helper normally. Pure so the truth table is unit-testable.
+ * So the installed version decides release skew: a newer signed release takes
+ * ownership immediately, an older release cannot downgrade it, and equal foreign
+ * releases retain the recorded owner. The plist's `AGENTS_ENTRY` remains the
+ * ownership signal for legacy state with no version marker, where the cooldown
+ * bounds takeover churn. Pure so the truth table is unit-testable.
  */
 export function mayInstallMenubarHelper(opts: {
   /** `AGENTS_ENTRY` baked into the installed plist — the recorded owner. */
@@ -517,6 +517,10 @@ export function mayInstallMenubarHelper(opts: {
   helperExecMissing: boolean;
   /** Installed copy is ad-hoc while the shipped source is Developer ID. */
   needsDevIdHeal: boolean;
+  /** Version stamped beside the installed helper, or null for legacy state. */
+  installedVersion: string | null;
+  /** Version of the agents-cli install now attempting the heal. */
+  currentVersion: string | null;
   /** ms since the last self-heal reinstall, or null if none is recorded. */
   msSinceLastHeal: number | null;
   /** How long a non-owner waits before it may take over. */
@@ -533,8 +537,14 @@ export function mayInstallMenubarHelper(opts: {
   if (!opts.activeEntry) return false;
   // No owner recorded yet (fresh or pre-`AGENTS_ENTRY` plist) — adopt it.
   if (!opts.plistEntry) return true;
-  if (opts.plistEntry === opts.activeEntry) return true; // we are the owner
   if (!opts.ownerEntryExists) return true; // the recorded owner is gone
+  if (opts.installedVersion && opts.currentVersion) {
+    const versionOrder = compareVersions(opts.currentVersion, opts.installedVersion);
+    if (versionOrder > 0) return opts.sourceIsDeveloperId;
+    if (versionOrder < 0) return false;
+    return opts.plistEntry === opts.activeEntry;
+  }
+  if (opts.plistEntry === opts.activeEntry) return true; // we are the owner
   // A foreign install while the owner still exists. Refusing outright bounds the
   // loop but strands the user when the recorded owner is a stale copy that simply
   // still sits on disk (an old nvm node dir) while their daily driver upgrades:
@@ -554,7 +564,8 @@ export function mayInstallMenubarHelper(opts: {
 }
 
 /**
- * How long a non-owner install waits before it may take the helper over. Long
+ * How long a non-owner install waits before it may take an unversioned legacy
+ * helper over. Long
  * enough that a multi-install box restarts the helper at most once an hour
  * instead of every few seconds; short enough that a user who switched installs
  * gets their upgrade without hunting for `agents menubar setup`.
@@ -593,6 +604,8 @@ function mayHealMenubar(needsDevIdHeal: boolean): boolean {
     ownerEntryExists: Boolean(plistEntry) && fs.existsSync(plistEntry as string),
     helperExecMissing: !fs.existsSync(installedExecutablePath()),
     needsDevIdHeal,
+    installedVersion: readInstalledMenubarVersion(),
+    currentVersion: getCliVersion(),
     msSinceLastHeal: msSinceLastMenubarHeal(),
     cooldownMs: MENUBAR_TAKEOVER_COOLDOWN_MS,
     sourceIsDeveloperId: Boolean(src) && hasDeveloperIdSignature(src as string),


### PR DESCRIPTION
Fixes #2210

## What changed

- Compare the active CLI release with the installed helper marker before legacy ownership arbitration.
- Let a newer Developer-ID release take over immediately; deny older downgrades; keep equal-version foreign ownership stable.
- Preserve missing-helper, Developer-ID repair, missing-owner, unresolved-entry, and unversioned cooldown behavior.

## Run evidence

- `bun test src/lib/menubar/install-menubar.test.ts` → `44 pass, 0 fail, 61 expect() calls`.
- `bun run build` → exit 0 (`tsc` and dist assembly completed).
- `bun run test` → suite ran; 3 unrelated host-dependent failures: `hooks.test.ts` home-directory `EPERM`, `usage.test.ts` Keychain authorization, and `models.test.ts` installed Codex catalog reasoning metadata.
- `bun run test:remote` / `scripts/sandbox.sh` unavailable: `HCLOUD_TOKEN is empty after secret resolution`.
- `git diff --check` → clean.

No user-visible UI surface is changed by this PR; the delivered surface is the pure ownership predicate and its regression suite.