### PR TITLE
bench(cli): measure the per-command init/migration triad (index.ts:1354-1411)

### DIFF
--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -74,8 +74,10 @@
  * `@ts-expect-error` (TS2578, unused directive) that no gate caught.
  */
 import { describe, bench } from 'vitest';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { Command } from 'commander';
 import {
   readUpdateCache,
   shouldPromptUpgrade,
@@ -83,7 +85,10 @@ import {
   findAgentsCliInstalls,
   resolveRunningPackageRoot,
 } from './self-update.js';
-import { getUpdateCheckPath } from './state.js';
+import { getUpdateCheckPath, getAgentsDir, getMigratedSentinelPath } from './state.js';
+import { isGitRepo } from './git.js';
+import { foldLegacySystemRepo } from './migrate.js';
+import { ensureInitialized } from '../commands/setup.js';
 // Real built artifact (see docblock above) -- NOT './auto-pull.js', which
 // would resolve to the unbuilt TS source and always miss the worker script.
 // dist/lib/auto-pull.d.ts exists (tsconfig.json declaration:true), so this
@@ -93,6 +98,19 @@ import { spawnDetachedSync } from '../../dist/lib/auto-pull.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const UPDATE_CHECK_FILE = getUpdateCheckPath();
 const REAL_PATH = process.env.PATH || '';
+
+// The bootstrap init/migration triad (index.ts:1354-1411): the SYSTEM_DIR and
+// sentinel paths, and the value the sentinel is compared against, exactly as
+// index.ts computes them. tests/setup.ts leaves HOME untouched (tests/setup.ts:44),
+// so these resolve to the real ~/.agents on this box -- no mocking.
+const SYSTEM_DIR = getAgentsDir();
+const MIGRATED_SENTINEL_FILE = getMigratedSentinelPath();
+// index.ts:1397 -- the sentinel value keyed to the migration SCHEMA version.
+const SENTINEL_VALUE = 'v15';
+// ensureInitialized(program) (setup.ts) only touches `program` on the
+// not-yet-set-up branch; on a settled install it returns right after isGitRepo,
+// so a bare Command is never read. Reused across iterations.
+const BENCH_PROGRAM = new Command();
 
 describe('checkForUpdates — maybeWarnMultiInstall (index.ts:535-575): the PATH + known-install-root scan', () => {
   bench('resolveRunningPackageRoot(__dirname) — real path math, no fs walk when not a bunfs virtual path (self-update.ts:177)', () => {
@@ -133,4 +151,74 @@ describe('spawnDetachedSync — real detached child_process.spawn against the bu
     delete process.env.AGENTS_NO_AUTOPULL;
     spawnDetachedSync();
   }, { time: 2000, iterations: 10 });
+});
+
+/**
+ * The SECOND half of the CLI-entry hot path: the init/migration triad that
+ * runs on EVERY ordinary `agents <cmd>` invocation AFTER checkForUpdates /
+ * spawnDetachedSync (benched above) and BEFORE `program.parseAsync()`
+ * (index.ts:1440). Three checks fire in sequence at index.ts:1354-1411, each
+ * unconditional on a non-exempt command (`setup`/`help`/`uninstall` are the
+ * only exemptions, index.ts:1357):
+ *
+ *   1. foldLegacySystemRepo()          index.ts:1369  (migrate.ts:49)
+ *        -> fs.lstatSync(~/.agents-system)  (migrate.ts:51) — one syscall.
+ *        Deliberately OUTSIDE the sentinel guard (index.ts:1359-1365): the
+ *        sentinel predates the fold, so it can't gate it. On this box
+ *        ~/.agents-system is absent, so the lstat THROWS ENOENT and is caught
+ *        (migrate.ts:51) — the settled-install steady state.
+ *   2. ensureInitialized(program)      index.ts:1380  (setup.ts)
+ *        -> isGitRepo(getAgentsDir())       (setup.ts) = fs.existsSync(
+ *        ~/.agents/.system/.git) (git.ts). On a set-up box that returns true
+ *        and ensureInitialized returns immediately — never reaching the
+ *        interactive/exit branches — so this single existsSync IS the whole
+ *        per-command cost of the function.
+ *   3. migration sentinel gate         index.ts:1399-1403
+ *        -> fs.existsSync(sentinel) && fs.readFileSync(sentinel,'utf-8').trim()
+ *        === 'v15'. When it matches (settled install), needRun=false and
+ *        runMigration() (index.ts:1405) is NOT called. Two syscalls
+ *        (existsSync THEN readFileSync — a TOCTOU double-stat of the same path).
+ *
+ * No mocking: every call hits the real filesystem via the real path constants
+ * (getAgentsDir / getMigratedSentinelPath), which tests/setup.ts leaves pointing
+ * at the real ~/.agents (tests/setup.ts:44 — HOME untouched).
+ *
+ * runMigration() (migrate.ts, ~40 sub-migrators) is NOT benched by executing it.
+ * It is gated by the sentinel (verified `v15` on this box), so it does NOT run on
+ * a settled install — the very path this file measures is the guard that keeps it
+ * off the hot path. And it MUTATES live state on a sentinel miss —
+ * migrateSplitDeviceLocalMeta (migrate.ts) rewrites the real ~/.agents/agents.yaml
+ * when it still carries machine-local `agents:`/`versions:` keys, migrateCliDirToClis
+ * (migrate.ts) throws on a cli/+clis/ collision, and repairAgentConfigSymlinks
+ * (migrate.ts:686) re-points ~/.claude & co. Running that sweep in a benchmark loop
+ * against the user's real ~/.agents would corrupt it, so it is deliberately left
+ * unexecuted; the sentinel-gate bench below is what quantifies its per-command
+ * amortized cost (one cache-file read that decides whether the sweep runs at all).
+ */
+describe('init/migration triad (index.ts:1354-1411) — per-command bootstrap checks before parse', () => {
+  bench('foldLegacySystemRepo() — real fs.lstatSync(~/.agents-system) ENOENT+catch on a folded install (index.ts:1369, migrate.ts:49-52)', () => {
+    foldLegacySystemRepo();
+  });
+
+  bench('isGitRepo(getAgentsDir()) — real fs.existsSync(~/.agents/.system/.git); the entire settled-install cost of ensureInitialized (index.ts:1380, setup.ts, git.ts)', () => {
+    isGitRepo(SYSTEM_DIR);
+  });
+
+  bench('ensureInitialized(program) — the real named function; on a set-up box returns right after isGitRepo, so ~equal to the bench above (index.ts:1380, setup.ts)', async () => {
+    await ensureInitialized(BENCH_PROGRAM);
+  });
+
+  bench('migration sentinel gate — real fs.existsSync + fs.readFileSync(~/.agents/.cache/.migrated).trim() === "v15" (index.ts:1399-1403)', () => {
+    if (fs.existsSync(MIGRATED_SENTINEL_FILE) && fs.readFileSync(MIGRATED_SENTINEL_FILE, 'utf-8').trim() === SENTINEL_VALUE) {
+      /* needRun = false — runMigration() skipped */
+    }
+  });
+
+  bench('full triad end-to-end: foldLegacySystemRepo + isGitRepo + sentinel gate — every fs syscall an ordinary command runs before parse (index.ts:1369,1380,1399-1403)', () => {
+    foldLegacySystemRepo();
+    isGitRepo(SYSTEM_DIR);
+    if (fs.existsSync(MIGRATED_SENTINEL_FILE) && fs.readFileSync(MIGRATED_SENTINEL_FILE, 'utf-8').trim() === SENTINEL_VALUE) {
+      /* needRun = false */
+    }
+  });
 });


### PR DESCRIPTION
**bench-only / test-only — no runtime behavior change.** Adds benchmarks to the existing CLI-entry hot-path bench (`src/lib/index.bench.ts`); touches no shipped code path.

## What changed

Extends `apps/cli/src/lib/index.bench.ts` (already the bench for `checkForUpdates`/`spawnDetachedSync`) with the **second half of the pre-parse bootstrap** — the init/migration triad every ordinary `agents <cmd>` runs at `index.ts:1354-1411` before `program.parseAsync()` (`index.ts:1440`). Extends the one existing bench rather than adding a second file (repo convention: test/bench next to source).

## Call path (read end to end, `file:line`)

Per non-exempt command (`setup`/`help`/`uninstall` exempt — `index.ts:1357`), three checks fire in order:

1. **`foldLegacySystemRepo()`** — `index.ts:1369` -> `migrate.ts:49`. Does `fs.lstatSync(~/.agents-system)` (`migrate.ts:51`); on a folded install the dir is absent so the lstat **throws ENOENT and is caught** (`migrate.ts:51`). Runs **outside** the sentinel guard by design (`index.ts:1359-1365`).
2. **`ensureInitialized(program)`** — `index.ts:1380` -> `setup.ts`: `getAgentsDir()` + `isGitRepo(agentsDir)` = `fs.existsSync(~/.agents/.system/.git)` (`git.ts:757` — `return fs.existsSync(path.join(dir, '.git'))`). On a set-up box `isGitRepo` returns true and the function `return`s immediately — never reaching the interactive/exit branches, so that one `existsSync` is its entire settled cost.
3. **Migration sentinel gate** — `index.ts:1399-1403`: `fs.existsSync(sentinel) && fs.readFileSync(sentinel,'utf-8').trim() === 'v15'` (`sentinel` = `getMigratedSentinelPath()` -> `~/.agents/.cache/.migrated`, `state.ts:706`/`state.ts:161`; value `'v15'` at `index.ts:1397`). On a match, `needRun=false` and **`runMigration()` (`index.ts:1405`, `migrate.ts`) is not called**.

On this box: `~/.agents-system` absent, `~/.agents/.system/.git` present, sentinel = `v15` — i.e. the settled-install steady state, so `runMigration` does not run per command.

## Why `runMigration()` is documented but NOT executed in the bench

`runMigration` (`migrate.ts`, ~40 sub-migrators) is **sentinel-gated** — it doesn't run on a settled install (the path this bench measures is the guard that keeps it off the hot path) — and it **mutates live state** on a miss: `migrateSplitDeviceLocalMeta` (`migrate.ts`) rewrites the real `~/.agents/agents.yaml` when it still carries machine-local `agents:`/`versions:` keys, `migrateCliDirToClis` throws on a `cli/`+`clis/` collision, and `repairAgentConfigSymlinks` (`migrate.ts:686`) re-points `~/.claude` & co. Looping that sweep in a benchmark against the user's real `~/.agents` would corrupt it, so it is deliberately left unexecuted (F5). The sentinel-gate bench is what quantifies its per-command amortized cost: one cache-file read that decides whether the sweep runs.

## MEASURED (real ~/.agents, no mocking; `tests/setup.ts:44` leaves HOME untouched)

Ran with `node ./node_modules/vitest/vitest.mjs bench --run` in `apps/cli` (vitest 4.1.9, Linux). Two runs, `loadavg` before each: `1.72 1.48 1.62` and `3.36 2.20 1.87`. Mean per op (both runs agree to +/-0.0001ms):

| Check (`file:line`) | mean | hz | note |
|---|---|---|---|
| `foldLegacySystemRepo()` (`index.ts:1369`, `migrate.ts:51`) | **0.0035 ms** | 283k | throwing `lstatSync` — costliest check, ~43% of the triad |
| `isGitRepo(getAgentsDir())` (`index.ts:1380`, `git.ts:757`) | 0.0012 ms | 830k | single `existsSync` |
| `ensureInitialized(program)` (`index.ts:1380`) | 0.0013 ms | 745k | ~= `isGitRepo` -> body is one syscall on the settled path |
| sentinel gate (`index.ts:1399-1403`) | 0.0028 ms | 353k | `existsSync` + `readFileSync` (TOCTOU double-stat) |
| **full triad end-to-end** | **0.0082 ms** | 120k | every fs syscall a command runs before parse |

Real output (run 1):

```
 v src/lib/index.bench.ts > init/migration triad (index.ts:1354-1411) — per-command bootstrap checks before parse 3432ms
   . foldLegacySystemRepo() ...                              284,102.69  mean 0.0035  rme +/-0.35%  142052 samples
   . isGitRepo(getAgentsDir()) ...                           836,021.78  mean 0.0012  rme +/-0.37%  418011 samples
   . ensureInitialized(program) ...                          789,594.41  mean 0.0013  rme +/-0.28%  394798 samples
   . migration sentinel gate ...                             353,787.08  mean 0.0028  rme +/-0.04%  176894 samples
   . full triad end-to-end ...                               122,575.04  mean 0.0082  rme +/-0.06%   61288 samples
```

**Honest magnitude:** the whole triad is ~8us — dwarfed by the `findAgentsCliInstalls` PATH scan already benched in this file (~0.85ms) and by Node/module startup. The proposals below are correctness-aligned syscall/import reductions, not a user-visible speedup on their own.

## PROPOSALS (each measured; `file:line` + mechanism)

1. **`index.ts:1366-1371` — gate `foldLegacySystemRepo()` on the sentinel.** Measured costliest triad check (0.0035ms, 2.9x `isGitRepo`, ~43% of the triad) precisely because it is a *throwing* `lstatSync` (`migrate.ts:51`), and it runs unconditionally every command. The comment (`index.ts:1359-1365`) justifies running it outside the sentinel guard because the sentinel "was set by pre-fold releases" — but the sentinel is now keyed to schema `v15` (`index.ts:1397`), which is **post-fold**, so any install reading `v15` has already folded. Hoist the sentinel read (already done at `index.ts:1399-1403`) above the fold block and skip `foldLegacySystemRepo()` when the sentinel is already at the post-fold version. Removes the throwing lstat from the hot path for every settled install; the fold still runs for a genuinely-legacy (absent / below-version) sentinel.

2. **`index.ts:1400` — collapse the sentinel `existsSync` + `readFileSync` into one `readFileSync` in try/catch.** Measured gate = 0.0028ms; the leading `existsSync` re-stats a path `readFileSync` immediately re-opens (TOCTOU double-stat). A single `fs.readFileSync` (ENOENT -> `needRun=true`) drops one syscall (~0.0012ms, the isolated `existsSync` cost measured by the `isGitRepo` bench) and is simpler.

3. **`index.ts:1368` & `index.ts:1391` — collapse the two `await import('./lib/migrate.js')` into one, and merge the two `AGENTS_SKIP_MIGRATION` guard blocks (`index.ts:1366`, `index.ts:1389`).** The module is dynamically imported twice; combined with (1) the fold and sentinel share one import + one sentinel read. Cached at runtime, so the fs saving is (1)'s lstat, but it removes a redundant dynamic-import await and de-duplicates the guard.

4. **`index.ts:1379` — defer `await import('./commands/setup.js')` to the not-initialized branch.** Measured: `ensureInitialized` (0.0013ms) ~= `isGitRepo(getAgentsDir())` (0.0012ms), i.e. the settled-path body is a single `existsSync`; yet every non-exempt command eagerly loads the whole `setup.js` graph (`ora` + `@inquirer/prompts` + 8 `setup-*` submodules) just to reach it. Run `isGitRepo(getAgentsDir())` inline in `index.ts` and import `setup.js` only when it's false (the rare first-run path). *Caveat:* the import cost itself is not benched (vitest caches module loads); the **measured** signal is that the function's hot-path work is one syscall, so the eager import buys nothing on the settled path — the highest-leverage change on a real cold start even though the syscalls are cheap.

## Conventions (repo `CLAUDE.md`)

- Bench lives next to source (`src/lib/index.bench.ts`); extends the existing bench rather than adding a second file.
- **No mocking** — every call hits the real filesystem via the real path constants (`getAgentsDir`/`getMigratedSentinelPath`); `tests/setup.ts:44` leaves HOME on the real `~/.agents`.
- `apps/cli/vitest.config.ts` includes only `*.test.ts`, so `vitest run` (the CI gate) does not execute `*.bench.ts` — consistent with the other committed `*.bench.ts` files. `typecheck:bench` (`package.json:58`) type-checks it; run locally, exit 0.
- No shipped behavior changed -> no CHANGELOG/docs entry (bench/test-only; declared above).
