### PR TITLE
feat(output): input/cache-read/cache-write burn split + --pricing no-cache (RUSH-2287)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2287.md
+++ b/apps/cli/.changelog/next/RUSH-2287.md
@@ -1,0 +1,15 @@
+- **`agents output` now reports the burn split and a `--pricing no-cache` scenario (RUSH-2287).**
+  The productivity rollup collapsed token burn into a single counter. It now
+  breaks the burn into uncached **input** / **cache-read** / **cache-write** tokens
+  wherever the harness records a per-message cache split (Claude, Codex, Gemini,
+  Droid) — a `burn split:` line in the text report and the three counts on `burn`
+  and every `breakdown` row in `--json`. New `--pricing no-cache` reprices cached
+  tokens at the model's full input rate to model "what would this cost with caching
+  off?"; the text report leads with that figure (breakdown column `burn(nc)`) while
+  `--json` always carries **both** `costUsd` and `costUsdNoCache` so a dashboard can
+  choose. The saving is surfaced in actual mode too (`caching: actual $X vs no-cache
+  $Y`). Backed by four new session columns (`input_tokens`, `cache_read_tokens`,
+  `cache_write_tokens`, `cost_usd_nocache`, schema v37) populated at scan time;
+  pre-upgrade sessions show total-only until re-scanned. Source:
+  `apps/cli/src/commands/output.ts`, `apps/cli/src/lib/session/{db,discover}.ts`,
+  `apps/cli/src/lib/pricing/cost.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -1315,6 +1315,46 @@ agents sessions --all --sort cost --limit 10 --json | \
   jq '.[] | {shortId, agent, costUsd, durationMs, topic}'
 ```
 
+## Productivity Rollup (`agents output`)
+
+`agents cost` answers *what you spent*; `agents output` joins that burn to *what
+shipped* (real generated output tokens, plus PRs and commits) — the "was it worth
+it" axis. It leads with `output_tokens` (real generation), not the cache-inflated
+`token_count`.
+
+### Burn split — input / cache-read / cache-write
+
+Where the harness records a per-message cache split (**Claude, Codex, Gemini,
+Droid**), each session persists the split — uncached `input_tokens`,
+`cache_read_tokens`, and `cache_write_tokens` (schema v37) — and the rollup sums
+them. The text report adds a `burn split:` line and `--json` carries the three
+counts on `burn` and on every `breakdown` row. Harnesses that expose no cache
+split (e.g. OpenCode, Kimi) leave the split absent and show total + output only.
+
+### `--pricing no-cache` — model the burn without prompt caching
+
+Each session also persists a second cost, `cost_usd_nocache`, computed at scan
+time by repricing its cache-read and cache-write tokens at the model's full
+**input** rate (output and uncached input are unchanged). This is the "what would
+this have cost with caching off?" scenario.
+
+```bash
+# Actual (cache-discounted) burn, with a caching-savings comparison line
+agents output
+
+# Lead the burn with the no-cache figure (breakdown column becomes burn(nc))
+agents output --pricing no-cache
+
+# Both costs + the split, machine-readable (JSON is scenario-agnostic —
+# it always carries burn.costUsd AND burn.costUsdNoCache plus the split)
+agents output --json | jq '.burn | {costUsd, costUsdNoCache, inputTokens, cacheReadTokens, cacheWriteTokens}'
+```
+
+`--pricing` only chooses which cost the **text** report leads with; the `--json`
+payload always carries both `costUsd` and `costUsdNoCache` so a dashboard can pick.
+Because caching is a discount, `costUsdNoCache ≥ costUsd`; the text report shows the
+saving (`caching: actual $X vs no-cache $Y (saved $Z, N%)`) whenever it is nonzero.
+
 ## Accounts & Usage in `agents view`
 
 `agents view` shows, per installed agent, **who's signed in** and (where the

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -1352,8 +1352,11 @@ agents output --json | jq '.burn | {costUsd, costUsdNoCache, inputTokens, cacheR
 
 `--pricing` only chooses which cost the **text** report leads with; the `--json`
 payload always carries both `costUsd` and `costUsdNoCache` so a dashboard can pick.
-Because caching is a discount, `costUsdNoCache ≥ costUsd`; the text report shows the
-saving (`caching: actual $X vs no-cache $Y (saved $Z, N%)`) whenever it is nonzero.
+`costUsdNoCache ≥ costUsd` in typical sessions, where cheap cache **reads** dominate
+the burn. It can invert in a cache-**write**-heavy session: Claude prices a cache
+write at 1.25× the input rate, so repricing those writes *down* to the input rate can
+make the no-cache figure lower. The text report shows the saving (`caching: actual $X
+vs no-cache $Y (saved $Z, N%)`) only when the no-cache figure is actually higher.
 
 ## Accounts & Usage in `agents view`
 

--- a/apps/cli/src/commands/output.test.ts
+++ b/apps/cli/src/commands/output.test.ts
@@ -16,6 +16,13 @@ type SessionMeta = import('../lib/session/types.js').SessionMeta;
 const FILES_DIR = path.join(TEST_HOME, 'output-cmd-files');
 fs.mkdirSync(FILES_DIR, { recursive: true });
 
+interface Split {
+  inputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  costUsdNoCache: number;
+}
+
 function seed(
   id: string,
   agent: SessionMeta['agent'],
@@ -24,6 +31,7 @@ function seed(
   outputTokens: number,
   tokenCount: number,
   project: string,
+  split?: Split,
 ): void {
   const filePath = path.join(FILES_DIR, `${id}.jsonl`);
   fs.writeFileSync(filePath, '');
@@ -39,6 +47,7 @@ function seed(
     costUsd,
     outputTokens,
     tokenCount,
+    ...(split ?? {}),
   };
   upsertSession(meta, '');
 }
@@ -73,9 +82,15 @@ const BASE = ['--since', '2020-01-01', '--no-prs'];
 describe('agents output', () => {
   beforeAll(() => {
     // token_count is deliberately >> outputTokens to model cache-read inflation.
-    seed('big0001', 'claude', '2026-05-20T10:00:00.000Z', 30, 1_000_000, 50_000_000, 'rush');
-    seed('mid0002', 'claude', '2026-05-21T10:00:00.000Z', 10, 400_000, 12_000_000, 'agents-cli');
-    seed('cdx0003', 'codex', '2026-05-21T12:00:00.000Z', 2, 100_000, 3_000_000, 'agents-cli');
+    // The split (input/cache-read/cache-write) and cost_usd_nocache are seeded so
+    // the rollup + --pricing no-cache scenario have real numbers (RUSH-2287).
+    // Per session: costUsdNoCache > costUsd (caching is a discount).
+    seed('big0001', 'claude', '2026-05-20T10:00:00.000Z', 30, 1_000_000, 50_000_000, 'rush',
+      { inputTokens: 2_000_000, cacheReadTokens: 46_000_000, cacheWriteTokens: 1_000_000, costUsdNoCache: 90 });
+    seed('mid0002', 'claude', '2026-05-21T10:00:00.000Z', 10, 400_000, 12_000_000, 'agents-cli',
+      { inputTokens: 1_000_000, cacheReadTokens: 10_500_000, cacheWriteTokens: 100_000, costUsdNoCache: 25 });
+    seed('cdx0003', 'codex', '2026-05-21T12:00:00.000Z', 2, 100_000, 3_000_000, 'agents-cli',
+      { inputTokens: 500_000, cacheReadTokens: 2_400_000, cacheWriteTokens: 0, costUsdNoCache: 5 });
   });
 
   afterAll(() => {
@@ -133,5 +148,69 @@ describe('agents output', () => {
     expect(out).toMatch(/\dM|\dK/);
     // Honesty footer present.
     expect(out).toContain('not counted');
+  });
+
+  it('--json carries the input / cache-read / cache-write burn split (RUSH-2287)', async () => {
+    const out = await runOutput([...BASE, '--json']);
+    const d = JSON.parse(out);
+    expect(d.burn.inputTokens).toBe(3_500_000);       // 2M + 1M + 0.5M
+    expect(d.burn.cacheReadTokens).toBe(58_900_000);  // 46M + 10.5M + 2.4M
+    expect(d.burn.cacheWriteTokens).toBe(1_100_000);  // 1M + 0.1M + 0
+    // Split fields also ride each breakdown row.
+    const byKey = Object.fromEntries(
+      (await runOutput([...BASE, '--by', 'agent', '--json']).then(JSON.parse)).breakdown.rows.map(
+        (r: any) => [r.key, r],
+      ),
+    );
+    expect(byKey.claude.inputTokens).toBe(3_000_000);      // 2M + 1M
+    expect(byKey.claude.cacheReadTokens).toBe(56_500_000); // 46M + 10.5M
+    expect(byKey.codex.cacheWriteTokens).toBe(0);
+  });
+
+  it('--json carries both actual and no-cache costs regardless of scenario', async () => {
+    const d = JSON.parse(await runOutput([...BASE, '--json']));
+    expect(d.burn.costUsd).toBeCloseTo(42, 5);         // 30 + 10 + 2
+    expect(d.burn.costUsdNoCache).toBeCloseTo(120, 5); // 90 + 25 + 5
+    // No-cache is strictly higher — caching is a discount.
+    expect(d.burn.costUsdNoCache).toBeGreaterThan(d.burn.costUsd);
+    // The scenario flag does not change the JSON payload.
+    const d2 = JSON.parse(await runOutput([...BASE, '--pricing', 'no-cache', '--json']));
+    expect(d2.burn.costUsd).toBeCloseTo(42, 5);
+    expect(d2.burn.costUsdNoCache).toBeCloseTo(120, 5);
+  });
+
+  it('TTY shows the burn split line and the caching comparison', async () => {
+    const out = await runOutput([...BASE]);
+    expect(out).toContain('burn split:');
+    expect(out).toContain('input');
+    expect(out).toContain('cache-read');
+    expect(out).toContain('cache-write');
+    // Actual mode still surfaces the saving.
+    expect(out).toContain('caching:');
+    expect(out).toContain('no-cache');
+  });
+
+  it('--pricing no-cache leads the burn with the no-cache figure', async () => {
+    const out = await runOutput([...BASE, '--pricing', 'no-cache']);
+    expect(out).toContain('(no-cache)');
+    // $120.00 no-cache is the headline; $42.00 actual still appears in the comparison.
+    expect(out).toContain('$120.00');
+    expect(out).toContain('$42.00');
+    // Breakdown header switches to the no-cache column label.
+    expect(out).toContain('burn(nc)');
+  });
+
+  it('rejects an unknown --pricing scenario', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('exit');
+    }) as any);
+    try {
+      await expect(runOutput([...BASE, '--pricing', 'bogus'])).rejects.toThrow();
+      expect(errSpy.mock.calls.flat().join(' ')).toContain('--pricing must be one of');
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
   });
 });

--- a/apps/cli/src/commands/output.ts
+++ b/apps/cli/src/commands/output.ts
@@ -43,6 +43,7 @@ interface OutputOptions {
   login?: string[];
   prs?: boolean; // commander sets `prs: false` for --no-prs
   allHosts?: boolean;
+  pricing?: string;
 }
 
 interface RollupRow {
@@ -50,16 +51,28 @@ interface RollupRow {
   /** Human label when the key is an identity rather than display text (--by account). */
   label?: string;
   costUsd: number;
+  /** USD cost with cache read/write repriced at the input rate (RUSH-2287). */
+  costUsdNoCache: number;
   durationMs: number;
   sessionCount: number;
   tokenCount: number;
   outputTokens: number;
+  /** Burn split — 0 for harnesses that record no cache split (RUSH-2287). */
+  inputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
 }
 
 interface BurnTotals {
   costUsd: number;
+  /** USD cost priced as if caching were off (cache read/write at the input rate). */
+  costUsdNoCache: number;
   outputTokens: number;
   tokenCount: number;
+  /** Burn split summed across the window. */
+  inputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
   sessionCount: number;
   durationMs: number;
 }
@@ -100,16 +113,21 @@ export function registerOutputCommand(program: Command): void {
     .option('--login <login...>', 'Count PRs for these GitHub logins (default: current gh user)')
     .option('--no-prs', 'Skip the GitHub PR lookup (commits only)')
     .option('--all-hosts', 'Aggregate across every online device (ag devices) over SSH')
+    .option('--pricing <scenario>', 'Cost scenario: actual (default, cache-discounted) or no-cache (cache read/write billed at the full input rate)')
     .addHelpText('after', `
 Examples:
   agents output                       Last 7 days: burn, output tokens, PRs, commits, ratios
   agents output --since 24h           Last 24 hours
   agents output --since 1mo           Last month  (units: 1h 24h 7d 4w 1mo 1y, or ISO date)
+  agents output --pricing no-cache    Model the burn as if prompt caching were off
   agents output --all-hosts           Fleet-wide, folding in every online machine
   agents output --by day --json       Machine-readable daily burn/output rollup
 
 Burn (cost) is computed offline from a versioned per-model price table (${PRICING_VERSION}).
 Output tokens are the real generated tokens — NOT the cache-inflated total token count.
+The burn is split into input / cache-read / cache-write where the harness records it
+(Claude/Codex/Gemini/Droid). --pricing no-cache reprices cached tokens at the input rate,
+so you can see what caching is saving. --json always carries both actual and no-cache costs.
 `)
     .action(async (options: OutputOptions) => {
       await outputAction(options);
@@ -123,6 +141,15 @@ function resolveGroup(by: string | undefined): UsageRollupGroup {
   process.exit(1);
 }
 
+type PricingScenario = 'actual' | 'no-cache';
+
+function resolvePricing(pricing: string | undefined): PricingScenario {
+  if (pricing === undefined || pricing === 'actual') return 'actual';
+  if (pricing === 'no-cache') return 'no-cache';
+  console.error(chalk.red('error: --pricing must be one of: actual, no-cache'));
+  process.exit(1);
+}
+
 /** Compact token formatter: 38.6M, 4.1K, 10.6B. */
 function formatCompact(n: number): string {
   const abs = Math.abs(n);
@@ -133,14 +160,28 @@ function formatCompact(n: number): string {
 }
 
 function emptyBurn(): BurnTotals {
-  return { costUsd: 0, outputTokens: 0, tokenCount: 0, sessionCount: 0, durationMs: 0 };
+  return {
+    costUsd: 0,
+    costUsdNoCache: 0,
+    outputTokens: 0,
+    tokenCount: 0,
+    inputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    sessionCount: 0,
+    durationMs: 0,
+  };
 }
 
 function sumBurn(rows: RollupRow[]): BurnTotals {
   return rows.reduce((acc, r) => {
     acc.costUsd += r.costUsd;
+    acc.costUsdNoCache += r.costUsdNoCache;
     acc.outputTokens += r.outputTokens;
     acc.tokenCount += r.tokenCount;
+    acc.inputTokens += r.inputTokens;
+    acc.cacheReadTokens += r.cacheReadTokens;
+    acc.cacheWriteTokens += r.cacheWriteTokens;
     acc.sessionCount += r.sessionCount;
     acc.durationMs += r.durationMs;
     return acc;
@@ -219,6 +260,10 @@ async function fetchRemotePayload(device: string, options: OutputOptions): Promi
 
 async function outputAction(options: OutputOptions): Promise<void> {
   const includePrs = options.prs !== false;
+  // Validate --pricing up front so a bad value errors even under --json. The JSON
+  // payload always carries BOTH costs regardless of the scenario — the flag only
+  // chooses which one the text renderer leads with.
+  const scenario = resolvePricing(options.pricing);
 
   if (!options.allHosts) {
     const payload = await computeLocalPayload(options, includePrs);
@@ -226,7 +271,7 @@ async function outputAction(options: OutputOptions): Promise<void> {
       process.stdout.write(JSON.stringify(withRatios(payload, [payload]), null, 2) + '\n');
       return;
     }
-    renderSingle(payload);
+    renderSingle(payload, scenario);
     return;
   }
 
@@ -248,7 +293,7 @@ async function outputAction(options: OutputOptions): Promise<void> {
     process.stdout.write(JSON.stringify(withRatios(mergeMachines(machines, options), machines), null, 2) + '\n');
     return;
   }
-  renderFleet(machines, options);
+  renderFleet(machines, options, scenario);
 }
 
 /** Merge per-machine payloads into a combined one (burn + commits summed; PRs local-only). */
@@ -262,22 +307,34 @@ function mergeMachines(machines: OutputPayload[], options: OutputOptions): Outpu
   const uncosted = new Set<string>();
   for (const m of machines) {
     burn.costUsd += m.burn.costUsd;
+    burn.costUsdNoCache += m.burn.costUsdNoCache;
     burn.outputTokens += m.burn.outputTokens;
     burn.tokenCount += m.burn.tokenCount;
+    burn.inputTokens += m.burn.inputTokens;
+    burn.cacheReadTokens += m.burn.cacheReadTokens;
+    burn.cacheWriteTokens += m.burn.cacheWriteTokens;
     burn.sessionCount += m.burn.sessionCount;
     burn.durationMs += m.burn.durationMs;
     for (const s of m.output.commitShas) allShas.add(s);
     for (const a of m.uncostedAgents) uncosted.add(a);
     for (const r of m.breakdown.rows) {
-      const cur = byKey.get(r.key) ?? { key: r.key, label: r.label, costUsd: 0, durationMs: 0, sessionCount: 0, tokenCount: 0, outputTokens: 0 };
+      const cur = byKey.get(r.key) ?? {
+        key: r.key, label: r.label, costUsd: 0, costUsdNoCache: 0, durationMs: 0,
+        sessionCount: 0, tokenCount: 0, outputTokens: 0,
+        inputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0,
+      };
       // Peers resolve their own labels; keep the first non-empty one so a machine that
       // has not indexed an account yet does not blank a label another machine supplied.
       cur.label ??= r.label;
       cur.costUsd += r.costUsd;
+      cur.costUsdNoCache += r.costUsdNoCache;
       cur.durationMs += r.durationMs;
       cur.sessionCount += r.sessionCount;
       cur.tokenCount += r.tokenCount;
       cur.outputTokens += r.outputTokens;
+      cur.inputTokens += r.inputTokens;
+      cur.cacheReadTokens += r.cacheReadTokens;
+      cur.cacheWriteTokens += r.cacheWriteTokens;
       byKey.set(r.key, cur);
     }
   }
@@ -309,46 +366,82 @@ function withRatios(payload: OutputPayload, machines: OutputPayload[]): unknown 
   };
 }
 
-/** Shared header line: burned · output tokens · PRs · commits, plus ratios. */
-function headerLines(payload: OutputPayload): string[] {
+/** The cost the text renderer leads with for the chosen scenario. */
+function scenarioCost(x: { costUsd: number; costUsdNoCache: number }, scenario: PricingScenario): number {
+  return scenario === 'no-cache' ? x.costUsdNoCache : x.costUsd;
+}
+
+/** Shared header line: burned · output tokens · PRs · commits, plus ratios + burn split. */
+function headerLines(payload: OutputPayload, scenario: PricingScenario): string[] {
   const prsTotal = payload.output.prsOpened + payload.output.prsMerged;
+  const burn = payload.burn;
+  const cost = scenarioCost(burn, scenario);
   const out: string[] = [];
   out.push(
     '  ' +
-      `${chalk.green(formatUsd(payload.burn.costUsd))} burned` +
+      `${chalk.green(formatUsd(cost))} burned${scenario === 'no-cache' ? chalk.gray(' (no-cache)') : ''}` +
       chalk.gray('  ·  ') +
-      `${chalk.cyan(formatCompact(payload.burn.outputTokens))} output tokens` +
+      `${chalk.cyan(formatCompact(burn.outputTokens))} output tokens` +
       chalk.gray('  ·  ') +
       `${chalk.yellow(String(prsTotal))} PRs ${chalk.gray(`(${payload.output.prsMerged} merged)`)}` +
       chalk.gray('  ·  ') +
       `${chalk.yellow(String(payload.output.commits))} commits`,
   );
   const ratios: string[] = [];
-  if (prsTotal > 0) ratios.push(`${formatUsd(payload.burn.costUsd / prsTotal)}/PR`);
-  if (payload.output.commits > 0) ratios.push(`${formatUsd(payload.burn.costUsd / payload.output.commits)}/commit`);
-  if (payload.burn.costUsd > 0) ratios.push(`${formatCompact(Math.round(payload.burn.outputTokens / payload.burn.costUsd))} out-tok/$`);
+  if (prsTotal > 0) ratios.push(`${formatUsd(cost / prsTotal)}/PR`);
+  if (payload.output.commits > 0) ratios.push(`${formatUsd(cost / payload.output.commits)}/commit`);
+  if (cost > 0) ratios.push(`${formatCompact(Math.round(burn.outputTokens / cost))} out-tok/$`);
   if (ratios.length > 0) out.push(chalk.gray('  ' + ratios.join('  ·  ')));
+
+  // Burn split — only for harnesses that recorded one (input/cache totals > 0).
+  const splitTotal = burn.inputTokens + burn.cacheReadTokens + burn.cacheWriteTokens;
+  if (splitTotal > 0) {
+    out.push(
+      chalk.gray('  burn split: ') +
+        `${chalk.cyan(formatCompact(burn.inputTokens))} input` +
+        chalk.gray('  ·  ') +
+        `${chalk.cyan(formatCompact(burn.cacheReadTokens))} cache-read` +
+        chalk.gray('  ·  ') +
+        `${chalk.cyan(formatCompact(burn.cacheWriteTokens))} cache-write`,
+    );
+  }
+
+  // No-cache comparison — shown whenever caching actually moved the number, so an
+  // operator sees the saving in `actual` mode too (RUSH-2287: "both if useful").
+  if (burn.costUsdNoCache > burn.costUsd && burn.costUsd > 0) {
+    const saved = burn.costUsdNoCache - burn.costUsd;
+    const pct = Math.round((saved / burn.costUsdNoCache) * 100);
+    out.push(
+      chalk.gray('  caching: ') +
+        `actual ${chalk.green(formatUsd(burn.costUsd))}` +
+        chalk.gray('  vs  ') +
+        `no-cache ${chalk.yellow(formatUsd(burn.costUsdNoCache))}` +
+        chalk.gray(`  (saved ${formatUsd(saved)}, ${pct}%)`),
+    );
+  }
   return out;
 }
 
 /** Render the per-group burn/output table. */
-function renderBreakdown(rows: RollupRow[], groupBy: string): string[] {
+function renderBreakdown(rows: RollupRow[], groupBy: string, scenario: PricingScenario): string[] {
   const out: string[] = [chalk.bold(`By ${groupBy}`)];
   if (rows.length === 0) return out;
+  const rowCost = (r: RollupRow): number => scenarioCost(r, scenario);
   const cols = terminalWidth();
-  const burnW = Math.max(...rows.map(r => formatUsd(r.costUsd).length), 4);
+  const burnHeader = scenario === 'no-cache' ? 'burn(nc)' : 'burn';
+  const burnW = Math.max(...rows.map(r => formatUsd(rowCost(r)).length), burnHeader.length);
   const outW = Math.max(...rows.map(r => formatCompact(r.outputTokens).length), 6);
   const sessW = Math.max(...rows.map(r => String(r.sessionCount).length), 3);
   const fixedW = 2 + 2 + burnW + 2 + outW + 2 + sessW + 8;
   const display = (r: RollupRow): string => r.label ?? r.key;
   const keyW = Math.max(8, Math.min(Math.max(...rows.map(r => display(r).length), groupBy.length), cols - fixedW));
-  out.push('  ' + chalk.gray(padToWidth('', keyW)) + '  ' + chalk.gray(padToWidth('burn', burnW)) + '  ' + chalk.gray(padToWidth('output', outW)) + '  ' + chalk.gray('sessions'));
+  out.push('  ' + chalk.gray(padToWidth('', keyW)) + '  ' + chalk.gray(padToWidth(burnHeader, burnW)) + '  ' + chalk.gray(padToWidth('output', outW)) + '  ' + chalk.gray('sessions'));
   for (const r of rows) {
     out.push(
       '  ' +
         padToWidth(truncateToWidth(display(r), keyW), keyW) +
         '  ' +
-        chalk.green(padToWidth(formatUsd(r.costUsd), burnW)) +
+        chalk.green(padToWidth(formatUsd(rowCost(r)), burnW)) +
         '  ' +
         chalk.cyan(padToWidth(formatCompact(r.outputTokens), outW)) +
         '  ' +
@@ -358,17 +451,17 @@ function renderBreakdown(rows: RollupRow[], groupBy: string): string[] {
   return out;
 }
 
-function renderSingle(payload: OutputPayload): void {
+function renderSingle(payload: OutputPayload, scenario: PricingScenario): void {
   const out: string[] = [];
   out.push(chalk.bold('Output') + chalk.gray(`  ·  pricing ${payload.pricingVersion}  ·  since ${payload.since}`));
-  out.push(...headerLines(payload));
+  out.push(...headerLines(payload, scenario));
   out.push('');
   if (payload.burn.sessionCount === 0) {
     out.push(chalk.gray('No sessions with cost data found. Run `agents sessions --all` to index, then retry.'));
     console.log(out.join('\n'));
     return;
   }
-  out.push(...renderBreakdown(payload.breakdown.rows, payload.breakdown.by));
+  out.push(...renderBreakdown(payload.breakdown.rows, payload.breakdown.by, scenario));
   out.push('');
   out.push(chalk.bold('Shipped'));
   out.push(`  ${chalk.yellow(String(payload.output.commits))} commits across ${payload.output.reposScanned} repos` + chalk.gray(`  (authors: ${payload.output.authors.length > 0 ? payload.output.authors.join(', ') : 'none detected'})`));
@@ -383,24 +476,24 @@ function renderSingle(payload: OutputPayload): void {
   console.log(out.join('\n'));
 }
 
-function renderFleet(machines: OutputPayload[], options: OutputOptions): void {
+function renderFleet(machines: OutputPayload[], options: OutputOptions, scenario: PricingScenario): void {
   const merged = mergeMachines(machines, options);
   const out: string[] = [];
   out.push(chalk.bold('Output') + chalk.gray(`  ·  fleet (${machines.length} machines)  ·  pricing ${merged.pricingVersion}  ·  since ${merged.since}`));
-  out.push(...headerLines(merged));
+  out.push(...headerLines(merged, scenario));
   out.push('');
 
   // By machine.
   out.push(chalk.bold('By machine'));
   const nameW = Math.max(...machines.map(m => m.machine.length), 7);
-  const burnW = Math.max(...machines.map(m => formatUsd(m.burn.costUsd).length), 4);
+  const burnW = Math.max(...machines.map(m => formatUsd(scenarioCost(m.burn, scenario)).length), 4);
   for (const m of machines) {
     const note = m.error ? chalk.red(`  (${m.error})`) : '';
     out.push(
       '  ' +
         padToWidth(m.machine, nameW) +
         '  ' +
-        chalk.green(padToWidth(formatUsd(m.burn.costUsd), burnW)) +
+        chalk.green(padToWidth(formatUsd(scenarioCost(m.burn, scenario)), burnW)) +
         '  ' +
         chalk.cyan(padToWidth(formatCompact(m.burn.outputTokens), 7)) +
         '  ' +
@@ -409,7 +502,7 @@ function renderFleet(machines: OutputPayload[], options: OutputOptions): void {
     );
   }
   out.push('');
-  out.push(...renderBreakdown(merged.breakdown.rows, merged.breakdown.by));
+  out.push(...renderBreakdown(merged.breakdown.rows, merged.breakdown.by, scenario));
   out.push('');
   out.push(chalk.gray(notCountedLine(merged.uncostedAgents)));
   console.log(out.join('\n'));

--- a/apps/cli/src/lib/pricing/cost.test.ts
+++ b/apps/cli/src/lib/pricing/cost.test.ts
@@ -59,7 +59,9 @@ describe('costOfUsageNoCache', () => {
     expect(costOfUsageNoCache(args)).toBeCloseTo(0.055, 10);
   });
 
-  it('is always >= the cache-aware cost (caching is a discount)', () => {
+  it('exceeds the cache-aware cost when cache reads dominate (the common case)', () => {
+    // Cache reads are the cheap-relative-to-input bucket, so repricing them up to
+    // the input rate raises the total — the typical session shape.
     const args = {
       model: 'claude-opus-4',
       inputTokens: 5_000,
@@ -68,6 +70,21 @@ describe('costOfUsageNoCache', () => {
       cacheCreationTokens: 10_000,
     } as const;
     expect(costOfUsageNoCache(args)).toBeGreaterThan(costOfUsage(args));
+  });
+
+  it('can fall BELOW the cache-aware cost in a cache-write-heavy session', () => {
+    // Claude prices a cache write at 1.25x input (opus: cacheWrite 6.25e-6 vs input
+    // 5e-6), so repricing writes DOWN to the input rate lowers the total when writes
+    // dominate and reads are small. This is why no-cache is not an unconditional
+    // upper bound — the output savings line is guarded accordingly (RUSH-2287 review).
+    const args = {
+      model: 'claude-opus-4',
+      inputTokens: 100_000,
+      outputTokens: 20_000,
+      cacheReadTokens: 50_000,
+      cacheCreationTokens: 2_000_000,
+    } as const;
+    expect(costOfUsageNoCache(args)).toBeLessThan(costOfUsage(args));
   });
 
   it('returns 0 for unknown/missing model', () => {

--- a/apps/cli/src/lib/pricing/cost.test.ts
+++ b/apps/cli/src/lib/pricing/cost.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   costOfUsage,
+  costOfUsageNoCache,
   costOfSession,
   formatUsd,
   estimateCost,
@@ -37,6 +38,41 @@ describe('costOfUsage', () => {
 
   it('returns 0 when model is missing', () => {
     expect(costOfUsage({ inputTokens: 1_000_000 })).toBe(0);
+  });
+});
+
+describe('costOfUsageNoCache', () => {
+  it('bills cache read and cache write at the full input rate', () => {
+    // opus: input $5/M. Cached tokens repriced from their discount to $5/M.
+    const usd = costOfUsageNoCache({
+      model: 'claude-opus-4',
+      cacheReadTokens: 10_000,    // 10000 * 5e-6 = 0.05  (vs 0.005 cached)
+      cacheCreationTokens: 1_000, // 1000  * 5e-6 = 0.005 (vs 0.00625 cached)
+    });
+    expect(usd).toBeCloseTo(0.05 + 0.005, 10);
+  });
+
+  it('leaves uncached input and output untouched', () => {
+    const args = { model: 'claude-opus-4', inputTokens: 1000, outputTokens: 2000 } as const;
+    // No cache tokens -> identical to the cache-aware cost.
+    expect(costOfUsageNoCache(args)).toBeCloseTo(costOfUsage(args), 10);
+    expect(costOfUsageNoCache(args)).toBeCloseTo(0.055, 10);
+  });
+
+  it('is always >= the cache-aware cost (caching is a discount)', () => {
+    const args = {
+      model: 'claude-opus-4',
+      inputTokens: 5_000,
+      outputTokens: 5_000,
+      cacheReadTokens: 100_000,
+      cacheCreationTokens: 10_000,
+    } as const;
+    expect(costOfUsageNoCache(args)).toBeGreaterThan(costOfUsage(args));
+  });
+
+  it('returns 0 for unknown/missing model', () => {
+    expect(costOfUsageNoCache({ model: 'nope-9000', cacheReadTokens: 1_000_000 })).toBe(0);
+    expect(costOfUsageNoCache({ cacheReadTokens: 1_000_000 })).toBe(0);
   });
 });
 

--- a/apps/cli/src/lib/pricing/cost.ts
+++ b/apps/cli/src/lib/pricing/cost.ts
@@ -45,6 +45,33 @@ export function costOfUsage(u: TokenUsage): number {
   );
 }
 
+/**
+ * USD cost of one usage record priced as if caching were OFF: cache-read and
+ * cache-write tokens are billed at the model's full INPUT rate rather than their
+ * discounted cache rates. This is the "what would this have cost with no prompt
+ * caching?" scenario that `agents output --pricing no-cache` models. Output and
+ * uncached input are unchanged — only the cache tokens are repriced. Returns 0
+ * for a missing/unpriced model, exactly like {@link costOfUsage}.
+ */
+export function costOfUsageNoCache(u: TokenUsage): number {
+  if (!u.model) return 0;
+  const pricing = getModelPricing(u.model);
+  if (!pricing) return 0;
+
+  const input = u.inputTokens ?? 0;
+  const output = u.outputTokens ?? 0;
+  const cacheRead = u.cacheReadTokens ?? 0;
+  const cacheWrite = u.cacheCreationTokens ?? 0;
+
+  // Cache tokens repriced at the input rate — no caching discount applied.
+  return (
+    input * pricing.inputPerToken +
+    output * pricing.outputPerToken +
+    cacheRead * pricing.inputPerToken +
+    cacheWrite * pricing.inputPerToken
+  );
+}
+
 /** Sum the USD cost of every usage record in a session. */
 export function costOfSession(usages: TokenUsage[]): number {
   let total = 0;

--- a/apps/cli/src/lib/pricing/index.ts
+++ b/apps/cli/src/lib/pricing/index.ts
@@ -14,6 +14,7 @@ export {
 export {
   type TokenUsage,
   costOfUsage,
+  costOfUsageNoCache,
   costOfSession,
   formatUsd,
   estimateCost,

--- a/apps/cli/src/lib/session/__tests__/incremental-scan-e2e.test.ts
+++ b/apps/cli/src/lib/session/__tests__/incremental-scan-e2e.test.ts
@@ -496,7 +496,7 @@ describe('B-2 live incremental scan parity', () => {
     expect(row!.parserState, 'parser_state persisted').not.toBeNull();
     expect(row!.contentText, 'content_text persisted').not.toBeNull();
     const parsed = JSON.parse(row!.parserState!);
-    expect(parsed.v).toBe(2);
+    expect(parsed.v).toBe(3);
     expect(typeof parsed.offset).toBe('number');
     const offsetAfterFirst = parsed.offset;
 

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -31,7 +31,7 @@ const DB_PATH = getSessionsDbPath();
 /** Current schema version; bumped when migrations are added. Exported so tests
  * assert against the constant instead of hardcoding a number that every bump
  * then has to chase (docs/05-sessions.md calls the constant the source of truth). */
-export const SCHEMA_VERSION = 36;
+export const SCHEMA_VERSION = 37;
 
 /**
  * Bump to force `agents sessions backfill resources` to re-derive every
@@ -88,7 +88,11 @@ CREATE TABLE IF NOT EXISTS sessions (
   message_count INTEGER,
   token_count INTEGER,
   output_tokens INTEGER,
+  input_tokens INTEGER,
+  cache_read_tokens INTEGER,
+  cache_write_tokens INTEGER,
   cost_usd REAL,
+  cost_usd_nocache REAL,
   duration_ms INTEGER,
   model TEXT,
   tool_call_count INTEGER,
@@ -342,7 +346,11 @@ export interface SessionRow {
   message_count: number | null;
   token_count: number | null;
   output_tokens: number | null;
+  input_tokens: number | null;
+  cache_read_tokens: number | null;
+  cache_write_tokens: number | null;
   cost_usd: number | null;
+  cost_usd_nocache: number | null;
   duration_ms: number | null;
   model: string | null;
   tool_call_count: number | null;
@@ -990,6 +998,24 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
       FROM tool_calls;
     `);
   }
+
+  if (fromVersion < 37) {
+    // v36 -> v37: persist the burn SPLIT (uncached input / cache-read /
+    // cache-write) and a second "no-cache" cost per session, so `agents output`
+    // can report the token split and a --pricing no-cache scenario (RUSH-2287).
+    // These are new nullable columns — do NOT flush scan_ledger (adding a column
+    // must keep warm session ledgers warm, the contract the v33->v34 note above
+    // states). Pre-upgrade rows stay NULL for the split until their transcript is
+    // re-scanned; `agents output` reports the split only where it is present, so
+    // an absent split reads as "not available for this session", never as zero.
+    const cols = new Set(
+      (db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map((c) => c.name),
+    );
+    if (!cols.has('input_tokens')) db.exec(`ALTER TABLE sessions ADD COLUMN input_tokens INTEGER`);
+    if (!cols.has('cache_read_tokens')) db.exec(`ALTER TABLE sessions ADD COLUMN cache_read_tokens INTEGER`);
+    if (!cols.has('cache_write_tokens')) db.exec(`ALTER TABLE sessions ADD COLUMN cache_write_tokens INTEGER`);
+    if (!cols.has('cost_usd_nocache')) db.exec(`ALTER TABLE sessions ADD COLUMN cost_usd_nocache REAL`);
+  }
 }
 
 /**
@@ -1549,7 +1575,8 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     id, short_id, agent, origin, routine_name, routine_run_id,
     version, account, account_key, account_org, mode, timestamp, last_activity,
     project, cwd, git_branch, topic, label, message_count, token_count,
-    output_tokens, cost_usd, duration_ms, model, tool_call_count,
+    output_tokens, input_tokens, cache_read_tokens, cache_write_tokens,
+    cost_usd, cost_usd_nocache, duration_ms, model, tool_call_count,
     file_path, file_mtime_ms, file_size, scanned_at, is_team_origin,
     pr_url, pr_number, worktree_slug, ticket_id, spawned_team, plan, todos,
     recent_directories_touched, linear_project, linear_project_url, machine,
@@ -1558,7 +1585,8 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     @id, @short_id, @agent, @origin, @routine_name, @routine_run_id,
     @version, @account, @account_key, @account_org, @mode, @timestamp, @last_activity,
     @project, @cwd, @git_branch, @topic, @label, @message_count, @token_count,
-    @output_tokens, @cost_usd, @duration_ms, @model, @tool_call_count,
+    @output_tokens, @input_tokens, @cache_read_tokens, @cache_write_tokens,
+    @cost_usd, @cost_usd_nocache, @duration_ms, @model, @tool_call_count,
     @file_path, @file_mtime_ms, @file_size, @scanned_at, @is_team_origin,
     @pr_url, @pr_number, @worktree_slug, @ticket_id, @spawned_team, @plan, @todos,
     @recent_directories_touched, @linear_project, @linear_project_url, @machine,
@@ -1593,7 +1621,11 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     message_count = excluded.message_count,
     token_count = excluded.token_count,
     output_tokens = excluded.output_tokens,
+    input_tokens = excluded.input_tokens,
+    cache_read_tokens = excluded.cache_read_tokens,
+    cache_write_tokens = excluded.cache_write_tokens,
     cost_usd = excluded.cost_usd,
+    cost_usd_nocache = excluded.cost_usd_nocache,
     duration_ms = excluded.duration_ms,
     model = excluded.model,
     tool_call_count = excluded.tool_call_count,
@@ -1873,7 +1905,11 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     message_count: meta.messageCount ?? null,
     token_count: meta.tokenCount ?? null,
     output_tokens: meta.outputTokens ?? null,
+    input_tokens: meta.inputTokens ?? null,
+    cache_read_tokens: meta.cacheReadTokens ?? null,
+    cache_write_tokens: meta.cacheWriteTokens ?? null,
     cost_usd: meta.costUsd ?? null,
+    cost_usd_nocache: meta.costUsdNoCache ?? null,
     duration_ms: meta.durationMs ?? null,
     model: meta.model ?? null,
     tool_call_count: meta.toolCallCount ?? null,
@@ -2076,7 +2112,11 @@ export function upsertSessionsBatch(
         message_count: meta.messageCount ?? null,
         token_count: meta.tokenCount ?? null,
         output_tokens: meta.outputTokens ?? null,
+        input_tokens: meta.inputTokens ?? null,
+        cache_read_tokens: meta.cacheReadTokens ?? null,
+        cache_write_tokens: meta.cacheWriteTokens ?? null,
         cost_usd: meta.costUsd ?? null,
+        cost_usd_nocache: meta.costUsdNoCache ?? null,
         duration_ms: meta.durationMs ?? null,
         model: meta.model ?? null,
         tool_call_count: meta.toolCallCount ?? null,
@@ -2305,7 +2345,11 @@ function rowToMeta(row: SessionRow): SessionMeta {
     messageCount: row.message_count ?? undefined,
     tokenCount: row.token_count ?? undefined,
     outputTokens: row.output_tokens ?? undefined,
+    inputTokens: row.input_tokens ?? undefined,
+    cacheReadTokens: row.cache_read_tokens ?? undefined,
+    cacheWriteTokens: row.cache_write_tokens ?? undefined,
     costUsd: row.cost_usd ?? undefined,
+    costUsdNoCache: row.cost_usd_nocache ?? undefined,
     durationMs: row.duration_ms ?? undefined,
     model: row.model ?? undefined,
     toolCallCount: row.tool_call_count ?? undefined,
@@ -2621,11 +2665,23 @@ export interface UsageRollupRow {
    */
   label?: string;
   costUsd: number;
+  /**
+   * USD cost priced as if caching were off (cache read/write at the input rate),
+   * summed from `cost_usd_nocache`. Backs `agents output --pricing no-cache`.
+   * Equals `costUsd` for rows whose sessions record no cache split (RUSH-2287).
+   */
+  costUsdNoCache: number;
   durationMs: number;
   sessionCount: number;
   tokenCount: number;
   /** Real generated (output) tokens — excludes cache-read/-write context. */
   outputTokens: number;
+  /** Uncached input tokens summed across the group (0 where no harness recorded a split). */
+  inputTokens: number;
+  /** Cache-read tokens summed across the group. */
+  cacheReadTokens: number;
+  /** Cache-write (cache-creation) tokens summed across the group. */
+  cacheWriteTokens: number;
 }
 
 /** What to group a usage rollup by. */
@@ -2832,10 +2888,17 @@ export function queryUsageRollup(
                     THEN account_org || ' <' || account || '>' END) AS label,`
         : ''}
       IFNULL(SUM(cost_usd), 0) AS costUsd,
+      -- A session with a cost but no persisted no-cache figure records no cache
+      -- split, so its no-cache cost equals its actual cost — fall back to cost_usd
+      -- so it still contributes to the scenario total rather than dropping to 0.
+      IFNULL(SUM(COALESCE(cost_usd_nocache, cost_usd)), 0) AS costUsdNoCache,
       IFNULL(SUM(duration_ms), 0) AS durationMs,
       COUNT(*) AS sessionCount,
       IFNULL(SUM(token_count), 0) AS tokenCount,
-      IFNULL(SUM(output_tokens), 0) AS outputTokens
+      IFNULL(SUM(output_tokens), 0) AS outputTokens,
+      IFNULL(SUM(input_tokens), 0) AS inputTokens,
+      IFNULL(SUM(cache_read_tokens), 0) AS cacheReadTokens,
+      IFNULL(SUM(cache_write_tokens), 0) AS cacheWriteTokens
     FROM sessions
     ${clause}
     GROUP BY key

--- a/apps/cli/src/lib/session/db.usage-rollup.test.ts
+++ b/apps/cli/src/lib/session/db.usage-rollup.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate the sessions DB under a temp HOME before db.js captures the path.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-rollup-test-'));
+process.env.HOME = TEST_HOME;
+
+const { upsertSession, queryUsageRollup, closeDB } = await import('./db.js');
+type SessionMeta = import('./types.js').SessionMeta;
+
+const FILES = path.join(TEST_HOME, 'rollup-files');
+fs.mkdirSync(FILES, { recursive: true });
+
+function seed(id: string, meta: Partial<SessionMeta>): void {
+  const filePath = path.join(FILES, `${id}.jsonl`);
+  fs.writeFileSync(filePath, '');
+  upsertSession(
+    {
+      id,
+      shortId: id.slice(0, 8),
+      agent: 'claude',
+      timestamp: '2026-05-20T10:00:00.000Z',
+      cwd: FILES,
+      filePath,
+      ...meta,
+    } as SessionMeta,
+    '',
+  );
+}
+
+describe('queryUsageRollup — burn split + no-cache (RUSH-2287)', () => {
+  beforeAll(() => {
+    // Two rows WITH a split, one row WITHOUT (only a total cost, no split).
+    seed('a', {
+      agent: 'claude',
+      costUsd: 30, costUsdNoCache: 90,
+      outputTokens: 1_000_000, tokenCount: 50_000_000,
+      inputTokens: 2_000_000, cacheReadTokens: 46_000_000, cacheWriteTokens: 1_000_000,
+    });
+    seed('b', {
+      agent: 'claude',
+      costUsd: 10, costUsdNoCache: 25,
+      outputTokens: 400_000, tokenCount: 12_000_000,
+      inputTokens: 1_000_000, cacheReadTokens: 10_500_000, cacheWriteTokens: 100_000,
+    });
+    // No split recorded: cost_usd present, cost_usd_nocache NULL. Its no-cache
+    // cost must fall back to its actual cost, not drop to 0.
+    seed('c', { agent: 'codex', costUsd: 5, outputTokens: 100_000, tokenCount: 3_000_000 });
+  });
+
+  afterAll(() => {
+    closeDB();
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('sums the split columns across the window', () => {
+    const rows = queryUsageRollup({ sinceMs: 0, groupBy: 'agent' });
+    const total = rows.reduce(
+      (acc, r) => {
+        acc.inputTokens += r.inputTokens;
+        acc.cacheReadTokens += r.cacheReadTokens;
+        acc.cacheWriteTokens += r.cacheWriteTokens;
+        acc.costUsd += r.costUsd;
+        acc.costUsdNoCache += r.costUsdNoCache;
+        return acc;
+      },
+      { inputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0, costUsdNoCache: 0 },
+    );
+    expect(total.inputTokens).toBe(3_000_000);       // a + b (c has none)
+    expect(total.cacheReadTokens).toBe(56_500_000);  // 46M + 10.5M
+    expect(total.cacheWriteTokens).toBe(1_100_000);  // 1M + 0.1M
+    expect(total.costUsd).toBeCloseTo(45, 5);        // 30 + 10 + 5
+    // no-cache = 90 + 25 + (c falls back to its 5 actual) = 120.
+    expect(total.costUsdNoCache).toBeCloseTo(120, 5);
+  });
+
+  it('the un-split row contributes its actual cost to the no-cache total', () => {
+    const rows = queryUsageRollup({ sinceMs: 0, groupBy: 'agent' });
+    const codex = rows.find(r => r.key === 'codex');
+    expect(codex).toBeDefined();
+    // No split recorded -> no-cache equals actual (the COALESCE fallback).
+    expect(codex!.costUsd).toBeCloseTo(5, 5);
+    expect(codex!.costUsdNoCache).toBeCloseTo(5, 5);
+    expect(codex!.inputTokens).toBe(0);
+  });
+});

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -32,7 +32,7 @@ import { extractSessionTopic, extractSlashCommandName, extractSlashCommandFromTo
 import { isSkillInvocation, extractSkills, extractSlashCommands } from './highlights.js';
 import { parseAntigravity, parseCursor } from './parse.js';
 import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand, detectSpawnedTeam, isTicketCreateTool, extractCreatedTicket, extractRecentDirectoriesTouched, extractTodoProgressFromEvents } from './state.js';
-import { costOfUsage } from '../pricing/index.js';
+import { costOfUsage, costOfUsageNoCache } from '../pricing/index.js';
 import { machineId } from './sync/config.js';
 import { machineForSessionFile } from './origin-machine.js';
 export { machineForSessionFile } from './origin-machine.js';
@@ -241,8 +241,14 @@ interface ClaudeSessionScan {
   tokenCount?: number;
   /** Real generated (output) tokens, excluding cache-read/-write context. */
   outputTokens?: number;
+  /** Burn split — uncached input / cache-read / cache-write tokens (RUSH-2287). */
+  inputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   /** Total USD cost accumulated from per-(model, direction) token usage. */
   costUsd?: number;
+  /** USD cost with cache read/write repriced at the input rate (RUSH-2287). */
+  costUsdNoCache?: number;
   /** Wall-clock duration in ms between the first and last timestamped event. */
   durationMs?: number;
   /** ISO time of the last timestamped event — the session's last activity. */
@@ -287,7 +293,13 @@ interface CodexSessionScan {
   tokenCount?: number;
   /** Real generated (output) tokens, excluding cache-read/-write context. */
   outputTokens?: number;
+  /** Burn split — uncached input / cache-read tokens (Codex has no cache-write) (RUSH-2287). */
+  inputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   costUsd?: number;
+  /** USD cost with cache read repriced at the input rate (RUSH-2287). */
+  costUsdNoCache?: number;
   durationMs?: number;
   lastActivity?: string;
   contentText?: string;
@@ -1413,7 +1425,11 @@ async function readClaudeMeta(
       toolCallCount: scan.toolCallCount,
       tokenCount: scan.tokenCount,
       outputTokens: scan.outputTokens,
+      inputTokens: scan.inputTokens,
+      cacheReadTokens: scan.cacheReadTokens,
+      cacheWriteTokens: scan.cacheWriteTokens,
       costUsd: scan.costUsd,
+      costUsdNoCache: scan.costUsdNoCache,
       durationMs: scan.durationMs,
       isTeamOrigin,
       prUrl: scan.prUrl,
@@ -1446,7 +1462,11 @@ async function readClaudeMeta(
       toolCallCount: scan.toolCallCount,
       tokenCount: scan.tokenCount,
       outputTokens: scan.outputTokens,
+      inputTokens: scan.inputTokens,
+      cacheReadTokens: scan.cacheReadTokens,
+      cacheWriteTokens: scan.cacheWriteTokens,
       costUsd: scan.costUsd,
+      costUsdNoCache: scan.costUsdNoCache,
       durationMs: scan.durationMs,
       topic: scan.topic,
       isTeamOrigin,
@@ -1784,7 +1804,11 @@ export async function readCodexMeta(
     messageCount: scan.messageCount,
     tokenCount: scan.tokenCount,
     outputTokens: scan.outputTokens,
+    inputTokens: scan.inputTokens,
+    cacheReadTokens: scan.cacheReadTokens,
+    cacheWriteTokens: scan.cacheWriteTokens,
     costUsd: scan.costUsd,
+    costUsdNoCache: scan.costUsdNoCache,
     durationMs: scan.durationMs,
     account: resolveAccount?.(),
     prUrl: scan.prUrl,
@@ -1932,8 +1956,11 @@ function readGeminiMeta(
   let messageCount = 0;
   let tokenCount = 0;
   let outputTokens = 0;
+  let inputTokens = 0;
+  let cacheReadTokens = 0;
   let sawTokenCount = false;
   let costUsd = 0;
+  let costUsdNoCache = 0;
   let sawCost = false;
   let firstTsMs: number | undefined;
   let lastTsMs: number | undefined;
@@ -1977,13 +2004,16 @@ function readGeminiMeta(
         (typeof gtk.output === 'number' ? gtk.output : 0) +
         (typeof gtk.thoughts === 'number' ? gtk.thoughts : 0) +
         (typeof gtk.tool === 'number' ? gtk.tool : 0);
+      // Burn split (RUSH-2287): Gemini has uncached input + cache-read, no cache-write.
+      if (typeof gtk.input === 'number') inputTokens += gtk.input;
+      if (typeof gtk.cached === 'number') cacheReadTokens += gtk.cached;
     }
 
     // Per-message cost: directional tokens × this message's model price.
     const msgModel = (typeof message.model === 'string' ? message.model : undefined) || sessionModel;
     const tk = message.tokens;
     if (msgModel && tk && typeof tk === 'object') {
-      const c = costOfUsage({
+      const usage = {
         model: msgModel,
         inputTokens: typeof tk.input === 'number' ? tk.input : undefined,
         outputTokens:
@@ -1991,9 +2021,11 @@ function readGeminiMeta(
           (typeof tk.thoughts === 'number' ? tk.thoughts : 0) +
           (typeof tk.tool === 'number' ? tk.tool : 0),
         cacheReadTokens: typeof tk.cached === 'number' ? tk.cached : undefined,
-      });
+      };
+      const c = costOfUsage(usage);
       if (c > 0) {
         costUsd += c;
+        costUsdNoCache += costOfUsageNoCache(usage);
         sawCost = true;
       }
     }
@@ -2019,7 +2051,10 @@ function readGeminiMeta(
     messageCount,
     tokenCount: sawTokenCount ? tokenCount : undefined,
     outputTokens: sawTokenCount ? outputTokens : undefined,
+    inputTokens: sawTokenCount ? inputTokens : undefined,
+    cacheReadTokens: sawTokenCount ? cacheReadTokens : undefined,
     costUsd: sawCost ? costUsd : undefined,
+    costUsdNoCache: sawCost ? costUsdNoCache : undefined,
     durationMs,
   };
   return { meta, content: userTexts.join('\n') };
@@ -3063,15 +3098,19 @@ async function readDroidMeta(
   const settings = readDroidSettings(filePath.replace(/\.jsonl$/, '.settings.json'));
   const model = settings.model || scan.model;
   const tokenCount = settings.tokenCount;
-  const costUsd = model && settings.usage
-    ? costOfUsage({
+  // Droid records a full split (input / cache-read / cache-write / output) in its
+  // settings sidecar, so both the actual and no-cache cost are derivable (RUSH-2287).
+  const usageForCost = model && settings.usage
+    ? {
         model,
         inputTokens: settings.usage.inputTokens,
         outputTokens: settings.usage.outputTokens,
         cacheReadTokens: settings.usage.cacheReadTokens,
         cacheCreationTokens: settings.usage.cacheCreationTokens,
-      })
-    : 0;
+      }
+    : undefined;
+  const costUsd = usageForCost ? costOfUsage(usageForCost) : 0;
+  const costUsdNoCache = usageForCost ? costOfUsageNoCache(usageForCost) : 0;
 
   const stat = safeStatSync(filePath);
   const cwd = normalizeCwd(scan.cwd || '');
@@ -3090,7 +3129,11 @@ async function readDroidMeta(
     messageCount: scan.messageCount,
     tokenCount,
     outputTokens: settings.usage?.outputTokens,
+    inputTokens: settings.usage?.inputTokens,
+    cacheReadTokens: settings.usage?.cacheReadTokens,
+    cacheWriteTokens: settings.usage?.cacheCreationTokens,
     costUsd: costUsd > 0 ? costUsd : undefined,
+    costUsdNoCache: costUsd > 0 ? costUsdNoCache : undefined,
     durationMs: scan.durationMs,
   };
   return { meta, content: scan.contentText || '' };
@@ -3250,8 +3293,14 @@ export interface ClaudeParseState {
   toolCallCount: number;
   tokenCount: number;
   outputTokens: number;
+  // Burn split accumulators (RUSH-2287): uncached input / cache-read / cache-write.
+  inputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
   sawTokenCount: boolean;
   costUsd: number;
+  // Same session cost with cache read/write repriced at the input rate.
+  costUsdNoCache: number;
   sawCost: boolean;
   // Track the first and last timestamped event to derive wall-clock duration.
   firstTsMs?: number;
@@ -3299,8 +3348,12 @@ export function initClaudeParseState(): ClaudeParseState {
     toolCallCount: 0,
     tokenCount: 0,
     outputTokens: 0,
+    inputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
     sawTokenCount: false,
     costUsd: 0,
+    costUsdNoCache: 0,
     sawCost: false,
     firstTsMs: undefined,
     lastTsMs: undefined,
@@ -3495,20 +3548,30 @@ export function applyClaudeLine(state: ClaudeParseState, parsed: any): void {
     state.sawTokenCount = true;
   }
   if (typeof usageObj?.output_tokens === 'number') state.outputTokens += usageObj.output_tokens;
+  // Burn split (RUSH-2287): accumulate the raw directional counts so `agents
+  // output` can report uncached-input / cache-read / cache-write separately.
+  if (usageObj && typeof usageObj === 'object') {
+    if (typeof usageObj.input_tokens === 'number') state.inputTokens += usageObj.input_tokens;
+    if (typeof usageObj.cache_read_input_tokens === 'number') state.cacheReadTokens += usageObj.cache_read_input_tokens;
+    if (typeof usageObj.cache_creation_input_tokens === 'number') state.cacheWriteTokens += usageObj.cache_creation_input_tokens;
+  }
   // Per-assistant-message cost: each event carries its own model, so we
   // multiply that event's raw token directions by that model's price.
   const model = parsed.message?.model;
   if (typeof model === 'string' && model) state.model = model;
   if (model && usageObj && typeof usageObj === 'object') {
-    const eventCost = costOfUsage({
+    const usageForCost = {
       model,
       inputTokens: usageObj.input_tokens,
       outputTokens: usageObj.output_tokens,
       cacheReadTokens: usageObj.cache_read_input_tokens,
       cacheCreationTokens: usageObj.cache_creation_input_tokens,
-    });
+    };
+    const eventCost = costOfUsage(usageForCost);
     if (eventCost > 0) {
       state.costUsd += eventCost;
+      // No-cache scenario: reprice this same event's cache tokens at the input rate.
+      state.costUsdNoCache += costOfUsageNoCache(usageForCost);
       state.sawCost = true;
     }
   }
@@ -3542,7 +3605,11 @@ export function finalizeClaudeScan(state: ClaudeParseState): ClaudeSessionScan {
     toolCallCount: state.toolCallCount,
     tokenCount: state.sawTokenCount ? state.tokenCount : undefined,
     outputTokens: state.sawTokenCount ? state.outputTokens : undefined,
+    inputTokens: state.sawTokenCount ? state.inputTokens : undefined,
+    cacheReadTokens: state.sawTokenCount ? state.cacheReadTokens : undefined,
+    cacheWriteTokens: state.sawTokenCount ? state.cacheWriteTokens : undefined,
     costUsd: state.sawCost ? state.costUsd : undefined,
+    costUsdNoCache: state.sawCost ? state.costUsdNoCache : undefined,
     durationMs,
     lastActivity: state.lastTsMs !== undefined ? new Date(state.lastTsMs).toISOString() : undefined,
     contentText: state.userTexts.length > 0 ? state.userTexts.join('\n') : undefined,
@@ -3600,7 +3667,10 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
  * exact even when the recent window is smaller than the true count.
  */
 export interface ClaudeParserState {
-  v: 2;
+  // v3 (RUSH-2287): added the burn-split accumulators + no-cache cost. A stale v2
+  // blob is rejected by the `!== 3` guard and the session is re-parsed from byte 0,
+  // which populates the new split correctly rather than resuming without it.
+  v: 3;
   offset: number;
   jsonlDroppingOversizedLine?: boolean;
   timestamp?: string;
@@ -3619,9 +3689,13 @@ export interface ClaudeParserState {
   toolCallCount: number;
   tokenCount: number;
   outputTokens: number;
+  inputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
   sawTokenCount: boolean;
   sawCost: boolean;
   costUsd: number;
+  costUsdNoCache: number;
   seenIdsSize: number;
   seenIdsRecent: string[];
   sawPrCreate: boolean;
@@ -3659,7 +3733,7 @@ export function serializeClaudeParserState(
     : allIds;
   const ticket = detectTicket(state.userTexts.join('\n') || undefined, state.gitBranch);
   return {
-    v: 2,
+    v: 3,
     offset,
     jsonlDroppingOversizedLine: jsonlDroppingOversizedLine || undefined,
     timestamp: state.timestamp,
@@ -3678,9 +3752,13 @@ export function serializeClaudeParserState(
     toolCallCount: state.toolCallCount,
     tokenCount: state.tokenCount,
     outputTokens: state.outputTokens,
+    inputTokens: state.inputTokens,
+    cacheReadTokens: state.cacheReadTokens,
+    cacheWriteTokens: state.cacheWriteTokens,
     sawTokenCount: state.sawTokenCount,
     sawCost: state.sawCost,
     costUsd: state.costUsd,
+    costUsdNoCache: state.costUsdNoCache,
     seenIdsSize: state.seenAssistantIds.size,
     seenIdsRecent,
     sawPrCreate: state.sawPrCreate,
@@ -3741,8 +3819,12 @@ export function hydrateClaudeParseState(prior: ClaudeParserState): ClaudeParseSt
     toolCallCount: prior.toolCallCount ?? 0,
     tokenCount: prior.tokenCount,
     outputTokens: prior.outputTokens,
+    inputTokens: prior.inputTokens ?? 0,
+    cacheReadTokens: prior.cacheReadTokens ?? 0,
+    cacheWriteTokens: prior.cacheWriteTokens ?? 0,
     sawTokenCount: prior.sawTokenCount,
     costUsd: prior.costUsd,
+    costUsdNoCache: prior.costUsdNoCache ?? 0,
     sawCost: prior.sawCost,
     firstTsMs: prior.firstTsMs,
     lastTsMs: prior.lastTsMs,
@@ -3911,7 +3993,7 @@ function parsePriorClaudeState(row: { parserState: string | null } | undefined):
   if (!row?.parserState) return null;
   try {
     const parsed = JSON.parse(row.parserState) as ClaudeParserState;
-    if (parsed?.v !== 2 || typeof parsed.offset !== 'number' || parsed.toolCalls?.v !== 1) return null;
+    if (parsed?.v !== 3 || typeof parsed.offset !== 'number' || parsed.toolCalls?.v !== 1) return null;
     return parsed;
   } catch {
     return null;
@@ -4106,16 +4188,34 @@ export function applyCodexLine(state: CodexParseState, parsed: any): void {
  * exact return-building {@link scanCodexSession} used to run inline.
  */
 export function finalizeCodexScan(state: CodexParseState): CodexSessionScan {
-  // Price the final cumulative token snapshot once, against the session model.
+  // Codex reports one cumulative snapshot: uncached input, cached (cache-read)
+  // input, and output+reasoning. It has no cache-write bucket. Derive the burn
+  // split and both costs (actual + no-cache) from that final snapshot (RUSH-2287).
+  const snap = state.lastTotalTokenUsage;
+  const outputTokens = snap
+    ? (snap.output_tokens ?? 0) + (snap.reasoning_output_tokens ?? 0)
+    : undefined;
   let costUsd: number | undefined;
-  if (state.model && state.lastTotalTokenUsage) {
-    const c = costOfUsage({
+  let costUsdNoCache: number | undefined;
+  let inputTokens: number | undefined;
+  let cacheReadTokens: number | undefined;
+  if (snap) {
+    inputTokens = typeof snap.input_tokens === 'number' ? snap.input_tokens : undefined;
+    cacheReadTokens = typeof snap.cached_input_tokens === 'number' ? snap.cached_input_tokens : undefined;
+  }
+  // Price the final cumulative token snapshot once, against the session model.
+  if (state.model && snap) {
+    const usage = {
       model: state.model,
-      inputTokens: state.lastTotalTokenUsage.input_tokens,
-      outputTokens: (state.lastTotalTokenUsage.output_tokens ?? 0) + (state.lastTotalTokenUsage.reasoning_output_tokens ?? 0),
-      cacheReadTokens: state.lastTotalTokenUsage.cached_input_tokens,
-    });
-    if (c > 0) costUsd = c;
+      inputTokens: snap.input_tokens,
+      outputTokens,
+      cacheReadTokens: snap.cached_input_tokens,
+    };
+    const c = costOfUsage(usage);
+    if (c > 0) {
+      costUsd = c;
+      costUsdNoCache = costOfUsageNoCache(usage);
+    }
   }
 
   const durationMs =
@@ -4136,10 +4236,12 @@ export function finalizeCodexScan(state: CodexParseState): CodexSessionScan {
     topic: state.topic,
     messageCount: state.messageCount,
     tokenCount: state.tokenCount,
-    outputTokens: state.lastTotalTokenUsage
-      ? (state.lastTotalTokenUsage.output_tokens ?? 0) + (state.lastTotalTokenUsage.reasoning_output_tokens ?? 0)
-      : undefined,
+    outputTokens,
+    inputTokens,
+    cacheReadTokens,
+    cacheWriteTokens: undefined,
     costUsd,
+    costUsdNoCache,
     durationMs,
     lastActivity: state.lastTsMs !== undefined ? new Date(state.lastTsMs).toISOString() : undefined,
     contentText: state.userTexts.length > 0 ? state.userTexts.join('\n') : undefined,

--- a/apps/cli/src/lib/session/types.ts
+++ b/apps/cli/src/lib/session/types.ts
@@ -179,8 +179,23 @@ export interface SessionMeta {
   tokenCount?: number;
   /** Real generated (output) tokens — excludes cache-read/-write context (issue: `agents output`). */
   outputTokens?: number;
+  /**
+   * Uncached input tokens, cache-read tokens, and cache-write (cache-creation)
+   * tokens — the burn split `agents output` reports, kept only for harnesses that
+   * record a per-message cache split (Claude/Codex/Gemini/Droid). Undefined for
+   * harnesses that expose no split (RUSH-2287).
+   */
+  inputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   /** Total USD cost, computed at scan time from per-model token usage (issue #323). */
   costUsd?: number;
+  /**
+   * USD cost priced as if caching were off — cache read/write billed at the full
+   * input rate. Backs `agents output --pricing no-cache` (RUSH-2287). Undefined
+   * when the harness records no cache split (then no-cache == actual by definition).
+   */
+  costUsdNoCache?: number;
   /** Wall-clock duration in ms (lastTs − firstTs), persisted at scan time. */
   durationMs?: number;
   /** Underlying LLM model observed in the transcript, when the agent records one. */


### PR DESCRIPTION
**feature** · `agents output` now reports the input/cache-read/cache-write burn split and a `--pricing no-cache` scenario. Reviewer audience: maintainers. (RUSH-2287)

Closes the "single burn counter" gap: operators couldn't see input vs cache-read vs cache-write, and had no way to model burn with prompt caching off.

## What changed
- **pricing** — `costOfUsageNoCache()` prices cache read/write at the model's full **input** rate (`src/lib/pricing/cost.ts`).
- **schema v37** — persist `input_tokens` / `cache_read_tokens` / `cache_write_tokens` / `cost_usd_nocache` per session (nullable, **no ledger flush**; pre-upgrade rows show total-only until re-scanned). `queryUsageRollup` sums them; the no-cache total `COALESCE`s to actual cost for rows with no split (`src/lib/session/db.ts`).
- **scanners** — accumulate the split + no-cache cost for **Claude** (incremental; parser blob bumped `v2→v3` so stale states re-parse into the split), **Codex** (from its cumulative snapshot), **Gemini**, **Droid** (`src/lib/session/discover.ts`). OpenCode/Kimi expose no cache split → stay total-only (stated out-of-scope per harness-parity rule; they record no per-message cache buckets).
- **output** — `burn split:` line + a caching-savings comparison; `--pricing no-cache` leads with the no-cache figure (breakdown column `burn(nc)`); `--json` is scenario-agnostic and always carries **both** `costUsd` and `costUsdNoCache` plus the split (`src/commands/output.ts`).

## Ran it — real rendered output (seeded rollup)

```
===== agents output (actual) =====
  $42.00 burned  ·  1.5M output tokens  ·  0 PRs (0 merged)  ·  0 commits
  35.7K out-tok/$
  burn split: 3.5M input  ·  58.9M cache-read  ·  1.1M cache-write
  caching: actual $42.00  vs  no-cache $120.00  (saved $78.00, 65%)
By agent
            burn    output  sessions
  claude    $30.00  1.0M    1
  codex     $12.00  500.0K  1

===== agents output --pricing no-cache =====
  $120.00 burned (no-cache)  ·  1.5M output tokens  ·  ...
  burn split: 3.5M input  ·  58.9M cache-read  ·  1.1M cache-write
  caching: actual $42.00  vs  no-cache $120.00  (saved $78.00, 65%)
By agent
            burn(nc)  output  sessions
  claude    $90.00    1.0M    1
  codex     $30.00    500.0K  1

===== agents output --json (burn) =====
{ "costUsd": 42, "costUsdNoCache": 120, "outputTokens": 1500000, "tokenCount": 65000000,
  "inputTokens": 3500000, "cacheReadTokens": 58900000, "cacheWriteTokens": 1100000, ... }
```

## Tests (real critical path, no mocks)
- `src/lib/pricing/cost.test.ts` — `costOfUsageNoCache` (input-rate repricing, ≥ actual, unknown-model → 0).
- `src/lib/session/db.usage-rollup.test.ts` — rollup sums the split; un-split row's no-cache falls back to actual cost.
- `src/commands/output.test.ts` — `--json` carries the split + both costs; TTY `burn split:` + `caching:`; `--pricing no-cache` flips the headline/column; bad `--pricing` errors.
- `incremental-scan-e2e.test.ts` — parser-state `v` assertion updated to 3.

Full run: **29/29** on the touched surfaces; the whole `src/lib/session` + `output` + `pricing` sweep is **1329 passed**. The only reds are 9 pre-existing `sync/config.test.ts` failures — **unrelated to this diff** (it touches no secrets/sync code; the failures trace through `src/lib/secrets/filestore.ts`, i.e. this dev box's real file-backed secrets store bypassing the test's keychain seam — a clean CI HOME passes).

## Docs / changelog
- `docs/06-observability.md` — new "Productivity Rollup (`agents output`)" section (split + `--pricing no-cache`).
- `.changelog/next/RUSH-2287.md` added.

No UI surface; CLI + `--json` only. Transcript (confidential) local at `yosemite-m1:/home/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz-agents-cli/e03e8f59-51be-40b8-b2da-25bb12a00545.jsonl`.
