### PR TITLE
fix(models): word-boundary anchor the Claude id-scan (#1892)

### DIFF
--- a/apps/cli/.changelog/next/issue-1892-models-idscan-boundary.md
+++ b/apps/cli/.changelog/next/issue-1892-models-idscan-boundary.md
@@ -1,0 +1,10 @@
+- **`agents models claude` no longer lists bare legacy ids that 404 (#1892).** The
+  native-binary id-scan fallback (`scanClaudeCatalogIds`, used when the curated maps
+  come up empty) is now word-boundary anchored and matches the id body atomically, so
+  it can't scrape a bare-major prefix (`claude-sonnet-4`) out of the binary's own dotted
+  `claude-sonnet-4.6` "Typo in model ID" troubleshooting string, out of a suffix-glued
+  token (`claude-opus-4-1x`), or out of a token glued to a preceding identifier char. The
+  existing `dropBareLegacyIds` sibling-drop still removes the standalone
+  `.includes("claude-opus-4")` prefix-check artifacts; genuine bare currents
+  (`claude-sonnet-5`) are kept. Catalog output is unchanged across all shipped Claude
+  binaries. Source: `apps/cli/src/lib/models.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 
+- **`agents models claude` no longer lists bare legacy ids that 404 (#1892).** The native-binary id-scan fallback is now word-boundary anchored, so it can't scrape the bare-major prefix (`claude-sonnet-4`) out of the binary's own dotted `claude-sonnet-4.6` "Typo in model ID" troubleshooting string or out of a glued token. The existing sibling-drop still removes the standalone `.includes("claude-opus-4")` prefix-check artifacts; genuine bare currents (`claude-sonnet-5`) are kept.
+
 - **`agents apply --provision-secrets` pushes the manifest's declared secrets
   bundles to each device, instead of only printing a reminder (RUSH-1968).** This
   gap is a direct cause of the ticket: an operator who needed secrets on a worker

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 
-- **`agents models claude` no longer lists bare legacy ids that 404 (#1892).** The native-binary id-scan fallback is now word-boundary anchored, so it can't scrape the bare-major prefix (`claude-sonnet-4`) out of the binary's own dotted `claude-sonnet-4.6` "Typo in model ID" troubleshooting string or out of a glued token. The existing sibling-drop still removes the standalone `.includes("claude-opus-4")` prefix-check artifacts; genuine bare currents (`claude-sonnet-5`) are kept.
-
 - **`agents apply --provision-secrets` pushes the manifest's declared secrets
   bundles to each device, instead of only printing a reminder (RUSH-1968).** This
   gap is a direct cause of the ticket: an operator who needed secrets on a worker

--- a/apps/cli/src/lib/model-tiers.test.ts
+++ b/apps/cli/src/lib/model-tiers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { isTierToken, tierizeModels, resolveTierMap, resolveTier, MODEL_TIERS, applyTierOverrides, type TierResolution } from './model-tiers.js';
-import { getModelCatalog, dropBareLegacyIds, type ModelInfo } from './models.js';
+import { getModelCatalog, dropBareLegacyIds, scanClaudeCatalogIds, type ModelInfo } from './models.js';
 import { listInstalledVersions } from './versions.js';
 import { buildExecCommand } from './exec.js';
 
@@ -56,6 +56,45 @@ describe('dropBareLegacyIds (#1892)', () => {
     expect(out).not.toContain('claude-haiku-4'); // has sibling -> dropped
     expect(out).toContain('claude-sonnet-5'); // no sibling -> kept
     expect(out).toContain('claude-opus-4-8'); // specific -> kept
+  });
+});
+
+describe('scanClaudeCatalogIds (#1892 — word-boundary anchored scan)', () => {
+  // A slice shaped like the real native binary's strings: `.includes(...)`
+  // prefix-check literals, a dotted "Typo in model ID" example, real dated /
+  // variant ids, and a bare current with no sibling.
+  const text = [
+    'if(m.includes("claude-opus-4")||m.includes("claude-haiku-4")){}', // prefix-check artifacts
+    '"Typo in model ID: claude-opus-9.0 (no dashed form exists yet)"', // sibling-less dotted typo
+    'DEFAULTS={firstParty:"claude-opus-4-8"} "claude-opus-4-6-fast" "claude-opus-4-1-20250805-v1"',
+    'HAIKU="claude-haiku-4-5" SONNET5="claude-sonnet-5" FABLE="claude-fable-5.md"',
+    'var x=zzclaude-opus-4-9zz;', // glued on both sides -> not a real id
+  ].join('\n');
+  const ids = scanClaudeCatalogIds(text);
+
+  it('does not scrape a bare major out of a sibling-less dotted-typo string (the anchor)', () => {
+    // `claude-opus-9.0` has no dashed `claude-opus-9-*` in-scan sibling for the
+    // sibling-drop to catch, so without the trailing `(?!\.\d)` anchor the scan
+    // would scrape and *keep* `claude-opus-9` — a 404-able id. The anchor stops
+    // the scrape at the source.
+    expect(ids).not.toContain('claude-opus-9');
+  });
+
+  it('drops the standalone .includes() prefix-check artifacts (the sibling drop)', () => {
+    expect(ids).not.toContain('claude-opus-4'); // sibling claude-opus-4-8 present
+    expect(ids).not.toContain('claude-haiku-4'); // sibling claude-haiku-4-5 present
+  });
+
+  it('keeps real ids: dated, -fast, -v1, and a bare current with no sibling', () => {
+    expect(ids).toContain('claude-opus-4-8');
+    expect(ids).toContain('claude-opus-4-6-fast');
+    expect(ids).toContain('claude-opus-4-1-20250805-v1');
+    expect(ids).toContain('claude-sonnet-5'); // no sibling -> kept
+    expect(ids).toContain('claude-fable-5'); // real id followed by an unrelated ".md"
+  });
+
+  it('does not capture an id glued to surrounding identifier characters', () => {
+    expect(ids).not.toContain('claude-opus-4-9'); // came from `zzclaude-opus-4-9zz`
   });
 });
 

--- a/apps/cli/src/lib/model-tiers.test.ts
+++ b/apps/cli/src/lib/model-tiers.test.ts
@@ -96,6 +96,16 @@ describe('scanClaudeCatalogIds (#1892 — word-boundary anchored scan)', () => {
   it('does not capture an id glued to surrounding identifier characters', () => {
     expect(ids).not.toContain('claude-opus-4-9'); // came from `zzclaude-opus-4-9zz`
   });
+
+  it('does not backtrack-emit a bare major from a suffix-glued multi-segment token', () => {
+    // `claude-opus-9-1x` — two packed strings glued with no separator, as the
+    // binary-string extractor can produce. The greedy `-\d+` run must match
+    // atomically: it must NOT fail the trailing anchor on the full token, drop
+    // the `-1` segment, and re-emit the bare `claude-opus-9` (a 404-able id).
+    const glued = scanClaudeCatalogIds('cfg={id:"claude-opus-9-1x"};');
+    expect(glued).not.toContain('claude-opus-9');
+    expect(glued).toHaveLength(0);
+  });
 });
 
 const m = (ids: string[]): ModelInfo[] => ids.map((id) => ({ id }));

--- a/apps/cli/src/lib/models.ts
+++ b/apps/cli/src/lib/models.ts
@@ -429,6 +429,14 @@ export function dropBareLegacyIds(ids: string[]): string[] {
  *    scraped as `claude-sonnet-4`, while a real id followed by an unrelated `.`
  *    suffix (`claude-fable-5.md`) still matches. Dash-separated segments only:
  *    the dotted form never appears in a genuine id.
+ *
+ *    The id body is captured inside a lookahead (`(?=(...))\1`) so the greedy
+ *    `-\d+` run matches **atomically**: without it, a suffix-glued token like
+ *    `claude-opus-4-1x` would fail the trailing anchor on the full match, then
+ *    backtrack a segment and re-emit the bare `claude-opus-4` — the exact 404-able
+ *    id this scan exists to suppress (two packed strings can end up glued with no
+ *    separator in the extracted binary text). The atomic match fails outright
+ *    instead of degrading to the bare form.
  *  - **`dropBareLegacyIds`.** A standalone `.includes("claude-opus-4")` prefix
  *    check is a fully delimited string the anchors cannot tell apart from a real
  *    bare id, so a bare `claude-<family>-<major>` is dropped only when a
@@ -437,10 +445,13 @@ export function dropBareLegacyIds(ids: string[]): string[] {
  */
 export function scanClaudeCatalogIds(text: string): string[] {
   const idRe =
-    /(?<![A-Za-z0-9_])claude-(?:opus|sonnet|haiku|fable|mythos)-\d+(?:-\d+)*(?:-(?:fast|v\d+))?(?![A-Za-z0-9])(?!\.\d)/g;
+    /(?<![A-Za-z0-9_])(?=(claude-(?:opus|sonnet|haiku|fable|mythos)-\d+(?:-\d+)*(?:-(?:fast|v\d+))?))\1(?![A-Za-z0-9])(?!\.\d)/g;
   const scanned = new Set<string>();
   let sm: RegExpExecArray | null;
-  while ((sm = idRe.exec(text)) !== null) scanned.add(sm[0]);
+  while ((sm = idRe.exec(text)) !== null) {
+    scanned.add(sm[0]);
+    if (sm.index === idRe.lastIndex) idRe.lastIndex++;
+  }
   return dropBareLegacyIds([...scanned]);
 }
 

--- a/apps/cli/src/lib/models.ts
+++ b/apps/cli/src/lib/models.ts
@@ -415,6 +415,35 @@ export function dropBareLegacyIds(ids: string[]): string[] {
   });
 }
 
+/**
+ * Scan raw binary/bundle text for canonical Claude model ids, then drop bare
+ * legacy prefixes (issue #1892). Two independent guards keep non-model strings
+ * out of the catalog:
+ *
+ *  - **Word-boundary anchors on the id regex.** The id must not be glued to a
+ *    surrounding identifier character, and must not be the truncated prefix of a
+ *    longer *version* token. `(?<![A-Za-z0-9_])` rejects a glued prefix;
+ *    `(?![A-Za-z0-9])` rejects a glued alnum suffix; `(?!\.\d)` rejects a
+ *    dotted-version continuation — so the bare-major prefix of the binary's own
+ *    "Typo in model ID" troubleshooting string `claude-sonnet-4.6` is not
+ *    scraped as `claude-sonnet-4`, while a real id followed by an unrelated `.`
+ *    suffix (`claude-fable-5.md`) still matches. Dash-separated segments only:
+ *    the dotted form never appears in a genuine id.
+ *  - **`dropBareLegacyIds`.** A standalone `.includes("claude-opus-4")` prefix
+ *    check is a fully delimited string the anchors cannot tell apart from a real
+ *    bare id, so a bare `claude-<family>-<major>` is dropped only when a
+ *    more-specific sibling (`claude-opus-4-8`) is also present; a genuinely bare
+ *    current id with no sibling (`claude-sonnet-5`) is kept.
+ */
+export function scanClaudeCatalogIds(text: string): string[] {
+  const idRe =
+    /(?<![A-Za-z0-9_])claude-(?:opus|sonnet|haiku|fable|mythos)-\d+(?:-\d+)*(?:-(?:fast|v\d+))?(?![A-Za-z0-9])(?!\.\d)/g;
+  const scanned = new Set<string>();
+  let sm: RegExpExecArray | null;
+  while ((sm = idRe.exec(text)) !== null) scanned.add(sm[0]);
+  return dropBareLegacyIds([...scanned]);
+}
+
 function extractClaudeCatalog(text: string): { models: ModelInfo[]; aliases: Record<string, string> } {
   const aliases: Record<string, string> = {};
 
@@ -482,15 +511,7 @@ function extractClaudeCatalog(text: string): { models: ModelInfo[]; aliases: Rec
   // catalog while a newer one still gets a real catalog (incl. fable/mythos and
   // the opus-5/sonnet-5 line) rather than an empty or single-model one.
   if (models.length < 2) {
-    const scanned = new Set<string>();
-    // Dash-separated segments only. Real ids are `claude-sonnet-4-6`; the dotted
-    // form `claude-sonnet-4.6` appears only inside the binary's own "Typo in
-    // model ID" troubleshooting text, so a `.`-permitting pattern would scrape a
-    // non-model string as if it were real.
-    const idRe = /claude-(?:opus|sonnet|haiku|fable|mythos)-\d+(?:-\d+)*(?:-(?:fast|v\d+))?/g;
-    let sm: RegExpExecArray | null;
-    while ((sm = idRe.exec(text)) !== null) scanned.add(sm[0]);
-    const filtered = dropBareLegacyIds([...scanned]);
+    const filtered = scanClaudeCatalogIds(text);
     if (filtered.length >= 2) models = build(filtered);
   }
 


### PR DESCRIPTION
**bugfix — `agents models claude` catalog scan. No new surface.** Closes #1892.

## What changed

The native-binary id-scan fallback in `extractClaudeCatalog` (used when the curated
maps come up empty, e.g. `claude@2.1.219`) had no boundary anchors, so it scraped the
**bare-major prefix** out of the binary's own dotted `"Typo in model ID:
claude-sonnet-4.6"` troubleshooting string (→ `claude-sonnet-4`) and out of tokens
glued to surrounding identifier chars. A bare `claude-opus-4` / `claude-sonnet-4` is a
prefix-check string, not a submittable id — `--model claude-opus-4` 404s.

The scan is now an exported `scanClaudeCatalogIds(text)` with a word-boundary-anchored
regex:

| Anchor | Rejects |
|---|---|
| `(?<![A-Za-z0-9_])` | id glued to a preceding identifier char |
| `(?![A-Za-z0-9])` | id glued to a trailing alnum |
| `(?!\.\d)` | a dotted-version continuation (`claude-sonnet-4.6`) — while still matching a real id followed by an unrelated `.` suffix (`claude-fable-5.md`) |

`dropBareLegacyIds` (the existing #1892 guard) is retained as the **second** guard: the
standalone `.includes("claude-opus-4")` literals are fully delimited strings the anchors
can't tell apart from a real bare id, so those are dropped only when a more-specific
sibling is present. The two guards are complementary — the anchor stops a **sibling-less**
dotted/glued scrape at the source (which the sibling-drop can't catch), the sibling-drop
removes the delimited prefix-check literals (which the anchor can't).

Scope note: the sibling-drop already suppressed the reported leak on every shipped binary
(all bare majors there have dashed siblings), so **the catalog is byte-for-byte unchanged
across all 10 installed Claude binaries** — this hardens the scan and closes the residual
sibling-less case, completing the regex's documented dash-only intent.

## Run result — real `getModelCatalog('claude', '2.1.219')` via this branch

```
agents models claude@2.1.219 -> 31 ids:
claude-fable-5  claude-haiku-4-5  ...  claude-opus-4-8  claude-opus-5
claude-sonnet-4-6  claude-sonnet-5  ...
BARE LEGACY (claude-opus-4 / -sonnet-4 / -haiku-4, should be empty): (none)
```

Bare `.includes()` artifacts gone; genuine bare currents (`claude-sonnet-5`, `claude-opus-5`,
`claude-fable-5`, `claude-mythos-5`) kept.

## Tests — `bunx vitest run src/lib/model-tiers.test.ts`

```
Test Files  1 passed (1)
     Tests  20 passed (20)
```

New `scanClaudeCatalogIds (#1892)` block asserts a real behavioral difference the anchor
fixes: on the old regex, a sibling-less dotted-typo `claude-opus-9.0` leaks `claude-opus-9`
and glued `zzclaude-opus-4-9zz` leaks `claude-opus-4-9`; on this branch both are dropped
while every real dated / `-fast` / `-v1` / bare-current id is kept.

The one local vitest failure (`getModelCatalog (codex) > extracts slugs and reasoning
levels`) is pre-existing and unrelated — it reads a live installed Codex binary that yields
0 models on this box; the diff touches zero Codex code, and in CI (no Codex installed) it
early-returns and passes.
