### PR TITLE
feat(hosts): dispatch detached runs to Windows

### DIFF
--- a/apps/cli/.changelog/next/rush-2267-windows-detached-dispatch.md
+++ b/apps/cli/.changelog/next/rush-2267-windows-detached-dispatch.md
@@ -1,0 +1,1 @@
+- **Detached agent dispatch now runs on Windows OpenSSH hosts (RUSH-2267).** Headless `agents run … --host <windows>` launches through a hidden PowerShell process, preserves actor/session/env context, and uses durable Windows-native log, follow, reconcile, stop, and cleanup operations.

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -514,6 +514,11 @@ Host dispatch has two shapes, chosen by whether a prompt is present:
   `--interactive` with `--host` also takes the interactive path and forwards the
   prompt to the remote TUI.
 
+Headless dispatch supports Linux, macOS, and Windows OpenSSH hosts. Windows uses
+a hidden detached PowerShell process plus the same durable per-task log and exit
+sentinel as POSIX hosts; follow, reconnect, `hosts logs`, `hosts ps`, and
+`hosts stop` select the matching remote protocol from the task record.
+
 (`--json`/`--quiet`/`--mode`/`--model` are real flags on `agents run`, registered in
 `src/commands/exec.ts`; there is no user-facing `--print` — the per-harness
 headless/`--print` mapping is internal to `buildExecCommand`.) `agents run` already

--- a/apps/cli/scripts/install.sh
+++ b/apps/cli/scripts/install.sh
@@ -130,11 +130,21 @@ npm install -g "$TARBALL" \
 # `agents` -- to use it instead of the registry one, put $LINK_DIR ahead of
 # the registry bin dir on PATH.
 mkdir -p "$LINK_DIR"
-for bin in agents ag browser; do
-  src="$PREFIX/bin/$bin"
-  [[ -e "$src" ]] || continue
-  ln -sf "$src" "$LINK_DIR/$bin"
-done
+if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
+  for bin in agents ag browser; do
+    for ext in '' .cmd .ps1; do
+      src="$PREFIX/$bin$ext"
+      [[ -e "$src" ]] || continue
+      cp -f "$src" "$LINK_DIR/$bin$ext"
+    done
+  done
+else
+  for bin in agents ag browser; do
+    src="$PREFIX/bin/$bin"
+    [[ -e "$src" ]] || continue
+    ln -sf "$src" "$LINK_DIR/$bin"
+  done
+fi
 
 # Prefer the standalone Mach-O when the staged dist carries one (macOS): the
 # node-shebang shim is what EDR flags (#315). Runnable-probe first - an
@@ -148,7 +158,7 @@ fi
 
 # Confirm the dev binary is runnable.
 LINKED_PATH="$LINK_DIR/agents"
-[[ -L "$LINKED_PATH" ]] || die "agents not installed at $LINKED_PATH"
+[[ -e "$LINKED_PATH" ]] || die "agents not installed at $LINKED_PATH"
 LINKED_VER=$("$LINKED_PATH" --version 2>/dev/null | head -1 || echo "?")
 
 # Install the signed macOS Keychain helper to its stable user path. The dev

--- a/apps/cli/scripts/install.sh
+++ b/apps/cli/scripts/install.sh
@@ -103,8 +103,8 @@ node -e "
   delete p.scripts?.postinstall;
   delete p.scripts?.prepack;
   delete p.scripts?.prepare;
-  fs.writeFileSync('$STAGE_DIR/package.json', JSON.stringify(p, null, 2));
-"
+  fs.writeFileSync(process.argv[1], JSON.stringify(p, null, 2));
+" "$STAGE_DIR/package.json"
 
 dim "  Packing tarball"
 (

--- a/apps/cli/scripts/install.sh
+++ b/apps/cli/scripts/install.sh
@@ -132,11 +132,11 @@ npm install -g "$TARBALL" \
 mkdir -p "$LINK_DIR"
 if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
   for bin in agents ag browser; do
-    for ext in '' .cmd .ps1; do
-      src="$PREFIX/$bin$ext"
-      [[ -e "$src" ]] || continue
-      cp -f "$src" "$LINK_DIR/$bin$ext"
-    done
+    [[ -e "$PREFIX/$bin.cmd" ]] || continue
+    printf '@"%%USERPROFILE%%\\.local\\agents-cli-dev\\%s.cmd" %%*\r\n' "$bin" > "$LINK_DIR/$bin.cmd"
+    printf '& "$HOME\\.local\\agents-cli-dev\\%s.ps1" @args\r\n' "$bin" > "$LINK_DIR/$bin.ps1"
+    printf '#!/usr/bin/env bash\nexec "$HOME/.local/agents-cli-dev/%s" "$@"\n' "$bin" > "$LINK_DIR/$bin"
+    chmod +x "$LINK_DIR/$bin"
   done
 else
   for bin in agents ag browser; do

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -44,6 +44,7 @@ describe('Windows detached protocol', () => {
     const innerEncoded = outer.match(/-EncodedCommand ([A-Za-z0-9+/=]+)/)?.[1];
     expect(innerEncoded).toBeTruthy();
     const inner = Buffer.from(innerEncoded!, 'base64').toString('utf16le');
+    expect(inner).toContain("$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'");
     expect(inner).toContain("$env:AGENTS_ACTOR = 'overnight'");
     expect(inner).toContain("Set-Location -LiteralPath 'C:\\src\\repo'");
     expect(inner).toContain("& 'agents' 'run' 'codex' 'hello world' '--mode' 'plan'");

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -7,9 +7,11 @@ import { randomUUID } from 'crypto';
 import { shellQuote, sshExec } from '../ssh-exec.js';
 import {
   buildDetachedLaunchCommand,
+  buildWindowsDetachedLaunchCommand,
   buildRunForwardedArgs,
   buildInteractiveRunForwardedArgs,
   buildStopRemoteCommand,
+  buildWindowsStopRemoteCommand,
   remoteCdPrefix,
   deriveMirroredCwd,
   terminateDispatchedTask,
@@ -21,6 +23,40 @@ import { resetActorCache } from '../actor.js';
 import type { HostTask } from './tasks.js';
 
 const LOCAL_HOME = process.env.HOME ?? os.homedir();
+
+function decodeWindows(command: string): string {
+  const encoded = command.match(/-EncodedCommand (\S+)$/)?.[1];
+  if (!encoded) throw new Error(`not encoded PowerShell: ${command}`);
+  return Buffer.from(encoded, 'base64').toString('utf16le');
+}
+
+describe('Windows detached protocol', () => {
+  it('starts a hidden process with actor env, cwd, log, and exit sentinel', () => {
+    const outer = decodeWindows(buildWindowsDetachedLaunchCommand({
+      forwardedArgs: ['run', 'codex', 'hello world', '--mode', 'plan'],
+      remoteCwd: 'C:\\src\\repo',
+      remoteLog: '$HOME/.agents/.cache/hosts/abc.log',
+      remoteExit: '$HOME/.agents/.cache/hosts/abc.exit',
+      env: { AGENTS_ACTOR: 'overnight' },
+    }));
+    expect(outer).toContain('Start-Process');
+    expect(outer).toContain('-WindowStyle Hidden');
+    const innerEncoded = outer.match(/'([A-Za-z0-9+/=]{40,})'\) -WindowStyle/)?.[1];
+    expect(innerEncoded).toBeTruthy();
+    const inner = Buffer.from(innerEncoded!, 'base64').toString('utf16le');
+    expect(inner).toContain("$env:AGENTS_ACTOR = 'overnight'");
+    expect(inner).toContain("Set-Location -LiteralPath 'C:\\src\\repo'");
+    expect(inner).toContain("& 'agents' 'run' 'codex' 'hello world' '--mode' 'plan'");
+    expect(inner).toContain('Set-Content -LiteralPath $exit -Value $code');
+  });
+
+  it('stops by pid without overwriting a completed exit sentinel', () => {
+    const script = decodeWindows(buildWindowsStopRemoteCommand(4242, '$HOME/.agents/.cache/hosts/abc.exit'));
+    expect(script).toContain('Get-Process -Id 4242');
+    expect(script).toContain('Stop-Process -Id 4242 -Force');
+    expect(script).toContain('ALREADY $code');
+  });
+});
 
 describe('buildStopRemoteCommand', () => {
   const exit = '$HOME/.agents/.cache/hosts/abc12345.exit';

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -39,9 +39,9 @@ describe('Windows detached protocol', () => {
       remoteExit: '$HOME/.agents/.cache/hosts/abc.exit',
       env: { AGENTS_ACTOR: 'overnight' },
     }));
-    expect(outer).toContain('Start-Process');
-    expect(outer).toContain('-WindowStyle Hidden');
-    const innerEncoded = outer.match(/'([A-Za-z0-9+/=]{40,})'\) -WindowStyle/)?.[1];
+    expect(outer).toContain('Invoke-CimMethod -ClassName Win32_Process -MethodName Create');
+    expect(outer).toContain('Win32_Process.Create failed with code');
+    const innerEncoded = outer.match(/-EncodedCommand ([A-Za-z0-9+/=]+)/)?.[1];
     expect(innerEncoded).toBeTruthy();
     const inner = Buffer.from(innerEncoded!, 'base64').toString('utf16le');
     expect(inner).toContain("$env:AGENTS_ACTOR = 'overnight'");

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -55,6 +55,8 @@ describe('Windows detached protocol', () => {
     expect(script).toContain('Get-Process -Id 4242');
     expect(script).toContain('Stop-Process -Id 4242 -Force');
     expect(script).toContain('ALREADY $code');
+    expect(script).not.toContain('}; elseif');
+    expect(script).not.toContain('}; else');
   });
 });
 

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -179,6 +179,7 @@ export function buildWindowsDetachedLaunchCommand(opts: {
     : '';
   const inner = [
     `$ProgressPreference = 'SilentlyContinue'`,
+    `$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'`,
     ...env,
     cwd,
     `$log = ${log}`,

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -183,9 +183,8 @@ export function buildWindowsDetachedLaunchCommand(opts: {
     cwd,
     `$log = ${log}`,
     `$exit = ${exit}`,
-    `& ${['agents', ...opts.forwardedArgs].map(powershellQuote).join(' ')} *> $log`,
-    `$code = $LASTEXITCODE`,
-    `Set-Content -LiteralPath $exit -Value $code -NoNewline -Encoding ascii`,
+    `$code = 1`,
+    `try { & ${['agents', ...opts.forwardedArgs].map(powershellQuote).join(' ')} *> $log; if ($null -ne $LASTEXITCODE) { $code = $LASTEXITCODE } } catch { $_ | Out-File -LiteralPath $log -Append; $code = 1 } finally { Set-Content -LiteralPath $exit -Value $code -NoNewline -Encoding ascii }`,
   ].filter(Boolean).join('; ');
   const encodedInner = encodePowershell(inner);
   const outer = [

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -193,7 +193,7 @@ export function buildWindowsDetachedLaunchCommand(opts: {
     `Remove-Item -LiteralPath ${exit} -Force -ErrorAction SilentlyContinue`,
     `$process = Start-Process -FilePath 'powershell.exe' -ArgumentList @('-NoProfile','-EncodedCommand',${powershellQuote(encodedInner)}) -WindowStyle Hidden -PassThru`,
     `Write-Output $process.Id`,
-  ].join(' ');
+  ].join('; ');
   return `powershell -NoProfile -EncodedCommand ${encodePowershell(outer)}`;
 }
 
@@ -265,7 +265,7 @@ export function buildWindowsStopRemoteCommand(pid: number, remoteExit: string): 
     `if ($process) { Stop-Process -Id ${pid} -Force; Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'SIGNALED' }`,
     `elseif (Test-Path -LiteralPath ${exit}) { $code = (Get-Content -LiteralPath ${exit} -Raw).Trim(); if ($code) { Write-Output (\"ALREADY $code\") } else { Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'GONE' } }`,
     `else { Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'GONE' }`,
-  ].join('; ');
+  ].join(' ');
   return `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;
 }
 

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -14,7 +14,7 @@ import { sshExec, sshStream, shellQuote } from '../ssh-exec.js';
 import type { Host } from './types.js';
 import { hostIdentityArgs, sshTargetFor } from './types.js';
 import { ensureHostReady } from './ready.js';
-import { remoteShellFor, posixEnvExports } from './remote-cmd.js';
+import { encodePowershell, powershellQuote, remoteShellFor, posixEnvExports } from './remote-cmd.js';
 import { resolveRemoteOsSync } from './remote-os.js';
 import { resolveActor, actorEnv } from '../actor.js';
 import { saveTask, updateTask, terminalPatch, type HostTask } from './tasks.js';
@@ -154,6 +154,50 @@ export function buildDetachedLaunchCommand(inner: string): string {
   return `bash -lc ${shellQuote(`node -e ${shellQuote(nodeScript)}`)}`;
 }
 
+function windowsRemotePath(path: string): string {
+  return path.startsWith('$HOME/')
+    ? `(Join-Path $HOME ${powershellQuote(path.slice('$HOME/'.length))})`
+    : powershellQuote(path);
+}
+
+/** Build the detached PowerShell launch protocol used by Windows SSH hosts. */
+export function buildWindowsDetachedLaunchCommand(opts: {
+  forwardedArgs: string[];
+  remoteCwd?: string;
+  mirrorCwd?: boolean;
+  remoteLog: string;
+  remoteExit: string;
+  env: Record<string, string>;
+}): string {
+  const log = windowsRemotePath(opts.remoteLog);
+  const exit = windowsRemotePath(opts.remoteExit);
+  const env = Object.entries(opts.env).map(([key, value]) => `$env:${key} = ${powershellQuote(value)}`);
+  const cwd = opts.remoteCwd
+    ? opts.mirrorCwd
+      ? `try { Set-Location -LiteralPath ${powershellQuote(opts.remoteCwd)} } catch { Set-Location -LiteralPath $HOME }`
+      : `Set-Location -LiteralPath ${powershellQuote(opts.remoteCwd)}`
+    : '';
+  const inner = [
+    `$ProgressPreference = 'SilentlyContinue'`,
+    ...env,
+    cwd,
+    `$log = ${log}`,
+    `$exit = ${exit}`,
+    `& ${['agents', ...opts.forwardedArgs].map(powershellQuote).join(' ')} *> $log`,
+    `$code = $LASTEXITCODE`,
+    `Set-Content -LiteralPath $exit -Value $code -NoNewline -Encoding ascii`,
+  ].filter(Boolean).join('; ');
+  const encodedInner = encodePowershell(inner);
+  const outer = [
+    `$dir = Join-Path $HOME '.agents/.cache/hosts'`,
+    `New-Item -ItemType Directory -Force -Path $dir | Out-Null`,
+    `Remove-Item -LiteralPath ${exit} -Force -ErrorAction SilentlyContinue`,
+    `$process = Start-Process -FilePath 'powershell.exe' -ArgumentList @('-NoProfile','-EncodedCommand',${powershellQuote(encodedInner)}) -WindowStyle Hidden -PassThru`,
+    `Write-Output $process.Id`,
+  ].join('; ');
+  return `powershell -NoProfile -EncodedCommand ${encodePowershell(outer)}`;
+}
+
 export interface DispatchResult {
   task: HostTask;
   /** Exit code when followed; undefined when detached (--no-follow). */
@@ -163,8 +207,9 @@ export interface DispatchResult {
 function terminateRemoteLaunch(task: HostTask): void {
   if (!task.pid) throw new Error(`Cannot terminate remote task ${task.id}: launch returned no PID.`);
   const pid = task.pid;
-  const command =
-    `if kill -TERM -- -${pid} 2>/dev/null; then ` +
+  const command = task.remoteShell === 'powershell'
+    ? `powershell -NoProfile -EncodedCommand ${encodePowershell(`Stop-Process -Id ${pid} -Force -ErrorAction SilentlyContinue; Remove-Item -LiteralPath ${windowsRemotePath(task.remoteLog)}, ${windowsRemotePath(task.remoteExit)} -Force -ErrorAction SilentlyContinue`)}`
+    : `if kill -TERM -- -${pid} 2>/dev/null; then ` +
       `sleep 1; kill -KILL -- -${pid} 2>/dev/null || true; ` +
     `elif kill -0 -- -${pid} 2>/dev/null; then exit 1; fi; ` +
     `rm -f ${task.remoteLog} ${task.remoteExit}`;
@@ -213,6 +258,18 @@ export function buildStopRemoteCommand(pid: number, remoteExit: string): string 
   );
 }
 
+export function buildWindowsStopRemoteCommand(pid: number, remoteExit: string): string {
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error(`Invalid remote task pid: ${pid}`);
+  const exit = windowsRemotePath(remoteExit);
+  const script = [
+    `$process = Get-Process -Id ${pid} -ErrorAction SilentlyContinue`,
+    `if ($process) { Stop-Process -Id ${pid} -Force; Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'SIGNALED' }`,
+    `elseif (Test-Path -LiteralPath ${exit}) { $code = (Get-Content -LiteralPath ${exit} -Raw).Trim(); if ($code) { Write-Output (\"ALREADY $code\") } else { Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'GONE' } }`,
+    `else { Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'GONE' }`,
+  ].join('; ');
+  return `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;
+}
+
 /**
  * Stop a running host task from the origin machine (`agents hosts stop <id>`).
  *
@@ -228,7 +285,9 @@ export function stopDispatchedTask(task: HostTask): HostTask {
   if (!task.pid) {
     throw new Error(`Cannot stop remote task ${task.id}: launch returned no PID.`);
   }
-  const command = buildStopRemoteCommand(task.pid, task.remoteExit);
+  const command = task.remoteShell === 'powershell'
+    ? buildWindowsStopRemoteCommand(task.pid, task.remoteExit)
+    : buildStopRemoteCommand(task.pid, task.remoteExit);
   const result = sshExec(task.target, command, { timeoutMs: 10000, multiplex: true, extraSshArgs: task.identityFile ? ['-i', task.identityFile, '-o', 'IdentitiesOnly=yes'] : undefined });
   if (result.code !== 0) {
     throw new Error(
@@ -272,23 +331,11 @@ interface LaunchOptions {
  * and `dispatchAgentsCommand` (teams) build their `forwardedArgs` and call here,
  * so the nohup/exit-file/offset-tail machinery lives in exactly one place.
  *
- * Windows remotes are refused up front: the detached launch is only half the
- * contract — the follow/reconcile layer (`progress.ts`/`reconcile.ts`) offset-
- * tails the log with POSIX `tail -c`/`printf`/`cat`/`stat`, which do not exist
- * in cmd.exe/PowerShell. Shipping the launch alone would leave `run --host
- * <windows>` dispatching but hanging on follow forever, so we fail fast with an
- * actionable message instead. Read-only `--host` commands (view/sessions/…) run
- * a single round-trip with no follow protocol and DO work against Windows.
+ * POSIX hosts use a detached bash process group; Windows hosts use a hidden
+ * detached PowerShell process and the same durable log/exit-file protocol.
  */
 async function launchDetached(host: Host, target: string, opts: LaunchOptions): Promise<DispatchResult> {
-  if (remoteShellFor(resolveRemoteOsSync(host.name)) === 'powershell') {
-    throw new Error(
-      `Detached dispatch to Windows host "${host.name}" is not supported yet — the run ` +
-        `follow/reconcile layer is POSIX-only (offset-tails the remote log with tail/cat/stat). ` +
-        `Read-only --host commands (view, sessions, usage, cost, doctor, list, teams) do work ` +
-        `against Windows.`,
-    );
-  }
+  const remoteShell = remoteShellFor(host.os ?? resolveRemoteOsSync(host.name));
   const id = randomUUID().slice(0, 8);
   const remoteLog = `${REMOTE_DIR}/${id}.log`;
   const remoteExit = `${REMOTE_DIR}/${id}.exit`;
@@ -313,7 +360,16 @@ async function launchDetached(host: Host, target: string, opts: LaunchOptions): 
 
   // Outer: ensure dir, launch the login-shell wrapper as a new process-group
   // leader, and print that leader PID.
-  const launch = `mkdir -p ${REMOTE_DIR}; ${buildDetachedLaunchCommand(inner)}`;
+  const launch = remoteShell === 'powershell'
+    ? buildWindowsDetachedLaunchCommand({
+        forwardedArgs: opts.forwardedArgs,
+        remoteCwd: opts.remoteCwd,
+        mirrorCwd: opts.mirrorCwd,
+        remoteLog,
+        remoteExit,
+        env: withActorEnv(opts.agentLabel === RUN_AUTO_KEYWORD ? { [RUN_AUTO_HOST_RESOLVED_ENV]: '1' } : {}),
+      })
+    : `mkdir -p ${REMOTE_DIR}; ${buildDetachedLaunchCommand(inner)}`;
   const res = sshExec(target, launch, {
     timeoutMs: 30000,
     multiplex: !opts.copyCreds,
@@ -330,6 +386,7 @@ async function launchDetached(host: Host, target: string, opts: LaunchOptions): 
     host: host.name,
     target,
     identityFile: host.identityFile,
+    remoteShell,
     agent: opts.agentLabel,
     prompt: opts.promptLabel,
     pid: Number.isFinite(pid) ? pid : undefined,
@@ -365,6 +422,7 @@ async function launchDetached(host: Host, target: string, opts: LaunchOptions): 
     echo: true,
     timeoutMs: opts.timeoutMs,
     extraSshArgs: hostIdentityArgs(host),
+    remoteShell,
   });
   // -1 = the follow window closed while the run continues on the host. Leave the
   // record 'running' (do NOT freeze it terminal) so a later `hosts ps`/`logs`

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -193,7 +193,7 @@ export function buildWindowsDetachedLaunchCommand(opts: {
     `Remove-Item -LiteralPath ${exit} -Force -ErrorAction SilentlyContinue`,
     `$process = Start-Process -FilePath 'powershell.exe' -ArgumentList @('-NoProfile','-EncodedCommand',${powershellQuote(encodedInner)}) -WindowStyle Hidden -PassThru`,
     `Write-Output $process.Id`,
-  ].join('; ');
+  ].join(' ');
   return `powershell -NoProfile -EncodedCommand ${encodePowershell(outer)}`;
 }
 

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -191,8 +191,9 @@ export function buildWindowsDetachedLaunchCommand(opts: {
     `$dir = Join-Path $HOME '.agents/.cache/hosts'`,
     `New-Item -ItemType Directory -Force -Path $dir | Out-Null`,
     `Remove-Item -LiteralPath ${exit} -Force -ErrorAction SilentlyContinue`,
-    `$process = Start-Process -FilePath 'powershell.exe' -ArgumentList @('-NoProfile','-EncodedCommand',${powershellQuote(encodedInner)}) -WindowStyle Hidden -PassThru`,
-    `Write-Output $process.Id`,
+    `$result = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{ CommandLine = ${powershellQuote(`powershell.exe -NoProfile -EncodedCommand ${encodedInner}`)} }`,
+    `if ($result.ReturnValue -ne 0) { throw \"Win32_Process.Create failed with code $($result.ReturnValue)\" }`,
+    `Write-Output $result.ProcessId`,
   ].join('; ');
   return `powershell -NoProfile -EncodedCommand ${encodePowershell(outer)}`;
 }
@@ -260,12 +261,11 @@ export function buildStopRemoteCommand(pid: number, remoteExit: string): string 
 export function buildWindowsStopRemoteCommand(pid: number, remoteExit: string): string {
   if (!Number.isInteger(pid) || pid <= 0) throw new Error(`Invalid remote task pid: ${pid}`);
   const exit = windowsRemotePath(remoteExit);
-  const script = [
-    `$process = Get-Process -Id ${pid} -ErrorAction SilentlyContinue`,
-    `if ($process) { Stop-Process -Id ${pid} -Force; Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'SIGNALED' }`,
-    `elseif (Test-Path -LiteralPath ${exit}) { $code = (Get-Content -LiteralPath ${exit} -Raw).Trim(); if ($code) { Write-Output (\"ALREADY $code\") } else { Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'GONE' } }`,
-    `else { Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'GONE' }`,
-  ].join(' ');
+  const script =
+    `$process = Get-Process -Id ${pid} -ErrorAction SilentlyContinue; ` +
+    `if ($process) { Stop-Process -Id ${pid} -Force; Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'SIGNALED' } ` +
+    `elseif (Test-Path -LiteralPath ${exit}) { $code = (Get-Content -LiteralPath ${exit} -Raw).Trim(); if ($code) { Write-Output (\"ALREADY $code\") } else { Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'GONE' } } ` +
+    `else { Set-Content -LiteralPath ${exit} -Value 143 -NoNewline -Encoding ascii; Write-Output 'GONE' }`;
   return `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;
 }
 

--- a/apps/cli/src/lib/hosts/logs.ts
+++ b/apps/cli/src/lib/hosts/logs.ts
@@ -17,6 +17,7 @@ import { loadTask, localLogPath, updateTask, terminalPatch, type HostTask } from
 import { followHostTask } from './progress.js';
 import { reconcileTask } from './reconcile.js';
 import { sshExecRaw } from '../ssh-exec.js';
+import { encodePowershell } from './remote-cmd.js';
 
 export interface HostLogResult {
   /** False when no host task with this id exists (caller may fall through to sessions). */
@@ -42,6 +43,8 @@ export async function showHostTaskLog(id: string, follow: boolean, full = false)
       remoteExit: task.remoteExit,
       taskId: id,
       echo: true,
+      remoteShell: task.remoteShell,
+      extraSshArgs: task.identityFile ? ['-i', task.identityFile, '-o', 'IdentitiesOnly=yes'] : [],
     });
     // -1 = follow window closed; the run continues on the host (not a failure,
     // so exit 0). Any real code is the finished run — persist the terminal
@@ -117,7 +120,10 @@ export function tailLines(text: string, n: number): string {
  * and progress.ts.
  */
 function fetchAndCacheRemoteLog(task: HostTask): Buffer | null {
-  const res = sshExecRaw(task.target, `cat ${task.remoteLog} 2>/dev/null`, { timeoutMs: 30000, multiplex: true });
+  const command = task.remoteShell === 'powershell'
+    ? `powershell -NoProfile -EncodedCommand ${encodePowershell(`$path = Join-Path $HOME '${task.remoteLog.replace(/^\$HOME\//, '').replace(/'/g, "''")}'; if (Test-Path -LiteralPath $path) { $bytes = [IO.File]::ReadAllBytes($path); [Console]::OpenStandardOutput().Write($bytes, 0, $bytes.Length) }`)}`
+    : `cat ${task.remoteLog} 2>/dev/null`;
+  const res = sshExecRaw(task.target, command, { timeoutMs: 30000, multiplex: true });
   if (res.code !== 0 || res.stdout.length === 0) return null;
   // The hosts cache dir already exists (saveTask created it) — write is best-effort.
   try { fs.writeFileSync(localLogPath(task.id), res.stdout); } catch { /* best-effort cache */ }

--- a/apps/cli/src/lib/hosts/progress.test.ts
+++ b/apps/cli/src/lib/hosts/progress.test.ts
@@ -32,7 +32,8 @@ it('builds a byte-accurate Windows log/exit poll from the requested offset', () 
   const script = Buffer.from(encoded!, 'base64').toString('utf16le');
   expect(script).toContain('$out.Write($bytes, 17, $bytes.Length - 17)');
   expect(script).toContain("Join-Path $HOME '.agents/.cache/hosts/abc.log'");
-  expect(script).toContain('@@AGENTS_HOST_EXIT_abc@@');
+  const marker = script.match(/FromBase64String\('([^']+)'\)/)?.[1];
+  expect(Buffer.from(marker!, 'base64').toString('utf8')).toBe(exitMarker('abc'));
 });
 
 beforeEach(() => {

--- a/apps/cli/src/lib/hosts/progress.test.ts
+++ b/apps/cli/src/lib/hosts/progress.test.ts
@@ -15,10 +15,25 @@ const {
   buildStreamingFollowCommand,
   parseStreamingExitFrame,
   followHostTask,
+  buildWindowsProgressCommand,
 } = await import('./progress.js');
 const { localLogPath } = await import('./tasks.js');
 
 const LOCALHOST_SSH = sshReachable('localhost', 5000);
+
+it('builds a byte-accurate Windows log/exit poll from the requested offset', () => {
+  const command = buildWindowsProgressCommand({
+    remoteLog: '$HOME/.agents/.cache/hosts/abc.log',
+    remoteExit: '$HOME/.agents/.cache/hosts/abc.exit',
+    taskId: 'abc',
+    offset: 17,
+  });
+  const encoded = command.match(/-EncodedCommand (\S+)$/)?.[1];
+  const script = Buffer.from(encoded!, 'base64').toString('utf16le');
+  expect(script).toContain('$out.Write($bytes, 17, $bytes.Length - 17)');
+  expect(script).toContain("Join-Path $HOME '.agents/.cache/hosts/abc.log'");
+  expect(script).toContain('@@AGENTS_HOST_EXIT_abc@@');
+});
 
 beforeEach(() => {
   CACHE_ROOT = mkdtempSync(join(tmpdir(), 'agents-cli-progress-'));

--- a/apps/cli/src/lib/hosts/progress.ts
+++ b/apps/cli/src/lib/hosts/progress.ts
@@ -14,6 +14,7 @@
 
 import * as fs from 'fs';
 import { sshExec, sshExecRaw, sshExecRawStream } from '../ssh-exec.js';
+import { encodePowershell } from './remote-cmd.js';
 import { localLogPath } from './tasks.js';
 
 function sleep(ms: number): Promise<void> {
@@ -73,6 +74,7 @@ export interface FollowOptions {
   /** Idle-backoff ceiling (default 4× the fast interval, min 4000ms). */
   maxPollMs?: number;
   extraSshArgs?: string[];
+  remoteShell?: 'posix' | 'powershell';
 }
 
 const STREAM_EXIT_POLL_SECONDS = 1;
@@ -126,17 +128,16 @@ export function splitProgressBytes(
  */
 export function fetchProgress(
   target: string,
-  opts: { remoteLog: string; remoteExit: string; taskId: string; offset: number },
+  opts: { remoteLog: string; remoteExit: string; taskId: string; offset: number; remoteShell?: 'posix' | 'powershell' },
 ): { logChunk: Buffer; exit: string } | null {
   // Derive the printf format from the SAME exitMarker the parser splits on, so
   // the emitted sentinel and the one we look for can never desync. The marker's
   // only escape-sensitive bytes are its newlines (→ `\n`); it carries no `%`,
   // single-quote, or other printf/shell-special chars (task id is hex).
   const printfArg = exitMarker(opts.taskId).replace(/\n/g, '\\n');
-  const remote =
-    `tail -c +${opts.offset + 1} ${opts.remoteLog} 2>/dev/null; ` +
-    `printf '${printfArg}'; ` +
-    `cat ${opts.remoteExit} 2>/dev/null`;
+  const remote = opts.remoteShell === 'powershell'
+    ? buildWindowsProgressCommand(opts)
+    : `tail -c +${opts.offset + 1} ${opts.remoteLog} 2>/dev/null; printf '${printfArg}'; cat ${opts.remoteExit} 2>/dev/null`;
   // Raw bytes (no UTF-8 decode): the log tail must be counted and re-emitted
   // byte-for-byte so a multibyte char split at the `tail -c` boundary neither
   // drifts the offset nor renders as U+FFFD. The exit code is pure ASCII → safe
@@ -145,6 +146,22 @@ export function fetchProgress(
   const parts = splitProgressBytes(res.stdout, opts.taskId);
   if (!parts) return null;
   return { logChunk: parts.logChunk, exit: parts.exit.toString('utf8') };
+}
+
+export function buildWindowsProgressCommand(opts: { remoteLog: string; remoteExit: string; taskId: string; offset: number }): string {
+  const windowsPath = (value: string): string => value.startsWith('$HOME/')
+    ? `(Join-Path $HOME '${value.slice('$HOME/'.length).replace(/'/g, "''")}')`
+    : `'${value.replace(/'/g, "''")}'`;
+  const script = [
+    `$out = [Console]::OpenStandardOutput()`,
+    `$log = ${windowsPath(opts.remoteLog)}`,
+    `$exit = ${windowsPath(opts.remoteExit)}`,
+    `if (Test-Path -LiteralPath $log) { $bytes = [IO.File]::ReadAllBytes($log); if ($bytes.Length -gt ${opts.offset}) { $out.Write($bytes, ${opts.offset}, $bytes.Length - ${opts.offset}) } }`,
+    `$marker = [Text.Encoding]::UTF8.GetBytes(${JSON.stringify(exitMarker(opts.taskId))})`,
+    `$out.Write($marker, 0, $marker.Length)`,
+    `if (Test-Path -LiteralPath $exit) { $bytes = [IO.File]::ReadAllBytes($exit); $out.Write($bytes, 0, $bytes.Length) }`,
+  ].join('; ');
+  return `powershell -NoProfile -EncodedCommand ${encodePowershell(script)}`;
 }
 
 /**
@@ -246,6 +263,20 @@ export async function followHostTask(target: string, opts: FollowOptions): Promi
     offset += logChunk.length; // exact wire bytes — no re-encode drift
     return true;
   };
+
+  if (opts.remoteShell === 'powershell') {
+    for (;;) {
+      if (Date.now() >= deadline) return -1;
+      const fetched = fetchProgress(target, { ...opts, offset, remoteShell: 'powershell' });
+      if (fetched) {
+        flush(fetched.logChunk);
+        const code = parseInt(fetched.exit.trim(), 10);
+        if (Number.isFinite(code)) return code;
+      }
+      await sleep(waitMs);
+      waitMs = Math.min(maxMs, Math.round(waitMs * 1.5));
+    }
+  }
 
   for (;;) {
     const remaining = deadline - Date.now();

--- a/apps/cli/src/lib/hosts/progress.ts
+++ b/apps/cli/src/lib/hosts/progress.ts
@@ -152,12 +152,13 @@ export function buildWindowsProgressCommand(opts: { remoteLog: string; remoteExi
   const windowsPath = (value: string): string => value.startsWith('$HOME/')
     ? `(Join-Path $HOME '${value.slice('$HOME/'.length).replace(/'/g, "''")}')`
     : `'${value.replace(/'/g, "''")}'`;
+  const markerBase64 = Buffer.from(exitMarker(opts.taskId), 'utf8').toString('base64');
   const script = [
     `$out = [Console]::OpenStandardOutput()`,
     `$log = ${windowsPath(opts.remoteLog)}`,
     `$exit = ${windowsPath(opts.remoteExit)}`,
     `if (Test-Path -LiteralPath $log) { $bytes = [IO.File]::ReadAllBytes($log); if ($bytes.Length -gt ${opts.offset}) { $out.Write($bytes, ${opts.offset}, $bytes.Length - ${opts.offset}) } }`,
-    `$marker = [Text.Encoding]::UTF8.GetBytes(${JSON.stringify(exitMarker(opts.taskId))})`,
+    `$marker = [Convert]::FromBase64String('${markerBase64}')`,
     `$out.Write($marker, 0, $marker.Length)`,
     `if (Test-Path -LiteralPath $exit) { $bytes = [IO.File]::ReadAllBytes($exit); $out.Write($bytes, 0, $bytes.Length) }`,
   ].join('; ');

--- a/apps/cli/src/lib/hosts/reconcile.ts
+++ b/apps/cli/src/lib/hosts/reconcile.ts
@@ -13,6 +13,7 @@
 
 import { sshExec, type SshExecResult } from '../ssh-exec.js';
 import { updateTask, terminalPatch, type HostTask } from './tasks.js';
+import { encodePowershell } from './remote-cmd.js';
 
 export type RemoteExitState =
   | { state: 'running' } //     .exit absent, or present-but-empty (mid-write) → not finished
@@ -41,8 +42,11 @@ export function classifyExit(res: Pick<SshExecResult, 'code' | 'stdout' | 'timed
  * $HOME-prefixed path with a safe (hex) basename — intentionally unquoted so the
  * remote shell expands $HOME (same contract as progress.ts's fetch).
  */
-export function readRemoteExit(target: string, remoteExit: string, timeoutMs = 6000, identityFile?: string): RemoteExitState {
-  return classifyExit(sshExec(target, `cat ${remoteExit} 2>/dev/null`, {
+export function readRemoteExit(target: string, remoteExit: string, timeoutMs = 6000, identityFile?: string, remoteShell: 'posix' | 'powershell' = 'posix'): RemoteExitState {
+  const command = remoteShell === 'powershell'
+    ? `powershell -NoProfile -EncodedCommand ${encodePowershell(`$path = Join-Path $HOME '${remoteExit.replace(/^\$HOME\//, '').replace(/'/g, "''")}'; if (Test-Path -LiteralPath $path) { Get-Content -LiteralPath $path -Raw }`)}`
+    : `cat ${remoteExit} 2>/dev/null`;
+  return classifyExit(sshExec(target, command, {
     timeoutMs,
     multiplex: true,
     extraSshArgs: identityFile ? ['-i', identityFile, '-o', 'IdentitiesOnly=yes'] : undefined,
@@ -56,7 +60,7 @@ export function readRemoteExit(target: string, remoteExit: string, timeoutMs = 6
  */
 export function reconcileTask(task: HostTask): HostTask {
   if (task.status !== 'running') return task;
-  const st = readRemoteExit(task.target, task.remoteExit, 6000, task.identityFile);
+  const st = readRemoteExit(task.target, task.remoteExit, 6000, task.identityFile, task.remoteShell);
   if (st.state !== 'done') return task;
   return updateTask(task.id, terminalPatch(st.code)) ?? task;
 }
@@ -84,7 +88,7 @@ export function reconcileRunningTasks(tasks: HostTask[]): HostTask[] {
       reachable.set(t.target, probe.code === 0);
     }
     if (!reachable.get(t.target)) continue; // host down → leave running
-    const st = readRemoteExit(t.target, t.remoteExit, 6000, t.identityFile);
+    const st = readRemoteExit(t.target, t.remoteExit, 6000, t.identityFile, t.remoteShell);
     if (st.state === 'done') {
       const updated = updateTask(t.id, terminalPatch(st.code));
       if (updated) patched.set(t.id, updated);

--- a/apps/cli/src/lib/hosts/tasks.ts
+++ b/apps/cli/src/lib/hosts/tasks.ts
@@ -20,6 +20,7 @@ export interface HostTask {
   target: string;
   /** OpenSSH private-key path retained for follow/reconcile/stop calls. */
   identityFile?: string;
+  remoteShell?: 'posix' | 'powershell';
   agent: string;
   prompt: string;
   pid?: number;


### PR DESCRIPTION
Windows host support for detached agent dispatch (feature).

## What changed

- Launches detached Windows runs through `Win32_Process.Create`, outside the OpenSSH job lifetime.
- Persists PowerShell host metadata and supports byte-offset log following, exit reconciliation, cancellation, and cleanup.
- Repairs canonical Windows dev-install launchers and preserves npm launcher prefixes.
- Documents Windows host behavior and adds the RUSH-2267 changelog fragment.

Ticket: RUSH-2267

## Actual verification

```text
vitest: 2 files passed; 66 tests passed, 1 platform skip
canonical install: /home/muqsit/.local/bin/agents (0.0.0-dev.6cbc0aefd)
live win-mini detached run: launched via Win32_Process.Create, streamed a UTF-8 remote log, read exit sentinel 1, and returned in 15.5 seconds
remote harness result: Not logged in · Please run /login
```

The live remote agent could not produce the requested token because win-mini Claude is signed out; the detached launch, durable log, exit sentinel, byte framing, and origin-side reconciliation all executed against the real Windows OpenSSH host.
