### PR TITLE
fix(teams): teammate-state reliability — cleanup, dead-teammate detection, detached-dispatch messaging (RUSH-2356, RUSH-2366)

### DIFF
--- a/apps/cli/.changelog/next/teams-reliability.md
+++ b/apps/cli/.changelog/next/teams-reliability.md
@@ -1,0 +1,29 @@
+- **`agents teams` no longer strands teammates on the silent-success path
+  (RUSH-2356, RUSH-2366).** Three teammate-state defects that let a track report
+  success while doing nothing:
+  - **Retention reaped live `pending` teammates.** `listCompleted()` classified
+    every non-`running` status as completed — including `pending` — so
+    `cleanupOldAgents()` swept staged `--after` teammates past the 50-record cap.
+    `teams add --after` printed a full success block and the teammate never
+    launched. Retention now only ever deletes terminal (completed/failed/stopped)
+    records, and `teams add` fails loud (non-zero exit) if the record is not
+    durably on disk after the write.
+  - **A rejected `teams add` left an orphan `agents/<name>` branch.** The worktree
+    was created before dependency validation, so a duplicate name / missing
+    `--after` dep left a branch that then broke the retry with `fatal: a branch
+    ... already exists`. Adds now validate before creating the worktree, and tear
+    it down if a later step fails.
+  - **A dead teammate reported `RUNNING` forever and `resume` refused to relaunch
+    it.** A `--device` teammate killed without writing its exit sentinel stayed
+    `running` indefinitely, and a stale supervisor could re-persist `running` over
+    an explicit `teams stop`. A gone-without-a-sentinel remote process is now
+    reconciled to `failed` within a bounded time, a stale in-memory `running`
+    never clobbers a newer on-disk terminal status, and stop-then-resume always
+    relaunches.
+  - **`agents message` could not reach a detached `--device --no-follow`
+    dispatch.** It returned "No running agent or cloud task matches" for a run
+    that was live with a pid. `agents message <name>`/`<session-id>` now resolves
+    the host dispatch records `agents hosts ps` reads and either forwards the
+    message to the host's mailbox over ssh or fails loud naming how to reach it.
+  Source: `apps/cli/src/lib/teams/agents.ts`, `apps/cli/src/commands/teams.ts`,
+  `apps/cli/src/commands/message.ts`, `apps/cli/src/lib/hosts/message-target.ts`.

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -382,6 +382,14 @@ agents run <agent> ["<task>"] --host <host>
 > local follower dies. `agents hosts stop <id>` (alias `kill`) terminates the
 > remote process group from this machine, writes exit `143`, and keeps the log
 > for `agents hosts logs <id>`.
+>
+> **Steering a detached dispatch.** `agents message <name>` / `agents message
+> <session-id>` reaches a running `--no-follow` dispatch too — it resolves the
+> same host records `agents hosts ps` reads and forwards your message to the
+> agent's mailbox on the host over ssh. If the run has finished (or has not
+> registered a resumable session id yet), the command fails loud naming the host
+> and pointing at `agents hosts logs <name>` / `agents hosts stop <name>` rather
+> than reporting "no running agent".
 
 ### Host sources — owned (registered) + leased on demand (crabbox)
 

--- a/apps/cli/src/commands/message.ts
+++ b/apps/cli/src/commands/message.ts
@@ -27,6 +27,10 @@ import { resolveProvider } from '../lib/cloud/registry.js';
 import { mailboxDir, enqueue } from '../lib/mailbox.js';
 import { getAgentsInvocation } from '../lib/daemon.js';
 import { resolveMessageTarget, mailboxIdForActiveSession } from '../lib/mailbox-target.js';
+import { findTaskByName, findTaskBySessionId, loadTask } from '../lib/hosts/tasks.js';
+import { reconcileTask } from '../lib/hosts/reconcile.js';
+import { decideHostDispatchDelivery, type HostDispatchDelivery } from '../lib/hosts/message-target.js';
+import { sshExec, shellQuote } from '../lib/ssh-exec.js';
 import {
   blockIdForSession,
   listBlocks,
@@ -269,8 +273,62 @@ export function registerMessageCommand(program: Command): void {
           die(`"${target}" matches ${res.candidates.length} running agents:\n${lines}\nRe-run with a full id.`);
           return;
         }
-        case 'none':
-          die(`No running agent or cloud task matches "${target}". List targets with \`agents sessions --active\`.`);
+        case 'none': {
+          // Not a live local/teams/cloud agent — try a detached `--device`
+          // dispatch (the records `agents hosts ps` reads). A `--no-follow`
+          // remote run has no LOCAL session, so it never appears above; without
+          // this branch `agents message <name>`/`<session-id>` returns a
+          // misleading "no running agent" for a dispatch that IS running with a
+          // live pid (RUSH-2366, third defect).
+          const dispatch = findTaskByName(target) ?? findTaskBySessionId(target) ?? loadTask(target);
+          if (dispatch) {
+            const healed = reconcileTask(dispatch);
+            const decision = decideHostDispatchDelivery(healed);
+            if (decision.kind === 'unreachable') die(decision.reason);
+            await forwardMessageToHostDispatch(decision, text);
+            return;
+          }
+          die(
+            `No running agent or cloud task matches "${target}". List local agents with ` +
+            `\`agents sessions --active\`, or a detached remote run with \`agents hosts ps\`.`,
+          );
+        }
       }
     });
+}
+
+/**
+ * Deliver a message to a detached `--device` dispatch by running `agents message`
+ * ON its host over ssh — the remote box owns the agent's mailbox, so we forward
+ * the steer to where the session actually lives. Fails loud with the host named
+ * if the ssh hop or the remote delivery fails.
+ */
+async function forwardMessageToHostDispatch(
+  decision: Extract<HostDispatchDelivery, { kind: 'forward' }>,
+  text: string,
+): Promise<void> {
+  const remoteCmd = `agents message ${shellQuote(decision.sessionId)} ${shellQuote(text)}`;
+  const res = sshExec(decision.target, remoteCmd, {
+    timeoutMs: 15000,
+    multiplex: true,
+    extraSshArgs: decision.identityFile ? ['-i', decision.identityFile, '-o', 'IdentitiesOnly=yes'] : undefined,
+  });
+  if (res.code === null) {
+    die(
+      `Could not reach ${decision.host} to deliver the message to '${decision.label}' ` +
+      `(ssh failed or timed out). Retry, or steer it directly: ` +
+      `\`agents ssh ${decision.host} 'agents message ${decision.sessionId} "<text>"'\`.`,
+    );
+  }
+  if (res.code !== 0) {
+    const detail = (res.stderr || res.stdout || '').trim();
+    die(
+      `Delivery to '${decision.label}' on ${decision.host} failed${detail ? `: ${detail}` : ''}. ` +
+      `Read its output with \`agents hosts logs ${decision.label}\`.`,
+    );
+  }
+  console.log(
+    chalk.green(`Message forwarded to ${chalk.cyan(decision.label)} on ${chalk.cyan(decision.host)}.`) +
+    (res.stdout.trim() ? `\n${chalk.dim(res.stdout.trim())}` : ''),
+  );
 }

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -1747,6 +1747,22 @@ export function registerTeamsCommands(program: Command): void {
       let worktreeName: string | null = null;
       let worktreePath: string | null = null;
 
+      const mgr = mkManager();
+
+      // Validate name uniqueness + --after deps BEFORE creating a worktree
+      // (RUSH-2356): a rejected add must not leave an orphan `agents/<name>`
+      // branch that then breaks the retry with `fatal: a branch ... already
+      // exists`. spawn() re-validates, so this is a fast fail, not the authority.
+      try {
+        await mgr.validateAddPreconditions(team, opts.name ?? null, after);
+      } catch (err) {
+        dieFriction('teams', 'add-precondition-failed', (err as Error).message);
+      }
+
+      // Track a worktree WE create in this add so a later failure (dep race,
+      // launch error) can tear it down instead of stranding the branch.
+      let createdWorktree: { baseCwd: string; name: string } | null = null;
+
       if (hostName) {
         // Distributed teammate: the checkout lives on the host, so we NEVER touch
         // the local filesystem here. A shared local worktree makes no sense for a
@@ -1796,6 +1812,7 @@ export function registerTeamsCommands(program: Command): void {
         try {
           worktreeName = opts.worktree;
           worktreePath = await createWorktree(baseCwd, worktreeName);
+          createdWorktree = { baseCwd, name: worktreeName };
         } catch (err) {
           dieFriction('teams', 'worktree-create-failed', `Failed to create worktree '${opts.worktree}': ${(err as Error).message}`);
         }
@@ -1807,7 +1824,6 @@ export function registerTeamsCommands(program: Command): void {
       // host (repoPath / the remote worktree). Local teammates default to the
       // worktree path, then --cwd, then the current directory.
       const cwd = hostName ? null : (worktreePath ?? opts.cwd ?? process.cwd());
-      const mgr = mkManager();
 
       // Factory teammates: prepend the worker-skill preamble to every task
       // prompt so implementers/testers/reviewers know about the Ledger, the
@@ -1940,6 +1956,23 @@ export function registerTeamsCommands(program: Command): void {
           console.log(chalk.gray(`Check in later:  agents teams status ${team}`));
         }
       } catch (err) {
+        // The add failed after we created its worktree — tear the worktree +
+        // branch down so a retry isn't blocked by `fatal: a branch ... already
+        // exists` (RUSH-2356). Best-effort: report the original failure either way.
+        if (createdWorktree) {
+          try {
+            await removeWorktree(createdWorktree.baseCwd, createdWorktree.name);
+          } catch (cleanupErr) {
+            process.stderr.write(
+              chalk.yellow(
+                `\nWarning: could not remove the orphaned worktree '${createdWorktree.name}' after the failed add: ` +
+                  `${(cleanupErr as Error).message}\n` +
+                  `  Remove it manually: git -C ${createdWorktree.baseCwd} worktree remove --force .agents/worktrees/${createdWorktree.name} ` +
+                  `&& git -C ${createdWorktree.baseCwd} branch -D agents/${createdWorktree.name}\n`,
+              ),
+            );
+          }
+        }
         dieFriction('teams', 'add-failed', `Could not add ${fullName(agent, version)} to ${team}: ${(err as Error).message}`);
       }
     });

--- a/apps/cli/src/lib/hosts/message-target.test.ts
+++ b/apps/cli/src/lib/hosts/message-target.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `agents message` reaching a detached `--device --no-follow` dispatch
+ * (RUSH-2366, third defect). The pure delivery decision is unit-tested here; a
+ * real-file test proves the same host records `agents hosts ps` reads are what
+ * resolve a message target by name / session id.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { decideHostDispatchDelivery } from './message-target.js';
+import type { HostTask } from './tasks.js';
+
+function task(overrides: Partial<HostTask>): HostTask {
+  return {
+    id: 'abcd1234',
+    host: 'yosemite-s0',
+    target: 'yosemite-s0.tail.ts.net',
+    agent: 'claude',
+    prompt: 'do a thing',
+    remoteLog: '$HOME/.agents/.cache/hosts/abcd1234.log',
+    remoteExit: '$HOME/.agents/.cache/hosts/abcd1234.exit',
+    status: 'running',
+    createdAt: '2026-08-07T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('decideHostDispatchDelivery', () => {
+  it('forwards a running dispatch that has a session id', () => {
+    const d = decideHostDispatchDelivery(task({ name: 'lifecycle', sessionId: 'sess-1', identityFile: '/k' }));
+    expect(d).toEqual({
+      kind: 'forward',
+      host: 'yosemite-s0',
+      target: 'yosemite-s0.tail.ts.net',
+      sessionId: 'sess-1',
+      identityFile: '/k',
+      label: 'lifecycle',
+    });
+  });
+
+  it('is unreachable (with a recovery hint) when running but no session id captured yet', () => {
+    const d = decideHostDispatchDelivery(task({ name: 'lifecycle', sessionId: undefined }));
+    expect(d.kind).toBe('unreachable');
+    if (d.kind === 'unreachable') {
+      expect(d.reason).toMatch(/has not registered a resumable session id/);
+      expect(d.reason).toMatch(/agents hosts logs lifecycle/);
+      expect(d.reason).toMatch(/agents hosts stop lifecycle/);
+    }
+  });
+
+  it('is unreachable (points at logs) once the dispatch has finished', () => {
+    const d = decideHostDispatchDelivery(task({ name: 'lifecycle', status: 'completed', exitCode: 0, sessionId: 'sess-1' }));
+    expect(d.kind).toBe('unreachable');
+    if (d.kind === 'unreachable') {
+      expect(d.reason).toMatch(/has already finished/);
+      expect(d.reason).toMatch(/agents hosts logs lifecycle/);
+    }
+  });
+
+  it('labels by id when the dispatch was launched without --name', () => {
+    const d = decideHostDispatchDelivery(task({ sessionId: 'sess-1' }));
+    if (d.kind === 'forward') expect(d.label).toBe('abcd1234');
+  });
+});
+
+describe('host dispatch records resolve a message target by name / session id', () => {
+  let cacheDir: string;
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-msg-hosts-'));
+    vi.resetModules();
+  });
+  afterEach(() => {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+    vi.doUnmock('../state.js');
+    vi.resetModules();
+  });
+
+  it('findTaskByName / findTaskBySessionId read the same <id>.json records', async () => {
+    vi.doMock('../state.js', async () => {
+      const actual = await vi.importActual<typeof import('../state.js')>('../state.js');
+      return { ...actual, getCacheDir: () => cacheDir };
+    });
+    const { saveTask, findTaskByName, findTaskBySessionId } = await import('./tasks.js');
+
+    saveTask(task({ id: 'ffff0000', name: 'lifecycle-recovery', sessionId: 'sess-xyz' }));
+
+    expect(findTaskByName('lifecycle-recovery')?.id).toBe('ffff0000');
+    expect(findTaskBySessionId('sess-xyz')?.id).toBe('ffff0000');
+    expect(findTaskByName('nope')).toBeNull();
+  });
+});

--- a/apps/cli/src/lib/hosts/message-target.ts
+++ b/apps/cli/src/lib/hosts/message-target.ts
@@ -1,0 +1,65 @@
+/**
+ * Resolve `agents message <target>` against detached `--device`/`--host`
+ * dispatches (the records `agents hosts ps` reads), so a message can reach — or
+ * fail loud with a real recovery path for — an `agents run --device --no-follow`
+ * run that has no LOCAL live session and so is invisible to the active-session
+ * resolver (RUSH-2366, third defect). Pure (no I/O) so it is unit-testable; the
+ * caller supplies the (already status-reconciled) HostTask.
+ */
+import type { HostTask } from './tasks.js';
+
+export type HostDispatchDelivery =
+  | {
+      // The dispatch is running and has a resumable remote session id, so the
+      // message can be forwarded over ssh to its mailbox ON the host.
+      kind: 'forward';
+      host: string;
+      target: string;
+      sessionId: string;
+      identityFile?: string;
+      label: string;
+    }
+  | {
+      // The dispatch matched a host record but cannot be steered from here; the
+      // reason names the real way to observe or end it.
+      kind: 'unreachable';
+      reason: string;
+    };
+
+/**
+ * Decide how (if at all) a message reaches a matched host dispatch. Three cases:
+ *   - terminal              -> unreachable, point at `agents hosts logs`.
+ *   - running, no sessionId -> unreachable (a --no-follow run captures its id
+ *                              only after its first turn), point at logs / stop.
+ *   - running, sessionId    -> forward over ssh to the host's mailbox.
+ */
+export function decideHostDispatchDelivery(task: HostTask): HostDispatchDelivery {
+  const label = task.name ?? task.id;
+  if (task.status !== 'running') {
+    const exit = task.exitCode != null ? ` (exit ${task.exitCode})` : '';
+    return {
+      kind: 'unreachable',
+      reason:
+        `Dispatch '${label}' on ${task.host} has already finished — status ${task.status}${exit}. ` +
+        `There is no running agent to message. Read its output with \`agents hosts logs ${label}\`, ` +
+        `or start a fresh run with \`agents run --device ${task.host} ...\`.`,
+    };
+  }
+  if (!task.sessionId) {
+    return {
+      kind: 'unreachable',
+      reason:
+        `Dispatch '${label}' is running on ${task.host} but has not registered a resumable session id yet ` +
+        `(a --no-follow run captures it only after its first turn), so it has no mailbox reachable from here. ` +
+        `Watch it with \`agents hosts logs ${label}\`, or end it with \`agents hosts stop ${label}\`.`,
+    };
+  }
+  return {
+    kind: 'forward',
+    host: task.host,
+    target: task.target,
+    sessionId: task.sessionId,
+    identityFile: task.identityFile,
+    label,
+  };
+}

--- a/apps/cli/src/lib/teams/agents.reliability.test.ts
+++ b/apps/cli/src/lib/teams/agents.reliability.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Teammate-state reliability — the silent-success failures that stranded a real
+ * 5-track swarm (RUSH-2356 + RUSH-2366).
+ *
+ * These exercise the real AgentManager/AgentProcess lifecycle against a temp
+ * meta.json dir (no mocking of the code under test). Only the ssh network
+ * boundary is stubbed — the same seam the existing remote-poll test stubs — so
+ * the `--device` liveness path runs for real without a live host.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawn as spawnProc } from 'child_process';
+
+const { sshExecMock, sshExecRawMock } = vi.hoisted(() => ({
+  sshExecMock: vi.fn(),
+  // pullRemoteLogDelta() runs before the liveness probe; return null-code so it
+  // mirrors no bytes and the test stays focused on the sshExec liveness reading.
+  sshExecRawMock: vi.fn(() => ({ code: null, stdout: Buffer.from(''), stderr: '' })),
+}));
+
+vi.mock('../ssh-exec.js', async () => {
+  const actual = await vi.importActual<typeof import('../ssh-exec.js')>('../ssh-exec.js');
+  return { ...actual, sshExec: sshExecMock, sshExecRaw: sshExecRawMock };
+});
+
+import {
+  AgentManager,
+  AgentProcess,
+  AgentStatus,
+  isTerminalStatus,
+  parseRemoteLivenessState,
+} from './agents.js';
+
+function tmpBase(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-reliability-'));
+}
+
+/** A local teammate persisted directly to disk at the given status. */
+async function seed(
+  base: string,
+  id: string,
+  status: AgentStatus,
+  opts: { name?: string; after?: string[]; completedAt?: Date } = {},
+): Promise<AgentProcess> {
+  const agent = new AgentProcess(
+    id, 'swarm', 'claude', 'do a thing',
+    null, 'plan', null, status, new Date('2026-08-07T00:00:00.000Z'),
+    opts.completedAt ?? (isTerminalStatus(status) ? new Date('2026-08-07T00:00:00.000Z') : null),
+    base, null, null, null, null, null, null, null,
+    opts.name ?? null, opts.after ?? [],
+  );
+  await agent.saveMeta();
+  return agent;
+}
+
+function makeRemote(base: string, id: string): AgentProcess {
+  const agent = new AgentProcess(
+    id, 'swarm', 'claude', 'remote work',
+    null, 'plan', null, AgentStatus.RUNNING, new Date('2026-08-07T00:00:00.000Z'),
+    null, base,
+  );
+  agent.hostName = 'yosemite-s0';
+  agent.hostTarget = 'yosemite-s0.tail1a85a1.ts.net';
+  agent.remotePid = 4242;
+  agent.remoteLog = '$HOME/.agents/.cache/hosts/aaaaaaaa.log';
+  agent.remoteExit = '$HOME/.agents/.cache/hosts/aaaaaaaa.exit';
+  return agent;
+}
+
+describe('RUSH-2356 — retention never reaps live teammates', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    sshExecMock.mockReset();
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it('listCompleted() returns only terminal statuses (never pending/running)', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    await seed(base, 'done-1', AgentStatus.COMPLETED);
+    await seed(base, 'failed-1', AgentStatus.FAILED);
+    await seed(base, 'stopped-1', AgentStatus.STOPPED);
+    await seed(base, 'pending-1', AgentStatus.PENDING, { name: 'p1', after: ['base'] });
+    // A local running teammate with a live pid so it loads (and stays) RUNNING.
+    const sleeper = spawnProc('sleep', ['60']);
+    const running = await seed(base, 'running-1', AgentStatus.RUNNING);
+    running.pid = sleeper.pid ?? null;
+    await running.saveMeta();
+
+    const mgr = new AgentManager(50, base);
+    const completed = await mgr.listCompleted();
+    const ids = completed.map((a) => a.agentId).sort();
+
+    sleeper.kill('SIGKILL');
+    expect(ids).toEqual(['done-1', 'failed-1', 'stopped-1']);
+    expect(completed.every((a) => isTerminalStatus(a.status))).toBe(true);
+  });
+
+  it('cleanup past the 50-record cap never deletes a pending --after teammate', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+
+    // 51 terminal records — one over the default cap, so cleanup WILL fire.
+    for (let i = 0; i < 51; i++) {
+      await seed(base, `term-${String(i).padStart(3, '0')}`, AgentStatus.COMPLETED, {
+        completedAt: new Date(Date.parse('2026-08-01T00:00:00.000Z') + i * 60_000),
+      });
+    }
+    // Five staged (pending) --after teammates — the case that used to vanish.
+    const pendingIds = ['stage-a', 'stage-b', 'stage-c', 'stage-d', 'stage-e'];
+    for (const id of pendingIds) {
+      await seed(base, id, AgentStatus.PENDING, { name: id, after: ['stage-anchor'] });
+    }
+
+    const mgr = new AgentManager(50, base);
+    // Trigger the real cleanupOldAgents via a cloud-backed spawn (no CLI check,
+    // no subprocess — the provider dispatch happened before spawn() in prod).
+    await mgr.spawn(
+      'swarm', 'claude', 'trigger', null, 'plan', 'medium', null, null,
+      null, 'cleanup-trigger', [], null, null, null,
+      'rush', 'sess-trigger',
+    );
+
+    // Every pending teammate MUST survive on disk and still be pending.
+    for (const id of pendingIds) {
+      const onDisk = await AgentProcess.loadFromDisk(id, base);
+      expect(onDisk, `pending teammate ${id} was reaped by cleanup`).not.toBeNull();
+      expect(onDisk!.status).toBe(AgentStatus.PENDING);
+    }
+    // Exactly one terminal record (the oldest) was reaped to honor the cap.
+    const remainingTerminal = fs.readdirSync(base).filter((e) => e.startsWith('term-'));
+    expect(remainingTerminal.length).toBe(50);
+  });
+
+  it('spawn() persists the record durably — loadFromDisk finds it', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    const mgr = new AgentManager(50, base);
+    const agent = await mgr.spawn(
+      'swarm', 'claude', 'work', null, 'plan', 'medium', null, null,
+      null, 'durable-1', [], null, null, null,
+      'rush', 'sess-1',
+    );
+    const onDisk = await AgentProcess.loadFromDisk(agent.agentId, base);
+    expect(onDisk).not.toBeNull();
+    expect(onDisk!.name).toBe('durable-1');
+  });
+
+  it('validateAddPreconditions rejects a duplicate name and an unknown --after dep', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    await seed(base, 'existing', AgentStatus.COMPLETED, { name: 'alice' });
+    const mgr = new AgentManager(50, base);
+
+    await expect(mgr.validateAddPreconditions('swarm', 'alice', [])).rejects.toThrow(/already has a teammate named 'alice'/);
+    await expect(mgr.validateAddPreconditions('swarm', 'bob', ['ghost'])).rejects.toThrow(/no teammate named 'ghost'/);
+    // A resolvable dep validates and returns the cleaned after-list (empties dropped).
+    await expect(mgr.validateAddPreconditions('swarm', 'bob', ['alice', ''])).resolves.toEqual(['alice']);
+  });
+});
+
+describe('RUSH-2366 — a dead teammate is reconciled, never RUNNING forever', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    sshExecMock.mockReset();
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it('parseRemoteLivenessState distinguishes ALIVE / EXITED / GONE', () => {
+    expect(parseRemoteLivenessState('ALIVE', undefined)).toEqual({ alive: true, exit: null, exitFilePresent: false });
+    expect(parseRemoteLivenessState('EXITED', '0')).toEqual({ alive: false, exit: '0', exitFilePresent: true });
+    expect(parseRemoteLivenessState('EXITED', undefined)).toEqual({ alive: false, exit: '', exitFilePresent: true });
+    expect(parseRemoteLivenessState('GONE', undefined)).toEqual({ alive: false, exit: null, exitFilePresent: false });
+  });
+
+  it('a local teammate whose pid is dead is marked FAILED on refresh', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    const agent = await seed(base, 'dead-local', AgentStatus.RUNNING);
+    // A pid that is not alive and never ours: refresh must reap it, not keep it
+    // RUNNING. reapProcess finds no sentinel -> exit 1 -> FAILED.
+    agent.pid = 2 ** 31 - 1;
+    await agent.saveMeta();
+
+    const mgr = new AgentManager(50, base);
+    const [refreshed] = await mgr.listAll();
+    expect(refreshed.status).toBe(AgentStatus.FAILED);
+    expect(refreshed.completedAt).toBeInstanceOf(Date);
+    expect(await mgr.listRunning()).toEqual([]);
+  });
+
+  it('a --device teammate whose process is GONE (no exit sentinel) is marked FAILED', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    const agent = makeRemote(base, 'dead-remote');
+    await agent.saveMeta();
+
+    // Host says: process gone, no `.exit` at all -> "<id> GONE".
+    sshExecMock.mockReturnValue({ code: 0, stdout: 'dead-remote GONE\n', stderr: '', timedOut: false });
+
+    const mgr = new AgentManager(50, base);
+    const [refreshed] = await mgr.listAll();
+    expect(refreshed.status).toBe(AgentStatus.FAILED);
+    expect(refreshed.completedAt).toBeInstanceOf(Date);
+    // The reconciled terminal status is persisted.
+    const onDisk = await AgentProcess.loadFromDisk('dead-remote', base);
+    expect(onDisk!.status).toBe(AgentStatus.FAILED);
+  });
+
+  it('a still-ALIVE --device teammate stays RUNNING (no false reap)', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    const agent = makeRemote(base, 'live-remote');
+    await agent.saveMeta();
+    sshExecMock.mockReturnValue({ code: 0, stdout: 'live-remote ALIVE\n', stderr: '', timedOut: false });
+
+    const mgr = new AgentManager(50, base);
+    const [refreshed] = await mgr.listAll();
+    expect(refreshed.status).toBe(AgentStatus.RUNNING);
+  });
+
+  it('a transient ssh failure never reaps a --device teammate', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    const agent = makeRemote(base, 'flaky-remote');
+    await agent.saveMeta();
+    sshExecMock.mockReturnValue({ code: null, stdout: '', stderr: 'ssh: connect timeout', timedOut: true });
+
+    const mgr = new AgentManager(50, base);
+    const [refreshed] = await mgr.listAll();
+    expect(refreshed.status).toBe(AgentStatus.RUNNING);
+  });
+
+  it('a stale in-memory RUNNING never clobbers a newer on-disk terminal status', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    // Manager A loads the teammate as RUNNING (remote, ALIVE at load).
+    const agent = makeRemote(base, 'stopped-then-polled');
+    await agent.saveMeta();
+    sshExecMock.mockReturnValue({ code: 0, stdout: 'stopped-then-polled ALIVE\n', stderr: '', timedOut: false });
+    const mgrA = new AgentManager(50, base);
+    const [cached] = await mgrA.listAll();
+    expect(cached.status).toBe(AgentStatus.RUNNING);
+
+    // Another process (a separate `teams stop`) writes STOPPED to disk.
+    const external = await AgentProcess.loadFromDisk('stopped-then-polled', base);
+    external!.status = AgentStatus.STOPPED;
+    external!.completedAt = new Date('2026-08-07T01:00:00.000Z');
+    await external!.saveMeta();
+
+    // Manager A polls its stale cached teammate. It must ADOPT the stopped status,
+    // never re-persist RUNNING over it.
+    await cached.updateStatusFromProcess();
+    expect(cached.status).toBe(AgentStatus.STOPPED);
+    const onDisk = await AgentProcess.loadFromDisk('stopped-then-polled', base);
+    expect(onDisk!.status).toBe(AgentStatus.STOPPED);
+  });
+
+  it('rescanFromDisk refreshes a cached teammate that disk latched terminal', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    const agent = makeRemote(base, 'rescan-me');
+    await agent.saveMeta();
+    sshExecMock.mockReturnValue({ code: 0, stdout: 'rescan-me ALIVE\n', stderr: '', timedOut: false });
+    const mgr = new AgentManager(50, base);
+    await mgr.listAll(); // caches it RUNNING
+
+    // Externally latch it STOPPED on disk.
+    const external = await AgentProcess.loadFromDisk('rescan-me', base);
+    external!.status = AgentStatus.STOPPED;
+    external!.completedAt = new Date('2026-08-07T01:00:00.000Z');
+    await external!.saveMeta();
+
+    await mgr.rescanFromDisk();
+    const running = await mgr.listRunning();
+    expect(running.find((a) => a.agentId === 'rescan-me')).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -133,6 +133,68 @@ export enum AgentStatus {
   STOPPED = 'stopped',
 }
 
+/**
+ * The statuses a teammate can never leave — its process has run and finished
+ * (or been stopped). Everything else (pending, running) is still live work.
+ *
+ * This is the ONLY set that retention (cleanupOldAgents) may reap: a `pending`
+ * teammate has not launched yet and a `running` one is doing work, so deleting
+ * either is data loss. Treating "not running" as "completed" was the RUSH-2356
+ * bug — it swept live `pending` `--after` teammates past the 50-record cap.
+ */
+export const TERMINAL_STATUSES: ReadonlySet<AgentStatus> = new Set([
+  AgentStatus.COMPLETED,
+  AgentStatus.FAILED,
+  AgentStatus.STOPPED,
+]);
+
+/** True when a teammate has reached a terminal (completed/failed/stopped) status. */
+export function isTerminalStatus(status: AgentStatus): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+/**
+ * One remote teammate's liveness, resolved by a single host probe. Three states,
+ * kept distinct on purpose (RUSH-2366):
+ *   - alive=true                                → process still running.
+ *   - exitFilePresent=true                      → the `.exit` sentinel exists;
+ *     `exit` is its (possibly empty, mid-write) contents.
+ *   - alive=false && !exitFilePresent  ("GONE") → the process is gone AND the
+ *     wrapper never recorded a sentinel — it was killed / the box died. There is
+ *     no exit code coming, so this MUST resolve terminal instead of "running
+ *     forever". Collapsing GONE into the empty-`.exit` case is exactly the bug
+ *     that left a dead `--device` teammate RUNNING indefinitely.
+ */
+export interface RemoteLivenessSnapshot {
+  alive: boolean;
+  exit: string | null;
+  exitFilePresent: boolean;
+}
+
+/**
+ * The per-teammate shell that emits `<id> <ALIVE|EXITED|GONE> <codeOrEmpty>`.
+ * Shared by the batched prefetch (many teammates, one round-trip) and the
+ * direct single-teammate probe, so both classify liveness identically.
+ * `exitFile` is interpolated UNQUOTED so `$HOME` in the dispatch path expands on
+ * the remote shell (shellQuote would defeat the `[ -f ]` test).
+ */
+export function remoteLivenessSnippet(id: string, exitFile: string, pid: number): string {
+  return (
+    `printf '%s ' ${shellQuote(id)}; ` +
+    `if [ -f ${exitFile} ]; then printf 'EXITED '; cat ${exitFile} 2>/dev/null | tr -d '\\n'; printf '\\n'; ` +
+    `elif kill -0 ${pid} 2>/dev/null; then printf 'ALIVE\\n'; ` +
+    `else printf 'GONE\\n'; fi`
+  );
+}
+
+/** Parse one `<STATE> <codeOrEmpty>` reading into a snapshot. */
+export function parseRemoteLivenessState(state: string, code: string | undefined): RemoteLivenessSnapshot {
+  if (state === 'ALIVE') return { alive: true, exit: null, exitFilePresent: false };
+  if (state === 'EXITED') return { alive: false, exit: code ?? '', exitFilePresent: true };
+  // GONE (or an unrecognised token): process not alive, no sentinel recorded.
+  return { alive: false, exit: null, exitFilePresent: false };
+}
+
 /** Task type label for Software Factory workflows. Drives planner fan-out. Optional — teammates without a task_type work exactly as before. */
 export type TaskType = 'plan' | 'implement' | 'test' | 'review' | 'bugfix' | 'docs';
 export const VALID_TASK_TYPES: readonly TaskType[] = [
@@ -577,7 +639,7 @@ export class AgentProcess {
   // scan + the supervisor's listByTask) yet never carries into the next wave. Null
   // outside a batched wave (e.g. a bare `teams status`), where a direct per-teammate
   // SSH probe is the correctness fallback.
-  remotePollSnapshot: { alive: boolean; exit: string | null } | null = null;
+  remotePollSnapshot: RemoteLivenessSnapshot | null = null;
   private eventsCache: any[] = [];
   private lastReadPos: number = 0;
   private baseDir: string | null = null;
@@ -829,34 +891,56 @@ export class AgentProcess {
       }
     }
 
-    // Resolve terminal status from the remote `.exit` sentinel (mirror
-    // reapProcess). Prefer this wave's batched snapshot; else fetch the exit file
-    // directly. The snapshot is left in place (refreshed each wave by prefetch),
-    // so a second poll pass within the same wave reuses it.
-    let exit: string | null = null;
-    const snap = this.remotePollSnapshot;
-    if (snap) {
-      exit = snap.exit;
-    } else if (this.remoteExit) {
-      // UNQUOTED so `$HOME` in the dispatch exit path expands on the remote shell.
-      const res = sshExec(this.hostTarget, `cat ${this.remoteExit} 2>/dev/null`, {
-        timeoutMs: 8000,
-        multiplex: true,
-        extraSshArgs: this.hostIdentityFile ? ['-i', this.hostIdentityFile, '-o', 'IdentitiesOnly=yes'] : [],
-      });
-      exit = res.code === 0 && res.stdout.trim() !== '' ? res.stdout.trim() : null;
-    }
+    // Resolve terminal status from the host. Prefer this wave's batched snapshot;
+    // else probe this teammate directly. The snapshot is left in place (refreshed
+    // each wave by prefetch), so a second poll pass within the same wave reuses it.
+    const snap = this.remotePollSnapshot ?? (await this.probeRemoteLiveness());
+    if (!snap) return; // transient ssh failure — leave RUNNING, retry next poll
+
     // Only latch terminal on a PARSEABLE exit code. A `.exit` that exists but is
     // momentarily empty (created, not yet written) or garbage must NOT force a
     // spurious FAILED — leave the teammate RUNNING and let the next poll resolve
-    // it once the code lands. Matches the direct-cat guard above.
-    if (exit !== null && exit.trim() !== '' && this.status === AgentStatus.RUNNING) {
-      const code = Number.parseInt(exit.trim(), 10);
+    // it once the code lands.
+    if (snap.exit !== null && snap.exit.trim() !== '' && this.status === AgentStatus.RUNNING) {
+      const code = Number.parseInt(snap.exit.trim(), 10);
       if (Number.isFinite(code)) {
         this.status = code === 0 ? AgentStatus.COMPLETED : AgentStatus.FAILED;
         if (!this.completedAt) this.completedAt = new Date();
+        return;
       }
     }
+
+    // No exit code resolved it. If the remote process is GONE with NO sentinel at
+    // all, the wrapper died before recording `$?` (killed, box lost, OOM) — it can
+    // never write a code, so this teammate is FAILED, not "running forever"
+    // (RUSH-2366). This is the remote analog of reapProcess()'s "sentinel absent
+    // -> 1 -> FAILED". An EXITED-but-empty `.exit` (wrapper mid-write) is left
+    // RUNNING above precisely so this branch does not misfire on that race.
+    if (this.status === AgentStatus.RUNNING && !snap.alive && !snap.exitFilePresent) {
+      this.status = AgentStatus.FAILED;
+      if (!this.completedAt) this.completedAt = this.getLatestEventTime() || this.startedAt || new Date();
+    }
+  }
+
+  /**
+   * One-shot direct liveness probe for a single remote teammate — the fallback
+   * used outside a batched supervisor wave (a bare `teams status`, `mgr.get()`
+   * for `teams resume`). Returns null on a transient ssh failure so the caller
+   * leaves the teammate RUNNING rather than reaping it on a dropped connection.
+   */
+  private async probeRemoteLiveness(): Promise<RemoteLivenessSnapshot | null> {
+    if (!this.hostTarget || !this.remotePid || !this.remoteExit) return null;
+    const res = sshExec(this.hostTarget, remoteLivenessSnippet(this.agentId, this.remoteExit, this.remotePid), {
+      timeoutMs: 8000,
+      multiplex: true,
+      extraSshArgs: this.hostIdentityFile ? ['-i', this.hostIdentityFile, '-o', 'IdentitiesOnly=yes'] : [],
+    });
+    if (res.code === null) return null; // transient ssh failure — don't reap early
+    const trimmed = res.stdout.trim();
+    if (!trimmed) return null;
+    const [, state, code] = trimmed.split(/\s+/);
+    if (!state) return null;
+    return parseRemoteLivenessState(state, code);
   }
 
   /** Reset the local stdout cursor for a newly truncated resume log. */
@@ -1177,11 +1261,61 @@ export class AgentProcess {
   }
 
   /**
+   * Read just the persisted status + completion time from meta.json, without
+   * reconstructing the whole teammate. Returns null when there is no readable
+   * record on disk. Used to detect that ANOTHER process (a `teams stop`, a
+   * sibling supervisor) has already moved this teammate to a terminal status.
+   */
+  private async readDiskStatus(): Promise<{ status: AgentStatus; completedAt: Date | null } | null> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(await this.getMetaPath(), 'utf-8');
+    } catch {
+      return null;
+    }
+    try {
+      const meta = JSON.parse(raw);
+      const validStatuses = Object.values(AgentStatus);
+      const status = validStatuses.includes(meta.status as AgentStatus)
+        ? (meta.status as AgentStatus)
+        : AgentStatus.RUNNING;
+      const completedAt = meta.completed_at ? new Date(meta.completed_at) : null;
+      return { status, completedAt };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * If this in-memory teammate is still non-terminal but disk already shows a
+   * terminal status, adopt the disk state. Returns true when it did.
+   *
+   * This is the guard against the stale-manager race (RUSH-2366): a long-lived
+   * supervisor holding a teammate as `running` must never re-persist that stale
+   * `running` over a `stopped`/`failed`/`completed` another process just wrote
+   * (e.g. an explicit `teams stop` in a separate CLI invocation). A terminal
+   * status is a one-way latch, so disk-terminal always wins over memory-running.
+   */
+  private async adoptDiskTerminalIfNewer(): Promise<boolean> {
+    if (isTerminalStatus(this.status)) return false;
+    const disk = await this.readDiskStatus();
+    if (!disk || !isTerminalStatus(disk.status)) return false;
+    this.status = disk.status;
+    this.completedAt = disk.completedAt ?? this.completedAt ?? new Date();
+    return true;
+  }
+
+  /**
    * @param opts.skipRemote A `--local` caller (RUSH-2118): a distributed
    *   teammate is never dialed — its in-memory state (already loaded from
    *   meta.json) stands as-is, no ssh, no re-save.
    */
   async updateStatusFromProcess(opts: { skipRemote?: boolean } = {}): Promise<void> {
+    // Stale-manager guard (RUSH-2366): if disk has already latched this teammate
+    // terminal, adopt that and stop — a poll of a process that no longer exists
+    // must not re-persist `running` over the newer on-disk terminal status.
+    if (await this.adoptDiskTerminalIfNewer()) return;
+
     if (!this.pid) {
       // Distributed (remote-host) teammates have no local PID by design; their
       // lifecycle lives on the host. readNewEvents() mirrors the remote log and
@@ -1458,8 +1592,12 @@ export class AgentManager {
    * manager is alive — the supervisor loop calls this each wave so
    * dynamically-added teammates get picked up.
    *
-   * Does not modify or re-load agents already in the cache; that path is
-   * covered by updateStatusFromProcess() which re-reads stdout.log.
+   * For a teammate ALREADY cached, refreshes it only when disk has latched it
+   * terminal while the cache still holds it non-terminal — the case where
+   * another process (e.g. `agents teams stop` in a separate CLI invocation)
+   * moved it to `stopped`/`failed` and this long-lived manager would otherwise
+   * never see it and re-persist a stale `running` (RUSH-2366). A still-live
+   * cached teammate is left untouched; updateStatusFromProcess() owns that path.
    */
   async rescanFromDisk(): Promise<number> {
     await this.initialize();
@@ -1471,10 +1609,24 @@ export class AgentManager {
     const entries = await fs.readdir(this.agentsDir);
     let added = 0;
     for (const entry of entries) {
-      if (this.agents.has(entry)) continue;
       const agentDir = path.join(this.agentsDir, entry);
       const stat = await fs.stat(agentDir).catch(() => null);
       if (!stat || !stat.isDirectory()) continue;
+
+      const cached = this.agents.get(entry);
+      if (cached) {
+        // Adopt a disk-terminal status the cache hasn't seen; never overwrite a
+        // cached teammate that is still live with a stale disk read. Terminal is
+        // a one-way latch, so this can only move a teammate forward.
+        if (!isTerminalStatus(cached.status)) {
+          const fresh = await AgentProcess.loadFromDisk(entry, this.agentsDir);
+          if (fresh && isTerminalStatus(fresh.status)) {
+            this.agents.set(entry, fresh);
+          }
+        }
+        continue;
+      }
+
       const agent = await AgentProcess.loadFromDisk(entry, this.agentsDir);
       if (!agent) continue;
       if (this.filterByCwd !== null && agent.cwd !== this.filterByCwd) continue;
@@ -1731,6 +1883,21 @@ export class AgentManager {
     }
 
     await this.cleanupOldAgents();
+
+    // Postcondition: the teammate MUST be durably on disk before we report
+    // success. saveMeta() ran above and cleanupOldAgents() can no longer reap a
+    // non-terminal record, but a failed write (full disk, permissions) or any
+    // future retention regression would otherwise let `teams add` print a full
+    // success block for a teammate that does not exist — the RUSH-2356
+    // silent-success class. Assert the outcome, not the exit code.
+    const persisted = await AgentProcess.loadFromDisk(agentId, this.agentsDir);
+    if (!persisted) {
+      this.agents.delete(agentId);
+      throw new Error(
+        `Teammate '${name ?? agentId}' was not durably persisted to disk after add ` +
+          `(no meta.json under ${this.agentsDir}/${agentId}). The add did not take effect.`,
+      );
+    }
     return agent;
   }
 
@@ -2221,22 +2388,12 @@ export class AgentManager {
     }
 
     for (const { target, agents } of byTarget.values()) {
-      // Emit one line per teammate: "<agentId> ALIVE|DEAD <exitOrEmpty>". A single
-      // round-trip over the multiplexed socket, regardless of teammate count.
-      const parts = agents.map((a) => {
-        const id = a.agentId;
-        // remoteExit is a dispatch `$HOME/.agents/.cache/hosts/<hex>.exit` path —
-        // interpolate UNQUOTED so `$HOME` expands (shellQuote would make `[ -f ]`
-        // always miss, so a finished teammate would never resolve terminal).
-        const exitFile = a.remoteExit!;
-        // exit code (if the sentinel exists) OR empty, then liveness.
-        return (
-          `printf '%s ' ${shellQuote(id)}; ` +
-          `if [ -f ${exitFile} ]; then printf 'DEAD '; cat ${exitFile} 2>/dev/null | tr -d '\\n'; printf '\\n'; ` +
-          `elif kill -0 ${a.remotePid} 2>/dev/null; then printf 'ALIVE\\n'; ` +
-          `else printf 'DEAD\\n'; fi`
-        );
-      });
+      // Emit one line per teammate: "<agentId> <ALIVE|EXITED|GONE> <codeOrEmpty>".
+      // A single round-trip over the multiplexed socket, regardless of teammate
+      // count. GONE (process gone, no `.exit`) is kept distinct from EXITED so a
+      // teammate killed without recording `$?` resolves terminal instead of
+      // reporting RUNNING forever (RUSH-2366).
+      const parts = agents.map((a) => remoteLivenessSnippet(a.agentId, a.remoteExit!, a.remotePid!));
       const identityFile = agents[0]?.hostIdentityFile;
       const res = sshExec(target, parts.join('; '), {
         timeoutMs: 12000,
@@ -2244,16 +2401,13 @@ export class AgentManager {
         extraSshArgs: identityFile ? ['-i', identityFile, '-o', 'IdentitiesOnly=yes'] : [],
       });
       if (res.code === null) continue; // transient ssh failure — skip this wave, no snapshot
-      const snapshots = new Map<string, { alive: boolean; exit: string | null }>();
+      const snapshots = new Map<string, RemoteLivenessSnapshot>();
       for (const line of res.stdout.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed) continue;
-        const [id, state, exit] = trimmed.split(/\s+/);
-        if (!id) continue;
-        snapshots.set(id, {
-          alive: state === 'ALIVE',
-          exit: state === 'DEAD' ? (exit ?? '') : null,
-        });
+        const [id, state, code] = trimmed.split(/\s+/);
+        if (!id || !state) continue;
+        snapshots.set(id, parseRemoteLivenessState(state, code));
       }
       for (const a of agents) {
         const snap = snapshots.get(a.agentId);
@@ -2506,9 +2660,16 @@ export class AgentManager {
     return all.filter(a => a.status === AgentStatus.RUNNING);
   }
 
+  /**
+   * Teammates that have reached a terminal status (completed/failed/stopped) —
+   * the ONLY records retention may reap. A `pending` teammate has not launched
+   * and a `running` one is working, so neither is "completed"; classifying them
+   * as such let cleanupOldAgents sweep live `pending` `--after` teammates past
+   * the cap (RUSH-2356). Filter on `isTerminalStatus`, never `!== RUNNING`.
+   */
   async listCompleted(): Promise<AgentProcess[]> {
     const all = await this.listAll();
-    return all.filter(a => a.status !== AgentStatus.RUNNING);
+    return all.filter(a => isTerminalStatus(a.status));
   }
 
   async listByTask(taskName: string): Promise<AgentProcess[]> {
@@ -2615,6 +2776,10 @@ export class AgentManager {
   }
 
   private async cleanupOldAgents(): Promise<void> {
+    // listCompleted() is terminal-only (isTerminalStatus), so a pending or
+    // running teammate is never a reap candidate — retention can only delete a
+    // record whose process has finished. (RUSH-2356: the old `!== RUNNING`
+    // filter reaped live `pending` `--after` teammates.)
     const completed = await this.listCompleted();
     if (completed.length > this.maxAgents) {
       completed.sort((a, b) => {

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -1690,6 +1690,60 @@ export class AgentManager {
     debug(`Loaded ${loadedCount} agents from disk`);
   }
 
+  /**
+   * Validate an add's name uniqueness and `--after` dependency graph, without
+   * any side effects. Throws a user-facing error on: a duplicate name, `--after`
+   * without `--name`, an unknown dependency, or a cycle. Returns the cleaned
+   * (whitespace-filtered) `after` list.
+   *
+   * Extracted from spawn() so the command layer can run it BEFORE creating a
+   * worktree — a rejected add must not leave an orphan `agents/<name>` branch
+   * that then breaks the retry with `fatal: a branch ... already exists`
+   * (RUSH-2356). spawn() calls it too, so validation lives in exactly one place.
+   */
+  async validateAddPreconditions(
+    taskName: string,
+    name: string | null,
+    after: string[],
+  ): Promise<string[]> {
+    await this.initialize();
+    const siblings = await this.listByTask(taskName);
+    if (name && siblings.some((a) => a.name === name)) {
+      throw new Error(
+        `Team '${taskName}' already has a teammate named '${name}'. Pick another name or leave --name off.`,
+      );
+    }
+
+    const cleanAfter = after.filter((s) => s && s.trim());
+    if (cleanAfter.length > 0) {
+      if (!name) {
+        throw new Error(
+          "Can't use --after without --name. Dependencies reference teammates by name.",
+        );
+      }
+      // Every --after entry must resolve to an existing teammate name.
+      const siblingNames = new Set(siblings.map((a) => a.name).filter(Boolean) as string[]);
+      const missing = cleanAfter.filter((dep) => !siblingNames.has(dep));
+      if (missing.length > 0) {
+        throw new Error(
+          `Team '${taskName}' has no teammate named ${missing.map((m) => `'${m}'`).join(', ')} yet.\n` +
+            `  Add them first, then add this one.`,
+        );
+      }
+      // Cycle check: walk the transitive deps of each --after entry; if the
+      // new teammate's own name shows up, we'd create a cycle.
+      const byName = new Map(siblings.filter((a) => a.name).map((a) => [a.name as string, a]));
+      for (const dep of cleanAfter) {
+        if (hasTransitiveDep(byName, dep, name)) {
+          throw new Error(
+            `Adding '${name}' after '${dep}' would create a cycle (${dep} already depends on ${name}).`,
+          );
+        }
+      }
+    }
+    return cleanAfter;
+  }
+
   async spawn(
     taskName: string,
     agentType: AgentType,
@@ -1728,42 +1782,10 @@ export class AgentManager {
       parentSessionId = process.env.AGENTS_SESSION_ID ?? null;
     }
 
-    // Enforce: teammate names are unique within a team.
-    const siblings = await this.listByTask(taskName);
-    if (name && siblings.some((a) => a.name === name)) {
-      throw new Error(
-        `Team '${taskName}' already has a teammate named '${name}'. Pick another name or leave --name off.`
-      );
-    }
-
-    // --- dependency validation ---
-    const cleanAfter = after.filter((s) => s && s.trim());
-    if (cleanAfter.length > 0) {
-      if (!name) {
-        throw new Error(
-          "Can't use --after without --name. Dependencies reference teammates by name."
-        );
-      }
-      // Every --after entry must resolve to an existing teammate name.
-      const siblingNames = new Set(siblings.map((a) => a.name).filter(Boolean) as string[]);
-      const missing = cleanAfter.filter((dep) => !siblingNames.has(dep));
-      if (missing.length > 0) {
-        throw new Error(
-          `Team '${taskName}' has no teammate named ${missing.map((m) => `'${m}'`).join(', ')} yet.\n` +
-            `  Add them first, then add this one.`
-        );
-      }
-      // Cycle check: walk the transitive deps of each --after entry; if the
-      // new teammate's own name shows up, we'd create a cycle.
-      const byName = new Map(siblings.filter((a) => a.name).map((a) => [a.name as string, a]));
-      for (const dep of cleanAfter) {
-        if (hasTransitiveDep(byName, dep, name)) {
-          throw new Error(
-            `Adding '${name}' after '${dep}' would create a cycle (${dep} already depends on ${name}).`
-          );
-        }
-      }
-    }
+    // Validate name uniqueness + --after deps. Throws on any violation. The
+    // command layer calls this BEFORE creating a worktree so a rejected add
+    // never leaves an orphan `agents/<name>` branch behind (RUSH-2356).
+    const cleanAfter = await this.validateAddPreconditions(taskName, name, after);
 
     // Resolve and validate cwd
     let resolvedCwd: string | null = null;


### PR DESCRIPTION
**fix — teams teammate-state reliability (RUSH-2356 + RUSH-2366).** Closes three
silent-success defects (exit 0, a success message, no work done) that stranded a
real 5-track swarm, plus a folded-in fourth. No UI surface — CLI/lib change.

## What changed

| # | Defect | Fix |
|---|--------|-----|
| RUSH-2356 | `teams add --after` printed a success block but persisted nothing | `listCompleted()` is now terminal-only (`isTerminalStatus`), so `cleanupOldAgents()` can never reap a live `pending` teammate past the 50-record cap; `spawn()` asserts the record is durably on disk after the write (fails loud otherwise). |
| RUSH-2356 (2nd) | a rejected add left an orphan `agents/<name>` branch → retry died on `branch already exists` | validate name/`--after` **before** creating the worktree (`validateAddPreconditions`); tear the worktree down if the add still fails. |
| RUSH-2366 | a dead teammate reported `RUNNING` forever; `resume` refused to relaunch | a remote process GONE-without-a-sentinel is reconciled to `failed` (three-state `ALIVE`/`EXITED`/`GONE` probe); `adoptDiskTerminalIfNewer` stops a stale in-memory `running` clobbering a newer on-disk terminal; `rescanFromDisk` refreshes cached teammates → stop-then-resume always relaunches. |
| RUSH-2366 (folded) | `agents message` couldn't reach a detached `--device --no-follow` dispatch | resolve the host dispatch records `agents hosts ps` reads; forward over ssh when running+session-id known, else fail loud naming the host. |

The `agents message` defect was **folded into RUSH-2366** (same teammate/dispatch
steerability surface, same delivery), not filed separately — noted here per the ask.

## Key files
- `apps/cli/src/lib/teams/agents.ts` — `TERMINAL_STATUSES`/`isTerminalStatus`, terminal-only `listCompleted`, spawn durability postcondition, `validateAddPreconditions`, three-state remote liveness (`RemoteLivenessSnapshot`/`remoteLivenessSnippet`/`probeRemoteLiveness`), `adoptDiskTerminalIfNewer`, `rescanFromDisk` refresh.
- `apps/cli/src/commands/teams.ts` — validate-before-worktree, orphan-worktree cleanup on failure.
- `apps/cli/src/commands/message.ts` + `apps/cli/src/lib/hosts/message-target.ts` — detached-dispatch resolution + ssh forward / actionable failure.

## Proof — ran the real code paths (no mocking of the code under test; ssh boundary stubbed)

`npx vitest run --reporter verbose agents.reliability.test.ts hosts/message-target.test.ts` — **16/16**:

```
✓ RUSH-2356 > listCompleted() returns only terminal statuses (never pending/running)
✓ RUSH-2356 > cleanup past the 50-record cap never deletes a pending --after teammate
✓ RUSH-2356 > spawn() persists the record durably — loadFromDisk finds it
✓ RUSH-2356 > validateAddPreconditions rejects a duplicate name and an unknown --after dep
✓ RUSH-2366 > parseRemoteLivenessState distinguishes ALIVE / EXITED / GONE
✓ RUSH-2366 > a local teammate whose pid is dead is marked FAILED on refresh
✓ RUSH-2366 > a --device teammate whose process is GONE (no exit sentinel) is marked FAILED
✓ RUSH-2366 > a still-ALIVE --device teammate stays RUNNING (no false reap)
✓ RUSH-2366 > a transient ssh failure never reaps a --device teammate
✓ RUSH-2366 > a stale in-memory RUNNING never clobbers a newer on-disk terminal status
✓ RUSH-2366 > rescanFromDisk refreshes a cached teammate that disk latched terminal
✓ message-target > forwards a running dispatch that has a session id
✓ message-target > unreachable (recovery hint) when running but no session id yet
✓ message-target > unreachable (points at logs) once the dispatch has finished
✓ message-target > labels by id when launched without --name
✓ message-target > findTaskByName / findTaskBySessionId read the same <id>.json records
 Test Files  2 passed (2)   Tests  16 passed (16)
```

Affected suites (`teams/` + `hosts/` + `teams.message`): **553 passed, 1 skipped**.
Terminal-styled render of the run: `yosemite-s1:/tmp/teamsfix-artifact/teamsfix-tests.html`.

**On `test:remote`:** the crabbox path can't run from this worktree — it lives under
the gitignored `.agents/worktrees/`, so crabbox's git-aware sync skips the tree
(`No packages / Script not found build`, not a test failure). This PR's `test` CI
check runs the same suite in a clean checkout, which is the clean-env gate. The broad
local failures (`exec`, `crabbox`, `monitors`, `feed`, `usage`, …) are pre-existing
environment noise in subsystems this diff doesn't touch — none are teams/message/hosts.

## Docs + CHANGELOG
- `apps/cli/.changelog/next/teams-reliability.md`
- `apps/cli/docs/hosts.md` — messaging a detached dispatch.

Tickets: RUSH-2356, RUSH-2366.
