### PR TITLE
bench(cli): measure the menu-bar startup self-heal import (index.ts:1421-1425)

### DIFF
--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -90,6 +90,7 @@ import {
   resolveRunningPackageRoot,
 } from './self-update.js';
 import { getUpdateCheckPath } from './state.js';
+import { installMenubarLaunchAgentOnUpgrade } from './menubar/install-menubar.js';
 // Real built artifact (see docblock above) -- NOT './auto-pull.js', which
 // would resolve to the unbuilt TS source and always miss the worker script.
 // dist/lib/auto-pull.d.ts exists (tsconfig.json declaration:true), so this
@@ -430,6 +431,7 @@ const COLD_OPTS = { time: 3000, iterations: 12 } as const;
 
 const SYNC_COMMANDS_SPEC = distUrl('lib/secrets/sync-commands.js');
 const SECRETS_AGENT_SPEC = distUrl('lib/secrets/agent.js');
+const MENUBAR_INSTALL_SPEC = distUrl('lib/menubar/install-menubar.js');
 
 /**
  * The two exit codes that mean `__secrets-ping` reached the intercept at
@@ -449,7 +451,7 @@ const PING_EXIT_CODES = [0, 3] as const;
  * one layer down; they stop a false number, this is what makes it loud.
  */
 (function preflightColdImports(): void {
-  for (const spec of [SYNC_COMMANDS_SPEC, SECRETS_AGENT_SPEC]) coldEval([spec]);
+  for (const spec of [SYNC_COMMANDS_SPEC, SECRETS_AGENT_SPEC, MENUBAR_INSTALL_SPEC]) coldEval([spec]);
   // Same reasoning for the one runCli row whose number is only meaningful if
   // the index.ts:71-84 intercept was actually reached.
   expectExit(runCli([SYNC_PING_CMD]), PING_EXIT_CODES, '__secrets-ping preflight');
@@ -497,4 +499,88 @@ describe('whole-invocation anchor — real cold `node dist/index.js --version` (
   bench('FLOOR: bare `node --input-type=module -e ""` — same Node startup, no CLI. The gap is everything agents-cli adds to `--version`', () => {
     coldEval([]);
   }, { time: 4000, iterations: 15 });
+});
+
+/**
+ * ============================================================================
+ * The menu-bar startup self-heal (index.ts:1421-1425):
+ *
+ *   if (process.platform === 'darwin' && process.env.AGENTS_SKIP_MIGRATION !== '1') {
+ *     try {
+ *       const { installMenubarLaunchAgentOnUpgrade } = await import('./lib/menubar/install-menubar.js');
+ *       installMenubarLaunchAgentOnUpgrade();
+ *     } catch { }
+ *   }
+ *
+ * Unlike checkForUpdates/spawnDetachedSync (index.ts:1322, guarded by
+ * `!helpOrVersionRequested`) this block has NO help/version guard, so on
+ * darwin it runs on every `agents <cmd>`, `agents --help`, and
+ * `agents --version` alike -- it sits between the migration triad
+ * (index.ts:1389-1411, benched in PR #2277) and the bare-invocation help
+ * branch (index.ts:1433).
+ *
+ * THIS BOX IS LINUX (yosemite-s1), so `process.platform === 'darwin'` is
+ * false and in real production this whole block -- import included -- never
+ * executes here. Two things are still truthfully measurable on Linux and are
+ * benched below; nothing about the macOS decision path is inferred or
+ * invented from them:
+ *
+ *   1. THE MODULE IMPORT ITSELF (index.ts:1423) is plain ESM module
+ *      resolution/evaluation with no platform branch at module scope in
+ *      install-menubar.ts or any of its static imports (fs-atomic.ts,
+ *      state.ts, version.ts, app-bundle-install.ts, agent-spec/primitives.ts
+ *      -- verified by reading each for `^import`/`process.platform` before
+ *      writing this bench). The bytes evaluated and the syscalls issued to
+ *      resolve them are the same on darwin and Linux; only wall-clock speed
+ *      differs by machine, which is why this whole file is dispatched on a
+ *      fixed box rather than compared across boxes. So a cold-process import
+ *      of dist/lib/menubar/install-menubar.js on this box IS the real cost
+ *      index.ts:1423 pays before installMenubarLaunchAgentOnUpgrade() can
+ *      even be called, on any platform.
+ *   2. CALLING installMenubarLaunchAgentOnUpgrade() ITSELF, in-process, on
+ *      this real Linux box. install-menubar.ts:630-632:
+ *
+ *        export function installMenubarLaunchAgentOnUpgrade(): void {
+ *          try {
+ *            if (!onDarwin()) return;
+ *
+ *      `onDarwin()` (install-menubar.ts:49-51) is `process.platform ===
+ *      'darwin'`, so on THIS box the call returns after one property read --
+ *      that is what the row below actually measures, honestly, for Linux.
+ *
+ * What is explicitly NOT benched, because it cannot be invoked truthfully on
+ * a non-darwin box (the task's own instruction): everything past the
+ * `!onDarwin()` guard -- menubarDisabledByUser() (existsSync on
+ * disabledSentinelPath), menubarServiceInstalled() (existsSync on
+ * servicePlistPath), menubarSetupStale() (existsSync + readFileSync on the
+ * installed version marker), menubarSetupNeedsRepoint() (readFileSync +
+ * regex match on the plist XML), installedNeedsDevIdHeal() (existsSync +
+ * codesign spawnSync via hasDeveloperIdSignature), and mayHealMenubar()'s
+ * cooldown read (install-menubar.ts:633-654). Those are the "two existsSync
+ * checks then return" the index.ts:1418 comment describes, and the docblock
+ * at install-menubar.ts:616-628 names them as running "on every darwin CLI
+ * invocation" -- but on Linux `onDarwin()` returns before a single one of
+ * them executes, so their real filesystem cost is UNVERIFIED here. No
+ * darwin timings are invented for them; the pure decision functions among
+ * them (isMenubarStale, menubarPlistNeedsRepoint, mayInstallMenubarHelper)
+ * are unit-tested in install-menubar.test.ts, not benched, since they take
+ * no I/O and are not where the described cost lives.
+ *
+ * No mocking: both groups run the real built dist/lib/menubar/install-
+ * menubar.js and the real exported installMenubarLaunchAgentOnUpgrade().
+ */
+describe('menu-bar startup self-heal (index.ts:1421-1425) — cold module import, the real cost paid before the darwin gate can even run', () => {
+  bench('FLOOR: bare `node --input-type=module -e ""` — same spawn cost every row below also pays; subtract it', () => {
+    coldEval([]);
+  }, COLD_OPTS);
+
+  bench('lib/menubar/install-menubar.js — the exact specifier dynamically imported at index.ts:1423, its static graph incl. state.js (1382 lines), version.js, app-bundle-install.js, fs-atomic.js, agent-spec/primitives.js', () => {
+    coldEval([MENUBAR_INSTALL_SPEC]);
+  }, COLD_OPTS);
+});
+
+describe('installMenubarLaunchAgentOnUpgrade() — warm in-process call on THIS Linux box (install-menubar.ts:630-658)', () => {
+  bench('real call on Linux: returns at the `!onDarwin()` guard (install-menubar.ts:632) after one process.platform read — NOT representative of the darwin decision path (menubarServiceInstalled/menubarSetupStale/mayHealMenubar fs checks), which is unverified on this box; see docblock above', () => {
+    installMenubarLaunchAgentOnUpgrade();
+  });
 });


### PR DESCRIPTION
**bench-only / test-only — no runtime behavior change.** Extends the existing CLI-entry hot-path bench (`src/lib/index.bench.ts`, already used by PR #2277/#2279/#2280/#2281) rather than adding a second file. Touches no shipped code path.

## Call path (read end to end, `file:line`)

`apps/cli/src/index.ts:1421-1425`:

```ts
if (process.platform === 'darwin' && process.env.AGENTS_SKIP_MIGRATION !== '1') {
  try {
    const { installMenubarLaunchAgentOnUpgrade } = await import('./lib/menubar/install-menubar.js');
    installMenubarLaunchAgentOnUpgrade();
  } catch { /* never block CLI startup on the menu bar */ }
}
```

Unlike `checkForUpdates`/`spawnDetachedSync` (`index.ts:1322`, guarded by `!helpOrVersionRequested`) and `ensureInitialized` (`index.ts:1377`, same guard), **this block carries no `helpOrVersionRequested` check** — confirmed by `grep -n helpOrVersionRequested index.ts`, which shows the variable defined at `index.ts:1236` and referenced at `1253`/`1322`/`1377`/`1439`, never at `1421`. So on darwin it dynamically imports and calls the self-heal on every ordinary invocation, `--help` and `--version` included.

`installMenubarLaunchAgentOnUpgrade()` (`install-menubar.ts:630-658`) itself:
- returns immediately when `!onDarwin()` (`install-menubar.ts:632`) — the only branch truthfully exercisable on this Linux box
- otherwise runs `menubarDisabledByUser()` (existsSync), `menubarServiceInstalled()` (existsSync), and on a fresh/matching install, `menubarSetupStale()`/`menubarSetupNeedsRepoint()`/`installedNeedsDevIdHeal()` (existsSync + readFileSync + a `codesign` spawnSync) before returning — the docblock at `install-menubar.ts:616-628` calls this "a couple of existsSync checks then return"

## Benchmark

Two new `describe` groups in `apps/cli/src/lib/index.bench.ts`, following the file's existing `coldEval`/`COLD_OPTS`/`runCli` patterns:

1. **Cold import of `dist/lib/menubar/install-menubar.js`** — the exact specifier dynamically imported at `index.ts:1423`, via a fresh `node --input-type=module -e` child process (no ESM caching), against the same bare-node FLOOR every other cold-import group in the file subtracts.
2. **`installMenubarLaunchAgentOnUpgrade()` called warm, in-process, on this real Linux box** — the true behavior here (`onDarwin()` short-circuit), explicitly **not** a stand-in for the darwin decision path.

## Platform honesty (per the task brief)

This bench runs on Linux for fixed-box comparability; the target code is macOS-gated. Only two things are truthfully measurable on Linux and nothing else is inferred:

- The **module import itself** is plain ESM resolution/evaluation with no platform branch at module scope in `install-menubar.ts` or its static imports (`fs-atomic.ts`, `state.ts`, `version.ts`, `app-bundle-install.ts`, `agent-spec/primitives.ts` — each grepped for `^import`/`process.platform` before writing the bench). Same bytes, same syscalls to resolve them, on darwin or Linux; only wall-clock speed differs by machine.
- The **`onDarwin()` short-circuit itself**, which is genuinely what runs on Linux.

Everything past `!onDarwin()` — `menubarServiceInstalled`, `menubarSetupStale`, `mayHealMenubar`'s cooldown read, the `codesign` spawn — is **left unverified**, not invented. See the docblock in the diff for the full accounting.

## MEASURED

`node ./node_modules/vitest/vitest.mjs bench --run src/lib/index.bench.ts`, vitest 4.1.9, Node, Linux (`yosemite-s1`, 20 cores). Two runs — first isolated (`-t menubar`), second the whole file (all 7 `describe` groups, exit 0, no failures):

| Row (`file:line`) | mean | hz | min | max | loadavg (before / after) |
|---|---|---|---|---|---|
| FLOOR: bare `node --input-type=module -e ""` | 19.23 ms | 51.99/s | 14.14 ms | 95.01 ms | 2.14 1.99 2.19 → 6.85 4.18 2.99 |
| `dist/lib/menubar/install-menubar.js` cold import (`index.ts:1423`) | 49.73 ms | 20.11/s | 39.84 ms | 67.17 ms | (same run) |
| `installMenubarLaunchAgentOnUpgrade()` warm, in-process, Linux (`install-menubar.ts:632`) | 0.0001 ms (~100 ns) | 19,149,219/s | 0.0000 ms | 0.0362 ms | (same run) |

Isolated run (`-t menubar`) agreed within noise: FLOOR mean 17.35ms/57.63hz, import mean 48.91-49.95ms/20.02-20.45hz, in-process call mean 0.0001ms/18.86M hz. `cat /proc/loadavg` before the isolated run: `1.69 1.90 2.18`; after: `2.14 1.99 2.19`.

**Attributable import-graph cost:** ~30.5ms (49.73 − 19.23), 2.59x the bare-node floor. This is real work `index.ts:1423` pays before `installMenubarLaunchAgentOnUpgrade()` can even be called, on any platform — the mechanism is import-graph size, not a platform-specific syscall, so it transfers even though absolute macOS milliseconds are unverified here.

Full raw output attached below (both runs, `tail` of `node ./node_modules/vitest/vitest.mjs bench --run`):

```
 ✓ src/lib/index.bench.ts > menu-bar startup self-heal (index.ts:1421-1425) — cold module import, the real cost paid before the darwin gate can even run 6574ms
     name                                                                      hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · FLOOR: bare node --input-type=module -e ""                            51.9923  14.1351  95.0115  19.2336  21.6426  24.0622  95.0115  95.0115  ±5.53%      157
   · lib/menubar/install-menubar.js cold import                            20.1084  39.8376  67.1683  49.7303  57.2964  67.1683  67.1683  67.1683  ±4.26%       61

 ✓ src/lib/index.bench.ts > installMenubarLaunchAgentOnUpgrade() — warm in-process call on THIS Linux box (install-menubar.ts:630-658) 2945ms
     name                                                                      hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · real call on Linux, onDarwin() guard                        19,149,218.85  0.0000  0.0362  0.0001  0.0001  0.0001  0.0001  0.0001  ±0.04%  9574610
```

## PROPOSALS (each measured; `file:line` + mechanism)

1. **`index.ts:1421` — add the `!helpOrVersionRequested` guard already used by every sibling block.** `checkForUpdates`/`spawnDetachedSync` (`index.ts:1322`) and `ensureInitialized` (`index.ts:1377`) both skip on `--help`/`--version`; the menu-bar self-heal, one block below `ensureInitialized`, does not. Mechanism: **missing guard** — a purely control-flow fact independent of platform, verified by grepping every reference to `helpOrVersionRequested` in `index.ts`. On darwin this means the ~30.5ms measured import cost (plus the darwin-only fs/codesign checks past it, unverified here) is paid even for `agents --help`/`agents --version`, which carry no menu-bar-relevant work.

2. **`install-menubar.ts:24` — stop importing the full 1382-line `state.ts` for one constant getter.** `getRuntimeStateDir()` is `return RUNTIME_STATE_DIR;` (`state.ts:664`), and it's the only one of the two imports (`getRuntimeStateDir`, `getHelpersDir`) used on the common no-op fast path (`disabledSentinelPath()`, `install-menubar.ts:108`, called from `menubarDisabledByUser()` inside `installMenubarLaunchAgentOnUpgrade`). `state.ts` itself statically imports `yaml`, `proper-lockfile` (via `fs-atomic.ts:4`), `machine-id.js`, and `child_process.execFileSync` for its ~1382 lines of unrelated agents.yaml/registry logic. Mechanism: **unnecessary heavy transitive import for a single trivial constant getter** — measured as part of the ~30.5ms attributable cold-import gap above (state.ts is the single largest file in the graph: `wc -l` shows 1382 lines vs 137/99/62/136 for the other four imports combined).

3. **`install-menubar.ts:26` — lazy-load `app-bundle-install.js` inside `ensureMenubarAppInstalled`, not at module top level.** `copyAppBundle`/`withInstallLock` are only called at `install-menubar.ts:254,256`, inside `ensureMenubarAppInstalled`, reached only when the self-heal decides something needs fixing (`installAndStartService` → `enableMenubarService`) — never on the common already-healthy no-op path, which returns at `install-menubar.ts:645` before touching either function. Mechanism: **eager import of install-only machinery on the no-op path** — `app-bundle-install.ts` pulls `withFileLock`/`ensureLockTarget` from `fs-atomic.ts`, which imports the `proper-lockfile` npm package. Deferring this behind a dynamic `await import('../app-bundle-install.js')` inside `ensureMenubarAppInstalled` would remove it from the cold-import graph for every invocation that takes the no-op branch (the steady-state case: menu bar already installed and fresh).

None of these were applied — this PR is bench-only, per the task brief. The next PR would apply (1) first (single-line, no risk) and re-run this bench to confirm the `--help`/`--version` case drops to zero.

## Conventions (repo `CLAUDE.md`)

- Bench lives next to source (`src/lib/index.bench.ts`); extends the existing bench rather than adding a second file, matching the sibling PRs #2277/#2279/#2280/#2281.
- **No mocking** — real cold `node dist/index.js` spawns, real dynamic import of the real built `dist/lib/menubar/install-menubar.js`, real call to the real exported `installMenubarLaunchAgentOnUpgrade()`.
- `apps/cli/vitest.config.ts` includes only `*.test.ts`, so `vitest run` (the CI gate) does not execute `*.bench.ts` — consistent with the other 6 committed `*.bench.ts` files in this repo. `bun run typecheck:bench` type-checks it; ran locally, exit 0.
- No shipped behavior changed → no CHANGELOG/docs entry (bench/test-only, same precedent as #2277).
- `.github/rush.yml`'s `prix/code-reviewer` is paused per #1767 — this PR's non-author review is a spawned subagent reviewer per the documented fallback, not that bot.
