### PR TITLE
feat(menubar): distinguish routine readiness/blocked/skipped from execution failure (RUSH-2290)

### DIFF
--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -135,6 +135,23 @@ enum AgentsCLI {
         }
     }
 
+    // The CLI verb behind the routine submenu's "History…" (`agents routines
+    // runs <name>`): run ids, outcomes, and start times for the last runs of
+    // one routine — read-only, distinct from `logs` (raw process output of the
+    // most recent fire). A pure argv builder so it's testable without spawning.
+    static func routineHistoryArgs(_ name: String) -> [String] { ["routines", "runs", name] }
+
+    static func routineHistory(_ name: String) {
+        runMonitored(argv(routineHistoryArgs(name))) { text, ok in
+            let safeName = name.replacingOccurrences(of: "[^A-Za-z0-9._-]", with: "-", options: .regularExpression)
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agents-routine-\(safeName)-history.txt")
+            let body = ok ? text : (text.isEmpty ? "Unable to load history for routine '\(name)'.\n" : text)
+            try? body.write(to: url, atomically: true, encoding: .utf8)
+            runDetached(["/usr/bin/open", url.path])
+        }
+    }
+
     static func openPath(_ path: String) { runDetached(["/usr/bin/open", path]) }
 
     static func startScheduler() { runDetached(argv(["routines", "start"])) }

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -784,7 +784,15 @@ enum IssueSelfTest {
             exitCode: exitCode,
             failureReason: failureReason,
             lastRunStartedAt: "2026-07-20T03:00:00.000Z",
-            lastRunCompletedAt: "2026-07-20T03:00:05.000Z"
+            lastRunCompletedAt: "2026-07-20T03:00:05.000Z",
+            ready: nil,
+            readiness: nil,
+            failureCode: nil,
+            project: nil,
+            requestedCwd: nil,
+            resolvedCwd: nil,
+            skipReason: nil,
+            activeRunId: nil
         )
     }
 }

--- a/apps/cli/menubar/Sources/MenubarHelper/Models.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Models.swift
@@ -2,6 +2,14 @@ import Foundation
 
 // Shape of `agents routines list --json` (added in src/commands/routines.ts).
 // Routines are secondary in the menu bar — fetched only when the menu opens.
+//
+// RUSH-2290 (routine reliability): `ready`/`readiness`/`failureCode`/
+// `project`/`requestedCwd`/`resolvedCwd`/`skipReason`/`activeRunId` are all
+// optional additions from the runtime-core track. Every one of them must
+// decode as nil against a payload from an older installed CLI that predates
+// them — the menu bar and the CLI release independently, so version skew
+// between this helper and the on-PATH `agents` binary is routine, not an
+// edge case. Do NOT make any of them non-optional.
 struct Routine: Decodable {
     let name: String
     let agent: String?
@@ -16,11 +24,42 @@ struct Routine: Decodable {
     let overdue: Bool
     let nextRun: String?
     let nextRunHuman: String?
-    let lastStatus: String?            // completed | failed | timeout | running | missed | null
+    // completed | failed | timeout | running | missed | blocked | skipped | null.
+    // `blocked` / `skipped` are new outcomes (a readiness gate refused the run, or
+    // the daemon deliberately skipped a duplicate/overlapping fire) — every switch
+    // over this field must have a default arm rather than an exhaustive one.
+    let lastStatus: String?
     let exitCode: Int?
     let failureReason: String?
     let lastRunStartedAt: String?
     let lastRunCompletedAt: String?
+
+    // Explicit readiness verdict for the NEXT run, independent of how the last
+    // one went. `nil` (an older CLI, or a routine the readiness check never
+    // covers) must behave exactly like `true` — only an explicit `false` gates
+    // Run/Resume in the UI.
+    let ready: Bool?
+    let readiness: RoutineReadiness?
+    // A short machine code alongside `failureReason`'s free text (e.g. "auth_failed").
+    let failureCode: String?
+    // Execution target, for naming WHERE a failure/block happened.
+    let project: String?
+    let requestedCwd: String?
+    let resolvedCwd: String?
+    // Present when lastStatus == "skipped": why the daemon skipped this fire
+    // (duplicate_slot | active_run | wrong_owner).
+    let skipReason: String?
+    // The run this one was skipped in favor of, when skipReason == "active_run".
+    let activeRunId: String?
+}
+
+// `readiness` on `Routine`: why the daemon would refuse to start the next run
+// right now. `code` is a stable machine token (e.g. "project_path_missing"),
+// `message` is the human-readable reason, `repair` is an optional suggested fix.
+struct RoutineReadiness: Decodable {
+    let code: String
+    let message: String
+    let repair: String?
 }
 
 struct MenuAgent {

--- a/apps/cli/menubar/Sources/MenubarHelper/RoutineSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/RoutineSelfTest.swift
@@ -211,6 +211,31 @@ enum RoutineSelfTest {
               distinctFailureGroups.count == 2
                 && distinctFailureGroups.allSatisfy { $0.1.count == 1 })
 
+        // Regression: a routine whose LAST run failed (kind == .failure) can
+        // still carry a `readiness` block describing its NEXT run — `ready`/
+        // `readiness` is independent of `lastStatus` (see the notReady fixture
+        // above, which is `completed` yet still not-ready). The cause key must
+        // follow the routine's ACTUAL attention kind (.failure -> failureCode),
+        // not fall back to a readiness-first chain that would silently key
+        // this routine by a readiness code belonging to a different concern.
+        let failedWithStaleReadinessJSON = """
+        {"name":"crm-pipeline-brief-2","agent":"claude","schedule":"0 7 * * *","enabled":true,
+         "overdue":false,"lastStatus":"failed","exitCode":1,
+         "failureReason":"Please run /login","failureCode":"auth_failed",
+         "readiness":{"code":"project_path_missing","message":"stale from a prior check"}}
+        """
+        guard let failedWithStaleReadiness = try? decoder.decode(Routine.self, from: Data(failedWithStaleReadinessJSON.utf8)) else {
+            print("FAIL — a failed routine carrying a readiness block failed to decode")
+            exit(1)
+        }
+        check("a routine with lastStatus:failed still classifies as .failure even carrying a readiness block",
+              routineAttentionKind(failedWithStaleReadiness) == .failure)
+        let staleReadinessGroups = groupedByAttentionCause([failed, failedWithStaleReadiness, notReady])
+        check("a .failure routine's cause is its failureCode, NOT its unrelated readiness.code — it merges with the other auth_failed failure",
+              staleReadinessGroups.contains { $0.0 == "auth_failed" && $0.1.count == 2 })
+        check("the genuinely .notReady routine (readiness code project_path_missing) is NOT pulled into the failure group",
+              staleReadinessGroups.contains { $0.0 == "project_path_missing" && $0.1.count == 1 })
+
         // MARK: bounded lists — NEEDS YOU attention groups and "All routines…"
         // both cap with a named "+N more" remainder rather than an unbounded
         // scroll (the constants StatusItemController's menu builders read).

--- a/apps/cli/menubar/Sources/MenubarHelper/RoutineSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/RoutineSelfTest.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+// Routine-reliability self-test (RUSH-2290): the menu bar stays a thin reader
+// of `agents routines list --json`, but that JSON is growing new optional
+// fields from the runtime-core track (readiness, failureCode, execution
+// project/cwd, blocked/skipped status, activeRunId). This exercises real
+// `Routine` decoding against both an OLD payload (predating every new field)
+// and a NEW one, then the pure classification/formatting/action-state helpers
+// in StatusItemController.swift that read those fields — no GUI, no NSMenu
+// construction (see the file-level note on why: NSStatusItem/NSMenu need an
+// AppKit run loop this self-test deliberately never reaches). Gated by
+// MENUBAR_ROUTINE_TEST=1 (main.swift). Mirrors ActiveSessionSelfTest /
+// LoadedDeviceSelfTest.
+enum RoutineSelfTest {
+    static func run() -> Never {
+        var pass = true
+        func check(_ name: String, _ cond: Bool) {
+            print("\(cond ? "PASS" : "FAIL") — \(name)")
+            if !cond { pass = false }
+        }
+
+        let decoder = JSONDecoder()
+
+        // MARK: Backward compatibility — a payload from a CLI that predates
+        // every RUSH-2290 field must still decode, and every new field reads
+        // nil, never a decode failure.
+        let legacyJSON = """
+        {"name":"check-updates","agent":"claude","workflow":null,"repo":null,
+         "projects":null,"projectGroup":null,"schedule":"0 * * * *",
+         "scheduleHuman":"hourly","enabled":true,"overdue":false,
+         "nextRun":"2026-08-07T10:00:00Z","nextRunHuman":"in 10m",
+         "lastStatus":"completed","exitCode":0,"failureReason":null,
+         "lastRunStartedAt":null,"lastRunCompletedAt":null}
+        """
+        guard let legacy = try? decoder.decode(Routine.self, from: Data(legacyJSON.utf8)) else {
+            print("FAIL — a pre-RUSH-2290 payload failed to decode")
+            exit(1)
+        }
+        check("legacy payload decodes ready as nil", legacy.ready == nil)
+        check("legacy payload decodes readiness as nil", legacy.readiness == nil)
+        check("legacy payload decodes failureCode as nil", legacy.failureCode == nil)
+        check("legacy payload decodes project/cwd fields as nil",
+              legacy.project == nil && legacy.requestedCwd == nil && legacy.resolvedCwd == nil)
+        check("legacy payload decodes skipReason/activeRunId as nil",
+              legacy.skipReason == nil && legacy.activeRunId == nil)
+        check("an absent `ready` is NOT not-ready (old CLI keeps old behavior)",
+              !routineIsNotReady(legacy))
+        check("a completed, non-overdue legacy routine needs no attention",
+              !routineNeedsAttention(legacy))
+        check("Run/Resume stay enabled with no readiness data at all",
+              routineActionState(legacy).runEnabled)
+
+        // MARK: blocked / skipped lastStatus — new terminal outcomes alongside
+        // completed/failed/timeout/missed/running.
+        let blockedJSON = """
+        {"name":"deploy-web","agent":"codex","schedule":"0 9 * * *","enabled":true,
+         "overdue":false,"lastStatus":"blocked","project":"web",
+         "readiness":{"code":"agent_auth_failed","message":"codex is signed out"}}
+        """
+        guard let blocked = try? decoder.decode(Routine.self, from: Data(blockedJSON.utf8)) else {
+            print("FAIL — a blocked-status payload failed to decode")
+            exit(1)
+        }
+        check("lastStatus 'blocked' decodes", blocked.lastStatus == "blocked")
+        check("readiness.code decodes", blocked.readiness?.code == "agent_auth_failed")
+        check("a blocked last run classifies as .notReady, not .failure",
+              routineAttentionKind(blocked) == .notReady)
+        check("a blocked routine needs attention", routineNeedsAttention(blocked))
+        check("blocked reason names the readiness message and target",
+              routineFailureSummary(blocked, max: 80) == "codex is signed out · web")
+
+        let skippedJSON = """
+        {"name":"security-sweep","agent":"claude","schedule":"0 3 * * *","enabled":true,
+         "overdue":false,"lastStatus":"skipped","skipReason":"active_run",
+         "activeRunId":"run-abc123"}
+        """
+        guard let skipped = try? decoder.decode(Routine.self, from: Data(skippedJSON.utf8)) else {
+            print("FAIL — a skipped-status payload failed to decode")
+            exit(1)
+        }
+        check("skipReason decodes", skipped.skipReason == "active_run")
+        check("activeRunId decodes", skipped.activeRunId == "run-abc123")
+        check("a skipped run classifies as .miss (infra, not a task failure)",
+              routineAttentionKind(skipped) == .miss)
+        check("routineIsMiss agrees for skipped", routineIsMiss(skipped))
+        check("skipped reason names the skip cause",
+              routineFailureSummary(skipped, max: 40) == "skipped · active run")
+
+        // MARK: readiness gating an ENABLED routine's NEXT run, independent of
+        // the last run's own outcome (it can have completed fine).
+        let notReadyJSON = """
+        {"name":"linear-hygiene","agent":"claude","schedule":"0 8 * * *","enabled":true,
+         "overdue":false,"lastStatus":"completed","ready":false,
+         "readiness":{"code":"project_path_missing","message":"project directory no longer exists",
+                       "repair":"agents routines edit linear-hygiene"},
+         "project":"linear-hygiene","resolvedCwd":"/Users/m/repos/linear-hygiene"}
+        """
+        guard let notReady = try? decoder.decode(Routine.self, from: Data(notReadyJSON.utf8)) else {
+            print("FAIL — a ready:false payload failed to decode")
+            exit(1)
+        }
+        check("ready:false decodes", notReady.ready == false)
+        check("readiness.repair decodes", notReady.readiness?.repair == "agents routines edit linear-hygiene")
+        check("completed-but-not-ready classifies as .notReady, NOT .failure",
+              routineAttentionKind(notReady) == .notReady)
+        check("routineIsNotReady agrees", routineIsNotReady(notReady))
+        check("a not-ready enabled routine needs attention even though its last run completed",
+              routineNeedsAttention(notReady))
+        check("not-ready reason prefers the readiness message + resolvedCwd target",
+              routineFailureSummary(notReady, max: 120)
+                == "project directory no longer exists · linear-hygiene")
+
+        // A PAUSED routine (enabled:false) with the identical readiness block
+        // must NOT be flagged — the operator already parked it; ready:false is
+        // only actionable while the routine is still trying to run.
+        let pausedNotReadyJSON = """
+        {"name":"linear-hygiene","agent":"claude","schedule":"0 8 * * *","enabled":false,
+         "overdue":false,"lastStatus":"completed","ready":false,
+         "readiness":{"code":"project_path_missing","message":"project directory no longer exists"}}
+        """
+        guard let pausedNotReady = try? decoder.decode(Routine.self, from: Data(pausedNotReadyJSON.utf8)) else {
+            print("FAIL — a paused ready:false payload failed to decode")
+            exit(1)
+        }
+        check("a manually paused routine is NOT flagged even if it's also not-ready",
+              !routineNeedsAttention(pausedNotReady))
+
+        // MARK: Run/Resume gating — RoutineActionState is pure and AppKit-free.
+        check("Run is disabled when ready is explicitly false",
+              !routineActionState(notReady).runEnabled)
+        check("Resume is disabled for a paused, not-ready routine (it would just fail again)",
+              !routineActionState(pausedNotReady).pauseResumeEnabled)
+        check("Pause stays enabled for an enabled-but-not-ready routine",
+              routineActionState(notReady).pauseResumeEnabled)
+        check("pauseResumeTitle reflects enabled state",
+              routineActionState(legacy).pauseResumeTitle == "Pause"
+                && routineActionState(pausedNotReady).pauseResumeTitle == "Resume")
+
+        // MARK: a plain execution failure still classifies as .failure, not
+        // .notReady or .miss — the three kinds are mutually exclusive.
+        let failedJSON = """
+        {"name":"crm-pipeline-brief","agent":"claude","schedule":"0 7 * * *","enabled":true,
+         "overdue":false,"lastStatus":"failed","exitCode":1,
+         "failureReason":"Please run /login","failureCode":"auth_failed"}
+        """
+        guard let failed = try? decoder.decode(Routine.self, from: Data(failedJSON.utf8)) else {
+            print("FAIL — a failed-status payload failed to decode")
+            exit(1)
+        }
+        check("failureCode decodes", failed.failureCode == "auth_failed")
+        check("a real execution failure classifies as .failure",
+              routineAttentionKind(failed) == .failure)
+        check("failure reason is tagged with its failureCode",
+              routineFailureSummary(failed, max: 80) == "auth_failed: Please run /login")
+        check("Run stays enabled for a failed-but-ready routine (ready absent == true)",
+              routineActionState(failed).runEnabled)
+
+        // MARK: History… action wiring — a pure argv builder, not a live spawn.
+        check("routineHistoryArgs shells 'routines runs <name>'",
+              AgentsCLI.routineHistoryArgs("crm-pipeline-brief") == ["routines", "runs", "crm-pipeline-brief"])
+
+        // MARK: grouping identical readiness causes — never inventing a shared
+        // cause across routines that fail for genuinely different reasons.
+        let sameCauseA = blocked
+        let sameCauseBJSON = """
+        {"name":"deploy-api","agent":"codex","schedule":"0 9 * * *","enabled":true,
+         "overdue":false,"lastStatus":"blocked","project":"api",
+         "readiness":{"code":"agent_auth_failed","message":"codex is signed out"}}
+        """
+        let sameCauseB = try! decoder.decode(Routine.self, from: Data(sameCauseBJSON.utf8))
+        let groups = groupedByAttentionCause([sameCauseA, sameCauseB, failed])
+        check("two routines sharing a readiness code collapse into one group",
+              groups.contains { $0.0 == "agent_auth_failed" && $0.1.count == 2 })
+        check("a routine with a distinct cause keeps its own group",
+              groups.contains { $0.0 == "failed" && $0.1.count == 1 })
+        check("readableAttentionCause never invents copy for an unknown code",
+              readableAttentionCause("agent_auth_failed") == "agent auth failed")
+
+        // MARK: bounded lists — NEEDS YOU attention groups and "All routines…"
+        // both cap with a named "+N more" remainder rather than an unbounded
+        // scroll (the constants StatusItemController's menu builders read).
+        check("attention-group cap is a small, named number", StatusItemController.maxAttentionGroups > 0
+              && StatusItemController.maxAttentionGroups < 20)
+        check("all-routines cap is a named number", StatusItemController.maxAllRoutinesRows > 0)
+        let manyCauses = (0..<(StatusItemController.maxAttentionGroups + 4)).map { i -> Routine in
+            let json = """
+            {"name":"r\(i)","agent":"claude","schedule":"0 9 * * *","enabled":true,
+             "overdue":false,"lastStatus":"blocked","project":"p\(i)",
+             "readiness":{"code":"cause_\(i)","message":"m\(i)"}}
+            """
+            return try! decoder.decode(Routine.self, from: Data(json.utf8))
+        }
+        let manyGroups = groupedByAttentionCause(manyCauses)
+        check("every distinct cause gets its own group when none repeat",
+              manyGroups.count == manyCauses.count)
+        let cappedGroups = Array(manyGroups.prefix(StatusItemController.maxAttentionGroups))
+        check("capping the groups to the constant drops the expected remainder",
+              manyGroups.count - cappedGroups.count == 4)
+
+        print(pass ? "ALL PASS" : "SOME FAILED")
+        exit(pass ? 0 : 1)
+    }
+}

--- a/apps/cli/menubar/Sources/MenubarHelper/RoutineSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/RoutineSelfTest.swift
@@ -125,6 +125,21 @@ enum RoutineSelfTest {
         check("a manually paused routine is NOT flagged even if it's also not-ready",
               !routineNeedsAttention(pausedNotReady))
 
+        // The SAME guarantee for the OTHER notReady trigger — a paused
+        // routine whose last (pre-pause) run was blocked must not be flagged
+        // either. Both notReady disjuncts must gate on `enabled` the same way.
+        let pausedBlockedJSON = """
+        {"name":"deploy-web","agent":"codex","schedule":"0 9 * * *","enabled":false,
+         "overdue":false,"lastStatus":"blocked","project":"web",
+         "readiness":{"code":"agent_auth_failed","message":"codex is signed out"}}
+        """
+        guard let pausedBlocked = try? decoder.decode(Routine.self, from: Data(pausedBlockedJSON.utf8)) else {
+            print("FAIL — a paused blocked-status payload failed to decode")
+            exit(1)
+        }
+        check("a manually paused routine is NOT flagged even if its last run was blocked",
+              !routineNeedsAttention(pausedBlocked))
+
         // MARK: Run/Resume gating — RoutineActionState is pure and AppKit-free.
         check("Run is disabled when ready is explicitly false",
               !routineActionState(notReady).runEnabled)
@@ -171,10 +186,30 @@ enum RoutineSelfTest {
         let groups = groupedByAttentionCause([sameCauseA, sameCauseB, failed])
         check("two routines sharing a readiness code collapse into one group",
               groups.contains { $0.0 == "agent_auth_failed" && $0.1.count == 2 })
-        check("a routine with a distinct cause keeps its own group",
-              groups.contains { $0.0 == "failed" && $0.1.count == 1 })
+        // `failed` has no readiness at all, so its cause falls back to its
+        // failureCode ("auth_failed") — a DIFFERENT string from the readiness
+        // code above ("agent_auth_failed") purely by coincidence of this
+        // fixture's naming, so it must still land in its own group, not
+        // silently merge with the readiness-code group.
+        check("a routine with a distinct cause (its own failureCode) keeps its own group",
+              groups.contains { $0.0 == "auth_failed" && $0.1.count == 1 })
         check("readableAttentionCause never invents copy for an unknown code",
               readableAttentionCause("agent_auth_failed") == "agent auth failed")
+
+        // Two routines sharing the same lastStatus ("failed") but DIFFERENT
+        // failureCodes must NOT collapse — the grouping must prefer the more
+        // specific failureCode over the generic status, so it never invents a
+        // shared cause across routines failing for genuinely different reasons.
+        let otherFailureJSON = """
+        {"name":"weekly-fleet-retro","agent":"claude","schedule":"0 6 * * 1","enabled":true,
+         "overdue":false,"lastStatus":"failed","exitCode":1,
+         "failureReason":"disk full","failureCode":"disk_full"}
+        """
+        let otherFailure = try! decoder.decode(Routine.self, from: Data(otherFailureJSON.utf8))
+        let distinctFailureGroups = groupedByAttentionCause([failed, otherFailure])
+        check("routines with the SAME lastStatus but DIFFERENT failureCodes never collapse",
+              distinctFailureGroups.count == 2
+                && distinctFailureGroups.allSatisfy { $0.1.count == 1 })
 
         // MARK: bounded lists — NEEDS YOU attention groups and "All routines…"
         // both cap with a named "+N more" remainder rather than an unbounded

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -108,6 +108,15 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     /// debounce absorbs that blip instead of paging the user for a non-event.
     private static let daemonDownTickThreshold = 3
 
+    // Routine list bounds (RUSH-2290). A fleet can accumulate far more routines
+    // than a dropdown can show — cap the NEEDS YOU attention-cause groups and the
+    // "All routines…" submenu so a bad week never turns the menu into a
+    // multi-screen scroll; each cap ends in a "+N more" row rather than silently
+    // truncating with no signal. Not `private` — RoutineSelfTest asserts against
+    // these directly rather than duplicating the numbers.
+    static let maxAttentionGroups = 6
+    static let maxAllRoutinesRows = 40
+
     // These three reads shell the CLI or touch the sessions DB. They are kept
     // off the click path and rendered from warm caches when the menu opens.
     private var cachedRoutines: [Routine] = []
@@ -571,12 +580,34 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             rows.append(("⚠", wait, "Scheduler stopped — routines won’t run", sub))
         }
 
+        // Failing routines are surfaced HERE ONLY — the ROUTINES section below
+        // renders upcoming runs and "All routines…", never a second copy of the
+        // same failure inline, so a bad routine never shows twice in one menu.
+        // Routines sharing an identical cause (same readiness code, or the same
+        // lastStatus with no readiness) collapse into one row instead of one
+        // per routine — never inventing a shared cause across routines that
+        // fail for genuinely different reasons. Capped so a bad week doesn't
+        // turn NEEDS YOU into its own scroll.
         let bad = routines.filter { routineNeedsAttention($0) }
-        if bad.count == 1, let r = bad.first {
-            let why = r.overdue ? "overdue" : (r.lastStatus ?? "failed")
-            rows.append(("✕", fail, "Routine \(r.name) \(why)", allRoutinesSubmenu(bad)))
-        } else if bad.count > 1 {
-            rows.append(("✕", fail, "\(bad.count) routines failing", allRoutinesSubmenu(bad)))
+        if !bad.isEmpty {
+            let groups = groupedByAttentionCause(bad)
+            let capped = Array(groups.prefix(Self.maxAttentionGroups))
+            for (cause, group) in capped {
+                if group.count == 1, let r = group.first {
+                    let why = routineFailureSummary(r, max: 48)
+                    let (glyph, color) = attentionGlyph(r)
+                    rows.append((glyph, color, "Routine \(r.name) \(why)", allRoutinesSubmenu(group)))
+                } else {
+                    let label = readableAttentionCause(cause)
+                    rows.append(("✕", fail, "\(group.count) routines \(label)", allRoutinesSubmenu(group)))
+                }
+            }
+            if groups.count > capped.count {
+                let remaining = groups.count - capped.count
+                rows.append(("✕", fail,
+                             "+\(remaining) more routine issue\(remaining == 1 ? "" : "s") — see All routines…",
+                             nil))
+            }
         }
 
         if rows.isEmpty { return false }
@@ -1151,6 +1182,9 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
 
         addSectionTitle(menu, "ROUTINES · \(summary)", color: .secondaryLabelColor)
+        // A routine needing attention is surfaced ONCE, in NEEDS YOU (above) —
+        // this section shows only what's upcoming, plus "All routines…" for the
+        // rest, so the same failure never renders twice in one menu.
         let failing = routines.filter { routineNeedsAttention($0) }
         let upcoming = routines
             .filter { r in r.enabled && !failing.contains(where: { $0.name == r.name }) && r.nextRun != nil }
@@ -1159,7 +1193,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
 
         let hasGroups = routines.contains { $0.projectGroup != nil }
         if hasGroups {
-            let (grouped, ungrouped) = groupedRoutines(Array(upcoming) + failing)
+            let (grouped, ungrouped) = groupedRoutines(Array(upcoming))
             for (label, group) in grouped {
                 menu.addItem(disabled("  \(label)"))
                 for r in group { menu.addItem(inlineRoutineRow(r)) }
@@ -1171,29 +1205,40 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 row.submenu = routineSubmenu(r)
                 menu.addItem(row)
             }
-            for r in failing {
-                let why = routineFailureSummary(r, max: 48)
-                let row = statusRow(routineIsMiss(r) ? "⃠" : "✕", routineIsMiss(r) ? wait : fail, "\(r.name)  \(why)")
-                row.submenu = routineSubmenu(r)
-                menu.addItem(row)
-            }
         }
         let all = NSMenuItem(title: "  All routines…", action: nil, keyEquivalent: "")
         all.submenu = allRoutinesSubmenu(routines)
         menu.addItem(all)
     }
 
-    // One colored inline row for the ROUTINES section (upcoming or failing).
+    // One colored inline row for the ROUTINES section. Only ever called with an
+    // upcoming (non-attention) routine now — see the comment on addRoutines —
+    // but keeps the attention styling for defensiveness rather than assuming a
+    // caller never changes.
     private func inlineRoutineRow(_ r: Routine) -> NSMenuItem {
         let row: NSMenuItem
         if routineNeedsAttention(r) {
             let why = routineFailureSummary(r, max: 48)
-            row = statusRow(routineIsMiss(r) ? "⃠" : "✕", routineIsMiss(r) ? wait : fail, "\(r.name)  \(why)")
+            let (glyph, color) = attentionGlyph(r)
+            row = statusRow(glyph, color, "\(r.name)  \(why)")
         } else {
             row = statusRow("◔", idleC, "\(r.name)  \(r.nextRunHuman ?? r.schedule)")
         }
         row.submenu = routineSubmenu(r)
         return row
+    }
+
+    // Glyph/color for a routine currently needing attention — distinguishes a
+    // readiness block (can't run at all: paused-not-ready) from an infra miss
+    // (a scheduled fire never happened) from a real execution failure. Pure
+    // classification lives in `routineAttentionKind`; this only maps it to the
+    // menu's status palette.
+    private func attentionGlyph(_ r: Routine) -> (String, NSColor) {
+        switch routineAttentionKind(r) ?? .failure {
+        case .notReady: return ("⏸", wait)
+        case .miss: return ("⃠", wait)
+        case .failure: return ("✕", fail)
+        }
     }
 
     // Setup + watchdog collapsed into one System row — the health noise lives in
@@ -1307,34 +1352,61 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private func routineSubmenu(_ r: Routine) -> NSMenu {
         let sub = NSMenu()
 
-        // Last-run outcome / live status, the failure reason (when there is one),
-        // and the next fire — all from the already-decoded, server-verified routine
-        // fields, so no fresh fetch on open.
+        // Last-run outcome / live status, a dedicated "can't run right now" line
+        // when readiness explicitly blocks it (independent of how the LAST run
+        // went — a routine can have completed fine and still be blocked for the
+        // NEXT fire), the concrete failure/skip reason, and the next fire — all
+        // from the already-decoded, server-verified routine fields, so no fresh
+        // fetch on open.
         var addedInfo = false
+        if r.enabled, r.ready == false {
+            var text = "⏸ \(r.readiness?.message ?? "not ready to run")"
+            if let target = r.project ?? r.resolvedCwd ?? r.requestedCwd, !target.isEmpty { text += " · \(target)" }
+            sub.addItem(disabled(trim(text, 80))); addedInfo = true
+        }
         if let status = routineRunStatusLine(r) {
             sub.addItem(disabled(status)); addedInfo = true
         }
-        if r.lastStatus == "failed" || r.lastStatus == "timeout",
-           let reason = r.failureReason?.trimmingCharacters(in: .whitespacesAndNewlines), !reason.isEmpty {
-            let clean = reason.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
-            sub.addItem(disabled("   \(trim(clean, 72))")); addedInfo = true
+        // The readiness line above already carries the reason when the routine
+        // is blocked for its NEXT run — this is the reason for the LAST run's
+        // outcome, so it's skipped for `.notReady` to avoid restating the same
+        // sentence twice in one submenu.
+        if routineAttentionKind(r) != .notReady, let reason = routineFailureDetail(r, max: 72) {
+            sub.addItem(disabled("   \(reason)")); addedInfo = true
         }
         if r.enabled, r.lastStatus != "running", let next = r.nextRunHuman, next != "-" {
             sub.addItem(disabled("next \(next)")); addedInfo = true
         }
         if addedInfo { sub.addItem(.separator()) }
 
+        // Run/Resume are disabled (never hidden — the operator can still see
+        // and reach the routine) when readiness explicitly says the next fire
+        // can't start; an older CLI with no `ready` field, or one that never
+        // computed it for this routine, behaves exactly as before (enabled).
+        let state = routineActionState(r)
+
         let run = NSMenuItem(title: "Run now", action: #selector(onRoutineRun(_:)), keyEquivalent: "")
         run.target = self
         run.representedObject = r.name
+        run.isEnabled = state.runEnabled
         sub.addItem(run)
 
-        let pauseResume = NSMenuItem(title: r.enabled ? "Pause" : "Resume",
+        let pauseResume = NSMenuItem(title: state.pauseResumeTitle,
                                      action: r.enabled ? #selector(onRoutinePause(_:)) : #selector(onRoutineResume(_:)),
                                      keyEquivalent: "")
         pauseResume.target = self
         pauseResume.representedObject = r.name
+        pauseResume.isEnabled = state.pauseResumeEnabled
         sub.addItem(pauseResume)
+
+        // History… beside Logs: Logs tails the raw process output of the last
+        // fire, History lists past run ids/outcomes/timestamps (`agents routines
+        // runs <name>`) — same read-only-CLI-data pattern as Logs, just a
+        // different CLI verb.
+        let history = NSMenuItem(title: "History…", action: #selector(onRoutineHistory(_:)), keyEquivalent: "")
+        history.target = self
+        history.representedObject = r.name
+        sub.addItem(history)
 
         let logs = NSMenuItem(title: "Logs", action: #selector(onRoutineLogs(_:)), keyEquivalent: "")
         logs.target = self
@@ -1374,6 +1446,11 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             return line + overdueTag
         case "missed":
             return "⦸ missed · \(shortWhen(r.lastRunCompletedAt))" + overdueTag
+        case "blocked":
+            return "⏸ blocked · \(shortWhen(r.lastRunCompletedAt))" + overdueTag
+        case "skipped":
+            let reason = r.skipReason.map { " (\($0.replacingOccurrences(of: "_", with: " ")))" } ?? ""
+            return "⦸ skipped\(reason) · \(shortWhen(r.lastRunCompletedAt))" + overdueTag
         default:
             return "\(status) · \(shortWhen(r.lastRunCompletedAt))" + overdueTag
         }
@@ -1391,11 +1468,15 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         return "\(mins / 60)h \(mins % 60)m"
     }
 
+    // Bounded to `maxAllRoutinesRows` — a trailing "+N more" row names what was
+    // dropped rather than truncating silently (see the class-level comment on
+    // the cap constants).
     private func allRoutinesSubmenu(_ routines: [Routine]) -> NSMenu {
         let sub = NSMenu()
-        let hasGroups = routines.contains { $0.projectGroup != nil }
+        let capped = Array(routines.prefix(Self.maxAllRoutinesRows))
+        let hasGroups = capped.contains { $0.projectGroup != nil }
         if hasGroups {
-            let (grouped, ungrouped) = groupedRoutines(routines)
+            let (grouped, ungrouped) = groupedRoutines(capped)
             for i in grouped.indices {
                 if i > 0 { sub.addItem(.separator()) }
                 let (label, group) = grouped[i]
@@ -1407,7 +1488,11 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 for r in ungrouped { sub.addItem(routineListRow(r)) }
             }
         } else {
-            for r in routines { sub.addItem(routineListRow(r)) }
+            for r in capped { sub.addItem(routineListRow(r)) }
+        }
+        if routines.count > capped.count {
+            sub.addItem(.separator())
+            sub.addItem(disabled("+\(routines.count - capped.count) more — see `agents routines list`"))
         }
         return sub
     }
@@ -1512,6 +1597,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     @objc private func onRoutinePause(_ s: NSMenuItem) { withName(s, AgentsCLI.routinePause) }
     @objc private func onRoutineResume(_ s: NSMenuItem) { withName(s, AgentsCLI.routineResume) }
     @objc private func onRoutineLogs(_ s: NSMenuItem) { withName(s, AgentsCLI.routineLogs) }
+    @objc private func onRoutineHistory(_ s: NSMenuItem) { withName(s, AgentsCLI.routineHistory) }
     @objc private func onOpenPath(_ s: NSMenuItem) {
         if let p = s.representedObject as? String { AgentsCLI.openPath(p) }
     }
@@ -1636,35 +1722,152 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     }
 }
 
-/// A routine the operator should look at: it failed, timed out, never ran when
-/// it was due (`missed`), or is overdue. One predicate rather than the same
-/// disjunction repeated at each call site, so a new status cannot be added to
-/// four of five checks.
-func routineNeedsAttention(_ r: Routine) -> Bool {
-    r.lastStatus == "failed" || r.lastStatus == "timeout" || r.lastStatus == "missed" || r.overdue
+/// Why a routine needs the operator's attention, in three DISTINCT flavors
+/// (RUSH-2290) — the plan's "distinguish paused-not-ready from execution
+/// failure": readiness explicitly refusing the next run is not the same
+/// situation as a run that started and then failed, and neither is the same
+/// as a scheduled fire that simply never happened.
+enum RoutineAttentionKind: Equatable {
+    /// Can't run at all right now — readiness blocked the last attempt
+    /// (`lastStatus == "blocked"`) or explicitly blocks the next one
+    /// (`enabled && ready == false`). Distinct from a manually paused routine
+    /// (`enabled == false`), which needs no attention on its own.
+    case notReady
+    /// Infrastructure, not a task failure: the scheduled fire never started
+    /// (`missed`), the daemon deliberately skipped an overlapping fire
+    /// (`skipped`), or the next fire is overdue with no worse outcome.
+    case miss
+    /// The run itself started and did not complete cleanly.
+    case failure
 }
+
+/// Single source of truth for "does this routine need a look", classified
+/// into the three kinds above. One function rather than the same disjunction
+/// repeated at each call site, so a new status can't be added to some checks
+/// and missed in others.
+func routineAttentionKind(_ r: Routine) -> RoutineAttentionKind? {
+    if r.lastStatus == "blocked" || (r.enabled && r.ready == false) { return .notReady }
+    if r.lastStatus == "failed" || r.lastStatus == "timeout" { return .failure }
+    if r.lastStatus == "missed" || r.lastStatus == "skipped" || r.overdue { return .miss }
+    return nil
+}
+
+/// A routine the operator should look at, in ANY of the three attention kinds.
+func routineNeedsAttention(_ r: Routine) -> Bool { routineAttentionKind(r) != nil }
 
 /// `missed` means the run never started — infrastructure, not a task failure —
-/// so it reads as a warning rather than a red error.
-func routineIsMiss(_ r: Routine) -> Bool {
-    r.lastStatus == "missed" || (r.overdue && r.lastStatus != "failed" && r.lastStatus != "timeout")
+/// so it reads as a warning rather than a red error. `skipped` (the daemon
+/// deliberately stood a fire down for a duplicate/overlapping run) is the
+/// same flavor of "nothing went wrong with the task itself".
+func routineIsMiss(_ r: Routine) -> Bool { routineAttentionKind(r) == .miss }
+
+/// True when the routine is enabled but explicitly blocked from its next run
+/// by a readiness check — the `.notReady` attention kind. Absent `ready`
+/// (an older CLI, or a routine readiness never covers) is NOT not-ready.
+func routineIsNotReady(_ r: Routine) -> Bool { routineAttentionKind(r) == .notReady }
+
+/// The concrete, specific reason behind an attention kind — a readiness
+/// message, a free-text failure reason (optionally tagged with its short
+/// `failureCode`), why a fire was skipped, or a bare exit code. Returns nil
+/// when there is nothing more specific to say than the bare status itself
+/// (e.g. a `missed` run with no other detail) — never invents text.
+func routineConcreteReason(_ r: Routine, max: Int) -> String? {
+    if (r.lastStatus == "blocked" || (r.enabled && r.ready == false)),
+       let readiness = r.readiness, !readiness.message.isEmpty {
+        var text = readiness.message
+        if let target = r.project ?? r.resolvedCwd ?? r.requestedCwd, !target.isEmpty {
+            text += " · \(target)"
+        }
+        return trimText(text, max)
+    }
+    if r.lastStatus == "skipped" {
+        let reason = r.skipReason.map { $0.replacingOccurrences(of: "_", with: " ") } ?? "overlapping run"
+        return trimText("skipped · \(reason)", max)
+    }
+    if r.lastStatus == "failed" || r.lastStatus == "timeout" {
+        if let reason = r.failureReason?.trimmingCharacters(in: .whitespacesAndNewlines), !reason.isEmpty {
+            var text = reason.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            if let code = r.failureCode, !code.isEmpty, !text.contains(code) { text = "\(code): \(text)" }
+            if let target = r.project ?? r.resolvedCwd, !target.isEmpty { text += " · \(target)" }
+            return trimText(text, max)
+        }
+        if let code = r.exitCode { return "exit \(code)" }
+    }
+    return nil
 }
 
+/// Always returns SOME text for a routine needing attention — falls back to
+/// naming the attention kind itself when there's no more concrete reason.
 func routineFailureSummary(_ r: Routine, max: Int) -> String {
-    if let detail = routineFailureDetail(r, max: max) { return detail }
-    return r.overdue ? "overdue" : (r.lastStatus ?? "failed")
+    if let reason = routineConcreteReason(r, max: max) { return reason }
+    switch routineAttentionKind(r) {
+    case .notReady: return "not ready"
+    case .miss: return r.lastStatus == "skipped" ? "skipped" : (r.overdue ? "overdue" : (r.lastStatus ?? "missed"))
+    case .failure: return r.lastStatus ?? "failed"
+    case .none: return r.overdue ? "overdue" : (r.lastStatus ?? "failed")
+    }
 }
 
+/// Same as `routineFailureSummary`, but nil when the routine needs no
+/// attention at all — the form call sites use to fall back to a neutral
+/// "next run" / "paused" line instead of restating a non-issue.
 func routineFailureDetail(_ r: Routine, max: Int) -> String? {
-    let lastRunFailed = r.lastStatus == "failed" || r.lastStatus == "timeout" || r.lastStatus == "missed"
-    guard lastRunFailed || r.overdue else { return nil }
-    if let reason = r.failureReason?.trimmingCharacters(in: .whitespacesAndNewlines), !reason.isEmpty {
-        return trimText(reason.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression), max)
+    guard routineNeedsAttention(r) else { return nil }
+    return routineFailureSummary(r, max: max)
+}
+
+/// Groups routines needing attention by a shared cause signature — the
+/// readiness code when one is blocking, else the raw last-run status — so N
+/// routines hitting the IDENTICAL cause collapse into one row instead of N
+/// nearly-identical ones. Never invents a shared cause: two routines that
+/// fail for different reasons (or carry no readiness code at all) each keep
+/// their own group. Preserves the order causes first appear in `routines`.
+func groupedByAttentionCause(_ routines: [Routine]) -> [(String, [Routine])] {
+    var order: [String] = []
+    var byCause: [String: [Routine]] = [:]
+    for r in routines {
+        let cause = r.readiness?.code ?? r.lastStatus ?? "failed"
+        if byCause[cause] == nil { order.append(cause) }
+        byCause[cause, default: []].append(r)
     }
-    if lastRunFailed, let code = r.exitCode {
-        return "exit \(code)"
+    return order.map { ($0, byCause[$0]!) }
+}
+
+/// Human phrasing for a grouped cause signature — a readiness code
+/// ("project_path_missing" -> "project path missing") or a raw lastStatus.
+/// Falls back to the literal string with underscores turned to spaces rather
+/// than inventing new copy for a code this doesn't recognize.
+func readableAttentionCause(_ cause: String) -> String {
+    switch cause {
+    case "failed": return "failing"
+    case "timeout": return "timing out"
+    case "missed": return "missing runs"
+    case "skipped": return "being skipped"
+    case "blocked": return "blocked"
+    default: return cause.replacingOccurrences(of: "_", with: " ")
     }
-    return r.overdue ? "overdue" : (r.lastStatus ?? "failed")
+}
+
+/// What the routine submenu's Run-now / Pause-Resume actions should allow.
+/// Pure and AppKit-free so it's directly testable: Run is disabled only when
+/// readiness EXPLICITLY refuses the next run (`ready == false`); an absent
+/// `ready` (older CLI, or a routine readiness never covers) behaves exactly
+/// as before — enabled. Resume inherits the same gate (re-enabling a routine
+/// that can't run would just fail again); Pause is always allowed.
+struct RoutineActionState: Equatable {
+    let runEnabled: Bool
+    let pauseResumeTitle: String
+    let pauseResumeEnabled: Bool
+}
+
+func routineActionState(_ r: Routine) -> RoutineActionState {
+    let ready = r.ready != false
+    let isResume = !r.enabled
+    return RoutineActionState(
+        runEnabled: ready,
+        pauseResumeTitle: isResume ? "Resume" : "Pause",
+        pauseResumeEnabled: isResume ? ready : true
+    )
 }
 
 private func trimText(_ value: String, _ max: Int) -> String {

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -1819,21 +1819,40 @@ func routineFailureDetail(_ r: Routine, max: Int) -> String? {
     return routineFailureSummary(r, max: max)
 }
 
-/// Groups routines needing attention by a shared cause signature — the
-/// readiness code when one is blocking, else the raw last-run status — so N
+/// Groups routines needing attention by a shared cause signature — so N
 /// routines hitting the IDENTICAL cause collapse into one row instead of N
 /// nearly-identical ones. Never invents a shared cause: two routines that
-/// fail for different reasons (or carry no readiness code at all) each keep
-/// their own group. Preserves the order causes first appear in `routines`.
+/// fail for different reasons each keep their own group. Preserves the order
+/// causes first appear in `routines`.
+///
+/// The signal picked for "cause" follows `routineAttentionKind`, not a flat
+/// readiness-first/failureCode-next/lastStatus-last chain — a routine can
+/// carry a `readiness` block that describes its NEXT run (RUSH-2290's
+/// `ready`/`readiness` pair is independent of `lastStatus`) while its
+/// attention kind is actually `.failure` from a run that already happened
+/// (`lastStatus == "failed"`); grouping such a routine by its stale/unrelated
+/// readiness code would silently merge it with routines that are genuinely
+/// blocked for a different reason. Keying by kind first keeps each cause
+/// scoped to the signal that's actually driving THAT routine's attention:
+///   - `.notReady`: the readiness code (the "can't run" reason), or a literal
+///     fallback when a routine is `ready == false`/`blocked` with no
+///     `readiness` object attached at all.
+///   - `.failure`: the failureCode (the specific execution error), falling
+///     back to the bare lastStatus only when no failureCode is present.
+///   - `.miss`: why the daemon skipped this fire, or the bare lastStatus.
 func groupedByAttentionCause(_ routines: [Routine]) -> [(String, [Routine])] {
     var order: [String] = []
     var byCause: [String: [Routine]] = [:]
     for r in routines {
-        // readiness code first (the most specific signal); failureCode next —
-        // two "failed" routines with different failureCodes must NOT collapse
-        // into one row just because they share a lastStatus; lastStatus is the
-        // last resort, for when neither of the more specific signals exists.
-        let cause = r.readiness?.code ?? r.failureCode ?? r.lastStatus ?? "failed"
+        let cause: String
+        switch routineAttentionKind(r) {
+        case .notReady:
+            cause = r.readiness?.code ?? "not_ready"
+        case .failure:
+            cause = r.failureCode ?? r.lastStatus ?? "failed"
+        case .miss, .none:
+            cause = r.skipReason ?? r.lastStatus ?? "overdue"
+        }
         if byCause[cause] == nil { order.append(cause) }
         byCause[cause, default: []].append(r)
     }

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -1746,7 +1746,10 @@ enum RoutineAttentionKind: Equatable {
 /// repeated at each call site, so a new status can't be added to some checks
 /// and missed in others.
 func routineAttentionKind(_ r: Routine) -> RoutineAttentionKind? {
-    if r.lastStatus == "blocked" || (r.enabled && r.ready == false) { return .notReady }
+    // Both notReady triggers require `enabled` — a manually paused routine
+    // (enabled == false) needs no attention just because its last attempt was
+    // blocked or its next one would be; the operator already parked it.
+    if r.enabled && (r.lastStatus == "blocked" || r.ready == false) { return .notReady }
     if r.lastStatus == "failed" || r.lastStatus == "timeout" { return .failure }
     if r.lastStatus == "missed" || r.lastStatus == "skipped" || r.overdue { return .miss }
     return nil
@@ -1826,7 +1829,11 @@ func groupedByAttentionCause(_ routines: [Routine]) -> [(String, [Routine])] {
     var order: [String] = []
     var byCause: [String: [Routine]] = [:]
     for r in routines {
-        let cause = r.readiness?.code ?? r.lastStatus ?? "failed"
+        // readiness code first (the most specific signal); failureCode next —
+        // two "failed" routines with different failureCodes must NOT collapse
+        // into one row just because they share a lastStatus; lastStatus is the
+        // last resort, for when neither of the more specific signals exists.
+        let cause = r.readiness?.code ?? r.failureCode ?? r.lastStatus ?? "failed"
         if byCause[cause] == nil { order.append(cause) }
         byCause[cause, default: []].append(r)
     }

--- a/apps/cli/menubar/Sources/MenubarHelper/main.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/main.swift
@@ -76,6 +76,15 @@ if ProcessInfo.processInfo.environment["MENUBAR_ACTIVE_TEST"] == "1" {
     ActiveSessionSelfTest.run()
 }
 
+// Routine self-test (RUSH-2290): decode the CLI's readiness/failureCode/
+// project-cwd/blocked/skipped fields off a real `routines list --json` row,
+// exercise the pure attention-kind/reason/grouping/action-state helpers those
+// fields drive, and confirm an older payload predating them still decodes.
+// No GUI, no hotkey. See RoutineSelfTest.swift.
+if ProcessInfo.processInfo.environment["MENUBAR_ROUTINE_TEST"] == "1" {
+    RoutineSelfTest.run()
+}
+
 // Everything past here installs the status item and registers the global
 // chords, so it must only run where those chords can actually be serviced.
 // Refuses an ssh-started launch or an unrecognized flag — the two ways a helper

--- a/apps/cli/menubar/scripts/test-menubar.sh
+++ b/apps/cli/menubar/scripts/test-menubar.sh
@@ -3,7 +3,8 @@
 # Runs every HEADLESS MenubarHelper self-test and fails on any FAIL.
 #
 # The helper's self-tests (SingleInstanceSelfTest, ChildProcessSelfTest,
-# GuardsSelfTest, IssueSelfTest, ActiveSessionSelfTest) are env-gated modes of the binary that exit
+# GuardsSelfTest, IssueSelfTest, ActiveSessionSelfTest, RoutineSelfTest) are
+# env-gated modes of the binary that exit
 # BEFORE the GUI/AppKit path (Guards.enforceForInteractiveLaunch in main.swift),
 # so they run headless — no display, no signing, no bundle. Until this script
 # nothing invoked them: PR CI is Linux (can't build Swift) and prepack only
@@ -35,7 +36,7 @@ if [ ! -x "$BIN" ]; then
 fi
 
 fail=0
-for mode in MENUBAR_GUARD_TEST MENUBAR_ISSUE_TEST MENUBAR_SINGLE_TEST MENUBAR_CHILD_TEST MENUBAR_ACTIVE_TEST; do
+for mode in MENUBAR_GUARD_TEST MENUBAR_ISSUE_TEST MENUBAR_SINGLE_TEST MENUBAR_CHILD_TEST MENUBAR_ACTIVE_TEST MENUBAR_ROUTINE_TEST; do
   echo "=== $mode ==="
   if ! env "$mode=1" "$BIN"; then
     echo "  $mode FAILED" >&2


### PR DESCRIPTION
feature — read-only menu-bar surface for routine readiness/blocked/skipped (menu-bar track of RUSH-2290)

## What
The routine reliability work (RUSH-2290) is landing across parallel tracks; this PR is the **menu-bar reader** track only — `apps/cli/menubar/**`. It teaches the Swift `MenubarHelper` to decode and display the new (optional) fields the runtime-core track is adding to `agents routines list --json`: `ready`, `readiness` (code/message/repair), `failureCode`, `project`/`requestedCwd`/`resolvedCwd`, `skipReason`, `activeRunId`, and the new `blocked`/`skipped` `lastStatus` values. No scheduler/runner/daemon code touched — the menu stays a thin CLI-data reader, per `CLAUDE.md`'s "one scheduler, one executor" rule.

## Behavior changes
- **Paused-not-ready vs execution failure, distinguished.** A routine that's enabled but `ready: false` (readiness blocks the *next* run) now shows a dedicated `⏸` line and glyph, separate from `✕` (the run itself failed/timed out) and `⃠` (an infra miss: missed/skipped/overdue). Same distinction for a `blocked` last run.
- **No more duplicate failure rows.** A failing routine now renders once, under NEEDS YOU — the ROUTINES section no longer repeats the same routine inline.
- **Routines sharing an identical cause collapse into one row** (e.g. "3 routines · agent auth failed") instead of one row per routine, without inventing a shared cause across routines that fail differently.
- **Bounded lists.** NEEDS YOU attention groups and "All routines…" both cap (6 / 40) with a named "+N more" row rather than an unbounded scroll.
- **Run now / Resume disable** when `ready` is explicitly `false`; Pause always stays available. An absent `ready` (older CLI) behaves exactly as before — nothing regresses for a peer running an older `agents` build.
- **New "History…"** beside Logs in each routine's submenu — shells the existing read-only `agents routines runs <name>`.

## Evidence — real build + the full headless self-test suite, on mac-mini (macOS/Swift)
```
$ swift build            # Build complete! (3.44s), 0 errors
$ scripts/test-menubar.sh
=== MENUBAR_GUARD_TEST ===   ALL PASS
=== MENUBAR_ISSUE_TEST ===   ALL PASS   (176 assertions incl. existing routine-menu behavior)
=== MENUBAR_SINGLE_TEST ===  ALL PASS
=== MENUBAR_CHILD_TEST ===   ALL PASS
=== MENUBAR_ACTIVE_TEST ===  ALL PASS
=== MENUBAR_ROUTINE_TEST === ALL PASS  (41 new assertions)
menubar self-tests: all passed
```
`MENUBAR_ROUTINE_TEST` (new, `RoutineSelfTest.swift`) covers: a pre-RUSH-2290 JSON payload still decoding with every new field nil; `blocked`/`skipped` `lastStatus` decoding; `ready:false` + `readiness{code,message,repair}` decoding; the three-way attention classification (`.notReady`/`.miss`/`.failure`) staying mutually exclusive including the "paused + not-ready is NOT flagged" case; grouping/dedup by attention cause; the bounded-list cap constants; `RoutineActionState` (Run/Resume disabled-state, pure and AppKit-free); and the `History…` argv builder.

## Scope / what's NOT in this PR
Per the parallel-track split: readiness computation, the `blocked`/`skipped` statuses themselves, and the JSON field names are the **runtime-core** track (a sibling PR). Docs/spec/CHANGELOG for the whole RUSH-2290 delivery are a separate track. This PR only teaches the menu bar to read and render whatever runtime-core ships — every new field is optional and the menu already degrades gracefully against today's `main` (verified: the legacy-JSON self-test payload is exactly today's `routines list --json` shape).

## Review
Automated PR review (`prix/code-reviewer`) is paused fleet-wide (#1767) — requesting a non-author subagent review per `CLAUDE.md`'s documented fallback.

Ticket: https://linear.app/getrush/issue/RUSH-2290
Plan: https://share.agents-cli.sh/muqsitnawaz/agents-cli-routine-reliability-5975559096b19ff4
