### PR TITLE
docs(readme): fix TOC anchor + em-dash count from #2248

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/phnx-labs/agents-cli"><img src="https://img.shields.io/badge/github-phnx--labs%2Fagents--cli-blue?style=flat-square" alt="github" /></a>
 </p>
 
-**A framework for running a distributed agent factory.** Dispatch Claude, Codex, Antigravity, Grok, and more across your own machines — in parallel, on your existing subscriptions. Measure every run with `agents perf` / `agents insights`, fold what you learn back into `AGENTS.md` and skills, then put the loop on a schedule with routines and monitors. Spawn parallel teams in isolated terminals or dispatch to the cloud for a PR. Watch live state across the fleet, nudge stalled runs, and message agents mid-flight. Store secrets behind Touch ID, drive real browsers and Electron apps, and steer the whole fleet from a menu bar — all from one CLI.
+**A framework for running a distributed agent factory.** Dispatch Claude, Codex, Antigravity, Grok, and more across your own machines, in parallel, on your existing subscriptions. Measure every run with `agents perf` / `agents insights`, fold what you learn back into `AGENTS.md` and skills, then put the loop on a schedule with routines and monitors. Spawn parallel teams in isolated terminals or dispatch to the cloud for a PR. Watch live state across the fleet, nudge stalled runs, and message agents mid-flight. Store secrets behind Touch ID, drive real browsers and Electron apps, and steer the whole fleet from a menu bar — all from one CLI.
 
 <p align="center">
   <a href="https://github.com/anthropics/claude-code" title="Claude Code"><img src="assets/harnesses/anthropic.svg" height="32" alt="Claude Code" /></a>
@@ -67,7 +67,7 @@ Also available as `ag` -- all commands work with both `agents` and `ag`.
 - [Control the fleet](#control-the-fleet)
 - [Sync the fleet](#sync-the-fleet)
 - [Pin versions per project](#pin-versions-per-project)
-- [Run open models through Claude Code](#run-open-models-through-claude-code)
+- [Run open models through Claude Code](#run-open-models-through-claude-code-experimental)
 - [Run on your own machines](#run-on-your-own-machines)
 - [Teams](#teams)
 - [Cloud](#cloud)


### PR DESCRIPTION
**docs-only** — follow-up to #2248, no CHANGELOG entry (README wording fix, not a flag/command/behavior change).

An independent non-author review of #2248 (spawned per this repo's convention since `prix/code-reviewer` is currently paused — see #1767) found two small nits and posted them as a PR comment: https://github.com/phnx-labs/agents-cli/pull/2248#issuecomment-5201977602

1. **README.md:70** — the `Run open models through Claude Code` TOC entry pointed at `#run-open-models-through-claude-code`, but the actual header is `## Run open models through Claude Code (experimental)` (README.md:503), whose GitHub slug is `...-claude-code-experimental`. This anchor was broken *before* #2248 too — #2248 rebuilt this exact TOC without catching it.
2. **README.md:14** — the rewritten opening paragraph used two em-dashes in one paragraph, over this repo's own one-em-dash-per-paragraph cap (see root CLAUDE.md). Swapped the first for a comma.

## Verification

```
$ python3 -c "
import re
text = open('README.md').read()
toc_links = re.findall(r'^- \[.*?\]\(#([a-z0-9-]+)\)', text, re.M)
print('run-open-models-through-claude-code-experimental' in toc_links)
"
True

$ sed -n '14p' README.md | grep -o "—" | wc -l
1
```