### PR TITLE
docs(routines): define execution reliability contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,23 +1014,29 @@ agents secrets list   # EXPIRING column flags secrets due in the next 30 days
 agents routines add daily-digest \
   --schedule "0 9 * * 1-5" \
   --agent claude \
+  --project-anchor agents-cli \
+  --cwd apps/cli \
   --prompt "Review yesterday's PRs and summarize key changes"
 
 agents routines list                   # All jobs + next run times
 agents routines run daily-digest       # Test it now, ignore the schedule
 agents routines logs daily-digest      # Last execution — status + report (add --full for raw stdout)
+agents routines runs daily-digest      # Every attempt, including blocked/skipped pre-session runs
+agents routines doctor daily-digest    # Project/CWD/trust/write/auth readiness
 agents routines stats                  # Run count, failed, missed, avg/p50/p95 duration — per job or all
 
 # Definitions sync to every device; activation is stored per hostname
 agents routines add nightly-drain --schedule "0 3 * * *" --agent claude \
+  --cwd '~' \
   --prompt "Drain the local work queue"
 
-agents routines devices nightly-drain --set yosemite-s0,mac-mini  # enable on both hosts
+agents routines devices nightly-drain --set yosemite-s0           # one schedule owner
 agents routines list --host yosemite-s0                            # query another device
 
 # Signed webhook trigger: Linear issue labeled "agent" fires a routine
 agents routines add agent-labeled-issue --on linear:Issue --action update \
   --team-key RUSH --label agent --agent claude \
+  --cwd '~' \
   --prompt "Work the Linear issue that was just labeled agent"
 agents webhook serve --secrets-bundle webhooks --port 8787          # /hooks/linear, /hooks/github
 agents funnel up yosemite-s0 --local-port 8787 --port 443           # public HTTPS ingress

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -101,6 +101,14 @@ reliability contract — context resolution, readiness/pause-on-blocker, single-
 (RT-1..RT-11) and §Scheduling & execution singularity (SING-11..SING-13); much of it
 is `[Intended]` (RUSH-2290), and each requirement marks landed vs intended.
 
+Routine execution context is separate from grouping and repository identity.
+Plural `projects` is metadata-only; singular `project` selects one `ProjectDef`
+execution base; `cwd` is resolved on the eventual execution device. A rootless
+Linear project may still use a relative `cwd`, which anchors at that target user's
+home. `repo` remains GitHub/cloud/webhook identity and MUST NOT be used to infer a
+local checkout. Readiness failures save valid definitions paused through device
+activation; they never write mutable activation into routine YAML.
+
 ### 8. Self-updating agents are ONE binary, not fictional version-homes
 
 Some harnesses (droid, grok, antigravity, cursor, hermes, muse, kiro, goose) install

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -157,6 +157,8 @@ devices:                      # optional: the ONE device that owns this routine
   - yosemite-s0               # omit entirely (or --clear) to run on every device
 projects:                     # optional: organises the routine under a project group in `list`
   - myapp                     # single name → "myapp" group; ["*"] → All projects
+project: myapp                # optional: singular execution anchor from `agents projects`
+cwd: apps/api                 # optional: portable execution directory (see below)
 # source:                     # set by `agents routines enable-project` / sync
 #   kind: project
 #   projectPath: /path/to/repo
@@ -175,6 +177,64 @@ allow:
     - Read
     - Grep
 ```
+
+### Execution project and working directory
+
+`projects` and `project` are intentionally different:
+
+- `projects` is a repeatable grouping tag. It affects list/menu organization only.
+- `project` is a singular execution anchor. The CLI resolves its
+  `defaultPath`, falling back to `root`, on the device that will execute the
+  routine.
+- `cwd` selects the execution directory. A relative value is joined to the
+  execution project's base. When the project was imported from Linear without a
+  local `root`/`defaultPath`, or no project is selected, a relative `cwd` is
+  joined to the execution device user's home directory.
+
+The daemon process's own current directory is never an execution default. `repo`
+identifies the external GitHub/cloud/webhook repository and does not determine a
+local checkout path.
+
+```yaml
+# A Linear-imported project may have tracker identity but no checkout binding.
+# This still runs from $HOME/src/github.com/acme/app on the selected device.
+project: acme-app
+cwd: src/github.com/acme/app
+```
+
+For agent and workflow routines, omitting both `project` and `cwd` is incomplete
+setup. The definition is saved but remains paused. Command routines may use the
+target user's home because device-local housekeeping commands commonly operate
+there. Absolute paths outside the user's home are local-device-only; host, fleet,
+and cloud placement rejects them as non-portable.
+
+Creation, edit, and resume all run the same readiness entry point. Every placement
+gets structural project/CWD and portability checks. Local agent routines also
+check the local directory, installed harness, live authentication, and Codex
+workspace trust. An explicit host placement additionally resolves the target's
+HOME/project catalog, proves reachability and real write access there, and probes
+the target harness. Fleet and cloud placement cannot prove a selected target at
+definition time, so target-dependent checks are deferred to the run path and any
+failure remains recorded in attempt history. Workflow and command routines receive
+the structural checks that apply to their execution path. A syntactically valid
+definition with a proven blocker is saved paused with a stable finding and repair
+command. `resume` reruns readiness and does not bypass it.
+
+```bash
+agents routines add morning-briefing \
+  --project-anchor acme-app \
+  --cwd src/github.com/acme/app \
+  --schedule "0 8 * * 1-5" \
+  --agent claude \
+  --prompt "Summarize the pipeline"
+
+agents routines doctor morning-briefing --fix
+agents routines resume morning-briefing
+```
+
+Raw YAML editing is transactional: `agents routines edit <name> --yaml` edits a
+temporary copy, then parses and validates it before replacing the live definition.
+Invalid YAML leaves the prior definition and activation untouched.
 
 ### One-Shot Jobs
 
@@ -1239,15 +1299,20 @@ agents routines add <name> --schedule "0 9 * * *" --agent claude --prompt "..." 
 agents routines add <name> --devices yosemite-s0 --schedule "0 3 * * *" \
   --agent claude --prompt "..."       # Add with device allowlist
 agents routines add <name> --project myapp --schedule "0 9 * * *" \
-  --agent claude --prompt "..."       # Tag to a named project (repeatable)
+  --agent claude --prompt "..."       # Group under a named project (repeatable metadata)
+agents routines add <name> --project-anchor myapp --cwd apps/api \
+  --schedule "0 9 * * *" --agent claude --prompt "..."  # Execution context
 agents routines add <name> --all-projects --schedule "0 9 * * *" \
   --agent claude --prompt "..."       # Tag to all defined projects
 agents routines add <path.yml>        # Add from YAML file
 agents routines add <name> --at "14:30" --agent claude --prompt "..."            # One-shot
-agents routines edit <name>           # Open job in $EDITOR
+agents routines edit <name>           # Transactional temporary-YAML editor
+agents routines edit <name> --yaml    # Same editor; explicit compatibility flag
 agents routines remove <name>         # Delete a job
 agents routines pause <name>          # Disable a job
 agents routines resume <name>         # Re-enable a paused job
+agents routines doctor <name>         # Check execution context + harness readiness
+agents routines doctor --all --fix    # Apply safe deterministic readiness repairs
 
 # Device allowlist management
 agents routines devices <name>                         # Interactive multi-select picker
@@ -1258,7 +1323,7 @@ agents routines devices <name> --clear                 # Disable on every regist
 agents routines run <name>            # Run immediately in foreground
 agents routines run <name> --host yosemite-s0  # Run on a specific remote device
 agents routines view <name>           # Show job config
-agents routines runs <name>           # View execution history (last 10)
+agents routines runs <name>           # Attempt history (session optional)
 agents routines stats                 # Run count/failed/missed/avg/p50/p95 duration, every job
 agents routines stats <name>          # Same rollup, scoped to one job
 agents routines logs <name>           # Show concise summary from latest run
@@ -1311,10 +1376,22 @@ agents routines status    # Check health, PID, binary, heartbeat, and upcoming r
 
 The scheduler **auto-starts on the first `agents routines add`**, so in most cases you never invoke `start` manually. When you `add`, `remove`, `pause`, or `resume` a job, it auto-reloads -- no manual restart needed.
 
-Scheduled fires are single-flight per routine. If the previous execution is still
-running, the next cron, catchup, or monitor fire exits without spawning another
-process. The claim is shared across CLI processes, so two simultaneous dispatchers
-cannot both pass the running-run check.
+Scheduled fires use two independent guards. An atomic slot claim keyed by routine
+name and the intended UTC schedule time ensures a delivered slot launches once,
+including across daemon reloads. A separate active-run claim prevents a routine
+from overlapping itself across scheduled, catch-up, webhook, detached, and manual
+foreground paths. A later slot while work is active writes a `skipped` attempt
+linked to the active run and spawns no process.
+
+Every requested attempt receives run metadata before placement, account selection,
+sandbox construction, readiness, or dispatch. `blocked` means the readiness gate
+prevented entry into placement; `failed` means placement, dispatch, or execution
+failed after the run path began;
+`skipped` means another slot/active/owner claim won. Routine history is therefore
+complete even when no transcript was created. `agents sessions --routines` builds
+its routine picker from definitions and run directories so zero-session routines
+remain selectable, but its result rows are archived sessions. Use `agents routines
+runs <name>` for canonical attempt history, including attempts with no transcript.
 
 `agents routines status` reports the scheduler as `running`, `wedged`, or `stopped`. A live PID whose heartbeat is more than three monitor ticks old is `wedged`; the status output includes the restart command. Both `routines list` and `routines status` also finalize orphaned `running` records before rendering. Run metadata records process birth time to reject recycled PIDs and persists the configured execution deadline. Detached children are killed when that deadline expires, including after a scheduler restart.
 

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -2356,6 +2356,24 @@ nothing but its own view cache.
   Routine definitions MUST NOT carry mutable `enabled:` or `devices:` activation fields. The same
   definition MAY be active on multiple devices when its input is device-local;
   shared-input work still requires the single-executor safeguards in SING-7.
+- **SING-5b (MUST).** Every scheduled occurrence MUST have a deterministic UTC
+  slot identity and MUST be atomically claimed before dispatch. Redelivery of the
+  same `(routine, scheduledFor)` slot MUST resolve to the existing attempt and
+  MUST NOT spawn a second process. Catch-up claims protect missed-fire recovery;
+  they do not replace the ordinary scheduled-slot claim.
+- **SING-5c (MUST).** A routine MUST NOT overlap itself across any entry point,
+  including manual foreground, detached, cron, catch-up, webhook, host, fleet,
+  and cloud execution. A losing request MUST produce an inspectable skipped result
+  linked to the active run and MUST NOT spawn.
+- **SING-5d (MUST).** Routine execution context MUST be resolved on the eventual
+  execution target from the singular project anchor and portable `cwd`. Plural
+  `projects` metadata and external `repo` identity MUST NOT affect the working
+  directory. A proven path, trust, write, authentication, reachability, or
+  placement blocker MUST leave the definition paused rather than defer failure to
+  its next schedule.
+- **SING-5e (MUST).** Run metadata MUST be allocated before pre-spawn work so every
+  blocked, skipped, failed, timed-out, missed, and completed attempt remains
+  inspectable without requiring an archived session transcript.
 - **SING-6 (MUST).** A new fleet-affecting feature MUST be implemented in
   `apps/cli` (daemon routine and/or command) first; the UI PR adds rendering and
   control wiring only. If the feature seemingly requires UI-side execution, SING-3


### PR DESCRIPTION
Docs-only follow-up for the routine reliability runtime merged in #2341.

## Audience

End users creating and debugging routines, plus maintainers changing scheduler/execution behavior.

## What changed

- Documents `project` as the singular execution anchor and `cwd` as the portable target path.
- Defines readiness/activation behavior for add, edit, resume, doctor, explicit hosts, fleet, cloud, and workflows.
- Specifies single-fire schedule slots, active-run skips, crash-recoverable launcher claims, and pre-session history.
- Explains `agents sessions --routines` discovery versus canonical `agents routines runs` history.
- Adds RFC-2119 and Given/When/Then coverage to the normative specification.

## Verification

- `npm run verify:index`: passed.
- `npm run verify-docs`: passed.
- Current-main TypeScript build: passed.

## Tracking

- Linear: RUSH-2290
- Plan: https://share.agents-cli.sh/muqsitnawaz/agents-cli-routine-reliability-5975559096b19ff4
- Supersedes #2337, whose approved docs diff was reapplied to current main.