### PR TITLE
test(tmux): fix flaky ENOENT/exit-status assertions blocking release (RUSH-2342)

### DIFF
--- a/apps/cli/src/lib/tmux/session.test.ts
+++ b/apps/cli/src/lib/tmux/session.test.ts
@@ -278,7 +278,9 @@ describe.skipIf(skipReason)('tmux session lifecycle', () => {
     const meta = await createSession({ name: 'exitcode', cmd: 'sh -c "exit 3"', socket });
     expect(meta.pane).toBeTruthy();
     await wait(400);
-    const exit = await paneExitStatus(meta.pane!, socket);
+    // See waitForExitStatus below: `pane_dead` can flip before `pane_dead_status`
+    // is populated under load, so poll for both together rather than one read.
+    const exit = await waitForExitStatus(meta.pane!, socket);
     expect(exit.dead).toBe(true);
     expect(exit.status).toBe(3);
   });
@@ -301,13 +303,25 @@ describe.skipIf(skipReason)('tmux session lifecycle', () => {
     });
     expect(meta.pane).toBeTruthy();
     await wait(400);
-    const exit = await paneExitStatus(meta.pane!, socket);
+    // tmux can flip `pane_dead` to 1 before `pane_dead_status` is populated —
+    // the same class of async settle race as the capture below, just on a
+    // different field. Poll both together instead of trusting a single read.
+    const exit = await waitForExitStatus(meta.pane!, socket);
     expect(exit.dead).toBe(true);
     expect(exit.status).toBe(1);
     // capture-pane must reach into scrollback (as runInTmux does with -S -200)
     // to recover the crash output — the dead pane's VISIBLE screen is just the
     // "Pane is dead" banner, so a history-less capture would miss the error.
-    const screen = await capturePane({ name: 'fastfail', pane: meta.pane!, socket, lines: 200 });
+    // The pty write of the crash line and tmux's own SIGCHLD-driven pane-dead
+    // transition are two independent async chains; on a loaded runner the
+    // dead-pane banner can render before the crash line has settled into the
+    // pane's screen/scrollback (RUSH-2342 — observed as a bare "Pane is dead"
+    // capture with no ENOENT on the crabbox VM, despite paneExitStatus above
+    // already confirming the process itself was dead+exit 1). Poll the same
+    // real capturePane() until the crash text lands, exactly like waitForPanes
+    // polls for pane teardown below — this still fails for real if the error
+    // text never appears, it just tolerates how long that takes under load.
+    const screen = await waitForCapture({ name: 'fastfail', pane: meta.pane!, socket, lines: 200 }, 'ENOENT');
     expect(screen).toContain('ENOENT');
   });
 
@@ -452,6 +466,51 @@ async function waitForPanes(
     panes = (await runTmux({ socket, args: ['list-panes', '-t', name, '-F', '#{pane_id}:#{pane_dead}'] }))
       .stdout.trim().split('\n').filter(Boolean);
     if (panes.length === expected || Date.now() >= deadline) return panes;
+    await wait(50);
+  }
+}
+
+/**
+ * Poll the real `paneExitStatus()` until it reports a finished exit (both
+ * `dead` AND a defined `status`), or the timeout elapses. `pane_dead` and
+ * `pane_dead_status` are two separate tmux format variables that can settle
+ * at slightly different times under load, so a single read can observe
+ * `dead: true, status: undefined`. Returns the last observed result either
+ * way — a genuine miss still fails the caller's assertions.
+ */
+async function waitForExitStatus(
+  pane: string,
+  socket: string,
+  timeoutMs = 5000,
+): Promise<Awaited<ReturnType<typeof paneExitStatus>>> {
+  const deadline = Date.now() + timeoutMs;
+  let exit: Awaited<ReturnType<typeof paneExitStatus>> = { found: false, dead: false };
+  for (;;) {
+    exit = await paneExitStatus(pane, socket);
+    if ((exit.dead && exit.status !== undefined) || Date.now() >= deadline) return exit;
+    await wait(50);
+  }
+}
+
+/**
+ * Poll the real `capturePane()` until its output contains `needle`, or the
+ * timeout elapses. Same rationale as `waitForPanes`: a dead pane's screen
+ * content settles asynchronously relative to tmux's own dead/exit-status
+ * bookkeeping, and a fixed sleep that is fine locally can be too tight on a
+ * loaded CI runner. Returns the last observed capture either way, so a
+ * genuine miss (the text never appears) still fails the caller's assertion —
+ * this only removes timing flakiness, it does not weaken what is checked.
+ */
+async function waitForCapture(
+  opts: Parameters<typeof capturePane>[0],
+  needle: string,
+  timeoutMs = 5000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let screen = '';
+  for (;;) {
+    screen = await capturePane(opts);
+    if (screen.includes(needle) || Date.now() >= deadline) return screen;
     await wait(50);
   }
 }


### PR DESCRIPTION
**test-only change** — no behavior change to production code.

## What
`apps/cli/src/lib/tmux/session.test.ts:311` blocks every release: `scripts/release.sh --apply` runs the full suite on a Linux crabbox before opening the release PR, and this assertion (`expect(screen).toContain('ENOENT')`) failed there during the 1.22.28 release with the pane instead showing a bare `Pane is dead (status 1, ...)` banner.

## Root cause
Two tmux format variables settle **asynchronously**, and a fixed `wait(400)` + single read isn't reliably enough time under CI load:

- `pane_dead` can flip to `1` before `pane_dead_status` is populated — `paneExitStatus()` can observe `dead: true, status: undefined`.
- The crash line written to the pane's pty and tmux's own SIGCHLD-driven dead-pane-banner render are two independent async chains. Under load, the banner can render before the crash text has settled into the pane's screen/scrollback — so `capture-pane -S -200` can miss text that was genuinely written, even though `paneExitStatus` already confirmed the process died with exit 1.

Reproduced the settle-timing sensitivity locally by loading all 20 cores while looping the test — surfaced both the `pane_dead_status: undefined` race and confirmed the fix converges.

## Fix
Poll the real production `paneExitStatus()` / `capturePane()` functions until the expected condition is observed (or a 5s timeout), instead of one read after a fixed sleep — same pattern already established in this file (`waitForPanes`, added for an earlier pane-teardown flake). This is **not a weakening**: a genuine miss (the text never appears, or the exit status never resolves) still fails the assertion after the timeout. It only removes timing flakiness against real, variable tmux settle latency.

```
it('a fast-failing agent leaves its error readable in the dead pane (runInTmux failure recap)', async () => {
  ...
  const exit = await waitForExitStatus(meta.pane!, socket);   // was: paneExitStatus(...)
  expect(exit.dead).toBe(true);
  expect(exit.status).toBe(1);
  const screen = await waitForCapture({ name: 'fastfail', pane: meta.pane!, socket, lines: 200 }, 'ENOENT'); // was: capturePane(...)
  expect(screen).toContain('ENOENT');
});
```

Applied the same `waitForExitStatus` fix to the neighboring `paneExitStatus reports the dead pane exit code` test — same race, same file, same fix.

## Verification
```
$ node ./node_modules/vitest/vitest.mjs run src/lib/tmux/session.test.ts

 Test Files  1 passed (1)
      Tests  27 passed (27)
```
Ran repeatedly (including under artificial 20-core CPU load) — consistently green after the fix; the pre-fix version reproduced both the `pane_dead_status: undefined` and the missing-`ENOENT` failures under the same load.

## What would still make this fail
Both polling helpers only wait for a *real* condition to become true (crash text present, exit status resolved) within 5s — they never assert success unconditionally. If `capturePane` genuinely never surfaces the ENOENT text, or `paneExitStatus` never resolves a status, the test still fails exactly as before.

Ticket: RUSH-2342