### PR TITLE
feat(bench): add core runner and result storage

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2302-2303.md
+++ b/apps/cli/.changelog/next/RUSH-2302-2303.md
@@ -1,0 +1,1 @@
+- Add `agents bench list`, `agents bench run`, and `agents bench results`: benchmark cells fan out through the existing `agents run` path with isolated fixture copies, bounded concurrency, custom harness names, wall-time/exit/token capture, and durable JSON results under `~/.agents/.history/bench/` (RUSH-2302, RUSH-2303).

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 1.22.26
 
-- Add `agents bench list`, `agents bench run`, and `agents bench results`: benchmark cells fan out through the existing `agents run` path with isolated fixture copies, bounded concurrency, custom harness names, wall-time/exit capture, and durable JSON results under `~/.agents/.history/bench/` (RUSH-2302, RUSH-2303).
-
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 
 - **`agents apply --provision-secrets` pushes the manifest's declared secrets

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.22.26
 
+- Add `agents bench list`, `agents bench run`, and `agents bench results`: benchmark cells fan out through the existing `agents run` path with isolated fixture copies, bounded concurrency, custom harness names, wall-time/exit capture, and durable JSON results under `~/.agents/.history/bench/` (RUSH-2302, RUSH-2303).
+
 - Make bare `agents setup` a re-runnable onboarding hub with live capability status and direct access to browser, computer, secrets, fleet, share, watchdog, and preference wizards.
 
 - **`agents apply --provision-secrets` pushes the manifest's declared secrets

--- a/apps/cli/src/commands/bench.test.ts
+++ b/apps/cli/src/commands/bench.test.ts
@@ -1,0 +1,22 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { registerBenchCommand } from "./bench.js";
+describe("agents bench command", () => {
+  it("registers list, results, and run with custom harness agent input", () => {
+    const program = new Command();
+    registerBenchCommand(program);
+    const bench = program.commands.find(
+      (command) => command.name() === "bench",
+    );
+    expect(bench?.commands.map((command) => command.name())).toEqual([
+      "list",
+      "results",
+      "run",
+    ]);
+    expect(
+      bench?.commands
+        .find((command) => command.name() === "run")
+        ?.options.some((option) => option.long === "--agent"),
+    ).toBe(true);
+  });
+});

--- a/apps/cli/src/commands/bench.ts
+++ b/apps/cli/src/commands/bench.ts
@@ -1,0 +1,136 @@
+import type { Command } from "commander";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { detectSignedInRuntimes } from "../lib/crabbox/runtimes.js";
+import {
+  listRuns,
+  loadRun,
+  loadTask,
+  runCells,
+  saveRun,
+  type BenchCell,
+  type BenchRunResult,
+} from "../lib/bench/index.js";
+import { setHelpSections } from "../lib/help.js";
+
+const TASKS_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../bench/tasks",
+);
+function csv(value: string | undefined): string[] {
+  return (
+    value
+      ?.split(",")
+      .map((item) => item.trim())
+      .filter(Boolean) ?? []
+  );
+}
+function taskIds(root = TASKS_ROOT): string[] {
+  if (!fs.existsSync(root)) return [];
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        fs.existsSync(path.join(root, entry.name, "task.json")),
+    )
+    .map((entry) => entry.name)
+    .sort();
+}
+function renderResult(result: BenchRunResult): void {
+  console.log(
+    `Run ${result.run_id}${result.task_id ? ` · ${result.task_id}` : ""}`,
+  );
+  for (const cell of result.cells)
+    console.log(
+      `${cell.status === "passed" ? "PASS" : "FAIL"}  ${cell.agent}${cell.model ? `/${cell.model}` : ""}  ${cell.wall_ms} ms  exit ${cell.exit ?? "spawn-error"}`,
+    );
+}
+
+export function registerBenchCommand(program: Command): void {
+  const bench = program
+    .command("bench")
+    .description(
+      "Run the same task across agent and model cells, with isolated fixtures and durable JSON results.",
+    );
+  setHelpSections(bench, {
+    examples: `agents bench list\nagents bench run hello-repo --agent claude,codex --model cheap,default\nagents bench results --json`,
+    notes: `Task definitions live under apps/cli/bench/tasks/<id>/task.json. Custom harness names accepted by agents run are valid --agent values.`,
+  });
+  bench
+    .command("list")
+    .description("List available benchmark tasks.")
+    .option("--json", "Emit JSON.")
+    .action((options: { json?: boolean }) => {
+      const tasks = taskIds();
+      if (options.json) console.log(JSON.stringify(tasks, null, 2));
+      else if (tasks.length === 0) console.log("No benchmark tasks installed.");
+      else tasks.forEach((id) => console.log(id));
+    });
+  bench
+    .command("results [run-id]")
+    .description("Show one saved run, or list saved runs newest first.")
+    .option("--json", "Emit JSON.")
+    .action((runId: string | undefined, options: { json?: boolean }) => {
+      const value = runId ? loadRun(runId) : listRuns();
+      if (options.json) console.log(JSON.stringify(value, null, 2));
+      else if (Array.isArray(value)) {
+        if (value.length === 0) console.log("No benchmark results yet.");
+        else value.forEach(renderResult);
+      } else renderResult(value);
+    });
+  bench
+    .command("run [task-id]")
+    .description("Run one task or prompt across an agent × model matrix.")
+    .option("--prompt <text>", "Prompt to benchmark instead of a house task.")
+    .option(
+      "--agent <names>",
+      "Comma-separated native agents or custom harness names. Defaults to signed-in native agents.",
+    )
+    .option(
+      "--model <models>",
+      "Comma-separated model tiers or concrete model ids.",
+    )
+    .option("--concurrency <n>", "Maximum cells running at once.", "3")
+    .option("--json", "Emit the saved JSON result.")
+    .action(
+      async (
+        taskId: string | undefined,
+        options: {
+          prompt?: string;
+          agent?: string;
+          model?: string;
+          concurrency: string;
+          json?: boolean;
+        },
+      ) => {
+        if (!!taskId === !!options.prompt)
+          throw new Error("Pass exactly one of <task-id> or --prompt.");
+        const task = taskId ? loadTask(taskId, TASKS_ROOT) : undefined;
+        const prompt = options.prompt ?? task!.prompt;
+        let agents = csv(options.agent);
+        if (agents.length === 0)
+          agents = (await detectSignedInRuntimes())
+            .filter((runtime) => runtime.signedIn)
+            .map((runtime) => runtime.id);
+        if (agents.length === 0)
+          throw new Error(
+            "No signed-in native agents found. Pass --agent <name>.",
+          );
+        const models = csv(options.model);
+        const cells: BenchCell[] = agents.flatMap((agent) =>
+          models.length > 0
+            ? models.map((model) => ({ agent, model }))
+            : [{ agent }],
+        );
+        const concurrency = Number(options.concurrency);
+        const result = await runCells({ task, prompt, cells, concurrency });
+        saveRun(result);
+        if (options.json) console.log(JSON.stringify(result, null, 2));
+        else renderResult(result);
+        if (result.cells.some((cell) => cell.status === "failed"))
+          process.exitCode = 1;
+      },
+    );
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -198,6 +198,7 @@ import {
   loadRepo,
   loadSetup,
   loadUninstall,
+  loadBench,
   loadShare,
   loadSend,
   loadFeed,
@@ -1125,6 +1126,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadCost);
   await reg(loadInsights);
   await reg(loadPerf);
+  await reg(loadBench);
   await reg(loadTrends);
   await reg(loadOutput);
   await reg(loadBudget);

--- a/apps/cli/src/lib/bench/index.ts
+++ b/apps/cli/src/lib/bench/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./schema.js";
+export * from "./storage.js";
+export * from "./runner.js";

--- a/apps/cli/src/lib/bench/runner.test.ts
+++ b/apps/cli/src/lib/bench/runner.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  extractTokenCount,
+  runCells,
+  type CellExecutionRequest,
+} from "./runner.js";
+import type { BenchTask } from "./types.js";
+describe("bench runner", () => {
+  it("isolates fixture copies and never exceeds the concurrency cap", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bench-runner-"));
+    const fixtureDir = path.join(root, "fixture");
+    fs.mkdirSync(fixtureDir);
+    fs.writeFileSync(path.join(fixtureDir, "seed.txt"), "seed");
+    const task: BenchTask = {
+      id: "isolation",
+      prompt: "run",
+      pass: [{ type: "exit_zero" }],
+      fixtureDir,
+      sourcePath: path.join(root, "task.json"),
+    };
+    let active = 0;
+    let peak = 0;
+    const seen = new Set<string>();
+    const execute = async (request: CellExecutionRequest) => {
+      active++;
+      peak = Math.max(peak, active);
+      seen.add(request.cwd);
+      expect(fs.readFileSync(path.join(request.cwd, "seed.txt"), "utf8")).toBe(
+        "seed",
+      );
+      fs.writeFileSync(
+        path.join(request.cwd, `${request.agent}.txt`),
+        request.agent,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      active--;
+      return { exit: 0, stdout: request.agent, stderr: "" };
+    };
+    const result = await runCells({
+      task,
+      prompt: task.prompt,
+      cells: ["a", "b", "c", "d"].map((agent) => ({ agent })),
+      concurrency: 2,
+      execute,
+      tempRoot: root,
+    });
+    expect(peak).toBe(2);
+    expect(seen.size).toBe(4);
+    expect(result.cells.map((cell) => cell.status)).toEqual([
+      "passed",
+      "passed",
+      "passed",
+      "passed",
+    ]);
+  });
+  it("captures cell failures without cancelling sibling cells", async () => {
+    const result = await runCells({
+      prompt: "x",
+      cells: [{ agent: "custom-harness" }, { agent: "native" }],
+      concurrency: 2,
+      execute: async ({ agent }) =>
+        agent === "custom-harness"
+          ? { exit: 7, stdout: "", stderr: "failed" }
+          : { exit: 0, stdout: "ok", stderr: "" },
+    });
+    expect(
+      result.cells.map((cell) => [cell.agent, cell.status, cell.exit]),
+    ).toEqual([
+      ["custom-harness", "failed", 7],
+      ["native", "passed", 0],
+    ]);
+  });
+  it("captures token totals when a harness reports them", () => {
+    expect(extractTokenCount("", "tokens used\n42,390")).toBe(42390);
+    expect(extractTokenCount("plain output", "")).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/bench/runner.ts
+++ b/apps/cli/src/lib/bench/runner.ts
@@ -1,0 +1,147 @@
+import { spawn } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { getCliLaunch } from "../cli-entry.js";
+import type {
+  BenchCell,
+  BenchCellResult,
+  BenchRunResult,
+  BenchTask,
+} from "./types.js";
+export interface CellExecutionRequest extends BenchCell {
+  prompt: string;
+  cwd: string;
+}
+export type CellExecutor = (
+  request: CellExecutionRequest,
+) => Promise<Omit<BenchCellResult, keyof BenchCell | "wall_ms" | "status">>;
+export function extractTokenCount(
+  stdout: string,
+  stderr: string,
+): number | undefined {
+  const matches = [
+    ...`${stdout}\n${stderr}`.matchAll(
+      /(?:tokens used|total tokens|token usage)\s*[:=]?\s*([\d,]+)/gi,
+    ),
+  ];
+  const raw = matches.at(-1)?.[1];
+  if (!raw) return undefined;
+  const tokens = Number(raw.replaceAll(",", ""));
+  return Number.isSafeInteger(tokens) && tokens >= 0 ? tokens : undefined;
+}
+export async function executeCellViaAgentsRun(
+  request: CellExecutionRequest,
+): ReturnType<CellExecutor> {
+  const args = [
+    "run",
+    request.agent,
+    request.prompt,
+    "--cwd",
+    request.cwd,
+    "--headless",
+    "--no-tmux",
+  ];
+  if (request.model) args.push("--model", request.model);
+  const launch = getCliLaunch(args);
+  return await new Promise((resolve, reject) => {
+    const child = spawn(launch.command, launch.args, {
+      cwd: request.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) =>
+      resolve({
+        exit: code,
+        stdout,
+        stderr,
+        tokens: extractTokenCount(stdout, stderr),
+      }),
+    );
+  });
+}
+function copyFixture(
+  task: BenchTask,
+  cellIndex: number,
+  runRoot: string,
+): string {
+  const cwd = path.join(runRoot, `cell-${cellIndex}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  if (fs.existsSync(task.fixtureDir))
+    fs.cpSync(task.fixtureDir, cwd, { recursive: true });
+  return cwd;
+}
+export async function runCells(options: {
+  task?: BenchTask;
+  prompt: string;
+  cells: BenchCell[];
+  concurrency: number;
+  execute?: CellExecutor;
+  tempRoot?: string;
+}): Promise<BenchRunResult> {
+  if (!Number.isInteger(options.concurrency) || options.concurrency < 1)
+    throw new Error("concurrency must be a positive integer");
+  if (options.cells.length === 0)
+    throw new Error("at least one bench cell is required");
+  const runId = `${new Date().toISOString().replace(/[-:.TZ]/g, "")}-${process.pid}`;
+  const startedAt = new Date();
+  const runRoot = fs.mkdtempSync(
+    path.join(options.tempRoot ?? os.tmpdir(), `agents-bench-${runId}-`),
+  );
+  const results = new Array<BenchCellResult>(options.cells.length);
+  const execute = options.execute ?? executeCellViaAgentsRun;
+  let next = 0;
+  const worker = async () => {
+    for (;;) {
+      const index = next++;
+      if (index >= options.cells.length) return;
+      const cell = options.cells[index];
+      const cwd = options.task
+        ? copyFixture(options.task, index, runRoot)
+        : path.join(runRoot, `cell-${index}`);
+      fs.mkdirSync(cwd, { recursive: true });
+      const started = performance.now();
+      try {
+        const output = await execute({ ...cell, prompt: options.prompt, cwd });
+        results[index] = {
+          ...cell,
+          ...output,
+          wall_ms: Math.round(performance.now() - started),
+          status: output.exit === 0 ? "passed" : "failed",
+        };
+      } catch (error) {
+        results[index] = {
+          ...cell,
+          exit: null,
+          stdout: "",
+          stderr: error instanceof Error ? error.message : String(error),
+          wall_ms: Math.round(performance.now() - started),
+          status: "failed",
+        };
+      }
+    }
+  };
+  await Promise.all(
+    Array.from(
+      { length: Math.min(options.concurrency, options.cells.length) },
+      worker,
+    ),
+  );
+  return {
+    schema_version: 1,
+    run_id: runId,
+    ...(options.task ? { task_id: options.task.id } : {}),
+    prompt: options.prompt,
+    started_at: startedAt.toISOString(),
+    finished_at: new Date().toISOString(),
+    cells: results,
+  };
+}

--- a/apps/cli/src/lib/bench/schema.test.ts
+++ b/apps/cli/src/lib/bench/schema.test.ts
@@ -31,5 +31,15 @@ describe("bench schemas", () => {
     expect(() => parseRunResult({ schema_version: 2 })).toThrow(
       "schema_version",
     );
+    expect(() =>
+      parseRunResult({
+        schema_version: 1,
+        run_id: "r",
+        prompt: "p",
+        started_at: "s",
+        finished_at: "f",
+        cells: [{ agent: "codex", status: "passed" }],
+      }),
+    ).toThrow("exit");
   });
 });

--- a/apps/cli/src/lib/bench/schema.test.ts
+++ b/apps/cli/src/lib/bench/schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { parseRunResult, parseTask } from "./schema.js";
+
+describe("bench schemas", () => {
+  it("parses the task contract shared with house tasks", () => {
+    const task = parseTask(
+      {
+        id: "hello-repo",
+        prompt: "Write the file",
+        pass: [
+          { type: "file_exists", path: "bench-out.txt" },
+          { type: "exit_zero" },
+          { type: "stdout_contains", value: "DONE" },
+          { type: "command_succeeds", command: "node --check index.js" },
+        ],
+      },
+      "/repo/apps/cli/bench/tasks/hello-repo/task.json",
+    );
+    expect(task.fixtureDir).toBe(
+      "/repo/apps/cli/bench/tasks/hello-repo/fixture",
+    );
+    expect(task.pass).toHaveLength(4);
+  });
+  it("rejects unsupported criteria and malformed saved results", () => {
+    expect(() =>
+      parseTask(
+        { id: "x", prompt: "x", pass: [{ type: "guess" }] },
+        "/task.json",
+      ),
+    ).toThrow("unsupported");
+    expect(() => parseRunResult({ schema_version: 2 })).toThrow(
+      "schema_version",
+    );
+  });
+});

--- a/apps/cli/src/lib/bench/schema.ts
+++ b/apps/cli/src/lib/bench/schema.ts
@@ -52,9 +52,52 @@ export function parseRunResult(raw: unknown): BenchRunResult {
   string(value.prompt, "bench result prompt");
   string(value.started_at, "bench result started_at");
   string(value.finished_at, "bench result finished_at");
+  if (value.task_id !== undefined)
+    string(value.task_id, "bench result task_id");
   if (!Array.isArray(value.cells))
     throw new Error("bench result cells must be an array");
+  value.cells.forEach((rawCell, index) => {
+    const cell = object(rawCell, `bench result cells[${index}]`);
+    string(cell.agent, `bench result cells[${index}].agent`);
+    if (cell.model !== undefined)
+      string(cell.model, `bench result cells[${index}].model`);
+    if (cell.status !== "passed" && cell.status !== "failed")
+      throw new Error(
+        `bench result cells[${index}].status must be passed or failed`,
+      );
+    if (
+      cell.exit !== null &&
+      (!Number.isInteger(cell.exit) || (cell.exit as number) < 0)
+    )
+      throw new Error(
+        `bench result cells[${index}].exit must be a non-negative integer or null`,
+      );
+    if (
+      typeof cell.wall_ms !== "number" ||
+      !Number.isFinite(cell.wall_ms) ||
+      cell.wall_ms < 0
+    )
+      throw new Error(
+        `bench result cells[${index}].wall_ms must be a non-negative number`,
+      );
+    if (
+      cell.tokens !== undefined &&
+      (!Number.isSafeInteger(cell.tokens) || (cell.tokens as number) < 0)
+    )
+      throw new Error(
+        `bench result cells[${index}].tokens must be a non-negative integer`,
+      );
+    if (typeof cell.stdout !== "string" || typeof cell.stderr !== "string")
+      throw new Error(
+        `bench result cells[${index}] stdout and stderr must be strings`,
+      );
+  });
   return value as unknown as BenchRunResult;
+}
+export function validateRunId(runId: string): string {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(runId))
+    throw new Error(`Invalid run id: ${runId}`);
+  return runId;
 }
 export function loadTask(taskId: string, tasksRoot: string): BenchTask {
   if (!/^[a-z0-9][a-z0-9-]*$/.test(taskId))

--- a/apps/cli/src/lib/bench/schema.ts
+++ b/apps/cli/src/lib/bench/schema.ts
@@ -1,0 +1,64 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { BenchPassCriterion, BenchRunResult, BenchTask } from "./types.js";
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim() === "")
+    throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+export function parseTask(raw: unknown, sourcePath: string): BenchTask {
+  const value = object(raw, "task.json");
+  const id = string(value.id, "task.id");
+  const prompt = string(value.prompt, "task.prompt");
+  if (!Array.isArray(value.pass) || value.pass.length === 0)
+    throw new Error("task.pass must be a non-empty array");
+  const pass = value.pass.map((item, index): BenchPassCriterion => {
+    const criterion = object(item, `task.pass[${index}]`);
+    const type = string(criterion.type, `task.pass[${index}].type`);
+    if (type === "exit_zero") return { type };
+    if (type === "file_exists")
+      return { type, path: string(criterion.path, `task.pass[${index}].path`) };
+    if (type === "stdout_contains")
+      return {
+        type,
+        value: string(criterion.value, `task.pass[${index}].value`),
+      };
+    if (type === "command_succeeds")
+      return {
+        type,
+        command: string(criterion.command, `task.pass[${index}].command`),
+      };
+    throw new Error(`task.pass[${index}].type is unsupported: ${type}`);
+  });
+  const taskDir = path.dirname(sourcePath);
+  return {
+    id,
+    prompt,
+    pass,
+    fixtureDir: path.join(taskDir, "fixture"),
+    sourcePath,
+  };
+}
+export function parseRunResult(raw: unknown): BenchRunResult {
+  const value = object(raw, "bench result");
+  if (value.schema_version !== 1)
+    throw new Error("bench result schema_version must be 1");
+  string(value.run_id, "bench result run_id");
+  string(value.prompt, "bench result prompt");
+  string(value.started_at, "bench result started_at");
+  string(value.finished_at, "bench result finished_at");
+  if (!Array.isArray(value.cells))
+    throw new Error("bench result cells must be an array");
+  return value as unknown as BenchRunResult;
+}
+export function loadTask(taskId: string, tasksRoot: string): BenchTask {
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(taskId))
+    throw new Error(`Invalid task id: ${taskId}`);
+  const sourcePath = path.join(tasksRoot, taskId, "task.json");
+  return parseTask(JSON.parse(fs.readFileSync(sourcePath, "utf8")), sourcePath);
+}

--- a/apps/cli/src/lib/bench/storage.test.ts
+++ b/apps/cli/src/lib/bench/storage.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { listRuns, loadRun, saveRun } from "./storage.js";
+import type { BenchRunResult } from "./types.js";
+function result(run_id: string, started_at: string): BenchRunResult {
+  return {
+    schema_version: 1,
+    run_id,
+    prompt: "test",
+    started_at,
+    finished_at: started_at,
+    cells: [],
+  };
+}
+describe("bench result storage", () => {
+  it("atomically saves, loads, and sorts durable JSON results", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bench-storage-"));
+    saveRun(result("older", "2026-08-05T01:00:00.000Z"), root);
+    const target = saveRun(result("newer", "2026-08-05T02:00:00.000Z"), root);
+    expect(fs.statSync(target).mode & 0o777).toBe(0o600);
+    expect(loadRun("newer", root).run_id).toBe("newer");
+    expect(listRuns(root).map((run) => run.run_id)).toEqual(["newer", "older"]);
+  });
+  it("does not allow a run id to escape the result directory", () => {
+    expect(() => loadRun("../outside", "/tmp/nope")).toThrow("Invalid run id");
+  });
+});

--- a/apps/cli/src/lib/bench/storage.test.ts
+++ b/apps/cli/src/lib/bench/storage.test.ts
@@ -25,5 +25,9 @@ describe("bench result storage", () => {
   });
   it("does not allow a run id to escape the result directory", () => {
     expect(() => loadRun("../outside", "/tmp/nope")).toThrow("Invalid run id");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bench-storage-"));
+    expect(() =>
+      saveRun(result("../outside", "2026-08-05T01:00:00.000Z"), root),
+    ).toThrow("Invalid run id");
   });
 });

--- a/apps/cli/src/lib/bench/storage.ts
+++ b/apps/cli/src/lib/bench/storage.ts
@@ -1,0 +1,43 @@
+import * as fs from "fs";
+import * as path from "path";
+import { getUserAgentsDir } from "../state.js";
+import { parseRunResult } from "./schema.js";
+import type { BenchRunResult } from "./types.js";
+export function benchHistoryDir(): string {
+  return path.join(getUserAgentsDir(), ".history", "bench");
+}
+export function saveRun(
+  result: BenchRunResult,
+  root = benchHistoryDir(),
+): string {
+  fs.mkdirSync(root, { recursive: true });
+  const target = path.join(root, `${result.run_id}.json`);
+  const temporary = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  fs.renameSync(temporary, target);
+  return target;
+}
+export function loadRun(
+  runId: string,
+  root = benchHistoryDir(),
+): BenchRunResult {
+  if (!/^[a-zA-Z0-9._-]+$/.test(runId))
+    throw new Error(`Invalid run id: ${runId}`);
+  return parseRunResult(
+    JSON.parse(fs.readFileSync(path.join(root, `${runId}.json`), "utf8")),
+  );
+}
+export function listRuns(root = benchHistoryDir()): BenchRunResult[] {
+  if (!fs.existsSync(root)) return [];
+  return fs
+    .readdirSync(root)
+    .filter((name) => name.endsWith(".json"))
+    .map((name) =>
+      parseRunResult(
+        JSON.parse(fs.readFileSync(path.join(root, name), "utf8")),
+      ),
+    )
+    .sort((a, b) => b.started_at.localeCompare(a.started_at));
+}

--- a/apps/cli/src/lib/bench/storage.ts
+++ b/apps/cli/src/lib/bench/storage.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { getUserAgentsDir } from "../state.js";
-import { parseRunResult } from "./schema.js";
+import { parseRunResult, validateRunId } from "./schema.js";
 import type { BenchRunResult } from "./types.js";
 export function benchHistoryDir(): string {
   return path.join(getUserAgentsDir(), ".history", "bench");
@@ -10,6 +10,8 @@ export function saveRun(
   result: BenchRunResult,
   root = benchHistoryDir(),
 ): string {
+  parseRunResult(result);
+  validateRunId(result.run_id);
   fs.mkdirSync(root, { recursive: true });
   const target = path.join(root, `${result.run_id}.json`);
   const temporary = `${target}.${process.pid}.tmp`;
@@ -23,8 +25,7 @@ export function loadRun(
   runId: string,
   root = benchHistoryDir(),
 ): BenchRunResult {
-  if (!/^[a-zA-Z0-9._-]+$/.test(runId))
-    throw new Error(`Invalid run id: ${runId}`);
+  validateRunId(runId);
   return parseRunResult(
     JSON.parse(fs.readFileSync(path.join(root, `${runId}.json`), "utf8")),
   );

--- a/apps/cli/src/lib/bench/types.ts
+++ b/apps/cli/src/lib/bench/types.ts
@@ -1,0 +1,34 @@
+export type BenchPassCriterion =
+  | { type: "file_exists"; path: string }
+  | { type: "exit_zero" }
+  | { type: "stdout_contains"; value: string }
+  | { type: "command_succeeds"; command: string };
+
+export interface BenchTask {
+  id: string;
+  prompt: string;
+  pass: BenchPassCriterion[];
+  fixtureDir: string;
+  sourcePath: string;
+}
+export interface BenchCell {
+  agent: string;
+  model?: string;
+}
+export interface BenchCellResult extends BenchCell {
+  status: "passed" | "failed";
+  exit: number | null;
+  wall_ms: number;
+  tokens?: number;
+  stdout: string;
+  stderr: string;
+}
+export interface BenchRunResult {
+  schema_version: 1;
+  run_id: string;
+  task_id?: string;
+  prompt: string;
+  started_at: string;
+  finished_at: string;
+  cells: BenchCellResult[];
+}

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -82,6 +82,7 @@ export const loadUsage: ModuleLoader = async () => (await import('../../commands
 export const loadCost: ModuleLoader = async () => (await import('../../commands/cost.js')).registerCostCommand;
 export const loadInsights: ModuleLoader = async () => (await import('../../commands/insights.js')).registerInsightsCommand;
 export const loadPerf: ModuleLoader = async () => (await import('../../commands/perf.js')).registerPerfCommand;
+export const loadBench: ModuleLoader = async () => (await import('../../commands/bench.js')).registerBenchCommand;
 // Thin deprecated alias of `agents insights mix` — no second mix implementation.
 export const loadTrends: ModuleLoader = async () => (await import('../../commands/trends.js')).registerTrendsCommand;
 export const loadOutput: ModuleLoader = async () => (await import('../../commands/output.js')).registerOutputCommand;
@@ -221,6 +222,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   cost: [loadCost],
   insights: [loadInsights],
   perf: [loadPerf],
+  bench: [loadBench],
   trends: [loadTrends],
   output: [loadOutput],
   budget: [loadBudget],


### PR DESCRIPTION
Adds the headless `agents bench` core for CLI users and benchmark-task authors.

## What changed

- Registers `agents bench list`, `run`, and `results` with workflow-first help.
- Runs agent × model cells through the existing `agents run` path, including custom harness names.
- Copies each fixture into its own temporary cwd and caps parallel execution.
- Stores schema-versioned JSON under `~/.agents/.history/bench/`, including exit, wall time, stdout/stderr, and tokens when a harness reports them.
- Exports `loadTask`, task/result types, storage, and runner interfaces for the house-task track.

Links RUSH-2302 and RUSH-2303 (parent RUSH-2299).

## Real run

No UI surface. Compiled `agents bench run` executed two live cells in parallel:

| Cell | Output | Exit | Wall time | Result |
|---|---|---:|---:|---|
| codex | `BENCH_OK` | 0 | 11,870 ms | passed |
| claude | `BENCH_OK` | 0 | 8,667 ms | passed |

Token capture was then verified against a live Codex cell: `tokens: 42362`, `exit: 0`, `wall_ms: 9640`, output `BENCH_TOKEN_OK`. Saved run ids: `20260806065717872-2737985`, `20260806065844880-2786382`.

Run artifact: yosemite-s0:/tmp/bench-run-proof.txt (fleet-local because the public-share bundle is biometric-locked).

## Verification

- `bun run build`
- `vitest`: 5 files, 12 tests passed (bench schemas/storage/runner/command + command-registry parity)
- `git diff --check`

Public repository: confidential session transcript omitted; local session remains in the fleet history.
