### PR TITLE
feat(daemon): last-wins takeover + stop postcondition (RUSH-2352, RUSH-2355)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2352.md
+++ b/apps/cli/.changelog/next/RUSH-2352.md
@@ -1,0 +1,10 @@
+- **Daemon: one instance per machine via last-wins takeover (RUSH-2352).** A second
+  `agents __daemon-run` on a box — from ANY install (homebrew, `.local` dev, nvm, npx)
+  — now evicts the incumbent and takes over, instead of exiting and leaving it running.
+  Four schedulers from four installs were observed firing the same cron queue against
+  one shared `~/.agents` state; `claimDaemonInstance` now SIGTERMs the incumbent, waits
+  for its graceful shutdown to release the secrets broker socket and browser IPC binding
+  (hard timeout → `killTree` → bind), and never binds before that release — closing the
+  two-brokers-on-one-socket orphan. `reapStrayDaemons` is no longer scoped to the same
+  install. In-flight detached routine children are adopted, never killed. Source:
+  `apps/cli/src/lib/daemon.ts`.

--- a/apps/cli/.changelog/next/RUSH-2352.md
+++ b/apps/cli/.changelog/next/RUSH-2352.md
@@ -1,10 +1,12 @@
-- **Daemon: one instance per machine via last-wins takeover (RUSH-2352).** A second
-  `agents __daemon-run` on a box — from ANY install (homebrew, `.local` dev, nvm, npx)
-  — now evicts the incumbent and takes over, instead of exiting and leaving it running.
-  Four schedulers from four installs were observed firing the same cron queue against
-  one shared `~/.agents` state; `claimDaemonInstance` now SIGTERMs the incumbent, waits
-  for its graceful shutdown to release the secrets broker socket and browser IPC binding
+- **Daemon: one instance per state dir via last-wins takeover (RUSH-2352).** A second
+  `agents __daemon-run` for the same state dir — from ANY install path (homebrew,
+  `.local` dev, nvm, npx) sharing one `~/.agents` — now evicts the incumbent and takes
+  over, instead of exiting and leaving it running. This inverts the old first-wins
+  refusal, an owner product decision: a restart always replaces the previous daemon.
+  `claimDaemonInstance` SIGTERMs the live pid-file owner of its own state dir, waits for
+  its graceful shutdown to release the secrets broker socket and browser IPC binding
   (hard timeout → `killTree` → bind), and never binds before that release — closing the
-  two-brokers-on-one-socket orphan. `reapStrayDaemons` is no longer scoped to the same
-  install. In-flight detached routine children are adopted, never killed. Source:
+  two-brokers-on-one-socket orphan. In-flight detached routine children survive and are
+  adopted by the new daemon, never killed. A daemon serving a DIFFERENT state dir (a
+  separate `HOME`, a test fixture) is never a takeover target. Source:
   `apps/cli/src/lib/daemon.ts`.

--- a/apps/cli/.changelog/next/RUSH-2355.md
+++ b/apps/cli/.changelog/next/RUSH-2355.md
@@ -1,9 +1,11 @@
 - **Daemon: `stop` asserts its postcondition instead of assuming it (RUSH-2355).**
   `stopDaemon` used to fire SIGTERM and report success without checking anything, so a
   stop that silently left a resource bound still read as "stopped". It now waits for
-  shutdown, then verifies each resource released — the secrets broker socket, the
-  browser IPC binding, and no surviving `__daemon-run` on the box (any install) — and
-  returns a structured result naming what released, what survived, and any detached
-  routine children (which survive a stop deliberately and are reported, never killed).
-  Escalates via `killTree` on a wedged daemon and never reports success on an unverified
-  stop. Source: `apps/cli/src/lib/daemon.ts`.
+  shutdown, escalates via `killTree` on a wedged daemon, then verifies each resource
+  released — the secrets broker socket, the browser IPC binding, and no surviving
+  `__daemon-run` for this state dir — reclaiming any stale socket the ungraceful exit
+  left behind. `agents daemon stop` prints what released vs what survived, exits non-zero
+  when a resource could not be released, and carries a structured result under `--json`.
+  In-flight detached routine children survive a stop deliberately and are reported, never
+  killed. It never reports success on an unverified stop. Source:
+  `apps/cli/src/lib/daemon.ts`, `apps/cli/src/commands/daemon.ts`.

--- a/apps/cli/.changelog/next/RUSH-2355.md
+++ b/apps/cli/.changelog/next/RUSH-2355.md
@@ -1,0 +1,9 @@
+- **Daemon: `stop` asserts its postcondition instead of assuming it (RUSH-2355).**
+  `stopDaemon` used to fire SIGTERM and report success without checking anything, so a
+  stop that silently left a resource bound still read as "stopped". It now waits for
+  shutdown, then verifies each resource released — the secrets broker socket, the
+  browser IPC binding, and no surviving `__daemon-run` on the box (any install) — and
+  returns a structured result naming what released, what survived, and any detached
+  routine children (which survive a stop deliberately and are reported, never killed).
+  Escalates via `killTree` on a wedged daemon and never reports success on an unverified
+  stop. Source: `apps/cli/src/lib/daemon.ts`.

--- a/apps/cli/docs/command-index.json
+++ b/apps/cli/docs/command-index.json
@@ -2724,7 +2724,12 @@
           "aliases": [],
           "description": "Stop the daemon.",
           "args": [],
-          "options": [],
+          "options": [
+            {
+              "flags": "--json",
+              "description": "Emit the structured stop result (released/surviving resources, detached children)."
+            }
+          ],
           "subcommands": []
         }
       ]

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -2401,15 +2401,68 @@ is not two daemons existing — it is two daemons consuming the **same** input.
   without an owner pin ship with a test that two concurrent fires cannot process
   the same item.
 
+#### 3.2 One daemon per machine — last-wins takeover, not first-wins refusal
+
+The pid-file claim in SING-5 guarantees one scheduler; SING-11/SING-12 fix *which*
+daemon survives and how the loser is torn down, so a second install can never leave
+two daemons — the double-fire root cause (RUSH-2352: four `__daemon-run` processes
+from four installs — homebrew, `.local` dev, nvm, npx — observed live on one box).
+
+- **SING-11 (MUST).** At most one daemon MUST be alive per machine, enforced by
+  **last-wins takeover**: a second `agents __daemon-run` — from ANY install, not
+  only the same launch entry — MUST evict the incumbent, never defer to it.
+  `claimDaemonInstance` (`lib/daemon.ts`) SIGTERMs the live pid-file owner and MUST
+  wait for it to be provably dead — its graceful `handleShutdown` releasing the
+  browser IPC binding (`await browserIPC.stop()`) and the secrets broker socket
+  (`hostedBroker?.close()`), or a `killTree` escalation after the grace window —
+  **before binding any of its own resources**. Binding before the incumbent's
+  release recreates the two-brokers-on-one-socket orphan (`daemon.ts` broker
+  hosting), so the pid file MUST NOT be written until the prior owner is dead.
+  `reapStrayDaemons` (`lib/daemon.ts`) MUST NOT scope its reap to `process.argv[1]`
+  — any `__daemon-run` on the box is a reap target regardless of install. This
+  INVERTS the historical first-wins behavior, where the incoming daemon logged
+  `Another daemon already owns the pid file` and exited, leaving the incumbent
+  (however stale, however many installs deep) running.
+- **SING-11a (MUST).** In-flight detached routine children (`runner.ts`'s `unref`'d
+  spawns, which run in their own process group and survive daemon death) MUST NOT
+  be killed by takeover — severing a live agent mid-run is worse than a daemon
+  restart. The evicting SIGTERM/`killTree` reaches only the incumbent daemon's pid,
+  never those children, and the new daemon adopts them by construction: its
+  `monitorRunningJobs` (`runner.ts`) reconciles every `running` on-disk run record
+  by pid liveness (`isPidOurs`), never by which daemon spawned it, so a live child
+  is picked back up on the next tick.
+- **SING-12 (MUST).** `stopDaemon` (`lib/daemon.ts`) MUST assert its postcondition,
+  not assume it: after the SIGTERM → grace → `killTree` sequence it MUST verify the
+  browser IPC binding was released, the secrets broker socket was released (a stale
+  socket present on disk but unreachable is the orphan of SING-11), and no
+  `__daemon-run` (any install) survives — and it MUST return a structured result
+  naming what released, what survived, and any detached children (which survive
+  deliberately per SING-11a and are reported, never killed). It MUST NOT report
+  success on an unverified stop (RUSH-2355).
+
 ### 4. Given/When/Then scenarios
 
 - **GIVEN** a session hits its weekly account limit, **WHEN** the daemon watchdog
   tick detects it, **THEN** the daemon alone decides and executes the rotate (or the
   skip) — no UI surface fires a second rotate for the same session.
-- **GIVEN** two daemon processes are alive on one machine, **WHEN** a routine's cron
-  occurrence arrives, **THEN** the pid-file claim ensures exactly one scheduler
-  executes it; the second daemon never runs its own `JobScheduler`
-  (`lib/daemon.ts`).
+- **GIVEN** a daemon already owns the pid file, **WHEN** a second `agents __daemon-run`
+  starts — from the same install or a different one — **THEN** last-wins takeover
+  makes the newcomer the survivor: `claimDaemonInstance` SIGTERMs the incumbent,
+  waits for it to be provably dead (releasing its broker + browser IPC), then binds,
+  so exactly one daemon is ever alive and no two `JobScheduler`s run concurrently
+  (`lib/daemon.ts`, SING-11). The first-wins path where the newcomer exited and left
+  the incumbent running is gone.
+- **GIVEN** the incumbent daemon has an in-flight detached routine child running,
+  **WHEN** takeover evicts that daemon, **THEN** the child survives (a different
+  process in its own group) and the new daemon adopts it via `monitorRunningJobs`
+  pid-liveness reconciliation — takeover never kills a live agent mid-run
+  (SING-11a).
+- **GIVEN** a wedged daemon that ignores SIGTERM, **WHEN** `agents daemon stop` runs,
+  **THEN** stop escalates to `killTree` after the grace window, then VERIFIES the
+  broker socket and browser IPC binding released and no `__daemon-run` survives, and
+  returns a structured result (exit non-zero if any resource could not be released),
+  reporting surviving detached children rather than pretending the tree is clean
+  (SING-12).
 - **GIVEN** a user disables a fleet-affecting capability from the Factory palette,
   **WHEN** the command completes, **THEN** the CLI's config is the state that
   changed (`agents watchdog rotate off`), and the daemon, the menubar, and every

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -2401,28 +2401,40 @@ is not two daemons existing — it is two daemons consuming the **same** input.
   without an owner pin ship with a test that two concurrent fires cannot process
   the same item.
 
-#### 3.2 One daemon per machine — last-wins takeover, not first-wins refusal
+#### 3.2 One daemon per state dir — last-wins takeover, not first-wins refusal
 
-The pid-file claim in SING-5 guarantees one scheduler; SING-11/SING-12 fix *which*
-daemon survives and how the loser is torn down, so a second install can never leave
-two daemons — the double-fire root cause (RUSH-2352: four `__daemon-run` processes
-from four installs — homebrew, `.local` dev, nvm, npx — observed live on one box).
+Singularity is scoped to the **state dir** (the daemon dir under `AGENTS_DAEMON_DIR`
+?? `<HOME>/.agents/.cache/helpers/daemon`), NOT the machine: one `HOME` may legitimately
+run many daemons under different state dirs (a developer's daemon, a vitest fixture's
+own `HOME`), and none of them contend. Within ONE state dir, the pid-file claim in
+SING-5 guarantees one scheduler; SING-11/SING-12 fix *which* daemon survives and how the
+loser is torn down, so a second install sharing that state dir can never leave two
+daemons. (RUSH-2352 originally read four `__daemon-run` on one box as four duplicate
+schedulers; adversarial verification refuted that — three ran under separate `HOME`s
+and never shared state. Last-wins is the owner's product decision that a restart replaces
+the previous daemon, deliberately NOT a machine-wide process sweep.)
 
-- **SING-11 (MUST).** At most one daemon MUST be alive per machine, enforced by
-  **last-wins takeover**: a second `agents __daemon-run` — from ANY install, not
-  only the same launch entry — MUST evict the incumbent, never defer to it.
+- **SING-11 (MUST).** At most one daemon MUST be alive per state dir, enforced by
+  **last-wins takeover**: a second `agents __daemon-run` for the same state dir — from
+  ANY install path sharing it, not only the same launch entry — MUST evict the incumbent,
+  never defer to it. The takeover target is the live owner of THIS state dir's pid file
+  (`resolveLiveDaemonPid`) and nothing else — a daemon serving a DIFFERENT state dir
+  (its own `HOME`, a test fixture) MUST be left completely untouched.
   `claimDaemonInstance` (`lib/daemon.ts`) SIGTERMs the live pid-file owner and MUST
   wait for it to be provably dead — its graceful `handleShutdown` releasing the
   browser IPC binding (`await browserIPC.stop()`) and the secrets broker socket
-  (`hostedBroker?.close()`), or a `killTree` escalation after the grace window —
+  (`hostedBroker?.close()`), or a `killTree` escalation (POSITIVE pid, so the kill never
+  reaches the incumbent's detached job children) after the grace window —
   **before binding any of its own resources**. Binding before the incumbent's
   release recreates the two-brokers-on-one-socket orphan (`daemon.ts` broker
   hosting), so the pid file MUST NOT be written until the prior owner is dead.
-  `reapStrayDaemons` (`lib/daemon.ts`) MUST NOT scope its reap to `process.argv[1]`
-  — any `__daemon-run` on the box is a reap target regardless of install. This
-  INVERTS the historical first-wins behavior, where the incoming daemon logged
-  `Another daemon already owns the pid file` and exited, leaving the incumbent
-  (however stale, however many installs deep) running.
+  `reapStrayDaemons` (`lib/daemon.ts`) reaps only registrants of THIS state dir's
+  instance registry (`<daemonDir>/instances/`) — because the registry lives inside the
+  daemon dir, a different state dir's daemons register elsewhere and are invisible, so
+  the reaper is state-dir-scoped by construction, never `process.argv[1]`-scoped and
+  never a machine-wide `ps` sweep. This INVERTS the historical first-wins behavior, where
+  the incoming daemon logged `Another daemon already owns the pid file` and exited,
+  leaving the incumbent (however stale) running.
 - **SING-11a (MUST).** In-flight detached routine children (`runner.ts`'s `unref`'d
   spawns, which run in their own process group and survive daemon death) MUST NOT
   be killed by takeover — severing a live agent mid-run is worse than a daemon
@@ -2434,11 +2446,14 @@ from four installs — homebrew, `.local` dev, nvm, npx — observed live on one
 - **SING-12 (MUST).** `stopDaemon` (`lib/daemon.ts`) MUST assert its postcondition,
   not assume it: after the SIGTERM → grace → `killTree` sequence it MUST verify the
   browser IPC binding was released, the secrets broker socket was released (a stale
-  socket present on disk but unreachable is the orphan of SING-11), and no
-  `__daemon-run` (any install) survives — and it MUST return a structured result
-  naming what released, what survived, and any detached children (which survive
-  deliberately per SING-11a and are reported, never killed). It MUST NOT report
-  success on an unverified stop (RUSH-2355).
+  socket present on disk but unreachable is the orphan of SING-11 — a still-live
+  standalone broker owning it is a release, not a survivor), and no `__daemon-run`
+  registered for THIS state dir survives — reclaiming any stale socket an ungraceful
+  exit left behind — and it MUST return a structured result naming what released, what
+  survived, and any detached children (which survive deliberately per SING-11a and are
+  reported, never killed). `agents daemon stop` MUST surface that result (human summary
+  plus `--json`) and exit non-zero when a resource could not be released. It MUST NOT
+  report success on an unverified stop (RUSH-2355).
 
 ### 4. Given/When/Then scenarios
 

--- a/apps/cli/src/commands/daemon.ts
+++ b/apps/cli/src/commands/daemon.ts
@@ -539,21 +539,42 @@ export function registerDaemonCommand(program: Command): void {
 
   cmd.command('stop')
     .description('Stop the daemon.')
-    .action(() => {
+    .option('--json', 'Emit the structured stop result (released/surviving resources, detached children).')
+    .action((_opts, command) => {
+      const asJson = command.optsWithGlobals().json === true;
       if (!isDaemonRunning()) {
-        console.log(chalk.yellow('Daemon is not running'));
+        if (asJson) {
+          console.log(JSON.stringify(
+            { ok: true, stoppedPid: null, escalated: false, released: [], surviving: [], detachedChildren: [] },
+            null, 2));
+        } else {
+          console.log(chalk.yellow('Daemon is not running'));
+        }
         return;
       }
-      stopDaemon();
-      console.log(chalk.green('Daemon stopped'));
+      // SING-12 / RUSH-2355: stop asserts its postcondition and returns what
+      // released vs survived — surface it and exit non-zero on an unclean stop.
+      const result = stopDaemon();
+      if (asJson) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(result.ok ? chalk.green('Daemon stopped') : chalk.red('Daemon stop incomplete'));
+        for (const r of result.released) console.log(chalk.gray(`  released: ${r}`));
+        for (const s of result.surviving) console.log(chalk.red(`  surviving: ${s}`));
+        if (result.detachedChildren.length > 0) {
+          console.log(chalk.gray(`  detached routine children left running (adopted on next daemon start): ${result.detachedChildren.join(', ')}`));
+        }
+      }
+      if (!result.ok) process.exitCode = 1;
     });
 
   cmd.command('restart')
     .description('Stop then start the daemon.')
     .action(() => {
       if (isDaemonRunning()) {
-        stopDaemon();
-        console.log(chalk.gray('Daemon stopped'));
+        const stop = stopDaemon();
+        console.log(stop.ok ? chalk.gray('Daemon stopped') : chalk.red('Daemon stop incomplete'));
+        for (const s of stop.surviving) console.log(chalk.red(`  surviving: ${s}`));
       }
       const result = startDaemon();
       if (result.pid) console.log(chalk.green(`Daemon started (PID: ${result.pid}, ${result.method})`));

--- a/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
+++ b/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
@@ -161,22 +161,30 @@ describe('isDaemonRunning — pid-file/heartbeat desync', () => {
     expect(readDaemonPid()).toBeNull(); // stale pid file cleared, none re-adopted
   });
 
-  it('blocks a second claim when a live daemon lost its pid file (heartbeat still proves it)', () => {
+  it('evicts a live daemon that lost its pid file (heartbeat still proves it) — last-wins (RUSH-2352)', async () => {
     // A real, foreign, live process stands in for the running daemon.
     const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60_000)'], { stdio: 'ignore' });
+    const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
     try {
       expect(child.pid).toBeTruthy();
       // The live daemon's pid file is gone; only its fresh heartbeat remains.
       removeDaemonPid();
       writeHeartbeat(child.pid!);
 
-      // Must refuse — a second claim would run a concurrent JobScheduler and
-      // double-fire every routine.
-      expect(claimDaemonInstance()).toBe(false);
-      // Healed to the live daemon's pid, not this process.
-      expect(readDaemonPid()).toBe(child.pid!);
+      // resolveLiveDaemonPid() must still find it via the heartbeat (so a lost
+      // pid file can't be used to dodge eviction), and claimDaemonInstance()
+      // always wins now: it SIGTERMs the incumbent and claims the pid file for
+      // itself, rather than deferring to it.
+      expect(claimDaemonInstance()).toBe(true);
+      expect(readDaemonPid()).toBe(process.pid);
+      // The evicted incumbent is actually gone, not just out-claimed on paper —
+      // Node's own 'exit' event is the unambiguous signal it is dead.
+      await Promise.race([
+        exited,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('incumbent never exited')), 5000)),
+      ]);
     } finally {
-      child.kill('SIGKILL');
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
     }
   });
 

--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -15,7 +15,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as net from 'net';
 import * as path from 'path';
-import { execFileSync, spawn } from 'child_process';
+import { execFileSync, spawn, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import {
   generateLaunchdPlist,
@@ -547,14 +547,14 @@ describe('daemon single-instance (#414)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('refuses a second concurrent daemon: it exits without clobbering the live pid file', async () => {
+  it('last-wins takeover (RUSH-2352): a second daemon evicts the incumbent and becomes the sole owner', async () => {
     // CI builds before tests; self-heal for a bare `vitest` run.
     if (!fs.existsSync(DIST_ENTRY)) {
       execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
     }
 
     // Short POSIX base keeps the daemon's AF_UNIX browser socket under the
-    // 104-byte sun_path cap (see the integration test above for the rationale).
+    // 104-byte sun_path cap.
     const tmpRoot = process.platform === 'win32' ? os.tmpdir() : '/tmp';
     const tmpHome = fs.mkdtempSync(path.join(tmpRoot, 'agd-si-'));
     // Satisfy the setup gate (`ensureInitialized`): ~/.agents/.system must be a repo.
@@ -585,17 +585,18 @@ describe('daemon single-instance (#414)', () => {
       expect(pidA).toBeTruthy();
       expect(await waitFor(() => readPid() === pidA, 20_000)).toBe(true);
 
-      // Daemon B — a second concurrent `__daemon-run` — must detect A and exit.
+      // Daemon B — a second `__daemon-run` — must EVICT A (last-wins), not defer.
+      // claimDaemonInstance SIGTERMs A, waits for its graceful shutdown to
+      // release its broker socket + browser IPC, then binds and writes its own
+      // pid. Exactly one daemon is ever alive.
       pidB = startDetached({ agentsBin: DIST_ENTRY, logPath: path.join(tmpHome, 'b.log'), env: childEnv }).pid!;
       expect(pidB).toBeTruthy();
       expect(pidB).not.toBe(pidA);
 
-      // B exits on its own (claimDaemonInstance() returned false → process.exit(0)).
-      expect(await waitFor(() => !alive(pidB!), 20_000)).toBe(true);
-
-      // A never lost ownership of the pid file and is still running.
-      expect(readPid()).toBe(pidA);
-      expect(alive(pidA)).toBe(true);
+      // A is evicted and gone; B owns the pid file and keeps running.
+      expect(await waitFor(() => !alive(pidA!), 20_000)).toBe(true);
+      expect(await waitFor(() => readPid() === pidB, 20_000)).toBe(true);
+      expect(alive(pidB)).toBe(true);
     } finally {
       for (const p of [pidA, pidB]) { try { if (p) process.kill(p, 'SIGKILL'); } catch { /* already gone */ } }
       // SIGKILL is async: the kernel delivers it but the daemon can still be
@@ -612,6 +613,239 @@ describe('daemon single-instance (#414)', () => {
       }
     }
   }, 60_000);
+
+  // THE CRITICAL REGRESSION TEST (RUSH-2352 correction). The refuted premise of
+  // this ticket's original version was that several `__daemon-run` processes on
+  // one box proved cross-install duplicate schedulers — when in fact three of the
+  // four ran under separate HOMEs (leaked vitest fixtures) and never shared state.
+  // A last-wins takeover that widened its blast radius to "every daemon on the
+  // box" would make that misreading real: it would start SIGTERMing genuinely
+  // separate daemons. This proves the opposite — a daemon serving its OWN state
+  // dir is never a takeover or reap target, no matter what else runs on the box.
+  it.skipIf(process.platform === 'win32')(
+    'DIFFERENT STATE DIR (the regression this correction exists to prevent): a daemon serving its own HOME survives another pair\'s last-wins takeover completely untouched',
+    async () => {
+      if (!fs.existsSync(DIST_ENTRY)) {
+        execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
+      }
+
+      const tmpRoot = '/tmp';
+      const tmpHomeAB = fs.mkdtempSync(path.join(tmpRoot, 'agd-ds-ab-'));
+      const tmpHomeC = fs.mkdtempSync(path.join(tmpRoot, 'agd-ds-c-'));
+      for (const home of [tmpHomeAB, tmpHomeC]) {
+        const systemDir = path.join(home, '.agents', '.system');
+        fs.mkdirSync(systemDir, { recursive: true });
+        execFileSync('git', ['init', '-q', systemDir]);
+      }
+
+      const pidFileFor = (home: string) => path.join(home, '.agents', '.cache', 'helpers', 'daemon', 'daemon.pid');
+      const envFor = (home: string) => {
+        const env = { ...process.env, HOME: home };
+        delete env.CLAUDE_CODE_OAUTH_TOKEN;
+        return env;
+      };
+      const alive = (pid: number) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+      const readPid = (home: string) => {
+        const p = pidFileFor(home);
+        return fs.existsSync(p) ? parseInt(fs.readFileSync(p, 'utf-8').trim(), 10) : null;
+      };
+      const waitFor = async (cond: () => boolean, timeoutMs: number) => {
+        const start = Date.now();
+        while (Date.now() - start < timeoutMs) {
+          if (cond()) return true;
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        return cond();
+      };
+
+      let pidA: number | null = null;
+      let pidB: number | null = null;
+      let pidC: number | null = null;
+      try {
+        // Daemon C — a completely separate state dir, standing in for a
+        // developer's own live daemon or another test's leaked fixture (the real
+        // shape behind the refuted premise). Started first and ticking through
+        // the whole A/B takeover below.
+        pidC = startDetached({ agentsBin: DIST_ENTRY, logPath: path.join(tmpHomeC, 'c.log'), env: envFor(tmpHomeC) }).pid!;
+        expect(pidC).toBeTruthy();
+        expect(await waitFor(() => readPid(tmpHomeC) === pidC, 20_000)).toBe(true);
+
+        // Daemon A, then B — last-wins takeover within their OWN (different from
+        // C's) state dir, exactly like the LAST-WINS test above.
+        pidA = startDetached({ agentsBin: DIST_ENTRY, logPath: path.join(tmpHomeAB, 'a.log'), env: envFor(tmpHomeAB) }).pid!;
+        expect(pidA).toBeTruthy();
+        expect(await waitFor(() => readPid(tmpHomeAB) === pidA, 20_000)).toBe(true);
+
+        pidB = startDetached({ agentsBin: DIST_ENTRY, logPath: path.join(tmpHomeAB, 'b.log'), env: envFor(tmpHomeAB) }).pid!;
+        expect(pidB).toBeTruthy();
+        expect(await waitFor(() => !alive(pidA!), 20_000)).toBe(true);
+        expect(await waitFor(() => readPid(tmpHomeAB) === pidB, 20_000)).toBe(true);
+
+        // C — a different state dir entirely — was never a candidate for either
+        // claimDaemonInstance's eviction or B's post-claim reapStrayDaemons()
+        // sweep: its pid file and its process are both intact throughout.
+        expect(readPid(tmpHomeC)).toBe(pidC);
+        expect(alive(pidC)).toBe(true);
+      } finally {
+        for (const p of [pidA, pidB, pidC]) { try { if (p) process.kill(p, 'SIGKILL'); } catch { /* already gone */ } }
+        for (const p of [pidA, pidB, pidC]) { if (p) await waitFor(() => !alive(p), 5_000); }
+        for (const home of [tmpHomeAB, tmpHomeC]) {
+          for (let attempt = 0; ; attempt++) {
+            try { fs.rmSync(home, { recursive: true, force: true }); break; }
+            catch (err) {
+              if (attempt >= 10) throw err;
+              await new Promise((r) => setTimeout(r, 100));
+            }
+          }
+        }
+      }
+    },
+    90_000,
+  );
+});
+
+/**
+ * stopDaemon postcondition assertion (RUSH-2355 / SING-12). Real path, no
+ * mocking: a genuine `__daemon-run` (or a real SIGTERM-ignoring process) is
+ * stopped through the actual `agents daemon stop` command in a subprocess under
+ * its OWN HOME, so every path constant (pid file, instance registry, browser
+ * socket, broker socket, runs dir) resolves inside the temp state dir and the
+ * test can never touch a live daemon on the dev machine.
+ */
+describe('agents daemon stop — asserts its postcondition (RUSH-2355)', () => {
+  const alive = (pid: number) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+  const waitFor = async (cond: () => boolean, timeoutMs: number) => {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (cond()) return true;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    return cond();
+  };
+  const mkHome = () => {
+    const home = fs.mkdtempSync(path.join(process.platform === 'win32' ? os.tmpdir() : '/tmp', 'agd-stop-'));
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q', systemDir]);
+    return home;
+  };
+  const daemonPidFile = (home: string) => path.join(home, '.agents', '.cache', 'helpers', 'daemon', 'daemon.pid');
+  const readDaemonPidOf = (home: string) => {
+    const p = daemonPidFile(home);
+    return fs.existsSync(p) ? parseInt(fs.readFileSync(p, 'utf-8').trim(), 10) : null;
+  };
+  const envFor = (home: string) => {
+    const env = { ...process.env, HOME: home };
+    delete env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete env.AGENTS_DAEMON_DIR; // let it derive from HOME
+    return env;
+  };
+  const runStop = (home: string) => {
+    const r = spawnSync(process.execPath, [DIST_ENTRY, 'daemon', 'stop', '--json'], {
+      env: envFor(home), encoding: 'utf-8',
+    });
+    // The --json action prints only the result object to stdout; be tolerant of
+    // any leading banner by slicing to the JSON braces.
+    const out = r.stdout || '';
+    const first = out.indexOf('{');
+    const last = out.lastIndexOf('}');
+    const parsed = first >= 0 && last > first ? JSON.parse(out.slice(first, last + 1)) : null;
+    return { status: r.status, result: parsed, stdout: out, stderr: r.stderr || '' };
+  };
+  const rmHome = async (home: string) => {
+    for (let attempt = 0; ; attempt++) {
+      try { fs.rmSync(home, { recursive: true, force: true }); break; }
+      catch (err) { if (attempt >= 10) throw err; await new Promise((r) => setTimeout(r, 100)); }
+    }
+  };
+
+  it.skipIf(process.platform === 'win32')(
+    'clean stop: releases the daemon, exits 0, and REPORTS an in-flight detached child rather than killing it',
+    async () => {
+      if (!fs.existsSync(DIST_ENTRY)) execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
+      const home = mkHome();
+      let daemonPid: number | null = null;
+      // A real detached routine child in its OWN process group — survives the
+      // daemon's death and must be reported, never killed (SING-11a).
+      const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], { detached: true, stdio: 'ignore' });
+      child.unref();
+      try {
+        expect(child.pid).toBeTruthy();
+        daemonPid = startDetached({ agentsBin: DIST_ENTRY, logPath: path.join(home, 'd.log'), env: envFor(home) }).pid!;
+        expect(await waitFor(() => readDaemonPidOf(home) === daemonPid, 20_000)).toBe(true);
+
+        // Seed a `running` run record pointing at the live detached child, under
+        // this HOME's runs dir, so the stop's postcondition enumerates it.
+        const runDir = path.join(home, '.agents', '.history', 'runs', 'testjob', 'run-1');
+        fs.mkdirSync(runDir, { recursive: true });
+        fs.writeFileSync(path.join(runDir, 'meta.json'), JSON.stringify({
+          status: 'running', pid: child.pid, agent: 'claude',
+          startedAt: new Date().toISOString(), spawnedAt: Date.now(),
+        }));
+
+        const { status, result } = runStop(home);
+        expect(result).toBeTruthy();
+        expect(result.ok).toBe(true);            // every resource released
+        expect(status).toBe(0);                  // clean stop exits 0
+        expect(result.stoppedPid).toBe(daemonPid);
+        expect(result.surviving).toEqual([]);
+        expect(result.released).toContain('daemon process');
+        expect(result.detachedChildren).toContain(child.pid);
+
+        // The daemon is gone; the detached child was reported, NOT killed.
+        expect(await waitFor(() => !alive(daemonPid!), 10_000)).toBe(true);
+        expect(alive(child.pid!)).toBe(true);
+      } finally {
+        try { if (child.pid) process.kill(child.pid, 'SIGKILL'); } catch { /* gone */ }
+        try { if (daemonPid) process.kill(daemonPid, 'SIGKILL'); } catch { /* gone */ }
+        for (const p of [child.pid, daemonPid]) { if (p) await waitFor(() => !alive(p), 5_000); }
+        await rmHome(home);
+      }
+    },
+    60_000,
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'wedged daemon: escalates past the grace window to killTree, then still verifies nothing survives',
+    async () => {
+      const home = mkHome();
+      // A real process that IGNORES SIGTERM and reads as a `__daemon-run` (its
+      // argv carries the token, so isDaemonRunProcess matches it) — the wedge the
+      // grace→killTree escalation exists for.
+      const wedge = spawn(
+        process.execPath,
+        ['-e', "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);", '__daemon-run'],
+        { detached: true, stdio: 'ignore' },
+      );
+      wedge.unref();
+      try {
+        expect(wedge.pid).toBeTruthy();
+        // Register the wedge as this state dir's daemon (pid file + instance
+        // marker), the way a real daemon would, so stop targets it.
+        const daemonDir = path.join(home, '.agents', '.cache', 'helpers', 'daemon');
+        fs.mkdirSync(path.join(daemonDir, 'instances'), { recursive: true });
+        fs.writeFileSync(daemonPidFile(home), String(wedge.pid));
+        fs.writeFileSync(path.join(daemonDir, 'instances', String(wedge.pid)), 'node -e ... __daemon-run');
+
+        const started = Date.now();
+        const { status, result } = runStop(home);
+        const elapsed = Date.now() - started;
+
+        expect(result).toBeTruthy();
+        expect(result.escalated).toBe(true);           // SIGTERM ignored → killTree
+        expect(elapsed).toBeGreaterThan(4000);         // it waited out the grace window
+        expect(result.ok).toBe(true);                  // killTree got it; nothing survives
+        expect(result.surviving).toEqual([]);
+        expect(status).toBe(0);
+        expect(await waitFor(() => !alive(wedge.pid!), 5_000)).toBe(true);
+      } finally {
+        try { if (wedge.pid) process.kill(wedge.pid, 'SIGKILL'); } catch { /* gone */ }
+        if (wedge.pid) await waitFor(() => !alive(wedge.pid!), 5_000);
+        await rmHome(home);
+      }
+    },
+    60_000,
+  );
 });
 
 /**

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -17,13 +17,14 @@ import { listJobs as listAllJobs, type JobConfig } from './routines.js';
 import { syncAllProjectRoutines } from './routines-project.js';
 import { JobScheduler } from './scheduler.js';
 import { MonitorEngine } from './monitors/engine.js';
-import { executeJobDetached, monitorRunningJobs } from './runner.js';
+import { executeJobDetached, monitorRunningJobs, listLiveRoutineChildren } from './runner.js';
 import { detectOverdueJobs, notifyOverdue } from './overdue.js';
 import { runCatchup } from './catchup.js';
 import { notifyRoutineStart, notifyRoutineFinish, notifyRoutineStartFailed } from './routine-notify.js';
 import { notifyOwnerRoutineFinish, notifyOwnerRoutineStartFailed } from './routine-notify-owner.js';
 import { BrowserService } from './browser/service.js';
-import { BrowserIPCServer } from './browser/ipc.js';
+import { BrowserIPCServer, getSocketPath as getBrowserIpcSocketPath } from './browser/ipc.js';
+import { secretsBrokerSocketPath, brokerPidAlive } from './secrets/agent.js';
 import { redactSecrets } from './redact.js';
 import { getAgentsBinPath, getCliLaunch, BUN_VIRTUAL_ROOT } from './cli-entry.js';
 import { isSchedulerEnabled, assertSchedulerEnabled, isDaemonEnabled } from './device-config.js';
@@ -269,35 +270,78 @@ export function isDaemonRunning(): boolean {
  * writeDaemonPid() unconditionally, clobber a live daemon's recorded PID, and
  * run a second JobScheduler concurrently, so every cron routine fires twice.
  *
- * Returns true and records our PID when no other live daemon owns the pid file;
- * returns false when a live daemon already holds it (the caller must exit
- * without touching any further state). The read-decide-write is serialized
- * behind the same O_EXCL start lock startDaemon() uses, so two _run processes
- * can't both claim in the window between the liveness check and the write.
+ * LAST-WINS takeover (SING-11, RUSH-2352): when a live daemon already owns the
+ * pid file, this does NOT defer to it — it evicts the incumbent and becomes the
+ * survivor, so a second install can never leave two daemons running. Returns true
+ * and records our PID once the incumbent is provably dead (its resources
+ * released). Returns false ONLY when another `__daemon-run` currently holds the
+ * O_EXCL start lock — i.e. a concurrent claimer is mid-takeover and will be the
+ * singleton — in which case the caller must exit without touching further state.
+ * The read-evict-write is serialized behind the same start lock startDaemon()
+ * uses, so two `_run` processes can't both claim in the window between the
+ * liveness check and the write.
  */
 export function claimDaemonInstance(): boolean {
   const release = acquireStartLock();
   // acquireStartLock() returns null only when another __daemon-run currently
   // holds the O_EXCL lock — a dead holder's lock is reclaimed and retried inside
   // acquireStartLock, so null means a *live* claimer is mid-claim. Bail rather
-  // than run the read-decide-write unlocked: otherwise two first-start processes
+  // than run the read-evict-write unlocked: otherwise two first-start processes
   // could each see no pid file (before either writes one) and both claim,
-  // running the concurrent JobScheduler this guard exists to prevent.
+  // running the concurrent JobScheduler this guard exists to prevent. The live
+  // claimer we bailed for becomes the singleton, so last-wins still holds.
   if (!release) return false;
   try {
     // resolveLiveDaemonPid() also consults a fresh heartbeat, so a live daemon
-    // whose pid file was lost still blocks a second claim — otherwise a missing
-    // pid file would let this instance start a concurrent JobScheduler and
-    // double-fire every routine.
+    // whose pid file was lost is still found and evicted — otherwise a missing
+    // pid file would let both this instance AND the orphaned incumbent run a
+    // JobScheduler at once and double-fire every routine.
     const existing = resolveLiveDaemonPid();
     if (existing !== null && existing !== process.pid) {
-      return false; // another live daemon already owns the instance
+      // Evict, and WAIT for the incumbent to be provably dead — its graceful
+      // handleShutdown releasing the browser IPC binding and the secrets broker
+      // socket — before we write our pid and (later, in runDaemon) bind our own.
+      // Binding before the release recreates the two-brokers-on-one-socket orphan
+      // documented at stopDaemon below, so the pid file is not written until the
+      // prior owner is gone.
+      evictIncumbentDaemon(existing);
     }
     writeDaemonPid(process.pid);
     return true;
   } finally {
     release();
   }
+}
+
+/**
+ * SIGTERM a live incumbent daemon and block until it is provably dead, so its
+ * graceful handleShutdown has released the browser IPC binding and the secrets
+ * broker socket BEFORE the newcomer binds anything of its own (SING-11). Escalates
+ * to killTree after the grace window. Passes the POSITIVE pid so the kill reaches
+ * only the incumbent daemon — never its detached routine children, which run in
+ * their own process groups and must survive takeover (SING-11a); the new daemon
+ * re-adopts them via monitorRunningJobs. Synchronous to match claimDaemonInstance's
+ * read-evict-write, which runs under the O_EXCL start lock; mirrors stopDaemon's
+ * grace-then-escalate shape and constants exactly, because the same
+ * proof-of-release requirement applies.
+ */
+function evictIncumbentDaemon(pid: number): void {
+  if (process.platform === 'win32') {
+    // No graceful termination signal on Windows — take the incumbent down and
+    // still wait for the kill to land before the caller binds anything (mirrors
+    // stopDaemon's win32 branch).
+    killTree(pid);
+    waitForExit(pid, STOP_KILL_GRACE_MS);
+    return;
+  }
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    return; // already gone between resolveLiveDaemonPid() and here
+  }
+  if (waitForExit(pid, STOP_GRACE_MS)) return; // graceful release complete
+  killTree(pid); // positive pid: SIGKILL reaches the daemon, not its job children
+  waitForExit(pid, STOP_KILL_GRACE_MS);
 }
 
 /** Directory that registers every live daemon of THIS device (one per daemon dir). */
@@ -490,12 +534,13 @@ export function warnEphemeralDaemonRoot(resolveBin: () => string = getAgentsBinP
 }
 
 export async function runDaemon(): Promise<void> {
-  // Single-instance guard: a direct `agents __daemon-run` (manual, or a
-  // service-manager restart racing a live predecessor) must not clobber a
-  // running daemon's pid file and start a second scheduler.
+  // Single-instance guard (last-wins, SING-11): a direct `agents __daemon-run`
+  // (manual, or a service-manager restart racing a live predecessor) EVICTS the
+  // incumbent and becomes the survivor. claimDaemonInstance returns false only
+  // when a concurrent `__daemon-run` currently holds the start lock — that peer
+  // is mid-takeover and will be the singleton, so this instance stands down.
   if (!claimDaemonInstance()) {
-    const owner = readDaemonPid();
-    log('WARN', `Another daemon already owns the pid file (PID: ${owner}); this instance (PID ${process.pid}) is exiting`);
+    log('WARN', `Another daemon is mid-takeover (holds the start lock); this instance (PID ${process.pid}) is exiting`);
     // Exit cleanly (0) so a service manager treats it as an orderly no-op
     // rather than a failure to restart-flap on.
     process.exit(0);
@@ -1331,9 +1376,68 @@ function waitForPid(timeoutMs: number): number | null {
   return readDaemonPid();
 }
 
-/** Stop the daemon, unloading it from launchd/systemd if applicable. */
-export function stopDaemon(): boolean {
+/**
+ * Structured outcome of {@link stopDaemon} (SING-12, RUSH-2355). `stopDaemon`
+ * asserts its postcondition instead of assuming it: `ok` is true only when every
+ * resource the daemon held is provably released. `surviving` names anything that
+ * did not release (a still-live daemon, or a stale socket that could not be
+ * cleared) and is what drives a non-zero exit; `detachedChildren` are the
+ * in-flight routine children that survive deliberately (SING-11a) and are
+ * reported, never killed.
+ */
+export interface DaemonStopResult {
+  ok: boolean;
+  stoppedPid: number | null;
+  escalated: boolean;
+  released: string[];
+  surviving: string[];
+  detachedChildren: number[];
+}
+
+/**
+ * Live `__daemon-run` processes still registered in THIS state dir's instance
+ * registry, excluding `exclude`. State-dir-scoped by construction: the registry
+ * lives inside this daemon dir, so a daemon serving a DIFFERENT state dir (a test
+ * fixture with its own HOME, a separate install/home) registers elsewhere and is
+ * invisible here — it is never a stop/takeover target. POSIX-only (the registry
+ * and its `ps` liveness probe are); `[]` on Windows.
+ */
+function findSurvivingStateDirDaemons(exclude: Set<number>): number[] {
+  if (process.platform === 'win32') return [];
+  const dir = getDaemonInstancesDir();
+  let entries: string[];
+  try { entries = fs.readdirSync(dir); } catch { return []; }
+  const found: number[] = [];
+  for (const name of entries) {
+    const pid = parseInt(name, 10);
+    if (isNaN(pid) || String(pid) !== name) continue; // not a pid marker
+    if (exclude.has(pid)) continue;
+    if (!isAlive(pid)) continue;            // dead marker — reaper self-heals it
+    if (!isDaemonRunProcess(pid)) continue; // pid reused by an unrelated process
+    found.push(pid);
+  }
+  return found;
+}
+
+/**
+ * Stop the daemon and ASSERT its postcondition (SING-12, RUSH-2355), unloading it
+ * from launchd/systemd if applicable.
+ *
+ * The SIGTERM → grace → killTree sequence is unchanged; what it adds is
+ * verification. After the daemon is gone it checks that the secrets broker socket
+ * and browser IPC binding actually released — a stale socket present on disk but
+ * with no live owner is the orphan that keeps clients holding unlocked bundles
+ * hanging (`daemon.ts` broker-hosting; the two-brokers-on-one-socket bug) — and
+ * that no `__daemon-run` for THIS state dir survives. A killTree escalation exits
+ * without running the daemon's graceful handleShutdown, so those sockets can be
+ * left stale; this reclaims each (the owner is provably dead) and reports it. It
+ * never reports success on an unverified stop.
+ */
+export function stopDaemon(): DaemonStopResult {
   const platform = os.platform();
+  const released: string[] = [];
+  const surviving: string[] = [];
+  let escalated = false;
 
   if (platform === 'darwin') {
     const plistPath = getLaunchdPlistPath();
@@ -1371,6 +1475,7 @@ export function stopDaemon(): boolean {
       // its job/browser child tree in one shot (taskkill /T), so stop doesn't
       // report success while children keep running.
       killTree(pid);
+      escalated = true;
     } else {
       try {
         process.kill(pid, 'SIGTERM');
@@ -1387,13 +1492,67 @@ export function stopDaemon(): boolean {
       // after an install into a second prefix.
       if (!waitForExit(pid, STOP_GRACE_MS)) {
         killTree(pid);
+        escalated = true;
         waitForExit(pid, STOP_KILL_GRACE_MS);
       }
     }
   }
 
   removeDaemonPid();
-  return true;
+
+  // ── Assert the postcondition (SING-12) ────────────────────────────────────
+  // No `__daemon-run` for this state dir may survive the stop.
+  const survivors = findSurvivingStateDirDaemons(new Set([process.pid]));
+  if (pid && process.platform === 'win32' && isAlive(pid) && !survivors.includes(pid)) {
+    survivors.push(pid); // registry is POSIX-only; check the killed pid directly
+  }
+  if (survivors.length > 0) {
+    for (const s of survivors) surviving.push(`__daemon-run pid ${s} still alive`);
+  } else if (pid) {
+    released.push('daemon process');
+  }
+
+  // Browser IPC binding: on POSIX the listening socket is a filesystem object.
+  // A graceful handleShutdown unlinks it; if it survives, the daemon exited
+  // ungracefully (killTree) and left a stale binding — the owner is provably
+  // dead, so reclaim it and report.
+  if (process.platform !== 'win32') {
+    const browserSock = getBrowserIpcSocketPath();
+    if (fs.existsSync(browserSock)) {
+      try { fs.unlinkSync(browserSock); } catch { /* raced with a fresh start */ }
+      if (fs.existsSync(browserSock)) surviving.push('browser IPC socket not released');
+      else released.push('browser IPC socket (reclaimed)');
+    } else {
+      released.push('browser IPC socket');
+    }
+
+    // Secrets broker socket: released when it is gone, or still owned by a
+    // DIFFERENT live broker (a standalone service the daemon never hosted). A
+    // socket present with NO live owner is the orphan — reclaim it.
+    const brokerSock = secretsBrokerSocketPath();
+    if (!fs.existsSync(brokerSock)) {
+      released.push('secrets broker socket');
+    } else if (brokerPidAlive()) {
+      released.push('secrets broker socket (standalone owner)');
+    } else {
+      try { fs.unlinkSync(brokerSock); } catch { /* raced with a fresh bind */ }
+      if (fs.existsSync(brokerSock)) surviving.push('secrets broker socket not released');
+      else released.push('secrets broker socket (reclaimed)');
+    }
+  }
+
+  // In-flight detached routine children survive on purpose (SING-11a) — report,
+  // never kill: severing a live agent mid-run is worse than a daemon restart.
+  const detachedChildren = listLiveRoutineChildren();
+
+  return {
+    ok: surviving.length === 0,
+    stoppedPid: pid,
+    escalated,
+    released,
+    surviving,
+    detachedChildren,
+  };
 }
 
 /** Get current daemon status including running state, PID, and enabled job count. */

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -1948,6 +1948,47 @@ function finalizeHostRun(meta: RunMeta): void {
   } catch { /* unreachable host or unreadable sidecar — retry next sweep */ }
 }
 
+/**
+ * PIDs of the in-flight detached routine children on THIS device — every local
+ * run record still marked `running` whose spawned process is genuinely alive
+ * (`isPidOurs`, so a dead-and-reused pid does not count). These are the `unref`'d
+ * spawns that survive a daemon exit in their own process group (SING-11a): a
+ * takeover must not kill them and `stopDaemon` reports them rather than pretending
+ * the process tree is clean (SING-12). Scoped to `getRunsDir()`, which is under
+ * this state dir's HOME, so a different state dir's children are invisible here.
+ * `host:`-placed runs have no local pid and are excluded.
+ */
+export function listLiveRoutineChildren(): number[] {
+  const runsDir = getRunsDir();
+  if (!fs.existsSync(runsDir)) return [];
+  const pids: number[] = [];
+  let jobDirs: fs.Dirent[];
+  try {
+    jobDirs = fs.readdirSync(runsDir, { withFileTypes: true }).filter((e) => e.isDirectory());
+  } catch {
+    return pids;
+  }
+  for (const jobDir of jobDirs) {
+    const jobRunsPath = path.join(runsDir, jobDir.name);
+    let runDirs: fs.Dirent[];
+    try {
+      runDirs = fs.readdirSync(jobRunsPath, { withFileTypes: true }).filter((e) => e.isDirectory());
+    } catch {
+      continue;
+    }
+    for (const runDirEntry of runDirs) {
+      const metaPath = path.join(jobRunsPath, runDirEntry.name, 'meta.json');
+      if (!fs.existsSync(metaPath)) continue;
+      try {
+        const meta: RunMeta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+        if (meta.status !== 'running' || meta.hostTaskId || !meta.pid) continue;
+        if (isPidOurs(meta.pid, meta.spawnedAt)) pids.push(meta.pid);
+      } catch { /* unreadable/partial record — skip */ }
+    }
+  }
+  return pids;
+}
+
 /** Scan all runs marked "running" and finalize any whose process has exited. */
 export function monitorRunningJobs(): void {
   const runsDir = getRunsDir();


### PR DESCRIPTION
**feature (daemon lifecycle)** — last-wins single-instance takeover (RUSH-2352) + `agents daemon stop` postcondition assertion (RUSH-2355).

## What changed & for whom

For anyone whose box ends up with a second `agents __daemon-run` (a side-by-side install, a service-manager restart racing a live predecessor):

- **Before (first-wins):** the newcomer logged `Another daemon already owns the pid file` and exited, leaving the incumbent — however stale — running. `agents daemon stop` fired SIGTERM and printed `Daemon stopped` without checking anything, so a stop that silently left a socket bound still read as success.
- **After (last-wins):** the newcomer **evicts the incumbent** that owns *its own state dir's* pid file and becomes the sole daemon. `agents daemon stop` **asserts its postcondition** — it verifies the broker socket + browser IPC released and no `__daemon-run` for this state dir survives — prints what released vs survived, and exits non-zero on an unclean stop.

## Relationship to merged PR #2315 (what was superseded vs what is new)

This branch was rebased onto `main` after #2315 (`41daaac6e`, "enforce one daemon per device across launch entries") merged. #2315 replaced the `argv[1]` `ps`-match reaper with an on-disk **instance registry** under `<daemonDir>/instances/`, which already achieves the state-dir safety property. During the rebase every one of my earlier commits **collapsed to empty and was dropped** because #2315 superseded them:

| My superseded commit | Superseded by #2315 because |
|---|---|
| `scope the stray-daemon reaper to the STATE DIR, not argv[1]` | the registry is state-dir-scoped by construction (lives inside the daemon dir) |
| `restore argv[1] safety scope` (revert) | moot — the registry replaced argv[1] scoping entirely |
| the process-scan `findDaemonProcesses` reaper | replaced by the registry enumeration |

**Genuinely new here (not in #2315):**

1. **Last-wins takeover (RUSH-2352)** — an owner product decision, not a bug fix. #2315 kept first-wins. `claimDaemonInstance` now evicts the incumbent (`evictIncumbentDaemon`: SIGTERM → wait for graceful release of the broker socket + browser IPC → `killTree` on timeout) **before binding**, so it never recreates the two-brokers-on-one-socket orphan. The `killTree` passes the **positive** pid, so the incumbent's detached routine children (own process groups) survive and are re-adopted by `monitorRunningJobs`.
2. **Stop postcondition (RUSH-2355)** — `stopDaemon` returns a structured `DaemonStopResult` and verifies each resource released, reclaiming a stale socket an ungraceful exit left; the command surfaces it and exits non-zero.

The refuted premise is corrected in the changelog and spec: the "four duplicate daemons double-firing shared Linear work" story was false (three ran under separate HOMEs — leaked fixtures — and never shared state). Singularity is **per state dir**, not per machine.

## The critical invariant (regression test)

A daemon under a **different** state dir (its own `HOME`, a test fixture) is **never** a takeover / reap / stop target. This is pinned by a real-path test: while daemon A/B do a last-wins takeover in their shared state dir, daemon C under a separate `HOME` keeps its pid file and process untouched throughout.

## Run evidence

`agents daemon stop --json` against a live daemon (real subprocess, temp HOME):

```json
{
  "ok": true,
  "stoppedPid": 4024495,
  "escalated": false,
  "released": ["daemon process", "browser IPC socket", "secrets broker socket"],
  "surviving": [],
  "detachedChildren": []
}
```
exit code 0.

Daemon tests (real path, no mocking) on the rebased base — `apps/cli`:

```
 Test Files  2 passed (2)
      Tests  79 passed (79)
```

covering: last-wins eviction (`claimDaemonInstance`), last-wins takeover integration (B evicts A, becomes sole owner), the **DIFFERENT STATE DIR** survival regression test, and `agents daemon stop --json` clean-stop (reports + exits 0 + reports-not-kills a detached child) and wedged-daemon escalation.

## Tests / CI note

The full suite runs on Linux in the `test` GitHub check (the required gate — the same suite `bun run test:remote` offloads to a crabbox). `test:remote` could not provision a crabbox from this box (the `hetzner.com` secrets bundle does not decrypt here); CI is the authoritative full-suite run.

## Docs

- `apps/cli/docs/specifications.md` §Scheduling & execution singularity: SING-11/11a/12 state last-wins, per-state-dir scope, the different-state-dir carve-out, positive-pid child preservation, and the stop postcondition + non-zero exit.
- Changelog fragments: `apps/cli/.changelog/next/RUSH-2352.md`, `RUSH-2355.md`.

Tickets: RUSH-2352, RUSH-2355. Not touched (owned elsewhere): `runDaemon` job timers (PR #2314), `apps/cli/src/commands/daemon.ts` command tree (PR #2309) — the only edit there is the additive stop-result surfacing.
