### PR TITLE
test(perf): correct the hook-registration side effects

### DIFF
--- a/apps/cli/src/lib/sync-umbrella.bench.ts
+++ b/apps/cli/src/lib/sync-umbrella.bench.ts
@@ -46,7 +46,7 @@
  *   - EXACTLY ONE version home is written: `writeTarget`, the OLDEST installed
  *     claude, never the newest and never the `~/.claude`-symlinked default. The
  *     stage-3 full sync copies resources into it, orphan-sweeps stale entries
- *     (versions.ts:2945/3013/3036/3067/3214) and rewrites its
+ *     (versions.ts:2945/2976/3013/3036/3067/3214) and rewrites its
  *     `.sync-manifest.json` (versions.ts:3264 `saveManifest`). Only the MANIFEST
  *     is restored on exit -- captured below as raw bytes, and deleted again if it
  *     did not exist before. The synced resources are left in place, exactly as a
@@ -65,12 +65,21 @@
  *   - The first sync of a version whose selectors are unset writes default
  *     resource patterns into ~/.agents/agents.yaml (versions.ts:2806 ->
  *     state.ts:1266 `ensureVersionResourcePatterns`, which no-ops once set).
- *   - `registerHooksToSettings` rewrites `writeTarget`'s settings.json AND, via
- *     `sweepOrphanShims` (hooks.ts:1632), unlinks stale shims from the GLOBAL
- *     hook-shims dir (hooks.ts:1607, `getHookShimsDir()` -> state.ts:138) --
- *     outside every version home. The bench passes the full live manifest, so
- *     only shims that are ALREADY orphaned are removed, identical to a real
- *     `agents sync`; no live shim is touched.
+ *   - `registerHooksToSettings` rewrites `writeTarget`'s settings.json and also
+ *     writes OUTSIDE every version home, in two places. All of it is exactly
+ *     what a real `agents sync` does, and none of it is inert:
+ *       * the GLOBAL hook-shims dir (`getHookShimsDir()` -> state.ts:138):
+ *         `sweepOrphanShims` (hooks.ts:1632) unlinks shims whose hook is gone
+ *         (hooks.ts:1607); `generateHookShim` (hooks.ts:390 ->
+ *         hooks/cache.ts:149/152) rewrites a live shim whose content drifted
+ *         and re-chmods 0o755 otherwise -- so a LIVE shim is touched on every
+ *         call, not only an orphaned one; and `removeHookShim` (hooks.ts:381 ->
+ *         hooks/cache.ts:611) unlinks the live shim of a hook that declares no
+ *         `cache:` / `matches:` / `matcher:`.
+ *       * the hook SOURCE scripts in the DotAgents repos: `ensureExecutable`
+ *         (hooks.ts:1644 -> hooks.ts:441) chmods `mode | 0o755` on any hook
+ *         script that is not already executable. Hooks register by source path
+ *         and are never copied, so this mutates the user's `hooks/` tree.
  *
  * This file is NOT part of `vitest run`: vitest.config.ts:11 includes only
  * `*.test.ts` globs and there is no `benchmark.include`, so it is reached


### PR DESCRIPTION
**test-only** — one docblock in one bench file. No source behavior changes, no user-visible surface. Docs/CHANGELOG exempt.

[#2256](https://github.com/phnx-labs/agents-cli/pull/2256) squash-merged only its **first** commit; the correction commit `af4296a7` never landed. So `main` (`45571d5e`) still carries a docblock claim the code contradicts. This PR is that correction, rebased onto current `main`. Found by the [second review pass on #2256](https://github.com/phnx-labs/agents-cli/pull/2256#issuecomment-5203109473). Ticket: [RUSH-2319](https://linear.app/muqsitnawaz/issue/RUSH-2319).

## The claim on `main` is false

`sync-umbrella.bench.ts:44-45` asserts *"The list is exhaustive; anything added here must be added to it"*, and item 5 currently ends **"no live shim is touched"**. `registerHooksToSettings` contradicts that three ways — each verified against source, none inert:

| Write | Path |
|---|---|
| A **live** shim is rewritten when its content drifted (`fs.writeFileSync(shimPath, content, { mode: 0o755 })`) and re-chmod'd `0o755` otherwise — every call | `hooks.ts:390` → `hooks/cache.ts:149` / `:152` |
| A **live** shim is unlinked for a hook declaring no `cache:`/`matches:`/`matcher:` — distinct from `sweepOrphanShims`, which removes one whose hook is *gone* | `hooks.ts:381` → `hooks/cache.ts:611` |
| Hook **source scripts** are chmod'd `mode \| 0o755`. Hooks register by source path and are never copied, so this mutates the user's `hooks/` tree — a repo the list named no write to at all | `hooks.ts:1644` → `hooks.ts:441` |

Those shims are real on this box — `~/.agents/.cache/shims/hooks/` holds `activity-log-intent.sh`, `ask-user-question-guard.sh`, `feed-clear-answered.sh` and others — so the sentence is not merely imprecise, it is wrong.

Item 5 now enumerates all four writes (those three plus `sweepOrphanShims`, `hooks.ts:1632` → `hooks.ts:1607`) and states each is exactly what a real `agents sync` does, with no affirmative "nothing live is touched" claim. Item 1 gains the sixth orphan sweep (`versions.ts:2976`) that the enumeration had missed.

**None of this is a new hazard** — every one of these writes is what `agents sync` already does, and "exactly one version home is written" still holds. It is worth a PR because a list that calls itself exhaustive has to be, and an affirmative false claim is worse than the incomplete text it replaced.

## Run result

```
$ npm run typecheck:bench --silent && echo BENCH_TSC_CLEAN
BENCH_TSC_CLEAN
$ npx tsc --noEmit && echo PROJECT_TSC_CLEAN
PROJECT_TSC_CLEAN
$ grep -c "no live shim is touched" apps/cli/src/lib/sync-umbrella.bench.ts
0
```

Docblock-only: no bench body, label, or measurement changes, so the numbers in #2254 are untouched.
