### PR TITLE
fix(hosts): bound the reconnect loop on a recurring local ssh failure (#1884)

### DIFF
--- a/apps/cli/.changelog/next/issue-1884-reconnect-hold.md
+++ b/apps/cli/.changelog/next/issue-1884-reconnect-hold.md
@@ -1,0 +1,11 @@
+- **Stop the interactive host auto-reconnect spinning forever on a flapping link
+  (#1884).** A reattach only refills the retry budget now if it reached the host
+  **and** held the remote pane for at least 10 seconds. Before, the budget refilled
+  on the preflight probe alone, so a link that reconnected and dropped the user
+  straight back out — or an attach that died at TTY negotiation every time — printed
+  `Reconnecting … (attempt 1/6)` on every cycle forever and `MAX_ATTEMPTS` bounded
+  nothing. A link that keeps dropping now spends the budget and gives up with a
+  message that says so ("kept dropping again within 10 seconds of getting back in"),
+  distinct from the unreachable-host "couldn't reconnect". A session that blinks all
+  day and reconnects into a working pane each time is unaffected. Source:
+  `apps/cli/src/lib/hosts/reconnect.ts`, `docs/hosts.md`.

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -313,7 +313,8 @@ agents run <agent> ["<task>"] --host <host>
 > survived and RESUMES the session in place when the pane is already gone (so a
 > reattach landing after the pane died recovers the agent instead of dead-ending at
 > a bare shell — RUSH-2085), with bounded exponential backoff (2s→30s, up to 6
-> attempts; the budget refills after a genuinely live reconnection). A clean detach
+> attempts; the budget refills after a genuinely live reconnection — one that
+> reached the host **and** held the pane for at least 10 seconds). A clean detach
 > (`Ctrl-b d`, exit 0) or a real agent exit (any non-255 code) is left alone, and
 > `--raw`/no-tmux runs are not retried (they don't survive a drop). If every attempt
 > fails the CLI prints the manual **`agents reconnect <id>`** to get back in once the
@@ -333,9 +334,20 @@ agents run <agent> ["<task>"] --host <host>
 > 254 before this process sees it — so a remote-side path that happened to exit
 > 255 for its own reasons would never be mistaken for the link dropping again.
 > This closes a channel-level flaw (any future remote-side 255 producer would
-> have been indistinguishable from a real drop) rather than a confirmed live
-> bug; a genuinely recurring *local* ssh failure can still refill the retry
-> budget on every attempt by design (that part is unchanged).
+> have been indistinguishable from a real drop) rather than a confirmed live bug.
+>
+> **A recurring *local* ssh failure is bounded too (#1884).** The retry budget
+> refills only on a reattach that reached the host **and** held the pane for at
+> least 10 seconds, timed on the attach alone (the reachability probe has already
+> returned by then). A fast-flapping link — or an attach that dies at TTY
+> negotiation on every reconnect — therefore drains the budget like an unreachable
+> host instead of refilling it forever, and the loop gives up with a message that
+> names what actually happened ("kept dropping again within 10 seconds of getting
+> back in"), not the unreachable-host "couldn't reconnect". The floor is
+> deliberately a *hold* requirement rather than a flat cap on total attempts: any
+> fixed total would eventually strand the all-day-blinking session this feature
+> exists for, while the hold floor only ever stops a loop that is failing to put
+> you back into the agent.
 >
 > Pass `--name <slug>` at dispatch to give the run a durable handle instead of an
 > opaque id: `agents hosts ps` shows it under a **NAME** column, and

--- a/apps/cli/src/lib/hosts/reconnect.test.ts
+++ b/apps/cli/src/lib/hosts/reconnect.test.ts
@@ -11,9 +11,11 @@ import { execFileSync } from 'node:child_process';
 import type { Host } from './types.js';
 import {
   reconnectStep,
+  refillsBudget,
   backoffMs,
   reconnectNotice,
   exhaustedNotice,
+  unstableNotice,
   remoteExitNotice,
   reconnectInteractiveSession,
   reattachRemoteCommand,
@@ -21,47 +23,75 @@ import {
   initialReconnectState,
   SSH_CONN_FAILURE,
   MAX_ATTEMPTS,
+  MIN_HOLD_MS,
   REMOTE_EXIT_255_REMAPPED,
   type ReconnectOutcome,
 } from './reconnect.js';
 
 const HOST = { name: 'zion' } as Host;
 const SID = '94c75686-145c-465d-b3f8-a9c0d3a0387c';
-const dropped = (connected: boolean): ReconnectOutcome => ({ code: SSH_CONN_FAILURE, connected });
+
+/** Reconnected, held the pane, then dropped — the one shape that refills the budget. */
+const heldThenDropped = (): ReconnectOutcome => ({ code: SSH_CONN_FAILURE, connected: true, heldMs: MIN_HOLD_MS });
+/** Never reached the host (the preflight probe failed): a sustained outage. */
+const unreachable = (): ReconnectOutcome => ({ code: SSH_CONN_FAILURE, connected: false, heldMs: 0 });
+/** Reached the host, then the attach died straight back — the flapping link / dead-at-
+ *  TTY-negotiation case that used to refill the budget forever (agents-cli#1884). */
+const flapped = (): ReconnectOutcome => ({ code: SSH_CONN_FAILURE, connected: true, heldMs: MIN_HOLD_MS - 1 });
 
 describe('reconnectStep — the pure retry decision', () => {
   test('a clean detach (exit 0) stops and surfaces 0 — never reconnects', () => {
-    expect(reconnectStep(initialReconnectState(), { code: 0, connected: true })).toEqual({ action: 'stop', code: 0 });
+    expect(reconnectStep(initialReconnectState(), { code: 0, connected: true, heldMs: MIN_HOLD_MS })).toEqual({
+      action: 'stop',
+      code: 0,
+    });
   });
 
   test('a real remote exit code (agent ended, non-255) stops and surfaces it', () => {
-    expect(reconnectStep({ attempt: 0 }, { code: 1, connected: true })).toEqual({ action: 'stop', code: 1 });
-    expect(reconnectStep({ attempt: 3 }, { code: 130, connected: false })).toEqual({ action: 'stop', code: 130 });
+    expect(reconnectStep({ attempt: 0 }, { code: 1, connected: true, heldMs: MIN_HOLD_MS })).toEqual({ action: 'stop', code: 1 });
+    expect(reconnectStep({ attempt: 3 }, { code: 130, connected: false, heldMs: 0 })).toEqual({ action: 'stop', code: 130 });
   });
 
-  test('a 255 drop from a connected attempt retries with backoff and advances the attempt', () => {
-    expect(reconnectStep({ attempt: 0 }, dropped(true))).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
-    expect(reconnectStep({ attempt: 1 }, dropped(true))).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
+  test('a 255 drop from an attempt that reconnected AND HELD retries with backoff and refills', () => {
+    expect(reconnectStep({ attempt: 0 }, heldThenDropped())).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
+    expect(reconnectStep({ attempt: 1 }, heldThenDropped())).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
   });
 
   test('a 255 from a FAILED connect counts against the budget (attempt accumulates)', () => {
-    expect(reconnectStep({ attempt: 0 }, dropped(false))).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
-    expect(reconnectStep({ attempt: 1 }, dropped(false))).toEqual({ action: 'retry', waitMs: 4_000, state: { attempt: 2 } });
-    expect(reconnectStep({ attempt: 3 }, dropped(false))).toEqual({ action: 'retry', waitMs: 16_000, state: { attempt: 4 } });
+    expect(reconnectStep({ attempt: 0 }, unreachable())).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
+    expect(reconnectStep({ attempt: 1 }, unreachable())).toEqual({ action: 'retry', waitMs: 4_000, state: { attempt: 2 } });
+    expect(reconnectStep({ attempt: 3 }, unreachable())).toEqual({ action: 'retry', waitMs: 16_000, state: { attempt: 4 } });
   });
 
   test('the budget is bounded: MAX_ATTEMPTS consecutive FAILED connects stops at 255', () => {
-    expect(reconnectStep({ attempt: MAX_ATTEMPTS }, dropped(false))).toEqual({ action: 'stop', code: SSH_CONN_FAILURE });
+    expect(reconnectStep({ attempt: MAX_ATTEMPTS }, unreachable())).toEqual({ action: 'stop', code: SSH_CONN_FAILURE });
   });
 
-  test('a genuine reconnection (connected) refills the budget even at the cap', () => {
+  test('a genuine reconnection (connected AND held) refills the budget even at the cap', () => {
     // The regression prix caught: a hung/failed connect must NOT look like a live
-    // session. Only `connected: true` refills; `connected: false` at the cap stops.
-    expect(reconnectStep({ attempt: MAX_ATTEMPTS }, dropped(true))).toEqual({
+    // session. `connected: false` at the cap stops; a held reconnection refills.
+    expect(reconnectStep({ attempt: MAX_ATTEMPTS }, heldThenDropped())).toEqual({
       action: 'retry',
       waitMs: backoffMs(0),
       state: { attempt: 1 },
     });
+  });
+
+  test('agents-cli#1884: an attach that CONNECTED but died inside MIN_HOLD_MS does NOT refill', () => {
+    // The bug: `connected` was set by the preflight probe alone, so a link that
+    // reconnected and dropped the user straight back out refilled the budget on
+    // every cycle — "attempt 1/6" forever, MAX_ATTEMPTS bounding nothing.
+    expect(refillsBudget(flapped())).toBe(false);
+    expect(reconnectStep({ attempt: 1 }, flapped())).toEqual({ action: 'retry', waitMs: 4_000, state: { attempt: 2 } });
+    expect(reconnectStep({ attempt: MAX_ATTEMPTS }, flapped())).toEqual({ action: 'stop', code: SSH_CONN_FAILURE });
+  });
+
+  test('MIN_HOLD_MS is the boundary: exactly at the floor refills, one ms under does not', () => {
+    expect(refillsBudget({ code: SSH_CONN_FAILURE, connected: true, heldMs: MIN_HOLD_MS })).toBe(true);
+    expect(refillsBudget({ code: SSH_CONN_FAILURE, connected: true, heldMs: MIN_HOLD_MS - 1 })).toBe(false);
+    // A long hold on an attempt that never connected is not reachable in production
+    // (heldMs is 0 there) and must not refill on the duration alone either.
+    expect(refillsBudget({ code: SSH_CONN_FAILURE, connected: false, heldMs: MIN_HOLD_MS * 10 })).toBe(false);
   });
 });
 
@@ -161,7 +191,9 @@ describe('reattachRemoteCommand — the real remote invocation, exercised throug
     }
     expect(status).toBe(REMOTE_EXIT_255_REMAPPED);
     expect(REMOTE_EXIT_255_REMAPPED).not.toBe(SSH_CONN_FAILURE);
-    expect(reconnectStep(initialReconnectState(), { code: REMOTE_EXIT_255_REMAPPED, connected: true })).toEqual({
+    expect(
+      reconnectStep(initialReconnectState(), { code: REMOTE_EXIT_255_REMAPPED, connected: true, heldMs: MIN_HOLD_MS }),
+    ).toEqual({
       action: 'stop',
       code: REMOTE_EXIT_255_REMAPPED,
     });
@@ -195,13 +227,26 @@ describe('notices — human readable', () => {
   test('exhausted notice hands back the manual reconnect command', () => {
     expect(exhaustedNotice(SID, 'zion')).toContain('agents reconnect 94c75686');
   });
+
+  test('unstable notice says the link kept dropping, not that it could not reconnect', () => {
+    const s = unstableNotice(SID, 'zion');
+    expect(s).toContain('zion');
+    expect(s).toContain('kept dropping again within');
+    expect(s).toContain(`${MAX_ATTEMPTS} attempts`);
+    expect(s).toContain('agents reconnect 94c75686');
+    // The distinction that makes it worth a second notice: it DID reconnect. It
+    // also claims no count of successful reconnections — the budget can be spent
+    // by unreachable attempts plus one that reconnected and dropped straight out.
+    expect(s).not.toContain("Couldn't reconnect");
+    expect(s).not.toMatch(/Reconnected to \w+ \d+ times/);
+  });
 });
 
 describe('reconnectInteractiveSession — the loop over the real state machine', () => {
   const noWait = async () => {};
 
   test('reattaches after a drop, then returns 0 when the user detaches cleanly', async () => {
-    const seq: ReconnectOutcome[] = [{ code: 0, connected: true }]; // reattach → clean detach
+    const seq: ReconnectOutcome[] = [{ code: 0, connected: true, heldMs: MIN_HOLD_MS }]; // reattach → clean detach
     const writes: string[] = [];
     const rc = await reconnectInteractiveSession({
       host: HOST,
@@ -227,21 +272,69 @@ describe('reconnectInteractiveSession — the loop over the real state machine',
       initialExit: SSH_CONN_FAILURE,
       reattach: () => {
         calls++;
-        return { code: SSH_CONN_FAILURE, connected: false }; // host unreachable every time
+        return unreachable(); // host unreachable every time
       },
       wait: noWait,
       write: (s) => writes.push(s),
     });
     expect(rc).toBe(SSH_CONN_FAILURE);
     expect(calls).toBe(MAX_ATTEMPTS); // exactly the budget, no infinite loop
+    expect(writes.some((w) => w.includes("Couldn't reconnect"))).toBe(true);
     expect(writes.some((w) => w.includes('agents reconnect 94c75686'))).toBe(true);
+  });
+
+  test('agents-cli#1884: a link that reconnects and drops straight back out ALSO terminates', async () => {
+    // The reported spin. Every reattach reaches the host (so the old `connected`
+    // check refilled the budget) but the attach dies inside MIN_HOLD_MS, so the
+    // loop printed "attempt 1/6" forever. It must now spend the budget and stop.
+    let calls = 0;
+    const writes: string[] = [];
+    const rc = await reconnectInteractiveSession({
+      host: HOST,
+      sessionId: SID,
+      initialExit: SSH_CONN_FAILURE,
+      reattach: () => {
+        calls++;
+        return flapped();
+      },
+      wait: noWait,
+      write: (s) => writes.push(s),
+    });
+    expect(rc).toBe(SSH_CONN_FAILURE);
+    expect(calls).toBe(MAX_ATTEMPTS); // bounded — this looped forever before the fix
+    // The attempt counter actually advances now instead of resetting to 1 each cycle.
+    expect(writes.some((w) => w.includes(`attempt ${MAX_ATTEMPTS}/${MAX_ATTEMPTS}`))).toBe(true);
+    // And the reason is reported truthfully: it reconnected, it could not stay.
+    expect(writes.some((w) => w.includes('kept dropping again within'))).toBe(true);
+    expect(writes.some((w) => w.includes("Couldn't reconnect"))).toBe(false);
+    expect(writes.some((w) => w.includes('agents reconnect 94c75686'))).toBe(true);
+  });
+
+  test('a mixed outage — unreachable attempts, then one that reconnects and drops out — reports the drop, not "couldn\'t reconnect"', async () => {
+    // The budget is spent by the run of unreachable attempts, but the attempt that
+    // spends it DID reach the host, so the notice must describe that, and must not
+    // claim a count of successful reconnections it never made.
+    const seq: ReconnectOutcome[] = [...Array(MAX_ATTEMPTS - 1).fill(unreachable()), flapped()];
+    const writes: string[] = [];
+    const rc = await reconnectInteractiveSession({
+      host: HOST,
+      sessionId: SID,
+      initialExit: SSH_CONN_FAILURE,
+      reattach: () => seq.shift()!,
+      wait: noWait,
+      write: (s) => writes.push(s),
+    });
+    expect(rc).toBe(SSH_CONN_FAILURE);
+    expect(seq).toHaveLength(0); // the whole budget was spent, no more, no fewer
+    expect(writes.some((w) => w.includes('kept dropping again within'))).toBe(true);
+    expect(writes.some((w) => /Reconnected to \w+ \d+ times/.test(w))).toBe(false);
   });
 
   test('a mid-run second drop after a genuine reconnection keeps reconnecting', async () => {
     // drop → reattach connects and holds, then drops again → reattach → clean exit.
     const seq: ReconnectOutcome[] = [
-      { code: SSH_CONN_FAILURE, connected: true }, // reconnected, then dropped
-      { code: 0, connected: true }, // reconnected, clean detach
+      heldThenDropped(), // reconnected, held, then dropped
+      { code: 0, connected: true, heldMs: MIN_HOLD_MS }, // reconnected, clean detach
     ];
     const rc = await reconnectInteractiveSession({
       host: HOST,
@@ -258,10 +351,10 @@ describe('reconnectInteractiveSession — the loop over the real state machine',
     // 3 unreachable attempts, then a connect that holds and cleanly exits — the
     // failed attempts alone are under MAX_ATTEMPTS, and the connect refills anyway.
     const seq: ReconnectOutcome[] = [
-      dropped(false),
-      dropped(false),
-      dropped(false),
-      { code: 0, connected: true },
+      unreachable(),
+      unreachable(),
+      unreachable(),
+      { code: 0, connected: true, heldMs: MIN_HOLD_MS },
     ];
     const rc = await reconnectInteractiveSession({
       host: HOST,
@@ -272,5 +365,26 @@ describe('reconnectInteractiveSession — the loop over the real state machine',
       write: () => {},
     });
     expect(rc).toBe(0);
+  });
+
+  test('the all-day-blinking session the feature exists for is still unbounded', async () => {
+    // The reason the fix is a hold FLOOR and not a flat total-attempt ceiling: a
+    // link that drops repeatedly but puts the user back into a working pane each
+    // time must keep reconnecting, well past MAX_ATTEMPTS drops in total.
+    const blinks = MAX_ATTEMPTS * 5;
+    let calls = 0;
+    const rc = await reconnectInteractiveSession({
+      host: HOST,
+      sessionId: SID,
+      initialExit: SSH_CONN_FAILURE,
+      reattach: () => {
+        calls++;
+        return calls <= blinks ? heldThenDropped() : { code: 0, connected: true, heldMs: MIN_HOLD_MS };
+      },
+      wait: noWait,
+      write: () => {},
+    });
+    expect(rc).toBe(0);
+    expect(calls).toBe(blinks + 1);
   });
 });

--- a/apps/cli/src/lib/hosts/reconnect.ts
+++ b/apps/cli/src/lib/hosts/reconnect.ts
@@ -19,15 +19,20 @@
  * fall through to resume so the user is put back into the agent. There is one
  * re-attach implementation (the peer's focus) to keep in sync.
  *
- * **Why the budget refills on `connected`, not on call duration.** ssh returns 255
- * for BOTH "couldn't connect at all" and "connected, then the link dropped." A
- * failed connect still takes up to `ConnectTimeout` (10s) to return, so timing
- * alone can't tell the two apart — a duration threshold below the connect timeout
- * would classify every hung connect as a live session and retry forever under a
- * sustained outage (the exact failure this feature exists to survive). Instead each
- * attempt runs a fast preflight probe: a reattach that genuinely reconnected (and
- * then dropped again) refills the retry budget; one that never reached the host
- * counts against it, so a sustained outage gives up after MAX_ATTEMPTS.
+ * **What it takes to refill the budget: reached the host AND held the pane.** ssh
+ * returns 255 for BOTH "couldn't connect at all" and "connected, then the link
+ * dropped." A failed connect still takes up to `ConnectTimeout` (10s) to return, so
+ * the duration of the whole call can't tell the two apart — a threshold below the
+ * connect timeout would classify every hung connect as a live session and retry
+ * forever under a sustained outage (the exact failure this feature exists to
+ * survive). So each attempt runs a fast preflight probe FIRST, and only once that
+ * probe proves the host reachable does the interactive attach run — which means the
+ * ATTACH's own duration is a clean signal, measured with the connect phase already
+ * behind it. A reattach that reached the host and then held for at least
+ * {@link MIN_HOLD_MS} refills the retry budget, so a long session that blinks all
+ * day keeps reconnecting. Everything else — never reached the host, or reached it
+ * and died right back — counts against the budget, so a sustained outage and a
+ * fast-flapping link both give up after {@link MAX_ATTEMPTS}.
  *
  * The retry policy is a pure state machine (`reconnectStep`) so it is unit-tested
  * without touching SSH; the loop (`reconnectInteractiveSession`) only adds the real
@@ -54,13 +59,18 @@
  * regardless of the peer's `agents` version (the remap happens in the shell
  * wrapper THIS process sends).
  *
- * This does NOT close every way `reconnectStep` can loop on a real transport
- * 255: a genuinely recurring LOCAL ssh failure (a fast-flapping link, an
- * attach that dies at the TTY stage on every reconnect) still refills the
- * budget every time by design (see "Why the budget refills on `connected`"
- * above) and can still print "attempt 1/N" indefinitely. That's an accepted,
- * pre-existing tradeoff of the original feature, not something this fix
- * changes either way — tracked separately (agents-cli#1884), not fixed here.
+ * A recurring LOCAL ssh failure used to defeat the budget the same way, and the
+ * remap alone did not close it (agents-cli#1884): `connected` was set by the
+ * preflight probe and said nothing about whether the attach that followed held, so
+ * a fast-flapping link — or an attach that died at the TTY-negotiation stage every
+ * single time — refilled the budget on every cycle, printed "attempt 1/N" forever,
+ * and left `MAX_ATTEMPTS` bounding nothing. The {@link MIN_HOLD_MS} floor above is
+ * what closes it: an attach that dies immediately is not a reconnection, so the
+ * budget drains and the loop gives up with {@link unstableNotice}. A flat total-
+ * attempt or wall-clock ceiling that ignored `connected` was the alternative and is
+ * deliberately NOT taken — any fixed total eventually strands the all-day-blinking
+ * session this feature exists for, while the hold floor only ever stops a loop that
+ * is failing to put the user back into the agent.
  */
 import { sshExec, sshStream, shellQuote } from '../ssh-exec.js';
 import { sshTargetFor, type Host } from './types.js';
@@ -74,16 +84,27 @@ export const SSH_CONN_FAILURE = 255;
  *  transport itself, so it can never be confused with {@link SSH_CONN_FAILURE}. */
 export const REMOTE_EXIT_255_REMAPPED = 254;
 
-/** Consecutive failed-to-connect reattaches before giving up. Backoff is capped at
- *  {@link MAX_BACKOFF_MS}. A reattach that actually reconnected (then dropped again)
- *  refills the budget, so a long session that blinks all day reconnects every time
- *  — only consecutive UNREACHABLE attempts exhaust it. */
+/** Consecutive unproductive reattaches before giving up. Backoff is capped at
+ *  {@link MAX_BACKOFF_MS}. A reattach that reconnected and HELD (then dropped again)
+ *  refills the budget, so a long session that blinks all day reconnects every time —
+ *  an attempt that never reached the host, or reached it and died back inside
+ *  {@link MIN_HOLD_MS}, counts against it. */
 export const MAX_ATTEMPTS = 6;
 const BASE_BACKOFF_MS = 2_000;
 const MAX_BACKOFF_MS = 30_000;
 
+/** How long a reattach must hold the remote pane before it counts as a genuine
+ *  reconnection that refills the budget. Measured on the interactive attach ALONE
+ *  — the preflight probe has already returned by then, so this is not the connect
+ *  timing the file header rules out. 10s is comfortably longer than any attach that
+ *  dies during TTY negotiation and far shorter than a session the user is working
+ *  in; a link that drops the user out inside 10s on every attempt is one this loop
+ *  should stop retrying, not one it should keep re-entering. */
+export const MIN_HOLD_MS = 10_000;
+
 export interface ReconnectState {
-  /** Consecutive failed-to-connect reattaches since the last genuine reconnection. */
+  /** Consecutive unproductive reattaches since the last genuine reconnection — one
+   *  that reached the host and held for {@link MIN_HOLD_MS}. */
   attempt: number;
 }
 
@@ -92,8 +113,13 @@ export interface ReconnectOutcome {
   code: number;
   /** Whether the ssh handshake for this attempt actually completed. The initial run
    *  and any reattach whose preflight probe succeeded are `connected`; a reattach
-   *  that couldn't reach the host is not. Drives the budget refill (see file head). */
+   *  that couldn't reach the host is not. Half of the budget refill (see file head). */
   connected: boolean;
+  /** Wall-clock ms the interactive attach ran for, timed from after the preflight
+   *  probe returned. `0` when the attempt never reached the host. The other half of
+   *  the refill: it must be at least {@link MIN_HOLD_MS} to count as a genuine
+   *  reconnection rather than a link that drops the user straight back out. */
+  heldMs: number;
 }
 
 export type ReconnectDecision =
@@ -110,19 +136,31 @@ export function backoffMs(attempt: number): number {
 }
 
 /**
+ * Did this attempt genuinely put the user back into the agent? Only such an attempt
+ * refills the retry budget — it must have reached the host AND held the pane for at
+ * least {@link MIN_HOLD_MS}. An attach that reached the host and died right back is
+ * a flapping link, not a reconnection, and counts against the budget like an
+ * unreachable host (agents-cli#1884; see the file header).
+ */
+export function refillsBudget(outcome: ReconnectOutcome): boolean {
+  return outcome.connected && outcome.heldMs >= MIN_HOLD_MS;
+}
+
+/**
  * Decide what to do after a run/re-attach returned `outcome`. Pure — the only
  * input is the prior state and the outcome, the only output is the next action.
  *
  *  - a non-255 code means the remote command spoke for itself (clean detach = 0,
  *    agent exit / no live session = non-zero) → stop and surface that code.
  *  - a 255 means the link dropped → retry, unless the budget is spent.
- *  - a 255 from an attempt that DID connect (a genuine reconnection that then
- *    dropped) refills the budget first; a 255 that never connected counts against
- *    it, so a host that stays unreachable gives up after MAX_ATTEMPTS.
+ *  - a 255 from an attempt that reconnected AND held ({@link refillsBudget})
+ *    refills the budget first; every other 255 counts against it, so a host that
+ *    stays unreachable — and a link that keeps dropping the attach immediately —
+ *    both give up after MAX_ATTEMPTS.
  */
 export function reconnectStep(state: ReconnectState, outcome: ReconnectOutcome): ReconnectDecision {
   if (outcome.code !== SSH_CONN_FAILURE) return { action: 'stop', code: outcome.code };
-  const attempts = outcome.connected ? 0 : state.attempt;
+  const attempts = refillsBudget(outcome) ? 0 : state.attempt;
   if (attempts >= MAX_ATTEMPTS) return { action: 'stop', code: SSH_CONN_FAILURE };
   return { action: 'retry', waitMs: backoffMs(attempts), state: { attempt: attempts + 1 } };
 }
@@ -134,10 +172,22 @@ export function reconnectNotice(sessionId: string, host: string, attempt: number
   return `\nConnection to ${host} dropped — the agent is still running there. Reconnecting to ${sessionId.slice(0, 8)} ${when} (attempt ${attempt}/${MAX_ATTEMPTS})…\n`;
 }
 
-/** Notice shown once the retry budget is spent. Hands back the one verb that
- *  re-enters the terminal — attach the live pane if it survived, else resume. */
+/** Notice shown once the retry budget is spent on a host that stayed UNREACHABLE.
+ *  Hands back the one verb that re-enters the terminal — attach the live pane if it
+ *  survived, else resume. */
 export function exhaustedNotice(sessionId: string, host: string): string {
   return `\nCouldn't reconnect to ${host} after ${MAX_ATTEMPTS} attempts. The agent may still be running — get back in when the network is back:\n  agents reconnect ${sessionId.slice(0, 8)}\n`;
+}
+
+/** Notice shown when the budget is spent the OTHER way: the last reattach reached
+ *  the host and the connection dropped again within {@link MIN_HOLD_MS}. Saying
+ *  "couldn't reconnect" there would be false — it did reconnect and could not stay
+ *  — and the user needs to know the link, not the host, is the problem. It claims
+ *  no count of successful reconnections: the budget can also be spent by a run of
+ *  unreachable attempts followed by one that reconnected and dropped straight out. */
+export function unstableNotice(sessionId: string, host: string): string {
+  const secs = Math.round(MIN_HOLD_MS / 1000);
+  return `\nGave up reconnecting to ${host} after ${MAX_ATTEMPTS} attempts — it kept dropping again within ${secs} seconds of getting back in. The agent may still be running there; reconnect once the link is stable:\n  agents reconnect ${sessionId.slice(0, 8)}\n`;
 }
 
 /** Notice shown when a reattach stops on a remapped remote-side exit
@@ -196,15 +246,20 @@ export function reattachRemoteCommand(sessionId: string): string {
  * a reachable host do we run the interactive attach-or-resume (which carries no
  * credentials — the agent already runs on the peer — so it rides the normal
  * transport). Returns the ssh exit code (255 = dropped again / unreachable; 0 =
- * clean detach; other = session ended) plus whether this attempt connected.
+ * clean detach; other = session ended), whether this attempt connected, and how
+ * long the attach held — the two inputs {@link refillsBudget} decides on.
  */
 export function reattachRemoteSession(host: Host, sessionId: string): ReconnectOutcome {
   const target = sshTargetFor(host);
   // Fresh (non-multiplexed) reachability probe: code 0 means the handshake actually
   // completed, so a hung/failed connect is never mistaken for a live reconnection.
   const probe = sshExec(target, 'true', { multiplex: false });
-  if (probe.code !== 0) return { code: SSH_CONN_FAILURE, connected: false };
-  return { code: sshStream(target, reattachRemoteCommand(sessionId), { tty: true }), connected: true };
+  if (probe.code !== 0) return { code: SSH_CONN_FAILURE, connected: false, heldMs: 0 };
+  // Timed from AFTER the probe returned, so this is the attach's own duration and
+  // carries none of the connect phase the file header rules out as a signal.
+  const startedAt = Date.now();
+  const code = sshStream(target, reattachRemoteCommand(sessionId), { tty: true });
+  return { code, connected: true, heldMs: Date.now() - startedAt };
 }
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -234,13 +289,24 @@ export async function reconnectInteractiveSession(opts: ReconnectLoopOpts): Prom
   const reattach = opts.reattach ?? reattachRemoteSession;
 
   let state = initialReconnectState();
-  // The initial run reached the point of running the agent, so it connected.
-  let outcome: ReconnectOutcome = { code: opts.initialExit, connected: true };
+  // The initial run reached the point of running the agent, so it connected. Its
+  // hold duration is never measured — exec.ts owns that call — and never needs to
+  // be: refilling is a no-op at attempt 0, which is where the loop starts, so this
+  // outcome can only ever produce the first retry either way.
+  let outcome: ReconnectOutcome = { code: opts.initialExit, connected: true, heldMs: 0 };
   for (;;) {
     const decision = reconnectStep(state, outcome);
     if (decision.action === 'stop') {
-      if (decision.code === SSH_CONN_FAILURE) write(exhaustedNotice(opts.sessionId, opts.host.name));
-      else if (decision.code === REMOTE_EXIT_255_REMAPPED) write(remoteExitNotice(opts.sessionId, opts.host.name));
+      // A spent budget has two shapes and one wrong message: `outcome` is the
+      // reattach that spent it, so an unreachable host reads "couldn't reconnect"
+      // and a link that reconnected but kept dropping reads as exactly that.
+      if (decision.code === SSH_CONN_FAILURE) {
+        write(outcome.connected
+          ? unstableNotice(opts.sessionId, opts.host.name)
+          : exhaustedNotice(opts.sessionId, opts.host.name));
+      } else if (decision.code === REMOTE_EXIT_255_REMAPPED) {
+        write(remoteExitNotice(opts.sessionId, opts.host.name));
+      }
       return decision.code;
     }
     write(reconnectNotice(opts.sessionId, opts.host.name, decision.state.attempt, decision.waitMs));


### PR DESCRIPTION
**Bug fix, no new UI surface** — internal retry policy for the `agents run --device/--host` auto-reconnect loop, plus the terminal notice it prints when it gives up. Closes #1884 (the item PR #1874 explicitly left open). Evidence below is real output from driving the actual loop, plus the passing suite.

## What was broken

`reconnectStep` reset the consecutive-attempt counter whenever an outcome carried `connected: true`. That flag is set by the **fast preflight probe** (`ssh … true`) — it says nothing about whether the interactive attach that follows put the user back into the agent for any length of time.

So a genuinely recurring **local** ssh failure refilled the budget on every single cycle: a fast-flapping link, or an attach that dies at TTY negotiation each reconnect. The terminal printed `Reconnecting … (attempt 1/6)` forever, never incrementing, and `MAX_ATTEMPTS` bounded nothing.

## The fix

A reattach refills the budget only when it **reached the host AND held the pane for ≥ `MIN_HOLD_MS` (10s)**:

```ts
export function refillsBudget(outcome: ReconnectOutcome): boolean {
  return outcome.connected && outcome.heldMs >= MIN_HOLD_MS;
}
```

`heldMs` is timed **on the attach alone** — `reattachRemoteSession` starts the clock *after* the preflight probe returns. That is what makes a duration usable here at all: the file header rejects a duration threshold because a failed connect burns up to `ConnectTimeout` (10s), but the connect phase is already behind us at this point, so this is not that measurement.

**Why a hold floor and not a total-attempt / wall-clock ceiling** (the other direction the issue lists): any fixed total eventually strands the all-day-blinking session this feature exists for. The hold floor only ever stops a loop that is failing to put you back into the agent.

A spent budget now also picks the right message from the outcome that spent it — the unreachable-host `Couldn't reconnect`, or a new `unstableNotice` for a link that reconnected and kept dropping. It claims no count of successful reconnections, because a mixed outage (unreachable attempts, then one that reconnects and drops straight out) can spend the budget too.

## Run result — driving the real loop, both shapes

Same code, same fake reattach, differing only in the signal the fix keys on (`heldMs`). Ran with `npx tsx` against `reconnectInteractiveSession` itself (only the SSH call and the wait are supplied, as in the unit tests):

```
=== reconnects and HOLDS each time — keeps reconnecting (bounded at 20 for this run) (heldMs=10000, MIN_HOLD_MS=10000, MAX_ATTEMPTS=6) ===
reattaches: 21, exit code: 0
  Connection to zion dropped — the agent is still running there. Reconnecting to 94c75686 in 2 seconds (attempt 1/6)…
  Connection to zion dropped — the agent is still running there. Reconnecting to 94c75686 in 2 seconds (attempt 1/6)…
  Connection to zion dropped — the agent is still running there. Reconnecting to 94c75686 in 2 seconds (attempt 1/6)…
  … 17 more
  Connection to zion dropped — the agent is still running there. Reconnecting to 94c75686 in 2 seconds (attempt 1/6)…

=== reconnects and drops straight back out — the #1884 spin (heldMs=9999, MIN_HOLD_MS=10000, MAX_ATTEMPTS=6) ===
reattaches: 6, exit code: 255
  Connection to zion dropped — the agent is still running there. Reconnecting to 94c75686 in 2 seconds (attempt 1/6)…
  Connection to zion dropped — the agent is still running there. Reconnecting to 94c75686 in 4 seconds (attempt 2/6)…
  Connection to zion dropped — the agent is still running there. Reconnecting to 94c75686 in 8 seconds (attempt 3/6)…
  … 3 more
  Gave up reconnecting to zion after 6 attempts — it kept dropping again within 10 seconds of getting back in. The agent may still be running there; reconnect once the link is stable:
  agents reconnect 94c75686
```

Top block is the reported symptom — `attempt 1/6` on every cycle, unbounded (capped at 20 here only so the demo terminates; in production it never does). It now happens **only** when the reattach genuinely holds, which is the feature working. Bottom block is #1884: the counter climbs 1→6, the loop stops at exit 255, and the message says what actually happened.

## Tests

```
$ npx vitest run src/lib/hosts/reconnect.test.ts
 Test Files  1 passed (1)
      Tests  26 passed (26)

$ npx vitest run src/lib/hosts src/commands/focus.test.ts src/commands/go.test.ts
 Test Files  22 passed (22)
      Tests  339 passed | 1 skipped (340)

$ npx tsc --noEmit -p .
(clean, no output)
```

New coverage, all against the real state machine and the real loop (no mocking):

| Test | Pins |
|---|---|
| `an attach that CONNECTED but died inside MIN_HOLD_MS does NOT refill` | the bug, at the pure-policy level |
| `MIN_HOLD_MS is the boundary` | ≥ floor refills, one ms under does not, duration alone never refills |
| `a link that reconnects and drops straight back out ALSO terminates` | the loop stops at exactly `MAX_ATTEMPTS` and the counter advances |
| `the all-day-blinking session the feature exists for is still unbounded` | 30 held drops keep reconnecting — no regression from a flat ceiling |
| `a mixed outage … reports the drop` | notice selection, and no false "reconnected N times" claim |

Note: reverting the predicate to the pre-fix `outcome.connected` does not make the new loop tests *fail* — it makes them **hang**, because the loop then never terminates. That non-termination is the bug.

## Docs

- `apps/cli/docs/hosts.md` — the reconnect section's "a recurring local ssh failure can still refill the budget by design" caveat is replaced by what now bounds it, including why the floor is a hold and not a cap.
- `.changelog/next/issue-1884-reconnect-hold.md` — release note fragment (queue, not a `CHANGELOG.md` hand-edit).
- The `reconnect.ts` file header's "tracked separately, not fixed here" paragraph is rewritten to describe the fix.
