### PR TITLE
fix(sessions): count Windows hosts in agents output token burn (RUSH-2286)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2286-windows-burn.md
+++ b/apps/cli/.changelog/next/RUSH-2286-windows-burn.md
@@ -1,0 +1,19 @@
+- **`agents output` and the session index no longer under-count Windows hosts
+  (RUSH-2286).** A Windows box could report zero token burn / zero sessions even
+  when it was actively used, because two per-harness scanners in
+  `session/discover.ts` failed on Windows: the OpenClaw scan gated on `which
+  openclaw`, which is POSIX-only (`which` throws ENOENT on Windows, so the whole
+  OpenClaw scan silently returned before indexing anything), and the Grok scanner
+  recovered a session's version from `summary.grok_home` with a `/`-only regex
+  that never matched a backslash-separated Windows path. The OpenClaw presence
+  check now uses the cross-platform `hasCommand`, its `openclaw` invocations route
+  through `execFileShellSpec` so a Windows `.cmd`/`.ps1` shim actually launches,
+  and the Grok version regex normalizes separators first. Separately, JSON relayed
+  from a Windows peer over SSH (`agents output --host <win> --json`,
+  `agents sessions … --json`) is now stripped of any PowerShell `#< CLIXML`
+  banner before parsing (`stripClixml` in `hosts/remote-cmd.ts`), so a fleet-wide
+  rollup that folds in a Windows box no longer drops it on a `JSON.parse` failure.
+  Source: `apps/cli/src/lib/session/discover.ts`,
+  `apps/cli/src/lib/hosts/remote-cmd.ts`,
+  `apps/cli/src/lib/remote-agents-json.ts`,
+  `apps/cli/src/lib/session/remote-list.ts`, `apps/cli/src/commands/output.ts`.

--- a/apps/cli/.changelog/next/RUSH-2286-windows-burn.md
+++ b/apps/cli/.changelog/next/RUSH-2286-windows-burn.md
@@ -13,7 +13,11 @@
   `agents sessions … --json`) is now stripped of any PowerShell `#< CLIXML`
   banner before parsing (`stripClixml` in `hosts/remote-cmd.ts`), so a fleet-wide
   rollup that folds in a Windows box no longer drops it on a `JSON.parse` failure.
+  The banner strip is applied at every remote-`--json` boundary a Windows peer's
+  output flows through: the `remote-agents-json` fan-out, the session
+  `remote-list` list/payload/tool-search parsers, the `--host` fleet passthrough
+  (`agents view --host all`), and `agents output`'s per-device fetch.
   Source: `apps/cli/src/lib/session/discover.ts`,
-  `apps/cli/src/lib/hosts/remote-cmd.ts`,
+  `apps/cli/src/lib/hosts/remote-cmd.ts`, `apps/cli/src/lib/hosts/passthrough.ts`,
   `apps/cli/src/lib/remote-agents-json.ts`,
   `apps/cli/src/lib/session/remote-list.ts`, `apps/cli/src/commands/output.ts`.

--- a/apps/cli/src/commands/output.ts
+++ b/apps/cli/src/commands/output.ts
@@ -31,6 +31,7 @@ import { terminalWidth, truncateToWidth, padToWidth } from '../lib/session/width
 import { collectGitOutput } from '../lib/output/git-output.js';
 import { loadDevices, isControlDevice } from '../lib/devices/registry.js';
 import { machineId } from '../lib/session/sync/config.js';
+import { stripClixml } from '../lib/hosts/remote-cmd.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -200,7 +201,9 @@ async function fetchRemotePayload(device: string, options: OutputOptions): Promi
       timeout: 120_000,
       maxBuffer: 64 * 1024 * 1024,
     });
-    const parsed = JSON.parse(stdout) as OutputPayload;
+    // A Windows device relays its payload through PowerShell, which can prefix a
+    // CLIXML banner ahead of the JSON — strip it before parsing (RUSH-2286).
+    const parsed = JSON.parse(stripClixml(stdout)) as OutputPayload;
     parsed.machine = parsed.machine || device;
     return parsed;
   } catch (err: any) {

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -25,6 +25,7 @@ import { dispatchAgentsCommand, withActorEnv } from './dispatch.js';
 import {
   stripRoutingFlags,
   buildRemoteAgentsInvocation,
+  stripClixml,
   HOST_ROUTING_SPECS,
   type StripSpec,
 } from './remote-cmd.js';
@@ -231,7 +232,9 @@ function buildFleetForwardedArgs(allArgs: string[]): string[] {
 /** Parse stdout as JSON; on failure return an object describing the error. */
 function safeJsonParse(stdout: string): unknown {
   try {
-    return JSON.parse(stdout);
+    // A Windows device relays its `--json` through PowerShell, which can prefix a
+    // CLIXML banner ahead of the payload — strip it before parsing (RUSH-2286).
+    return JSON.parse(stripClixml(stdout));
   } catch {
     return { parseError: 'invalid JSON', snippet: stdout.trim().slice(0, 200) };
   }

--- a/apps/cli/src/lib/hosts/remote-cmd.test.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.test.ts
@@ -49,6 +49,24 @@ describe('stripClixml', () => {
   it('yields empty output when the whole stream is CLIXML (no real payload)', () => {
     expect(stripClixml(CLIXML_BANNER)).toBe('');
   });
+
+  it('strips two consecutive CLIXML flushes', () => {
+    const payload = '{"outputTokens":9}';
+    expect(stripClixml(CLIXML_BANNER + '\n' + CLIXML_BANNER + '\n' + payload)).toBe(payload);
+  });
+
+  it('does NOT delete a legitimate JSON value that merely quotes CLIXML text', () => {
+    // A real CLIXML banner is present (so the guard fires), and the payload's own
+    // string fields contain the literal substrings `<Objs` and `</Objs>`. A naive
+    // global `<Objs>…</Objs>` strip would silently delete the JSON between them;
+    // the banner-anchored strip must leave the payload intact.
+    const payload = '{"topic":"debug <Objs> parsing","label":"</Objs> handler","outputTokens":5}';
+    const cleaned = stripClixml(CLIXML_BANNER + '\n' + payload);
+    const parsed = JSON.parse(cleaned);
+    expect(parsed.topic).toBe('debug <Objs> parsing');
+    expect(parsed.label).toBe('</Objs> handler');
+    expect(parsed.outputTokens).toBe(5);
+  });
 });
 
 /** Decode the PowerShell script a Windows `--host` invocation ships, by pulling

--- a/apps/cli/src/lib/hosts/remote-cmd.test.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.test.ts
@@ -9,9 +9,47 @@ import {
   remoteShellFor,
   powershellQuote,
   decodePowershell,
+  stripClixml,
   HOST_ROUTING_SPECS,
   type StripSpec,
 } from './remote-cmd.js';
+
+describe('stripClixml', () => {
+  // The exact banner + progress element a live win-mini (PowerShell 5.1) emits
+  // ahead of relayed output — the RUSH-2286 reproduction.
+  const CLIXML_BANNER =
+    '#< CLIXML\n' +
+    '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">' +
+    '<Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T>' +
+    '<T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record">' +
+    '<AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC>' +
+    '<T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>';
+
+  it('leaves clean stdout untouched (no CLIXML marker → identity)', () => {
+    const json = '{"burn":{"outputTokens":123}}';
+    expect(stripClixml(json)).toBe(json);
+    expect(stripClixml('[]')).toBe('[]');
+  });
+
+  it('strips the banner + <Objs> block prefixed to a JSON payload so it parses', () => {
+    const payload = '[{"id":"abc","outputTokens":42}]';
+    const polluted = CLIXML_BANNER + '\n' + payload;
+    const cleaned = stripClixml(polluted);
+    expect(cleaned).toBe(payload);
+    expect(() => JSON.parse(cleaned)).not.toThrow();
+    expect(JSON.parse(cleaned)[0].outputTokens).toBe(42);
+  });
+
+  it('strips a CLIXML block appended after the JSON payload', () => {
+    const payload = '{"burn":{"outputTokens":7}}';
+    const polluted = payload + '\n' + CLIXML_BANNER;
+    expect(JSON.parse(stripClixml(polluted)).burn.outputTokens).toBe(7);
+  });
+
+  it('yields empty output when the whole stream is CLIXML (no real payload)', () => {
+    expect(stripClixml(CLIXML_BANNER)).toBe('');
+  });
+});
 
 /** Decode the PowerShell script a Windows `--host` invocation ships, by pulling
  * the base64 payload off `powershell -NoProfile -EncodedCommand <b64>` and

--- a/apps/cli/src/lib/hosts/remote-cmd.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.ts
@@ -330,11 +330,14 @@ export const POWERSHELL_PROGRESS_SILENCE = "$ProgressPreference = 'SilentlyConti
  */
 export function stripClixml(stdout: string): string {
   if (!stdout.includes('#< CLIXML')) return stdout;
+  // A CLIXML flush is the `#< CLIXML` banner immediately followed by one or more
+  // <Objs …>…</Objs> elements, as one contiguous block. Remove that whole unit,
+  // ANCHORED to the banner: the <Objs> removal is scoped to blocks that follow a
+  // banner, so a stray `<Objs>` appearing inside a legitimate JSON string value
+  // (a session title/prompt that quotes CLIXML text) is never touched — stripping
+  // <Objs> globally would silently delete JSON between two such substrings.
   return stdout
-    // The `#< CLIXML` banner line (a stream may flush it mid-output, so match anywhere).
-    .replace(/^#< CLIXML[^\n]*\r?\n?/gm, '')
-    // Each CLIXML object element carrying the serialized progress/error records.
-    .replace(/<Objs\b[\s\S]*?<\/Objs>/g, '')
+    .replace(/#< CLIXML[^\n]*\r?\n?(?:\s*<Objs\b[\s\S]*?<\/Objs>)*/g, '')
     .trim();
 }
 

--- a/apps/cli/src/lib/hosts/remote-cmd.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.ts
@@ -312,6 +312,32 @@ export interface WindowsAgentsCommand {
  */
 export const POWERSHELL_PROGRESS_SILENCE = "$ProgressPreference = 'SilentlyContinue'";
 
+/**
+ * Strip a PowerShell CLIXML wrapper from stdout relayed off a Windows host.
+ *
+ * PowerShell 5.1 serializes progress / error / verbose records to CLIXML when a
+ * stream is a redirected pipe (an ssh capture, not a console): a `#< CLIXML`
+ * banner followed by one or more `<Objs …>…</Objs>` elements. {@link
+ * POWERSHELL_PROGRESS_SILENCE} suppresses the common "Preparing modules for
+ * first use." progress record at the source, but a Windows peer reached WITHOUT
+ * that prelude — a raw `agents ssh <win> 'agents … --json'`, an older peer, or a
+ * record on a stream we did not silence — can still emit the banner ahead of the
+ * real payload, which breaks a naive `JSON.parse` of the relayed `--json`
+ * (RUSH-2286). Remove the banner and every self-contained `<Objs …>…</Objs>`
+ * block, leaving the genuine payload untouched. A no-op (returns the input
+ * unchanged) when no `#< CLIXML` marker is present, so it is safe to apply on
+ * every remote-JSON boundary regardless of the peer's OS.
+ */
+export function stripClixml(stdout: string): string {
+  if (!stdout.includes('#< CLIXML')) return stdout;
+  return stdout
+    // The `#< CLIXML` banner line (a stream may flush it mid-output, so match anywhere).
+    .replace(/^#< CLIXML[^\n]*\r?\n?/gm, '')
+    // Each CLIXML object element carrying the serialized progress/error records.
+    .replace(/<Objs\b[\s\S]*?<\/Objs>/g, '')
+    .trim();
+}
+
 export function windowsAgentsScript(cmd: WindowsAgentsCommand): string {
   const { args, env, cwd, propagateExit = true } = cmd;
   const parts: string[] = [POWERSHELL_PROGRESS_SILENCE];

--- a/apps/cli/src/lib/remote-agents-json.ts
+++ b/apps/cli/src/lib/remote-agents-json.ts
@@ -13,7 +13,7 @@ import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from './ssh-e
 import { sshTargetFor } from './devices/connect.js';
 import { resolveExplicitTargets } from './devices/resolve-target.js';
 import { loadDevices, isControlDevice, isDialableDevice, type DeviceProfile } from './devices/registry.js';
-import { remoteShellFor, buildWindowsAgentsCommand } from './hosts/remote-cmd.js';
+import { remoteShellFor, buildWindowsAgentsCommand, stripClixml } from './hosts/remote-cmd.js';
 import { machineId, normalizeHost } from './machine-id.js';
 
 const REMOTE_TIMEOUT_MS = 12_000;
@@ -89,7 +89,9 @@ export function parseRemoteAgentsJsonPayload<T>(
   machine: string,
   parse: RemoteAgentsJsonOptions<T>['parse'],
 ): { items: T[]; parseFailed: boolean } {
-  const parsed = normalizeRemoteAgentsJsonParse(parse(stdout, machine));
+  // A Windows peer can prefix the JSON with a PowerShell CLIXML banner; strip it
+  // before handing stdout to the command-specific parser (RUSH-2286).
+  const parsed = normalizeRemoteAgentsJsonParse(parse(stripClixml(stdout), machine));
   return parsed.valid
     ? { items: parsed.items, parseFailed: false }
     : { items: [], parseFailed: true };

--- a/apps/cli/src/lib/session/__tests__/discover.test.ts
+++ b/apps/cli/src/lib/session/__tests__/discover.test.ts
@@ -340,6 +340,21 @@ describe('readGrokMeta', () => {
     expect(r!.meta.shortId).toBe(uuid.slice(0, 8));
   });
 
+  it('resolves the version from a Windows (backslash) grok_home path (RUSH-2286)', () => {
+    // The Grok CLI writes grok_home in the writing host's native separators; a
+    // Windows-authored summary is backslash-separated. The summary lives in a
+    // tmp dir (no versions/grok path on disk), so grok_home is the ONLY version
+    // source — before the fix the `/`-only regex left version undefined here.
+    const fp = writeSummary({
+      info: { id: uuid, cwd: 'C:\\Users\\muqsit\\src' },
+      generated_title: 'Windows session',
+      grok_home: 'C:\\Users\\muqsit\\.agents\\.history\\versions\\grok\\0.2.101\\home\\.grok',
+    });
+    const r = readGrokMeta(fp);
+    expect(r).not.toBeNull();
+    expect(r!.meta.version).toBe('0.2.101');
+  });
+
   it('falls back to session_summary when no generated_title, and to the dir uuid when info.id is absent', () => {
     const fp = writeSummary({
       info: { cwd: '/tmp/x' },

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -24,6 +24,8 @@ import type { SessionAgentId, SessionEvent, SessionMeta, TodoProgress } from './
 import type { AgentId } from '../types.js';
 import { AGENTS, agentConfigDirName, getCliVersion } from '../agents.js';
 import { walkForFilesWithStat } from '../fs-walk.js';
+import { hasCommand } from '../cli-resources.js';
+import { execFileShellSpec } from '../platform/exec.js';
 import { getConfigSymlinkVersion } from '../shims.js';
 import { SESSION_AGENTS } from './types.js';
 import { deriveShortId } from './short-id.js';
@@ -2452,12 +2454,11 @@ async function scanOpenCodeIncremental(): Promise<void> {
 
 /** Scan active OpenClaw channels and cron jobs via the openclaw CLI. */
 async function scanOpenClawIncremental(): Promise<void> {
-  // Check if openclaw is installed — silently skip if not.
-  try {
-    await execFileAsync('which', ['openclaw']);
-  } catch {
-    return;
-  }
+  // Check if openclaw is installed — silently skip if not. `which` is POSIX-only
+  // (Windows resolves PATH with `where`), so a bare `which` throws ENOENT on every
+  // Windows run and silently disabled the entire OpenClaw scan there — its sessions
+  // never reached the index (RUSH-2286). hasCommand() probes cross-platform.
+  if (!hasCommand('openclaw')) return;
 
   // TTL cache: skip subprocess calls if we scanned recently. Stored in the
   // meta table so we skip even when no channels/cron exist to produce rows.
@@ -2474,8 +2475,13 @@ async function scanOpenClawIncremental(): Promise<void> {
   const entries: ScanEntry[] = [];
 
   try {
-    const { stdout: output } = await execFileAsync('openclaw', ['channels', 'status'], {
+    // On Windows `openclaw` resolves to a .cmd/.ps1 shim that execFile can't launch
+    // directly; execFileShellSpec composes a shell-safe invocation there and is a
+    // no-op passthrough on POSIX (RUSH-2286).
+    const channelsSpec = execFileShellSpec('openclaw', ['channels', 'status']);
+    const { stdout: output } = await execFileAsync(channelsSpec.command, channelsSpec.args, {
       encoding: 'utf-8',
+      shell: channelsSpec.shell,
     });
 
     for (const line of output.split('\n')) {
@@ -2504,8 +2510,10 @@ async function scanOpenClawIncremental(): Promise<void> {
   }
 
   try {
-    const { stdout: output } = await execFileAsync('openclaw', ['cron', 'list'], {
+    const cronSpec = execFileShellSpec('openclaw', ['cron', 'list']);
+    const { stdout: output } = await execFileAsync(cronSpec.command, cronSpec.args, {
       encoding: 'utf-8',
+      shell: cronSpec.shell,
     });
 
     const lines = output.split('\n');
@@ -5230,10 +5238,13 @@ export function readGrokMeta(
         : undefined;
 
   // Grok records its managed home in summary.grok_home
-  // (…/versions/grok/<version>/home/.grok) — recover the version from it.
+  // (…/versions/grok/<version>/home/.grok) — recover the version from it. The
+  // value is written by the Grok CLI in the writing host's native separators, so
+  // a Windows-authored summary is backslash-separated; normalize to `/` before
+  // matching or the version never resolves on Windows (RUSH-2286).
   let embeddedVersion: string | undefined;
   if (typeof summary?.grok_home === 'string') {
-    embeddedVersion = summary.grok_home.match(/versions\/grok\/([^/]+)\//)?.[1];
+    embeddedVersion = summary.grok_home.replace(/\\/g, '/').match(/versions\/grok\/([^/]+)\//)?.[1];
   }
 
   const meta: SessionMeta = {

--- a/apps/cli/src/lib/session/remote-list.test.ts
+++ b/apps/cli/src/lib/session/remote-list.test.ts
@@ -262,6 +262,31 @@ describe('parseRemoteToolSearch', () => {
     expect(parseRemoteToolSearch(payload, 'mac-mini', ['program:git'])?.sessions).toHaveLength(1);
   });
 
+  it('parses an envelope a Windows peer prefixed with a CLIXML banner (RUSH-2286)', () => {
+    const payload = JSON.stringify({
+      schemaVersion: 1,
+      generatedAt: '2026-08-06T00:00:00Z',
+      query: { clauses: ['program:git'] },
+      coverage: { indexedFiles: 0, indexedCalls: 0, skippedFiles: 0, limitedFiles: 0, remainingFiles: 0, complete: true },
+      sessions: [{
+        id: 'w', shortId: 'w', agent: 'codex', timestamp: '2026-08-06T00:00:00Z',
+        filePath: 'C:\\peer\\w.jsonl', calls: [{
+          id: 'c', ordinal: 0, timestamp: '2026-08-06T00:00:01Z', tool: 'exec_command',
+          programs: ['git'], programOccurrences: [{ program: 'git', role: 'effective' }],
+          input: 'git status', outcome: 'unknown',
+        }],
+      }],
+    });
+    const polluted =
+      '#< CLIXML\n' +
+      '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">' +
+      '<Obj S="progress" RefId="0"><MS><AV>Preparing modules for first use.</AV></MS></Obj></Objs>\n' +
+      payload;
+    const parsed = parseRemoteToolSearch(polluted, 'win-mini');
+    expect(parsed?.sessions).toHaveLength(1);
+    expect(parsed?.sessions[0].machine).toBe('win-mini');
+  });
+
   it('preserves the transcript origin machine across a peer hop', () => {
     const payload = JSON.stringify({
       schemaVersion: 1,

--- a/apps/cli/src/lib/session/remote-list.test.ts
+++ b/apps/cli/src/lib/session/remote-list.test.ts
@@ -193,6 +193,21 @@ describe('parseRemoteList', () => {
     expect(parseRemoteList('bash: agents: command not found\n', 'zion')).toEqual([]);
   });
 
+  it('parses a payload a Windows peer prefixed with a PowerShell CLIXML banner (RUSH-2286)', () => {
+    const payload = JSON.stringify([
+      { id: 'w', shortId: 'w', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', filePath: 'C:\\r\\w.jsonl' },
+    ]);
+    const polluted =
+      '#< CLIXML\n' +
+      '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">' +
+      '<Obj S="progress" RefId="0"><MS><AV>Preparing modules for first use.</AV></MS></Obj></Objs>\n' +
+      payload;
+    const out = parseRemoteList(polluted, 'win-mini');
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('w');
+    expect(out[0].machine).toBe('win-mini');
+  });
+
   it('returns [] when the top level is not an array', () => {
     expect(parseRemoteList(JSON.stringify({ error: 'nope' }), 'zion')).toEqual([]);
   });

--- a/apps/cli/src/lib/session/remote-list.ts
+++ b/apps/cli/src/lib/session/remote-list.ts
@@ -20,7 +20,7 @@ import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from '../ssh-
 import { sshTargetFor } from '../devices/connect.js';
 import { resolveExplicitTargetSet } from '../devices/resolve-target.js';
 import { loadDevices, isControlDevice, isDialableDevice, type DeviceProfile } from '../devices/registry.js';
-import { remoteShellFor, buildWindowsAgentsCommand } from '../hosts/remote-cmd.js';
+import { remoteShellFor, buildWindowsAgentsCommand, stripClixml } from '../hosts/remote-cmd.js';
 import { gatherRemoteAgentsJson, type RemoteAgentsJsonParseResult } from '../remote-agents-json.js';
 import { machineId, normalizeHost } from './sync/config.js';
 import { NO_FANOUT_ENV } from './remote-active.js';
@@ -126,7 +126,7 @@ export function remoteListCommand(forwardedArgs: string[], os?: string): string 
 export function parseRemoteList(stdout: string, machine: string): SessionMeta[] {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(stdout);
+    parsed = JSON.parse(stripClixml(stdout));
   } catch {
     return [];
   }
@@ -155,7 +155,7 @@ export function parseRemoteListPayload(stdout: string, machine: string, safeReso
 } {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(stdout);
+    parsed = JSON.parse(stripClixml(stdout));
   } catch {
     return { items: [], valid: false };
   }

--- a/apps/cli/src/lib/session/remote-list.ts
+++ b/apps/cli/src/lib/session/remote-list.ts
@@ -472,6 +472,10 @@ export function parseRemoteToolSearch(
   machine: string,
   expectedClauses?: string[],
 ): ToolSearchEnvelope | undefined {
+  // The fleet tool-search fan-out reads a raw sshCapture (not the stripped
+  // gatherRemoteAgentsJson wrapper), so a Windows peer's PowerShell CLIXML banner
+  // must be removed here too or the box reads as "no envelope" (RUSH-2286).
+  stdout = stripClixml(stdout);
   if (Buffer.byteLength(stdout) > REMOTE_STDOUT_MAX_BYTES) return undefined;
   try {
     const parsed = JSON.parse(stdout) as Record<string, unknown>;


### PR DESCRIPTION
**fix / bugfix — no user-visible UI surface (CLI behavior + scanner correctness).**

Closes RUSH-2286 — https://linear.app/getrush/issue/RUSH-2286

## What changed

`agents output` (and the session index) reported **zero token burn / zero sessions** on a Windows host that was actively used. Two independent Windows defects:

| Bug | Fix |
|---|---|
| OpenClaw scan gated on `which openclaw` — `which` is POSIX-only, throws ENOENT on Windows, so `scanOpenClawIncremental` silently returned before indexing anything | Cross-platform `hasCommand('openclaw')`; the `openclaw` invocations route through `execFileShellSpec` so a Windows `.cmd`/`.ps1` shim launches. POSIX path byte-identical. |
| Grok recovered a session's version from `summary.grok_home` with a `/`-only regex that never matches a backslash Windows path | Normalize separators before the match. |
| JSON relayed off a Windows peer over SSH arrives with a PowerShell `#< CLIXML` banner that breaks `JSON.parse` | New `stripClixml` (`hosts/remote-cmd.ts`) applied at every remote `--json` boundary: `remote-agents-json` fan-out, session `remote-list` parsers, and `output.ts fetchRemotePayload`. No-op on clean output. |

## Evidence

**The CLIXML pollution, reproduced live against win-mini** (`agents ssh win-mini 'set USERPROFILE'`):
```
#< CLIXML
<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0">…Preparing modules for first use.…</Objs>
```
That exact banner is the fixture the new `stripClixml` tests parse past.

**Test run (this branch):**
```
$ vitest run src/lib/hosts/remote-cmd.test.ts src/lib/session/remote-list.test.ts
 Test Files  2 passed (2)
      Tests  62 passed (62)

$ vitest run src/lib/session/__tests__/discover.test.ts -t readGrokMeta
      Tests  5 passed | 33 skipped (38)   # incl. the new backslash grok_home case

$ vitest run src/lib/remote-agents-json.test.ts src/commands/output.test.ts
 Test Files  2 passed (2)
      Tests  12 passed (12)

$ tsc --noEmit         # EXIT=0, 0 errors
```

New tests: `stripClixml` unit tests (using the real win-mini CLIXML sample), a CLIXML-prefixed `parseRemoteList` test, and a Windows (backslash) `grok_home` version-resolution test — each reproduces its bug and fails on `main`.

## Scope note

Investigation confirmed the version-home enumeration in `getAgentSessionDirs` is already `path.join`-portable, so there is **no missing claude/codex transcript root** on Windows — the reproducible scanner gaps were the two above (openclaw / grok). A latent risk remains where `process.env.HOME` is set to a non-native path on Windows (git-bash/MSYS) and diverges from `os.homedir()` (`state.ts:36` vs `discover.ts:73`); not touched here because `state.ts`'s HOME is load-bearing for the whole app and the test harness relies on overriding it — filed as a follow-up thought, not this fix.
