### PR TITLE
bench(cli): measure eager self-update import graph (index.ts:86-95)

### DIFF
--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -259,24 +259,41 @@ describe('command-registry.ts loaders — warm in-process registration only (mod
  * from './versions.js'` (self-update.ts:20 -- the binding is used once, at
  * self-update.ts:132) drags the ENTIRE versions.ts dependency graph onto the
  * eager path: versions.ts statically imports yaml, chalk, smol-toml,
- * @inquirer/prompts and ~40 local modules (state, resources, agents,
+ * @inquirer/prompts and 27 local modules (state, resources, agents,
  * permissions, mcp, plugins, hooks, staleness, ...) at versions.ts:17-68. That
  * is the "versions.ts reaches the eager graph by two edges (~94ms)" cost tracked
  * in RUSH-2331; the self-update.ts:20 import is one of those two edges.
  * self-update.ts's OTHER local import, needsWindowsShell from './platform/
- * index.js' (self-update.ts:21), is a zero-import leaf (platform/index.ts has no
- * imports; IS_WINDOWS = process.platform === 'win32' at platform/index.ts:15),
- * benched below to show it is not the cost.
+ * index.js' (self-update.ts:21), is NOT a leaf: platform/index.ts re-exports six
+ * submodules (paths/exec/links/process/ipc/winpath, platform/index.ts:19-24) and
+ * transitively pulls the third-party proper-lockfile (process.ts:7 ->
+ * fs-atomic.ts:4). Benched standalone below it costs ~18-20ms -- real, but a
+ * fraction of the versions.js graph, and NOT the dominant cost. It matters for
+ * the swap arithmetic (see below), not as the headline.
  *
  * compareVersions is defined in the zero-dependency leaf ./agent-spec/
  * primitives.ts (primitives.ts:50, docblock "zero dependencies") and merely
  * RE-EXPORTED by versions.ts (versions.ts:34 imports it from primitives;
- * versions.ts:2327-2328 re-exports it "so existing `import { compareVersions }
- * from './versions.js'` sites keep working"). So the compareVersions self-update
+ * versions.ts:2329 `export { compareVersions };`, with the explanatory comment
+ * at versions.ts:2327-2328, "so existing `import { compareVersions } from
+ * './versions.js'` sites keep working"). So the compareVersions self-update
  * calls is byte-for-byte the same function whether reached via versions.js or
  * primitives.js -- primitives.js is benched below as the proposed replacement
- * source, and the delta versions.js MINUS primitives.js is the measured cost of
- * the heavy edge that swapping self-update.ts:20 would remove.
+ * source.
+ *
+ * SWAP ARITHMETIC (why the win is ~66ms, NOT the full versions.js delta):
+ * versions.ts:48 ITSELF imports './platform/index.js', so today platform is
+ * already resident once versions.js loads -- Node caches by resolved URL, so
+ * self-update.ts:21's own platform import is currently free. The measured proof
+ * is below: self-update.js's over-baseline delta (~83ms) matches versions.js's
+ * (~87ms) almost exactly, NOT versions.js + platform -- platform is subsumed in
+ * versions.js. After swapping self-update.ts:20 to primitives.js, versions.js no
+ * longer loads, so self-update.ts:21's platform import stops being subsumed and
+ * becomes a standalone ~18-20ms cost. Projected post-swap self-update.js import
+ * ~= baseline + primitives (~2ms) + platform (~18-20ms) ~= baseline + ~20ms, vs
+ * baseline + ~83ms today: a real saving of ~63ms, not the ~84ms that a naive
+ * versions.js-MINUS-primitives.js subtraction implies. Every term is measured
+ * in the group below.
  *
  * MEASUREMENT REGIME: each module is imported in a FRESH `node` child process
  * (spawnSync, --input-type=module, a bare `await import(<file url>)`), because
@@ -315,15 +332,15 @@ describe('eager self-update import graph — cold `node` module-eval, fresh proc
     importCost('agent-spec/primitives.js');
   }, { time: 4000, iterations: 20 });
 
-  bench('import dist/lib/platform/index.js — self-update.ts:21 needsWindowsShell dep, a zero-import leaf (platform/index.ts) — shown to NOT be the cost', () => {
+  bench('import dist/lib/platform/index.js — self-update.ts:21 needsWindowsShell dep; re-exports 6 submodules + transitively proper-lockfile (platform/index.ts:19-24). Subsumed in versions.js today (versions.ts:48); standalone ~18-20ms AFTER the swap', () => {
     importCost('platform/index.js');
   }, { time: 4000, iterations: 20 });
 
-  bench('import dist/lib/self-update.js — the FULL eager graph as shipped: self-update body + versions.js (via self-update.ts:20) + platform leaf. This is what index.ts:86-95 evaluates on EVERY invocation', () => {
+  bench('import dist/lib/self-update.js — the FULL eager graph as shipped: self-update body + versions.js (via self-update.ts:20; platform is subsumed inside it via versions.ts:48). This is what index.ts:86-95 evaluates on EVERY invocation', () => {
     importCost('self-update.js');
   }, { time: 4000, iterations: 20 });
 
-  bench('import dist/lib/versions.js — the heavy transitive dep pulled in SOLELY for compareVersions (yaml/chalk/smol-toml/@inquirer/prompts + ~40 locals, versions.ts:17-68); RUSH-2331 ~94ms', () => {
+  bench('import dist/lib/versions.js — the heavy transitive dep pulled in SOLELY for compareVersions (yaml/chalk/smol-toml/@inquirer/prompts + 27 locals, versions.ts:17-68); RUSH-2331 ~94ms', () => {
     importCost('versions.js');
   }, { time: 4000, iterations: 20 });
 });

--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -75,7 +75,7 @@
  */
 import { describe, bench } from 'vitest';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { Command } from 'commander';
 import {
@@ -239,4 +239,91 @@ describe('command-registry.ts loaders — warm in-process registration only (mod
   bench('loadSessions()(new Command()) — registerSessionsCommands body only, no import cost after first sample', async () => {
     (await loadSessions())(new Command());
   });
+});
+
+/**
+ * ============================================================================
+ * Eager self-update IMPORT GRAPH — cold module-evaluation cost (index.ts:86-95).
+ *
+ * The groups above bench the RUNTIME cost of the functions checkForUpdates
+ * calls. This group benches a different, earlier cost: the one-time
+ * module-EVALUATION of the `import { ... } from './self-update.js'` statement
+ * at index.ts:86-95, which ESM hoists and runs on EVERY `agents` invocation
+ * before command registration -- including the `--version`/`--help` fast paths
+ * that skip checkForUpdates/spawnDetachedSync entirely (index.ts:114-118 sets
+ * only env; the checkForUpdates/spawnDetachedSync guards live at the parse site,
+ * but the self-update MODULE body still evaluates unconditionally because the
+ * import is static, not dynamic like the COMMAND_LOADERS thunks at index.ts:124).
+ *
+ * self-update.ts's own body is tiny, but its static `import { compareVersions }
+ * from './versions.js'` (self-update.ts:20 -- the binding is used once, at
+ * self-update.ts:132) drags the ENTIRE versions.ts dependency graph onto the
+ * eager path: versions.ts statically imports yaml, chalk, smol-toml,
+ * @inquirer/prompts and ~40 local modules (state, resources, agents,
+ * permissions, mcp, plugins, hooks, staleness, ...) at versions.ts:17-68. That
+ * is the "versions.ts reaches the eager graph by two edges (~94ms)" cost tracked
+ * in RUSH-2331; the self-update.ts:20 import is one of those two edges.
+ * self-update.ts's OTHER local import, needsWindowsShell from './platform/
+ * index.js' (self-update.ts:21), is a zero-import leaf (platform/index.ts has no
+ * imports; IS_WINDOWS = process.platform === 'win32' at platform/index.ts:15),
+ * benched below to show it is not the cost.
+ *
+ * compareVersions is defined in the zero-dependency leaf ./agent-spec/
+ * primitives.ts (primitives.ts:50, docblock "zero dependencies") and merely
+ * RE-EXPORTED by versions.ts (versions.ts:34 imports it from primitives;
+ * versions.ts:2327-2328 re-exports it "so existing `import { compareVersions }
+ * from './versions.js'` sites keep working"). So the compareVersions self-update
+ * calls is byte-for-byte the same function whether reached via versions.js or
+ * primitives.js -- primitives.js is benched below as the proposed replacement
+ * source, and the delta versions.js MINUS primitives.js is the measured cost of
+ * the heavy edge that swapping self-update.ts:20 would remove.
+ *
+ * MEASUREMENT REGIME: each module is imported in a FRESH `node` child process
+ * (spawnSync, --input-type=module, a bare `await import(<file url>)`), because
+ * Node caches an ESM module after its first import IN THIS PROCESS -- and this
+ * bench file already statically imports self-update.js at its top, so an
+ * in-process dynamic import would measure a warm cache (~0), not the real cold
+ * cost a user's shell pays on a fresh `agents` process. Spawning the real built
+ * dist/lib/*.js (produced by `bun run build`; NOT the TS source, which Node
+ * cannot import without a loader) mirrors exactly how the installed CLI pays
+ * this: one cold node process, one cold module graph, per invocation. Every
+ * number therefore includes node's ~14ms process-startup floor -- the `bare
+ * node, imports nothing` baseline below measures that floor so the module-graph
+ * cost is read as (module MINUS bare), not the raw number. No mocking: real
+ * child processes, real built artifacts, real filesystem.
+ *
+ * Bounded iteration counts (each spawn is a real fork+exec of node, ~15-110ms),
+ * mirroring the real-cold-process groups earlier in this file.
+ */
+const DIST_LIB = path.join(__dirname, '../../dist/lib');
+function importCost(relFromDistLib: string | null): void {
+  const code = relFromDistLib === null
+    ? ''
+    : `await import(${JSON.stringify(pathToFileURL(path.join(DIST_LIB, relFromDistLib)).href)})`;
+  // spawnSync (not execFileSync) so a non-zero child exit never throws inside
+  // the timed callback; every path below is verified to import cleanly on this
+  // box, but the bench stays robust to environment drift.
+  spawnSync(process.execPath, ['--input-type=module', '-e', code], { stdio: 'ignore' });
+}
+
+describe('eager self-update import graph — cold `node` module-eval, fresh process per sample (index.ts:86-95)', () => {
+  bench('baseline: bare `node -e ""`, imports nothing — the process-startup floor every number below sits on top of', () => {
+    importCost(null);
+  }, { time: 4000, iterations: 20 });
+
+  bench('import dist/lib/agent-spec/primitives.js — the zero-dependency leaf that OWNS compareVersions (primitives.ts:50); proposed replacement source for self-update.ts:20', () => {
+    importCost('agent-spec/primitives.js');
+  }, { time: 4000, iterations: 20 });
+
+  bench('import dist/lib/platform/index.js — self-update.ts:21 needsWindowsShell dep, a zero-import leaf (platform/index.ts) — shown to NOT be the cost', () => {
+    importCost('platform/index.js');
+  }, { time: 4000, iterations: 20 });
+
+  bench('import dist/lib/self-update.js — the FULL eager graph as shipped: self-update body + versions.js (via self-update.ts:20) + platform leaf. This is what index.ts:86-95 evaluates on EVERY invocation', () => {
+    importCost('self-update.js');
+  }, { time: 4000, iterations: 20 });
+
+  bench('import dist/lib/versions.js — the heavy transitive dep pulled in SOLELY for compareVersions (yaml/chalk/smol-toml/@inquirer/prompts + ~40 locals, versions.ts:17-68); RUSH-2331 ~94ms', () => {
+    importCost('versions.js');
+  }, { time: 4000, iterations: 20 });
 });


### PR DESCRIPTION
**test-only** — extends `apps/cli/src/lib/index.bench.ts` with one new vitest `bench` group. No behavior change, no runtime code touched. Audience: maintainers profiling CLI cold-start.

## What this measures

`index.ts:86-95` statically imports 8 bindings from `./self-update.js`. ESM hoists that import, so `self-update.js`'s module body — and its whole transitive graph — **evaluates on every `agents` invocation before command registration**, including the `--version`/`--help` fast paths that skip `checkForUpdates`/`spawnDetachedSync`. The existing groups in this file bench the *runtime* cost of the functions `checkForUpdates` calls; this new group benches the earlier, unconditional *module-evaluation* cost.

The cost is dominated by one edge: `self-update.ts:20` statically imports `compareVersions` from `./versions.js` (used once, at `self-update.ts:132`), which drags the entire `versions.ts` dependency graph — `yaml`, `chalk`, `smol-toml`, `@inquirer/prompts` and 27 local modules (`versions.ts:17-68`) — onto the eager path. This is the "versions.ts reaches the eager graph by two edges (~94ms)" cost tracked in **RUSH-2331**; the `self-update.ts:20` import is one of those two edges.

### Method (no mocking)
Each module is imported in a **fresh `node` child process** (`spawnSync`, `--input-type=module`, a bare `await import(<file url>)` of the real built `dist/lib/*.js`). Node caches an ESM module after first import in-process, and this bench file already statically imports `self-update.js` at its top — so an in-process dynamic import would measure a warm cache (~0), not the real cold cost a user's shell pays on a fresh `agents` process. Spawning the real built artifact mirrors exactly how the installed CLI pays this: one cold node process, one cold module graph, per invocation. A `bare node, imports nothing` baseline measures node's ~17ms startup floor, so module-graph cost reads as (module − bare).

## Measured (yosemite-s1, `npx vitest bench --run src/lib/index.bench.ts`)

`/proc/loadavg`: **1.69** before → **1.80** after.

Fresh `node` child process per sample, **mean** (hz):

| module imported | mean | vs bare |
|---|---:|---:|
| bare `node -e ""` (startup floor) | 17.20 ms (58.14 hz) | — |
| `agent-spec/primitives.js` — zero-dep leaf, **owns** `compareVersions` | 18.81 ms (53.16 hz) | +1.6 ms |
| `platform/index.js` — self-update's other dep (re-exports 6 submodules + proper-lockfile) | 35.67 ms (28.04 hz) | +18.5 ms |
| **`self-update.js` — full eager graph as shipped** | **100.06 ms (9.99 hz)** | **+82.9 ms** |
| `versions.js` — heavy dep pulled in solely for `compareVersions` | 105.34 ms (9.49 hz) | +88.1 ms |

Reading: the eager `self-update.js` import adds **~83 ms of module-eval to every invocation**, essentially all of it the `versions.js` graph. Note `self-update.js` (+82.9) ≈ `versions.js` (+88.1), **not** `versions.js` + `platform` — proof that `platform/index.js` is already subsumed inside the `versions.js` graph today (`versions.ts:48` imports it).

## Proposals (each measured above; nothing unmeasured)

1. **Swap `self-update.ts:20`** `import { compareVersions } from './versions.js'` → `from './agent-spec/primitives.js'`. `compareVersions` is *defined* in the zero-dep leaf `primitives.ts:50` and only *re-exported* by `versions.ts` (`versions.ts:34` imports it from primitives; `versions.ts:2329` `export { compareVersions };`, comment at `:2327-2328` "so existing `import { compareVersions } from './versions.js'` sites keep working") — so the swap is byte-for-byte behavior-identical. It severs the sole heavy edge from `self-update.js`'s eager graph.

   **Measured win ≈ 63 ms per invocation, not the naive ~85 ms.** Because `versions.ts:48` itself imports `platform/index.js`, `self-update.ts:21`'s `platform` import is *free today* (already resident once `versions.js` loads — Node caches by resolved URL). After the swap, `versions.js` no longer loads, so `platform/index.js` stops being subsumed and becomes a standalone ~18.5 ms cost. Projected post-swap `self-update.js` import ≈ baseline + primitives (+1.6) + platform (+18.5) ≈ **~37 ms**, vs **~100 ms** today → **~63 ms saved** on every invocation, `--version`/`--help` included. Mechanism: `self-update.ts:20` is the only `versions.js` import in the file; `platform/index.js` (`self-update.ts:21`) and node builtins (`fs`/`os`/`path`/`crypto`/`child_process`) stay, so post-swap `self-update.js` pulls no application graph beyond `platform`.

2. **Second edge (out of scope here, tracked by RUSH-2331):** RUSH-2331 notes `versions.ts` reaches the eager graph by *two* edges; `self-update.ts:20` is one. The other eager static importer of `versions.js` is a separate fix and is not measured or touched by this PR — flagged so proposal 1 isn't mistaken for closing RUSH-2331 alone.

## Evidence
- Eager import site: `apps/cli/src/index.ts:86-95` (static, hoisted) vs the lazy `COMMAND_LOADERS` thunks at `index.ts:124`.
- Heavy edge: `apps/cli/src/lib/self-update.ts:20` (import), `:132` (sole use).
- Heavy graph: `apps/cli/src/lib/versions.ts:17-68` (27 local + yaml/chalk/smol-toml/@inquirer/prompts).
- `platform` subsumption: `versions.ts:48` imports `./platform/index.js`; `platform/index.ts:19-24` re-exports 6 submodules; `process.ts:7` → `fs-atomic.ts:4` pulls `proper-lockfile`.
- Free replacement: `apps/cli/src/lib/agent-spec/primitives.ts:50` (`compareVersions`, docblock "zero dependencies"); re-export at `versions.ts:34`, `:2329`.

`typecheck:bench` passes. Bench is committed beside its source per the repo convention that `vitest.config.ts` `include` matches only `*.test.ts`, so `*.bench.ts` runs only under `vitest bench`.

_Docblock accuracy corrected in the second commit per non-author review (platform is not a leaf; ~63 ms not ~85 ms)._