### PR TITLE
bench(cli): measure the eager startup module graph (index.ts:10-215)

### DIFF
--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -75,7 +75,7 @@
  */
 import { describe, bench } from 'vitest';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { Command } from 'commander';
 import {
@@ -239,4 +239,222 @@ describe('command-registry.ts loaders — warm in-process registration only (mod
   bench('loadSessions()(new Command()) — registerSessionsCommands body only, no import cost after first sample', async () => {
     (await loadSessions())(new Command());
   });
+});
+
+/**
+ * ============================================================================
+ * Module loading: the eager ESM graph index.ts evaluates BEFORE any argv fast
+ * path (index.ts:10-16, 36, 86-95, 124-215) and the command modules
+ * COMMAND_LOADERS pulls in afterwards (command-registry.ts:32-119).
+ *
+ * This is a different cost from the registration group above. Registration
+ * measures the commander work a command's registrar does; this measures the
+ * cost of *evaluating the module graph itself* — disk reads, parse, and
+ * top-level evaluation of every transitively imported module. ESM hoists the
+ * static imports at index.ts:10-16 / 36 / 86-95 / 124-215 above every statement
+ * in the file, so all of it is paid before `process.argv[2] === '__vault-age-
+ * helper'` (index.ts:38) can short-circuit, before the secrets-broker intercept
+ * (index.ts:71-84), and before `--version` prints. index.ts:17-21 states this is
+ * the thing "that gets cold starts under the target"; command-registry.ts:4-13
+ * states the same for the command tree.
+ *
+ * Method — cold child process per sample, no mocking. Node caches an ESM module
+ * for the life of a process, so a second in-process `import()` of the same
+ * specifier measures nothing but a Map lookup: an honest module-load number can
+ * only come from a fresh process. Each bench below spawns a real `node
+ * --input-type=module -e "await import(...)"` that imports the REAL built
+ * modules under dist/ (the same artifacts `agents` runs, built by
+ * scripts/build.sh / bun install's `prepare`), against this machine's real
+ * filesystem. Every bench in the group spawns the identical shape, so the
+ * constant Node-spawn floor cancels between rows; `BASELINE` below is that floor
+ * measured directly, so any row minus BASELINE is that graph's own load cost.
+ *
+ * index.ts itself is deliberately NOT imported here, for the reason in this
+ * file's top docblock: it has top-level await, reads process.argv, and ends in
+ * program.parseAsync() (index.ts:1440), so importing it would run the CLI. The
+ * import list below is transcribed from its static imports instead, in source
+ * order, and `bootstrapGraph` unions them into the single graph a real
+ * invocation evaluates.
+ */
+const DIST_DIR = path.join(__dirname, '../../dist');
+/** A dist module, as the `file://` specifier a spawned child can import. */
+const dist = (rel: string): string => pathToFileURL(path.join(DIST_DIR, rel)).href;
+
+/** Cold-import `specs` in a fresh Node process. Empty list = the spawn floor. */
+function coldImport(specs: string[]): void {
+  const src = specs.map((s) => `await import(${JSON.stringify(s)});`).join('\n');
+  spawnSync(process.execPath, ['--input-type=module', '-e', src], { stdio: 'ignore' });
+}
+
+/** The static imports of src/index.ts, in source order. */
+const BOOTSTRAP_GRAPH: string[] = [
+  'commander', // index.ts:10
+  'chalk', // index.ts:11
+  'node:fs', 'node:os', 'node:path', 'node:url', // index.ts:12-15
+  dist('lib/startup/dev-build.js'), // index.ts:16
+  dist('lib/secrets/sync-commands.js'), // index.ts:36
+  dist('lib/self-update.js'), // index.ts:86-95
+  dist('lib/startup/command-registry.js'), // index.ts:124-207
+  dist('lib/help.js'), // index.ts:208
+  dist('lib/whats-new.js'), // index.ts:209
+  dist('lib/platform/index.js'), // index.ts:211
+  dist('lib/cli-entry.js'), // index.ts:212
+  dist('lib/events.js'), // index.ts:213
+  dist('lib/event-provenance.js'), // index.ts:214
+  dist('lib/format.js'), // index.ts:215
+];
+
+const SPAWN_OPTS = { time: 3000, iterations: 12 } as const;
+
+describe('startup module loading — one cold `node -e "await import(...)"` per index.ts eager import (index.ts:10-215)', () => {
+  bench('BASELINE: bare `node -e ""` — the spawn floor every row below also pays; subtract it to get load cost', () => {
+    coldImport([]);
+  }, SPAWN_OPTS);
+
+  bench('commander (index.ts:10)', () => {
+    coldImport(['commander']);
+  }, SPAWN_OPTS);
+
+  bench('chalk (index.ts:11)', () => {
+    coldImport(['chalk']);
+  }, SPAWN_OPTS);
+
+  bench('node:fs + node:os + node:path + node:url (index.ts:12-15) — builtins, snapshot-resident', () => {
+    coldImport(['node:fs', 'node:os', 'node:path', 'node:url']);
+  }, SPAWN_OPTS);
+
+  bench('lib/startup/dev-build.js (index.ts:16)', () => {
+    coldImport([dist('lib/startup/dev-build.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/secrets/sync-commands.js (index.ts:36) — the leaf the docblock at index.ts:58-61 says is cheap to bind here', () => {
+    coldImport([dist('lib/secrets/sync-commands.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/self-update.js (index.ts:86-95) — pulls lib/versions.js via self-update.ts:20', () => {
+    coldImport([dist('lib/self-update.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/startup/command-registry.js (index.ts:124-207) — every COMMAND_LOADERS entry is a dynamic import inside a thunk (command-registry.ts:32-119), so the table itself loads no command module', () => {
+    coldImport([dist('lib/startup/command-registry.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/help.js (index.ts:208)', () => {
+    coldImport([dist('lib/help.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/whats-new.js (index.ts:209)', () => {
+    coldImport([dist('lib/whats-new.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/platform/index.js (index.ts:211) — `export *` barrel over paths/exec/links/process/ipc/winpath (platform/index.ts:19-24)', () => {
+    coldImport([dist('lib/platform/index.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/cli-entry.js (index.ts:212)', () => {
+    coldImport([dist('lib/cli-entry.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/events.js (index.ts:213) — pulls lib/state.js + lib/fs-atomic.js (events.ts:20-21)', () => {
+    coldImport([dist('lib/events.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/event-provenance.js (index.ts:214)', () => {
+    coldImport([dist('lib/event-provenance.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/format.js (index.ts:215) — re-enters the events graph via format.ts:12', () => {
+    coldImport([dist('lib/format.js')]);
+  }, SPAWN_OPTS);
+});
+
+/**
+ * The graphs, not the pieces. Individual rows above double-count shared
+ * subgraphs (state.js is reached from events.js AND format.js, platform/index.js
+ * from self-update.js AND directly), so their sum is not the real cost. These
+ * rows import a whole graph in ONE child, which is what an invocation pays.
+ *
+ * `redirected` is not hypothetical arithmetic: it imports the exact set
+ * self-update.js's graph reduces to when its one `compareVersions` import
+ * (self-update.ts:20) points at the leaf that actually owns that function
+ * (agent-spec/primitives.ts:50) instead of at ./versions.js, which merely
+ * re-exports it (versions.ts:34, and the note at versions.ts:2327-2328). Its
+ * only other module import is platform/index.js (self-update.ts:21); the rest is
+ * builtins (self-update.ts:15-19).
+ *
+ * `deferrable` additionally drops events.js / event-provenance.js / format.js.
+ * Every symbol index.ts binds from those three is called only inside a function
+ * body, never at module scope: emit (index.ts:292, 314) and redactArgs
+ * (index.ts:298) inside the preAction/postAction hooks, stampProvenance
+ * (index.ts:337) inside postAction, emitFriction (index.ts:942) inside the
+ * `_internal friction` action, die (index.ts:919) inside the `hq` tombstone
+ * action.
+ *
+ * `floor` is the irreducible cost: commander + chalk + the builtins, which the
+ * CLI cannot start without.
+ */
+const SELF_UPDATE_REDIRECTED: string[] = [
+  'node:fs', 'node:os', 'node:path', 'node:crypto', 'node:child_process', // self-update.ts:15-19
+  dist('lib/agent-spec/primitives.js'), // where compareVersions is defined (primitives.ts:50)
+  dist('lib/platform/index.js'), // self-update.ts:21
+];
+const WITHOUT_SELF_UPDATE = BOOTSTRAP_GRAPH.filter((s) => !s.endsWith('self-update.js'));
+const REDIRECTED_GRAPH = [...WITHOUT_SELF_UPDATE, ...SELF_UPDATE_REDIRECTED];
+const DEFERRABLE_GRAPH = REDIRECTED_GRAPH.filter(
+  (s) => !s.endsWith('events.js') && !s.endsWith('event-provenance.js') && !s.endsWith('format.js'),
+);
+const FLOOR_GRAPH = ['commander', 'chalk', 'node:fs', 'node:os', 'node:path', 'node:url'];
+
+describe('startup module loading — the whole eager graph in one cold process (what every `agents` invocation actually pays before argv is read)', () => {
+  bench('BASELINE: bare `node -e ""` — same spawn floor as the rows below', () => {
+    coldImport([]);
+  }, SPAWN_OPTS);
+
+  bench('TODAY: the full index.ts:10-215 graph', () => {
+    coldImport(BOOTSTRAP_GRAPH);
+  }, SPAWN_OPTS);
+
+  bench('self-update.ts:20 redirected to agent-spec/primitives.js — drops the 3738-line lib/versions.js sync engine from the graph', () => {
+    coldImport(REDIRECTED_GRAPH);
+  }, SPAWN_OPTS);
+
+  bench('...and events.js + event-provenance.js + format.js deferred into the hook bodies that use them', () => {
+    coldImport(DEFERRABLE_GRAPH);
+  }, SPAWN_OPTS);
+
+  bench('FLOOR: commander + chalk + builtins only — what the CLI cannot start without', () => {
+    coldImport(FLOOR_GRAPH);
+  }, SPAWN_OPTS);
+});
+
+/**
+ * The command modules COMMAND_LOADERS imports once a top-level name is resolved
+ * (index.ts:1271-1280 -> command-registry.ts:32-119). These load AFTER the
+ * bootstrap graph above and are the larger half of a real cold start, so the
+ * last row measures one on TOP of the bootstrap graph — the true marginal cost
+ * of `agents view` over the bootstrap the process already paid, not a number
+ * measured in isolation and assumed to add.
+ */
+const COMMAND_MODULE_OPTS = { time: 6000, iterations: 12 } as const;
+
+describe('startup module loading — command modules pulled by COMMAND_LOADERS (command-registry.ts:32-119)', () => {
+  bench('BASELINE: bare `node -e ""` — same spawn floor as the rows below', () => {
+    coldImport([]);
+  }, COMMAND_MODULE_OPTS);
+
+  bench('commands/view.js (loadView, command-registry.ts:32)', () => {
+    coldImport([dist('commands/view.js')]);
+  }, COMMAND_MODULE_OPTS);
+
+  bench('commands/doctor.js (loadDoctor, command-registry.ts:65)', () => {
+    coldImport([dist('commands/doctor.js')]);
+  }, COMMAND_MODULE_OPTS);
+
+  bench('commands/sessions.js (loadSessions, command-registry.ts:107) — the SQLite-backed session stack', () => {
+    coldImport([dist('commands/sessions.js')]);
+  }, COMMAND_MODULE_OPTS);
+
+  bench('bootstrap graph THEN commands/view.js — the real `agents view` module-load path, in order', () => {
+    coldImport([...BOOTSTRAP_GRAPH, dist('commands/view.js')]);
+  }, COMMAND_MODULE_OPTS);
 });

--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -280,20 +280,53 @@ const DIST_DIR = path.join(__dirname, '../../dist');
 /** A dist module, as the `file://` specifier a spawned child can import. */
 const dist = (rel: string): string => pathToFileURL(path.join(DIST_DIR, rel)).href;
 
-/** Cold-import `specs` in a fresh Node process. Empty list = the spawn floor. */
+/**
+ * Cold-import `specs` in a fresh Node process. Empty list = the spawn floor.
+ *
+ * Fails loud on a non-zero exit. A mistyped or moved specifier makes the child
+ * die in ~13ms — BELOW the ~14-18ms bare-spawn baseline — so a swallowed
+ * failure would not just go unnoticed, it would read as the fastest row in the
+ * table. The repo's fail-loud-at-boundaries convention, applied to a benchmark:
+ * a row that measures nothing must say so, not post a good number.
+ */
 function coldImport(specs: string[]): void {
   const src = specs.map((s) => `await import(${JSON.stringify(s)});`).join('\n');
-  spawnSync(process.execPath, ['--input-type=module', '-e', src], { stdio: 'ignore' });
+  const r = spawnSync(process.execPath, ['--input-type=module', '-e', src], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  if (r.status !== 0) {
+    throw new Error(`cold import failed (status ${r.status}, signal ${r.signal}): ${String(r.stderr).slice(0, 400)}`);
+  }
 }
 
-/** The static imports of src/index.ts, in source order. */
+/**
+ * The static imports of src/index.ts, in source order.
+ *
+ * They do NOT stop at index.ts:215. index.ts:513-524 declares three more, and
+ * ESM hoists them into the same block as the rest — the built entry proves it:
+ * dist/index.js:393 (state.js) and dist/index.js:394 (brand.js) sit in the same
+ * unbroken import block as dist/index.js:8 (commander). Both are load-bearing
+ * here, not incidental: brand.ts:20 imports agents.js, and agents.ts:26 imports
+ * ./versions.js — so this list reaches the 3738-line sync engine by a SECOND
+ * edge, independent of self-update.ts:20. A version of this bench that stopped
+ * at index.ts:215 measured a saving that the real graph does not get (caught in
+ * review on PR #2280).
+ *
+ * index.ts:515-524 is a second import statement from ./lib/self-update.js,
+ * already listed once below — ESM evaluates a module once per process, so
+ * listing it twice would measure nothing extra.
+ *
+ * `node:os` is deliberately absent though index.ts:13 declares it: nothing in
+ * index.ts references `os`, so tsc elides it (dist/index.js:8-13 has no os
+ * import). This list is the graph the built entry actually loads.
+ */
 const BOOTSTRAP_GRAPH: string[] = [
   'commander', // index.ts:10
   'chalk', // index.ts:11
-  'node:fs', 'node:os', 'node:path', 'node:url', // index.ts:12-15
+  'node:fs', 'node:path', 'node:url', // index.ts:12, 14, 15
   dist('lib/startup/dev-build.js'), // index.ts:16
   dist('lib/secrets/sync-commands.js'), // index.ts:36
-  dist('lib/self-update.js'), // index.ts:86-95
+  dist('lib/self-update.js'), // index.ts:86-95 (and again at index.ts:515-524)
   dist('lib/startup/command-registry.js'), // index.ts:124-207
   dist('lib/help.js'), // index.ts:208
   dist('lib/whats-new.js'), // index.ts:209
@@ -302,6 +335,8 @@ const BOOTSTRAP_GRAPH: string[] = [
   dist('lib/events.js'), // index.ts:213
   dist('lib/event-provenance.js'), // index.ts:214
   dist('lib/format.js'), // index.ts:215
+  dist('lib/state.js'), // index.ts:513
+  dist('lib/brand.js'), // index.ts:514
 ];
 
 const SPAWN_OPTS = { time: 3000, iterations: 12 } as const;
@@ -319,8 +354,8 @@ describe('startup module loading — one cold `node -e "await import(...)"` per 
     coldImport(['chalk']);
   }, SPAWN_OPTS);
 
-  bench('node:fs + node:os + node:path + node:url (index.ts:12-15) — builtins, snapshot-resident', () => {
-    coldImport(['node:fs', 'node:os', 'node:path', 'node:url']);
+  bench('node:fs + node:path + node:url (index.ts:12, 14, 15) — builtins, snapshot-resident; index.ts:13 `os` is unused and tsc elides it (absent from dist/index.js:8-13)', () => {
+    coldImport(['node:fs', 'node:path', 'node:url']);
   }, SPAWN_OPTS);
 
   bench('lib/startup/dev-build.js (index.ts:16)', () => {
@@ -366,21 +401,48 @@ describe('startup module loading — one cold `node -e "await import(...)"` per 
   bench('lib/format.js (index.ts:215) — re-enters the events graph via format.ts:12', () => {
     coldImport([dist('lib/format.js')]);
   }, SPAWN_OPTS);
+
+  bench('lib/state.js (index.ts:513) — imported directly, not only via events.ts:21', () => {
+    coldImport([dist('lib/state.js')]);
+  }, SPAWN_OPTS);
+
+  bench('lib/brand.js (index.ts:514) — the SECOND edge to lib/versions.js: brand.ts:20 -> agents.js, agents.ts:26 -> versions.js', () => {
+    coldImport([dist('lib/brand.js')]);
+  }, SPAWN_OPTS);
 });
 
 /**
  * The graphs, not the pieces. Individual rows above double-count shared
- * subgraphs (state.js is reached from events.js AND format.js, platform/index.js
- * from self-update.js AND directly), so their sum is not the real cost. These
- * rows import a whole graph in ONE child, which is what an invocation pays.
+ * subgraphs (state.js is reached from events.js, format.js AND index.ts:513
+ * directly; platform/index.js from self-update.js and directly), so their sum is
+ * not the real cost. These rows import a whole graph in ONE child, which is what
+ * an invocation pays.
  *
- * `redirected` is not hypothetical arithmetic: it imports the exact set
- * self-update.js's graph reduces to when its one `compareVersions` import
- * (self-update.ts:20) points at the leaf that actually owns that function
- * (agent-spec/primitives.ts:50) instead of at ./versions.js, which merely
- * re-exports it (versions.ts:34, and the note at versions.ts:2327-2328). Its
- * only other module import is platform/index.js (self-update.ts:21); the rest is
- * builtins (self-update.ts:15-19).
+ * lib/versions.js — 3738 lines, and the single largest thing in the graph —
+ * enters by TWO independent edges, which is the point of the rows below:
+ *
+ *   index.ts:86-95  -> self-update.ts:20  -> versions.js   (a re-export shim)
+ *   index.ts:514    -> brand.ts:20        -> agents.js -> agents.ts:26 -> versions.js
+ *
+ * The first edge is removable on one line: versions.ts does not define
+ * `compareVersions`, it re-exports it (versions.ts:34, note at
+ * versions.ts:2327-2328) from agent-spec/primitives.ts:50, a file with zero
+ * imports. The second is NOT — agents.ts:26 imports three real functions
+ * (resolveVersion, getVersionHomePath, getBinaryPath; versions.ts:2205, :1126,
+ * :1006), and brand.js cannot be deferred because resolveBrandName() is called
+ * at module scope (index.ts:241), as is getUpdateCheckPath() from state.js
+ * (index.ts:525).
+ *
+ * agents.js is the sole waypoint for that second edge, and it has two feeders:
+ * brand.ts:20 and capabilities.ts:11. Both therefore reach versions.js, which is
+ * why cutting agents.ts:26 — not deferring brand.js — is what the third row
+ * measures.
+ *
+ * So `oneEdgeCut` measures what cutting ONLY the easy edge buys — the honest
+ * answer being "almost nothing", because the other edge still pulls the same
+ * module. `bothEdgesCut` measures the headroom if agents.ts:26 were also cut:
+ * it substitutes agents.js's own imports (agents.ts:12-27) MINUS the versions.js
+ * edge, so it is a real measured lower bound on that graph, not arithmetic.
  *
  * `deferrable` additionally drops events.js / event-provenance.js / format.js.
  * Every symbol index.ts binds from those three is called only inside a function
@@ -388,7 +450,7 @@ describe('startup module loading — one cold `node -e "await import(...)"` per 
  * (index.ts:298) inside the preAction/postAction hooks, stampProvenance
  * (index.ts:337) inside postAction, emitFriction (index.ts:942) inside the
  * `_internal friction` action, die (index.ts:919) inside the `hq` tombstone
- * action.
+ * action. state.js stays regardless — index.ts:513 imports it directly.
  *
  * `floor` is the irreducible cost: commander + chalk + the builtins, which the
  * CLI cannot start without.
@@ -398,27 +460,55 @@ const SELF_UPDATE_REDIRECTED: string[] = [
   dist('lib/agent-spec/primitives.js'), // where compareVersions is defined (primitives.ts:50)
   dist('lib/platform/index.js'), // self-update.ts:21
 ];
+/**
+ * agents.ts:12-27 minus the one `./versions.js` edge at agents.ts:26.
+ *
+ * capabilities.js (agents.ts:27) is deliberately excluded, and that exclusion is
+ * the whole subtlety of this row. capabilities.ts:11 imports `./agents.js` and
+ * nothing else local, so as BUILT today `capabilities.js -> agents.js ->
+ * versions.js` — importing it here would silently re-add the exact module this
+ * row exists to remove, and the row would measure nothing (it initially did: it
+ * came out SLOWER than TODAY). In the counterfactual where agents.ts:26 is gone,
+ * capabilities.js's only edge leads to an agents.js that carries no versions.js,
+ * so it contributes nothing beyond what this list already holds.
+ */
+const AGENTS_WITHOUT_VERSIONS: string[] = [
+  'node:child_process', 'node:util', 'node:crypto', 'node:fs', 'node:path', 'node:os', // agents.ts:12-17
+  'smol-toml', 'yaml', 'chalk', // agents.ts:18-20
+  dist('lib/platform/index.js'), // agents.ts:22
+  dist('lib/fs-walk.js'), // agents.ts:23
+  dist('lib/fuzzy.js'), // agents.ts:24
+  dist('lib/state.js'), // agents.ts:25
+];
 const WITHOUT_SELF_UPDATE = BOOTSTRAP_GRAPH.filter((s) => !s.endsWith('self-update.js'));
-const REDIRECTED_GRAPH = [...WITHOUT_SELF_UPDATE, ...SELF_UPDATE_REDIRECTED];
-const DEFERRABLE_GRAPH = REDIRECTED_GRAPH.filter(
+const ONE_EDGE_CUT = [...WITHOUT_SELF_UPDATE, ...SELF_UPDATE_REDIRECTED];
+const BOTH_EDGES_CUT = [
+  ...ONE_EDGE_CUT.filter((s) => !s.endsWith('brand.js')),
+  ...AGENTS_WITHOUT_VERSIONS,
+];
+const DEFERRABLE_GRAPH = BOTH_EDGES_CUT.filter(
   (s) => !s.endsWith('events.js') && !s.endsWith('event-provenance.js') && !s.endsWith('format.js'),
 );
-const FLOOR_GRAPH = ['commander', 'chalk', 'node:fs', 'node:os', 'node:path', 'node:url'];
+const FLOOR_GRAPH = ['commander', 'chalk', 'node:fs', 'node:path', 'node:url'];
 
 describe('startup module loading — the whole eager graph in one cold process (what every `agents` invocation actually pays before argv is read)', () => {
   bench('BASELINE: bare `node -e ""` — same spawn floor as the rows below', () => {
     coldImport([]);
   }, SPAWN_OPTS);
 
-  bench('TODAY: the full index.ts:10-215 graph', () => {
+  bench('TODAY: the full graph (index.ts:10-215 AND index.ts:513-524)', () => {
     coldImport(BOOTSTRAP_GRAPH);
   }, SPAWN_OPTS);
 
-  bench('self-update.ts:20 redirected to agent-spec/primitives.js — drops the 3738-line lib/versions.js sync engine from the graph', () => {
-    coldImport(REDIRECTED_GRAPH);
+  bench('ONE EDGE CUT: self-update.ts:20 redirected to agent-spec/primitives.js — versions.js still arrives via index.ts:514 -> brand.ts:20 -> agents.ts:26', () => {
+    coldImport(ONE_EDGE_CUT);
   }, SPAWN_OPTS);
 
-  bench('...and events.js + event-provenance.js + format.js deferred into the hook bodies that use them', () => {
+  bench('BOTH EDGES CUT: that plus agents.ts:26 no longer importing versions.js (agents.ts:12-27 substituted without it) — the headroom, and the only shape where versions.js leaves the graph', () => {
+    coldImport(BOTH_EDGES_CUT);
+  }, SPAWN_OPTS);
+
+  bench('...and events.js + event-provenance.js + format.js deferred into the hook bodies that use them (state.js stays: index.ts:513)', () => {
     coldImport(DEFERRABLE_GRAPH);
   }, SPAWN_OPTS);
 

--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -303,9 +303,10 @@ function coldImport(specs: string[]): void {
  * The static imports of src/index.ts, in source order.
  *
  * They do NOT stop at index.ts:215. index.ts:513-524 declares three more, and
- * ESM hoists them into the same block as the rest — the built entry proves it:
- * dist/index.js:393 (state.js) and dist/index.js:394 (brand.js) sit in the same
- * unbroken import block as dist/index.js:8 (commander). Both are load-bearing
+ * ESM hoists them with the rest — the built entry keeps them as top-level
+ * imports at dist/index.js:393 (state.js) and dist/index.js:394 (brand.js),
+ * evaluated before any statement runs, exactly like dist/index.js:8
+ * (commander). Both are load-bearing
  * here, not incidental: brand.ts:20 imports agents.js, and agents.ts:26 imports
  * ./versions.js — so this list reaches the 3738-line sync engine by a SECOND
  * edge, independent of self-update.ts:20. A version of this bench that stopped
@@ -318,7 +319,12 @@ function coldImport(specs: string[]): void {
  *
  * `node:os` is deliberately absent though index.ts:13 declares it: nothing in
  * index.ts references `os`, so tsc elides it (dist/index.js:8-13 has no os
- * import). This list is the graph the built entry actually loads.
+ * import). platform/index.js is elided from the entry for the same reason —
+ * index.ts:211 binds IS_WINDOWS and nothing uses it, so `platform/index.js`
+ * appears nowhere in dist/index.js — but unlike `os` it stays in this list,
+ * because the graph loads it anyway one level down (self-update.ts:21,
+ * agents.ts:22). Its row below is labelled accordingly. This list is the graph
+ * the built entry actually loads, not the one the source appears to declare.
  */
 const BOOTSTRAP_GRAPH: string[] = [
   'commander', // index.ts:10
@@ -330,7 +336,7 @@ const BOOTSTRAP_GRAPH: string[] = [
   dist('lib/startup/command-registry.js'), // index.ts:124-207
   dist('lib/help.js'), // index.ts:208
   dist('lib/whats-new.js'), // index.ts:209
-  dist('lib/platform/index.js'), // index.ts:211
+  dist('lib/platform/index.js'), // declared at index.ts:211 but elided; really loaded via self-update.ts:21 / agents.ts:22
   dist('lib/cli-entry.js'), // index.ts:212
   dist('lib/events.js'), // index.ts:213
   dist('lib/event-provenance.js'), // index.ts:214
@@ -382,7 +388,7 @@ describe('startup module loading — one cold `node -e "await import(...)"` per 
     coldImport([dist('lib/whats-new.js')]);
   }, SPAWN_OPTS);
 
-  bench('lib/platform/index.js (index.ts:211) — `export *` barrel over paths/exec/links/process/ipc/winpath (platform/index.ts:19-24)', () => {
+  bench('lib/platform/index.js — `export *` barrel over paths/exec/links/process/ipc/winpath (platform/index.ts:19-24); index.ts:211 binds IS_WINDOWS but nothing uses it so tsc elides that edge, and the graph reaches it via self-update.ts:21 / agents.ts:22 instead', () => {
     coldImport([dist('lib/platform/index.js')]);
   }, SPAWN_OPTS);
 


### PR DESCRIPTION
**bench-only (test-only, no behavior change)** — extends the existing `apps/cli/src/lib/index.bench.ts` with three groups measuring the eager **module graph** `src/index.ts` evaluates before it ever looks at argv. No product code changed; docs/CHANGELOG exempt (test-only).

Tickets: **[RUSH-2331 — CLI bootstrap: versions.ts reaches the eager graph by two edges (94ms)](https://linear.app/getrush/issue/RUSH-2331)**, opened from this measurement and carrying the proposals below. Related: [RUSH-2329 — CLI command imports add 113-333ms before parse](https://linear.app/getrush/issue/RUSH-2329/cli-command-imports-add-113-333ms-before-parse), whose comment estimated "about 80-90ms of CLI bootstrap over bare Node" — this PR measures that bootstrap half and finds where all of it goes.

> **Revised after review.** The first revision's `BOOTSTRAP_GRAPH` stopped at `index.ts:215` and missed the hoisted imports at `index.ts:513-514`. That omission inverted the headline: the one-line fix it proposed saves **nothing**, because `brand.js` gives `versions.js` a second edge. Both the bench and the proposals below are corrected and re-measured. Thanks to the reviewer for catching it.

## Why this is a distinct measurement

The bench file already measured command *registration* (PR #2278). This measures the cost of **evaluating the module graph itself**. ESM hoists every static import — `index.ts:10-16`, `:36`, `:86-95`, `:124-215` **and `:513-524`** — above every statement in the file, so the whole graph is evaluated *before* the `__vault-age-helper` intercept (`index.ts:38`), before the secrets-broker sync intercept (`index.ts:71-84`), and before `--version` prints. `index.ts:66-70` states this ordering. The built entry confirms the hoisting: `dist/index.js:393` (`state.js`) and `dist/index.js:394` (`brand.js`) sit in the same unbroken import block as `dist/index.js:8` (`commander`).

Method, no mocking: Node caches an ESM module for the life of a process, so a second in-process `import()` measures a Map lookup. Every sample is a **fresh child process** — `node --input-type=module -e "await import(...)"` — importing the **real built `dist/` modules** against the real filesystem. Every row spawns the identical shape, so the constant spawn floor cancels; `BASELINE` measures that floor directly. `coldImport` throws on a non-zero child exit: a bad specifier dies in ~13 ms, *below* the ~17 ms baseline, so a swallowed failure would post the fastest number in the table.

## Measured — `npx vitest bench --run src/lib/index.bench.ts`, yosemite-s1

Mean ms. "load cost" = mean − that group's BASELINE.

### The whole eager graph in one cold process
`/proc/loadavg` **2.75 2.27 2.29** → **2.59 2.27 2.29**

| Row | mean | load cost |
|---|---|---|
| BASELINE bare `node -e ""` | 17.0035 | — |
| **TODAY: full graph (`index.ts:10-215` **and** `:513-524`)** | **111.40** | **94.4 ms** |
| ONE EDGE CUT: `self-update.ts:20` redirected to `agent-spec/primitives.js` | 108.06 | 91.1 ms |
| **BOTH EDGES CUT: that plus `agents.ts:26` not importing `versions.js`** | **62.1599** | **45.2 ms** |
| …and `events`/`event-provenance`/`format` deferred | 58.1991 | 41.2 ms |
| FLOOR: commander + chalk + builtins | 33.3477 | 16.3 ms |

**The one-line fix alone is worth ~3 ms — inside the noise.** That is the finding, and it is the opposite of what this PR first claimed.

### Per static import
`/proc/loadavg` **1.04 1.81 2.18**; BASELINE 18.0400

| Import | mean | over baseline |
|---|---|---|
| `lib/self-update.js` (`index.ts:86-95`) | **103.93** | **+85.9** |
| `lib/brand.js` (`index.ts:514`) | **102.55** | **+84.5** |
| `lib/format.js` (`index.ts:215`) | 53.9825 | +35.9 |
| `lib/events.js` (`index.ts:213`) | 48.9766 | +30.9 |
| `lib/event-provenance.js` (`index.ts:214`) | 47.9658 | +29.9 |
| `lib/state.js` (`index.ts:513`) | 47.4716 | +29.4 |
| `lib/platform/index.js` (`index.ts:211`) | 37.1702 | +19.1 |
| `commander` (`index.ts:10`) | 31.9287 | +13.9 |
| `lib/whats-new.js` (`index.ts:209`) | 30.3173 | +12.3 |
| `chalk` (`index.ts:11`) | 28.8409 | +10.8 |
| `lib/cli-entry.js` (`index.ts:212`) | 22.9641 | +4.9 |
| `lib/startup/dev-build.js` (`index.ts:16`) | 21.4414 | +3.4 |
| `node:fs`/`path`/`url` (`index.ts:12, 14, 15`) | 20.9169 | +2.9 |
| `lib/secrets/sync-commands.js` (`index.ts:36`) | 20.0418 | +2.0 |
| `lib/help.js` (`index.ts:208`) | 19.5398 | +1.5 |
| `lib/startup/command-registry.js` (`index.ts:124-207`) | 19.3038 | +1.3 |

`self-update.js` (+85.9) and `brand.js` (+84.5) are near-identical because they pull the **same** `versions.js` tree — which is exactly why removing one changes nothing. Rows double-count shared subgraphs, so the graph table above, not this sum, is the real cost.

### Command modules `COMMAND_LOADERS` pulls
BASELINE 18.2067

| Row | mean |
|---|---|
| `commands/view.js` (`command-registry.ts:32`) | 225.17 |
| `commands/doctor.js` (`command-registry.ts:65`) | 212.44 |
| `commands/sessions.js` (`command-registry.ts:107`) | 302.41 |
| bootstrap graph **then** `commands/view.js` | 234.76 |

## Proposals — each measured, none speculative

`lib/versions.js` (3738 lines) is the single largest thing in the graph and reaches it by **two independent edges**, verified by a static walk of the built graph:

```
index.ts:86-95  -> self-update.ts:20 -> versions.js
index.ts:514    -> brand.ts:20 -> agents.js -> agents.ts:26 -> versions.js
```

`agents.js` is the sole waypoint on the second edge and has two feeders — `brand.ts:20` and `capabilities.ts:11`.

**1 and 2 are a package. Either alone is worth ~3 ms; together, −49.2 ms (94.4 → 45.2 ms of load cost).**

**1. `apps/cli/src/lib/self-update.ts:20` — import `compareVersions` from the leaf that defines it.** `versions.ts` does not define it: `versions.ts:34` imports it from `./agent-spec/primitives.js` and re-exports it for compatibility (`versions.ts:2327-2328`); `agent-spec/primitives.ts:50` defines it, in a file with **zero imports**. `compareVersions` is `self-update.ts`'s only import from `versions.js`; its other module import is `platform/index.js` (`self-update.ts:21`), the rest builtins (`self-update.ts:15-19`).

**2. `apps/cli/src/lib/agents.ts:26` — move `resolveVersion`, `getVersionHomePath`, `getBinaryPath` out of `versions.ts` into a leaf.** Defined at `versions.ts:2205`, `:1126`, `:1006`. This is a real refactor, not a redirect — these are three genuine functions, and this edge is the one that actually keeps the graph expensive. Deferring `brand.js` is **not** an alternative: `resolveBrandName()` is called at module scope (`index.ts:241`), as is `getUpdateCheckPath()` from `state.js` (`index.ts:525`). The `BOTH EDGES CUT` row measures this by substituting `agents.ts:12-27` without the `versions.js` edge; `capabilities.js` is excluded from that substitution because `capabilities.ts:11` imports `agents.js` and would silently re-add the module the row removes — the first attempt did exactly that and measured *slower* than TODAY.

**3. `apps/cli/src/index.ts:213-215` — defer `events.js`, `event-provenance.js`, `format.js`. A further −4.0 ms (45.2 → 41.2 ms).** Small, and smaller than it looks in the per-import table: `state.js` is imported directly at `index.ts:513`, so it stays regardless. Every symbol bound from the three is called only inside a function body: `emit` (`index.ts:292`, `:314`), `redactArgs` (`:298`), `stampProvenance` (`:337`), `emitFriction` (`:942`), `die` (`:919`). `format.ts:12` imports `events.js`, so all three must move together. `index.ts:1216` must also become `await program.parseAsync(...)`: it is a sync `parse()` inside the async IIFE at `index.ts:1211-1217`, and commander does not await an async hook from `parse()` (`command.js:1081-1087`, `_chainOrCall` at `:1493-1500`) — so the audit `emit` would be raced rather than rejected. The root parse (`index.ts:1440`) is already `parseAsync`.

**4. Floor: 16.3 ms** (commander + chalk + builtins). After 1-3 the graph is 41.2 ms, so ~25 ms of headroom remains, all of it below `platform/index.js` and `commander`.

**5. Scope note, measured — this lands on the module-less paths, not on `agents view`.** `bootstrap then commands/view.js` (234.76) is only **+9.6 ms** over `commands/view.js` alone (225.17), because `view.ts:60` imports `../lib/versions.js` itself. The saving lands in full on paths that load no command module: `--version` and bare `--help` (`index.ts:1281-1284` registers zero loaders), `__shim` (`index.ts:221`), `__daemon-run` (`index.ts:232`), `__vault-age-helper` (`index.ts:38`), and the secrets-broker sync intercepts (`index.ts:71-84`) — which `index.ts:44-47` calls "the hot read path", spawned synchronously per secret read. The remaining 200-300 ms of command-module cost is RUSH-2329's scope.

## Notes for the reviewer

- Two commits: the bench, then the review fix (missing `index.ts:513-514`, the `capabilities.js` counterfactual, `node:os` elision, fail-loud `coldImport`).
- The bench is **committed** at `apps/cli/src/lib/index.bench.ts`. `apps/cli/vitest.config.ts:18` includes only `*.test.ts`, so it does not run under `vitest run` and cannot slow CI; it runs explicitly via `npx vitest bench --run`. It is inside the `typecheck:bench` glob (`package.json:58`) and `bun run typecheck:bench` exits 0.
- It depends on a built `dist/` — as this file already did at `index.bench.ts:93` before this PR — produced by `bun install`'s `prepare` hook.
