### PR TITLE
bench(cli): measure the command-registration hot path (index.ts:1007-1063)

### DIFF
--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -76,6 +76,8 @@
 import { describe, bench } from 'vitest';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { Command } from 'commander';
 import {
   readUpdateCache,
   shouldPromptUpgrade,
@@ -89,6 +91,7 @@ import { getUpdateCheckPath } from './state.js';
 // dist/lib/auto-pull.d.ts exists (tsconfig.json declaration:true), so this
 // resolves and type-checks normally -- no @ts-expect-error needed here.
 import { spawnDetachedSync } from '../../dist/lib/auto-pull.js';
+import { loadDoctor, loadVersions, loadPrune, loadSessions } from './startup/command-registry.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const UPDATE_CHECK_FILE = getUpdateCheckPath();
@@ -133,4 +136,107 @@ describe('spawnDetachedSync — real detached child_process.spawn against the bu
     delete process.env.AGENTS_NO_AUTOPULL;
     spawnDetachedSync();
   }, { time: 2000, iterations: 10 });
+});
+
+/**
+ * ============================================================================
+ * Command registration hot path: registerEagerForRequest / COMMAND_LOADERS
+ * (index.ts:1007-1063, lib/startup/command-registry.ts) and the
+ * program.parseAsync() call it feeds (index.ts:1440).
+ *
+ * Every ordinary `agents <cmd>` invocation resolves `requestedCommand` from
+ * argv (index.ts:1232), looks it up in COMMAND_LOADERS
+ * (command-registry.ts:155-274), dynamically imports the one-or-two command
+ * modules that name maps to, and calls the returned registrar(program)
+ * (index.ts:1010-1012 `reg`) BEFORE program.parseAsync() ever runs
+ * (index.ts:1440) -- unconditionally, regardless of `--help`/`--version`
+ * (index.ts:1271-1280 has no helpOrVersionRequested guard). An unrecognized
+ * top-level name (typo, or the brand-disabled path) instead falls back to
+ * registerAllEagerCommands() (index.ts:1072-1161), which imports and
+ * registers EVERY command module in the CLI so the Levenshtein "did you mean"
+ * spellcheck (index.ts:1184-1226) has the full candidate set.
+ *
+ * index.ts cannot be imported directly (see the docblock at the top of this
+ * file -- top-level await, process.argv reads, eventual program.parse()), and
+ * neither `reg` nor `registerEagerForRequest` nor `registerAllEagerCommands`
+ * is exported, so there is no way to call them in-process without duplicating
+ * their dispatch/ordering logic -- exactly the real coupling command-
+ * registry.ts's own docblock (command-registry.ts:141-153) says not to
+ * re-derive. Two complementary regimes are benched instead:
+ *
+ *   1. REAL SPAWNED PROCESS (below): `spawnSync` the actual built
+ *      dist/index.js with a handful of representative top-level names, each a
+ *      fresh Node process -- i.e. a genuinely COLD run of the entire dispatch
+ *      path above, exactly as a user's shell invokes it. `--help` is appended
+ *      to every invocation so each run exits fast and deterministically
+ *      (commander prints help and exits 0) without touching stdin. `--help`
+ *      does skip checkForUpdates/spawnDetachedSync (benched above) and
+ *      ensureInitialized/runMigration (index.ts:1373-1381, both DO carry a
+ *      `!helpOrVersionRequested` guard -- the sibling migration-triad bench in
+ *      PR #2277 covers that path), so this isolates the registration/import
+ *      cost from those other two hot-path pieces instead of conflating them.
+ *   2. WARM IN-PROCESS REGISTRATION (further below): call the real, exported
+ *      command-registry.ts loaders directly -- `(await loadX())(new
+ *      Command())` -- for a representative subset. Node's ESM loader caches a
+ *      module after its first import in this process, so after the first
+ *      sample every further call pays ONLY the registrar function's own
+ *      synchronous commander-construction work (.command/.option/.action
+ *      calls), not disk read + parse + top-level module evaluation. Compared
+ *      against group 1's real cold-process numbers for the SAME command, the
+ *      gap approximates how much of the real-world cost is "importing the
+ *      module and its dependency graph" versus "building the commander
+ *      command tree" -- the same decomposition PR #2277 used to show
+ *      ensureInitialized's hot-path body is a single syscall dwarfed by its
+ *      eager unconditional import.
+ *
+ * No mocking: group 1 runs the real built dist/index.js against this
+ * machine's real ~/.agents (same real filesystem/PATH every other group in
+ * this file uses); group 2 calls the real, unmodified command registrars
+ * exported from command-registry.ts.
+ */
+const CLI_ENTRY = path.join(__dirname, '../../dist/index.js');
+
+function runCli(args: string[]): void {
+  // spawnSync (not execFileSync) so a non-zero exit never throws inside the
+  // timed callback -- every arg list below is verified to exit 0 on this
+  // machine, but the bench must stay robust to environment drift.
+  spawnSync(process.execPath, [CLI_ENTRY, ...args], { stdio: 'ignore' });
+}
+
+describe('registerEagerForRequest / COMMAND_LOADERS — real cold `node dist/index.js <cmd> --help` process spawn (index.ts:1007-1063, 1271-1280)', () => {
+  bench('baseline: `agents --help` — requestedCommand undefined, ZERO command loaders run (index.ts:1281-1284)', () => {
+    runCli(['--help']);
+  }, { time: 4000, iterations: 15 });
+
+  bench('`agents doctor --help` — 1 loader (loadDoctor), single COMMAND_LOADERS entry (command-registry.ts:201)', () => {
+    runCli(['doctor', '--help']);
+  }, { time: 4000, iterations: 15 });
+
+  bench('`agents prune --help` — 2 loaders in sequence (loadVersions, loadPrune — command-registry.ts:177, ordering comment at 148-149)', () => {
+    runCli(['prune', '--help']);
+  }, { time: 4000, iterations: 15 });
+
+  bench('`agents sessions --help` — lazy-tree command, the SQLite-backed session module (index.ts:1290-1291, LAZY_COMMAND_NAMES)', () => {
+    runCli(['sessions', '--help']);
+  }, { time: 4000, iterations: 15 });
+
+  bench('`agents <unknown> --help` — registerAllEagerCommands() fallback, EVERY command module in the CLI (index.ts:1072-1161, 1271-1280)', () => {
+    runCli(['zzzznotarealcommand', '--help']);
+  }, { time: 6000, iterations: 12 });
+});
+
+describe('command-registry.ts loaders — warm in-process registration only (module import cached after the first sample; see docblock above)', () => {
+  bench('loadDoctor()(new Command()) — registerDoctorCommand body only, no import cost after first sample', async () => {
+    (await loadDoctor())(new Command());
+  });
+
+  bench('loadVersions()(new Command()) then loadPrune()(...) — the real `prune` two-loader sequence, in order', async () => {
+    const program = new Command();
+    (await loadVersions())(program);
+    (await loadPrune())(program);
+  });
+
+  bench('loadSessions()(new Command()) — registerSessionsCommands body only, no import cost after first sample', async () => {
+    (await loadSessions())(new Command());
+  });
 });


### PR DESCRIPTION
**bench-only / no runtime behavior change.** Extends the existing CLI-entry hot-path bench (`apps/cli/src/lib/index.bench.ts` — already benches `checkForUpdates`/`spawnDetachedSync`, and is being extended by the sibling PR #2277 for the migration triad) with the **command-registration dispatch**: every ordinary `agents <cmd>` resolves its command and imports+registers the matching module(s) BEFORE `program.parseAsync()` runs.

## Call path (read end to end, `file:line`)

- `index.ts:1232` — `requestedCommand` is the first non-flag argv token.
- `index.ts:1271-1280` — for a known, non-lazy command: `registerEagerForRequest(requestedCommand)` (`index.ts:1022-1063`) looks it up in `COMMAND_LOADERS[name]` (`lib/startup/command-registry.ts:155-274`) and awaits `reg(loader)` (`index.ts:1010-1012`, `(await loader())(program)`) for each loader in order. This runs **unconditionally**, regardless of `--help`/`--version` — there is no `helpOrVersionRequested` guard on this block (unlike `ensureInitialized`/`runMigration`, `index.ts:1373-1381`, which both do gate on it).
- `index.ts:1290-1307` — for a lazy command (`sessions`/`teams`/`cloud`/…, `LAZY_COMMAND_NAMES` at `command-registry.ts:130-139`), the same `reg()` loop runs after `applyGlobalHelpConventions`.
- `index.ts:1072-1161` `registerAllEagerCommands()` — the unknown-command/typo fallback: imports and registers **every** command module (~70 loaders) so the Levenshtein "did you mean" (`index.ts:1184-1226`) has the full candidate set; its ordering breaks minDist ties (`index.ts:1186`, `program.commands.map(c => c.name())`).
- `index.ts:1440` — `program.parseAsync()`, reached only after all of the above.

`command-registry.ts:141-153` documents `prune`'s real 2-loader ordering coupling (`loadVersions` then `loadPrune` — `command-registry.ts:177` — `prune.js` finds the `prune` subcommand `versions.ts` already created).

## Why two bench regimes, not one

`index.ts` cannot be imported directly (top-level `await`, `process.argv` reads, eventual `program.parse()` — same constraint the existing bench docblock already documents for `checkForUpdates`), and none of `reg`/`registerEagerForRequest`/`registerAllEagerCommands` is exported. Re-implementing their dispatch/ordering logic in the bench file to call them "in-process" would be exactly the coupling `command-registry.ts:141-153` warns not to re-derive, and risks silent drift from the real order (which matters for the tie-break, see PROPOSAL 2). So:

1. **Real cold process spawn** — `spawnSync(process.execPath, [dist/index.js, ...args])`, a genuinely fresh Node process per sample, `--help` appended so every run exits fast and deterministically (0 exit, no stdin). This is exactly what a user's shell does.
2. **Warm in-process registration** — call the real, exported `command-registry.ts` loaders directly against a fresh `Command()`. Node's ESM cache means every sample after the first pays only the registrar's own synchronous `.command()`/`.option()` work, not import cost — isolating "loading the module" from "building the commander tree."

## MEASURED (real dist/index.js, real ~/.agents, no mocking)

Ran `npx vitest bench --run src/lib/index.bench.ts` in `apps/cli` (vitest 4.1.9, Linux, `bun run build` first). Two runs, `loadavg` before each: `3.41 2.94 2.30` and `3.44 3.05 2.38` (this box also carries ~7000 other processes/sessions — see the `36ms`/`4.7%` rme spread below).

### Group 1 — real cold `node dist/index.js <cmd> --help` process spawn

| Invocation (`file:line`) | mean (run1 / run2) | delta over baseline |
|---|---|---|
| `agents --help` — 0 loaders (`index.ts:1281-1284`) | 113.19ms / 109.01ms | — (baseline) |
| `agents doctor --help` — 1 loader, `loadDoctor` (`command-registry.ts:201`) | 222.68ms / 225.57ms | **+~113ms** |
| `agents prune --help` — 2 loaders, `loadVersions`+`loadPrune` (`command-registry.ts:177`) | 242.23ms / 232.62ms | **+~127ms** |
| `agents sessions --help` — lazy, SQLite-backed (`index.ts:1290-1291`) | 309.99ms / 305.03ms | **+~197ms** |
| `agents <unknown> --help` — `registerAllEagerCommands()`, ~70 loaders (`index.ts:1072-1161`) | 444.52ms / 441.44ms | **+~333ms** |

Real output (run1):
```
 ✓ registerEagerForRequest / COMMAND_LOADERS — real cold `node dist/index.js <cmd> --help` process spawn 32732ms
     name                                                                        hz      min     max    mean     p75     p99    p995    p999     rme  samples
   · baseline: `agents --help`                                              8.8351   93.9106  136.48  113.19  120.01  136.48  136.48  136.48  ±3.11%       36
   · `agents doctor --help`                                                 4.4908   206.18  243.00  222.68  232.58  243.00  243.00  243.00  ±2.30%       19
   · `agents prune --help`                                                  4.1283   222.53  261.81  242.23  252.70  261.81  261.81  261.81  ±2.65%       17
   · `agents sessions --help`                                               3.2259   292.93  324.44  309.99  320.69  324.44  324.44  324.44  ±2.04%       15
   · `agents <unknown> --help`                                              2.2496   426.86  490.03  444.52  449.61  490.03  490.03  490.03  ±2.02%       14
```

### Group 2 — warm in-process registration (module import cached; isolates registrar body from import cost)

| Loader (`file:line`) | mean | vs. group-1 delta for the same command |
|---|---|---|
| `loadDoctor()(new Command())` (`command-registry.ts:65`) | **0.0125ms** | 113ms / 0.0125ms ≈ **9000x** |
| `loadVersions()` then `loadPrune()` (`command-registry.ts:47,62`) | **0.0207ms** | 127ms / 0.0207ms ≈ **6100x** |
| `loadSessions()(new Command())` (`command-registry.ts:254` loader def) | **0.1412ms** | 197ms / 0.1412ms ≈ **1400x** |

Real output:
```
 ✓ command-registry.ts loaders — warm in-process registration only 3502ms
     name                                                                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · loadDoctor()(new Command())                                          80,160.44  0.0101  1.8497  0.0125  0.0116  0.0349  0.0396  0.2197  ±1.21%    40081
   · loadVersions()(new Command()) then loadPrune()(...)                  48,388.35  0.0154  2.6752  0.0207  0.0180  0.0447  0.0565  0.5516  ±2.07%    24195
   · loadSessions()(new Command())                                         7,083.35  0.1196  2.7197  0.1412  0.1286  0.3139  0.6571  1.1463  ±1.98%     3542
```

**Honest read:** the group-1/group-2 gap (3-4 orders of magnitude) shows the dispatch logic itself (`COMMAND_LOADERS[name]` lookup, the `reg()` closure, the registrar's own `.command()`/`.option()` calls) is essentially free. Virtually **all** of the +113ms/+127ms/+197ms real-world cost is `import()` — disk read + V8 parse/compile + top-level module evaluation of the command file and its transitive dependency graph (confirmed for `sessions.ts`: 20+ top-level imports at `commands/sessions.ts:10-40`, including `remote-list.ts`, `discover.ts`, `active.ts`, `ghostty-tabs.ts`, `tmux/session.ts`).

## PROPOSALS (measured, `file:line` + mechanism)

1. **Per-command import weight is the entire cost, not the dispatch logic.** `index.ts:1059-1062` (`for (const loader of loaders) await reg(loader)`) and `command-registry.ts:32-129` (the `ModuleLoader` definitions). Since group 2 proves the registrar body itself is ~0.01-0.14ms against a +113-197ms real cost, the highest-leverage lever is auditing each command module's **top-level** imports for weight that a plain `--help`/listing invocation never needs — e.g. `commands/sessions.ts:10-40` eagerly imports the full remote-fanout/discover/tmux/ghostty-tabs stack at module scope. Deferring those into the specific subcommand `action()` closures that actually use them (rather than the module top level, which `command-registry.ts`'s loader always evaluates in full just to register the command tree) would shrink `agents sessions --help`'s +197ms without touching the lazy-loading design already in place.

2. **`registerAllEagerCommands()` (`index.ts:1072-1161`) pays for ~70 imports just to build a spellcheck candidate list, and it's 2-4x the cost of any single command.** Measured +333ms over baseline vs. +113-197ms for a real command. The Levenshtein match (`index.ts:1184-1226`) reads its candidate set from `program.commands.map(c => c.name())` (`index.ts:1186`), which requires every module to already be registered — but `KNOWN_TOP_LEVEL_COMMANDS` (`command-registry.ts:306-309`, `Object.keys(COMMAND_LOADERS)` + inline aliases) already carries the same name set as a **plain string Set, no imports needed**. Swapping the candidate source would let the "typo, no auto-correct match, print unknown-command error" branch (`index.ts:1221-1225`) skip `registerAllEagerCommands()` entirely, cutting +333ms toward the ~110ms baseline for that case. **Caveat, measured structurally not empirically:** `index.ts:1186`'s loop uses strict `<` (first-seen wins ties), so `KNOWN_TOP_LEVEL_COMMANDS`'s `Object.keys(COMMAND_LOADERS)` order does **not** match `registerAllEagerCommands()`'s explicit call sequence (e.g. `inspect` is COMMAND_LOADERS' 2nd key but `registerAllEagerCommands` registers it 5th, after `share`/`send`) — a naive swap changes which command wins a tied minDist, so the tie-break order would need to be reconciled (or accepted as a documented behavior change) before landing this. The auto-correct **re-parse** branch (`index.ts:1198-1219`) would still need the corrected single command registered before re-parsing, which `registerEagerForRequest(closest)` already does cheaply — so this optimization composes with the existing lazy design rather than replacing it.

3. **Not proposed: parallelizing `prune`'s two loaders.** `command-registry.ts:148-149` documents `loadVersions`→`loadPrune` as a genuine ordering dependency (`prune.js` looks up the `prune` subcommand `versions.ts` creates), so `Promise.all`-ing them would break — measured +127ms is consistent with 2 sequential imports, not evidence of avoidable serialization.

## Conventions (repo `CLAUDE.md`)

- Extends the existing bench (`apps/cli/src/lib/index.bench.ts`) rather than adding a second file — checked for `*.bench.ts` files first (`src/lib/exec.bench.ts`, `hosts/dispatch.bench.ts`, `session/db.bench.ts`, `session/hook-sessions.bench.ts`, `session/pid-registry.bench.ts`, `sync-umbrella.bench.ts`); none covers this hot path.
- No mocking — group 1 spawns the real built `dist/index.js` against this machine's real `~/.agents`; group 2 calls the real, unmodified `command-registry.ts` loaders.
- `apps/cli/vitest.config.ts` `include` matches only `*.test.ts`, so `vitest run` (the CI gate) never executes this file — consistent with every other committed `*.bench.ts`. `typecheck:bench` (`package.json:58`) type-checks it; ran locally, exit 0.
- No shipped behavior changed → no CHANGELOG/docs entry (bench/test-only, declared here).
