### PR TITLE
fix(daemon): preserve state-root deletion signal

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2367.md
+++ b/apps/cli/.changelog/next/RUSH-2367.md
@@ -3,8 +3,10 @@
   processes were found alive on a fleet box for up to 3.5 days, each spawned by a
   vitest fixture under its own `/tmp` `HOME` and invisible to every `agents daemon`
   guard, since a different `HOME` resolves a different state dir and instance registry.
-  The daemon now polls (`AGENTS_DAEMON_STATE_DIR_CHECK_MS`, default 60s) whether its own
-  state dir still exists on disk and exits gracefully if it does not — the only defense
+  The daemon now polls (`AGENTS_DAEMON_STATE_DIR_CHECK_MS`, default 60s) for a
+  per-lifetime marker and exits gracefully if it disappears — unlike the pid and
+  heartbeat files, status repair cannot recreate that marker after deleting the state
+  tree. This is the only defense
   that survives the whole test runner being killed externally before any in-test cleanup
   can run. The routines test suite also gained a leak detector that fails the run and
   force-kills anything it spawned (or, on CI, any daemon it finds under its own fixture

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -32,6 +32,7 @@ import { reapTerminalRoutineProcesses } from './routine-process-cleanup.js';
 import { recordSubsystemOk, recordSubsystemError, SUBSYSTEM_SECRETS_BROKER, SUBSYSTEM_BROWSER_IPC } from './daemon-health.js';
 
 const PID_FILE = 'daemon.pid';
+const LIFETIME_FILE = 'daemon.lifetime';
 const LOCK_FILE = 'daemon.lock';
 const LOG_FILE = 'logs.jsonl';
 const HEARTBEAT_FILE = 'heartbeat.json';
@@ -545,6 +546,12 @@ export async function runDaemon(): Promise<void> {
     // rather than a failure to restart-flap on.
     process.exit(0);
   }
+  // Unlike the pid and heartbeat files, this marker is written exactly once
+  // for this daemon lifetime. Status probes deliberately repair those other
+  // files, so they cannot prove that the original state tree still exists.
+  const lifetimePath = path.join(getDaemonDirRoot(), LIFETIME_FILE);
+  const lifetimeToken = `${process.pid}:${Date.now()}`;
+  fs.writeFileSync(lifetimePath, lifetimeToken, 'utf-8');
   log('INFO', `Daemon started (PID: ${process.pid})`);
 
   anchorDaemonCwd();
@@ -923,15 +930,22 @@ export async function runDaemon(): Promise<void> {
   // daemon in that state: no `agents daemon` command targets it, since a
   // different HOME resolves a different getDaemonDir() and therefore a
   // different instance registry — without this it runs forever. Reads
-  // getDaemonDirRoot() directly, never the local getDaemonDir() wrapper,
-  // which recreates the directory as a side effect and would defeat the very
-  // check it exists to perform.
+  // Reads the lifetime marker directly, never the local getDaemonDir() wrapper,
+  // which recreates the directory as a side effect and would defeat the check.
+  // Heartbeat/status paths may recreate the directory and pid file after a
+  // deletion; they never recreate this per-lifetime token.
   let checkingStateDir = false;
   const runStateDirSelfCheck = (): void => {
     if (checkingStateDir) return;
     checkingStateDir = true;
     try {
-      if (!fs.existsSync(getDaemonDirRoot())) {
+      let markerMatches = false;
+      try {
+        markerMatches = fs.readFileSync(lifetimePath, 'utf-8') === lifetimeToken;
+      } catch {
+        // A missing state tree or marker is the condition this guard detects.
+      }
+      if (!markerMatches) {
         log('WARN', `Daemon state dir ${getDaemonDirRoot()} no longer exists; exiting (self-terminate guard)`);
         void handleShutdown();
       }
@@ -990,6 +1004,11 @@ export async function runDaemon(): Promise<void> {
     clearInterval(brokerSelfHealInterval);
     clearInterval(keychainReapInterval);
     clearInterval(stateDirCheckInterval);
+    try {
+      if (fs.readFileSync(lifetimePath, 'utf-8') === lifetimeToken) fs.unlinkSync(lifetimePath);
+    } catch {
+      // Already removed with the state tree, or replaced by a newer owner.
+    }
     hostedBroker?.close();
     removeDaemonPid();
     removeHeartbeat();


### PR DESCRIPTION
Fixes the daemon self-termination race that blocked the 1.22.32 release.

## What changed

- write a per-daemon lifetime token immediately after the singleton claim
- detect deletion through that token, which heartbeat and pid-file repair cannot recreate
- remove only the current owner token during graceful shutdown
- update the existing RUSH-2367 changelog fragment

## Verification

No visual surface: daemon runtime fix.

```text
node v26.0.0
src/lib/daemon.test.ts: 60/60 passed
daemon.test.ts passed 5/5 repeated runs
```

Release CI failure reproduced on PR #2350 at `src/lib/daemon.test.ts:768` on Ubuntu Node 24 and macOS Node 22/24.