### PR TITLE
test(session): benchmark session-index query + pid-registry hot path

### DIFF
--- a/apps/cli/src/lib/session/db.bench.ts
+++ b/apps/cli/src/lib/session/db.bench.ts
@@ -1,0 +1,144 @@
+/**
+ * Benchmark for the session-index query hot path in db.ts: the listing
+ * (`querySessions`, db.ts:2596), the id / short-id lookups (`getSessionById`
+ * db.ts:3202, `findSessionsByShortIds` db.ts:3240, `findSessionsById`
+ * db.ts:3216), full-text search (`ftsSearch`, db.ts:3308) and the paginator
+ * count (`countSessions`, db.ts:2647). These back `agents sessions`
+ * (listing/preview), the `--active` scanner's tmux short-id resolution, and the
+ * interactive type-ahead search — the frequent operational paths named in the
+ * task. (There is no `src/lib/session/index.ts`; db.ts is the session-index
+ * query module, so the bench lives beside it.)
+ *
+ * No mocking, real data. Setup takes a consistent `VACUUM INTO` snapshot of THIS
+ * machine's real `~/.agents/.history/sessions/sessions.db` (6,635 sessions /
+ * 65,488 tool_calls / 6,633 FTS rows at schema v37 when this was written) into a
+ * throwaway temp file, and points db.ts at it via the `AGENTS_SESSIONS_DB` test
+ * seam (state.ts:592) set BEFORE the dynamic import so db.ts:29
+ * `const DB_PATH = getSessionsDbPath()` captures it. The snapshot is a faithful
+ * copy of the real index — every row, real `file_path`s, the real FTS content —
+ * so `querySessions`'s existence check (findMissingFilePaths, db.ts:2562) does
+ * its REAL `readdirSync` over the ~735 distinct transcript directories those
+ * rows point at on this disk. The snapshot (not the live db) is used for two
+ * reasons: (1) `querySessions({})` runs a purge WRITE transaction
+ * (db.ts:2635 `db.transaction(() => purgeToolCalls(...))`) for every row whose
+ * `file_path` has vanished, and 443 of 6,513 local transcripts on this box are
+ * already gone, so running it against the live index would delete real
+ * tool_call evidence; (2) it avoids WAL contention with the live daemon writer.
+ * That 443/6,513-stale state is real and is exactly why the WITH-existence-check
+ * listing is the dominant cost measured below.
+ *
+ * The dominant, measured cost driver in `querySessions` is the existence check,
+ * not the SQL: the same query with `skipExistenceCheck: true` (db.ts:2622,
+ * the warm-cache path the picker's small result sets use) skips
+ * findMissingFilePaths entirely, and the delta between the two `full listing`
+ * benches below is the ~735-directory `readdirSync` sweep plus the stale-row
+ * purge transaction. Every uncached `db.prepare(sql)` in these functions
+ * re-compiles its statement each call — db.ts builds the SQL string dynamically
+ * (db.ts:2620) and never caches the compiled statement, so `getSessionById`
+ * (a fixed `SELECT * FROM sessions WHERE id = ?`, db.ts:3204) re-prepares on
+ * every lookup; that is isolated by the id-lookup group.
+ *
+ * This file is NOT wired into `vitest run` — vitest.config.ts:11 includes only
+ * `*.test.ts`, so a `*.bench.ts` adds no CI assertion or flakiness; run it
+ * explicitly with `npx vitest bench --run` from apps/cli.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll, describe, bench } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { getSessionsDbPath } from '../state.js';
+
+// Snapshot the REAL index into a throwaway file and point db.ts at it BEFORE
+// importing db.js, so its module-level DB_PATH capture (db.ts:29) resolves here.
+const REAL_DB = path.join(os.homedir(), '.agents', '.history', 'sessions', 'sessions.db');
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-dbbench-'));
+const SNAPSHOT = path.join(TMP, 'sessions.db');
+const haveRealDb = fs.existsSync(REAL_DB) && fs.statSync(REAL_DB).size > 0;
+if (haveRealDb) {
+  const src = new DatabaseSync(REAL_DB, { readOnly: true });
+  // A single transactional snapshot of committed + WAL state into one file.
+  src.exec(`VACUUM INTO '${SNAPSHOT.replace(/'/g, "''")}'`);
+  src.close();
+  process.env.AGENTS_SESSIONS_DB = SNAPSHOT;
+}
+
+// Dynamic import so the AGENTS_SESSIONS_DB seam above is set first.
+const dbmod = await import('./db.js');
+const { querySessions, countSessions, getSessionById, findSessionsById, findSessionsByShortIds, ftsSearch, closeDB } = dbmod;
+
+// Real ids / short-ids pulled from the snapshot for the lookup benches — actual
+// rows, not synthesized keys. Reads through the warm skip-existence path so this
+// setup itself does no fs sweep.
+const sample = haveRealDb ? querySessions({ limit: 40, skipExistenceCheck: true }) : [];
+const realId = sample[0]?.id ?? '';
+const realShortIds = sample.map((s) => s.shortId).filter((s): s is string => !!s).slice(0, 20);
+const realIdPrefix = realId ? realId.slice(0, 8) : '';
+
+afterAll(() => {
+  try { closeDB(); } catch { /* already closed */ }
+  try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe.skipIf(!haveRealDb)('querySessions — session listing (agents sessions)', () => {
+  // The real operational default: unfiltered fleet listing WITH the existence
+  // check (findMissingFilePaths readdir sweep + stale-row purge). Dominant cost.
+  bench('full listing, existence check ON (readdir ~735 dirs + purge stale rows)', () => {
+    querySessions({});
+  });
+
+  // Same SELECT + rowToMeta over the same ~6.6k rows, existence check OFF —
+  // isolates the SQL + row mapping from the fs sweep above.
+  bench('full listing, skipExistenceCheck (SQL + rowToMeta only, no fs)', () => {
+    querySessions({ skipExistenceCheck: true });
+  });
+
+  // The interactive picker's real path: newest 15 (PICKER_RECENT_COUNT). The
+  // LIMIT over-fetches limit+16 rows (db.ts:2603) so only ~31 rows are existence-
+  // checked — the cheap, common case.
+  bench('recent 15 (interactive picker path, existence check ON)', () => {
+    querySessions({ limit: 15 });
+  });
+
+  bench('filtered agent=claude, limit 50', () => {
+    querySessions({ agent: 'claude', limit: 50 });
+  });
+
+  bench('sortBy=cost, limit 50 (priciest-first, unindexed expression sort)', () => {
+    querySessions({ sortBy: 'cost', limit: 50 });
+  });
+});
+
+describe.skipIf(!haveRealDb)('countSessions — paginator count', () => {
+  bench('countSessions({}) — COUNT(*) over the whole index', () => {
+    countSessions({});
+  });
+});
+
+describe.skipIf(!haveRealDb)('id / short-id lookup (pid->session context, tmux scan resolution)', () => {
+  bench('getSessionById — indexed PK lookup, re-prepares each call (db.ts:3204)', () => {
+    getSessionById(realId);
+  });
+
+  bench('findSessionsById — exact-first-then-prefix (db.ts:3216)', () => {
+    findSessionsById(realIdPrefix);
+  });
+
+  bench('findSessionsByShortIds — batch 20 short ids in one IN query (tmux scan, db.ts:3240)', () => {
+    findSessionsByShortIds(realShortIds);
+  });
+});
+
+describe.skipIf(!haveRealDb)('ftsSearch — interactive full-text + label search', () => {
+  bench('ftsSearch("rush") — multi-term content + label tiers', () => {
+    ftsSearch('rush');
+  });
+
+  bench('ftsSearch("a") — single-char label type-ahead (FTS label column)', () => {
+    ftsSearch('a');
+  });
+
+  bench('ftsSearch("session index perf") — 3-term OR query', () => {
+    ftsSearch('session index perf');
+  });
+});

--- a/apps/cli/src/lib/session/pid-registry.bench.ts
+++ b/apps/cli/src/lib/session/pid-registry.bench.ts
@@ -1,0 +1,71 @@
+/**
+ * Benchmark for the per-pid session registry read path (pid-registry.ts): the
+ * pid->session lookup the headless `agents sessions --active` scanner uses to
+ * attribute a `ps`-discovered agent process to its exact launch session
+ * (pid-registry.ts docblock). `readPidSessionEntry` (pid-registry.ts:111) is one
+ * file read + JSON.parse; `listPidSessionEntries` (pid-registry.ts:136) is a
+ * `readdirSync` + a `readFileSync`+`JSON.parse` PER entry, called once per
+ * active-sessions scan to index every recorded launch by tmuxPane.
+ *
+ * No mocking, realistic input. Setup points state.ts at a throwaway temp HOME
+ * (state.ts:36 captures `process.env.HOME` at module load, so HOME is set BEFORE
+ * the dynamic import) and seeds `~/.agents/.cache/terminals/by-pid/` (state.ts:146)
+ * with SEED_COUNT real-shaped PidSessionEntry files — a busy fleet box
+ * accumulates one per tracked `ag run` launch until dead pids are pruned. The
+ * functions then do their real per-file readdir + read + parse over that
+ * directory; nothing is stubbed. SEED_COUNT is the realistic-input knob, called
+ * out here rather than hidden: 60 tracked launches models an actively-used box.
+ *
+ * Not wired into `vitest run` (vitest.config.ts:11 includes only `*.test.ts`);
+ * run with `npx vitest bench --run` from apps/cli.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll, describe, bench } from 'vitest';
+
+const SEED_COUNT = 60;
+
+// Redirect state.ts's HOME-derived paths to a throwaway dir BEFORE importing the
+// module under test, then seed a realistic by-pid registry.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-pidbench-'));
+process.env.HOME = TMP;
+process.env.USERPROFILE = TMP;
+
+const BY_PID = path.join(TMP, '.agents', '.cache', 'terminals', 'by-pid');
+fs.mkdirSync(BY_PID, { recursive: true });
+const AGENTS = ['claude', 'codex', 'grok', 'kimi', 'droid', 'antigravity'];
+const seededPids: number[] = [];
+for (let i = 0; i < SEED_COUNT; i++) {
+  const pid = 100000 + i;
+  seededPids.push(pid);
+  const entry = {
+    pid,
+    agent: AGENTS[i % AGENTS.length],
+    sessionId: `${'0'.repeat(8)}-0000-4000-8000-${String(i).padStart(12, '0')}`,
+    cwd: `/home/muqsit/src/github.com/muqsitnawaz/repo-${i % 7}`,
+    actor: 'muqsit@zion',
+    initiatedBy: i % 3 === 0 ? 'agent' : 'human',
+    launchId: `launch-${i}-${'a'.repeat(8)}`,
+    tmuxPane: `%${i}`,
+    startedAtMs: 1_750_000_000_000 + i * 1000,
+  };
+  fs.writeFileSync(path.join(BY_PID, `${pid}.json`), JSON.stringify(entry), 'utf8');
+}
+
+const { readPidSessionEntry, listPidSessionEntries } = await import('./pid-registry.js');
+const midPid = seededPids[Math.floor(SEED_COUNT / 2)];
+
+afterAll(() => {
+  try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe(`pid-registry read path (${SEED_COUNT} seeded launches)`, () => {
+  bench('readPidSessionEntry — single pid read + parse (pid-registry.ts:111)', () => {
+    readPidSessionEntry(midPid);
+  });
+
+  bench('listPidSessionEntries — readdir + read + parse every entry (pid-registry.ts:136)', () => {
+    listPidSessionEntries();
+  });
+});


### PR DESCRIPTION
**test-only** — adds two vitest benchmarks for the session-index query + pid-registry hot path (`agents sessions` listing/preview, `--active` tmux resolution, `agents resume` selector lookup, interactive search). No source behavior changes. `*.bench.ts` is **not** run by `vitest run` (`vitest.config.ts:11` includes only `*.test.ts`), so this adds no CI assertion or flakiness; run with `npx vitest bench --run` from `apps/cli`.

There is no `src/lib/session/index.ts` — `db.ts` is the session-index query module, so the bench lives beside it (`db.bench.ts`), with the pid lookup beside `pid-registry.ts`.

## How it was measured (no mocking)
- `db.bench.ts` takes a consistent `VACUUM INTO` snapshot of **this box's real** `~/.agents/.history/sessions/sessions.db` — **6,635 sessions / 65,488 tool_calls / 6,633 FTS rows, schema v37** — into a throwaway temp file, and points `db.ts` at it via the `AGENTS_SESSIONS_DB` seam (`state.ts:592`) set before the dynamic import. The snapshot has real `file_path`s, so `querySessions`' existence check (`findMissingFilePaths`, `db.ts:2562`) does its **real `readdirSync`** over the ~735 transcript directories those rows point at. The snapshot (not the live db) is used because `querySessions({})` runs a purge **write** transaction (`db.ts:2635`) for every vanished `file_path`, and **443 of 6,513** local transcripts on this box are already gone — running it against the live index would delete real tool-call evidence and contend with the daemon's WAL writer.
- `pid-registry.bench.ts` points `state.ts` at a temp `HOME` and seeds `terminals/by-pid/` with **60** realistic launch entries (a busy fleet box), then reads them through the real functions.

## MEASURED
Machine `yosemite-s1`, 20 cores, `node:sqlite`. `/proc/loadavg` **7.96 → 7.84** across the run (benches are single-threaded). vitest 4.1.9, `mean` in ms.

### `querySessions` — listing (`db.ts:2596`)
| bench | hz | mean (ms) |
|---|--:|--:|
| full listing, existence check ON (readdir ~735 dirs + purge stale rows) | 8.64 | **115.70** |
| full listing, `skipExistenceCheck` (SQL + `rowToMeta` only, no fs) | 19.94 | **50.16** |
| recent 15 (interactive picker path, existence ON) | 2,228 | 0.449 |
| filtered `agent=claude`, limit 50 | 122.5 | 8.16 |
| `sortBy=cost`, limit 50 (unindexed expression sort) | 171.3 | 5.84 |

### id / short-id lookup (`db.ts`)
| bench | hz | mean (ms) |
|---|--:|--:|
| `getSessionById` — indexed PK, re-prepares each call (`db.ts:3204`) | 27,840 | 0.036 |
| `findSessionsByShortIds` — batch 20 in one `IN` (`db.ts:3240`) | 5,817 | 0.172 |
| `findSessionsById` — exact-then-prefix (`db.ts:3216`) | 541 | **1.847** |
| `countSessions({})` — `COUNT(*)` (`db.ts:2647`) | 208,291 | 0.0048 |

### `ftsSearch` — interactive search (`db.ts:3308`)
| bench | hz | mean (ms) |
|---|--:|--:|
| `ftsSearch("a")` — single-char label type-ahead | 192.7 | 5.19 |
| `ftsSearch("rush")` — multi-term content + label | 154.7 | 6.47 |
| `ftsSearch("session index perf")` — 3-term OR | 54.2 | 18.46 |

### pid registry (`pid-registry.ts`, 60 seeded launches)
| bench | hz | mean (ms) |
|---|--:|--:|
| `readPidSessionEntry` — single read + parse (`pid-registry.ts:111`) | 301,411 | 0.0033 |
| `listPidSessionEntries` — readdir + read + parse per entry (`pid-registry.ts:136`) | 4,757 | 0.210 |

## PROPOSALS (each measured, file:line)
1. **Existence sweep dominates the unlimited listing — cache it or lift it off the read path.** `findMissingFilePaths` (`db.ts:2562`, called at `db.ts:2632`) is synchronous `readdirSync` per distinct directory in a loop (`db.ts:2578`), re-run over the same ~735 dirs on every call. Measured delta: **115.70ms with vs 50.16ms without** the check (`skipExistenceCheck`) → **~65ms (57% of the call)** is the readdir sweep + purge. Cache each directory's `readdirSync` keyed by `(dir, mtimeMs)` across calls (invalidate on dir mtime), or drop this "belt-and-suspenders" check (its own docblock, `db.ts:2626`, names the incremental scanner as the authoritative sync).
2. **Stale-row purge write-transaction runs on every listing call** (`db.ts:2634–2639`). With 443/6,513 rows stale, `missing.length > 0` every call → a `BEGIN IMMEDIATE`/`COMMIT` with 443 `purgeToolCalls` DELETEs on every `querySessions({})`, even after the first call purged them (files stay gone on disk → re-flagged missing each call, so the txn keeps firing on 0-row deletes). Guard the transaction to rows that still have tool-call evidence, or reconcile stale rows in the scanner, not the read path.
3. **`agents resume` / `--resume` loads the ENTIRE index (with the existence sweep) to resolve one selector.** `resolveSessionMetadataValue` (`sessions.ts:4616`) and `resolveSessionMetadata` (`sessions.ts:4662`) call bare `querySessions()` (unlimited, existence ON) then filter in JS. Measured: **115.70ms** vs `getSessionById` **0.036ms**. For a full-UUID selector (`FULL_SESSION_ID_RE`, already special-cased at `sessions.ts:4626`) go straight to `getSessionById`; otherwise push the selector (`idExact`/`idPrefix`) + scope (`agent`/`project`) into `querySessions({ ..., skipExistenceCheck: true })` so SQLite's indexes filter instead of a full scan + fs sweep.
4. **`findSessionsById` runs the existence sweep twice** (`db.ts:3222`, `db.ts:3224`). Measured **1.847ms** (51× `getSessionById`). Each inner `querySessions` does a `readdir` existence check on its result rows; id resolution doesn't need file presence. Pass `skipExistenceCheck: true` in both inner calls.
5. **No prepared-statement cache — fixed-SQL lookups recompile each call.** `getSessionById` (`db.ts:3204`, fixed `SELECT * FROM sessions WHERE id = ?`) and `countSessions` with no filter (`db.ts:2650`) build + compile the same SQL on every call. Memoize the compiled statement for these fixed-SQL paths (the dynamic `querySessions` SQL, `db.ts:2620`, can't be trivially cached). Small per-call, but these are the highest-frequency lookups.
6. **`listPidSessionEntries` is readdir + read + parse per file** (`pid-registry.ts:136`): **0.210ms for 60 entries** (~3.5µs/entry, 63× a single `readPidSessionEntry`), called once per `--active` scan. Fine at typical sizes but scales linearly; a caller needing one pid should use `readPidSessionEntry` (301k hz). No change proposed beyond that call-site guidance — flagged, not a defect at current sizes.

Nothing above is unmeasured, and this PR carries the benchmark only — the optimizations are proposals, not implemented here.

## No screenshot
No UI / user-visible surface — this is a benchmark file that runs on demand. The run output above is the evidence.
