### PR TITLE
test(exec): benchmark buildExecEnv/buildExecCommand/execAgent spawn

### DIFF
--- a/apps/cli/src/lib/exec.bench.ts
+++ b/apps/cli/src/lib/exec.bench.ts
@@ -1,0 +1,205 @@
+/**
+ * Benchmark for the agent-execution hot path: env construction (buildExecEnv),
+ * argv assembly (buildExecCommand), and process spawn (execAgent -> spawnAgent).
+ *
+ * No mocking. Runs against this machine's REAL ~/.agents layout — the actual
+ * agents.yaml (state.ts:1124 readMeta), the actual installed version homes
+ * under ~/.agents/.history/versions/<agent>/ (versions.ts:1284
+ * listInstalledVersions), and, for the spawn group, the actual installed
+ * `claude` binary. `process.cwd()` during a real `vitest bench` run is this
+ * package's directory inside whatever checkout invoked it (typically several
+ * levels deep under a git worktree), so the project-version directory walk in
+ * versions.ts:2287 getProjectVersion runs its REAL depth here, not a synthetic
+ * shallow stub.
+ *
+ * The dominant, measured cost driver in buildExecEnv turned out to be neither
+ * of the two caches below on their own -- it's claude-account-token.ts:51
+ * resolveClaudeSetupToken(), called from exec.ts:424 for EVERY resolved claude
+ * version (pinned or auto-resolved) whose version home has a signed-in
+ * account. It is entirely uncached: each call re-derives an AES key via
+ * `scryptSync` (secrets/filestore.ts:208-210, invoked from
+ * decryptForFallback at secrets/filestore.ts:230-240) to decrypt the
+ * file-backed `auth` secrets bundle. Measured standalone (a one-off
+ * `performance.now()` probe against the real bundle, not part of this
+ * benchmark file): ~150-170ms per call, first call and every call after —
+ * scrypt is deliberately memory-hard/slow and nothing memoizes the derived
+ * key or the decrypted token across calls. A version home with NO signed-in
+ * account short-circuits at claude-account-token.ts:56-57
+ * (readClaudeAccountEmail returns null) before ever reaching the decrypt, so
+ * the SAME code path costs ~0.07ms or ~150ms purely depending on whether that
+ * specific version is logged in — that split, not warm/cold cache state, is
+ * the headline finding, so it is what this file isolates directly with two
+ * explicit version pins discovered from the real ~/.agents/.history/versions/
+ * layout: `loggedInClaudeVersion` and `loggedOutClaudeVersion`.
+ *
+ * Two cache regimes are ALSO benchmarked, because they cost meaningfully
+ * different amounts on top of the above:
+ *
+ *   - WARM: state.ts:1124 readMeta()'s mtime-keyed cache and actor.ts:163
+ *     resolveActor()'s process-lifetime cache are both hot. This is the
+ *     steady state inside one long-lived orchestrator process that calls
+ *     buildExecEnv many times (loop.ts:214, teams, runner.ts:720).
+ *   - COLD: both caches invalidated before every sample, matching the FIRST
+ *     buildExecEnv call in a freshly spawned `agents run` process -- the
+ *     common case, since every real CLI invocation is its own process.
+ *     Measured here it costs about the same as warm (readMeta's re-parse of a
+ *     ~5KB agents.yaml and a fresh actor resolve are both sub-millisecond) --
+ *     NOT because the invalidation is a no-op, but because this shell's
+ *     process.env already carries `AGENTS_ACTOR=UNRESOLVED@zion` (inherited
+ *     from the agent harness that launched this session), so actor.ts:149
+ *     `inheritedActor(env)` returns immediately and computeActor() never
+ *     reaches the SSH branch. A genuinely fresh interactive terminal (no
+ *     inherited AGENTS_ACTOR) would instead hit actor.ts:152-154 and, on an
+ *     SSH-connected box (SSH_CONNECTION set), pay actor.ts:62 tailscaleWhois()
+ *     — a real `spawnSync('tailscale', ['whois', ...])` subprocess capped at
+ *     2s (actor.ts:53 WHOIS_TIMEOUT_MS) — on that literal first call. That
+ *     cost is real but environment-dependent and not reproduced by this bench
+ *     run; it is called out here rather than silently assumed.
+ *
+ * The execAgent group spawns the REAL installed `claude` binary (real fork+exec,
+ * real buildExecEnv/buildExecCommand output) with `passthroughArgs: ['--version']`
+ * appended. Claude's own arg parsing short-circuits on `--version` before doing
+ * any network/session work (verified: `claude -p "x" --permission-mode plan
+ * --version` exits in ~0.2s printing only the version string) — this measures
+ * exec.ts's own spawn overhead without paying for (or depending on) a real,
+ * non-deterministic, network-bound agent conversation.
+ */
+import { describe, bench } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { buildExecEnv, buildExecCommand, execAgent } from './exec.js';
+import type { ExecOptions } from './exec.js';
+import { resetActorCache } from './actor.js';
+import { getUserAgentsDir, getHistoryDir } from './state.js';
+import { listInstalledVersions } from './versions.js';
+
+function execOpts(over: Partial<ExecOptions> & { agent: ExecOptions['agent'] }): ExecOptions {
+  return { mode: 'plan', effort: 'auto', cwd: process.cwd(), ...over } as ExecOptions;
+}
+
+// Discovered from the REAL version-home layout so this bench runs unmodified
+// on any dev box (or degrades gracefully when nothing is installed, e.g. a
+// bare CI runner -- this file is not wired into `vitest run`, see
+// vitest.config.ts:9, so that only matters for a human running it locally).
+const installedClaudeVersions = listInstalledVersions('claude');
+const installedCodex = listInstalledVersions('codex').at(-1);
+
+/**
+ * Whether a claude version's home has a resolvable oauth account email
+ * (claude-account-token.ts:29 readClaudeAccountEmail's own check), WITHOUT
+ * going through the secrets bundle at all -- this only reads the plaintext
+ * `.claude.json` account marker, never a secret value, so it is safe to run
+ * as bench setup and never prints anything sensitive.
+ */
+function hasResolvableAccount(version: string): boolean {
+  const home = path.join(getHistoryDir(), 'versions', 'claude', version, 'home');
+  for (const p of [path.join(home, '.claude', '.claude.json'), path.join(home, '.claude.json')]) {
+    try {
+      const email = (JSON.parse(fs.readFileSync(p, 'utf-8')) as {
+        oauthAccount?: { emailAddress?: unknown };
+      }).oauthAccount?.emailAddress;
+      if (typeof email === 'string' && email.trim().length > 0) return true;
+    } catch { /* try the next candidate path */ }
+  }
+  return false;
+}
+
+const loggedInClaudeVersion = installedClaudeVersions.find(hasResolvableAccount);
+const loggedOutClaudeVersion = installedClaudeVersions.find((v) => !hasResolvableAccount(v));
+
+const metaFile = path.join(getUserAgentsDir(), 'agents.yaml');
+
+/**
+ * Force the next buildExecEnv call to pay full cold-start cost: clears the
+ * process-lifetime actor cache (actor.ts:157 `cached`) and bumps agents.yaml's
+ * mtime so state.ts:1130 readMeta()'s stamp check misses and it re-parses --
+ * exactly the "another process touched the file" invalidation path the module
+ * doc at state.ts:1120 describes.
+ *
+ * tinybench's bench-level `setup` hook (the only per-task hook vitest's
+ * `bench(name, fn, options)` actually exposes -- `beforeEach`/`afterEach` are
+ * tinybench's internal per-Task `FnOptions`, not part of the `Options` shape
+ * vitest forwards, and using them here is a type error) fires ONCE before a
+ * task's `run()`, not once per sample. So to measure a genuinely cold call
+ * rather than one cold sample diluted into a mean with many warm ones, every
+ * cold bench() below pairs this `setup` with `{ iterations: 1, time: 1,
+ * warmupIterations: 0, warmupTime: 0 }` -- no warmup, and a near-zero time
+ * budget so the run loop stops as soon as its 1-sample floor is met.
+ */
+function invalidateCaches(_task: unknown, mode: 'warmup' | 'run'): void {
+  if (mode !== 'run') return;
+  resetActorCache();
+  try {
+    const now = new Date();
+    fs.utimesSync(metaFile, now, now);
+  } catch {
+    // No ~/.agents/agents.yaml on this box -- readMeta() has nothing cached
+    // to invalidate either, so the cold/warm distinction collapses; proceed.
+  }
+}
+
+/** Bench options for a single, genuinely-cold sample — see invalidateCaches doc. */
+const COLD_SAMPLE_OPTS = { setup: invalidateCaches, iterations: 1, time: 1, warmupIterations: 0, warmupTime: 0 } as const;
+
+describe.skipIf(!loggedInClaudeVersion || !loggedOutClaudeVersion)(
+  'buildExecEnv — resolveClaudeSetupToken cost split (exec.ts:424, claude-account-token.ts:51): same code path, signed-in vs not',
+  () => {
+    bench('pinned version WITH a signed-in account (pays the uncached scrypt decrypt every call)', () => {
+      buildExecEnv(execOpts({ agent: 'claude', version: loggedInClaudeVersion, sessionId: randomUUID() }));
+    });
+
+    bench('pinned version WITHOUT a signed-in account (readClaudeAccountEmail short-circuits, claude-account-token.ts:56)', () => {
+      buildExecEnv(execOpts({ agent: 'claude', version: loggedOutClaudeVersion, sessionId: randomUUID() }));
+    });
+  },
+);
+
+describe('buildExecEnv — warm cache (steady state: loop.ts/teams/runner calling it repeatedly in one process)', () => {
+  bench('claude, auto-resolved version (resolveVersion + isVersionInstalled + resolveClaudeSetupToken chain)', () => {
+    buildExecEnv(execOpts({ agent: 'claude', sessionId: randomUUID() }));
+  });
+
+  bench('codex, explicit pinned version (no claude-account-token path at all)', () => {
+    buildExecEnv(execOpts({ agent: 'codex', version: installedCodex ?? '0.146.0', sessionId: randomUUID() }));
+  });
+
+  bench('codex, auto-resolved version', () => {
+    buildExecEnv(execOpts({ agent: 'codex', sessionId: randomUUID() }));
+  });
+});
+
+describe('buildExecEnv — cold cache (single sample: the first call in a fresh `agents run` process)', () => {
+  bench('claude, auto-resolved version', () => {
+    buildExecEnv(execOpts({ agent: 'claude', sessionId: randomUUID() }));
+  }, COLD_SAMPLE_OPTS);
+
+  bench.skipIf(!loggedOutClaudeVersion)('claude, pinned version WITHOUT a signed-in account (isolates readMeta+actor cold cost from the scrypt cost above)', () => {
+    buildExecEnv(execOpts({ agent: 'claude', version: loggedOutClaudeVersion, sessionId: randomUUID() }));
+  }, COLD_SAMPLE_OPTS);
+});
+
+describe('buildExecCommand — argv assembly (runs immediately before spawn in spawnAgent, exec.ts:1745)', () => {
+  bench('claude headless, explicit pinned version', () => {
+    buildExecCommand(execOpts({
+      agent: 'claude', version: loggedOutClaudeVersion ?? installedClaudeVersions.at(-1) ?? '2.1.221', prompt: 'benchmark prompt', sessionId: randomUUID(),
+    }));
+  });
+
+  bench('claude headless, auto-resolved version + model tier (re-walks resolveVersion a second time, exec.ts:972)', () => {
+    buildExecCommand(execOpts({
+      agent: 'claude', prompt: 'benchmark prompt', model: 'sonnet', sessionId: randomUUID(),
+    }));
+  });
+});
+
+describe.skipIf(!loggedOutClaudeVersion)('execAgent — real subprocess spawn (real claude binary; --version passthrough keeps it network-free)', () => {
+  bench('claude headless spawn, pinned version without a signed-in account (isolates spawn overhead from the scrypt cost above)', async () => {
+    await execAgent(execOpts({
+      agent: 'claude',
+      version: loggedOutClaudeVersion,
+      prompt: 'benchmark prompt',
+      passthroughArgs: ['--version'],
+    }));
+  }, { time: 3000, iterations: 15 });
+});


### PR DESCRIPTION
**test-only** — adds a vitest benchmark for `apps/cli/src/lib/exec.ts`'s env-construction and process-spawn hot path (`buildExecEnv`, `buildExecCommand`, `execAgent`). No production code changed.

## What this measures

`buildExecEnv(options: ExecOptions)` (`exec.ts:406`) builds the child process env for every agent launch — `agents run`'s `execAgent` → `spawnAgent` → `env: buildExecEnv(options)` at `exec.ts:1842`, plus `loop.ts:214`, `runner.ts:720`, teams. `buildExecCommand` (`exec.ts:897`) assembles the argv right before it, at `exec.ts:1745`.

No mocking — the bench runs against this box's real `~/.agents` layout (real `agents.yaml`, real installed version homes under `~/.agents/.history/versions/<agent>/`, the real installed `claude` binary) and a real, several-levels-deep `process.cwd()` (this worktree), so `versions.ts:2287 getProjectVersion`'s directory walk runs its actual depth, not a synthetic stub.

## Measured (real run, `npx vitest bench --run` inside `apps/cli`)

`cat /proc/loadavg` at run time: `4.16 4.38 5.34 6/7209 1389938`

```
buildExecEnv — resolveClaudeSetupToken cost split (same code path, signed-in vs not)
  pinned version WITH a signed-in account:      140.64ms mean (7.1 ops/sec, 10 samples)
  pinned version WITHOUT a signed-in account:      0.0739ms mean (13,526 ops/sec, 6764 samples)
  -> 1902x difference on the identical code path

buildExecEnv — warm cache (repeated calls in one process: loop/teams/runner steady state)
  claude, auto-resolved version:   138.84ms mean (7.2 ops/sec, 10 samples)
  codex, explicit pinned version:    0.0751ms mean (13,323 ops/sec, 6662 samples)
  codex, auto-resolved version:      0.2008ms mean (4,981 ops/sec, 2491 samples)

buildExecEnv — cold cache (single sample: first call in a fresh `agents run` process)
  claude, auto-resolved version:                     138.87ms (1 sample)
  claude, pinned version WITHOUT a signed-in account:  0.0756ms mean (14 samples)

buildExecCommand — argv assembly (immediately precedes spawn)
  claude headless, explicit pinned version:                 0.0017ms mean (581,323 ops/sec, 290662 samples)
  claude headless, auto-resolved + model tier (re-walks resolveVersion): 0.1594ms mean (6,273 ops/sec, 3137 samples)
  -> 93x difference

execAgent — real subprocess spawn (real claude binary, --version passthrough to stay network-free)
  claude headless spawn, pinned version without a signed-in account: 170.74ms mean (5.9 ops/sec, 18 samples)
```

Full raw output (all 5 groups, tinybench hz/min/max/mean/p75/p99/p995/p999/rme columns) is in the benchmark file's own run — reproduce with:

```bash
cd apps/cli && npx vitest bench src/lib/exec.bench.ts --run
```

Not wired into CI: `vitest.config.ts:9`'s `include` only matches `*.test.ts`, so `*.bench.ts` never runs under `vitest run` — verified (`npx vitest run src/lib/exec.bench.ts` → "No test files found").

## Root cause of the two big splits (traced, not guessed)

**1. `resolveClaudeSetupToken` is an uncached scrypt-based decrypt on every call.**
`exec.ts:424` calls `resolveClaudeSetupToken(versionHome)` (`claude-account-token.ts:51`) for every resolved claude version — pinned or auto-resolved — whose version home has a signed-in account (`claude-account-token.ts:56-57` `readClaudeAccountEmail` short-circuits to null otherwise, the cheap path). When an account IS present, it reaches `readAndResolveBundleEnv` → the file-backed secrets store → `decryptForFallback` (`secrets/filestore.ts:230-240`) → `deriveKey` (`secrets/filestore.ts:208-210`), which calls `scryptSync(passphrase, salt, 32)` fresh, every single call. Nothing memoizes the derived key or the decrypted token for the process lifetime, even though the passphrase+salt pair for the `auth` bundle is stable across repeat reads within one process. Confirmed independently with a one-off `performance.now()` probe against the real bundle (not part of the committed bench, to avoid printing the decrypted token anywhere): ~150-170ms on both the first AND second call.

**2. `buildExecCommand` redundantly re-resolves the version `buildExecEnv` already resolved.**
`spawnAgent` (`exec.ts:1729`) calls `buildExecCommand(options)` at `exec.ts:1745`, then later `buildExecEnv(options)` at `exec.ts:1842` — both given the identical `options.agent`/`options.cwd`. When `options.version` is unset and a model+`modelFlag` combination requires tier resolution, `buildExecCommand` calls `resolveVersion(options.agent, ...)` again at `exec.ts:972` — a second, independent walk of `getProjectVersion`'s directory tree (`versions.ts:2287`, `fs.existsSync` at every ancestor dir up to `/`) that `buildExecEnv` already paid for moments earlier resolving the same options.

## Proposals (measured, not guessed)

1. **`claude-account-token.ts:51` `resolveClaudeSetupToken`** — memoize the decrypted `auth` bundle env (or at minimum the scrypt-derived key for its stable salt) for the process lifetime. This is the single highest-leverage fix: it collapses `buildExecEnv` from ~140ms to ~0.07ms for every claude launch after the first in a multi-launch process (`loop.ts:214`, teams, `runner.ts:720`), and — since a single `agents run` CLI process only ever needs this token once — is safe to cache unconditionally within the process (mirrors the existing pattern at `actor.ts:157` `resolveActor()`'s process-lifetime `cached` variable).
2. **`exec.ts:1745`/`exec.ts:1842` (inside `spawnAgent`)** — resolve the agent version once and thread it into both `buildExecCommand` and `buildExecEnv` (e.g. set `options.version` to the resolved value before either call), eliminating the second `resolveVersion` walk at `exec.ts:972`.
3. **`versions.ts:2287` `getProjectVersion`** — add a per-(agent, cwd) cache mirroring `state.ts:1124` `readMeta()`'s mtime-keyed cache. A CLI invocation's cwd is fixed for its whole process lifetime, so the directory walk (12 `fs.existsSync` calls + 2 real `agents.yaml` reads/parses measured on this checkout) never needs to run more than once per process even without proposal 2.

**Not proposed:** the `execAgent` real-spawn group (170.74ms mean) is dominated by the child `claude` binary's own OS fork/exec + Node startup, not by `exec.ts`'s own code — the isolated `buildExecEnv`+`buildExecCommand` cost for the same (no-login, pinned) options is ~0.075ms combined, under 0.05% of the total. Nothing in `exec.ts` is worth optimizing there.
