### PR TITLE
perf(hosts): bench the --host passthrough bootstrap every CLI invocation pays (RUSH-2374)

### DIFF
--- a/apps/cli/src/lib/hosts/passthrough.bench.ts
+++ b/apps/cli/src/lib/hosts/passthrough.bench.ts
@@ -29,8 +29,9 @@
  * any box.
  *
  * No existing bench covered this path before this file. `index.bench.ts` covers
- * the OTHER two per-invocation entry costs (`checkForUpdates` index.ts:755 and
- * `spawnDetachedSync` index.ts:1330) and states so in its own header;
+ * the OTHER two per-invocation entry costs (`checkForUpdates` index.ts:774 and
+ * `spawnDetachedSync` index.ts:1366-1367 — `index.bench.ts:2-3` still cites the
+ * pre-drift 755/1330, verified against HEAD here) and states so in its header;
  * `hosts/dispatch.bench.ts` covers host resolution and SSH command-building —
  * i.e. what runs AFTER `maybeRunOnHost` decides to route. Neither imports
  * `passthrough.ts`, so the every-invocation bootstrap measured here was

--- a/apps/cli/src/lib/hosts/passthrough.bench.ts
+++ b/apps/cli/src/lib/hosts/passthrough.bench.ts
@@ -1,0 +1,187 @@
+/**
+ * Benchmark for the `--host` passthrough bootstrap — the hot path every named
+ * CLI invocation pays.
+ *
+ * `src/index.ts:1290-1295` runs, for EVERY invocation that names a command and
+ * is not `--help`/`--version`:
+ *
+ *   const { maybeRunOnHost } = await import('./lib/hosts/passthrough.js');
+ *   if (await maybeRunOnHost(requestedCommand, passedArgs)) { … }
+ *
+ * That happens before command registration (`registerEagerForRequest`,
+ * `src/index.ts:1309`), so it is serial cold-start latency on `agents view`,
+ * `agents sync`, `agents skills list` — every one of which passes no routing
+ * flag and gets `false` back from `maybeRunOnHost:475`.
+ *
+ * Two costs are measured separately because they have different fixes:
+ *
+ *  1. **module graph** — what `await import('./lib/hosts/passthrough.js')`
+ *     costs cold, measured against a same-flag `node` baseline in a fresh
+ *     process (`dist/` is the artifact the shipped CLI actually loads).
+ *  2. **function body** — what `maybeRunOnHost` costs once the graph is warm,
+ *     across realistic argvs on both the no-flag path and the flag-present
+ *     early-return branches.
+ *
+ * Only side-effect-free branches are exercised: the no-flag return at
+ * `passthrough.ts:475`, the `OWN_HOST_COMMANDS` return at `:481` and the
+ * unknown-command return at `:515`. No branch here opens an SSH connection,
+ * loads the device registry, or writes anything — the bench is safe to run on
+ * any box.
+ *
+ * No existing bench covered this path before this file. `index.bench.ts` covers
+ * the OTHER two per-invocation entry costs (`checkForUpdates` index.ts:755 and
+ * `spawnDetachedSync` index.ts:1330) and states so in its own header;
+ * `hosts/dispatch.bench.ts` covers host resolution and SSH command-building —
+ * i.e. what runs AFTER `maybeRunOnHost` decides to route. Neither imports
+ * `passthrough.ts`, so the every-invocation bootstrap measured here was
+ * unbenched. One bench file per source file is this package's existing layout
+ * (`brand.bench.ts`, `events.bench.ts`, `exec.bench.ts`, `hosts/dispatch.bench.ts`,
+ * `session/db.bench.ts`, …), so this sits beside `passthrough.ts`.
+ *
+ * Not run by `vitest run`: `vitest.config.ts:18` includes only `*.test.ts`, so
+ * this file adds no CI assertion and no flakiness. It IS type-checked, by
+ * `typecheck:bench` (package.json:60, globs `src/lib/**\/*.bench.ts`). Run it:
+ *
+ *   npx vitest bench --run src/lib/hosts/passthrough.bench.ts   # from apps/cli
+ */
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { bench, describe } from 'vitest';
+import { maybeRunOnHost, flagValue } from './passthrough.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// src/lib/hosts -> apps/cli
+const cliRoot = path.resolve(here, '../../..');
+const distPassthrough = path.join(cliRoot, 'dist/lib/hosts/passthrough.js');
+
+// Fail loud rather than silently skipping: a cold-import number measured
+// against a missing artifact would be meaningless.
+if (!fs.existsSync(distPassthrough)) {
+  throw new Error(
+    `passthrough.bench.ts needs the built artifact at ${distPassthrough}. ` +
+      `Build it first: bash scripts/build.sh (from apps/cli).`,
+  );
+}
+
+/** Spawn a fresh node and return only after it exits — one full cold start. */
+function coldNode(source: string): void {
+  execFileSync(process.execPath, ['--input-type=module', '-e', source], {
+    stdio: 'ignore',
+    cwd: cliRoot,
+  });
+}
+
+const distUrl = pathToFileURL(distPassthrough).href;
+
+describe('cold module graph (per CLI invocation, out-of-process)', () => {
+  bench(
+    'node baseline (no import)',
+    () => {
+      coldNode('void 0;');
+    },
+    { iterations: 20, time: 0 },
+  );
+
+  bench(
+    'node + import dist/lib/hosts/passthrough.js',
+    () => {
+      coldNode(`await import(${JSON.stringify(distUrl)});`);
+    },
+    { iterations: 20, time: 0 },
+  );
+});
+
+/**
+ * Which of `passthrough.ts`'s static imports carry the graph. Each is imported
+ * alone in a fresh process, so the numbers are per-subgraph (they overlap — the
+ * subgraphs share deps — and do not sum to the whole-file number above).
+ *
+ * Every entry here is reached ONLY after a routing flag is found, i.e. never on
+ * the `return false` at `passthrough.ts:475` that the overwhelming majority of
+ * invocations take:
+ *   - `smart-launch.js`  (passthrough.ts:34) — used at :558 (`--device auto`)
+ *   - `dispatch.js`      (passthrough.ts:24) — used at :607, :716
+ *   - `registry.js`      (passthrough.ts:22) — used at :183, :187
+ *   - `sync/config.js`   (passthrough.ts:33) — `machineId` at :395, and it is a
+ *                         pure re-export of `machine-id.js` (sync/config.ts:145)
+ *   - `health-report.js` (passthrough.ts:45) — `platformGroupLabel` at :335
+ */
+const HEAVY_IMPORTS: Array<[string, string]> = [
+  ['lib/smart-launch.js (passthrough.ts:34)', 'smart-launch.js'],
+  ['lib/hosts/dispatch.js (passthrough.ts:24)', 'hosts/dispatch.js'],
+  ['lib/hosts/registry.js (passthrough.ts:22)', 'hosts/registry.js'],
+  ['lib/session/sync/config.js (passthrough.ts:33)', 'session/sync/config.js'],
+  ['lib/devices/health-report.js (passthrough.ts:45)', 'devices/health-report.js'],
+  ['lib/machine-id.js (the leaf sync/config re-exports)', 'machine-id.js'],
+  ['lib/startup/command-registry.js (passthrough.ts:46)', 'startup/command-registry.js'],
+];
+
+describe('cold import per static dependency (out-of-process)', () => {
+  for (const [label, rel] of HEAVY_IMPORTS) {
+    const target = path.join(cliRoot, 'dist/lib', rel);
+    bench(
+      label,
+      () => {
+        coldNode(`await import(${JSON.stringify(pathToFileURL(target).href)});`);
+      },
+      { iterations: 20, time: 0 },
+    );
+  }
+});
+
+/**
+ * Realistic no-flag invocations — the 100% case for a local `agents <cmd>`.
+ * Each returns `false` at `passthrough.ts:475` after four `flagValue` scans.
+ */
+const NO_FLAG_ARGVS: Array<[string, string[]]> = [
+  ['view', ['view']],
+  ['sync claude --yes', ['sync', 'claude', '--yes']],
+  ['skills list', ['skills', 'list']],
+  ['doctor', ['doctor']],
+  [
+    'run claude (long argv)',
+    ['run', 'claude', '--mode', 'edit', '--name', 'bench', '--profile', 'default', '-p', 'do the thing', '--json'],
+  ],
+];
+
+describe('maybeRunOnHost — no routing flag (warm graph)', () => {
+  for (const [label, argv] of NO_FLAG_ARGVS) {
+    bench(`agents ${label}`, async () => {
+      await maybeRunOnHost(argv[0], argv);
+    });
+  }
+});
+
+describe('maybeRunOnHost — routing flag present, side-effect-free returns', () => {
+  // OWN_HOST_COMMANDS member -> returns false at passthrough.ts:481.
+  bench('agents sessions --host box (own-host early return)', async () => {
+    await maybeRunOnHost('sessions', ['sessions', '--host', 'box']);
+  });
+
+  // Not a known top-level command -> returns false at passthrough.ts:515.
+  bench('agents sessoins --host box (unknown-command return)', async () => {
+    await maybeRunOnHost('sessoins', ['sessoins', '--host', 'box']);
+  });
+});
+
+describe('flagValue — the four argv scans maybeRunOnHost:467-470 always runs', () => {
+  const short = ['view'];
+  const long = NO_FLAG_ARGVS[4][1];
+
+  bench('flagValue x4 over ["view"]', () => {
+    flagValue(short, 'host', 'H');
+    flagValue(short, 'device');
+    flagValue(short, 'hosts');
+    flagValue(short, 'devices');
+  });
+
+  bench('flagValue x4 over an 11-token argv', () => {
+    flagValue(long, 'host', 'H');
+    flagValue(long, 'device');
+    flagValue(long, 'hosts');
+    flagValue(long, 'devices');
+  });
+});


### PR DESCRIPTION
**Adds one committed vitest benchmark — `apps/cli/src/lib/hosts/passthrough.bench.ts`. Bench-only: no runtime code changes, no user-visible surface** (so no docs/CHANGELOG entry, and no screenshot — the run result below *is* the artifact this PR produces).

Ticket: RUSH-2374

## What it measures, and why

`src/index.ts:1290-1295` runs, for **every** invocation that names a command and is not `--help`/`--version`:

```ts
if (requestedCommand !== undefined && !helpOrVersionRequested && !requestedIsDisabled) {
  const { maybeRunOnHost } = await import('./lib/hosts/passthrough.js');
  if (await maybeRunOnHost(requestedCommand, passedArgs)) {
    process.exit(process.exitCode ?? 0);
  }
}
```

That is serial, and it happens **before** command registration (`registerEagerForRequest`, `src/index.ts:1309`) — the very thing `startup/command-registry.ts:5-13` exists to make lazy. An invocation with no routing flag walks four `flagValue` scans (`passthrough.ts:467-470`) and returns `false` at `passthrough.ts:475`, using none of the module's imports.

No bench covered this before: `index.bench.ts` covers the other two per-invocation entry costs (`checkForUpdates` `index.ts:755`, `spawnDetachedSync` `index.ts:1330`) and `hosts/dispatch.bench.ts` covers what runs *after* routing is decided. Neither imports `passthrough.ts`.

## MEASURED

Host `yosemite-s1`, 20 cores, node v24.11.1, vitest 4.1.9. Cold-import groups run out-of-process against `dist/` — the artifact the shipped CLI actually loads (built with `apps/cli/scripts/build.sh`). `cat /proc/loadavg` **before `4.00 8.08 8.52`**, **after `6.91 8.40 8.61`**.

`npx vitest bench --run src/lib/hosts/passthrough.bench.ts`:

```
 ✓ cold module graph (per CLI invocation, out-of-process) 6067ms
     name                                              hz      min      max     mean      p75      p99      rme  samples
   · node baseline (no import)                    56.6881  14.7929  22.8136  17.6404  20.3856  22.8136   ±7.07%       20
   · node + import dist/lib/hosts/passthrough.js   4.8736   189.02   228.54   205.19   210.86   228.54   ±2.67%       20

 ✓ cold import per static dependency (out-of-process) 25729ms
     name                                                      hz      min      max     mean      p75      rme  samples
   · lib/smart-launch.js (passthrough.ts:34)               4.8532   185.18   236.90   206.05   212.94   ±2.97%       20
   · lib/hosts/dispatch.js (passthrough.ts:24)             4.9312   183.02   219.91   202.79   214.51   ±2.90%       20
   · lib/hosts/registry.js (passthrough.ts:22)             4.9073   185.25   228.16   203.78   208.63   ±2.39%       20
   · lib/session/sync/config.js (passthrough.ts:33)        7.0597   127.25   163.08   141.65   147.51   ±3.26%       20
   · lib/devices/health-report.js (passthrough.ts:45)      6.8251   135.61   164.52   146.52   148.13   ±2.81%       20
   · lib/machine-id.js (the leaf sync/config re-exports)  48.8490  14.7380  25.8368   20.4712  23.5586  ±8.69%       20
   · lib/startup/command-registry.js (passthrough.ts:46)  32.3628  23.6638  41.5733   30.8996  38.1350 ±10.86%       20

 ✓ maybeRunOnHost — no routing flag (warm graph) 4870ms
     name                                     hz     min      max    mean     p75      rme  samples
   · agents view                    3,252,612.20  0.0002   7.8326  0.0003  0.0003   ±3.63%  1626307
   · agents sync claude --yes       1,890,482.90  0.0004   0.6533  0.0005  0.0006   ±0.33%   945242
   · agents skills list             2,431,759.22  0.0003   0.3232  0.0004  0.0004   ±0.13%  1215885
   · agents doctor                  3,291,406.04  0.0002   0.3951  0.0003  0.0003   ±0.38%  1645704
   · agents run claude (long argv)    599,363.57  0.0013  37.7816  0.0017  0.0015  ±14.81%   299682

 ✓ maybeRunOnHost — routing flag present, side-effect-free returns 1976ms
   · agents sessions --host box (own-host early return)   2,649,539.43  mean 0.0004  ±0.46%  1324770
   · agents sessoins --host box (unknown-command return)  2,453,883.24  mean 0.0004  ±0.33%  1226942

 ✓ flagValue — the four argv scans maybeRunOnHost:467-470 always runs 2014ms
   · flagValue x4 over ["view"]          5,206,506.21  mean 0.0002  ±0.34%  2603254
   · flagValue x4 over an 11-token argv    699,370.04  mean 0.0014  ±8.85%   349686
```

### The one number that matters

| | mean |
|---|---|
| bare `node` startup | **17.64 ms** |
| `node` + `import('dist/lib/hosts/passthrough.js')` | **205.19 ms** |
| **module graph** | **~187 ms** |
| `maybeRunOnHost` body, no-flag path | **0.0003 ms** |

**The cost is ~100% imports and ~0% function.** Optimizing `maybeRunOnHost` itself is worthless; not loading it is worth ~187 ms of cold start on every named invocation.

(The per-dependency numbers overlap — those subgraphs share deps — so they do not sum to 187 ms. Each is what that one import costs alone.)

## PROPOSALS

Every proposal names a measurement above. Nothing unmeasured is proposed.

1. **`src/index.ts:1291` — gate the dynamic import on a routing flag actually being present.** Scan `passedArgs` for `--host`/`-H`/`--device`/`--hosts`/`--devices` before importing; skip the import entirely when absent. That scan is what `passthrough.ts:467-470` already does and costs **0.0014 ms** on an 11-token argv — free next to the **187 ms** it avoids. This is the primary fix: it removes the whole graph from the majority path (`passthrough.ts:475` returns `false`).

2. **`src/lib/hosts/passthrough.ts:33` — import `machineId` from `../machine-id.js`, not `../session/sync/config.js`.** `session/sync/config.ts:145` is a pure re-export (`export { machineId, normalizeHost } from '../../machine-id.js';`), so the value is identical, but going through it drags in `secrets/bundles.ts` (`sync/config.ts:15`). Measured **141.65 ms** vs **20.47 ms** for the leaf — **6.92x**.

3. **`src/lib/hosts/passthrough.ts:34` — make `smart-launch.js` a dynamic import inside the `isDeviceAuto` branch.** Heaviest single subgraph at **206.05 ms** (it pulls `session/db.js` via `smart-launch.ts:9`). `isDeviceAuto`/`resolveDeviceAffinity` are used only at `passthrough.ts:558`, unreachable without `--device auto`.

4. **`src/lib/hosts/passthrough.ts:24` — make `dispatch.js` dynamic.** **202.79 ms**. `dispatchAgentsCommand` is used only at `passthrough.ts:607` (`teams start --watch`) and `withActorEnv` only at `passthrough.ts:716` (`streamAgentsOnHost`) — both strictly after a routing decision.

5. **`src/lib/hosts/passthrough.ts:22` — make `hosts/registry.js` dynamic inside `resolveTargetHost`.** **203.78 ms**. `resolveHost`/`resolveHostByCap` are used only at `passthrough.ts:183`/`:187`, and `resolveTargetHost` is first called at `passthrough.ts:586` — past every early return.

6. **`src/lib/hosts/passthrough.ts:45` — make `devices/health-report.js` dynamic inside `renderFleetRoster`.** **146.52 ms**. `platformGroupLabel` is used only at `passthrough.ts:335`, on the `all`-sentinel fan-out.

Proposal 1 alone fixes the no-flag path. 2-6 still matter after it: they cut the cost of the routed path and of `maybeRunStandaloneOnHost` (`passthrough.ts:659`), which the standalone `browser` binary enters on every run.

## Why this file is safe to merge

- **Never executed by CI.** `apps/cli/vitest.config.ts:18` sets `include: ['tests/**/*.test.ts', 'src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts', 'scripts/**/*.test.ts']` — no `*.bench.ts` glob. `.github/workflows/bench.yml` runs the `bench/*.ts` harnesses, not vitest bench files. Zero new assertions, zero flakiness.
- **It is type-checked**, by `typecheck:bench` (`apps/cli/package.json:60`, globs `src/lib/**/*.bench.ts`). Verified green: `bun run typecheck:bench` exited 0.
- **No mocking.** Cold-import groups spawn a real `node` against the real built `dist/`; warm groups call the real exported `maybeRunOnHost` with real argvs.
- **No side effects.** Only the three branches that return without touching the network or disk are exercised: `passthrough.ts:475` (no flag), `:481` (`OWN_HOST_COMMANDS`), `:515` (unknown command). Nothing here opens SSH, loads the device registry, or writes a file.
- **It fails loud, not silent**, when `dist/` is missing — it throws naming `scripts/build.sh` rather than skipping and reporting a meaningless number.

Raw run log (fleet-local path, not an embed): `yosemite-s1:/tmp/pt-bench-final.txt`
