### PR TITLE
test(perf): benchmark the SessionStart-hook state reader (hook-sessions.ts)

### DIFF
--- a/apps/cli/src/lib/session/hook-sessions.bench.ts
+++ b/apps/cli/src/lib/session/hook-sessions.bench.ts
@@ -1,0 +1,134 @@
+/**
+ * Benchmark for the SessionStart-hook state reader (hook-sessions.ts): the
+ * two on-disk sources `agents sessions --active` joins a `ps`-discovered pid
+ * against on every ~3s poll (active.ts:1490 "The ~3s poll must not re-read
+ * the dir ... per candidate") and exec.ts:1953/1708 reads once per
+ * `--host`-dispatched non-Claude run --
+ *
+ *   - loadHookSessionIndex() (hook-sessions.ts:126) -- readdirSync + one
+ *     readFileSync+JSON.parse PER FILE over ~/.agents/.cache/terminals/sessions/.
+ *   - readStateSessionRecord() (hook-sessions.ts:81) -- ONE targeted
+ *     readFileSync+JSON.parse over ~/.agents/.cache/state/sessions/<pid>.json,
+ *     never a directory scan (hook-sessions.ts:66-67).
+ *   - resolveHookSessionRecord() (hook-sessions.ts:183) -- the pure
+ *     launchId -> terminalId -> pid -> childPids priority chain both
+ *     exec.ts:1708 and active.ts:1533-1541/1637-1642 run per candidate over
+ *     the pre-built index.
+ *
+ * No mocking of the read path itself -- every bench below calls the real
+ * exported functions against real on-disk JSON files with the real
+ * HookSessionRecord/state-record shapes. What IS controlled is HOME (state.ts:36
+ * captures `process.env.HOME` at module load, so it's set BEFORE the dynamic
+ * import below, exactly like pid-registry.bench.ts), because the two real counts
+ * on THIS box, measured directly before writing this file
+ * (`ls ~/.agents/.cache/terminals/sessions | wc -l` and
+ * `ls ~/.agents/.cache/state/sessions | wc -l`, 2026-08-06), are:
+ *
+ *   - ~/.agents/.cache/terminals/sessions/  ->  0 files
+ *   - ~/.agents/.cache/state/sessions/      ->  5021 files
+ *
+ * which is exactly what the module docblock predicts: the `terminals/sessions/`
+ * writer, @agents/session-tracker, "is NOT deployed on the fleet -- its dir is
+ * empty there" (hook-sessions.ts:8-9), while `state/sessions/` is "an unpruned
+ * graveyard (thousands of dead-pid files)" (hook-sessions.ts:66). Because the
+ * real terminals/sessions/ dir is permanently empty in production, benching it
+ * unmodified would only prove "readdir on an empty dir is fast" -- not useful.
+ * So loadHookSessionIndex() is seeded at pid-registry.bench.ts's SEED_COUNT (60,
+ * "an actively-used box") as the stated counterfactual: what the scan would cost
+ * if the writer package were ever deployed. readStateSessionRecord() IS seeded at
+ * this box's REAL measured count (5021) -- not a guess, the actual current
+ * graveyard size -- since that dir already accumulates on every real fleet box.
+ *
+ * Not wired into `vitest run` (vitest.config.ts:18 includes only `*.test.ts`);
+ * run with `npx vitest bench --run` from apps/cli.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll, describe, bench } from 'vitest';
+
+// Redirect state.ts's HOME-derived paths to a throwaway dir BEFORE importing the
+// module under test (see pid-registry.bench.ts for the same pattern + rationale).
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-hooksessbench-'));
+process.env.HOME = TMP;
+process.env.USERPROFILE = TMP;
+
+const TERMINALS_SESSIONS_DIR = path.join(TMP, '.agents', '.cache', 'terminals', 'sessions');
+const STATE_SESSIONS_DIR = path.join(TMP, '.agents', '.cache', 'state', 'sessions');
+fs.mkdirSync(TERMINALS_SESSIONS_DIR, { recursive: true });
+fs.mkdirSync(STATE_SESSIONS_DIR, { recursive: true });
+
+const AGENTS = ['claude', 'codex', 'grok', 'kimi', 'droid', 'antigravity'];
+
+// -- terminals/sessions/: counterfactual scale (real fleet count is 0) --
+const TERMINALS_SEED_COUNT = 60;
+const seededTerminalsPids: number[] = [];
+let midLaunchId = '';
+for (let i = 0; i < TERMINALS_SEED_COUNT; i++) {
+  const pid = 200000 + i;
+  seededTerminalsPids.push(pid);
+  const launchId = `launch-${i}-${'a'.repeat(8)}`;
+  if (i === Math.floor(TERMINALS_SEED_COUNT / 2)) midLaunchId = launchId;
+  const record = {
+    session_id: `${'1'.repeat(8)}-0000-4000-8000-${String(i).padStart(12, '0')}`,
+    agent: AGENTS[i % AGENTS.length],
+    cwd: `/home/muqsit/src/github.com/muqsitnawaz/repo-${i % 7}`,
+    pid,
+    launch_id: launchId,
+    terminal_id: `%${i}`,
+    ts: 1_780_000_000 + i,
+  };
+  fs.writeFileSync(path.join(TERMINALS_SESSIONS_DIR, `${pid}.json`), JSON.stringify(record), 'utf8');
+}
+
+// -- state/sessions/: seeded at THIS box's REAL measured graveyard size --
+const STATE_SEED_COUNT = 5021;
+const midStatePid = 300000 + Math.floor(STATE_SEED_COUNT / 2);
+for (let i = 0; i < STATE_SEED_COUNT; i++) {
+  const pid = 300000 + i;
+  const record = { session_id: `${'2'.repeat(8)}-0000-4000-8000-${String(i).padStart(12, '0')}`, cwd: '/home/muqsit', pid, ts: 1_780_000_000 + i };
+  fs.writeFileSync(path.join(STATE_SESSIONS_DIR, `${pid}.json`), JSON.stringify(record), 'utf8');
+}
+
+const { loadHookSessionIndex, readStateSessionRecord, resolveHookSessionRecord, resolveHookSessionId } = await import('./hook-sessions.js');
+
+const index = loadHookSessionIndex();
+const midTerminalsPid = seededTerminalsPids[Math.floor(TERMINALS_SEED_COUNT / 2)];
+
+afterAll(() => {
+  try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe(`loadHookSessionIndex — terminals/sessions/ scan (hook-sessions.ts:126, ${TERMINALS_SEED_COUNT} seeded files — counterfactual scale; REAL fleet count is 0, writer package not deployed)`, () => {
+  bench('readdirSync + read+parse every entry', () => {
+    loadHookSessionIndex();
+  });
+});
+
+describe(`readStateSessionRecord — targeted single-pid read (hook-sessions.ts:81, state/sessions/ seeded at THIS box's REAL measured scale: ${STATE_SEED_COUNT} files)`, () => {
+  bench('HIT — pid present, no staleness check', () => {
+    readStateSessionRecord(midStatePid);
+  });
+
+  bench('HIT — pid present, WITH startedAtMs freshness check (the exec.ts/active.ts call shape)', () => {
+    readStateSessionRecord(midStatePid, (1_780_000_000 + Math.floor(STATE_SEED_COUNT / 2)) * 1000);
+  });
+
+  bench('MISS — untracked pid (the common case, hook-sessions.ts:90)', () => {
+    readStateSessionRecord(999_999_999);
+  });
+});
+
+describe('resolveHookSessionRecord / resolveHookSessionId — priority-chain Map lookup over the pre-built index (hook-sessions.ts:183,207)', () => {
+  bench('direct pid hit (no launchId/terminalId — active.ts:1637 fallback shape)', () => {
+    resolveHookSessionRecord(index, { pid: midTerminalsPid, kind: AGENTS[Math.floor(TERMINALS_SEED_COUNT / 2) % AGENTS.length] });
+  });
+
+  bench('launchId hit (priority path exec.ts:1708/active.ts:1534 take first)', () => {
+    resolveHookSessionId(index, { pid: 0, kind: AGENTS[Math.floor(TERMINALS_SEED_COUNT / 2) % AGENTS.length], launchId: midLaunchId });
+  });
+
+  bench('miss — all keys absent (a hookless harness, or the hook hasn\'t landed yet)', () => {
+    resolveHookSessionRecord(index, { pid: 1, kind: 'claude' });
+  });
+});


### PR DESCRIPTION
test-only — adds a committed vitest benchmark for `apps/cli/src/lib/session/hook-sessions.ts`. No behavior change.

## What / why

`hook-sessions.ts` is the reader the `sessions --active` ~3s poll and `--host` dispatch use to join a `ps`-discovered pid to its SessionStart-hook-recorded session id. It had no `*.bench.ts` (checked: `apps/cli/src/lib/*.bench.ts` and `apps/cli/src/lib/session/*.bench.ts` only had `exec.bench.ts`, `sync-umbrella.bench.ts`, `session/db.bench.ts`, `session/pid-registry.bench.ts` — none cover this file), so this adds one rather than extending an unrelated one.

## MEASURED (real ~/.agents/.cache layout, load `2.37 3.19 2.91` before / `2.39 3.14 2.90` after — `yosemite-s1`)

| Bench | Scale | Mean | Ops/sec |
|---|---|---|---|
| `loadHookSessionIndex()` — `hook-sessions.ts:126` readdir+parse scan | 60 seeded files (counterfactual — **real fleet count is 0**, writer package `@agents/session-tracker` not deployed, `hook-sessions.ts:8-9`) | 0.216ms | 4,631 |
| `readStateSessionRecord()` HIT, no ts check — `hook-sessions.ts:81` | seeded at THIS box's **real measured** graveyard size, `ls ~/.agents/.cache/state/sessions \| wc -l` = 5021 | 0.0028ms | 356,317 |
| `readStateSessionRecord()` HIT, with `startedAtMs` check (the real exec.ts/active.ts call shape) | same, 5021 | 0.0029ms | 339,906 |
| `readStateSessionRecord()` MISS — the documented common case, `hook-sessions.ts:90` | same, 5021 | 0.0046ms | 215,863 — **1.65x slower than HIT** |
| `resolveHookSessionRecord`/`resolveHookSessionId` (pure Map-lookup chain) — `hook-sessions.ts:183,207` | 60-entry index | 0.00–0.0001ms | 17M–27M |

Full run: `npx vitest bench --run src/lib/session/hook-sessions.bench.ts` from `apps/cli` (pasted verbatim from the actual run):

```
 ✓ loadHookSessionIndex — terminals/sessions/ scan (60 seeded files) 605ms
     name                                        hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · readdirSync + read+parse every entry  4,631.33  0.2081  0.7188  0.2159  0.2148  0.2845  0.2967  0.6817  ±0.41%     2316

 ✓ readStateSessionRecord — targeted single-pid read (5021 files) 1960ms
     name                                                                                            hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · HIT — pid present, no staleness check                                                   356,317.20  0.0026  0.6327  0.0028  0.0028  0.0031  0.0039  0.0055  ±0.31%   178159
   · HIT — pid present, WITH startedAtMs freshness check                                     339,906.00  0.0026  3.8488  0.0029  0.0030  0.0043  0.0050  0.0098  ±1.56%   169953
   · MISS — untracked pid (the common case, hook-sessions.ts:90)                             215,863.09  0.0043  1.5697  0.0046  0.0046  0.0055  0.0061  0.0076  ±0.63%   107932

 ✓ resolveHookSessionRecord / resolveHookSessionId — Map lookup over the pre-built index 10622ms
     name                                                                                   hz     min     max    mean     p75     p99    p995    p999     rme   samples
   · direct pid hit (no launchId/terminalId)                                     25,765,973.78  0.0000  0.0263  0.0000  0.0000  0.0000  0.0000  0.0000  ±0.03%  12882988
   · launchId hit (priority path)                                                17,441,316.88  0.0000  0.1047  0.0001  0.0001  0.0001  0.0001  0.0001  ±0.05%   8720659
   · miss — all keys absent                                                      27,018,841.19  0.0000  0.0284  0.0000  0.0000  0.0000  0.0000  0.0000  ±0.04%  13509421
```

## PROPOSALS (supported by the measurements above)

1. **`apps/cli/src/lib/session/active.ts:1492,1533` (`listUnattributedActive`) and `apps/cli/src/lib/session/active.ts:1702-1703` (`listTmuxAgentSessions`) each maintain their own local `hookIndex` memo, but `getActiveSessions()` (`apps/cli/src/lib/session/active.ts:1818-1841`) calls both within one poll cycle** (`listTmuxAgentSessions` at line 1820, `listUnattributedActive` at line 1831) — so `loadHookSessionIndex()` (`hook-sessions.ts:126`) can run twice per single `sessions --active` ~3s tick instead of once, whenever both functions have at least one candidate needing the hook join. Measured cost of one extra scan at the 60-file counterfactual scale: 0.216ms. Negligible today (real fleet count is 0 files), but it doubles for zero benefit the moment `@agents/session-tracker` is deployed — which is the scenario this reader module exists for. Fix: hoist one `hookIndex` memo to `getActiveSessions()` and thread it into both call sites (mirrors how `listTmuxAgentSessions` already threads its own `getHookIndex` callback into `resolvePaneIdentity` at line 1726).
2. **`hook-sessions.ts:87-91` `readStateSessionRecord`'s ENOENT path — the documented common case (`hook-sessions.ts:90`: "absent (the common case) or unreadable") — measures 1.65x slower than the hit path** (0.0046ms vs 0.0028ms mean, at the real 5021-file graveyard scale), plausibly the cost of throwing+catching a `fs.readFileSync` `ENOENT` `Error` (V8 stack-capture) on every miss. Flagging as informational, not urging a change: absolute magnitude is ~1.8 microseconds/call, and a `fs.existsSync()` precheck would add a syscall to the (already-fast) hit path to save one on the miss path — the net direction depends on the real hit/miss ratio in the tmux-pane loop (`active.ts:1742-1743`), which this bench doesn't measure.
3. **No optimization needed for `resolveHookSessionRecord`/`resolveHookSessionId`** — pure `Map` lookups, 17M-27M ops/sec, not a measurable cost at any realistic index size.

## Evidence

- `apps/cli/src/lib/session/hook-sessions.ts:6-15` — module docblock describes the two on-disk sources this file reads.
- `apps/cli/src/lib/session/hook-sessions.ts:8-9` — "`@agents/session-tracker`... is NOT deployed on the fleet — its dir is empty there" (verified directly: `ls ~/.agents/.cache/terminals/sessions | wc -l` → 0 on this box).
- `apps/cli/src/lib/session/hook-sessions.ts:66` — `state/sessions/` is "an unpruned graveyard (thousands of dead-pid files)" (verified: 5021 files on this box).
- `apps/cli/src/lib/exec.ts:1704-1717` (`emitResolvedSessionId`) and `apps/cli/src/lib/exec.ts:1953` — the `--host` dispatch call site.
- `apps/cli/src/lib/session/active.ts:1487-1541` and `apps/cli/src/lib/session/active.ts:1668-1745` — the `sessions --active` poll call sites (`listUnattributedActive`, `listTmuxAgentSessions`).
- `apps/cli/vitest.config.ts:18` — `include` lists only `*.test.ts` globs, confirming `*.bench.ts` files aren't run by `vitest run`.

## Test plan

- [x] `npx vitest bench --run src/lib/session/hook-sessions.bench.ts` from `apps/cli` — real numbers pasted above.
- [x] Benchmark committed beside the source (`apps/cli/src/lib/session/hook-sessions.bench.ts`).
- [x] No mocking — exercises the real exported reader functions against real on-disk JSON with realistic shapes; `state/sessions/` seeded at this box's actual measured file count.
