### PR TITLE
fix: label Codex weekly and monthly usage limits

### DIFF
--- a/apps/cli/.changelog/next/rush-2341-codex-usage-windows.md
+++ b/apps/cli/.changelog/next/rush-2341-codex-usage-windows.md
@@ -1,0 +1,1 @@
+- Fix `agents view` and `agents usage` labeling Codex's weekly or monthly quota as session usage when the native CLI publishes the long-duration limit in its `primary` rate-limit window. Codex windows are now labeled from their reported duration (`S`, `W`, or `M`) instead of their primary/secondary position.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -1369,7 +1369,8 @@ a stable per-account key:
   surfaces an email when one is readable, else a stable account id, else a bare
   `signed in`.
 - **Usage bars** — a separate network pass ([`src/lib/usage.ts`](../src/lib/usage.ts))
-  fetches live quota and renders `S:`/`W:` bars + plan. It's **stale-while-revalidate**
+  fetches live quota and renders `S:`/`W:`/`M:` bars + plan, according to each
+  provider's reported window duration. It's **stale-while-revalidate**
   (on-disk cache under `~/.agents/.cache/`, keyed per account: 2-min fresh, 24-h
   block) so `agents view` stays off the network on the hot path.
 - **Routing reads the same cache, CACHE-ONLY — never on the hot path's network

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -782,7 +782,7 @@ describe('getUsageInfo(codex) — usage is scoped to the current login', () => {
     fs.utimesSync(p, t, t);
   }
 
-  function writeSession(mtimeMs: number, usedPercent: number): void {
+  function writeSession(mtimeMs: number, usedPercent: number, windowMinutes = 300): void {
     const dir = path.join(home, '.codex', 'sessions', '2026', '08', '05');
     fs.mkdirSync(dir, { recursive: true });
     const p = path.join(dir, `rollout-${mtimeMs}.jsonl`);
@@ -793,7 +793,7 @@ describe('getUsageInfo(codex) — usage is scoped to the current login', () => {
         type: 'event_msg',
         payload: {
           type: 'token_count',
-          rate_limits: { primary: { used_percent: usedPercent, window_minutes: 300 } },
+          rate_limits: { primary: { used_percent: usedPercent, window_minutes: windowMinutes } },
         },
       }) + '\n'
     );
@@ -819,6 +819,28 @@ describe('getUsageInfo(codex) — usage is scoped to the current login', () => {
     const info = await getUsageInfo('codex', { home });
     const session = info.snapshot?.windows.find((w) => w.key === 'session');
     expect(session?.usedPercent).toBe(42);
+  });
+
+  it('labels a primary 7-day quota as weekly usage', async () => {
+    writeAuth(NOW);
+    writeSession(NOW + HOUR, 54, 10_080);
+
+    const info = await getUsageInfo('codex', { home });
+    expect(info.snapshot?.windows).toEqual([
+      expect.objectContaining({ key: 'week', label: 'Current week', shortLabel: 'W', usedPercent: 54 }),
+    ]);
+    expect(formatUsageSummary(null, info.snapshot)).toContain('W:');
+  });
+
+  it('labels a primary 30-day quota as monthly usage', async () => {
+    writeAuth(NOW);
+    writeSession(NOW + HOUR, 21, 43_200);
+
+    const info = await getUsageInfo('codex', { home });
+    expect(info.snapshot?.windows).toEqual([
+      expect.objectContaining({ key: 'month', label: 'Current month', shortLabel: 'M', usedPercent: 21 }),
+    ]);
+    expect(formatUsageSummary(null, info.snapshot)).toContain('M:');
   });
 
   it('prefers the current account session over a stale pre-login one', async () => {

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -1559,26 +1559,19 @@ async function readLatestCodexRateLimits(filePath: string): Promise<CodexRateLim
 
 /** Normalize Codex rate-limit windows into the common UsageWindow shape. */
 function normalizeCodexWindows(rateLimits: CodexRateLimits): UsageWindow[] {
-  const windows: UsageWindow[] = [];
-
-  const primary = normalizeCodexWindow(rateLimits.primary, 'session', 'Current session', 'S');
-  if (primary) windows.push(primary);
-
-  const secondary = normalizeCodexWindow(rateLimits.secondary, 'week', 'Current week', 'W');
-  if (secondary) windows.push(secondary);
-
-  return windows;
+  return [rateLimits.primary, rateLimits.secondary]
+    .map(normalizeCodexWindow)
+    .filter((window): window is UsageWindow => window !== null)
+    .sort((a, b) => (a.windowMinutes ?? 0) - (b.windowMinutes ?? 0));
 }
 
 /** Normalize a single Codex rate-limit window. */
-function normalizeCodexWindow(
-  window: CodexRateLimitWindow | null | undefined,
-  key: UsageWindowKey,
-  label: string,
-  shortLabel: string
-): UsageWindow | null {
+function normalizeCodexWindow(window: CodexRateLimitWindow | null | undefined): UsageWindow | null {
   const usedPercent = normalizePercent(window?.used_percent);
   if (usedPercent === null) return null;
+
+  const windowMinutes = normalizeWindowMinutes(window?.window_minutes);
+  const { key, label, shortLabel } = classifyCodexWindow(windowMinutes);
 
   return {
     key,
@@ -1586,8 +1579,19 @@ function normalizeCodexWindow(
     shortLabel,
     usedPercent,
     resetsAt: parseDateValue(window?.resets_at),
-    windowMinutes: normalizeWindowMinutes(window?.window_minutes),
+    windowMinutes,
   };
+}
+
+/** Codex assigns quota windows to primary/secondary by plan, so duration carries their meaning. */
+function classifyCodexWindow(windowMinutes: number | null): Pick<UsageWindow, 'key' | 'label' | 'shortLabel'> {
+  if (windowMinutes !== null && windowMinutes >= 28 * 24 * 60) {
+    return { key: 'month', label: 'Current month', shortLabel: 'M' };
+  }
+  if (windowMinutes !== null && windowMinutes >= 7 * 24 * 60) {
+    return { key: 'week', label: 'Current week', shortLabel: 'W' };
+  }
+  return { key: 'session', label: 'Current session', shortLabel: 'S' };
 }
 
 /** Normalize Claude API usage windows into the common UsageWindow shape. */


### PR DESCRIPTION
Fixes the Codex quota label shown by `agents view` and `agents usage`.

## What changed

- Classify Codex rate-limit windows from `window_minutes`, not `primary`/`secondary` position.
- Render short windows as `S`, 7-day windows as `W`, and 28+ day windows as `M`.
- Add regression coverage for current 7-day and 30-day primary-window payloads.
- Companion `.agents-system` audit: no command syntax or guidance changed, so no companion edit is required.

## Run result

CLI-only surface. Redacted screenshot from the installed dev build: `yosemite-s0:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/2026-08-06/codex-weekly-usage.png`.

The screenshot shows both installed Codex accounts rendering `W`, including `W: ███░░ 54% (6d)`. `agents usage codex` renders the same quota as `Current week`. Installed artifact: `agents --version` → `0.0.0-dev.45dd7faa6-dirty`. The screenshot is fleet-local because the public share credential is unavailable on this host.

## Verification

- `bun test src/lib/usage.test.ts` → 51 pass, 0 fail
- `bun install --frozen-lockfile` completed and TypeScript build passed
- `agents view codex` and `agents usage codex` exercised against live local Codex session data
- Repository `test:remote` infrastructure synced the monorepo root but ran `bun run build` there, where no root package exists (`Script not found "build"`); CI remains the clean full-suite gate.

Tracking: RUSH-2341