### PR TITLE
test(cli): accept the Windows directory code in the two remaining doctor sites

### DIFF
--- a/apps/cli/src/commands/doctor.test.ts
+++ b/apps/cli/src/commands/doctor.test.ts
@@ -411,7 +411,10 @@ describe('doctor generated hook runtime integration (RUSH-2382)', () => {
     expect(payload.hookRuntimeRepair.attempts).toHaveLength(1);
     expect(payload.hookRuntimeRepair.attempts[0]).toMatchObject({ attempted: true, repaired: false });
     expect(payload.hookRuntimeRepair.needsAttention).toHaveLength(1);
-    expect(payload.hookRuntimeRepair.needsAttention[0]).toContain('repair failed [EISDIR]');
+    // Replacing a directory reports EISDIR on POSIX and EPERM on Windows.
+    // Both are stable platform-native codes; neither exposes the temp path.
+    const expectedCode = process.platform === 'win32' ? 'EPERM' : 'EISDIR';
+    expect(payload.hookRuntimeRepair.needsAttention[0]).toContain(`repair failed [${expectedCode}]`);
     expect(fs.existsSync(cachePath)).toBe(false);
   });
 
@@ -436,7 +439,10 @@ describe('doctor generated hook runtime integration (RUSH-2382)', () => {
     expect(payload.hookRuntimeRepair.attempts).toHaveLength(1);
     expect(payload.hookRuntimeRepair.attempts[0]).toMatchObject({ attempted: true, repaired: false });
     expect(payload.hookRuntimeRepair.needsAttention).toHaveLength(1);
-    expect(payload.hookRuntimeRepair.needsAttention[0]).toContain('repair failed [EISDIR]');
+    // Replacing a directory reports EISDIR on POSIX and EPERM on Windows.
+    // Both are stable platform-native codes; neither exposes the temp path.
+    const expectedCode = process.platform === 'win32' ? 'EPERM' : 'EISDIR';
+    expect(payload.hookRuntimeRepair.needsAttention[0]).toContain(`repair failed [${expectedCode}]`);
     expect(payload.hookRuntimeRepair.needsAttention[0]).not.toContain('.tmp.');
     expect(fs.existsSync(cachePath)).toBe(false);
   });


### PR DESCRIPTION
**test-only** — no production code changes. Unblocks the `windows` leg for every PR based on current `main`.

## The failure

```
FAIL src/commands/doctor.test.ts > doctor generated hook runtime integration (RUSH-2382)
  > --fix runs one bounded repair and exits nonzero when the wrapper remains unusable
  > --fix records a Claude rewire failure, then still runs one bounded runtime repair

AssertionError: expected 'hook shim runtime-guard: repair faile…' to contain 'repair failed [EISDIR]'
```

Observed on the `windows` leg of PR #2334 (run 31229367457, job 93030022772). Linux and macOS pass.

## Cause

Replacing a directory reports **`EISDIR` on POSIX** and **`EPERM` on Windows**. Commit `eada7c2ef` (*test(cli): accept Windows directory replacement code*) already established this and switched one assertion to a platform-derived code:

```ts
// Replacing a directory reports EISDIR on POSIX and EPERM on Windows.
// Both are stable platform-native codes; neither exposes the temp path.
const expectedCode = process.platform === 'win32' ? 'EPERM' : 'EISDIR';
```

Two sites in `doctor.test.ts` (lines 414 and 439) still hardcoded `EISDIR` and were missed by that pass.

## The change

Applies the identical pattern to both remaining sites. The POSIX expectation is unchanged, so this narrows nothing on Linux or macOS — it only stops asserting a POSIX-specific errno on Windows.

## Verification

```
$ bun x tsc --noEmit -p .      # clean
$ bun x vitest run src/commands/doctor.test.ts -t "hook runtime"
 Test Files  1 passed (1)
      Tests  5 passed | 40 skipped (45)
```

The Windows leg on this PR is the real confirmation — the failure only reproduces there.