### PR TITLE
test(release): create a real zombie on macOS

### DIFF
--- a/apps/cli/scripts/release-lease.test.ts
+++ b/apps/cli/scripts/release-lease.test.ts
@@ -66,14 +66,18 @@ function procState(pid: number): string {
 const zombieParents: ChildProcess[] = [];
 
 /**
- * A real, unreaped zombie: a bash that backgrounds a short `sleep` and then
- * blocks without waiting on it, so the exited child sits in the process table
- * with nothing to collect it. That is exactly the shape a SIGKILLed release.sh
- * leaves behind, and `ps -p <pid>` still lists it.
+ * A real, unreaped zombie: Perl forks a child that exits while its parent blocks
+ * without waiting, so the exited child sits in the process table with nothing
+ * to collect it. That is exactly the shape a SIGKILLed release.sh leaves behind,
+ * and `ps -p <pid>` still lists it.
  */
 function spawnZombie(): number {
   const pidFile = path.join(root, `zombie-${zombieParents.length}.pid`);
-  const parent = spawn('bash', ['-c', `sleep 0.2 & echo $! > "${pidFile}"; sleep 60`], { stdio: 'ignore' });
+  const parent = spawn(
+    'perl',
+    ['-e', 'my $pid = fork(); if ($pid == 0) { exit 0 } open(my $fh, ">", $ARGV[0]) or die $!; print $fh $pid; close($fh); sleep 60', pidFile],
+    { stdio: 'ignore' },
+  );
   zombieParents.push(parent);
   for (let i = 0; i < 200; i++) {
     if (fs.existsSync(pidFile)) {


### PR DESCRIPTION
Test-only fix: make the release-lease zombie regression deterministic on macOS and Linux. Closes #2245.

## What changed

- Replaced the Bash background-job fixture with a Perl `fork()` whose parent intentionally never waits for its exited child.
- Preserved `procState` and the real `ps`-based `Z` assertion before the lease script runs.
- Kept parent-process cleanup in the existing `afterEach` path.

## Root cause

Bash reaped the background `sleep` on macOS, so the fixture never observed a zombie even though the production lease implementation was correct.

## Exact macOS run

Executed five consecutive times through the mac-mini host path. Each run completed with:

```text
✓ scripts/release-lease.test.ts (29 tests)
Test Files  1 passed (1)
Tests  29 passed (29)
```

Final run:

```text
Test Files  1 passed (1)
Tests  29 passed (29)
Duration  19.23s (transform 20ms, setup 14ms, import 13ms, tests 19.15s, environment 0ms)
```

`git diff --check` produced no output.

No UI surface: this PR changes only a real-process test fixture.
