### PR TITLE
perf(sessions): throttle headless ps/lsof scan + memo process table (#2047)

### DIFF
--- a/apps/cli/.changelog/next/issue-2047-unattrib-ps-cache.md
+++ b/apps/cli/.changelog/next/issue-2047-unattrib-ps-cache.md
@@ -1,0 +1,1 @@
+- perf(sessions): throttle headless `ps`/`lsof` scan + memoize process table across an active-session poll (#2047)

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -77,6 +77,88 @@ const LSOF_STAGGER_MS = 10;
 const LSOF_TIMEOUT_MS = 5_000;
 const PS_SNAPSHOT_TIMEOUT_MS = 10_000;
 
+/**
+ * Process-local process-table memo (#2047). One `getActiveSessions` scan can
+ * call `ps -A` from the terminal path, the headless path, and host ancestry —
+ * without this, each is a full process-table snapshot. 5s is well under the
+ * ~10–30s menu-bar / `--active` poll so a quiet re-poll usually reuses the
+ * snapshot; a brand-new agent pid still appears on the next full refresh.
+ */
+export const PROCESS_TABLE_FRESH_MS = 5_000;
+
+/**
+ * How long {@link listUnattributedActive} may reuse its last full `ps`+`lsof`
+ * result (#2047). Between full rescans the previous rows are re-emitted after
+ * dropping dead PIDs and PIDs that are now attributed. A *shrinking* attributed
+ * set forces a rescan so a process that just left teams/terminals can reappear
+ * as headless instead of vanishing until the next cold poll.
+ */
+export const UNATTRIBUTED_RESCAN_MS = 15_000;
+
+/** Injectable clock for the active-scan memos (tests only). */
+let activeScanNow: () => number = () => Date.now();
+
+/** Test seam: override the clock used by process-table / unattributed memos. */
+export function setActiveScanClockForTest(fn?: () => number): void {
+  activeScanNow = fn ?? (() => Date.now());
+}
+
+let processTableCache: { at: number; rows: ProcRow[] } | undefined;
+let processTableLiveReads = 0;
+let unattributedCache: {
+  at: number;
+  attributed: Set<number>;
+  sessions: ActiveSession[];
+} | undefined;
+let unattributedFullRescans = 0;
+
+/** Test seam: drop the process-table + unattributed memos and their counters. */
+export function clearActiveScanCachesForTest(): void {
+  processTableCache = undefined;
+  processTableLiveReads = 0;
+  unattributedCache = undefined;
+  unattributedFullRescans = 0;
+  activeScanNow = () => Date.now();
+}
+
+/** Test seam: how many times the live `ps` / CIM path actually ran. */
+export function processTableLiveReadCountForTest(): number {
+  return processTableLiveReads;
+}
+
+/** Test seam: how many full unattributed (ps + lsof) rescans ran. */
+export function unattributedFullRescanCountForTest(): number {
+  return unattributedFullRescans;
+}
+
+/**
+ * True when any pid in `prev` is absent from `next` — the attributed set
+ * shrank, so a process may need to reappear as unattributed. Pure for tests.
+ */
+export function attributedSetLostPids(prev: Set<number>, next: Set<number>): boolean {
+  for (const p of prev) {
+    if (!next.has(p)) return true;
+  }
+  return false;
+}
+
+/**
+ * Drop rows whose pid is now attributed or no longer alive. Pure over the
+ * inputs so the unattributed TTL reuse path is unit-testable without a live
+ * process table.
+ */
+export function filterCachedUnattributed(
+  sessions: ActiveSession[],
+  attributed: Set<number>,
+  alive: (pid: number) => boolean,
+): ActiveSession[] {
+  return sessions.filter((s) => {
+    if (s.pid == null) return false;
+    if (attributed.has(s.pid)) return false;
+    return alive(s.pid);
+  });
+}
+
 export type ActiveContext = 'terminal' | 'teams' | 'cloud' | 'headless';
 
 /**
@@ -1263,8 +1345,25 @@ const HOST_MATCHERS: Array<{ host: string; tokens: string[] }> = [
  * walk ancestry chains to attribute child processes to their terminal hosts.
  * `comm` may be an absolute path for shim-launched agents, so basename before
  * matching against AGENT_CLI_NAMES.
+ *
+ * Memoized for {@link PROCESS_TABLE_FRESH_MS} so one active-session scan (and a
+ * quiet re-poll within the window) does not re-shell `ps -A` / CIM for every
+ * caller — terminal host detection, headless attribution, and `hostFromPid`
+ * all share the same snapshot (#2047).
  */
 async function readProcessTable(): Promise<ProcRow[]> {
+  const now = activeScanNow();
+  if (processTableCache && now - processTableCache.at < PROCESS_TABLE_FRESH_MS) {
+    return processTableCache.rows;
+  }
+  const rows = await readProcessTableLive();
+  processTableCache = { at: now, rows };
+  return rows;
+}
+
+/** Uncached process-table snapshot (the live `ps` / CIM path). */
+async function readProcessTableLive(): Promise<ProcRow[]> {
+  processTableLiveReads += 1;
   if (process.platform === 'win32') return readProcessTableWin32();
   let out: string;
   try {
@@ -1526,8 +1625,30 @@ export function foldSubordinateAgents(
  * Classified by walking the ppid chain: any recognised UI ancestor (IDE
  * helper, terminal-app, or multiplexer) means `terminal`; nothing of the
  * sort means `headless` (daemon, launchd-spawned, orphan).
+ *
+ * Full `ps`+`lsof` rescans are throttled to {@link UNATTRIBUTED_RESCAN_MS}
+ * (#2047). Between rescans the previous rows are re-emitted after dropping
+ * dead PIDs and PIDs that are now attributed. A shrinking attributed set
+ * forces a rescan so a process that just left teams/terminals can reappear
+ * as headless.
  */
 export async function listUnattributedActive(attributed: Set<number>): Promise<ActiveSession[]> {
+  const now = activeScanNow();
+  if (
+    unattributedCache &&
+    now - unattributedCache.at < UNATTRIBUTED_RESCAN_MS &&
+    !attributedSetLostPids(unattributedCache.attributed, attributed)
+  ) {
+    return filterCachedUnattributed(unattributedCache.sessions, attributed, (pid) => isPidAlive(pid));
+  }
+  const out = await listUnattributedActiveLive(attributed);
+  unattributedCache = { at: now, attributed: new Set(attributed), sessions: out };
+  return out;
+}
+
+/** Unthrottled headless scan (live process table + cwd probes). */
+async function listUnattributedActiveLive(attributed: Set<number>): Promise<ActiveSession[]> {
+  unattributedFullRescans += 1;
   const table = await readProcessTable();
   const procByPid = new Map<number, ProcRow>();
   const ppidMap = new Map<number, number>();

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -145,17 +145,18 @@ export function attributedSetLostPids(prev: Set<number>, next: Set<number>): boo
 /**
  * Drop rows whose pid is now attributed or no longer alive. Pure over the
  * inputs so the unattributed TTL reuse path is unit-testable without a live
- * process table.
+ * process table. `alive` receives the row's `startedAtMs` so callers can apply
+ * the same pid-reuse guard {@link isPidAlive} uses elsewhere.
  */
 export function filterCachedUnattributed(
   sessions: ActiveSession[],
   attributed: Set<number>,
-  alive: (pid: number) => boolean,
+  alive: (pid: number, startedAtMs?: number) => boolean,
 ): ActiveSession[] {
   return sessions.filter((s) => {
     if (s.pid == null) return false;
     if (attributed.has(s.pid)) return false;
-    return alive(s.pid);
+    return alive(s.pid, s.startedAtMs);
   });
 }
 
@@ -1639,7 +1640,7 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
     now - unattributedCache.at < UNATTRIBUTED_RESCAN_MS &&
     !attributedSetLostPids(unattributedCache.attributed, attributed)
   ) {
-    return filterCachedUnattributed(unattributedCache.sessions, attributed, (pid) => isPidAlive(pid));
+    return filterCachedUnattributed(unattributedCache.sessions, attributed, isPidAlive);
   }
   const out = await listUnattributedActiveLive(attributed);
   unattributedCache = { at: now, attributed: new Set(attributed), sessions: out };

--- a/apps/cli/src/lib/session/active.unattrib-cache.test.ts
+++ b/apps/cli/src/lib/session/active.unattrib-cache.test.ts
@@ -46,6 +46,18 @@ describe('filterCachedUnattributed', () => {
     expect(out.map((s) => s.pid)).toEqual([10]);
   });
 
+  it('passes startedAtMs to the alive predicate (pid-reuse guard)', () => {
+    const sessions: ActiveSession[] = [
+      { context: 'headless', kind: 'claude', status: 'running', pid: 42, startedAtMs: 1_700_000_000_000 },
+    ];
+    const seen: Array<{ pid: number; startedAtMs?: number }> = [];
+    filterCachedUnattributed(sessions, new Set(), (pid, startedAtMs) => {
+      seen.push({ pid, startedAtMs });
+      return true;
+    });
+    expect(seen).toEqual([{ pid: 42, startedAtMs: 1_700_000_000_000 }]);
+  });
+
   it('drops rows with no pid', () => {
     const sessions: ActiveSession[] = [
       { context: 'headless', kind: 'claude', status: 'running' },

--- a/apps/cli/src/lib/session/active.unattrib-cache.test.ts
+++ b/apps/cli/src/lib/session/active.unattrib-cache.test.ts
@@ -102,8 +102,12 @@ describe('unattributed rescan throttle (#2047)', () => {
 
     const second = await listUnattributedActive(new Set());
     expect(unattributedFullRescanCountForTest()).toBe(1);
-    // Same pids present (filtered only for death/attribution — none here).
-    expect(second.map((s) => s.pid).sort()).toEqual(first.map((s) => s.pid).sort());
+    // Reuse path only DROPS rows (dead / pid-reuse / newly attributed) — never
+    // invents pids. Second is a subset of first.
+    const firstPids = new Set(first.map((s) => s.pid));
+    for (const s of second) {
+      expect(firstPids.has(s.pid)).toBe(true);
+    }
 
     // Growing the attributed set filters without a full rescan.
     const samplePid = first.find((s) => s.pid != null)?.pid;

--- a/apps/cli/src/lib/session/active.unattrib-cache.test.ts
+++ b/apps/cli/src/lib/session/active.unattrib-cache.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  PROCESS_TABLE_FRESH_MS,
+  UNATTRIBUTED_RESCAN_MS,
+  attributedSetLostPids,
+  filterCachedUnattributed,
+  clearActiveScanCachesForTest,
+  setActiveScanClockForTest,
+  processTableLiveReadCountForTest,
+  unattributedFullRescanCountForTest,
+  listUnattributedActive,
+  hostFromPid,
+  type ActiveSession,
+} from './active.js';
+
+afterEach(() => {
+  clearActiveScanCachesForTest();
+});
+
+describe('attributedSetLostPids', () => {
+  it('is false when next is a superset of prev', () => {
+    expect(attributedSetLostPids(new Set([1, 2]), new Set([1, 2, 3]))).toBe(false);
+    expect(attributedSetLostPids(new Set([1]), new Set([1]))).toBe(false);
+    expect(attributedSetLostPids(new Set(), new Set([1]))).toBe(false);
+  });
+
+  it('is true when any prev pid is missing from next', () => {
+    expect(attributedSetLostPids(new Set([1, 2]), new Set([1]))).toBe(true);
+    expect(attributedSetLostPids(new Set([5]), new Set())).toBe(true);
+  });
+});
+
+describe('filterCachedUnattributed', () => {
+  const row = (pid: number): ActiveSession => ({
+    context: 'headless',
+    kind: 'claude',
+    status: 'running',
+    pid,
+  });
+
+  it('drops attributed and dead pids; keeps live unattributed', () => {
+    const sessions = [row(10), row(20), row(30)];
+    const attributed = new Set([20]);
+    const alive = (pid: number) => pid !== 30;
+    const out = filterCachedUnattributed(sessions, attributed, alive);
+    expect(out.map((s) => s.pid)).toEqual([10]);
+  });
+
+  it('drops rows with no pid', () => {
+    const sessions: ActiveSession[] = [
+      { context: 'headless', kind: 'claude', status: 'running' },
+      row(11),
+    ];
+    expect(filterCachedUnattributed(sessions, new Set(), () => true).map((s) => s.pid)).toEqual([11]);
+  });
+});
+
+describe('process-table memo (#2047)', () => {
+  it('reuses one live ps/CIM snapshot across callers within PROCESS_TABLE_FRESH_MS', async () => {
+    // hostFromPid walks the process table; two calls in the same window must
+    // share the snapshot (one live read, not two).
+    let t = 1_000_000;
+    setActiveScanClockForTest(() => t);
+    clearActiveScanCachesForTest();
+    setActiveScanClockForTest(() => t);
+
+    await hostFromPid(process.pid);
+    const afterFirst = processTableLiveReadCountForTest();
+    expect(afterFirst).toBeGreaterThanOrEqual(1);
+
+    await hostFromPid(process.pid);
+    expect(processTableLiveReadCountForTest()).toBe(afterFirst);
+
+    // Advance past the fresh window — next call must re-snapshot.
+    t += PROCESS_TABLE_FRESH_MS + 1;
+    await hostFromPid(process.pid);
+    expect(processTableLiveReadCountForTest()).toBe(afterFirst + 1);
+  });
+});
+
+describe('unattributed rescan throttle (#2047)', () => {
+  it('reuses the last full scan within UNATTRIBUTED_RESCAN_MS when attributed did not shrink', async () => {
+    let t = 2_000_000;
+    setActiveScanClockForTest(() => t);
+
+    const first = await listUnattributedActive(new Set());
+    expect(unattributedFullRescanCountForTest()).toBe(1);
+    // Shape: array of sessions (may be empty on a quiet box).
+    expect(Array.isArray(first)).toBe(true);
+
+    const second = await listUnattributedActive(new Set());
+    expect(unattributedFullRescanCountForTest()).toBe(1);
+    // Same pids present (filtered only for death/attribution — none here).
+    expect(second.map((s) => s.pid).sort()).toEqual(first.map((s) => s.pid).sort());
+
+    // Growing the attributed set filters without a full rescan.
+    const samplePid = first.find((s) => s.pid != null)?.pid;
+    if (samplePid != null) {
+      const filtered = await listUnattributedActive(new Set([samplePid]));
+      expect(unattributedFullRescanCountForTest()).toBe(1);
+      expect(filtered.some((s) => s.pid === samplePid)).toBe(false);
+    }
+
+    // Past the rescan window → full rescan.
+    t += UNATTRIBUTED_RESCAN_MS + 1;
+    await listUnattributedActive(new Set());
+    expect(unattributedFullRescanCountForTest()).toBe(2);
+  });
+
+  it('forces a full rescan when the attributed set loses a pid', async () => {
+    let t = 3_000_000;
+    setActiveScanClockForTest(() => t);
+
+    await listUnattributedActive(new Set([999_001, 999_002]));
+    expect(unattributedFullRescanCountForTest()).toBe(1);
+
+    // Still inside the window, but a pid left the attributed set — rescan.
+    await listUnattributedActive(new Set([999_001]));
+    expect(unattributedFullRescanCountForTest()).toBe(2);
+  });
+});


### PR DESCRIPTION
perf / hot-path fix for open issue #2047 (next slice after #2272)

## What

Active-session polls (`agents sessions --active`, menu-bar) re-shelled `ps -A` from every reader and re-ran the full unattributed `lsof` fan-out every ~10–30s.

1. **Process-table memo** (`PROCESS_TABLE_FRESH_MS` = 5s) — terminals host detection, headless attribution, and `hostFromPid` share one snapshot.
2. **Unattributed rescan throttle** (`UNATTRIBUTED_RESCAN_MS` = 15s) — between full rescans, re-emit the previous rows after dropping dead PIDs and PIDs that are now attributed. A *shrinking* attributed set forces a rescan so a process that just left teams/terminals can reappear as headless.

## Why

#2047 names `ps -A` + `lsof` every poll as one of the menu-bar / doctor cliffs. #2272 covered live-signals / Claude-path memo; this is the headless-scan half.

## Out of scope (still open on #2047)

- menubar teams `meta.json` historical scan
- further doctor incremental probes (overview already has 90s singleflight cache)

## Run result (no UI surface — real-path vitest)

```
$ bun run vitest run src/lib/session/active.unattrib-cache.test.ts src/lib/session/active.livesignals.test.ts
 ✓ src/lib/session/active.livesignals.test.ts (8 tests)
 ✓ src/lib/session/active.unattrib-cache.test.ts (7 tests)
 Test Files  2 passed (2)
      Tests  15 passed (15)
```

Also green: `active.test.ts` (41).

## Files

- `apps/cli/src/lib/session/active.ts`
- `apps/cli/src/lib/session/active.unattrib-cache.test.ts`
- `apps/cli/.changelog/next/issue-2047-unattrib-ps-cache.md`

Closes nothing yet — #2047 is multi-part.