### PR TITLE
bench(cli): fix index.bench.ts placement + stale ts-expect-error (follow-up to #2273)

### DIFF
--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -46,14 +46,14 @@
  * but with one twist: it resolves its worker script relative to
  * `fileURLToPath(import.meta.url)` (auto-pull.ts:51), i.e. relative to wherever
  * the RUNNING copy of this module lives. Importing it the normal bench way (via
- * './lib/auto-pull.js', vitest's TS-source resolution) would put that module at
+ * './auto-pull.js', vitest's TS-source resolution) would put that module at
  * src/lib/auto-pull.ts, where only auto-pull-worker.TS exists -- so
  * `fs.existsSync(workerPath)` (auto-pull.ts:53) would ALWAYS be false and the
  * function would always take the early-return guard path, never actually
  * spawning anything. That is real behavior for an unbuilt checkout, but it is
  * not what a real user's installed copy does (npm ships dist/lib/auto-pull-
  * worker.js). To measure the real spawn this file imports the ACTUAL BUILT
- * ARTIFACT at ../dist/lib/auto-pull.js (produced by `bun run build` /
+ * ARTIFACT at ../../dist/lib/auto-pull.js (produced by `bun run build` /
  * `bun install`'s `prepare` hook) so `import.meta.url` resolves inside dist/lib/
  * and the real dist/lib/auto-pull-worker.js is found. Both regimes are benched
  * explicitly below so the guard-path cost and the real fork+exec cost are never
@@ -66,6 +66,12 @@
  * background (detached, unref'd, so it does not block this process or this
  * benchmark's timing; see auto-pull-worker.ts). That group is therefore bounded
  * to a small iteration count, mirroring exec.bench.ts's execAgent group.
+ *
+ * Lives at src/lib/index.bench.ts, not src/index.bench.ts, so that
+ * `typecheck:bench` (package.json:58, globs `src/lib/*.bench.ts
+ * src/lib/**\/*.bench.ts`) actually type-checks it -- a prior version at
+ * src/index.bench.ts silently sat outside that glob and shipped a stale
+ * `@ts-expect-error` (TS2578, unused directive) that no gate caught.
  */
 import { describe, bench } from 'vitest';
 import * as path from 'node:path';
@@ -76,12 +82,13 @@ import {
   buildMultiInstallInventory,
   findAgentsCliInstalls,
   resolveRunningPackageRoot,
-} from './lib/self-update.js';
-import { getUpdateCheckPath } from './lib/state.js';
-// Real built artifact (see docblock above) -- NOT './lib/auto-pull.js', which
+} from './self-update.js';
+import { getUpdateCheckPath } from './state.js';
+// Real built artifact (see docblock above) -- NOT './auto-pull.js', which
 // would resolve to the unbuilt TS source and always miss the worker script.
-// @ts-expect-error -- plain JS build output, no .d.ts resolution needed here.
-import { spawnDetachedSync } from '../dist/lib/auto-pull.js';
+// dist/lib/auto-pull.d.ts exists (tsconfig.json declaration:true), so this
+// resolves and type-checks normally -- no @ts-expect-error needed here.
+import { spawnDetachedSync } from '../../dist/lib/auto-pull.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const UPDATE_CHECK_FILE = getUpdateCheckPath();


### PR DESCRIPTION
**bench-only, follow-up fix** — no production code changed.

#2273 added `apps/cli/src/index.bench.ts` (the `checkForUpdates`/`spawnDetachedSync` hot-path benchmark) and got merged by the owner before the non-author review's fix landed on the branch. This PR is that fix, rebased onto current `main`.

## What the review found on #2273

Independent subagent review (the documented fallback while `prix/code-reviewer` is paused, #1767) found:

- The bench file lived at `src/index.bench.ts`, **outside** `typecheck:bench`'s glob (`package.json:58`: `src/lib/*.bench.ts src/lib/**/*.bench.ts`), so it was never type-checked by that gate.
- Because of that gap, a stale `@ts-expect-error` on the `dist/lib/auto-pull.js` import went uncaught — `dist/lib/auto-pull.d.ts` exists (`tsconfig.json` `declaration: true`), so the import type-checks cleanly and the directive was **unused** (`TS2578`). Reproduced:
  ```
  npx tsc --noEmit --ignoreConfig --skipLibCheck --module esnext --moduleResolution bundler \
    --target es2022 --strict --esModuleInterop --lib es2022 --types node src/index.bench.ts

  src/index.bench.ts(83,1): error TS2578: Unused '@ts-expect-error' directive.
  ```

Review comment: https://github.com/phnx-labs/agents-cli/pull/2273#issuecomment-5205119845

## What this PR does

- Moves the file to `apps/cli/src/lib/index.bench.ts` — now covered by `typecheck:bench`.
- Fixes the relative imports for the new depth: `./self-update.js`, `./state.js`, `../../dist/lib/auto-pull.js`.
- Removes the incorrect `@ts-expect-error` directive and its comment.

Verified against current `main`:
```
$ npx tsc --noEmit --ignoreConfig --skipLibCheck --module esnext --moduleResolution bundler \
    --target es2022 --strict --esModuleInterop --lib es2022 --types node src/lib/index.bench.ts
(exit 0, no output)

$ npm run typecheck:bench
(exit 0, no output)
```

Re-ran the full benchmark from the new location to confirm nothing broke — numbers are consistent with the ones already merged in #2273 (`findAgentsCliInstalls` mean ~1.03ms, `spawnDetachedSync` real-spawn mean ~7.4ms, p99 ~20ms; `/proc/loadavg` ~2.6–6.9 during this run).
