### PR TITLE
test(perf): scope the shims-dir write to what a bench run actually does

### DIFF
--- a/apps/cli/src/lib/sync-umbrella.bench.ts
+++ b/apps/cli/src/lib/sync-umbrella.bench.ts
@@ -68,18 +68,24 @@
  *   - `registerHooksToSettings` rewrites `writeTarget`'s settings.json and also
  *     writes OUTSIDE every version home, in two places. All of it is exactly
  *     what a real `agents sync` does, and none of it is inert:
- *       * the GLOBAL hook-shims dir (`getHookShimsDir()` -> state.ts:138):
- *         `sweepOrphanShims` (hooks.ts:1632) unlinks shims whose hook is gone
- *         (hooks.ts:1607); `generateHookShim` (hooks.ts:390 ->
- *         hooks/cache.ts:149/152) rewrites a live shim whose content drifted
- *         and re-chmods 0o755 otherwise -- so a LIVE shim is touched on every
+ *       * the hook-shims dir: `sweepOrphanShims` (hooks.ts:1632) unlinks shims
+ *         whose hook is gone (hooks.ts:1607); `generateHookShim` (hooks.ts:390
+ *         -> hooks/cache.ts:149/152) rewrites a live shim whose content drifted
+ *         and re-chmods 0o755 otherwise -- so a LIVE shim is written on every
  *         call, not only an orphaned one; and `removeHookShim` (hooks.ts:381 ->
  *         hooks/cache.ts:611) unlinks the live shim of a hook that declares no
- *         `cache:` / `matches:` / `matcher:`.
+ *         `cache:` / `matches:` / `matcher:`. UNDER `vitest bench` these land in
+ *         a fork-private temp dir, NOT the real `~/.agents/.cache/shims/hooks`:
+ *         tests/setup.ts:62 pins `AGENTS_HOOK_SHIMS_DIR` and state.ts:550 reads
+ *         it at call time. So stage 5 pays first-write shim GENERATION rather
+ *         than the warm re-chmod production takes -- read its number with that
+ *         in mind. Outside vitest the same code writes the real global dir.
  *       * the hook SOURCE scripts in the DotAgents repos: `ensureExecutable`
  *         (hooks.ts:1644 -> hooks.ts:441) chmods `mode | 0o755` on any hook
  *         script that is not already executable. Hooks register by source path
- *         and are never copied, so this mutates the user's `hooks/` tree.
+ *         and are never copied, and there is NO env indirection here -- unlike
+ *         the shims dir above, this one hits the user's real `hooks/` tree even
+ *         under vitest.
  *
  * This file is NOT part of `vitest run`: vitest.config.ts:11 includes only
  * `*.test.ts` globs and there is no `benchmark.include`, so it is reached


### PR DESCRIPTION
**test-only** — one docblock bullet in one bench file. No source behavior changes, no user-visible surface. Docs/CHANGELOG exempt.

Final accuracy pass on the side-effect list, from the [approving review of #2257](https://github.com/phnx-labs/agents-cli/pull/2257#issuecomment-5203188385) (non-blocking there; #2257's branch auto-merged before this could ride along). Ticket: [RUSH-2319](https://linear.app/muqsitnawaz/issue/RUSH-2319).

## The bullet is true of the code and false of a run

`sync-umbrella.bench.ts` item 5 says `registerHooksToSettings` writes the **global** hook-shims dir. That is right about the code path, but under `vitest bench` those writes are redirected:

```
tests/setup.ts:62   process.env.AGENTS_HOOK_SHIMS_DIR = path.join(tmp, 'hook-shims');
state.ts:550        return process.env.AGENTS_HOOK_SHIMS_DIR ?? HOOK_SHIMS_DIR;
```

`state.ts:550` reads the env at call time, and `tests/setup.ts` runs in every fork before the bench file's imports — so the shim writes land in a fork-private temp dir, never `~/.agents/.cache/shims/hooks`.

**Proven by ctime, not by reading the code.** `chmod` bumps ctime, so a re-chmod would show. Every live shim reads `2026-08-06 01:00:28` — before the `02:07`, `02:40` and later bench runs:

```
2026-08-06_01:00:28  activity-log-intent.sh
2026-08-06_01:00:28  activity-log-result.sh
2026-08-06_01:00:28  ask-user-question-guard.sh
```

The redirect triangulates correctly: paths `setup.ts` does **not** redirect *were* written by those same runs — the version home at `02:40:19` and the project `.claude/` at `02:11:28` — because `setup.ts` leaves `HOME` untouched. So this is a redirect, not an absent write.

The bullet now says the code writes the shims dir, that vitest redirects it to a temp dir, and that outside vitest the same code writes the real global dir. It also records the consequence for the measurement: **stage 5 pays first-write shim *generation*, not the warm re-chmod production takes** — worth knowing before treating its number as production-representative.

## `ensureExecutable` gains a caveat in the opposite direction

`hooks.ts:1644` → `hooks.ts:441` chmods `mode | 0o755` on hook **source** scripts, and there is **no** env indirection for the hooks source tree. That one hits the user's real `hooks/` scripts even under vitest, so the bullet now says so explicitly rather than leaving it to inherit the shims-dir caveat.

## Run result

```
$ npm run typecheck:bench --silent && echo BENCH_TSC_CLEAN
BENCH_TSC_CLEAN
```

Docblock-only: no bench body, label, or measurement changes, so the numbers in #2254 are untouched.
