### PR TITLE
bench(cli): measure the startup package.json read + parse (index.ts:31-34)

### DIFF
--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -74,6 +74,7 @@
  * `@ts-expect-error` (TS2578, unused directive) that no gate caught.
  */
 import { describe, bench } from 'vitest';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
@@ -239,4 +240,142 @@ describe('command-registry.ts loaders — warm in-process registration only (mod
   bench('loadSessions()(new Command()) — registerSessionsCommands body only, no import cost after first sample', async () => {
     (await loadSessions())(new Command());
   });
+});
+
+/**
+ * ============================================================================
+ * Startup package.json read + parse (index.ts:30-34).
+ *
+ * The first four statements of the entrypoint, verbatim:
+ *
+ *   30  // Get version from package.json
+ *   31  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+ *   32  const packageJsonPath = path.join(__dirname, '..', 'package.json');
+ *   33  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+ *   34  const VERSION = packageJson.version;
+ *
+ * These are top-level module statements, so they run on EVERY `agents`
+ * invocation without exception -- including the argv fast paths that exit
+ * before commander is ever constructed:
+ *
+ *   index.ts:38     `__vault-age-helper`  -> import + run + process.exit
+ *   index.ts:71-84  `__secrets-get` / `__secrets-ping` / `__secrets-lock`
+ *                    -> import agent.js + run + process.exit(code)
+ *
+ * Neither fast path reads VERSION: the first VERSION consumer is
+ * `detectDevBuild(process.argv[1] || '', VERSION)` at index.ts:113, which is
+ * BELOW both blocks. (`grep -n packageJson src/index.ts` returns exactly
+ * index.ts:32, :33, :34 -- the parsed object is never used for anything but
+ * `.version` at index.ts:34.) So on those paths the whole read + parse is
+ * dead work.
+ *
+ * That matters because the `__secrets-*` tokens are not a rare debug surface:
+ * `agentGetSync` (secrets/agent.ts:994-996) and `agentPingSync`
+ * (secrets/agent.ts:1040) call `syncClient` (secrets/agent.ts:973-987), which
+ * does a real `spawnSync(command, args, ...)` (secrets/agent.ts:983) of THIS
+ * CLI -- one whole fresh Node process, and therefore one whole fresh
+ * package.json read + parse, per synchronous secrets read. index.ts:44-51
+ * documents that spawn-per-read design and is why those tokens are
+ * intercepted above commander in the first place.
+ *
+ * The file being read is the real published `apps/cli/package.json` (20
+ * top-level keys, 21 dependencies, 3987 bytes as of this commit). This bench
+ * resolves it the same way index.ts does at runtime -- relative to the running
+ * module -- so it measures the identical file: dist/index.js's
+ * `path.join(__dirname, '..')` (index.ts:32) is `apps/cli/`, and this file's
+ * `path.join(__dirname, '../..')` from `src/lib/` is also `apps/cli/`.
+ *
+ * As with the other groups in this file, index.ts itself cannot be imported
+ * (top-level await, process.argv reads, an eventual program.parse() -- see the
+ * docblock at the top of this file), and these four statements are inline
+ * module-level code rather than an exported function, so there is nothing to
+ * call. The statements are therefore re-executed here against the real file --
+ * identical calls in identical order, with one extra pure `..` segment in the
+ * path.join because this file sits one directory deeper than the entrypoint --
+ * and complemented by a real cold-process group that runs the actual built
+ * dist/index.js on the fast paths described above.
+ *
+ * Decomposition benched below: the path math (index.ts:31-32) separately from
+ * the fs read and the JSON.parse (index.ts:33), so a proposal that removes
+ * only one half can be costed. Two alternatives are measured against the real
+ * statement rather than asserted: a targeted `"version"` extraction off the
+ * same raw string (no full parse), and a compiled-in constant (the floor: zero
+ * fs, zero parse).
+ *
+ * No mocking: every call reads the real apps/cli/package.json off this
+ * machine's real filesystem, and the cold-process group spawns the real built
+ * dist/index.js.
+ */
+const PKG_JSON_PATH = path.join(__dirname, '..', '..', 'package.json');
+const PKG_JSON_RAW = fs.readFileSync(PKG_JSON_PATH, 'utf-8');
+const PKG_JSON_BYTES = Buffer.byteLength(PKG_JSON_RAW, 'utf-8');
+const VERSION_RE = /"version"\s*:\s*"([^"]+)"/;
+
+describe(`startup package.json read + parse (index.ts:31-34) — real apps/cli/package.json, ${PKG_JSON_BYTES} bytes`, () => {
+  // One `..` more than index.ts:32 in every path.join below: this file sits at
+  // src/lib/, one directory deeper than the entrypoint, so `../..` lands on the
+  // same apps/cli/ that dist/index.js's single `..` does. Same file, same
+  // syscall, one extra pure string segment.
+  bench('index.ts:31-32 path math only: path.dirname(fileURLToPath(import.meta.url)) + path.join(..., "package.json") — no fs, no parse', () => {
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    path.join(dir, '..', '..', 'package.json');
+  });
+
+  bench('index.ts:33 read half only: fs.readFileSync(packageJsonPath, "utf-8")', () => {
+    fs.readFileSync(PKG_JSON_PATH, 'utf-8');
+  });
+
+  bench('index.ts:33 parse half only: JSON.parse(<already-read string>) — 20 top-level keys, 21 dependencies', () => {
+    JSON.parse(PKG_JSON_RAW);
+  });
+
+  bench('index.ts:31-34 end to end: path math + readFileSync + JSON.parse + .version — what every `agents` process pays before any argv dispatch', () => {
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    const p = path.join(dir, '..', '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(p, 'utf-8'));
+    void pkg.version;
+  });
+
+  bench('ALTERNATIVE A — read, then targeted "version" extraction instead of JSON.parse: fs.readFileSync + /"version"\\s*:\\s*"([^"]+)"/ (keeps the fs read, drops the full parse)', () => {
+    const raw = fs.readFileSync(PKG_JSON_PATH, 'utf-8');
+    void VERSION_RE.exec(raw)?.[1];
+  });
+
+  bench('ALTERNATIVE B — compiled-in constant (the floor): zero fs, zero parse, what a build-time version stamp would cost', () => {
+    void '0.0.0-bench';
+  });
+});
+
+/**
+ * Real cold-process cost of the two argv fast paths that pay index.ts:31-34
+ * and never read VERSION (index.ts:38, index.ts:71-84), measured against
+ * `--version`, which does consume it (index.ts:248 `.version(VERSION)`).
+ *
+ * Every arg list here is verified to exit deterministically on this machine
+ * without touching stdin or the network: `--version` exits 0,
+ * `__secrets-ping` exits 3 (secrets/agent.ts:1040 -> broker miss/down),
+ * `__vault-age-helper` exits 1. `spawnSync` is used (not execFileSync) so a
+ * non-zero exit never throws inside the timed callback.
+ *
+ * These numbers are the denominator for the in-process group above: they say
+ * what fraction of a real fast-path process the package.json read + parse
+ * actually is, which is the difference between a worthwhile optimization and
+ * noise inside Node's own startup.
+ */
+describe('startup package.json — real cold `node dist/index.js <fast-path>` process spawn (index.ts:38, 71-84)', () => {
+  bench('FLOOR: bare `node -e ""` — Node bootstrap alone, zero agents-cli code; the irreducible cost every row below sits on top of', () => {
+    spawnSync(process.execPath, ['-e', ''], { stdio: 'ignore' });
+  }, { time: 4000, iterations: 15 });
+
+  bench('`--version` — VERSION genuinely consumed (index.ts:248 .version(VERSION))', () => {
+    runCli(['--version']);
+  }, { time: 4000, iterations: 15 });
+
+  bench('`__secrets-ping` — argv fast path at index.ts:71-84, exits at index.ts:83 without ever reading VERSION; spawned per secrets read by secrets/agent.ts:983', () => {
+    runCli(['__secrets-ping']);
+  }, { time: 4000, iterations: 15 });
+
+  bench('`__vault-age-helper` — argv fast path at index.ts:38, exits at index.ts:41 without ever reading VERSION', () => {
+    runCli(['__vault-age-helper']);
+  }, { time: 4000, iterations: 15 });
 });

--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -270,8 +270,8 @@ describe('command-registry.ts loaders — warm in-process registration only (mod
  * dead work.
  *
  * That matters because the `__secrets-*` tokens are not a rare debug surface:
- * `agentGetSync` (secrets/agent.ts:994-996) and `agentPingSync`
- * (secrets/agent.ts:1040) call `syncClient` (secrets/agent.ts:973-987), which
+ * `agentGetSync` (secrets/agent.ts:994-996) and `agentReachableSync`
+ * (secrets/agent.ts:1037-1042) call `syncClient` (secrets/agent.ts:973-987), which
  * does a real `spawnSync(command, args, ...)` (secrets/agent.ts:983) of THIS
  * CLI -- one whole fresh Node process, and therefore one whole fresh
  * package.json read + parse, per synchronous secrets read. index.ts:44-51


### PR DESCRIPTION
**bench-only** — adds two benchmark groups to `apps/cli/src/lib/index.bench.ts`. No production code, no behavior change. Test-only, so docs + CHANGELOG are exempt per the root `CLAUDE.md` review conventions.

## What is measured

The fourth CLI-entry hot path: the top-level package.json read + parse, `apps/cli/src/index.ts:31-34`.

```
30  // Get version from package.json
31  const __dirname = path.dirname(fileURLToPath(import.meta.url));
32  const packageJsonPath = path.join(__dirname, '..', 'package.json');
33  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
34  const VERSION = packageJson.version;
```

These are top-level module statements, so they run on **every** `agents` invocation — including the two argv fast paths that exit before commander is constructed: `index.ts:38` (`__vault-age-helper`) and `index.ts:71-84` (`__secrets-get`/`__secrets-ping`/`__secrets-lock`). Neither reads `VERSION`: the first consumer is `detectDevBuild(process.argv[1] || '', VERSION)` at `index.ts:113`, below both blocks. `grep -n packageJson src/index.ts` returns exactly `:32`, `:33`, `:34` — the parsed object is never used for anything but `.version`.

That matters because `__secrets-*` is not a debug surface: `agentGetSync` (`src/lib/secrets/agent.ts:994-996`) and `agentReachableSync` (`:1037-1042`) call `syncClient` (`:973-987`), which does a real `spawnSync(command, args, ...)` at `src/lib/secrets/agent.ts:983` — one whole fresh CLI process, and one whole fresh package.json read+parse, per synchronous secrets read.

`index.ts` cannot be imported (top-level `await`, `process.argv` reads, an eventual `program.parse()`) and these four statements are inline module code, not an exported function, so the bench re-executes the identical calls in identical order against the real file, and pairs them with real cold-process spawns for a denominator. No mocking: the real 3987-byte `apps/cli/package.json`, the real built `dist/index.js`.

## MEASURED

`npx vitest bench --run src/lib/index.bench.ts -t "startup package.json"` in `apps/cli`, on `yosemite-s1` (20 cores, node v24.11.1). Full run log (all rows, `hz`/`min`/`max`/`mean`/`p75`/`p99`/`rme`/`samples`, with `/proc/loadavg` before and after): **https://gist.github.com/muqsitnawaz/ce8cd0b22c04dcbe14c4b994edf58776**

In-process, real `apps/cli/package.json` — `loadavg` before `2.33 3.31 2.67`, after `2.94 3.33 2.70`:

| Row | mean | hz | rme |
|---|---|---|---|
| `index.ts:31-32` path math only | **1.7 us** | 603,552 | ±1.12% |
| `index.ts:33` `fs.readFileSync` only | **2.9 us** | 340,960 | ±0.29% |
| `index.ts:33` `JSON.parse` only | **4.8 us** | 207,055 | ±0.41% |
| **`index.ts:31-34` end to end** | **9.7 us** | 103,318 | ±0.54% |
| ALT A: read + targeted `"version"` regex (no full parse) | **3.1 us** | 327,260 | ±0.33% |
| ALT B: compiled-in constant (zero fs, zero parse) | **0.00004 us** | 25,804,999 | ±0.06% |

Real cold process spawns, same run:

| Row | mean | rme |
|---|---|---|
| FLOOR: bare `node -e ""` (Node bootstrap, zero agents-cli code) | **21.6 ms** | ±2.06% |
| `node dist/index.js --version` (VERSION consumed, `index.ts:248`) | **110.4 ms** | ±2.26% |
| `node dist/index.js __secrets-ping` (fast path, VERSION unread) | **111.3 ms** | ±4.24% |
| `node dist/index.js __vault-age-helper` (fast path, VERSION unread) | **124.5 ms** | ±2.56% |

Reproducibility: three additional independent runs at `loadavg` 4.30 / 6.12 / 3.42 gave end-to-end `9.9 / 9.5 / 9.8 us` and `--version` `110.7 / 109.6 / 111.7 ms` — every figure inside its own `rme`.

## PROPOSALS

**Nothing here is worth changing, and that is the measurement, not a hedge.**

1. **Do NOT drop `JSON.parse` for a targeted `"version"` extraction.** Mechanism: only `.version` is consumed (`index.ts:34`), so the parse of the other 19 keys is waste, and ALT A shows the extraction itself is free — `3.1 us` vs `2.9 us` for the bare read, inside `rme`. Measured saving: `4.8 us` of `9.7 us` (49% of the statement). Measured value: `4.8 us` on a `110.4 ms` process = **0.004%**. Rejected — it trades a spec-correct parse for a regex over untrusted-shape JSON to buy four microseconds.
2. **Do NOT stamp VERSION in at build time.** Mechanism: `scripts/build.sh:45` already rewrites `package.json`'s `version`, so it could emit a constant instead and delete `index.ts:31-34` (ALT B is that floor). Measured saving: the whole `9.7 us` = **0.009%** of a `110.4 ms` fast-path process. Rejected on the same arithmetic.
3. **Do NOT defer the read past the argv fast paths.** Mechanism: make `VERSION` a lazy getter so `index.ts:38` and `index.ts:71-84` exit without it. This is the structurally cleanest of the three (it removes dead work on the path `src/lib/secrets/agent.ts:983` spawns per secrets read) and it is still `9.7 us` of `111.3 ms` = **0.009%**. Rejected: the win is unmeasurable at the process level and the ordering constraints in the `index.ts:44-70` comment block are load-bearing enough that moving statements across them is not a free edit.

**Where the cost actually is, from these same numbers.** A fast-path `agents` process is `110.4 ms`; bare Node is `21.6 ms`; so **~89 ms — 80% of the process — is agents-cli's own module loading and work**, four orders of magnitude above this statement. The sibling groups already in this file localize it: `agents --help` `107 ms` vs `agents doctor --help` `223 ms` vs `agents sessions --help` `304 ms` vs an unrecognized name (`registerAllEagerCommands`, `index.ts:1072-1161`) `451 ms`. Startup work belongs in the module graph and the eager-registration fallback, not in `index.ts:31-34`.

## Verification

- `npm run typecheck:bench` (`apps/cli`) — clean, exit 0. The file stays at `src/lib/index.bench.ts` so it sits inside that glob (`package.json:58`).
- Pre-existing groups in the file re-ran unchanged in the full-file run.

## Review round 1 (non-author subagent, prix/code-reviewer paused per #1767)

Reviewer found one real FAIL and it is fixed in `f7431067`: the docblock cited a function `agentPingSync` at `secrets/agent.ts:1040` that does not exist — line 1040 is the `syncClient([SYNC_PING_CMD], ...)` call inside `agentReachableSync`, defined at `secrets/agent.ts:1037`. Corrected here and in the bench docblock. Everything else passed, and the reviewer independently reproduced all ten rows on different hardware (its `loadavg 0.93 → 1.43`): path math `1.7 us`, read `2.9 us`, `JSON.parse` `4.8 us`, end-to-end `9.6 us`, ALT A `2.9 us`, bare node `21.3 ms`, `--version` `108.1 ms`, `__secrets-ping` `112.3 ms`, `__vault-age-helper` `126.5 ms` — every headline number inside a few percent of the figures above.
