### PR TITLE
bench(cli): measure the core bootstrap block (index.ts:71-113, 243-251)

### DIFF
--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -74,10 +74,14 @@
  * `@ts-expect-error` (TS2578, unused directive) that no gate caught.
  */
 import { describe, bench } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { Command } from 'commander';
+import { detectDevBuild } from './startup/dev-build.js';
+import { SYNC_PING_CMD } from './secrets/sync-commands.js';
 import {
   readUpdateCache,
   shouldPromptUpgrade,
@@ -239,4 +243,178 @@ describe('command-registry.ts loaders — warm in-process registration only (mod
   bench('loadSessions()(new Command()) — registerSessionsCommands body only, no import cost after first sample', async () => {
     (await loadSessions())(new Command());
   });
+});
+
+/**
+ * ============================================================================
+ * The core bootstrap block: everything index.ts evaluates and RUNS before the
+ * first argv fast path can return — `detectDevBuild()` (index.ts:113), the
+ * secrets-broker token dispatch (index.ts:71-84), and the root commander
+ * program (index.ts:243-251). Paid by `--version` and `--help` too: the
+ * `!helpOrVersionRequested` guard is at index.ts:1322, ~1200 lines below all of
+ * it, and it only gates `checkForUpdates()` + `spawnDetachedSync()`.
+ *
+ * The groups below measure the WORK these lines do, not the cost of loading
+ * their modules. The module-graph question — what `import { Command } from
+ * 'commander'` (index.ts:10) and `import chalk from 'chalk'` (index.ts:11) cost
+ * to evaluate — is the subject of the open sibling PR #2280, which adds a
+ * per-import cold-child group to this same file. These groups deliberately do
+ * not restate those rows; where a number here needs the import cost to be
+ * interpretable it uses the whole-invocation anchor at the bottom instead.
+ *
+ * Two of these ARE in scope here and are not in that PR, because they are
+ * counterfactuals rather than inventory:
+ *   - lib/secrets/agent.js, the graph the leaf lib/secrets/sync-commands.js
+ *     (index.ts:36) exists to keep OFF the eager path. index.ts:58-61 asserts
+ *     that binding the tokens from agent.js "would pull the whole secrets graph
+ *     into every invocation". That is an unmeasured claim in the source; the
+ *     group below measures both sides of it.
+ *   - the real cold `node dist/index.js --version`, the denominator every
+ *     other row in this file is a fraction of.
+ *
+ * No mocking anywhere below: real syscalls against this checkout and this
+ * machine's real filesystem, real cold `node` processes importing the real
+ * built dist/ artifacts, and the real unmodified `commander` package.
+ *
+ * `detectDevBuild` is imported from the TS source (`./startup/dev-build.js` ->
+ * src/lib/startup/dev-build.ts under vitest), unlike `spawnDetachedSync` above
+ * which had to come from dist/. The distinction is `import.meta.url`:
+ * spawnDetachedSync resolves a sibling worker script relative to its own module
+ * location (auto-pull.ts:51), so the source copy takes a different branch;
+ * detectDevBuild reads nothing but its two arguments (dev-build.ts:25-38), so
+ * source and dist are the same code doing the same syscalls.
+ */
+
+/** Repo root of THIS checkout — dirname³ of src/lib/, i.e. apps/cli/../.. */
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+/** apps/cli of THIS checkout. */
+const CLI_ROOT = path.resolve(__dirname, '../..');
+const DIST_ROOT = path.join(CLI_ROOT, 'dist');
+
+/**
+ * A real symlink to the built entry, modelling the npm-global bin shim
+ * (`<prefix>/bin/agents -> <prefix>/lib/node_modules/@phnx-labs/agents-cli/dist
+ * /index.js`) that is `process.argv[1]` on a real user's invocation. It exists
+ * so the `fs.realpathSync` hop at dev-build.ts:28 is measured on a genuine
+ * symlink, which is the input the whole function was rewritten for: without
+ * resolving it, `dirname(dirname())` walks to the npm prefix, and on Homebrew
+ * that prefix is itself a git repo, so every Homebrew-node user was misread as
+ * a dev build (dev-build.ts:13-23). A real link, not a fixture: the readlink is
+ * a real syscall on a real inode.
+ */
+const SHIM_LINK = path.join(os.tmpdir(), 'agents-cli-bench-shim-agents');
+fs.rmSync(SHIM_LINK, { force: true });
+fs.symlinkSync(path.join(DIST_ROOT, 'index.js'), SHIM_LINK);
+
+/**
+ * A real file two levels under a real git repo root — `<repo>/scripts/release.sh`.
+ * `dirname(dirname())` of it is REPO_ROOT, which carries both `.git` and a
+ * `package.json`, so this is the only one of these inputs that reaches the end
+ * of detectDevBuild: realpath -> existsSync(.git) HIT -> existsSync(package.json)
+ * HIT -> readFileSync -> JSON.parse -> name compare (dev-build.ts:28-34). The
+ * name there is `agents-cli-monorepo`, not `@phnx-labs/agents-cli`, so it
+ * returns false — this is exactly the false-positive the guard at dev-build.ts:34
+ * was added to reject, priced end to end.
+ */
+const GIT_ROOT_TWO_LEVELS_DOWN = path.join(REPO_ROOT, 'scripts', 'release.sh');
+
+/**
+ * The real installed version string, read from this checkout's package.json the
+ * same way index.ts:31-34 does. Using a literal here would silently take the
+ * `0.0.0-dev` fast path (dev-build.ts:26) and measure nothing.
+ */
+const REAL_VERSION: string = JSON.parse(
+  fs.readFileSync(path.join(CLI_ROOT, 'package.json'), 'utf-8'),
+).version;
+
+describe('detectDevBuild(process.argv[1], VERSION) — runs unconditionally at index.ts:113, before --version/--help can return (dev-build.ts:25-38)', () => {
+  bench(`version fast path: a 0.0.0-dev stamp returns at dev-build.ts:26 with ZERO syscalls — what scripts/install.sh dev installs hit (real version here is ${REAL_VERSION}, which does NOT take this branch)`, () => {
+    detectDevBuild(SHIM_LINK, '0.0.0-dev.deadbeef');
+  });
+
+  bench('npm-global shim (the real production input): realpathSync through a real symlink + ONE existsSync(.git) miss -> false (dev-build.ts:28-30)', () => {
+    detectDevBuild(SHIM_LINK, REAL_VERSION);
+  });
+
+  bench('`node apps/cli/dist/index.js` from this working tree: realpathSync (no link) + ONE existsSync(.git) miss -> false. dirname(dirname(dist/index.js)) is apps/cli, and .git is TWO levels above that, so index.ts:106 case 2 ("running node dist/index.js from a working tree") does not fire in the monorepo layout', () => {
+    detectDevBuild(path.join(DIST_ROOT, 'index.js'), REAL_VERSION);
+  });
+
+  bench('full path — realpath + existsSync(.git) HIT + existsSync(package.json) HIT + readFileSync + JSON.parse + name compare (dev-build.ts:28-34). The Homebrew-shaped false positive the rewrite rejects', () => {
+    detectDevBuild(GIT_ROOT_TWO_LEVELS_DOWN, REAL_VERSION);
+  });
+});
+
+/**
+ * Cold-import `specs` in a fresh Node process; empty list = the bare spawn floor.
+ *
+ * Node caches an ESM module for the life of a process, so a second in-process
+ * `import()` of the same specifier measures a Map lookup, not a module load.
+ * An honest module-load number only comes from a fresh process. Every row in
+ * the group below spawns the identical shape, so the constant Node floor
+ * cancels between rows and (row - FLOOR) is that graph's own load cost.
+ *
+ * Fails loud on a non-zero exit rather than posting a number for a child that
+ * died: a mistyped or moved specifier makes the child exit in less time than
+ * the bare-spawn floor, so a swallowed failure would read as the FASTEST row in
+ * the table. That is the repo's fail-loud-at-boundaries rule applied to a
+ * benchmark — a row that measured nothing must say so.
+ */
+function coldEval(specs: string[]): void {
+  const src = specs.map((s) => `await import(${JSON.stringify(s)});`).join('\n');
+  const r = spawnSync(process.execPath, ['--input-type=module', '-e', src], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  if (r.status !== 0) {
+    throw new Error(
+      `cold import failed (status ${r.status}, signal ${r.signal}): ${String(r.stderr).slice(0, 400)}`,
+    );
+  }
+}
+
+const distUrl = (rel: string): string => pathToFileURL(path.join(DIST_ROOT, rel)).href;
+const COLD_OPTS = { time: 3000, iterations: 12 } as const;
+
+describe('the secrets-broker intercept (index.ts:36, 71-84) — what the leaf module buys, measured on both sides', () => {
+  bench('FLOOR: bare `node --input-type=module -e ""` — the spawn cost every row below also pays; subtract it', () => {
+    coldEval([]);
+  }, COLD_OPTS);
+
+  bench('lib/secrets/sync-commands.js — the leaf actually imported at index.ts:36. Three exported string constants, zero imports (sync-commands.ts:19-21)', () => {
+    coldEval([distUrl('lib/secrets/sync-commands.js')]);
+  }, COLD_OPTS);
+
+  bench('lib/secrets/agent.js — the graph index.ts:58-61 says binding the tokens from agent.ts would drag in on EVERY invocation. agent.ts:27-44 declares 18 static imports; 17 survive into dist/lib/secrets/agent.js:26-42 (the type-only one at agent.ts:38 is elided), reaching ../state.js, ./install-helper.js, ./session-store.js, ../version.js, ../cli-entry.js, ./lease.js and ./audit.js. NOT on the eager path today; this row is the counterfactual that prices that decision', () => {
+    coldEval([distUrl('lib/secrets/agent.js')]);
+  }, COLD_OPTS);
+
+  bench('the dispatch itself: real cold `node dist/index.js __secrets-ping` (index.ts:71-84). index.ts:44-47 calls this "the hot read path" — readAndResolveBundleEnv is synchronous all the way down, so it cannot await a socket and spawns one of these per read instead, reading the exit code. Off darwin the broker no-ops (agent.ts:23-24) and it exits 3, so this row is the BOOTSTRAP the token dispatch pays before answering, not broker work', () => {
+    runCli([SYNC_PING_CMD]);
+  }, { time: 4000, iterations: 15 });
+});
+
+describe('root program construction (index.ts:243-251) — commander work every invocation does before parse, warm in-process', () => {
+  bench('new Command() alone (index.ts:243)', () => {
+    new Command();
+  });
+
+  bench('the real chain: new Command() + .name().description().version().option().helpOption().addHelpCommand(false) (index.ts:243-251), with the real VERSION and the unbranded name', () => {
+    new Command()
+      .name('agents')
+      .description('Environment manager for AI agents')
+      .version(REAL_VERSION)
+      .option('--verbose', 'Show startup self-heal details on stderr')
+      .helpOption('-h, --help', 'Show help')
+      .addHelpCommand(false);
+  });
+});
+
+describe('whole-invocation anchor — real cold `node dist/index.js --version` (the denominator for every row above)', () => {
+  bench('`agents --version` — pays the full eager module graph (index.ts:10-215, 513-524), detectDevBuild (index.ts:113) and the program chain (index.ts:243-251); skips checkForUpdates + spawnDetachedSync via index.ts:1322 and ensureInitialized + runMigration via index.ts:1377', () => {
+    runCli(['--version']);
+  }, { time: 4000, iterations: 15 });
+
+  bench('FLOOR: bare `node --input-type=module -e ""` — same Node startup, no CLI. The gap is everything agents-cli adds to `--version`', () => {
+    coldEval([]);
+  }, { time: 4000, iterations: 15 });
 });

--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -176,12 +176,12 @@ describe('spawnDetachedSync — real detached child_process.spawn against the bu
  *      (commander prints help and exits 0) without touching stdin. `--help`
  *      does skip checkForUpdates/spawnDetachedSync (benched above, guarded by
  *      `!helpOrVersionRequested` at index.ts:1322) and ensureInitialized
- *      (index.ts:1373-1378, the only member of the migration triad that
+ *      (index.ts:1373-1381, the only member of the migration triad that
  *      carries that guard -- the sibling migration-triad bench in PR #2277
  *      covers that path), so this isolates the registration/import cost from
  *      those pieces instead of conflating them. It does NOT skip
  *      foldLegacySystemRepo (index.ts:1366-1369) or runMigration
- *      (index.ts:1386-1391): both are gated only by the AGENTS_SKIP_MIGRATION
+ *      (index.ts:1389-1391): both are gated only by the AGENTS_SKIP_MIGRATION
  *      env var, so a `--help` row still pays their `await import(
  *      './lib/migrate.js')`. An earlier revision of this docblock claimed
  *      runMigration was skipped too; it is not.
@@ -333,12 +333,22 @@ const DIST_ROOT = path.dirname(CLI_ENTRY);
  * a dev build (dev-build.ts:13-23). A real link, not a fixture: the readlink is
  * a real syscall on a real inode.
  *
- * Named per-pid and removed in afterAll: a fixed name races two concurrent
- * runs of this file into an EEXIST between the rmSync and the symlinkSync
- * (which, at module scope, kills the whole file), and leaks the link into
- * tmpdir when the run ends.
+ * Three things keep the link from becoming a hazard, and they are
+ * complementary rather than alternatives:
+ *   - Named per-pid, so two concurrent runs of this file (two worktrees on one
+ *     box, or CI beside a local run) cannot collide on the same path. A fixed
+ *     name raced them into an EEXIST at MODULE scope, which kills the whole
+ *     file rather than one row.
+ *   - Removed in afterAll, so a normal run leaves nothing in tmpdir.
+ *   - Unlinked before creation anyway, because afterAll does NOT run when a
+ *     module-scope throw happens after it is registered (verified in review:
+ *     the hook is skipped and the file exits 1). A leaked link would then make
+ *     `symlinkSync` throw EEXIST for whichever later worker lands on that pid,
+ *     killing that run at module scope for an unrelated reason. `force: true`
+ *     unlinks the link itself without following it, and is a no-op when absent.
  */
 const SHIM_LINK = path.join(os.tmpdir(), `agents-cli-bench-shim-agents-${process.pid}`);
+fs.rmSync(SHIM_LINK, { force: true });
 fs.symlinkSync(CLI_ENTRY, SHIM_LINK);
 afterAll(() => {
   fs.rmSync(SHIM_LINK, { force: true });
@@ -422,12 +432,6 @@ const SYNC_COMMANDS_SPEC = distUrl('lib/secrets/sync-commands.js');
 const SECRETS_AGENT_SPEC = distUrl('lib/secrets/agent.js');
 
 /**
- * Prove every cold-import spec resolves BEFORE any row is timed. Module scope,
- * not a bench callback, so a bad or moved specifier throws where vitest
- * actually reports it — the file fails instead of quietly posting `NaN` for
- * the row that measured nothing.
- */
-/**
  * The two exit codes that mean `__secrets-ping` reached the intercept at
  * index.ts:71-84 and answered: 0 = a live broker replied (darwin, unlocked),
  * 3 = nothing was listening (agent.ts:1094-1097 returns one or the other).
@@ -436,6 +440,14 @@ const SECRETS_AGENT_SPEC = distUrl('lib/secrets/agent.js');
  */
 const PING_EXIT_CODES = [0, 3] as const;
 
+/**
+ * Prove every cold-import spec resolves, and that the token intercept still
+ * answers, BEFORE any row is timed. Module scope, not a bench callback, so a
+ * bad or moved specifier throws where vitest actually reports it — the file
+ * fails (exit 1, a real Failed Suite) instead of quietly posting `NaN` for the
+ * row that measured nothing. The in-row checks below are the same assertions
+ * one layer down; they stop a false number, this is what makes it loud.
+ */
 (function preflightColdImports(): void {
   for (const spec of [SYNC_COMMANDS_SPEC, SECRETS_AGENT_SPEC]) coldEval([spec]);
   // Same reasoning for the one runCli row whose number is only meaningful if
@@ -478,7 +490,7 @@ describe('root program construction (index.ts:243-251) — commander work every 
 });
 
 describe('whole-invocation anchor — real cold `node dist/index.js --version` (the denominator for every row above)', () => {
-  bench('`agents --version` — pays the full eager module graph (index.ts:10-215, 513-524), detectDevBuild (index.ts:113), the program chain (index.ts:243-251), AND the two migration hops that carry no help/version guard: foldLegacySystemRepo (index.ts:1366-1369) and runMigration (index.ts:1386-1391), both gated only by AGENTS_SKIP_MIGRATION, so `await import("./lib/migrate.js")` is inside this number. It skips only checkForUpdates + spawnDetachedSync (index.ts:1322) and ensureInitialized (index.ts:1373-1378)', () => {
+  bench('`agents --version` — pays the full eager module graph (index.ts:10-215, 513-524), detectDevBuild (index.ts:113), the program chain (index.ts:243-251), AND the two migration hops that carry no help/version guard: foldLegacySystemRepo (index.ts:1366-1369) and runMigration (index.ts:1389-1391), both gated only by AGENTS_SKIP_MIGRATION, so `await import("./lib/migrate.js")` is inside this number. It skips only checkForUpdates + spawnDetachedSync (index.ts:1322) and ensureInitialized (index.ts:1373-1381)', () => {
     runCli(['--version']);
   }, { time: 4000, iterations: 15 });
 

--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -73,7 +73,7 @@
  * src/index.bench.ts silently sat outside that glob and shipped a stale
  * `@ts-expect-error` (TS2578, unused directive) that no gate caught.
  */
-import { describe, bench } from 'vitest';
+import { describe, bench, afterAll } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -174,11 +174,17 @@ describe('spawnDetachedSync — real detached child_process.spawn against the bu
  *      path above, exactly as a user's shell invokes it. `--help` is appended
  *      to every invocation so each run exits fast and deterministically
  *      (commander prints help and exits 0) without touching stdin. `--help`
- *      does skip checkForUpdates/spawnDetachedSync (benched above) and
- *      ensureInitialized/runMigration (index.ts:1373-1381, both DO carry a
- *      `!helpOrVersionRequested` guard -- the sibling migration-triad bench in
- *      PR #2277 covers that path), so this isolates the registration/import
- *      cost from those other two hot-path pieces instead of conflating them.
+ *      does skip checkForUpdates/spawnDetachedSync (benched above, guarded by
+ *      `!helpOrVersionRequested` at index.ts:1322) and ensureInitialized
+ *      (index.ts:1373-1378, the only member of the migration triad that
+ *      carries that guard -- the sibling migration-triad bench in PR #2277
+ *      covers that path), so this isolates the registration/import cost from
+ *      those pieces instead of conflating them. It does NOT skip
+ *      foldLegacySystemRepo (index.ts:1366-1369) or runMigration
+ *      (index.ts:1386-1391): both are gated only by the AGENTS_SKIP_MIGRATION
+ *      env var, so a `--help` row still pays their `await import(
+ *      './lib/migrate.js')`. An earlier revision of this docblock claimed
+ *      runMigration was skipped too; it is not.
  *   2. WARM IN-PROCESS REGISTRATION (further below): call the real, exported
  *      command-registry.ts loaders directly -- `(await loadX())(new
  *      Command())` -- for a representative subset. Node's ESM loader caches a
@@ -200,11 +206,35 @@ describe('spawnDetachedSync — real detached child_process.spawn against the bu
  */
 const CLI_ENTRY = path.join(__dirname, '../../dist/index.js');
 
-function runCli(args: string[]): void {
+function runCli(args: string[]): number | null {
   // spawnSync (not execFileSync) so a non-zero exit never throws inside the
   // timed callback -- every arg list below is verified to exit 0 on this
-  // machine, but the bench must stay robust to environment drift.
-  spawnSync(process.execPath, [CLI_ENTRY, ...args], { stdio: 'ignore' });
+  // machine, but the bench must stay robust to environment drift. The status
+  // is RETURNED rather than swallowed so a caller whose row depends on
+  // reaching a specific code path can assert it (see expectExit below);
+  // callers that only need "a real cold process ran" ignore it.
+  return spawnSync(process.execPath, [CLI_ENTRY, ...args], { stdio: 'ignore' }).status;
+}
+
+/**
+ * Assert a `runCli` row actually reached the code path it claims to measure.
+ *
+ * Without this, a row is only ever "a cold node process ran": if the argv
+ * intercept it targets were moved or renamed, commander would take over,
+ * print "unknown command" and exit 1, and the row would keep posting a
+ * plausible number for entirely different work. Same reason coldEval throws.
+ *
+ * Takes a SET of acceptable codes, not one: the intercepted token's exit code
+ * legitimately differs by machine (see the `__secrets-ping` row), and the
+ * property being defended is "the intercept answered", not "it answered with
+ * this specific number".
+ */
+function expectExit(status: number | null, allowed: readonly number[], label: string): void {
+  if (status === null || !allowed.includes(status)) {
+    throw new Error(
+      `${label}: expected exit in {${allowed.join(', ')}}, got ${status} — this row is measuring the wrong path`,
+    );
+  }
 }
 
 describe('registerEagerForRequest / COMMAND_LOADERS — real cold `node dist/index.js <cmd> --help` process spawn (index.ts:1007-1063, 1271-1280)', () => {
@@ -289,7 +319,8 @@ describe('command-registry.ts loaders — warm in-process registration only (mod
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
 /** apps/cli of THIS checkout. */
 const CLI_ROOT = path.resolve(__dirname, '../..');
-const DIST_ROOT = path.join(CLI_ROOT, 'dist');
+/** Derived from CLI_ENTRY (declared above) so the two can never disagree. */
+const DIST_ROOT = path.dirname(CLI_ENTRY);
 
 /**
  * A real symlink to the built entry, modelling the npm-global bin shim
@@ -301,10 +332,17 @@ const DIST_ROOT = path.join(CLI_ROOT, 'dist');
  * that prefix is itself a git repo, so every Homebrew-node user was misread as
  * a dev build (dev-build.ts:13-23). A real link, not a fixture: the readlink is
  * a real syscall on a real inode.
+ *
+ * Named per-pid and removed in afterAll: a fixed name races two concurrent
+ * runs of this file into an EEXIST between the rmSync and the symlinkSync
+ * (which, at module scope, kills the whole file), and leaks the link into
+ * tmpdir when the run ends.
  */
-const SHIM_LINK = path.join(os.tmpdir(), 'agents-cli-bench-shim-agents');
-fs.rmSync(SHIM_LINK, { force: true });
-fs.symlinkSync(path.join(DIST_ROOT, 'index.js'), SHIM_LINK);
+const SHIM_LINK = path.join(os.tmpdir(), `agents-cli-bench-shim-agents-${process.pid}`);
+fs.symlinkSync(CLI_ENTRY, SHIM_LINK);
+afterAll(() => {
+  fs.rmSync(SHIM_LINK, { force: true });
+});
 
 /**
  * A real file two levels under a real git repo root — `<repo>/scripts/release.sh`.
@@ -337,7 +375,7 @@ describe('detectDevBuild(process.argv[1], VERSION) — runs unconditionally at i
   });
 
   bench('`node apps/cli/dist/index.js` from this working tree: realpathSync (no link) + ONE existsSync(.git) miss -> false. dirname(dirname(dist/index.js)) is apps/cli, and .git is TWO levels above that, so index.ts:106 case 2 ("running node dist/index.js from a working tree") does not fire in the monorepo layout', () => {
-    detectDevBuild(path.join(DIST_ROOT, 'index.js'), REAL_VERSION);
+    detectDevBuild(CLI_ENTRY, REAL_VERSION);
   });
 
   bench('full path — realpath + existsSync(.git) HIT + existsSync(package.json) HIT + readFileSync + JSON.parse + name compare (dev-build.ts:28-34). The Homebrew-shaped false positive the rewrite rejects', () => {
@@ -354,11 +392,16 @@ describe('detectDevBuild(process.argv[1], VERSION) — runs unconditionally at i
  * the group below spawns the identical shape, so the constant Node floor
  * cancels between rows and (row - FLOOR) is that graph's own load cost.
  *
- * Fails loud on a non-zero exit rather than posting a number for a child that
- * died: a mistyped or moved specifier makes the child exit in less time than
- * the bare-spawn floor, so a swallowed failure would read as the FASTEST row in
- * the table. That is the repo's fail-loud-at-boundaries rule applied to a
- * benchmark — a row that measured nothing must say so.
+ * The throw on a non-zero exit stops a dead child from posting a good number: a
+ * mistyped or moved specifier makes the child exit in LESS time than the
+ * bare-spawn floor, so a swallowed failure would read as the fastest row in the
+ * table. Be precise about how loud that throw actually is, though — measured
+ * under this repo's pinned vitest, a throw inside a `bench` callback does NOT
+ * fail the run: tinybench catches it and the row reports no result (the summary
+ * prints `NaNx faster than …`). So the throw alone buys "no false number", not
+ * "the run fails". `preflightColdImports()` below is what makes it genuinely
+ * loud: it runs each spec list ONCE at module scope, where a throw aborts the
+ * whole bench file before a single sample is taken.
  */
 function coldEval(specs: string[]): void {
   const src = specs.map((s) => `await import(${JSON.stringify(s)});`).join('\n');
@@ -375,21 +418,46 @@ function coldEval(specs: string[]): void {
 const distUrl = (rel: string): string => pathToFileURL(path.join(DIST_ROOT, rel)).href;
 const COLD_OPTS = { time: 3000, iterations: 12 } as const;
 
+const SYNC_COMMANDS_SPEC = distUrl('lib/secrets/sync-commands.js');
+const SECRETS_AGENT_SPEC = distUrl('lib/secrets/agent.js');
+
+/**
+ * Prove every cold-import spec resolves BEFORE any row is timed. Module scope,
+ * not a bench callback, so a bad or moved specifier throws where vitest
+ * actually reports it — the file fails instead of quietly posting `NaN` for
+ * the row that measured nothing.
+ */
+/**
+ * The two exit codes that mean `__secrets-ping` reached the intercept at
+ * index.ts:71-84 and answered: 0 = a live broker replied (darwin, unlocked),
+ * 3 = nothing was listening (agent.ts:1094-1097 returns one or the other).
+ * Anything else — notably commander's unknown-command exit — means the
+ * intercept was missed and the row is timing the wrong path.
+ */
+const PING_EXIT_CODES = [0, 3] as const;
+
+(function preflightColdImports(): void {
+  for (const spec of [SYNC_COMMANDS_SPEC, SECRETS_AGENT_SPEC]) coldEval([spec]);
+  // Same reasoning for the one runCli row whose number is only meaningful if
+  // the index.ts:71-84 intercept was actually reached.
+  expectExit(runCli([SYNC_PING_CMD]), PING_EXIT_CODES, '__secrets-ping preflight');
+})();
+
 describe('the secrets-broker intercept (index.ts:36, 71-84) — what the leaf module buys, measured on both sides', () => {
   bench('FLOOR: bare `node --input-type=module -e ""` — the spawn cost every row below also pays; subtract it', () => {
     coldEval([]);
   }, COLD_OPTS);
 
   bench('lib/secrets/sync-commands.js — the leaf actually imported at index.ts:36. Three exported string constants, zero imports (sync-commands.ts:19-21)', () => {
-    coldEval([distUrl('lib/secrets/sync-commands.js')]);
+    coldEval([SYNC_COMMANDS_SPEC]);
   }, COLD_OPTS);
 
   bench('lib/secrets/agent.js — the graph index.ts:58-61 says binding the tokens from agent.ts would drag in on EVERY invocation. agent.ts:27-44 declares 18 static imports; 17 survive into dist/lib/secrets/agent.js:26-42 (the type-only one at agent.ts:38 is elided), reaching ../state.js, ./install-helper.js, ./session-store.js, ../version.js, ../cli-entry.js, ./lease.js and ./audit.js. NOT on the eager path today; this row is the counterfactual that prices that decision', () => {
-    coldEval([distUrl('lib/secrets/agent.js')]);
+    coldEval([SECRETS_AGENT_SPEC]);
   }, COLD_OPTS);
 
-  bench('the dispatch itself: real cold `node dist/index.js __secrets-ping` (index.ts:71-84). index.ts:44-47 calls this "the hot read path" — readAndResolveBundleEnv is synchronous all the way down, so it cannot await a socket and spawns one of these per read instead, reading the exit code. Off darwin the broker no-ops (agent.ts:23-24) and it exits 3, so this row is the BOOTSTRAP the token dispatch pays before answering, not broker work', () => {
-    runCli([SYNC_PING_CMD]);
+  bench('the dispatch itself: real cold `node dist/index.js __secrets-ping` (index.ts:71-84). index.ts:44-47 calls this "the hot read path" — readAndResolveBundleEnv is synchronous all the way down, so it cannot await a socket and spawns one of these per read instead, reading the exit code. What this row measures is MACHINE-DEPENDENT past the bootstrap: runAgentPingSync (agent.ts:1094-1097) has no darwin gate (the onDarwin check at agent.ts:937-939 is a different function), it just connects — so with no broker listening the connect fails ENOENT, request() resolves null (agent.ts:906-911) and it exits 3 having done no broker work, which is the pure-bootstrap case reported here; on darwin with a live broker the same row exits 0 and additionally carries a real socket round-trip, bounded by SOCKET_PING_TIMEOUT_MS = 700 (agent.ts:113)', () => {
+    expectExit(runCli([SYNC_PING_CMD]), PING_EXIT_CODES, '__secrets-ping');
   }, { time: 4000, iterations: 15 });
 });
 
@@ -410,7 +478,7 @@ describe('root program construction (index.ts:243-251) — commander work every 
 });
 
 describe('whole-invocation anchor — real cold `node dist/index.js --version` (the denominator for every row above)', () => {
-  bench('`agents --version` — pays the full eager module graph (index.ts:10-215, 513-524), detectDevBuild (index.ts:113) and the program chain (index.ts:243-251); skips checkForUpdates + spawnDetachedSync via index.ts:1322 and ensureInitialized + runMigration via index.ts:1377', () => {
+  bench('`agents --version` — pays the full eager module graph (index.ts:10-215, 513-524), detectDevBuild (index.ts:113), the program chain (index.ts:243-251), AND the two migration hops that carry no help/version guard: foldLegacySystemRepo (index.ts:1366-1369) and runMigration (index.ts:1386-1391), both gated only by AGENTS_SKIP_MIGRATION, so `await import("./lib/migrate.js")` is inside this number. It skips only checkForUpdates + spawnDetachedSync (index.ts:1322) and ensureInitialized (index.ts:1373-1378)', () => {
     runCli(['--version']);
   }, { time: 4000, iterations: 15 });
 


### PR DESCRIPTION
**test-only / bench-only** — one file changed, `apps/cli/src/lib/index.bench.ts`. No behavior change, no runtime code touched, so there is no user-visible surface to screenshot and no docs or CHANGELOG entry (bench files are excluded from `vitest run`; `vitest.config.ts:18` includes `*.test.ts` only).

Ticket: [RUSH-2335](https://linear.app/getrush/issue/RUSH-2335/cli-bootstrap-every-secrets-broker-read-pays-140ms-before-indexts71) — filed from these numbers.

## What this measures

The core bootstrap block of `apps/cli/src/index.ts`: `detectDevBuild()` (index.ts:113), the secrets-broker token dispatch (index.ts:36, 71-84), and the root commander program (index.ts:243-251). Every ordinary invocation runs all of it, `--version` and `--help` included: the `helpOrVersionRequested` guard is at index.ts:1322, roughly 1200 lines below, and it only gates `checkForUpdates()` + `spawnDetachedSync()`.

It **extends the existing** `src/lib/index.bench.ts` rather than adding a second bench file, per the existing groups' conventions (real syscalls, real cold processes, real built `dist/` artifacts, no mocking).

Relationship to the open sibling **#2280**, which adds a per-import cold-child group to the same file: that PR prices *loading* `commander` (index.ts:10), `chalk` (index.ts:11), `dev-build.js` (index.ts:16) and `sync-commands.js` (index.ts:36). These groups price the *work those lines do* plus two things #2280 does not have — the `lib/secrets/agent.js` counterfactual, and a whole-invocation denominator. Both PRs append to the end of the same file, so whichever lands second resolves a trivial append conflict.

## Measured

Run on **yosemite-s1** was rejected: 20 cores at load 27 from other fleet agents would have made every spawn row noise. All numbers below are from **yosemite-m2** (16 cores, Node v24.18.0), `npx vitest bench --run src/lib/index.bench.ts` in `apps/cli`.

`/proc/loadavg` **0.62 0.90 0.79** before, **1.26 1.07 0.86** after (full-file run). The `detectDevBuild` rows and their `--version` re-check come from a `-t detectDevBuild` run at `/proc/loadavg` **1.14 1.07 0.87** before, **1.12 1.07 0.88** after; both runs agree within 2%.

### detectDevBuild — index.ts:113, dev-build.ts:25-38

| input shape | mean | rme | samples |
|---|---|---|---|
| `0.0.0-dev` version fast path, zero syscalls (dev-build.ts:26) | **0.0001 ms** | ±0.06% | 9,011,979 |
| full path: realpath + 2× existsSync HIT + readFileSync + JSON.parse (dev-build.ts:28-34) | **0.0138 / 0.0142 ms** | ±0.18% | 36,275 |
| `node apps/cli/dist/index.js` from a working tree: realpath + 1 existsSync miss | **0.0192 / 0.0235 ms** | ±0.08% | 26,030 |
| npm-global bin symlink (the real production `argv[1]`): realpath through a link + 1 existsSync miss | **0.0274 / 0.0390 ms** | ±0.16% | 18,240 |

The ordering on this box is counter-intuitive and worth stating: the "full path" row came out *fastest* of the three non-trivial rows even though it does the most work, because the dominant cost is `realpathSync` walking path components rather than the branch taken — its input is three components deep, while the shim's resolves a link into a deep `dist/` path. The reviewer did not reproduce that ordering on a different box (full path 0.0175 ms, working-tree 0.0161 ms, shim 0.0194 ms), so treat it as a property of path depth on this machine, not a general rule. The conclusion the PR rests on — that all three are under 0.04 ms — holds on both boxes.

### The secrets-broker intercept — index.ts:36, 71-84

| row | mean | over floor | rme |
|---|---|---|---|
| FLOOR: bare `node --input-type=module -e ""` | 22.19 ms | — | ±0.76% |
| `lib/secrets/sync-commands.js` (the leaf index.ts:36 imports) | 22.59 ms | **+0.40 ms** | ±0.63% |
| `lib/secrets/agent.js` (the graph index.ts:58-61 says binding the tokens there would drag in) | 77.13 ms | **+54.9 ms** | ±4.67% |
| real cold `node dist/index.js __secrets-ping` (index.ts:71-84) | **162.60 ms** | **+140.4 ms** | ±2.26% |

### Root commander program — index.ts:243-251

| row | mean | rme |
|---|---|---|
| `new Command()` alone (index.ts:243) | 0.0001 ms | ±0.49% |
| the real `.name().description().version().option().helpOption().addHelpCommand(false)` chain | **0.0026 ms** | ±0.42% |

### Whole-invocation anchor

| row | mean | rme |
|---|---|---|
| real cold `node dist/index.js --version` | **156.79 / 155.77 ms** | ±0.63% |
| FLOOR: bare `node --input-type=module -e ""` | 21.75 ms | ±0.58% |

agents-cli adds **~135 ms** to `--version`. Of that, `detectDevBuild` is **0.029%** and the commander chain is **0.0019%**.

What the anchor does *not* skip, and the label now says so: `foldLegacySystemRepo()` (index.ts:1366-1369) and `runMigration` (index.ts:1386-1391) are gated only by `AGENTS_SKIP_MIGRATION`, not by `helpOrVersionRequested`, so the 156.79 ms includes their `await import('./lib/migrate.js')`. Only `checkForUpdates` + `spawnDetachedSync` (index.ts:1322) and `ensureInitialized` (index.ts:1373-1378) are skipped. An earlier revision of this PR — and a pre-existing docblock on `main` at index.bench.ts:178-180 — claimed `runMigration` was skipped too; both are corrected in this branch.

## Proposals

Each names a measured number. Nothing unmeasured is proposed.

1. **Split the entry so the argv fast paths return before the graph loads** — `apps/cli/src/index.ts:10-16, :36, :86-95, :124-215, :513-524`. ESM hoists all of those above every statement, so the intercepts at index.ts:38/71/221/232 cannot skip them; index.ts:67-70 already says so in prose. Mechanism: keep `dist/index.js` to the leaf `./lib/secrets/sync-commands.js` plus `node:process`, dispatch the four fast paths, `await import('./bootstrap.js')` for everything else. Measured ceiling: the leaf costs +0.40 ms over a 22.19 ms floor, so `__secrets-ping` could answer in ~23 ms instead of **162.60 ms** — ~139 ms per synchronous secret read, and index.ts:44-47 says one such child is spawned *per read*. Same split moves `--version` (156.79 ms) toward the 21.75 ms floor. Tracked as RUSH-2335.

2. **Pin `lib/secrets/agent.js` out of the eager graph with a test** — `apps/cli/src/index.ts:36` / `src/lib/secrets/sync-commands.ts:1-18`. The leaf exists solely to keep that graph off every invocation, and the counterfactual is now priced: **+54.9 ms vs +0.40 ms**, i.e. 40% of the 135 ms agents-cli adds to `--version`. Today nothing stops a future edit from importing `agent.js` at index.ts:36 for a type or a constant. A test asserting `dist/index.js`'s transitive static graph excludes `lib/secrets/agent.js` makes that a red build instead of a silent 55 ms regression.

3. **Do not touch `detectDevBuild` (index.ts:113) or the commander chain (index.ts:243-251).** Stated as a proposal because both look like obvious startup targets and are not: 0.0138-0.0390 ms and 0.0026 ms respectively, together under 0.03% of a real invocation. Deferring or caching either is churn with no measurable return.

## One correctness observation, filed not fixed

`index.ts:106` documents case 2 as "Running `node dist/index.js` from a working tree — repo root has .git/". In the monorepo layout `dirname(dirname(apps/cli/dist/index.js))` is `apps/cli`, which has no `.git` — it is two levels higher. Verified directly against the built module: `detectDevBuild('<wt>/apps/cli/dist/index.js', '1.22.27')` returns `false`, taking the early return at dev-build.ts:30. Signal 1 (the `0.0.0-dev` stamp, dev-build.ts:26) still covers `scripts/install.sh` dev installs, so this is a stale comment plus a dead signal, not a live breakage. Out of scope for a bench PR; noted here so it is not lost.

## Run evidence

```
LOAD_BEFORE: 0.62 0.90 0.79 1/815 2688450

 ✓ src/lib/index.bench.ts > detectDevBuild(process.argv[1], VERSION) — runs unconditionally at index.ts:113 ...
   · version fast path (dev-build.ts:26)          hz=18,023,956.38  mean=0.0001  rme=±0.06%  samples=9011979
   · npm-global shim (dev-build.ts:28-30)         hz=36,479.30      mean=0.0274  rme=±0.16%  samples=18240
   · dist/index.js from working tree              hz=52,059.80      mean=0.0192  rme=±0.08%  samples=26030
   · full path (dev-build.ts:28-34)               hz=72,549.97      mean=0.0138  rme=±0.18%  samples=36275

 ✓ src/lib/index.bench.ts > the secrets-broker intercept (index.ts:36, 71-84) 15370ms
   · FLOOR bare node -e ""                        hz=45.0691   mean=22.1881   rme=±0.76%  samples=136
   · lib/secrets/sync-commands.js                 hz=44.2756   mean=22.5858   rme=±0.63%  samples=133
   · lib/secrets/agent.js                         hz=12.9652   mean=77.1294   rme=±4.67%  samples=39
   · cold `node dist/index.js __secrets-ping`     hz=6.1499    mean=162.60    rme=±2.26%  samples=25

 ✓ src/lib/index.bench.ts > root program construction (index.ts:243-251) 2827ms
   · new Command() alone                          hz=7,324,413.05  mean=0.0001  rme=±0.49%  samples=3662207
   · the real chain (index.ts:243-251)            hz=385,555.30    mean=0.0026  rme=±0.42%  samples=192778

 ✓ src/lib/index.bench.ts > whole-invocation anchor 9348ms
   · cold `node dist/index.js --version`          hz=6.3781    mean=156.79    rme=±0.63%  samples=26
   · FLOOR bare node -e ""                        hz=45.9842   mean=21.7466   rme=±0.58%  samples=184

LOAD_AFTER: 1.26 1.07 0.86 1/801 2708452
```

`bun run typecheck:bench` passes (the `src/lib/*.bench.ts` glob at `apps/cli/package.json:58` covers this file).
