### PR TITLE
fix(menubar): version-aware arbitration prevents older installs reclaiming the helper

### DIFF
--- a/apps/cli/.changelog/1.22.26.md
+++ b/apps/cli/.changelog/1.22.26.md
@@ -1,3 +1,5 @@
+- **Fix: an older agents-cli install could reclaim and downgrade the menu-bar helper (#2210).** `mayInstallMenubarHelper` now compares the invoking install's own version against the version stamped on the currently installed helper: a strictly newer install takes over immediately (no cooldown wait), a strictly older install is refused outright, and equal-version installs no longer trade ownership every cooldown. A helper that predates the version stamp still recovers through the original ownership-cooldown path. Source: `apps/cli/src/lib/menubar/install-menubar.ts`.
+
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 
 - **`agents apply --provision-secrets` pushes the manifest's declared secrets

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -693,24 +693,45 @@ executable or a Developer-ID heal proceeds from any install, since a bundle that
 isn't there cannot be contested and blocking it leaves the menu bar dead with no
 automatic recovery; (2) a non-owner takes over immediately once the recorded owner
 is **gone from disk**; (3) otherwise a non-owner may still take over **once per
-`MENUBAR_TAKEOVER_COOLDOWN_MS`** (1h, stamped in `.menubar-last-heal`). Without (3)
-a stale-but-present copy — an old nvm node dir nobody runs — owns the plist forever
-while the user's actual daily driver upgrades and never heals again. The cooldown
-turns an every-invocation storm into at most one restart per hour while leaving
-every install able to make progress. `agents menubar setup` bypasses the gate
-entirely and stays the immediate manual fix.
+`MENUBAR_TAKEOVER_COOLDOWN_MS`** (1h, stamped in `.menubar-last-heal`) — but ONLY
+when the helper predates the version stamp (see version-aware arbitration below).
+Without (3) a stale-but-present LEGACY copy — an old nvm node dir nobody runs —
+owns the plist forever while the user's actual daily driver upgrades and never
+heals again. `agents menubar setup` bypasses the gate entirely and stays the
+immediate manual fix.
 
-Two caveats worth knowing before you tune any of this. **(a)** Escape (3) is
-refused to a source bundle that is not Developer-ID signed: `scripts/install.sh`
-puts an ad-hoc dev build beside the npm global, and letting it win a *timed*
-takeover would recopy an un-notarized bundle over a good one, which Gatekeeper
-rejects as "damaged" and AppKit crashes on (RUSH-2134) — a broken menu bar rather
-than a cosmetic restart. It can still adopt via (2), the case that must never
-deadlock. **(b)** The cooldown bounds the loop but does not converge it: two
-installs that are *both* invoked regularly trade ownership every cooldown, so the
-helper restarts roughly hourly until one is removed. That is deliberate — the
-alternative is stranding one of them — and the real fix is a single install
-(#2147 covers making the multi-install banner actually name them all).
+**Version-aware arbitration replaced the cooldown as the primary decision
+(#2210).** The pure ownership gate above could not tell "real upgrade" from "any
+other foreign install", so a NEWER install waited out the same hour as any
+contender, and once the cooldown lapsed an OLDER install could reclaim and
+downgrade the helper — a released Swift fix could sit in npm while the user kept
+running the pre-fix binary (observed on Zion: CLI 1.22.25 vs. a helper still
+running 1.22.5). `mayInstallMenubarHelper` now compares the candidate's OWN cli
+version against the version stamped next to the currently installed helper
+(`.menubar-version`) once ownership and the repair escapes are settled:
+
+- **strictly newer → takes over immediately**, no cooldown wait (still gated on
+  `sourceIsDeveloperId`, below);
+- **strictly older → refused outright**, cooldown or not — a stale copy can never
+  downgrade a newer helper;
+- **equal → refused** — no correctness benefit to swapping identical versions,
+  and this is what closes caveat (b): two equal-version installs invoked
+  regularly no longer trade ownership every cooldown.
+
+A helper with no stamped version (predates the `.menubar-version` marker) falls
+through to the ORIGINAL ownership-cooldown escape (3) above, so recovery from
+that legacy state is exactly as possible as before this arbitration existed.
+
+Two caveats worth knowing before you tune any of this. **(a)** Both the timed
+legacy escape (3) and the "newer wins" branch are refused to a source bundle that
+is not Developer-ID signed: `scripts/install.sh` puts an ad-hoc dev build beside
+the npm global, and letting it win — on a timer, or because its (often synthetic)
+version string sorts higher — would recopy an un-notarized bundle over a good one,
+which Gatekeeper rejects as "damaged" and AppKit crashes on (RUSH-2134) — a broken
+menu bar rather than a cosmetic restart. It can still adopt via (2), the case that
+must never deadlock. **(b)** (resolved by #2210) — equal-version installs no
+longer oscillate; the real fix of collapsing to a single install is still tracked
+separately (#2147 covers making the multi-install banner actually name them all).
 
 **Do NOT "improve" this by comparing bundle content.** It looks like the obvious
 gate and it does not work: the helper is rebuilt, re-signed and re-notarized on

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.22.26
 
-- **Fix: an older agents-cli install could reclaim and downgrade the menu-bar helper (#2210).** `mayInstallMenubarHelper` now compares the invoking install's own version against the version stamped on the currently installed helper: a strictly newer install takes over immediately (no cooldown wait), a strictly older install is refused outright, and equal-version installs no longer trade ownership every cooldown. A helper that predates the version stamp still recovers through the original ownership-cooldown path.
+- **Fix: an older agents-cli install could reclaim and downgrade the menu-bar helper (#2210).** `mayInstallMenubarHelper` now compares the invoking install's own version against the version stamped on the currently installed helper: a strictly newer install takes over immediately (no cooldown wait), a strictly older install is refused outright, and equal-version installs no longer trade ownership every cooldown. A helper that predates the version stamp still recovers through the original ownership-cooldown path. Source: `apps/cli/src/lib/menubar/install-menubar.ts`.
 
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.22.26
 
+- **Fix: an older agents-cli install could reclaim and downgrade the menu-bar helper (#2210).** `mayInstallMenubarHelper` now compares the invoking install's own version against the version stamped on the currently installed helper: a strictly newer install takes over immediately (no cooldown wait), a strictly older install is refused outright, and equal-version installs no longer trade ownership every cooldown. A helper that predates the version stamp still recovers through the original ownership-cooldown path.
+
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 
 - **`agents apply --provision-secrets` pushes the manifest's declared secrets

--- a/apps/cli/src/commands/menubar.ts
+++ b/apps/cli/src/commands/menubar.ts
@@ -62,10 +62,10 @@ function printStatus(s: MenubarStatus, opts: { brief?: boolean } = {}): void {
   }
   if (s.stale) {
     // Not "runs on next startup": the self-heal only reinstalls from the install
-    // that owns the helper, or from another one once the takeover cooldown has
-    // passed (mayInstallMenubarHelper) — so on a box with several agents-cli
-    // copies this can persist for a while. `setup` bypasses the gate and is the
-    // immediate fix.
+    // that owns the helper, from a strictly newer install (immediately), or from
+    // another one once the legacy takeover cooldown has passed
+    // (mayInstallMenubarHelper) — so on a box with several agents-cli copies this
+    // can persist for a while. `setup` bypasses the gate and is the immediate fix.
     console.log(chalk.yellow('\n  Installed AGI Menu is stale — `agents menubar setup` updates it now.'));
   } else if (!s.serviceInstalled && !s.disabledByUser) {
     console.log(chalk.gray('\n  Set it up with `agents menubar setup`.'));

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -198,13 +198,18 @@ describe('mayInstallMenubarHelper', () => {
   const brew = '/opt/homebrew/lib/node_modules/@phnx-labs/agents-cli/dist/index.js';
   const nvm = '/Users/me/.nvm/versions/node/v24.15.0/lib/node_modules/@phnx-labs/agents-cli/dist/index.js';
   const HOUR = 60 * 60 * 1000;
-  // Healthy install, recent heal — the fields that are not what a case is about.
+  // Healthy install, recent heal, no stamped helper version — the fields that
+  // are not what a case is about. `installedHelperVersion: null` means these
+  // pre-existing cases exercise the LEGACY (pre-version-stamp) path unchanged;
+  // version-arbitration cases below set it explicitly.
   const base = {
     helperExecMissing: false,
     needsDevIdHeal: false,
     msSinceLastHeal: 60_000,
     cooldownMs: HOUR,
     sourceIsDeveloperId: true,
+    installedHelperVersion: null as string | null,
+    activeVersion: '1.22.25',
   };
 
   it('refuses a foreign install while the recorded owner still exists (#2109)', () => {
@@ -296,6 +301,87 @@ describe('mayInstallMenubarHelper', () => {
     // must not be written into the plist or used to seize ownership.
     expect(mayInstallMenubarHelper({
       ...base, plistEntry: brew, activeEntry: null, ownerEntryExists: true,
+    })).toBe(false);
+  });
+});
+
+// Regression guard for #2210: the ownership cooldown above treated every
+// foreign signed install alike, so it never compared the CANDIDATE's own CLI
+// version against the version actually STAMPED on the installed helper
+// (`.menubar-version`). Observed on Zion: CLI 1.22.25 (Homebrew) invoked while
+// the running helper was still 1.22.5 (an NVM install had reclaimed ownership
+// after the cooldown) — the newer binary sat in npm while the pre-fix helper
+// kept running.
+describe('mayInstallMenubarHelper — version-aware arbitration (#2210)', () => {
+  const brew = '/opt/homebrew/lib/node_modules/@phnx-labs/agents-cli/dist/index.js';
+  const nvm = '/Users/me/.nvm/versions/node/v24.15.0/lib/node_modules/@phnx-labs/agents-cli/dist/index.js';
+  const HOUR = 60 * 60 * 1000;
+  // Owner (`plistEntry`) still exists, so every case here goes through the
+  // version-arbitration branch, not the missing-owner escape.
+  const base = {
+    plistEntry: brew,
+    activeEntry: nvm,
+    ownerEntryExists: true,
+    helperExecMissing: false,
+    needsDevIdHeal: false,
+    cooldownMs: HOUR,
+    sourceIsDeveloperId: true,
+  };
+
+  it('a newer install takes over immediately, bypassing the cooldown entirely', () => {
+    // The exact Zion shape: the invoking install (1.22.25) is newer than the
+    // helper actually running (1.22.5), and the last heal was seconds ago — well
+    // inside the cooldown window. Version-aware arbitration must not wait it out.
+    expect(mayInstallMenubarHelper({
+      ...base, installedHelperVersion: '1.22.5', activeVersion: '1.22.25',
+      msSinceLastHeal: 5_000,
+    })).toBe(true);
+  });
+
+  it('an older install never replaces a newer helper, even long past the cooldown', () => {
+    // Before this fix, waiting out MENUBAR_TAKEOVER_COOLDOWN_MS let the OLDER
+    // install reclaim and downgrade the helper — the second bullet in #2210's
+    // root cause. Age of the last heal must not matter here.
+    expect(mayInstallMenubarHelper({
+      ...base, installedHelperVersion: '1.22.25', activeVersion: '1.22.5',
+      msSinceLastHeal: HOUR + 1,
+    })).toBe(false);
+  });
+
+  it('equal-version installations do not oscillate ownership, even past the cooldown', () => {
+    // Two installs at the identical version have no correctness reason to trade
+    // ownership — that trade is exactly the "restarts roughly hourly until one
+    // is removed" churn the old pure-cooldown rule produced.
+    expect(mayInstallMenubarHelper({
+      ...base, installedHelperVersion: '1.22.25', activeVersion: '1.22.25',
+      msSinceLastHeal: HOUR + 1,
+    })).toBe(false);
+  });
+
+  it('a version-newer ad-hoc/dev build still cannot seize a healthy Developer-ID helper', () => {
+    // RUSH-2134 extended to the version-aware path: a dev build's version string
+    // sorting higher must not be enough to recopy an un-notarized bundle over a
+    // good one (Gatekeeper then rejects the result as "damaged").
+    expect(mayInstallMenubarHelper({
+      ...base, installedHelperVersion: '1.22.5', activeVersion: '1.22.25',
+      msSinceLastHeal: 5_000, sourceIsDeveloperId: false,
+    })).toBe(false);
+  });
+
+  it('legacy unversioned recovery remains possible: a pre-stamp helper still uses the ad-hoc/cooldown gate', () => {
+    // No `.menubar-version` marker to compare against (an install that predates
+    // the stamp) — falls through to the original ownership-cooldown escape
+    // rather than being permanently refused.
+    expect(mayInstallMenubarHelper({
+      ...base, installedHelperVersion: null, activeVersion: '1.22.25',
+      msSinceLastHeal: HOUR + 1,
+    })).toBe(true);
+  });
+
+  it('legacy unversioned recovery still refuses an ad-hoc build on the timer', () => {
+    expect(mayInstallMenubarHelper({
+      ...base, installedHelperVersion: null, activeVersion: '1.22.25',
+      msSinceLastHeal: HOUR + 1, sourceIsDeveloperId: false,
     })).toBe(false);
   });
 });

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -24,6 +24,7 @@ import { sleepSync } from '../fs-atomic.js';
 import { getRuntimeStateDir, getHelpersDir } from '../state.js';
 import { getCliVersion, resolveAgentsBin, resolveInstalledLayout } from '../version.js';
 import { copyAppBundle, withInstallLock } from '../app-bundle-install.js';
+import { compareVersions } from '../agent-spec/primitives.js';
 
 const APP_BUNDLE_NAME = 'MenubarHelper.app';
 const INSTALL_DIR_NAME = 'agents-cli';
@@ -505,6 +506,30 @@ export function disableMenubarService(): void {
  * install cannot hold the helper hostage, and a live one cannot be fought over.
  * A same-install upgrade keeps its entry path, so `npm update` still installs
  * the new helper normally. Pure so the truth table is unit-testable.
+ *
+ * Ownership alone left one gap (#2210): it treats every foreign signed install
+ * alike, so a NEWER install waits out the same cooldown as any other contender,
+ * and once the cooldown lapses an OLDER install can reclaim and downgrade the
+ * helper — a released fix can sit in npm while the user keeps running the
+ * pre-fix binary. Version-aware arbitration closes that: once ownership and the
+ * repair escapes above are settled, compare the CANDIDATE'S OWN cli version
+ * (`activeVersion`, what it would stamp if it installs) against the version
+ * stamped next to the CURRENTLY INSTALLED helper (`installedHelperVersion`,
+ * read from `.menubar-version` — not the candidate's *plist* entry, since the
+ * stamp is what says which binary is actually running):
+ *   - strictly newer -> take over immediately, no cooldown wait (still gated on
+ *     `sourceIsDeveloperId` — RUSH-2134: an ad-hoc build must never seize a
+ *     healthy Developer-ID helper just because its version string sorts higher);
+ *   - strictly older -> refuse outright, cooldown or not, so a stale copy can
+ *     never downgrade a newer helper;
+ *   - equal -> refuse. There is no correctness benefit to swapping identical
+ *     versions, and the old cooldown-based takeover let two regularly-invoked
+ *     equal-version installs trade ownership every cooldown forever — the
+ *     oscillation this closes.
+ * A null `installedHelperVersion` (the helper predates the `.menubar-version`
+ * stamp) falls through to the pre-version ad-hoc/cooldown gate below, so
+ * recovery from that legacy unstamped state remains exactly as possible as
+ * before this arbitration existed.
  */
 export function mayInstallMenubarHelper(opts: {
   /** `AGENTS_ENTRY` baked into the installed plist — the recorded owner. */
@@ -519,10 +544,15 @@ export function mayInstallMenubarHelper(opts: {
   needsDevIdHeal: boolean;
   /** ms since the last self-heal reinstall, or null if none is recorded. */
   msSinceLastHeal: number | null;
-  /** How long a non-owner waits before it may take over. */
+  /** How long a non-owner waits before it may take over (legacy/unversioned only). */
   cooldownMs: number;
   /** This install's OWN shipped bundle is Developer-ID signed (not ad-hoc/dev). */
   sourceIsDeveloperId: boolean;
+  /** Version stamped next to the currently installed helper (`.menubar-version`),
+   *  or null when it predates the stamp (legacy install). */
+  installedHelperVersion: string | null;
+  /** This install's own CLI version — what it would stamp if it installs. */
+  activeVersion: string;
 }): boolean {
   // Repairs are never gated: a missing binary or a broken signing identity leaves
   // the menu bar dead or re-prompting for Accessibility, and no other install can
@@ -535,7 +565,18 @@ export function mayInstallMenubarHelper(opts: {
   if (!opts.plistEntry) return true;
   if (opts.plistEntry === opts.activeEntry) return true; // we are the owner
   if (!opts.ownerEntryExists) return true; // the recorded owner is gone
-  // A foreign install while the owner still exists. Refusing outright bounds the
+
+  // A foreign install while the owner still exists. Version-aware arbitration
+  // (see the docblock above) — only when there IS a stamped version to compare;
+  // a legacy pre-stamp helper falls through to the ad-hoc/cooldown gate below.
+  if (opts.installedHelperVersion) {
+    const cmp = compareVersions(opts.activeVersion, opts.installedHelperVersion);
+    if (cmp > 0) return opts.sourceIsDeveloperId; // strictly newer — take over now
+    return false; // equal or older — never downgrade, never oscillate
+  }
+
+  // Legacy path: the installed helper predates the `.menubar-version` stamp, so
+  // there is nothing to compare versions against. Refusing outright bounds the
   // loop but strands the user when the recorded owner is a stale copy that simply
   // still sits on disk (an old nvm node dir) while their daily driver upgrades:
   // that install would never heal again. So it may take over, but only once per
@@ -596,6 +637,8 @@ function mayHealMenubar(needsDevIdHeal: boolean): boolean {
     msSinceLastHeal: msSinceLastMenubarHeal(),
     cooldownMs: MENUBAR_TAKEOVER_COOLDOWN_MS,
     sourceIsDeveloperId: Boolean(src) && hasDeveloperIdSignature(src as string),
+    installedHelperVersion: readInstalledMenubarVersion(),
+    activeVersion: getCliVersion(),
   });
 }
 


### PR DESCRIPTION
**bugfix** — no UI surface (pure decision logic in `mayInstallMenubarHelper`).

Fixes #2210.

## What changed

`mayInstallMenubarHelper` (`apps/cli/src/lib/menubar/install-menubar.ts`) gated menu-bar-helper reinstallation on ownership + a 1h cooldown only, never comparing versions. That let:
- a **newer** install wait out the same cooldown as any other contender,
- an **older** install reclaim and downgrade the helper once the cooldown lapsed,
- two equal-version installs invoked regularly trade ownership every cooldown forever.

Observed on Zion: CLI 1.22.25 (Homebrew) running while the launchd-owned helper stayed at 1.22.5 (an NVM install had reclaimed it after the cooldown).

Now, once ownership + the repair escapes (missing binary, ad-hoc→Developer-ID heal, owner gone from disk) are settled, the candidate's own CLI version is compared against the version stamped on the currently installed helper (`.menubar-version`):

| Comparison | Result |
| --- | --- |
| candidate strictly **newer** | takes over immediately, no cooldown wait (still refused to a non-Developer-ID/ad-hoc source, RUSH-2134) |
| candidate strictly **older** | refused outright, cooldown or not |
| **equal** version | refused — no benefit to swapping, closes the every-cooldown oscillation |
| helper has **no stamped version** (legacy, pre-marker) | falls through to the original ownership-cooldown escape unchanged |

## Files

- `apps/cli/src/lib/menubar/install-menubar.ts` — `mayInstallMenubarHelper` + `mayHealMenubar` wiring
- `apps/cli/src/lib/menubar/install-menubar.test.ts` — regression tests: newer-wins, older-cannot-downgrade, equal-version-stability, legacy-unversioned-recovery, ad-hoc-build-guard (both paths)
- `apps/cli/src/commands/menubar.ts` — updated the `stale` help text for the new immediate-newer-wins path
- `apps/cli/AGENTS.md`, `apps/cli/CHANGELOG.md` — doc + changelog (resolves the documented caveat (b) oscillation gap)

## Proof of run

![test run: vitest 55 passed, tsc clean](https://share.agents-cli.sh/gitconfig-user/muqsit-menubar-2210-test-run-fe54fa8808733561)

The 3 skipped tests are darwin-only real-`codesign`/`spctl` checks (this box is Linux); the pure-logic truth table this PR changes is fully covered on any platform.

## Zion repair (from the issue, already completed before this code fix)

- Homebrew agents-cli: 1.22.25; NVM agents-cli: 1.22.25
- MenubarHelper: installedVersion=1.22.25, currentVersion=1.22.25, stale=false
- Exactly one helper instance (PID 32348)
- Accessibility E2E: expanding the agents-cli project left the menu open, item count 54→115, header collapsed→expanded

This PR is the permanent code fix the issue's immediate repair was standing in for — without it, the drift can recur on any multi-install box.