### PR TITLE
fix(self-update): inventory hidden agents-cli installs

### DIFF
--- a/apps/cli/.changelog/next/issue-2147-multi-install.md
+++ b/apps/cli/.changelog/next/issue-2147-multi-install.md
@@ -1,0 +1,9 @@
+- **The multi-install warning now inventories copies outside `PATH` and flags
+  legacy installs that can corrupt the shared macOS helper bundle (#2147).**
+  Discovery covers NVM, fnm, Volta, Bun, common npm global prefixes, and npm's
+  `_npx` cache in addition to resolving every `agents` entry on `PATH`. Dev
+  installs are no longer hidden: a copy without the atomic
+  `app-bundle-install` module is labelled `unsafe legacy helper installer —
+  remove this copy`, because invoking it can still replace a live `.app` with a
+  partial bundle. Source: `apps/cli/src/lib/self-update.ts`,
+  `apps/cli/src/index.ts`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -710,7 +710,11 @@ deadlock. **(b)** The cooldown bounds the loop but does not converge it: two
 installs that are *both* invoked regularly trade ownership every cooldown, so the
 helper restarts roughly hourly until one is removed. That is deliberate — the
 alternative is stranding one of them — and the real fix is a single install
-(#2147 covers making the multi-install banner actually name them all).
+(#2147 expanded the multi-install banner beyond `PATH` to NVM, fnm, Volta, Bun,
+common npm prefixes, and the npm `_npx` cache). The banner also checks each
+copy for `dist/lib/app-bundle-install.js`; a copy without it is labelled an
+unsafe legacy helper installer and must be removed, because current code cannot
+make an older executable use the atomic installer it predates.
 
 **Do NOT "improve" this by comparing bundle content.** It looks like the obvious
 gate and it does not work: the helper is rebuilt, re-signed and re-notarized on

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 1.22.26
 
+- **The multi-install warning now inventories copies outside `PATH` and flags
+  legacy installs that can corrupt the shared macOS helper bundle (#2147).**
+  Discovery covers NVM, fnm, Volta, Bun, common npm global prefixes, and npm's
+  `_npx` cache in addition to resolving every `agents` entry on `PATH`. Dev
+  installs are no longer hidden: a copy without the atomic
+  `app-bundle-install` module is labelled `unsafe legacy helper installer —
+  remove this copy`, because invoking it can still replace a live `.app` with a
+  partial bundle. Source: `apps/cli/src/lib/self-update.ts`,
+  `apps/cli/src/index.ts`.
+
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 
 - **`agents apply --provision-secrets` pushes the manifest's declared secrets

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 ## 1.22.26
 
-- **The multi-install warning now inventories copies outside `PATH` and flags
-  legacy installs that can corrupt the shared macOS helper bundle (#2147).**
-  Discovery covers NVM, fnm, Volta, Bun, common npm global prefixes, and npm's
-  `_npx` cache in addition to resolving every `agents` entry on `PATH`. Dev
-  installs are no longer hidden: a copy without the atomic
-  `app-bundle-install` module is labelled `unsafe legacy helper installer —
-  remove this copy`, because invoking it can still replace a live `.app` with a
-  partial bundle. Source: `apps/cli/src/lib/self-update.ts`,
-  `apps/cli/src/index.ts`.
-
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 
 - **`agents apply --provision-secrets` pushes the manifest's declared secrets

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -516,6 +516,7 @@ import {
   saveUpdateCheck,
   dismissUpdateVersion,
   shouldPromptUpgrade,
+  buildMultiInstallInventory,
   findAgentsCliInstalls,
   resolveRunningPackageRoot,
   type UpdateCheckCache,
@@ -541,23 +542,19 @@ function maybeWarnMultiInstall(): void {
     // "/$bunfs" install. This warning is advisory — stay silent instead.
     return;
   }
-  const byRoot = new Map<string, { version: string; note: string }>();
-  byRoot.set(runningRoot, { version: VERSION, note: 'running' });
-  for (const install of findAgentsCliInstalls(process.env.PATH || '')) {
-    if (!byRoot.has(install.packageRoot)) {
-      const notes = [install.binPath ? `agents on PATH: ${install.binPath}` : 'discovered install'];
-      if (!install.atomicHelperInstall) notes.push('unsafe legacy helper installer — remove this copy');
-      byRoot.set(install.packageRoot, { version: install.version, note: notes.join('; ') });
-    }
-  }
+  const inventory = buildMultiInstallInventory(
+    runningRoot,
+    VERSION,
+    findAgentsCliInstalls(process.env.PATH || ''),
+  );
 
-  if (byRoot.size < 2) {
+  if (inventory.length < 2) {
     try { fs.unlinkSync(sentinel); } catch { /* nothing recorded */ }
     return;
   }
 
-  const key = [...byRoot.entries()]
-    .map(([root, info]) => `${root}\t${info.version}\t${info.note}`)
+  const key = inventory
+    .map((info) => `${info.packageRoot}\t${info.version}\t${info.note}`)
     .sort()
     .join('\n');
   try {
@@ -565,8 +562,8 @@ function maybeWarnMultiInstall(): void {
   } catch { /* not warned for this set yet */ }
 
   console.error(chalk.yellow('Multiple agents-cli installs detected:'));
-  for (const [root, info] of byRoot) {
-    console.error(chalk.gray(`  ${root}  ${info.version}  (${info.note})`));
+  for (const info of inventory) {
+    console.error(chalk.gray(`  ${info.packageRoot}  ${info.version}  (${info.note})`));
   }
   console.error(chalk.gray('Upgrades apply to the running copy. Remove a stale copy with: npm uninstall -g --prefix <prefix> @phnx-labs/agents-cli'));
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -523,12 +523,12 @@ import {
 const UPDATE_CHECK_FILE = getUpdateCheckPath();
 
 /**
- * Warn once when PATH resolves `agents` to a different agents-cli install
- * than the copy that is currently running (or to several). Divergent installs
+ * Warn once when this machine contains a different agents-cli install than the
+ * copy that is currently running (or several). Divergent installs
  * are how self-updates "succeed" without changing the command the user types.
- * The warning re-fires only when the set of install roots changes; dev builds
- * (0.0.0-dev) are ignored because side-by-side dev installs are a supported
- * workflow.
+ * The warning re-fires only when the set of install roots or their helper-copy
+ * safety changes. Dev builds are included because old dev copies can still
+ * overwrite the shared macOS helper bundle non-atomically.
  */
 function maybeWarnMultiInstall(): void {
   const sentinel = path.join(getRuntimeStateDir(), 'multi-install-warned');
@@ -544,9 +544,10 @@ function maybeWarnMultiInstall(): void {
   const byRoot = new Map<string, { version: string; note: string }>();
   byRoot.set(runningRoot, { version: VERSION, note: 'running' });
   for (const install of findAgentsCliInstalls(process.env.PATH || '')) {
-    if (install.version.startsWith('0.0.0-dev')) continue;
     if (!byRoot.has(install.packageRoot)) {
-      byRoot.set(install.packageRoot, { version: install.version, note: `agents on PATH: ${install.binPath}` });
+      const notes = [install.binPath ? `agents on PATH: ${install.binPath}` : 'discovered install'];
+      if (!install.atomicHelperInstall) notes.push('unsafe legacy helper installer — remove this copy');
+      byRoot.set(install.packageRoot, { version: install.version, note: notes.join('; ') });
     }
   }
 
@@ -555,7 +556,10 @@ function maybeWarnMultiInstall(): void {
     return;
   }
 
-  const key = [...byRoot.keys()].sort().join('\n');
+  const key = [...byRoot.entries()]
+    .map(([root, info]) => `${root}\t${info.version}\t${info.note}`)
+    .sort()
+    .join('\n');
   try {
     if (fs.readFileSync(sentinel, 'utf-8') === key) return;
   } catch { /* not warned for this set yet */ }

--- a/apps/cli/src/lib/self-update.test.ts
+++ b/apps/cli/src/lib/self-update.test.ts
@@ -374,6 +374,15 @@ describe('update-check cache', () => {
 // symlinks — the function returns [] on win32), and the fixtures here create
 // symlinks that need Developer Mode on Windows. Skip the whole block there.
 describe.skipIf(process.platform === 'win32')('findAgentsCliInstalls', () => {
+  function pathOnlyOptions(base: string) {
+    return {
+      homeDir: path.join(base, 'empty-home'),
+      fnmDir: path.join(base, 'empty-fnm'),
+      npmCacheDir: path.join(base, 'empty-cache'),
+      globalNodeModulesDirs: [],
+    };
+  }
+
   /** Lay out an npm-global-shaped install and a bin dir whose `agents` symlinks into it. */
   function makeInstall(base: string, name: string, version: string, pkgName = '@phnx-labs/agents-cli') {
     const packageRoot = path.join(base, name, 'lib', 'node_modules', ...pkgName.split('/'));
@@ -388,13 +397,25 @@ describe.skipIf(process.platform === 'win32')('findAgentsCliInstalls', () => {
     return { packageRoot: fs.realpathSync(packageRoot), binDir };
   }
 
+  function makeDiscoveredInstall(packageRoot: string, version: string, atomic: boolean): string {
+    fs.mkdirSync(path.join(packageRoot, 'dist', 'lib'), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, 'package.json'),
+      JSON.stringify({ name: '@phnx-labs/agents-cli', version }),
+    );
+    if (atomic) {
+      fs.writeFileSync(path.join(packageRoot, 'dist', 'lib', 'app-bundle-install.js'), '// atomic installer\n');
+    }
+    return fs.realpathSync(packageRoot);
+  }
+
   it('resolves each PATH entry to its package root, deduplicating repeats', () => {
     const base = makeTempDir('installs');
     const a = makeInstall(base, 'prefix-a', '1.20.4');
     const b = makeInstall(base, 'prefix-b', '1.20.7');
     const pathEnv = [a.binDir, b.binDir, a.binDir].join(path.delimiter);
 
-    const installs = findAgentsCliInstalls(pathEnv);
+    const installs = findAgentsCliInstalls(pathEnv, pathOnlyOptions(base));
 
     expect(installs).toHaveLength(2);
     expect(installs.map((i) => i.packageRoot).sort()).toEqual([a.packageRoot, b.packageRoot].sort());
@@ -409,7 +430,7 @@ describe.skipIf(process.platform === 'win32')('findAgentsCliInstalls', () => {
     fs.mkdirSync(localBin, { recursive: true });
     fs.symlinkSync(path.join(real.binDir, 'agents'), path.join(localBin, 'agents'));
 
-    const installs = findAgentsCliInstalls(localBin);
+    const installs = findAgentsCliInstalls(localBin, pathOnlyOptions(base));
 
     expect(installs).toHaveLength(1);
     expect(installs[0].packageRoot).toBe(real.packageRoot);
@@ -432,13 +453,13 @@ describe.skipIf(process.platform === 'win32')('findAgentsCliInstalls', () => {
 
     // A compiled shim on its own must resolve — before the fix this was [],
     // i.e. the copy that actually runs was invisible to the scan entirely.
-    const compiledOnly = findAgentsCliInstalls(localBin);
+    const compiledOnly = findAgentsCliInstalls(localBin, pathOnlyOptions(base));
     expect(compiledOnly).toHaveLength(1);
     expect(compiledOnly[0].packageRoot).toBe(real.packageRoot);
     expect(compiledOnly[0].version).toBe('1.20.73');
 
     // And alongside the sibling npm bin it dedups to one install, not two.
-    const both = findAgentsCliInstalls([localBin, real.binDir].join(path.delimiter));
+    const both = findAgentsCliInstalls([localBin, real.binDir].join(path.delimiter), pathOnlyOptions(base));
     expect(both).toHaveLength(1);
     expect(both[0].binPath).toBe(path.join(localBin, 'agents'));
   });
@@ -459,6 +480,60 @@ describe.skipIf(process.platform === 'win32')('findAgentsCliInstalls', () => {
     fs.mkdirSync(empty, { recursive: true });
 
     const pathEnv = [plainBin, foreign.binDir, dangling, empty].join(path.delimiter);
-    expect(findAgentsCliInstalls(pathEnv)).toEqual([]);
+    expect(findAgentsCliInstalls(pathEnv, pathOnlyOptions(base))).toEqual([]);
+  });
+
+  it('discovers installs outside PATH across node managers and the npx cache (#2147)', () => {
+    const homeDir = makeTempDir('managed-installs');
+    const npmCacheDir = path.join(homeDir, 'npm-cache');
+    const roots = [
+      makeDiscoveredInstall(
+        path.join(homeDir, '.nvm', 'versions', 'node', 'v24.15.0', 'lib', 'node_modules', '@phnx-labs', 'agents-cli'),
+        '1.22.5',
+        true,
+      ),
+      makeDiscoveredInstall(
+        path.join(homeDir, '.local', 'share', 'fnm', 'node-versions', 'v24.14.0', 'installation', 'lib', 'node_modules', '@phnx-labs', 'agents-cli'),
+        '1.22.4',
+        true,
+      ),
+      makeDiscoveredInstall(
+        path.join(homeDir, '.volta', 'tools', 'image', 'packages', '@phnx-labs', 'agents-cli', 'lib', 'node_modules', '@phnx-labs', 'agents-cli'),
+        '1.22.3',
+        true,
+      ),
+      makeDiscoveredInstall(
+        path.join(npmCacheDir, '_npx', 'run-1', 'node_modules', '@phnx-labs', 'agents-cli'),
+        '1.20.88',
+        false,
+      ),
+    ];
+
+    const installs = findAgentsCliInstalls('', {
+      homeDir,
+      npmCacheDir,
+      globalNodeModulesDirs: [],
+    });
+
+    expect(installs.map((install) => install.packageRoot).sort()).toEqual(roots.sort());
+    expect(installs.every((install) => install.binPath === undefined)).toBe(true);
+    expect(installs.find((install) => install.version === '1.20.88')?.atomicHelperInstall).toBe(false);
+    expect(installs.filter((install) => install.atomicHelperInstall)).toHaveLength(3);
+  });
+
+  it('deduplicates a managed install already found through PATH and preserves its PATH note', () => {
+    const homeDir = makeTempDir('managed-dedup');
+    const nvmRoot = path.join(homeDir, '.nvm', 'versions', 'node', 'v24.15.0');
+    const install = makeInstall(path.dirname(nvmRoot), path.basename(nvmRoot), '1.22.5');
+
+    const installs = findAgentsCliInstalls(install.binDir, {
+      homeDir,
+      npmCacheDir: path.join(homeDir, 'empty-cache'),
+      globalNodeModulesDirs: [],
+    });
+
+    expect(installs).toHaveLength(1);
+    expect(installs[0].packageRoot).toBe(install.packageRoot);
+    expect(installs[0].binPath).toBe(path.join(install.binDir, 'agents'));
   });
 });

--- a/apps/cli/src/lib/self-update.test.ts
+++ b/apps/cli/src/lib/self-update.test.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { needsWindowsShell, toPosix } from './platform/index.js';
 import {
   bunGlobalDir,
+  buildMultiInstallInventory,
   deriveGlobalPrefix,
   detectPackageManager,
   dismissUpdateVersion,
@@ -535,5 +536,23 @@ describe.skipIf(process.platform === 'win32')('findAgentsCliInstalls', () => {
     expect(installs).toHaveLength(1);
     expect(installs[0].packageRoot).toBe(install.packageRoot);
     expect(installs[0].binPath).toBe(path.join(install.binDir, 'agents'));
+  });
+});
+
+describe('buildMultiInstallInventory', () => {
+  it('marks the running copy unsafe when it predates the atomic helper installer', () => {
+    const runningRoot = '/prefix/lib/node_modules/@phnx-labs/agents-cli';
+    const inventory = buildMultiInstallInventory(runningRoot, '1.20.88', [{
+      binPath: '/prefix/bin/agents',
+      packageRoot: runningRoot,
+      version: '1.20.88',
+      atomicHelperInstall: false,
+    }]);
+
+    expect(inventory).toEqual([{
+      packageRoot: runningRoot,
+      version: '1.20.88',
+      note: 'running; unsafe legacy helper installer — remove this copy',
+    }]);
   });
 });

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -392,6 +392,35 @@ export interface FindAgentsCliInstallsOptions {
   globalNodeModulesDirs?: string[];
 }
 
+export interface MultiInstallInventoryEntry {
+  packageRoot: string;
+  version: string;
+  note: string;
+}
+
+export function buildMultiInstallInventory(
+  runningRoot: string,
+  runningVersion: string,
+  installs: AgentsCliInstall[],
+): MultiInstallInventoryEntry[] {
+  const byRoot = new Map<string, MultiInstallInventoryEntry>();
+  byRoot.set(runningRoot, { packageRoot: runningRoot, version: runningVersion, note: 'running' });
+  for (const install of installs) {
+    const notes = [install.packageRoot === runningRoot
+      ? 'running'
+      : install.binPath
+        ? `agents on PATH: ${install.binPath}`
+        : 'discovered install'];
+    if (!install.atomicHelperInstall) notes.push('unsafe legacy helper installer — remove this copy');
+    byRoot.set(install.packageRoot, {
+      packageRoot: install.packageRoot,
+      version: install.version,
+      note: notes.join('; '),
+    });
+  }
+  return [...byRoot.values()];
+}
+
 function childDirectories(parent: string): string[] {
   try {
     return fs.readdirSync(parent, { withFileTypes: true })

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -376,16 +376,94 @@ function packageRootForEntry(real: string): string | null {
 }
 
 export interface AgentsCliInstall {
-  /** The PATH entry (`<dir>/agents`) that resolves to this install. */
-  binPath: string;
+  /** The PATH entry (`<dir>/agents`) that resolves to this install, when found through PATH. */
+  binPath?: string;
   /** Package root containing package.json and dist/. */
   packageRoot: string;
   version: string;
+  /** Whether this copy uses the serialized, atomic helper-bundle installer. */
+  atomicHelperInstall: boolean;
+}
+
+export interface FindAgentsCliInstallsOptions {
+  homeDir?: string;
+  fnmDir?: string;
+  npmCacheDir?: string;
+  globalNodeModulesDirs?: string[];
+}
+
+function childDirectories(parent: string): string[] {
+  try {
+    return fs.readdirSync(parent, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(parent, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+function knownPackageRoots(opts: FindAgentsCliInstallsOptions): string[] {
+  const homeDir = opts.homeDir ?? os.homedir();
+  const fnmRoots = opts.fnmDir !== undefined
+    ? [opts.fnmDir]
+    : [process.env.FNM_DIR, path.join(homeDir, '.local', 'share', 'fnm')]
+      .filter((value): value is string => Boolean(value));
+  const roots: string[] = [];
+  const packageTail = path.join('lib', 'node_modules', ...NPM_PACKAGE_NAME.split('/'));
+
+  for (const nodeDir of childDirectories(path.join(homeDir, '.nvm', 'versions', 'node'))) {
+    roots.push(path.join(nodeDir, packageTail));
+  }
+  for (const fnmRoot of fnmRoots) {
+    for (const versionDir of childDirectories(path.join(fnmRoot, 'node-versions'))) {
+      roots.push(path.join(versionDir, 'installation', packageTail));
+    }
+  }
+
+  roots.push(
+    path.join(homeDir, '.volta', 'tools', 'image', 'packages', ...NPM_PACKAGE_NAME.split('/'), packageTail),
+    path.join(homeDir, '.local', packageTail),
+    path.join(homeDir, '.bun', 'install', 'global', 'node_modules', ...NPM_PACKAGE_NAME.split('/')),
+  );
+
+  const npmCacheDir = opts.npmCacheDir ?? process.env.npm_config_cache ?? path.join(homeDir, '.npm');
+  for (const npxRunDir of childDirectories(path.join(npmCacheDir, '_npx'))) {
+    roots.push(path.join(npxRunDir, 'node_modules', ...NPM_PACKAGE_NAME.split('/')));
+  }
+
+  const globalNodeModulesDirs = opts.globalNodeModulesDirs ?? [
+    '/opt/homebrew/lib/node_modules',
+    '/usr/local/lib/node_modules',
+    '/usr/lib/node_modules',
+  ];
+  for (const nodeModulesDir of globalNodeModulesDirs) {
+    roots.push(path.join(nodeModulesDir, ...NPM_PACKAGE_NAME.split('/')));
+  }
+  return roots;
+}
+
+function readAgentsCliInstall(packageRoot: string, binPath?: string): AgentsCliInstall | null {
+  let canonicalRoot: string;
+  let pkg: { name?: unknown; version?: unknown };
+  try {
+    canonicalRoot = fs.realpathSync(packageRoot);
+    pkg = JSON.parse(fs.readFileSync(path.join(canonicalRoot, 'package.json'), 'utf-8'));
+  } catch {
+    return null;
+  }
+  if (pkg.name !== NPM_PACKAGE_NAME || typeof pkg.version !== 'string') return null;
+  return {
+    ...(binPath ? { binPath } : {}),
+    packageRoot: canonicalRoot,
+    version: pkg.version,
+    atomicHelperInstall: fs.existsSync(path.join(canonicalRoot, 'dist', 'lib', 'app-bundle-install.js')),
+  };
 }
 
 /**
- * Scan PATH for `agents` entrypoints and resolve each to the agents-cli
- * package root it executes. More than one distinct root means upgrades,
+ * Resolve every `agents` entrypoint on PATH, then inspect the bounded global
+ * install layouts used by NVM, fnm, Volta, Bun, npm, and npx. More than one
+ * distinct package root means upgrades,
  * shims, and the command the user types can act on different copies — the
  * divergence behind silently-failing self-updates.
  *
@@ -399,10 +477,18 @@ export interface AgentsCliInstall {
  * @phnx-labs/agents-cli is some other tool and is skipped.
  * POSIX-only: Windows npm bins are .cmd wrappers, not symlinks.
  */
-export function findAgentsCliInstalls(pathEnv: string): AgentsCliInstall[] {
+export function findAgentsCliInstalls(
+  pathEnv: string,
+  opts: FindAgentsCliInstallsOptions = {},
+): AgentsCliInstall[] {
   if (process.platform === 'win32') return [];
   const installs: AgentsCliInstall[] = [];
   const seenRoots = new Set<string>();
+  const addInstall = (install: AgentsCliInstall | null): void => {
+    if (!install || seenRoots.has(install.packageRoot)) return;
+    seenRoots.add(install.packageRoot);
+    installs.push(install);
+  };
   for (const dir of pathEnv.split(path.delimiter).filter(Boolean)) {
     const candidate = path.join(dir, 'agents');
     let real: string;
@@ -413,16 +499,10 @@ export function findAgentsCliInstalls(pathEnv: string): AgentsCliInstall[] {
     }
     const packageRoot = packageRootForEntry(real);
     if (!packageRoot) continue;
-    if (seenRoots.has(packageRoot)) continue;
-    let pkg: { name?: unknown; version?: unknown };
-    try {
-      pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf-8'));
-    } catch {
-      continue;
-    }
-    if (pkg.name !== NPM_PACKAGE_NAME || typeof pkg.version !== 'string') continue;
-    seenRoots.add(packageRoot);
-    installs.push({ binPath: candidate, packageRoot, version: pkg.version });
+    addInstall(readAgentsCliInstall(packageRoot, candidate));
+  }
+  for (const packageRoot of knownPackageRoots(opts)) {
+    addInstall(readAgentsCliInstall(packageRoot));
   }
   return installs;
 }


### PR DESCRIPTION
Fixes #2147.

## What changed

- Inventory agents-cli copies in NVM, fnm, Volta, Bun, common npm globals, and npm `_npx` caches in addition to `PATH`.
- Include development installs instead of hiding them.
- Detect `dist/lib/app-bundle-install.js`; label pre-atomic copies `unsafe legacy helper installer — remove this copy` because current code cannot retrofit safe writes into an older executable.
- Re-fire the warning when a discovered copy changes version or helper-install safety, not only when paths change.

This takes the issue's diagnostic-escalation direction: every discoverable legacy writer is named and identified for removal. It does not claim an old executable can be made atomic by newer code.

## Run evidence

Terminal capture: `yosemite-s0:/tmp/issue-2147-self-update-tests.txt` (fleet-local path; public upload was unavailable because this host's `share` bundle is locked).

- `bun test src/lib/self-update.test.ts` → `34 pass, 0 fail, 63 expect() calls`.
- `bunx tsc --noEmit` → exit 0.
- `apps/cli/scripts/build.sh` → dependency install, TypeScript compile, and test phases completed with exit 0.
- Built `findAgentsCliInstalls(process.env.PATH)` on yosemite-s0 returned 7 distinct copies: the PATH dev install, 3 NVM installs, the current local npm install, 1 `_npx` cache copy, and 1 `/usr/local` copy; the four pre-atomic copies returned `atomicHelperInstall: false`.
- `git diff --check` → clean.

## Surface

CLI text-only diagnostic; no graphical UI surface. The regression suite constructs real package layouts and symlinks without mocks.
