### PR TITLE
test(perf): benchmark the agents sync config-translation path

### DIFF
--- a/apps/cli/src/lib/sync-umbrella.bench.ts
+++ b/apps/cli/src/lib/sync-umbrella.bench.ts
@@ -1,0 +1,257 @@
+/**
+ * Benchmark for the `agents sync` config-translation hot path: the reconcile
+ * stage that turns the DotAgents repos into each agent's native on-disk format.
+ *
+ * The entry point is sync-umbrella.ts:96 `runUmbrellaSync`, but that function is
+ * a sequencer, not the cost. Its planner is pure (sync-umbrella.ts:51
+ * `planUmbrellaStages`, "Pure -- no I/O"), its repos stage is a `git pull`
+ * (sync-umbrella.ts:109 `pullRepo`) and its secrets stage is network + scrypt.
+ * Every local CPU/IO cost of a bare `agents sync` lives behind one line --
+ * sync-umbrella.ts:152 `await refresh({ skipPrompts: yes, quiet })` -- so that is
+ * what this file measures, decomposed into the four stages refresh.ts actually
+ * runs per agent version:
+ *
+ *   1. DISCOVERY   refresh.ts:201 `getAvailableResources()` -> versions.ts:224,
+ *                  re-called a second time per version inside the sync itself
+ *                  (versions.ts:2799). Name-set scan across every layer.
+ *   2. GUARD       versions.ts:2874-2875 `loadManifest` + `isStale` -- the fast
+ *                  guard that returns early (versions.ts:2878) when nothing
+ *                  drifted. The steady-state cost of `agents sync` on an
+ *                  already-current machine.
+ *   3. TRANSLATE   versions.ts:2777 `syncResourcesToVersion` -- the actual
+ *                  translation into agent-native format (writers for commands,
+ *                  skills, hooks, rules, permissions, mcp, subagents, plugins,
+ *                  workflows).
+ *   4. MANIFEST    versions.ts:3262 `buildSyncManifest` -> staleness/index.ts:89
+ *                  `buildManifest`, written after EVERY full sync. Unlike the
+ *                  guard it sha256s every byte of every source
+ *                  (fingerprint.ts:24 `fingerprintFile`, fingerprint.ts:59
+ *                  `fingerprintDir`).
+ *
+ * plus the hook lifecycle registration refresh.ts:275/289 runs per version
+ * (`parseHookManifest` hooks.ts:1369, `registerHooksToSettings` hooks.ts:1611).
+ *
+ * NO MOCKING. Every bench runs against this machine's REAL ~/.agents layout --
+ * the real user repo (`getUserAgentsDir()`), the real system repo, the real
+ * extra repos (`getEnabledExtraRepos()`), and a REAL installed version home
+ * under ~/.agents/.history/versions/claude/<version>/home discovered at runtime
+ * via versions.ts:1284 `listInstalledVersions`. `process.cwd()` during a real
+ * `vitest bench` run is apps/cli inside the invoking checkout, so the
+ * project-layer walk (`getProjectAgentsDir`) runs at its real depth.
+ *
+ * Side effects, stated plainly -- these are real writes, identical to what
+ * `agents sync claude@<version>` does today, not test scaffolding:
+ *   - the write benches copy resources into the chosen version home and rewrite
+ *     its `.sync-manifest.json` (versions.ts:3264 `saveManifest`);
+ *   - the first full sync of a version whose selectors are unset writes default
+ *     resource patterns into ~/.agents/agents.yaml (versions.ts:2806 ->
+ *     state.ts:1266 `ensureVersionResourcePatterns`, which no-ops once set);
+ *   - `registerHooksToSettings` rewrites that version home's settings.json.
+ * The target version is deliberately the OLDEST installed claude, never the
+ * newest, so a bench run never writes into the version home most likely to be
+ * running the session that invoked it.
+ *
+ * This file is NOT part of `vitest run`: vitest.config.ts:9 includes only
+ * `*.test.ts`, so it is reached exclusively by `vitest bench`.
+ */
+import { describe, bench } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { planUmbrellaStages } from './sync-umbrella.js';
+import {
+  getAvailableResources,
+  getActuallySyncedResources,
+  getNewResources,
+  getProjectOnlyResources,
+  getVersionHomePath,
+  listInstalledVersions,
+  syncResourcesToVersion,
+} from './versions.js';
+import { listResources } from './resources.js';
+import { buildManifest, isStale, loadManifest, saveManifest } from './staleness/index.js';
+import { getDetector } from './staleness/registry.js';
+import { clearLayerCache } from './staleness/layers.js';
+import { parseHookManifest, registerHooksToSettings } from './hooks.js';
+
+const cwd = process.cwd();
+
+/**
+ * Real installed claude versions, oldest first (versions.ts:1315 sorts with
+ * `compareVersions`). Write benches target the oldest; read-only benches prefer
+ * a version that already carries a `.sync-manifest.json` so the guard path is
+ * measured against a manifest this bench did not just author.
+ */
+const installedClaude = listInstalledVersions('claude');
+const writeTarget = installedClaude[0];
+const manifestTarget =
+  installedClaude.find((v) => fs.existsSync(path.join(getVersionHomePath('claude', v), '.sync-manifest.json'))) ??
+  writeTarget;
+
+const hookManifest = parseHookManifest();
+
+/**
+ * Guard-path input. `loadManifest` (staleness/index.ts:66) returns null when the
+ * file is absent or its `v` does not match MANIFEST_VERSION, in which case
+ * versions.ts:2875 never reaches `isStale` -- so a null here means the guard
+ * benches have nothing real to measure and skip rather than fabricate one.
+ */
+const storedManifest = manifestTarget ? loadManifest('claude', manifestTarget) : null;
+
+describe('stage 0 -- planUmbrellaStages (sync-umbrella.ts:51): the only work the umbrella itself does', () => {
+  bench('bare `agents sync` (fetchRepos + reconcile)', () => {
+    planUmbrellaStages({});
+  });
+
+  bench('`agents sync --local` (reconcile only, the flag that skips straight to refresh)', () => {
+    planUmbrellaStages({ local: true });
+  });
+});
+
+describe.skipIf(!writeTarget)('stage 1 -- discovery: the name-set scan run once per refresh AND once per version', () => {
+  bench('getAvailableResources(cwd) (versions.ts:224) -- refresh.ts:201 and again at versions.ts:2799', () => {
+    getAvailableResources(cwd);
+  });
+
+  bench('listResources("skills") (resources.ts:184) -- called by resourceSourceMap, versions.ts:2674', () => {
+    listResources('skills', cwd);
+  });
+
+  bench('listResources("commands") (resources.ts:184)', () => {
+    listResources('commands', cwd);
+  });
+
+  bench('listResources("hooks") (resources.ts:184, the group-expanding branch at resources.ts:208)', () => {
+    listResources('hooks', cwd);
+  });
+
+  bench('listResources("subagents") (resources.ts:184)', () => {
+    listResources('subagents', cwd);
+  });
+
+  bench('the four listResources calls resourceSourceMap makes per pattern-derived sync (versions.ts:2838)', () => {
+    for (const kind of ['commands', 'skills', 'hooks', 'subagents'] as const) {
+      new Map(listResources(kind, cwd).map((r) => [r.name, r.source]));
+    }
+  });
+});
+
+describe.skipIf(!writeTarget)('stage 1b -- refresh.ts:211-212 new-resource diff (runs per agent even on the interactive path)', () => {
+  const available = getAvailableResources(cwd);
+
+  bench('getActuallySyncedResources + getNewResources (refresh.ts:211-212)', () => {
+    const synced = getActuallySyncedResources('claude', writeTarget!);
+    getNewResources(available, synced, getProjectOnlyResources());
+  });
+});
+
+/**
+ * `getActuallySyncedResources` is a fan-out over nine detectors
+ * (versions.ts:460-468 `getDetector(kind, agent).list(ctx)`), so measuring it
+ * whole says only that it is slow. This attributes the cost to a single kind,
+ * which is what a proposal has to name.
+ */
+describe.skipIf(!writeTarget)('stage 1c -- per-detector breakdown of getActuallySyncedResources (versions.ts:460-468)', () => {
+  const ctx = { version: writeTarget!, versionHome: getVersionHomePath('claude', writeTarget!), cwd };
+  const kinds = ['commands', 'skills', 'hooks', 'rules', 'mcp', 'permissions', 'subagents', 'plugins', 'workflows'] as const;
+
+  for (const kind of kinds) {
+    bench(`detector "${kind}" (staleness/detectors/${kind}.ts) .list()`, () => {
+      getDetector(kind, 'claude')?.list(ctx);
+    }, kind === 'skills' || kind === 'plugins' ? { time: 3000, iterations: 5 } : {});
+  }
+});
+
+describe.skipIf(!storedManifest)('stage 2 -- staleness guard (versions.ts:2874-2875): steady-state `agents sync` on a current box', () => {
+  bench('isStale (staleness/index.ts:122), warm layer cache -- 2nd..Nth version in one refresh', () => {
+    isStale(storedManifest!, 'claude', manifestTarget!, cwd);
+  });
+
+  bench(
+    'isStale, COLD layer cache (layers.ts:53 clearLayerCache) -- the first version in a fresh `agents sync` process',
+    () => {
+      isStale(storedManifest!, 'claude', manifestTarget!, cwd);
+    },
+    {
+      setup: (_t: unknown, mode: 'warmup' | 'run') => {
+        if (mode === 'run') clearLayerCache();
+      },
+      iterations: 1,
+      time: 1,
+      warmupIterations: 0,
+      warmupTime: 0,
+    },
+  );
+
+  bench('loadManifest (staleness/index.ts:66) -- the JSON read in front of every guard', () => {
+    loadManifest('claude', manifestTarget!);
+  });
+});
+
+describe.skipIf(!writeTarget)('stage 4 -- buildManifest (staleness/index.ts:89): sha256 of every source, written after EVERY full sync', () => {
+  bench('buildManifest (versions.ts:3262 buildSyncManifest) -- fingerprintFile/fingerprintDir over all layers', () => {
+    buildManifest('claude', writeTarget!, cwd);
+  });
+});
+
+describe.skipIf(!writeTarget)('stage 3 -- syncResourcesToVersion (versions.ts:2777): the real translation into agent-native format', () => {
+  bench(
+    'full sync, force:true (refresh.ts:247 forceFullSync) -- writers + orphan sweeps + buildManifest, every time',
+    () => {
+      syncResourcesToVersion('claude', writeTarget!, undefined, { force: true, cwd });
+    },
+    { time: 3000, iterations: 5 },
+  );
+
+  bench(
+    'guard-hit sync (no force, no selection) -- the versions.ts:2878 early return when nothing drifted',
+    () => {
+      syncResourcesToVersion('claude', writeTarget!, undefined, { cwd });
+    },
+    { time: 2000 },
+  );
+});
+
+describe.skipIf(!writeTarget || Object.keys(hookManifest).length === 0)(
+  'stage 5 -- hook lifecycle registration (refresh.ts:275/289), run once per installed version',
+  () => {
+    bench('parseHookManifest (hooks.ts:1369) -- refresh.ts:275, once per refresh', () => {
+      parseHookManifest({ warn: false });
+    });
+
+    bench('registerHooksToSettings (hooks.ts:1611) -- refresh.ts:289, once PER VERSION', () => {
+      registerHooksToSettings('claude', getVersionHomePath('claude', writeTarget!), hookManifest);
+    });
+  },
+);
+
+/**
+ * refresh.ts:207-209: an unattended `agents sync --yes` syncs
+ * `listInstalledVersions(agentId)` -- every installed version, not just the
+ * default -- and refresh.ts:283-285 registers hooks over the same set. So the
+ * per-version costs above are multiplied by the install count. This measures
+ * that multiplication directly on the real fan-out for one agent, using the
+ * guard path (the realistic steady state) rather than forcing N full writes.
+ */
+describe.skipIf(installedClaude.length < 2)(
+  `stage 6 -- per-version fan-out (refresh.ts:207-209): ${installedClaude.length} installed claude versions`,
+  () => {
+    bench('syncResourcesToVersion across EVERY installed claude version (guard path)', () => {
+      for (const v of installedClaude) {
+        syncResourcesToVersion('claude', v, undefined, { cwd });
+      }
+    }, { time: 3000 });
+  },
+);
+
+// Keep the guard target's manifest exactly as found: the write benches above
+// rewrite `.sync-manifest.json` for `writeTarget`, and when writeTarget ===
+// manifestTarget that would leave the box with a manifest authored by a
+// benchmark rather than by a real sync. Restoring is a correctness step, not
+// cleanup -- a stale/foreign manifest changes what the NEXT real `agents sync`
+// decides to do (versions.ts:2873-2879).
+if (storedManifest && manifestTarget) {
+  process.on('exit', () => {
+    try { saveManifest('claude', manifestTarget, storedManifest); } catch { /* best effort */ }
+  });
+}


### PR DESCRIPTION
**test-only** — adds one vitest benchmark file. No src behavior changes, no flags, no commands. Per the repo rule, test-only changes are exempt from docs + CHANGELOG.

Ticket: [RUSH-2319](https://linear.app/muqsitnawaz/issue/RUSH-2319)
Raw run output (with `/proc/loadavg` before/after): https://share.agents-cli.sh/muqsitnawaz/perf-bench-config-sync-20260806-0158-agents-sync-bench-2026-08-06-8a0128c392dcd37d

## What this benchmarks

`runUmbrellaSync` (`sync-umbrella.ts:96`) is a sequencer, not a cost: its planner is pure (`sync-umbrella.ts:51`, "Pure — no I/O"), its repos stage is `pullRepo` (`sync-umbrella.ts:109`), its secrets stage is network. Every local CPU/IO cost of a bare `agents sync` sits behind one line — `sync-umbrella.ts:152` `await refresh({ skipPrompts: yes, quiet })` — so `apps/cli/src/lib/sync-umbrella.bench.ts` decomposes that into the stages `refresh.ts` runs per agent version.

No mocking. Real `~/.agents` (25 user + 22 system skills, 30 system commands, 21 hooks, 15 plugins, 14 permission groups), real installed version homes discovered via `listInstalledVersions` (`versions.ts:1284`), real writes. The write target is the **oldest** installed claude (`2.1.186`) — not the `~/.claude`-symlinked default (`2.1.219`) and not the home running the session. The guard target's `.sync-manifest.json` is restored on exit.

Not wired into `vitest run`: `vitest.config.ts:9` includes only `*.test.ts`.

## Measured — `npx vitest bench --run src/lib/sync-umbrella.bench.ts`

Host `yosemite-s1`, 16 cores, node v24.11.1, vitest 4.1.9. `/proc/loadavg` **2.34 3.15 2.88** immediately before, **3.63 3.40 2.99** immediately after. A second independent run agreed within 5% on every headline number (`getActuallySyncedResources` 1041 vs 1048 ms, `buildManifest` 720 vs 711 ms, full sync 836 vs 847 ms, guard hit 22.5 vs 21.7 ms, 8-version fan-out 163 vs 169 ms).

```
 ✓ stage 0 -- planUmbrellaStages (sync-umbrella.ts:51): the only work the umbrella itself does
     name                                                                            hz     min     max    mean     rme    samples
   · bare `agents sync` (fetchRepos + reconcile)                        22,493,375.15  0.0000  0.2344  0.0000  ±0.10%  11246688
   · `agents sync --local` (reconcile only)                             22,585,326.06  0.0000  0.0486  0.0000  ±0.05%  11292664

 ✓ stage 1 -- discovery: the name-set scan run once per refresh AND once per version
   · getAvailableResources(cwd) (versions.ts:224)                              125.42  7.4980  9.8808  7.9732  ±1.32%       63
   · listResources("skills") (resources.ts:184)                                500.34  1.8257  4.3958  1.9987  ±1.25%      251
   · listResources("commands") (resources.ts:184)                              773.71  1.1359  3.6923  1.2925  ±1.02%      387
   · listResources("hooks") (resources.ts:184)                                 462.64  1.6782  5.9198  2.1615  ±3.21%      232
   · listResources("subagents") (resources.ts:184)                          13,453.46  0.0627  3.7748  0.0743  ±1.54%     6727
   · the four listResources calls resourceSourceMap makes (versions.ts:2838)   183.17  4.9954  7.8794  5.4595  ±1.26%       92

 ✓ stage 1b -- refresh.ts:211-212 new-resource diff
   · getActuallySyncedResources + getNewResources                              0.9539  1027.69  1067.43  1048.34  ±0.83%     10

 ✓ stage 1c -- per-detector breakdown of getActuallySyncedResources (versions.ts:460-468)
   · detector "commands"                                                  75,735.19    0.0124    0.4391    0.0132  ±0.28%   37868
   · detector "skills"                                                       0.9803  1007.01   1039.44   1020.08  ±1.52%       5
   · detector "hooks"                                                        140.50    6.9581    7.6373    7.1172  ±0.36%      71
   · detector "rules"                                                    25,098.45    0.0318    0.3931    0.0398  ±0.20%   12550
   · detector "mcp"                                                       3,271.19    0.2818   21.9495    0.3057  ±8.49%    1636
   · detector "permissions"                                               1,566.53    0.6041    1.4736    0.6384  ±0.78%     784
   · detector "subagents"                                               648,785.31    0.0014    0.4834    0.0015  ±0.20%  324393
   · detector "plugins"                                                   2,086.05    0.4612    1.4214    0.4794  ±0.27%    6259
   · detector "workflows"                                                55,669.02    0.0172    0.6503    0.0180  ±0.39%   27835

 ✓ stage 2 -- staleness guard (versions.ts:2874-2875)
   · isStale (staleness/index.ts:122), warm layer cache                       199.82  4.6835   6.8695  5.0045  ±1.31%      100
   · isStale, COLD layer cache (layers.ts:53 clearLayerCache)                 202.91  4.9283   4.9283  4.9283  ±0.00%        1
   · loadManifest (staleness/index.ts:66)                                   3,844.09  0.2163  12.0114  0.2601  ±8.01%     1926

 ✓ stage 4 -- buildManifest (staleness/index.ts:89)
   · buildManifest (versions.ts:3262 buildSyncManifest)                       1.4072  707.59  719.63  710.63  ±0.36%       10

 ✓ stage 3 -- syncResourcesToVersion (versions.ts:2777)
   · full sync, force:true                                                    1.1810  834.34  859.98  846.75  ±1.53%        5
   · guard-hit sync (versions.ts:2878 early return)                          46.1559  19.3028 31.0358 21.6657  ±1.42%       93

 ✓ stage 5 -- hook lifecycle registration (refresh.ts:275/289)
   · parseHookManifest (hooks.ts:1369) -- once per refresh                    350.96  2.6958  4.0987  2.8493  ±1.59%      176
   · registerHooksToSettings (hooks.ts:1611) -- once PER VERSION              191.40  5.1181  6.2427  5.2248  ±0.68%       96

 ✓ stage 6 -- per-version fan-out (refresh.ts:207-209): 8 installed claude versions
   · syncResourcesToVersion across EVERY installed claude version              5.9137  157.12  183.04  169.10  ±2.64%       18
```

## Proposals (each one derived from a number above; nothing unmeasured)

**1. `refresh.ts:211-220` — 1048 ms per agent of provably dead work on every `agents sync --yes`.**
`getActuallySyncedResources` (`refresh.ts:211`), `getNewResources` (`refresh.ts:212`) and `hasAnySynced` (`refresh.ts:214-220`) are computed unconditionally. Their only readers are the interactive branches `refresh.ts:228` (`!hasAnySynced`) and `refresh.ts:232` (`hasNewResources(newResources, …)`), both in the `else` of `if (skipPrompts) { forceFullSync = true; }` (`refresh.ts:226-227`). The unattended path — `sync-umbrella.ts:152` passes `skipPrompts: yes` — never reads any of them. Measured 1048 ms per agent, and `refresh.ts:202` loops `MANAGED_AGENT_IDS`. Mechanism: wrap `refresh.ts:211-220` in `if (!skipPrompts)`. No behavior change.

**2. `staleness/detectors/skills.ts:16-32` — 1020 ms, 97% of the above, because `skillDirsMatch` has no stat pre-check.**
It recurses both trees and does `fs.readFileSync(srcPath) !== fs.readFileSync(destPath)` on every file (`skills.ts:28`) with no `statSync` guard. Here that is 72.3 MB / 358 files in the version home plus the matching source read. The same repo already implements the cheap rule: `fingerprint.ts:81-90` `isFileStale` returns early when `mtimeMs` and `size` match and hashes only on a miss, and `fingerprint.ts:97-114` `isDirStale` does the directory form — which is why the whole 7-checker `isStale` over the same source tree measures **5.0 ms**, 204× cheaper than this detector. Mechanism: `statSync` both sides first; a `size` mismatch is a definitive miss with zero reads, and `mtimeMs + size` match takes the same fast-accept `isFileStale` already takes.

**3. `staleness/index.ts:104-110` `buildManifest` — 711 ms, 84% of the 847 ms full sync, re-hashing what was just stat'd.**
`versions.ts:3262` calls it after every full sync, and it always goes through `fingerprintFile` (`fingerprint.ts:24`: `statSync` **and** `readFileSync` **and** `sha256`) / `fingerprintDir` (`fingerprint.ts:59`). Full sync 847 ms − buildManifest 711 ms leaves ~136 ms for the actual writers. The `isStale` call at `versions.ts:2875` immediately before it walked the identical name set for 5.0 ms using the two-tier rule. Mechanism: pass the already-loaded previous manifest (`versions.ts:2874`) into `buildManifest` and carry forward any `Fingerprint` whose stored `path`/`mtime`/`size` still match `statSync`, hashing only the misses.

**4. `versions.ts:2799` + `2823-2863` — 13.4 ms of the 21.7 ms guard-hit sync happens before the guard that discards it.**
The guard is `versions.ts:2873-2879` and needs only `loadManifest` + `isStale` (0.26 + 5.0 = 5.3 ms measured). Ahead of it sit `getAvailableResources(cwd)` (`versions.ts:2799`, 7.97 ms) and the pattern-expansion block (`versions.ts:2823-2863`), whose `resourceSourceMap` fans out to four `listResources` calls (`versions.ts:2838`, `2844`, `2847`, `2850`, `2853` — 5.46 ms for the four). 7.97 + 5.46 = 13.4 ms wasted per version on a guard hit; across the 8 installed claude versions an unattended sync fans out to (`refresh.ts:207-209`) the whole fan-out measures 169 ms. Mechanism: hoist the guard above both, leaving `syncProjectResourcesToAgent` (`versions.ts:2866`) ahead of it so the early return's `projectSkipped` contract (`versions.ts:2876-2878`) is byte-identical.

**5. `versions.ts:2799` re-scans what `refresh.ts:201` already built — 7.97 ms × versions.**
`refresh.ts:201` computes `available` once and every `syncResourcesToVersion` recomputes it from the same default `cwd`. `syncResourcesToVersion` already takes an options bag (`versions.ts:2777` `{ projectDir, cwd, force }`); an optional `available` lets refresh pass its own. ~64 ms per agent at 8 versions. Strictly smaller than 1–4; listed for completeness.

Nothing is proposed for `sync-umbrella.ts` itself: `planUmbrellaStages` measures ~44 ns (22.5 M ops/s). The umbrella is free; the cost is all in reconcile.
