### PR TITLE
fix(hooks): cap duration timeout strings (#1853)

### DIFF
--- a/apps/cli/src/lib/__tests__/hooks-layering.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks-layering.test.ts
@@ -155,6 +155,21 @@ describe('parseHookManifest layering', () => {
     );
   });
 
+  it('drops a 100h duration timeout with a warning, leaving other fields intact', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fs.writeFileSync(
+      path.join(USER_DIR, 'agents.yaml'),
+      'hooks:\n  bad:\n    script: bad.sh\n    events: [Stop]\n    timeout: 100h\n',
+      'utf-8'
+    );
+    const out = parseHookManifest();
+    expect(out['bad'].script).toBe('bad.sh');
+    expect(out['bad'].timeout).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Hook 'bad' has an invalid timeout"),
+    );
+  });
+
   it('enabled: false in user entry disables a system-shipped hook by name', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     fs.writeFileSync(
@@ -291,6 +306,13 @@ describe('normalizeHookTimeoutSeconds', () => {
     expect(normalizeHookTimeoutSeconds('1h')).toBe(3600);
     expect(normalizeHookTimeoutSeconds('1h30m')).toBe(5400);
     expect(normalizeHookTimeoutSeconds('1m30s')).toBe(90);
+  });
+
+  it('rejects a 100h duration without capping bare seconds', () => {
+    expect(normalizeHookTimeoutSeconds('24h')).toBe(86400);
+    expect(normalizeHookTimeoutSeconds('100h')).toBeNull();
+    expect(normalizeHookTimeoutSeconds(360000)).toBe(360000);
+    expect(normalizeHookTimeoutSeconds('360000')).toBe(360000);
   });
 
   it('treats a bare integer string as seconds', () => {

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -1313,17 +1313,22 @@ export function listCentralHooks(): HookEntry[] {
   return results;
 }
 
+const MAX_HOOK_DURATION_SECONDS = 24 * 60 * 60;
+
 /**
  * Normalize a hook `timeout` from agents.yaml into a whole number of seconds.
  *
  * A bare number stays seconds (`timeout: 30` → 30) for backward compatibility.
  * A Go-style duration string is parsed into seconds: `5s`, `2m`, `1h30m`,
- * `90s`, `1h`. This intentionally does NOT reuse {@link parseTimeout} from
- * routines.ts — that one returns milliseconds, has no seconds (`s`) unit, and
- * floors at one minute, none of which fit hook timeouts (typically 5–600s).
+ * `90s`, `1h`. Suffixed durations longer than 24 hours are rejected as likely
+ * typos, while bare seconds stay uncapped for backward compatibility. This
+ * intentionally does NOT reuse {@link parseTimeout} from routines.ts — that one
+ * returns milliseconds, has no seconds (`s`) unit, and floors at one minute,
+ * none of which fit hook timeouts (typically 5–600s).
  *
- * Returns the seconds value, or `null` when the input is not a positive number
- * or a parseable duration string — the caller decides how to surface that.
+ * Returns the seconds value, or `null` when the input is not a positive number,
+ * is not parseable, or is a suffixed duration longer than 24 hours — the caller
+ * decides how to surface that.
  */
 export function normalizeHookTimeoutSeconds(value: unknown): number | null {
   if (typeof value === 'number') {
@@ -1345,7 +1350,7 @@ export function normalizeHookTimeoutSeconds(value: unknown): number | null {
     const minutes = Number(m[4] || 0);
     const seconds = Number(m[5] || 0);
     const total = ((weeks * 7 + days) * 24 + hours) * 3600 + minutes * 60 + seconds;
-    return total > 0 ? total : null;
+    return total > 0 && total <= MAX_HOOK_DURATION_SECONDS ? total : null;
   }
   return null;
 }


### PR DESCRIPTION
Fixes #1853

## What changed

- Reject suffixed hook timeout durations above 24 hours, so the reported `100h` typo is dropped through the existing invalid-timeout warning path.
- Keep numeric seconds and bare integer strings uncapped for backward compatibility.
- Cover the `100h` normalizer boundary and full manifest behavior.

A one-week ceiling would still accept the issue reproduction (`100h`), so this uses 24 hours as the maximum suffixed duration.

## Verification

No visual surface: this is a hook-manifest validation bug fix.

- [`bun run test -- src/lib/__tests__/hooks-layering.test.ts` - captured run, 19/19 passed](https://gist.github.com/muqsitnawaz/18a1b4c12e4a23fb052e27294b072a50)
- `bun run build` - passed on yosemite-s1
- `git diff --check` - passed

Pure bug-fix exemption: no user-facing command, flag, configuration shape, or documented behavior changed, so no docs or CHANGELOG entry is required.
