### PR TITLE
bench(cli): measure brand bootstrap on every invocation (index.ts:514,1244)

### DIFF
--- a/apps/cli/src/lib/brand.bench.ts
+++ b/apps/cli/src/lib/brand.bench.ts
@@ -1,0 +1,195 @@
+/**
+ * Benchmark for the brand ("white-label") bootstrap that runs on EVERY `agents`
+ * invocation, including the unbranded fast path. Two distinct costs are measured
+ * and kept separate, because they have opposite shapes:
+ *
+ *   A) The RUNTIME compute at index.ts:1244 (`const brandDisabled =
+ *      disabledCommandsForActiveBrand()`), plus the two sibling calls at
+ *      index.ts:241 (`const BRAND = resolveBrandName()`) and index.ts:367
+ *      (`disabledCommandsForActiveBrand()` inside the help re-brander). This is
+ *      measured in-process below.
+ *
+ *   B) The eager MODULE-IMPORT cost of `import { resolveBrandName,
+ *      disabledCommandsForActiveBrand } from './lib/brand.js'` at index.ts:514.
+ *      brand.ts's own body is tiny, but its import pulls in agents.js:
+ *      brand.ts:20 does `import { ALL_AGENT_IDS, AGENTS } from './agents.js'`
+ *      (used only by reservedBrandNames()/validateBrandName(), brand.ts:52-67 —
+ *      NEITHER of which is on the startup path). A grep of index.ts's own static
+ *      imports shows brand.js (index.ts:514) is the SOLE eager edge that names
+ *      agents.js — no other top-level `import` in index.ts references it. This is
+ *      measured with real cold `node -e "await import(...)"` subprocesses, since
+ *      Node caches an ESM module for the life of a process, so an in-process
+ *      second import cannot see cold cost (same method as index.bench.ts's
+ *      startup-graph group on the sibling perf branches).
+ *
+ * Call path (each claim file:line-quoted):
+ *   index.ts:1244  disabledCommandsForActiveBrand()      (brand.ts:102)
+ *     -> getActiveBrandConfig()                          (brand.ts:84)
+ *        -> activeBrandName()                            (brand.ts:41)
+ *           -> resolveBrandName()  env AGENTS_BRAND read (brand.ts:34-38)
+ *        -> [UNBRANDED] name === null -> return null BEFORE any readMeta
+ *           (brand.ts:86: `if (!name) return null;`)
+ *        -> [BRANDED]   getBrandConfig(name)             (brand.ts:75)
+ *              -> listBrands()                           (brand.ts:70)
+ *                 -> readMeta().brands                   (state.ts:1124)
+ *
+ * The UNBRANDED path (AGENTS_BRAND unset — every plain `agents`/`ag` call) never
+ * reaches readMeta: activeBrandName() returns null at brand.ts:43 and
+ * getActiveBrandConfig() short-circuits at brand.ts:86, so the whole compute is
+ * one env read + one regex test (brand.ts:36) + `new Set(undefined ?? [])`
+ * (brand.ts:104). The BRANDED path (AGENTS_BRAND set) instead reaches
+ * readMeta() (state.ts:1124), which serves from a stamp-keyed cache on a warm
+ * hit (state.ts:1130-1134, ~2 stat syscalls) and reads+parses both
+ * ~/.agents/.system/agents.yaml and ~/.agents/agents.yaml on a cold miss
+ * (state.ts:1176-1189, fs.readFileSync + yaml.parse of each). The branded bench
+ * sets AGENTS_BRAND to a name absent from the real meta, so it exercises the
+ * real readMeta lookup (state.ts:1124) and then finds no config (brand.ts:88) —
+ * the readMeta hop is the branded add-on regardless of whether a brand is
+ * actually configured, and this box has none (`grep brands: ~/.agents/agents.yaml`
+ * is empty).
+ *
+ * No mocking. The runtime benches call the real exported functions; the branded
+ * ones hit the real ~/.agents/{,.system}/agents.yaml on this machine. The cold
+ * import benches spawn a real `node` that imports the REAL BUILT artifacts under
+ * ../../dist/lib/ (produced by `bun run build`), never the TS source, so the
+ * measured graph is exactly what an installed CLI loads.
+ *
+ * Lives at src/lib/brand.bench.ts (1:1 with brand.ts) so `typecheck:bench`
+ * (package.json:58, globs `src/lib/*.bench.ts`) type-checks it, and so
+ * `vitest bench` picks it up. It is NOT run by `vitest run` — vitest.config.ts
+ * `include` matches only `*.test.ts`, so this file never runs in the PR test gate;
+ * run it explicitly with `bun run bench` (`vitest bench --run`) inside apps/cli.
+ */
+import { describe, bench } from 'vitest';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import {
+  resolveBrandName,
+  activeBrandName,
+  isBranded,
+  disabledCommandsForActiveBrand,
+} from './brand.js';
+import { readMeta } from './state.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Ensure the runtime UNBRANDED benches see a genuinely unset brand, whatever the
+// invoking shell exported.
+delete process.env.AGENTS_BRAND;
+
+// A brand name that passes brand.ts's BRAND_NAME_PATTERN (brand.ts:27) but is
+// absent from the real meta.brands on this box, so the branded path runs the
+// real readMeta() lookup (state.ts:1124) and then returns null (brand.ts:88).
+const BENCH_BRAND = 'benchbrand';
+const setBranded = () => { process.env.AGENTS_BRAND = BENCH_BRAND; };
+const clearBranded = () => { delete process.env.AGENTS_BRAND; };
+
+describe('brand runtime compute — index.ts:241 / index.ts:367 / index.ts:1244 (unbranded fast path)', () => {
+  bench('resolveBrandName() — env read + regex test, AGENTS_BRAND unset (brand.ts:34-38)', () => {
+    resolveBrandName();
+  });
+
+  bench('activeBrandName() — unbranded, returns null (brand.ts:41-44)', () => {
+    activeBrandName();
+  });
+
+  bench('isBranded() — unbranded (brand.ts:47-49)', () => {
+    isBranded();
+  });
+
+  bench('disabledCommandsForActiveBrand() — THE index.ts:1244 call, unbranded: short-circuits before readMeta, `new Set([])` (brand.ts:102-105 -> brand.ts:86)', () => {
+    disabledCommandsForActiveBrand();
+  });
+});
+
+describe('brand runtime compute — branded invocation (AGENTS_BRAND set): the readMeta hop', () => {
+  bench('resolveBrandName() — branded, regex-validated name returned (brand.ts:36)', () => {
+    resolveBrandName();
+  }, { setup: setBranded, teardown: clearBranded });
+
+  bench('disabledCommandsForActiveBrand() — branded: activeBrandName -> getBrandConfig -> listBrands -> readMeta().brands (brand.ts:102 -> brand.ts:70 -> state.ts:1124), meta cache warm after first call', () => {
+    disabledCommandsForActiveBrand();
+  }, { setup: setBranded, teardown: clearBranded });
+
+  bench('readMeta() alone — the branded add-on, warm stamp-keyed cache hit (state.ts:1130-1134, ~2 stat syscalls + spread)', () => {
+    readMeta();
+  });
+});
+
+// --- Cold module-import cost (real subprocess per sample) ---------------------
+//
+// Node caches an ESM module for a process's life, so cold cost can only come
+// from a fresh process. Each sample spawns `node --input-type=module -e "await
+// import(<dist url>)"` importing the REAL built artifacts. `dist(p)` resolves
+// under ../../dist/lib relative to this file (src/lib -> apps/cli), the same
+// place the installed CLI runs from.
+const distUrl = (p: string): string =>
+  pathToFileURL(path.resolve(__dirname, '../../dist/lib', p)).href;
+
+function coldImport(specs: string[]): void {
+  const src = specs.map((s) => `await import(${JSON.stringify(s)});`).join('\n');
+  const r = spawnSync(process.execPath, ['--input-type=module', '-e', src || ';'], {
+    stdio: 'ignore',
+  });
+  if (r.status !== 0) {
+    throw new Error(
+      `cold import failed (status ${r.status}, signal ${r.signal}): ${String(r.stderr).slice(0, 400)}`,
+    );
+  }
+}
+
+// index.ts's own static local-module imports (the eager startup graph), by
+// line: dev-build(16), sync-commands(36), self-update(86), command-registry(124),
+// help(208), whats-new(209), platform(211), cli-entry(212), events(213),
+// event-provenance(214), format(215), state(513), brand(514). types.js (210) is
+// type-only and erased at compile, so it is not a runtime edge.
+const EAGER_MINUS_BRAND = [
+  'startup/dev-build.js',
+  'secrets/sync-commands.js',
+  'self-update.js',
+  'startup/command-registry.js',
+  'help.js',
+  'whats-new.js',
+  'platform/index.js',
+  'cli-entry.js',
+  'events.js',
+  'event-provenance.js',
+  'format.js',
+  'state.js',
+].map(distUrl);
+const EAGER_WITH_BRAND = [...EAGER_MINUS_BRAND, distUrl('brand.js')];
+
+const COLD = { time: 0, iterations: 20, warmupIterations: 3 } as const;
+
+describe('cold module import — isolate what the brand.js edge costs (real node subprocess per sample)', () => {
+  bench('baseline: empty `node -e` process (fork+exec+runtime, no user import)', () => {
+    coldImport([]);
+  }, COLD);
+
+  bench('import dist/lib/brand.js — brand.js + its full transitive (state.js + agents.js + types.js) into a fresh process', () => {
+    coldImport([distUrl('brand.js')]);
+  }, COLD);
+
+  bench('import dist/lib/state.js alone — already paid at index.ts:513 regardless of brand', () => {
+    coldImport([distUrl('state.js')]);
+  }, COLD);
+
+  bench('import dist/lib/agents.js alone — the 138KB module brand.js:20 drags into every process', () => {
+    coldImport([distUrl('agents.js')]);
+  }, COLD);
+
+  bench('import dist/lib/types.js alone — the third brand.js import (mostly type-only)', () => {
+    coldImport([distUrl('types.js')]);
+  }, COLD);
+});
+
+describe('cold module import — brand.js MARGINAL cost on top of the rest of the eager graph', () => {
+  bench('EAGER_MINUS_BRAND: the 12 other index.ts eager local imports, no brand edge', () => {
+    coldImport(EAGER_MINUS_BRAND);
+  }, COLD);
+
+  bench('EAGER_WITH_BRAND: same 12 + dist/lib/brand.js (index.ts:514) — delta vs above is brand.js\'s true marginal startup cost, net of any transitive sharing', () => {
+    coldImport(EAGER_WITH_BRAND);
+  }, COLD);
+});


### PR DESCRIPTION
**test-only** — adds `apps/cli/src/lib/brand.bench.ts` (a vitest `bench`). No runtime code changes, no user-visible surface, so no CHANGELOG/docs entry. Not run by the PR test gate: `vitest.config.ts` `include` is `*.test.ts` only, so this runs under `bun run bench`, never `vitest run`.

## What this measures
The brand ("white-label") bootstrap that runs on **every** `agents` invocation, including the unbranded fast path:
- the runtime compute at `index.ts:1244` (`const brandDisabled = disabledCommandsForActiveBrand()`, `brand.ts:102`), plus the sibling calls at `index.ts:241` / `index.ts:367`;
- the eager import at `index.ts:514` (`import … from './lib/brand.js'`), whose `brand.ts:20` pulls the 138KB `agents.js`.

No mocking: real exported functions, real `~/.agents/{,.system}/agents.yaml` on this box, and real cold `node --input-type=module -e "await import(...)"` subprocesses importing the **built** `dist/lib/*.js`.

## Measured (real run)
Host **yosemite-s1**, node **v24.11.1**, 20 cores. `cat /proc/loadavg` **1.56 → 2.27** across the run. Benchmarked source (`brand.ts`/`agents.ts`/`state.ts`/`self-update.ts`/`versions.ts`/`index.ts`) is **byte-identical** between the run base and this PR base (`git diff --stat` empty; 1 commit apart = the 1.22.29 release).

### Runtime compute (in-process)
| bench | hz | mean |
|---|---:|---:|
| `resolveBrandName()` unbranded (`brand.ts:34-38`) | 4,102,568 | 0.2µs |
| `disabledCommandsForActiveBrand()` **UNBRANDED — the `index.ts:1244` call** (`brand.ts:102`→`:86`) | 3,788,969 | **0.26µs** |
| `disabledCommandsForActiveBrand()` **BRANDED** (→`readMeta`, `state.ts:1124`) | 27,959 | **35.8µs** |
| `readMeta()` alone, warm stamp cache (`state.ts:1130`) | 28,895 | 34.6µs |

The unbranded fast-path compute is **free** (0.26µs; short-circuits before `readMeta` at `brand.ts:86`). The branded path is **128× slower** and is **entirely `readMeta`** — and only branded invocations pay it.

### Cold module import (real subprocess per sample)
| bench | mean |
|---|---:|
| baseline empty `node -e` | 17.6ms |
| `dist/lib/brand.js` (full transitive: state+agents+types) | 98.6ms |
| `dist/lib/state.js` alone (already paid at `index.ts:513`) | 43.8ms |
| `dist/lib/agents.js` alone (the 138KB module) | 100.2ms |
| `dist/lib/types.js` alone | 21.0ms |
| **EAGER_MINUS_BRAND** (12 other eager `index.ts` imports) | **105.40ms** |
| **EAGER_WITH_BRAND** (+ `brand.js`, `index.ts:514`) | **105.39ms** |

**Key result:** `brand.js`'s *marginal* startup cost is **~0** (105.39 vs 105.40ms), even though it looks like 98.6ms in isolation — because `agents.js` is **already** loaded by the eager graph via `index.ts:86` → `self-update.ts:20` (`import { compareVersions } from './versions.js'`) → `versions.ts:35` (imports `agents.js`). Confirmed with a targeted run: `EAGER minus self-update minus brand` = **49.8ms** (no `agents.js`); adding `versions.js` back → **97.6ms**; `self-update.js` alone = **109.2ms**.

## Proposals (measured, with file:line + mechanism)
1. **Keep the 138KB `agents.js` off the eager startup graph — ~50ms/invocation cold.** It reaches startup via **two redundant** eager edges: (a) `index.ts:86`→`self-update.ts:20`→`versions.ts:35`→`agents.js`, and (b) `index.ts:514`→`brand.ts:20`. Because either alone loads `agents.js`, cutting one saves ~0 (the marginal-0 result). Cutting **both** drops the eager graph ~105ms→~50ms (measured `EAGER minus self-update minus brand` = 49.8ms). Mechanism: (a) move `compareVersions` (the only symbol `self-update.ts:20` needs from `versions.ts`) into a leaf semver module that doesn't import `agents.js`; (b) lazify `brand.ts:20` — its only consumers, `reservedBrandNames()`/`validateBrandName()` (`brand.ts:52-67`), run under `agents mine`/setup, never at startup, so `await import('./agents.js')` inside them removes the eager edge.
2. **`brand.ts:20` eager `agents.js` import is dead weight on the hot path regardless** (`brand.ts:52-67` are off-startup). Lazifying it is the load-bearing half of #1 and drops `brand.js`'s isolated cold cost from 98.6ms toward `state.js`'s 43.8ms (the ~55ms gap = `agents.js`). Standalone it saves ~0 today (self-update re-loads `agents.js`), so it only pays off paired with 1a.
3. **No change to the runtime compute.** The `index.ts:1244` unbranded call is 0.26µs; the branded 35.8µs is all `readMeta`, already stamp-cached (`state.ts:1130`) and paid only by branded shims. Reported for completeness — not a bottleneck.

## Run it
```
cd apps/cli && bun run bench src/lib/brand.bench.ts
```
