### PR TITLE
bench(hosts): benchmark --host/--device dispatch resolution + SSH command building

### DIFF
--- a/apps/cli/src/lib/hosts/dispatch.bench.ts
+++ b/apps/cli/src/lib/hosts/dispatch.bench.ts
@@ -1,0 +1,170 @@
+/**
+ * Benchmark for the `--host`/`--device` dispatch hot path: host resolution
+ * (registry.ts:196 matchHost, registry.ts:296 resolveHost) and the pure SSH
+ * command-building functions (dispatch.ts, remote-cmd.ts) every offload
+ * caller (`run --host`, `agents ssh`, `agents teams start --host`) runs
+ * before the actual SSH round-trip.
+ *
+ * No mocking. `tests/setup.ts` (a vitest setupFile, so it also applies to
+ * `vitest bench`) redirects AGENTS_DEVICES_DIR to a fork-private temp dir for
+ * hermeticity (state.ts:613 getDevicesDir reads it at CALL time, never at
+ * module load — see the comment there), so a bare `loadDevices()` call in
+ * this fork sees an EMPTY registry, not this machine's real fleet. Rather
+ * than fight that isolation (or depend on whichever devices happen to be
+ * enrolled on the machine running the bench, which would make the numbers
+ * non-reproducible across boxes and leak real hostnames/IPs into a committed
+ * file), this file seeds ITS OWN fork-private registry with data shaped
+ * exactly like a real fleet: 14 devices — matching the actual device count
+ * measured directly against this machine's live
+ * ~/.agents/.history/devices/registry.json (8765 bytes, 14 entries) on
+ * 2026-08-06 — spanning macos/linux/windows platforms, tailscale addresses,
+ * and key auth, the same shape `devices/registry.ts:94` DeviceProfile
+ * defines and `agents devices sync` writes for real.
+ *
+ * agents.yaml (state.ts:1124 readMeta) and ~/.ssh/config (ssh-config.ts:67
+ * listSshConfigHosts) are NOT redirected by setup.ts, so those two read this
+ * machine's REAL files — same "real ~/.agents layout" philosophy as
+ * exec.bench.ts. This box's agents.yaml has no top-level `hosts:` overlay
+ * (verified directly), so every overlay lookup below is a real miss.
+ *
+ * Not wired into `vitest run` (vitest.config.ts:18 include is *.test.ts
+ * only) — run by hand: `npx vitest bench --run dispatch.bench.ts`.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, bench } from 'vitest';
+import type { DispatchOptions } from './dispatch.js';
+
+// Read at CALL time by state.ts:613 getDevicesDir(), so reassigning it here
+// (this file's imports run AFTER tests/setup.ts's own assignment) safely
+// repoints every loadDevices()/loadDevicesSync() call below at a registry
+// this file controls, with no lock/network contention and no risk of ever
+// touching a real fleet file.
+const BENCH_DEVICES_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-hosts-bench-devices-'));
+process.env.AGENTS_DEVICES_DIR = BENCH_DEVICES_DIR;
+
+const PLATFORMS = ['macos', 'linux', 'windows'] as const;
+const DEVICE_COUNT = 14; // matches this machine's real fleet size, measured 2026-08-06
+const seededRegistry: Record<string, unknown> = {};
+for (let i = 0; i < DEVICE_COUNT; i++) {
+  const name = `bench-device-${i}`;
+  const platform = PLATFORMS[i % PLATFORMS.length];
+  seededRegistry[name] = {
+    name,
+    platform,
+    shell: platform === 'windows' ? 'powershell' : 'posix',
+    user: 'bench',
+    address: { via: 'tailscale', dnsName: `${name}.tailnet-bench.ts.net`, ip: `100.64.0.${i + 1}` },
+    auth: { method: 'key' },
+    tailscale: { online: true, direct: i % 2 === 0, relay: i % 2 === 0 ? undefined : 'sfo', lastSeen: '2026-01-01T00:00:00Z' },
+    reachability: { reachable: true, via: 'tailscale', checkedAt: '2026-01-01T00:00:00Z' },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  };
+}
+fs.mkdirSync(BENCH_DEVICES_DIR, { recursive: true });
+fs.writeFileSync(path.join(BENCH_DEVICES_DIR, 'registry.json'), JSON.stringify(seededRegistry, null, 2));
+
+const { matchHost, resolveHost } = await import('./registry.js');
+const { resolveRemoteOsSync } = await import('./remote-os.js');
+const {
+  buildRunForwardedArgs,
+  remoteCdPrefix,
+  buildDetachedLaunchCommand,
+  withActorEnv,
+  remoteRunShellPrelude,
+} = await import('./dispatch.js');
+const { loadDevices, loadDevicesSync } = await import('../devices/registry.js');
+const { readMeta } = await import('../state.js');
+const { isSshConfigHost } = await import('./ssh-config.js');
+
+const REAL_DEVICE_NAME = 'bench-device-0';
+const ALL_DEVICE_NAMES = Array.from({ length: DEVICE_COUNT }, (_, i) => `bench-device-${i}`);
+
+describe('matchHost / resolveHost — device resolution (registry.ts:196, :296)', () => {
+  bench(`matchHost: registered device short-circuit ("${REAL_DEVICE_NAME}")`, async () => {
+    await matchHost(REAL_DEVICE_NAME);
+  });
+
+  bench(`resolveHost: same device, plus control/password/address checks (registry.ts:296)`, async () => {
+    await resolveHost(REAL_DEVICE_NAME);
+  });
+});
+
+describe('matchHost — miss path (worst case: device miss -> overlay miss -> real ~/.ssh/config scan -> null)', () => {
+  bench('matchHost: bare name matching nothing (loadDevices + readMeta + isSshConfigHost all pay, registry.ts:217-236)', async () => {
+    await matchHost('agents-cli-bench-nonexistent-host-zzz');
+  });
+
+  bench('matchHost: ad-hoc user@literal (skips the ssh-config scan; still pays loadDevices + readMeta, registry.ts:241-243)', async () => {
+    await matchHost('bench-user@203.0.113.5');
+  });
+});
+
+describe('loadDevices / loadDevicesSync — UNCACHED read+JSON.parse of the whole registry file (devices/registry.ts:255, :279)', () => {
+  bench('loadDevices (async, fs.readFile) — every matchHost call pays this fresh, no mtime cache unlike readMeta', async () => {
+    await loadDevices();
+  });
+
+  bench('loadDevicesSync (fs.readFileSync) — resolveRemoteOsSync pays this fresh on every call too', () => {
+    loadDevicesSync();
+  });
+});
+
+describe('resolveRemoteOsSync — UNCACHED loadDevicesSync call (remote-os.ts:21)', () => {
+  bench(`resolveRemoteOsSync("${REAL_DEVICE_NAME}") — re-reads + re-parses the registry file every call, called once in matchHost's ssh-config branch and again in dispatch.ts:339 launchDetached when host.os is undefined`, () => {
+    resolveRemoteOsSync(REAL_DEVICE_NAME);
+  });
+});
+
+describe('readMeta vs isSshConfigHost — the CACHED overlay lookup next to the UNCACHED ssh-config scan (state.ts:1124, ssh-config.ts:117)', () => {
+  bench('readMeta() — mtime-cached (state.ts:1130-1134); this box has no top-level `hosts:` overlay so every matchHost overlay lookup is a real miss', () => {
+    readMeta();
+  });
+
+  bench('isSshConfigHost("agents-cli-bench-nonexistent-host-zzz") — fs.readFileSync(~/.ssh/config) + full re-parse, no cache at all (ssh-config.ts:67-90, :117-119)', () => {
+    isSshConfigHost('agents-cli-bench-nonexistent-host-zzz');
+  });
+});
+
+describe('matchHost fan-out — resolving every device in a 14-host fleet sequentially (agents fleet status / doctor --devices / teams --host shape)', () => {
+  bench(`matchHost across all ${DEVICE_COUNT} seeded devices, one call per host — each pays a fresh loadDevices() with no cache`, async () => {
+    for (const name of ALL_DEVICE_NAMES) {
+      await matchHost(name);
+    }
+  });
+});
+
+describe('dispatch.ts — pure command-building (runs on every --host/--device dispatch before the ssh round-trip)', () => {
+  const opts: DispatchOptions = {
+    agent: 'claude',
+    prompt: 'benchmark prompt for the host dispatch path',
+    mode: 'auto',
+    env: ['FOO=bar', 'BAZ=qux'],
+    addDir: ['/tmp/one', '/tmp/two'],
+    name: 'bench-run',
+  };
+
+  bench('buildRunForwardedArgs (dispatch.ts:511)', () => {
+    buildRunForwardedArgs(opts);
+  });
+
+  bench('remoteCdPrefix, mirrored home-relative cwd (dispatch.ts:79)', () => {
+    remoteCdPrefix('~/src/github.com/muqsitnawaz/agents-cli', { mirror: true });
+  });
+
+  bench('buildDetachedLaunchCommand (dispatch.ts:147)', () => {
+    buildDetachedLaunchCommand(
+      "agents run claude 'hi' --quiet > $HOME/.agents/.cache/hosts/x.log 2>&1; echo $? > $HOME/.agents/.cache/hosts/x.exit",
+    );
+  });
+
+  bench('withActorEnv — resolveActor() + terminalIdEnv() on every launchDetached/runInteractiveOnHost call (dispatch.ts:98)', () => {
+    withActorEnv();
+  });
+
+  bench('remoteRunShellPrelude — full env-export prelude assembled for every launchDetached call (dispatch.ts:113)', () => {
+    remoteRunShellPrelude('claude');
+  });
+});


### PR DESCRIPTION
**bench-only — no production code changed.** Adds `apps/cli/src/lib/hosts/dispatch.bench.ts`, a vitest benchmark of the `--host`/`--device` dispatch hot path per RUSH request: host resolution (`matchHost`/`resolveHost`, `apps/cli/src/lib/hosts/registry.ts`) and the pure SSH command-building helpers (`apps/cli/src/lib/hosts/dispatch.ts`, `remote-cmd.ts`). Not wired into `vitest run` — `apps/cli/vitest.config.ts:18` `include` is `*.test.ts` only, so this file is invisible to CI and run by hand.

No mocking: it exercises the real production code paths. `readMeta()` (`apps/cli/src/lib/state.ts:1124`) and `~/.ssh/config` scanning (`apps/cli/src/lib/hosts/ssh-config.ts:67`) read THIS machine's real files. The devices registry is seeded in a fork-private temp dir (via `AGENTS_DEVICES_DIR`, the same test-isolation hook `apps/cli/src/lib/hosts/registry.test.ts` already uses) with 14 devices shaped exactly like a real fleet entry (`devices/registry.ts:94` `DeviceProfile`) — 14 matches this machine's real `~/.agents/.history/devices/registry.json` device count, measured directly (8765 bytes, 14 entries) on 2026-08-06. Seeding rather than reading the live registry keeps the bench reproducible across machines/CI and avoids committing real hostnames/IPs.

## Measured (this box, `/proc/loadavg` 1.52→1.77 across the run)

```
matchHost / resolveHost — device resolution (registry.ts:196, :296)
  matchHost: registered device short-circuit                                    mean 0.1393ms  (7,181 hz)
  resolveHost: same device + control/password/address checks                    mean 0.1216ms  (8,226 hz)

matchHost — miss path (device miss -> overlay miss -> ssh-config scan -> null)
  matchHost: bare unmatched name (all 3 lookups pay)                            mean 0.1345ms  (7,436 hz)
  matchHost: ad-hoc user@literal (skips ssh-config scan)                        mean 0.1309ms  (7,641 hz)

loadDevices / loadDevicesSync — UNCACHED read+JSON.parse (devices/registry.ts:255, :279)
  loadDevices (async, fs.readFile)                                              mean 0.1247ms  (8,019 hz)
  loadDevicesSync (fs.readFileSync)                                             mean 0.0186ms  (53,879 hz)

resolveRemoteOsSync — UNCACHED loadDevicesSync call (remote-os.ts:21)
  resolveRemoteOsSync("bench-device-0")                                         mean 0.0186ms  (53,870 hz)

readMeta (mtime-cached) vs isSshConfigHost (uncached)
  readMeta() — state.ts:1130-1134 mtime-stamp cache                             mean 0.0369ms  (27,121 hz)
  isSshConfigHost() — fs.readFileSync(~/.ssh/config), no cache                  mean 0.0034ms  (296,381 hz)

matchHost fan-out — 14 devices resolved sequentially (fleet status / doctor --devices shape)
  matchHost x 14, one call per host                                             mean 1.7065ms  (586 hz total)

dispatch.ts — pure command-building
  buildRunForwardedArgs (dispatch.ts:511)                                       mean 0.0001ms
  remoteCdPrefix, mirrored cwd (dispatch.ts:79)                                 mean 0.0001ms
  buildDetachedLaunchCommand (dispatch.ts:147)                                  mean 0.0013ms
  withActorEnv (dispatch.ts:98)                                                 mean 0.0002ms
  remoteRunShellPrelude (dispatch.ts:113)                                       mean 0.0006ms
```

Full raw output: `npx vitest bench --run src/lib/hosts/dispatch.bench.ts` inside `apps/cli` (re-run twice, numbers stable within ~5%).

## Proposals (from the measured numbers above — nothing unmeasured)

1. **Cache `loadDevices`/`loadDevicesSync`** (`apps/cli/src/lib/devices/registry.ts:255`, `:279`) with the same mtime-stamp pattern `readMeta()` already uses (`apps/cli/src/lib/state.ts:1124-1134`). `matchHost()` (`registry.ts:196`) calls `loadDevices()` unconditionally as its first step (`registry.ts:219`) on *every* invocation regardless of match outcome, with zero caching — measured mean 0.09-0.12ms per call vs `readMeta`'s cached 0.037ms for a comparably-sized file. The cost is invisible on a single dispatch (dwarfed by the SSH round-trip) but compounds linearly under fan-out: the measured 14-host sequential resolution (`agents fleet status`, `agents doctor --devices`, `teams --host` scheduling all resolve one host at a time) costs 1.71ms total for reading the *same unchanged file* 14 times. A cache collapses repeat in-process calls toward the warm `loadDevicesSync` cost (~0.02ms), i.e. one real read instead of N.

2. **Cache `isSshConfigHost`/`listSshConfigHosts()`** (`apps/cli/src/lib/hosts/ssh-config.ts:67`, `:117`), called unconditionally on every `matchHost()` miss (`registry.ts:235`) and by `resolveHostByCap`'s `listAllHosts()` fan-out (`registry.ts:319`). Measured mean 0.0034ms on this box's small `~/.ssh/config`, but it re-reads the file plus follows every `Include` glob (`ssh-config.ts:78-86`) with no caching at all — scales with config size and repeat-lookup count exactly like proposal 1, just currently cheaper because this file happens to be small.

3. **Stop double-resolving a host's OS.** `resolveRemoteOsSync` (`remote-os.ts:21`) is called from three sites that can all fire for the same dispatch: `registry.ts:236` (`matchHost`'s bare ssh-config-alias branch), `ready.ts:308` (`ensureHostReady`, invoked from `dispatchToHost` at `dispatch.ts:659`), and `dispatch.ts:339` (`launchDetached`, invoked right after `ensureHostReady` in the same `dispatchToHost` call, `dispatch.ts:662`). Each pays a fresh uncached `loadDevicesSync()` (measured mean 0.0186ms). This only matters for hosts with no registry `platform`/overlay `os` hint (an ssh-config-only alias, or a device recorded `platform: 'unknown'`) — a normally-registered device already short-circuits via `host.os ?? resolveRemoteOsSync(...)`. Once (1) lands this becomes near-free automatically; alternatively thread the OS `ensureHostReady` already resolved into `launchDetached` instead of re-deriving it.

None of these move the needle on a single dispatch — SSH connection setup (tens to hundreds of ms) dominates every real call. The payoff is fleet-wide fan-out (`fleet status`, `doctor --devices`, `sessions --host`, `teams` scheduling across many devices), where it's currently O(N) reads of one unchanged file that the `readMeta()` pattern already shows how to make O(1).

## Test plan
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx vitest run src/lib/hosts/` — 20 files, 321 passed / 1 skipped (unaffected; bench file not picked up)
- [x] `npx vitest bench --run src/lib/hosts/dispatch.bench.ts` — real numbers above, `/proc/loadavg` recorded before/after
