### PR TITLE
fix(sessions): retain routine scope for artifact lookup

### DIFF
--- a/apps/cli/src/commands/__tests__/sessions-team-lineage.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-team-lineage.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { applyScopeFilters, buildRoutineChoices, buildRoutineRunGroups, filterSessionsByRoutine, formatPickerLabel, hasNoBrowserDisqualifyingFlags, matchesTeam, printRoutineRunOverview, resolveRoutineName, teamBadge } from '../sessions.js';
+import { applyScopeFilters, artifactLookupScope, buildRoutineChoices, buildRoutineRunGroups, filterSessionsByRoutine, formatPickerLabel, hasNoBrowserDisqualifyingFlags, matchesTeam, printRoutineRunOverview, resolveRoutineName, teamBadge } from '../sessions.js';
 import { resolveSessionById } from '../../lib/session/discover.js';
 import { formatTeamLineage } from '../sessions-picker.js';
 import type { SessionMeta } from '../../lib/session/types.js';
@@ -91,6 +91,19 @@ describe('resolveRoutineName', () => {
     const globallyScoped = applyScopeFilters([wanted, other], { routine: 'nightly' });
     expect(resolveSessionById(globallyScoped, 'other-id')).toEqual([]);
     expect(resolveSessionById(globallyScoped, 'wanted-id')).toEqual([wanted]);
+  });
+});
+
+describe('artifact lookup routine scope', () => {
+  it('excludes a session from another routine before resolving its artifacts', () => {
+    const wanted = meta({ id: 'wanted-id', origin: 'routine', routineName: 'nightly-review' });
+    const other = meta({ id: 'other-id', origin: 'routine', routineName: 'release-notes' });
+    const scoped = applyScopeFilters(
+      [wanted, other],
+      artifactLookupScope(undefined, undefined, 'nightly-review'),
+    );
+    expect(resolveSessionById(scoped, 'other-id')).toEqual([]);
+    expect(resolveSessionById(scoped, 'wanted-id')).toEqual([wanted]);
   });
 });
 

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -2300,11 +2300,12 @@ async function sessionsAction(
 
   // Artifact-list or artifact-read paths: widen scope and resolve session globally.
   if ((options.artifacts || options.artifact !== undefined) && searchQuery) {
-    await renderArtifactsGlobal(searchQuery, options.artifacts ?? false, options.artifact, {
-      agent: options.agent,
-      project: options.project,
-      routine: options.routine,
-    });
+    await renderArtifactsGlobal(
+      searchQuery,
+      options.artifacts ?? false,
+      options.artifact,
+      artifactLookupScope(options.agent, options.project, options.routine),
+    );
     return;
   }
 
@@ -4255,6 +4256,14 @@ export function applyScopeFilters(
   }
 
   return filtered;
+}
+
+export function artifactLookupScope(
+  agent?: string,
+  project?: string,
+  routine?: boolean | string,
+): { agent?: string; project?: string; routine?: boolean | string } {
+  return { agent, project, routine };
 }
 
 async function renderArtifactsGlobal(

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -2300,7 +2300,11 @@ async function sessionsAction(
 
   // Artifact-list or artifact-read paths: widen scope and resolve session globally.
   if ((options.artifacts || options.artifact !== undefined) && searchQuery) {
-    await renderArtifactsGlobal(searchQuery, options.artifacts ?? false, options.artifact, { agent: options.agent, project: options.project });
+    await renderArtifactsGlobal(searchQuery, options.artifacts ?? false, options.artifact, {
+      agent: options.agent,
+      project: options.project,
+      routine: options.routine,
+    });
     return;
   }
 
@@ -4257,7 +4261,7 @@ async function renderArtifactsGlobal(
   query: string,
   listAll: boolean,
   name: string | undefined,
-  scope: { agent?: string; project?: string },
+  scope: { agent?: string; project?: string; routine?: boolean | string },
 ): Promise<void> {
   const spinner = ora().start();
   const tracker = createScanProgressTracker(FIND_VERBS, 'session', spinner);


### PR DESCRIPTION
Bug fix following #2212: `agents sessions --routine <name> --artifacts <session>` now keeps the routine selector during global artifact lookup.

## Review finding addressed

- Passes `routine: options.routine` into `renderArtifactsGlobal`.
- Extends that helper's scope type so `applyScopeFilters` applies the routine name before resolving the session.

## Verification

No UI surface. Focused Vitest run: 29 passed, 0 failed. Build passed.

Run artifact (fleet-local path): `yosemite-s0:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/2026-08-05/pr-2212-followup-tests.txt`
