### PR TITLE
bench(cli): index.bench.ts for checkForUpdates + spawnDetachedSync hot path

### DIFF
--- a/apps/cli/src/index.bench.ts
+++ b/apps/cli/src/index.bench.ts
@@ -1,0 +1,129 @@
+/**
+ * Benchmark for the CLI entry hot path: `checkForUpdates()` (index.ts:755) and
+ * `spawnDetachedSync()` (index.ts:1330), both of which run on EVERY ordinary
+ * `agents` invocation except pure `--help`/`--version` (index.ts:1319-1331 guards
+ * them behind `!helpOrVersionRequested`). The comment at index.ts:51 flags this
+ * same pair as the reason the secrets-broker sync commands are intercepted
+ * above commander registration, before `checkForUpdates()`/`spawnDetachedSync()`
+ * would otherwise fire on every cache-hit read.
+ *
+ * `checkForUpdates` (index.ts:755-779) and its helper `maybeWarnMultiInstall`
+ * (index.ts:535-575) are NOT exported -- they are private to index.ts, and
+ * index.ts cannot be imported directly: it has top-level `await`, reads
+ * `process.argv`, and (outside the two early-intercept blocks at index.ts:38 and
+ * index.ts:71) eventually calls `program.parse()`, so importing the module as
+ * ESM would run the real CLI bootstrap as a side effect of loading this bench
+ * file. Instead this benchmarks the exact exported functions `checkForUpdates`
+ * calls, with the same real arguments (this machine's real PATH, its real
+ * ~/.agents/.cache/.update-check file):
+ *
+ *   maybeWarnMultiInstall (index.ts:535-575)
+ *     -> resolveRunningPackageRoot (self-update.ts:177)
+ *     -> findAgentsCliInstalls(process.env.PATH)      (self-update.ts:509)
+ *     -> buildMultiInstallInventory(...)              (self-update.ts:401)
+ *   checkForUpdates body (index.ts:755-779)
+ *     -> readUpdateCache(UPDATE_CHECK_FILE)           (self-update.ts:79)
+ *     -> shouldFetchLatest(cache)                     (index.ts:578, PRIVATE -- see note below)
+ *     -> shouldPromptUpgrade(cache, VERSION)           (self-update.ts:128)
+ *
+ * `shouldFetchLatest` (index.ts:578) is itself private to index.ts (not
+ * self-update.ts, despite living right beside the exported update-cache
+ * helpers there) -- it is NOT benched directly for the same reason
+ * `checkForUpdates` itself isn't: nothing can import it without importing all
+ * of index.ts. It is one pure comparison (`Date.now() - cache.lastCheck >
+ * UPDATE_CHECK_INTERVAL_MS`), immaterial next to the real fs/PATH work
+ * measured below -- readUpdateCache's real fs.readFileSync + JSON.parse
+ * dominates it by construction, and readUpdateCache is exported and benched.
+ *
+ * `refreshUpdateCacheInBackground` (index.ts:739-752) and the interactive
+ * `promptUpgrade` path are NOT benched: the former is a fire-and-forget network
+ * fetch (`fetch(...).then(...)`, never awaited by the caller) and the latter is
+ * an interactive TTY prompt -- neither is on the synchronous hot path this file
+ * measures, and neither fires on a plain terminal `agents <cmd>` run against a
+ * fresh cache.
+ *
+ * `spawnDetachedSync` (auto-pull.ts:46-72) IS exported and is benched directly,
+ * but with one twist: it resolves its worker script relative to
+ * `fileURLToPath(import.meta.url)` (auto-pull.ts:51), i.e. relative to wherever
+ * the RUNNING copy of this module lives. Importing it the normal bench way (via
+ * './lib/auto-pull.js', vitest's TS-source resolution) would put that module at
+ * src/lib/auto-pull.ts, where only auto-pull-worker.TS exists -- so
+ * `fs.existsSync(workerPath)` (auto-pull.ts:53) would ALWAYS be false and the
+ * function would always take the early-return guard path, never actually
+ * spawning anything. That is real behavior for an unbuilt checkout, but it is
+ * not what a real user's installed copy does (npm ships dist/lib/auto-pull-
+ * worker.js). To measure the real spawn this file imports the ACTUAL BUILT
+ * ARTIFACT at ../dist/lib/auto-pull.js (produced by `bun run build` /
+ * `bun install`'s `prepare` hook) so `import.meta.url` resolves inside dist/lib/
+ * and the real dist/lib/auto-pull-worker.js is found. Both regimes are benched
+ * explicitly below so the guard-path cost and the real fork+exec cost are never
+ * conflated.
+ *
+ * No mocking: every call below hits the real filesystem (real PATH, real
+ * ~/.agents/.cache files) and, in the "real spawn" group, a real
+ * child_process.spawn of the real dist/lib/auto-pull-worker.js -- which itself
+ * does a real `git fetch` against this machine's real ~/.agents repos in the
+ * background (detached, unref'd, so it does not block this process or this
+ * benchmark's timing; see auto-pull-worker.ts). That group is therefore bounded
+ * to a small iteration count, mirroring exec.bench.ts's execAgent group.
+ */
+import { describe, bench } from 'vitest';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  readUpdateCache,
+  shouldPromptUpgrade,
+  buildMultiInstallInventory,
+  findAgentsCliInstalls,
+  resolveRunningPackageRoot,
+} from './lib/self-update.js';
+import { getUpdateCheckPath } from './lib/state.js';
+// Real built artifact (see docblock above) -- NOT './lib/auto-pull.js', which
+// would resolve to the unbuilt TS source and always miss the worker script.
+// @ts-expect-error -- plain JS build output, no .d.ts resolution needed here.
+import { spawnDetachedSync } from '../dist/lib/auto-pull.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const UPDATE_CHECK_FILE = getUpdateCheckPath();
+const REAL_PATH = process.env.PATH || '';
+
+describe('checkForUpdates — maybeWarnMultiInstall (index.ts:535-575): the PATH + known-install-root scan', () => {
+  bench('resolveRunningPackageRoot(__dirname) — real path math, no fs walk when not a bunfs virtual path (self-update.ts:177)', () => {
+    resolveRunningPackageRoot(__dirname);
+  });
+
+  bench(`findAgentsCliInstalls(process.env.PATH) — real PATH scan (${REAL_PATH.split(path.delimiter).filter(Boolean).length} real entries on this box) + known nvm/fnm/volta/bun/npx roots (self-update.ts:509)`, () => {
+    findAgentsCliInstalls(REAL_PATH);
+  });
+
+  bench('maybeWarnMultiInstall end-to-end: resolveRunningPackageRoot + findAgentsCliInstalls + buildMultiInstallInventory (index.ts:539-550) -- dominated by the PATH scan above; the Map-based aggregation itself (self-update.ts:401) is negligible over the small install list it runs on', () => {
+    const runningRoot = resolveRunningPackageRoot(__dirname);
+    const installs = findAgentsCliInstalls(REAL_PATH);
+    buildMultiInstallInventory(runningRoot, '0.0.0-bench', installs);
+  });
+});
+
+describe('checkForUpdates — cache read + prompt decision (index.ts:755-779)', () => {
+  bench(`readUpdateCache(UPDATE_CHECK_FILE) — real ~/.agents/.cache/.update-check read (self-update.ts:79)`, () => {
+    readUpdateCache(UPDATE_CHECK_FILE);
+  });
+
+  bench('shouldPromptUpgrade — pure comparison against the real cached value, incl. compareVersions (self-update.ts:128)', () => {
+    const cache = readUpdateCache(UPDATE_CHECK_FILE);
+    shouldPromptUpgrade(cache, '0.0.0-bench');
+  });
+});
+
+describe('spawnDetachedSync (index.ts:1330, auto-pull.ts:46-72) — guard-path only (AGENTS_NO_AUTOPULL=1, no spawn)', () => {
+  bench('early return: env check only (auto-pull.ts:47)', () => {
+    process.env.AGENTS_NO_AUTOPULL = '1';
+    spawnDetachedSync();
+  });
+});
+
+describe('spawnDetachedSync — real detached child_process.spawn against the built dist/lib/auto-pull-worker.js', () => {
+  bench('fileURLToPath + path.join + fs.existsSync + spawn().unref() (auto-pull.ts:51-68) — forks a real process, real background git fetch', () => {
+    delete process.env.AGENTS_NO_AUTOPULL;
+    spawnDetachedSync();
+  }, { time: 2000, iterations: 10 });
+});


### PR DESCRIPTION
**bench-only** — no production code changed. Adds `apps/cli/src/index.bench.ts`, measures the entry-point cost every ordinary `agents` invocation pays.

## What's benchmarked

`index.ts:1319-1331` runs `checkForUpdates()` (`index.ts:755-779`) and `spawnDetachedSync()` (`index.ts:1330`, `auto-pull.ts:46-72`) on **every** invocation except pure `--help`/`--version`. `checkForUpdates` and its helper `maybeWarnMultiInstall` (`index.ts:535-575`) are private to `index.ts`, which can't be imported directly (top-level `await`, reads `process.argv`, eventually calls `program.parse()`) — so the bench targets the exact exported functions they call, with the same real arguments (this machine's real `PATH`, its real `~/.agents/.cache/.update-check` file):

- `resolveRunningPackageRoot` (`self-update.ts:177`)
- `findAgentsCliInstalls` (`self-update.ts:509`) — the PATH + known-install-root scan
- `buildMultiInstallInventory` (`self-update.ts:401`)
- `readUpdateCache` (`self-update.ts:79`)
- `shouldPromptUpgrade` (`self-update.ts:128`)
- `spawnDetachedSync` (`auto-pull.ts:46-72`) — benched against the real **built** `dist/lib/auto-pull-worker.js` (imported from `../dist/lib/auto-pull.js`, not the TS source) so the real fork+exec is measured, not the early-return guard path an unbuilt checkout hits

Full rationale for each choice is in the file's docblock, including the one bug I hit and fixed: `shouldFetchLatest` looked like a `self-update.ts` export but is actually private to `index.ts:578` — importing it from `self-update.ts` silently resolved to `undefined`, and calling it threw, which silently dropped that bench group's table (no error printed, `NaN` in the summary). Fixed by removing it from the bench and documenting why.

Not wired into `vitest run` — `vitest.config.ts:18` include is `*.test.ts` only. Run by hand: `npx vitest bench --run src/index.bench.ts` (from `apps/cli`; needs `bun install && bun run build` first so `dist/lib/auto-pull-worker.js` exists for the real-spawn group).

## Measured (this box, `/proc/loadavg` ~2.8–3.4 during the runs, 3 consecutive runs, consistent)

| Call | mean | p99 | max |
|---|---|---|---|
| `resolveRunningPackageRoot` | 0.0007ms | 0.0009ms | 4.4ms (GC outlier) |
| `findAgentsCliInstalls` (49 real PATH entries + known roots) | ~1.02–1.03ms | ~1.2–1.5ms | ~2.0ms |
| `maybeWarnMultiInstall` end-to-end | ~1.03ms | ~1.5ms | ~2.0ms |
| `readUpdateCache` | ~0.0022ms | ~0.0026ms | 0.67ms |
| `shouldPromptUpgrade` (incl. `compareVersions`) | ~0.0025ms | ~0.003ms | 1.3ms |
| `spawnDetachedSync`, `AGENTS_NO_AUTOPULL=1` guard | 0.0006ms | 0.0007ms | 0.08ms |
| `spawnDetachedSync`, real spawn (dist worker present) | **~7.3–7.7ms** | **~30–45ms** | **up to 68ms** |

Raw table output for one run:
```
 ✓ checkForUpdates — maybeWarnMultiInstall … 2097ms
   resolveRunningPackageRoot           hz 1,489,957.21  mean 0.0007ms
   findAgentsCliInstalls (49 entries)  hz       981.31  mean 1.0190ms  p99 1.2361ms
   maybeWarnMultiInstall end-to-end    hz       970.74  mean 1.0301ms  p99 1.4720ms

 ✓ checkForUpdates — cache read + prompt decision … 1334ms
   readUpdateCache                     hz 451,997.50  mean 0.0022ms
   shouldPromptUpgrade                 hz 396,230.36  mean 0.0025ms

 ✓ spawnDetachedSync — guard-path only … 916ms
   early return (env check)            hz 1,771,644.89  mean 0.0006ms

 ✓ spawnDetachedSync — real detached spawn … 2125ms
   real fork+exec                      hz       129.36  mean 7.7306ms  p99 44.9776ms  max 68.1187ms
```

Estimated added latency per ordinary (non-doc) CLI invocation: **~1.03ms (multi-install scan) + ~0.0022ms (cache read) + ~7.3–7.7ms (detached spawn) ≈ 8.3ms mean, tail up to ~50-70ms.**

## Proposals (measured, not implemented here)

1. **Skip the detached spawn when the sync lock is still fresh** (`auto-pull.ts:46-72` `spawnDetachedSync`, guarded by `auto-pull-worker.ts:24` `LOCK_TTL_MS = 5 * 60 * 1000` + `auto-pull-worker.ts:51-56` `tryAcquireLock`). Right now `spawnDetachedSync()` unconditionally forks a full node/bun process (measured mean **7.3–7.7ms**, p99 **30–45ms**, max **68ms**) on *every single invocation*, even when the child immediately no-ops because a sync ran under 5 minutes ago (`tryAcquireLock` returns `false` and `processTarget` returns without doing anything, `auto-pull-worker.ts:104`). The lock files' mtimes (`auto-pull.ts:27-29` `lockFilePath`) are cheap to `fs.statSync` from the parent — checking them in `spawnDetachedSync()` before calling `spawn()` and skipping when all locks are fresh would eliminate this cost on the overwhelmingly common case of several commands run back-to-back within 5 minutes (typical for agent-driven CLI usage), which the measured **7.3ms mean / up to 68ms tail** confirms is the single largest contributor to this hot path.
2. **Cache the multi-install PATH scan behind a TTL**, mirroring the existing 24h `UPDATE_CHECK_INTERVAL_MS` pattern already used for the npm registry check (`index.ts:512`, `index.ts:763` `shouldFetchLatest`). `findAgentsCliInstalls` (`self-update.ts:509`, called from `maybeWarnMultiInstall` at `index.ts:546`) re-scans 49 real PATH entries plus ~9 known nvm/fnm/volta/bun/npx install roots (measured mean **~1.02–1.03ms**) on *every* invocation, but the set of installed copies on a machine changes only on `npm install`/upgrade — never between ordinary commands. Caching the scan result (e.g. keyed by a short TTL like 5–15 min, written next to the existing `~/.agents/.cache/.update-check` file) would turn this into a near-zero-cost cache read (`readUpdateCache` itself measures **~0.0022ms**) except once per TTL window.

Both proposals are measured cost-drivers only — no fix is included in this PR, per the bench-first scope of this task.
