### PR TITLE
feat(menubar): collapsible project-group accordion for ROUTINES

### DIFF
--- a/apps/cli/.changelog/next/menubar-routines-accordion.md
+++ b/apps/cli/.changelog/next/menubar-routines-accordion.md
@@ -1,0 +1,12 @@
+- **Menu bar: the ROUTINES section is now a collapsible project-group accordion.**
+  Routines render the same way ACTIVE sessions do — one collapsible header per
+  project group (a project name, or the `Operations` / `All projects` /
+  `Cross-project` specials the CLI derives from each routine's `projects:` field),
+  collapsed by default, click `▶` to fold every routine in that group inline. Each
+  header carries per-state glyph counts (`◔` upcoming, `✕` failing, `⃠` missed,
+  `⏸` not-ready) and a paused tail, so a collapsed group still shows what is inside
+  it; the header row also names the group count (`ROUTINES · … · N groups`).
+  Expanding a group orders it attention-first, then by next run, then paused last.
+  This replaces the flat group labels plus the single "All routines…" flyout for a
+  CLI that emits `projectGroup`; an older CLI falls back to the previous view.
+  Source: `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift`.

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -24,6 +24,7 @@ enum IssueSelfTest {
         testDraftPreservation()
         testRoutineFailureReason()
         testRoutineGrouping()
+        testRoutineGroupAccordion()
         testLinearProjectResolution()
         testLinearTicketRanking()
         testLinearTicketFilter()
@@ -391,6 +392,51 @@ enum IssueSelfTest {
         // Empty input.
         let (g3, u3) = groupedRoutines([])
         check("empty input yields empty output", g3.isEmpty && u3.isEmpty)
+    }
+
+    // The ROUTINES accordion: header summaries carry per-state glyph counts, the
+    // header group count includes an ungrouped tail, and an expanded group orders
+    // attention-first / next-run / paused-last.
+    private static func testRoutineGroupAccordion() {
+        let ok1     = routine(name: "seo-draft", nextRun: "2026-08-07T18:00:00Z")
+        let ok2     = routine(name: "blog-draft", nextRun: "2026-08-07T09:00:00Z")
+        let failing = routine(name: "usage-refresh", lastStatus: "failed", exitCode: 1)
+        let missed  = routine(name: "device-probe", lastStatus: "missed", overdue: true)
+        let paused  = routine(name: "release-train", enabled: false)
+
+        // Summary: label + glyph counts (◔ ok, ✕ failing, ⃠ miss) + paused tail.
+        // Whole-string equality — `⃠` is a combining scalar, so a `.contains("⃠1")`
+        // substring check would split its grapheme cluster and spuriously fail.
+        let summary = routineGroupSummary(label: "Operations",
+                                          routines: [ok1, ok2, failing, missed, paused])
+        check("summary is label + per-state glyph counts + paused tail",
+              summary == "Operations  ·  ◔2 ✕1 ⃠1  ·  1 paused", detail: summary)
+
+        // A clean, all-enabled group shows only the ◔ count, no paused tail.
+        let clean = routineGroupSummary(label: "agents-cli", routines: [ok1])
+        check("a clean single-routine group is just label + ◔1",
+              clean == "agents-cli  ·  ◔1", detail: clean)
+
+        // Header group count: named groups + one bucket for the ungrouped tail.
+        let grouped = [routine(name: "a", projectGroup: "agents-cli"),
+                       routine(name: "b", projectGroup: "rush-app"),
+                       routine(name: "c", projectGroup: nil)]
+        check("group count includes the ungrouped tail as one bucket",
+              routineGroupCount(grouped) == 3, detail: "\(routineGroupCount(grouped))")
+        check("no ungrouped tail is not counted",
+              routineGroupCount([grouped[0], grouped[1]]) == 2)
+
+        // Expanded order: attention first (failing before missed by name), then
+        // enabled by next run (blog 09:00 before seo 18:00), then paused last.
+        let ordered = orderedGroupRoutines([ok1, paused, missed, ok2, failing]).map { $0.name }
+        check("attention routines sort ahead of upcoming and paused",
+              Array(ordered.prefix(2)).sorted() == ["device-probe", "usage-refresh"],
+              detail: ordered.joined(separator: ","))
+        check("upcoming routines sort by next run within the group",
+              ordered[2] == "blog-draft" && ordered[3] == "seo-draft",
+              detail: ordered.joined(separator: ","))
+        check("paused routine sorts to the tail",
+              ordered.last == "release-train", detail: ordered.joined(separator: ","))
     }
 
     // The repo picker drives the ticket scope, so `agents-cli` has to land on the
@@ -764,6 +810,8 @@ enum IssueSelfTest {
         exitCode: Int? = nil,
         failureReason: String? = nil,
         overdue: Bool = false,
+        enabled: Bool = true,
+        nextRun: String? = nil,
         projects: [String]? = nil,
         projectGroup: String? = nil
     ) -> Routine {
@@ -776,9 +824,9 @@ enum IssueSelfTest {
             projectGroup: projectGroup,
             schedule: "0 3 * * *",
             scheduleHuman: nil,
-            enabled: true,
+            enabled: enabled,
             overdue: overdue,
-            nextRun: nil,
+            nextRun: nextRun,
             nextRunHuman: "tomorrow",
             lastStatus: lastStatus,
             exitCode: exitCode,

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -426,8 +426,9 @@ enum IssueSelfTest {
         check("no ungrouped tail is not counted",
               routineGroupCount([grouped[0], grouped[1]]) == 2)
 
-        // Expanded order: attention first (failing before missed by name), then
-        // enabled by next run (blog 09:00 before seo 18:00), then paused last.
+        // Expanded order: attention first (failing + missed, in either order —
+        // the assert sorts them), then enabled by next run (blog 09:00 before
+        // seo 18:00), then paused last.
         let ordered = orderedGroupRoutines([ok1, paused, missed, ok2, failing]).map { $0.name }
         check("attention routines sort ahead of upcoming and paused",
               Array(ordered.prefix(2)).sorted() == ["device-probe", "usage-refresh"],

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -159,6 +159,14 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private var expandedProjects = Set<String>()
     private var projectSessionItems: [String: [NSMenuItem]] = [:]
 
+    // ROUTINES project-group accordion — same in-memory, collapsed-by-default
+    // model as the ACTIVE project accordion, keyed by the routine's project-group
+    // display label (the CLI's `projectGroup`: a project name, or one of the
+    // "Operations" / "All projects" / "Cross-project" specials). Toggling rebuilds
+    // from the warm routines cache with no extra CLI calls.
+    private var expandedRoutineGroups = Set<String>()
+    private var routineGroupItems: [String: [NSMenuItem]] = [:]
+
     // The DEVICES section is ONE collapsible block (collapsed by default), so its
     // state is a single flag + the rows currently shown — not the per-key Set the
     // project accordion needs. Same in-place insert/remove, no CLI on toggle.
@@ -1181,34 +1189,83 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             return
         }
 
-        addSectionTitle(menu, "ROUTINES · \(summary)", color: .secondaryLabelColor)
-        // A routine needing attention is surfaced ONCE, in NEEDS YOU (above) —
-        // this section shows only what's upcoming, plus "All routines…" for the
-        // rest, so the same failure never renders twice in one menu.
-        let failing = routines.filter { routineNeedsAttention($0) }
-        let upcoming = routines
-            .filter { r in r.enabled && !failing.contains(where: { $0.name == r.name }) && r.nextRun != nil }
-            .sorted { ($0.nextRun ?? "") < ($1.nextRun ?? "") }
-            .prefix(3)
-
         let hasGroups = routines.contains { $0.projectGroup != nil }
+        addSectionTitle(menu, "ROUTINES · \(summary)\(hasGroups ? " · \(routineGroupCount(routines)) groups" : "")",
+                        color: .secondaryLabelColor)
+
         if hasGroups {
-            let (grouped, ungrouped) = groupedRoutines(Array(upcoming))
+            // One collapsible header per project group (collapsed by default,
+            // like ACTIVE) — expanding folds every routine in that group inline,
+            // so the whole roster lives here instead of a flat "All routines…"
+            // flyout. A routine needing attention still surfaces in NEEDS YOU
+            // above; its group header carries the ✕/⃠ count so a collapsed group
+            // still shows there is something wrong inside it.
+            let (grouped, ungrouped) = groupedRoutines(routines)
             for (label, group) in grouped {
-                menu.addItem(disabled("  \(label)"))
-                for r in group { menu.addItem(inlineRoutineRow(r)) }
+                let open = expandedRoutineGroups.contains(label)
+                let summaryLine = routineGroupSummary(label: label, routines: group)
+                let header = NSMenuItem(title: summaryLine, action: nil, keyEquivalent: "")
+                let headerView = AccordionRowView(
+                    summary: summaryLine, expanded: open,
+                    accessibilityLabel: "\(label) routines",
+                    accessibilityHelp: "Expand or collapse \(group.count) routine\(group.count == 1 ? "" : "s")",
+                    expandTip: "Expand group", collapseTip: "Collapse group")
+                headerView.onToggle = { [weak self, weak menu, weak header] shouldExpand in
+                    guard let self, let menu, let header else { return }
+                    self.setRoutineGroup(label, expanded: shouldExpand, routines: group,
+                                         in: menu, after: header)
+                }
+                header.view = headerView
+                menu.addItem(header)
+
+                guard open else { continue }
+                let rows = orderedGroupRoutines(group).map { inlineRoutineRow($0) }
+                routineGroupItems[label] = rows
+                for row in rows { menu.addItem(row) }
             }
-            for r in ungrouped { menu.addItem(inlineRoutineRow(r)) }
+            // Routines the CLI could not place in a group (older CLI, or a
+            // group label it did not emit) render flat under the accordion.
+            for r in orderedGroupRoutines(ungrouped) { menu.addItem(inlineRoutineRow(r)) }
         } else {
+            // Fallback for a CLI that emits no `projectGroup`: the pre-accordion
+            // view — top upcoming inline, the rest behind "All routines…".
+            let failing = routines.filter { routineNeedsAttention($0) }
+            let upcoming = routines
+                .filter { r in r.enabled && !failing.contains(where: { $0.name == r.name }) && r.nextRun != nil }
+                .sorted { ($0.nextRun ?? "") < ($1.nextRun ?? "") }
+                .prefix(3)
             for r in upcoming {
                 let row = statusRow("◔", idleC, "\(r.name)  \(r.nextRunHuman ?? r.schedule)")
                 row.submenu = routineSubmenu(r)
                 menu.addItem(row)
             }
+            let all = NSMenuItem(title: "  All routines…", action: nil, keyEquivalent: "")
+            all.submenu = allRoutinesSubmenu(routines)
+            menu.addItem(all)
         }
-        let all = NSMenuItem(title: "  All routines…", action: nil, keyEquivalent: "")
-        all.submenu = allRoutinesSubmenu(routines)
-        menu.addItem(all)
+    }
+
+    /// Mutate only the rows under the clicked routine group, in place — the
+    /// enclosing menu stays in its tracking session and no CLI call runs. Mirrors
+    /// `setProject` for the ACTIVE accordion.
+    private func setRoutineGroup(_ label: String, expanded: Bool, routines: [Routine],
+                                 in menu: NSMenu, after header: NSMenuItem) {
+        if expanded {
+            expandedRoutineGroups.insert(label)
+            let rows = orderedGroupRoutines(routines).map { inlineRoutineRow($0) }
+            routineGroupItems[label] = rows
+            let headerIndex = menu.index(of: header)
+            guard headerIndex >= 0 else { return }
+            for (offset, row) in rows.enumerated() {
+                menu.insertItem(row, at: headerIndex + offset + 1)
+            }
+        } else {
+            expandedRoutineGroups.remove(label)
+            for row in routineGroupItems.removeValue(forKey: label) ?? [] {
+                menu.removeItem(row)
+            }
+        }
+        menu.update()
     }
 
     // One colored inline row for the ROUTINES section. Only ever called with an
@@ -1946,4 +2003,53 @@ func groupedRoutines(_ routines: [Routine]) -> (grouped: [(String, [Routine])], 
         }
     }
     return (order.map { ($0, byGroup[$0]!) }, ungrouped)
+}
+
+/// Distinct project-group count for the ROUTINES header (`… · N groups`) — the
+/// named/special groups plus one bucket for any ungrouped tail.
+func routineGroupCount(_ routines: [Routine]) -> Int {
+    let (grouped, ungrouped) = groupedRoutines(routines)
+    return grouped.count + (ungrouped.isEmpty ? 0 : 1)
+}
+
+/// Header line for one routine project group: the label plus per-state glyph
+/// counts (◔ upcoming/ok · ✕ failing · ⃠ missed · ⏸ not-ready) and a paused tail,
+/// mirroring `ActiveDisplay.projectSummary`'s shape for ACTIVE projects. Pure so
+/// the accordion header text is unit-testable without AppKit.
+func routineGroupSummary(label: String, routines: [Routine]) -> String {
+    var ok = 0, failure = 0, miss = 0, notReady = 0, paused = 0
+    for r in routines {
+        if !r.enabled { paused += 1; continue }
+        switch routineAttentionKind(r) {
+        case .some(.failure): failure += 1
+        case .some(.miss): miss += 1
+        case .some(.notReady): notReady += 1
+        case .none: ok += 1
+        }
+    }
+    var chips: [String] = []
+    if ok > 0 { chips.append("◔\(ok)") }
+    if failure > 0 { chips.append("✕\(failure)") }
+    if miss > 0 { chips.append("⃠\(miss)") }
+    if notReady > 0 { chips.append("⏸\(notReady)") }
+    var parts = [label]
+    if !chips.isEmpty { parts.append(chips.joined(separator: " ")) }
+    if paused > 0 { parts.append("\(paused) paused") }
+    return parts.joined(separator: "  ·  ")
+}
+
+/// Triage order within an expanded group: attention first (failing/missed/
+/// not-ready), then enabled by next run, then paused last.
+func orderedGroupRoutines(_ routines: [Routine]) -> [Routine] {
+    routines.sorted { a, b in
+        func rank(_ r: Routine) -> Int {
+            if routineNeedsAttention(r) { return 0 }
+            if r.enabled { return 1 }
+            return 2
+        }
+        let ra = rank(a), rb = rank(b)
+        if ra != rb { return ra < rb }
+        if ra == 1 { return (a.nextRun ?? "~") < (b.nextRun ?? "~") }
+        return a.name < b.name
+    }
 }

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -425,6 +425,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                          loaded: [LoadedDevice], devices: [Device]) {
         menu.removeAllItems()
         projectSessionItems.removeAll()
+        routineGroupItems.removeAll()
         deviceRowItems.removeAll()
 
         // Prefer the engine's active list once the warm cache has it — full
@@ -588,9 +589,12 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             rows.append(("⚠", wait, "Scheduler stopped — routines won’t run", sub))
         }
 
-        // Failing routines are surfaced HERE ONLY — the ROUTINES section below
-        // renders upcoming runs and "All routines…", never a second copy of the
-        // same failure inline, so a bad routine never shows twice in one menu.
+        // Failing routines LEAD the triage strip here — always visible, no click.
+        // The ROUTINES accordion below is the complete grouped roster (successor
+        // to the old "All routines…" flyout, which likewise listed failing rows):
+        // a failing routine also appears, marked ✕/⃠, in its project group's
+        // expanded rows. That is deliberate — the strip is the always-visible
+        // shortcut, the accordion the full per-project roster — not a bug.
         // Routines sharing an identical cause (same readiness code, or the same
         // lastStatus with no readiness) collapse into one row instead of one
         // per routine — never inventing a shared cause across routines that


### PR DESCRIPTION
**feat(menubar) — user-visible.** The ROUTINES section in the menu-bar dropdown becomes a collapsible project-group accordion, matching how ACTIVE sessions already render.

## Why
Routines showed flat, non-collapsible project-group labels plus a single "All routines…" fly-out, while ACTIVE sessions used a real inline accordion grouped by workspace. Reported: routines read as "not linked to projects" and the display is harder to scan than the sessions one. (The grouping itself is correct — a routine's group is derived purely from its `projects:` YAML field; 22 of 31 routines simply declare no project, so they land in the honest "Operations" bucket.)

## Behavior — before / after
```
  before                              after (click ▶ to fold a group open inline)
  ROUTINES · 31 · 1 paused            ROUTINES · 31 · 1 paused · 6 groups
    agents-cli            (label)     ▶ Operations     ◔18 ✕2 ⃠1
  ◔ perf-watch  today 6PM  ›          ▼ agents-cli     ◔1
    All projects          (label)         ◔ perf-watch · today 6:00 PM  ›
  ◔ linear-hygiene  tmrw   ›          ▶ rush-app       ◔2 · 1 paused
    All routines…            ›        ▶ All projects   ◔2
    (flat + one big flyout)           ▶ Cross-project  ◔2
```
- One collapsible header per project group (collapsed by default, like ACTIVE), keyed by the CLI's `projectGroup`.
- Header carries per-state glyph counts (`◔` upcoming · `✕` failing · `⃠` missed · `⏸` not-ready) + a paused tail, so a **collapsed** group still shows something is wrong inside it. NEEDS YOU still surfaces failures at the top.
- Expanding folds every routine in that group inline (attention-first → next-run → paused-last), replacing the flyout.
- An older CLI that emits no `projectGroup` falls back to the previous upcoming-inline + "All routines…" view.

## How
Reuses the already-shipping `AccordionRowView` + in-place insert/remove pattern that ACTIVE projects use (`setRoutineGroup` mirrors `setProject`; `expandedRoutineGroups` mirrors `expandedProjects`). No new CLI calls on toggle — rebuilds from the warm routines cache. `routineGroupSummary` / `orderedGroupRoutines` / `routineGroupCount` are pure free functions (like `groupedRoutines`).

## Run result — headless self-tests (the build gate)
`swift build` clean; `MENUBAR_ISSUE_TEST` (new accordion cases) + all four gate suites (`SINGLE`/`GUARD`/`CHILD`/`ISSUE`) **ALL PASS**:
```
  PASS  two project groups present
  PASS  summary is label + per-state glyph counts + paused tail
  PASS  group count includes the ungrouped tail as one bucket
  PASS  no ungrouped tail is not counted
  PASS  attention routines sort ahead of upcoming and paused
  PASS  upcoming routines sort by next run within the group
  PASS  paused routine sorts to the tail
ALL PASS
```

**No GUI screenshot:** the menu is a native `NSMenu` that only renders in an aqua session; the build/test shell is headless (AppKit `NSStatusBar` hangs there, the documented `SLSNewConnection` limitation), and the *installed* live menu bar runs the notarized release build, not this change. The rendered structure is proven by the pure-logic self-tests above; the render itself is the exact `AccordionRowView` mechanism ACTIVE already ships.

Transcript: zion:/Users/muqsit/.agents/.history/versions/claude/2.1.217/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/47e32571-5582-4a8b-be05-5383bfacefa6.jsonl
