### PR TITLE
fix(sessions): restore routine run history

### DIFF
--- a/apps/cli/.changelog/next/rush-2403-routine-session-browser.md
+++ b/apps/cli/.changelog/next/rush-2403-routine-session-browser.md
@@ -1,0 +1,1 @@
+`agents sessions --routines` once again opens the routine picker across every working directory instead of an empty current-repository session browser.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -836,9 +836,11 @@ run metadata:
 ```
 
 Those archives are indexed by `agents sessions` with `origin: "routine"`,
-`routineName`, and `routineRunId`. Use `agents sessions --routine --all` (or the
+`routineName`, and `routineRunId`. Use `agents sessions --routine` (or the
 `--routines` alias) to pick a routine interactively, or pass a fuzzy name such
-as `agents sessions --routine nightly-review --all`, to list them. The picker
+as `agents sessions --routine nightly-review`, to list them. Routine discovery
+spans every working directory because a scheduled run is not tied to the shell
+where its history is inspected. The picker
 includes last-run and session-count context, and the selected view groups sessions
 by run ID and timestamp. Use `agents sessions <run-id>` to render the existing session summary view
 for a specific routine run.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -757,10 +757,10 @@ agents sessions --teams   # --team is an alias
 # In the browser, `t` cycles the same filter over the teams in view.
 agents sessions --in-team redesign --teams
 
-# Show routine-run sessions, then open one by routine run id
-agents sessions --routine --all
-agents sessions --routine nightly-review --all
-agents sessions --routines --all      # alias; pick a routine interactively on a TTY
+# Show routine-run sessions across every working directory, then open one by run id
+agents sessions --routine
+agents sessions --routine nightly-review
+agents sessions --routines            # alias; pick a routine interactively on a TTY
 agents sessions 2026-07-21T10-30-00-000Z
 
 # The picker shows last-run/run-count/session-count context. After selection,

--- a/apps/cli/src/commands/__tests__/sessions-team-lineage.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-team-lineage.test.ts
@@ -53,9 +53,9 @@ describe('hasNoBrowserDisqualifyingFlags — which views the browser can represe
     }
   });
 
-  it('routes routine previews and a named team view through the shared browser', () => {
-    expect(hasNoBrowserDisqualifyingFlags({ routine: true }, undefined)).toBe(true);
-    expect(hasNoBrowserDisqualifyingFlags({ routine: 'nightly-review' }, undefined)).toBe(true);
+  it('keeps routine views grouped while routing a named team view through the shared browser', () => {
+    expect(hasNoBrowserDisqualifyingFlags({ routine: true }, undefined)).toBe(false);
+    expect(hasNoBrowserDisqualifyingFlags({ routine: 'nightly-review' }, undefined)).toBe(false);
     expect(hasNoBrowserDisqualifyingFlags({ teams: true, inTeam: 'redesign' }, undefined)).toBe(true);
   });
 

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -21,7 +21,7 @@ import { gatherRemoteList } from '../lib/session/remote-list.js';
 import { resolveVersionAliasLoose } from '../lib/versions.js';
 import { AGENTS } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
-import { enrichTeamOrigins, safeTeamText } from '../lib/session/team-filter.js';
+import { enrichTeamOrigins, safeTeamText, shouldShowTeamSessions } from '../lib/session/team-filter.js';
 import { listBookmarks, toggleBookmark } from '../lib/session/bookmarks.js';
 import { machineId, normalizeHost } from '../lib/session/sync/config.js';
 import { buildPreview } from './sessions-picker.js';
@@ -360,7 +360,7 @@ async function fetchRawPool(
         origin: f.routine ? 'routine' : undefined,
         skill: f.skill,
         plugin: f.plugin,
-        excludeTeamOrigin: !f.teams,
+        excludeTeamOrigin: !shouldShowTeamSessions(f),
         // A team filter reaches back past the usual browse window, so the pool it
         // draws from has to as well — otherwise the newest 500 rows decide which
         // teams exist.

--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -31,6 +31,7 @@ import {
   requestedLiveStatuses,
   parseInstalledAgentVersionQuery,
   buildRoutineChoices,
+  hasNoBrowserDisqualifyingFlags,
 } from './sessions.js';
 import { remoteAgentsJsonCommand } from '../lib/remote-agents-json.js';
 import { NO_FANOUT_ENV } from '../lib/session/remote-active.js';
@@ -63,6 +64,53 @@ describe('routine session catalog', () => {
     expect(buildRoutineChoices([], ['never-ran'])).toEqual([
       { name: 'never-ran', lastRunAt: '', runCount: 0, latestRunSessionCount: 0 },
     ]);
+  });
+
+  it('keeps --routines on the routine-specific picker instead of the generic browser', () => {
+    expect(hasNoBrowserDisqualifyingFlags({ routine: true }, undefined)).toBe(false);
+    expect(hasNoBrowserDisqualifyingFlags({ routine: 'nightly-review' }, undefined)).toBe(false);
+  });
+
+  it('finds a named routine archive outside the invoking directory without --all', () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-routine-cross-cwd-'));
+    try {
+      writeUpdateCache(tempHome);
+      const invokingCwd = path.join(tempHome, 'work', 'unrelated-repo');
+      const routineCwd = path.join(tempHome, 'work', 'scheduled-repo');
+      const sessionId = 'face2403-1111-4222-8333-444455556666';
+      const runId = '2026-08-08T03-00-00-000Z';
+      fs.mkdirSync(invokingCwd, { recursive: true });
+      const archiveDir = path.join(
+        tempHome, '.agents', '.history', 'runs', 'nightly-review', runId,
+        'sessions', 'claude', 'projects', '-scheduled-repo',
+      );
+      fs.mkdirSync(archiveDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(archiveDir, `${sessionId}.jsonl`),
+        JSON.stringify({
+          type: 'user', timestamp: '2026-08-08T03:00:00.000Z', cwd: routineCwd,
+          sessionId, version: '2.1.110', gitBranch: 'main', entrypoint: 'sdk-cli',
+          message: { role: 'user', content: 'inspect the scheduled repository' },
+        }) + '\n',
+        'utf-8',
+      );
+
+      const result = runAgents(
+        ['sessions', '--routine', 'nightly-review', '--json', '--local'],
+        invokingCwd,
+        tempHome,
+      );
+      expect(result.status, result.stderr).toBe(0);
+      const rows = JSON.parse(result.stdout) as SessionMeta[];
+      expect(rows.map((row) => row.id)).toEqual([sessionId]);
+      expect(rows[0]).toMatchObject({
+        origin: 'routine', routineName: 'nightly-review', routineRunId: runId,
+        cwd: routineCwd,
+        isTeamOrigin: true,
+      });
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -41,6 +41,7 @@ import { discoverSessions, queryIndexedSessions, countSessionsInScope, resolveSe
 import { findSessionsById, querySessions, getSessionById } from '../lib/session/db.js';
 import {
   filterTeamSessions,
+  shouldShowTeamSessions,
   safeTeamText,
   groupSessionsByTeam,
   NO_TEAM_GROUP_KEY,
@@ -1729,6 +1730,11 @@ export function hasNoBrowserDisqualifyingFlags(
     !options.skill &&
     !options.plugin &&
     !options.sort &&
+    // --routine without a name owns a two-stage picker (routine -> run ->
+    // session), and a named routine owns the run-grouped overview. The generic
+    // browser can only flatten routine sessions into its ordinary row list, so
+    // routing this flag there silently bypasses both routine-specific views.
+    !options.routine &&
     !options.artifacts &&
     options.artifact === undefined &&
     // --cloud lists a provider's tasks, not the transcript index, and
@@ -2562,6 +2568,11 @@ async function sessionsAction(
   // silently returns nothing for any team older than that — so the flag widens its
   // own scope, the way --all does, unless the caller set an explicit --limit.
   const wantsWholeTeam = !!options.inTeam;
+  // A routine is not tied to the shell's cwd: its archived sessions retain the
+  // working directory in which the scheduled agent actually ran. Scope the
+  // routine catalog across directories so invoking it from ~/.agents/.system,
+  // a project repo, or $HOME yields the same routine history.
+  const wantsWholeRoutine = !!options.routine;
   // `--limit` has a commander default, so an untouched flag still arrives as a
   // string and truthiness can't tell it from a typed one. Commander records where
   // each value came from, which is the only signal that distinguishes an explicit
@@ -2571,7 +2582,7 @@ async function sessionsAction(
   const limit = wantsOverview
     ? OVERVIEW_POOL_LIMIT
     : parseInt(
-        userSetLimit ? options.limit! : wantsWholeTeam ? String(WHOLE_TEAM_POOL_LIMIT) : DEFAULT_LIMIT,
+        userSetLimit ? options.limit! : wantsWholeTeam || wantsWholeRoutine ? String(WHOLE_TEAM_POOL_LIMIT) : DEFAULT_LIMIT,
         10
       );
   if (toolEvidenceMode && (!Number.isSafeInteger(limit) || limit < 1 || limit > TOOL_QUERY_MAX_RESULT_SESSIONS)) {
@@ -2583,7 +2594,7 @@ async function sessionsAction(
   // --since still narrows. Non-overview keeps the prior interactive-30d default.
   const since = wantsOverview
     ? options.since
-    : (options.since ?? (isInteractive && !options.all && !wantsWholeTeam ? '30d' : undefined));
+    : (options.since ?? (isInteractive && !options.all && !wantsWholeTeam && !wantsWholeRoutine ? '30d' : undefined));
   const toolSpansDevices = toolEvidenceMode
     && (options.fleet || (options.host?.length ?? 0) > 0);
   const toolSortError = toolSearchFleetSortError(options.sort, toolSpansDevices);
@@ -2610,12 +2621,12 @@ async function sessionsAction(
       // --in-team spans directories by construction: a team's teammates run in
       // their own worktrees, so scoping to the current cwd hides most of the
       // lineage the flag exists to show.
-      all: pathFilter ? undefined : options.all || wantsWholeTeam || toolSpansDevices,
+      all: pathFilter ? undefined : options.all || wantsWholeTeam || wantsWholeRoutine || toolSpansDevices,
       cwd: process.cwd(),
       // Default overview scopes to the current repo SUBTREE (prefix match), so a
       // monorepo shows its sub-projects grouped instead of collapsing to the one
       // exact-cwd project. `--all` clears the prefix and spans the whole index.
-      cwdPrefix: pathFilter ?? (wantsOverview && !options.all && !wantsWholeTeam && !toolSpansDevices ? process.cwd() : undefined),
+      cwdPrefix: pathFilter ?? (wantsOverview && !options.all && !wantsWholeTeam && !wantsWholeRoutine && !toolSpansDevices ? process.cwd() : undefined),
       project: options.project,
       since,
       until: options.until,
@@ -2651,7 +2662,7 @@ async function sessionsAction(
       const readOptions: DiscoverOptions = {
         ...scope,
         limit,
-        excludeTeamOrigin: !options.teams,
+        excludeTeamOrigin: !shouldShowTeamSessions(options),
         onProgress: tracker.onProgress,
         includeUnmanaged: options.unmanaged,
         onHiddenUnmanaged: (n) => { hiddenUnmanaged = n; },
@@ -2670,7 +2681,7 @@ async function sessionsAction(
     // meta.json in ~/.agents/teams/agents whose is_team_origin flag was
     // never set (legacy rows). Keep the in-memory pass so those are still
     // enriched/hidden.
-    const { visible: visibleSessions } = filterTeamSessions(sessions, !!options.teams);
+    const { visible: visibleSessions } = filterTeamSessions(sessions, shouldShowTeamSessions(options));
     sessions = visibleSessions;
 
     // --in-team spans both ends of the lineage, so it can't be one SQL predicate:
@@ -2753,7 +2764,7 @@ async function sessionsAction(
 
     // Under --in-team the visible list is one team, so the whole-index team-origin
     // count would be a non-sequitur next to it.
-    const hiddenCount = options.teams || options.inTeam
+    const hiddenCount = shouldShowTeamSessions(options) || options.inTeam
       ? 0
       : countSessionsInScope({ ...scope, onlyTeamOrigin: true });
 
@@ -5209,9 +5220,9 @@ export function registerSessionsCommands(program: Command): void {
       # teammate row [<team>/<handle>]. --in-team narrows to one team's lineage.
       agents sessions --in-team redesign --teams
 
-      # Show routine-run sessions and open one by routine run id
-      agents sessions --routine --all
-      agents sessions --routine nightly-review --all
+      # Pick a routine across every directory, then open one of its run sessions
+      agents sessions --routine
+      agents sessions --routine nightly-review
       agents sessions 2026-07-21T10-30-00-000Z
 
       # Export for analysis
@@ -5259,7 +5270,7 @@ export function registerSessionsCommands(program: Command): void {
       - --first and --last are mutually exclusive.
       - A filter flag (--include/--exclude/--first/--last) without --markdown/--json defaults to --markdown output.
       - --cloud sources from Rush Cloud captured runs instead of local disk.
-      - --routine [name] shows transcripts archived from routine runs. On a TTY, omit the name to pick a routine; a name accepts exact, substring, or unambiguous typo matches. --routines is an alias. Routine rows also resolve by run id.
+      - --routine [name] spans every directory and shows transcripts archived from routine runs. On a TTY, omit the name to pick a routine; a name accepts exact, substring, or unambiguous typo matches. --routines is an alias. Routine rows also resolve by run id.
       - Without --teams, team-spawned sessions are hidden by default.
     `,
   });

--- a/apps/cli/src/lib/session/team-filter.test.ts
+++ b/apps/cli/src/lib/session/team-filter.test.ts
@@ -7,6 +7,7 @@ import {
   classifyTeamSession,
   enrichTeamOrigins,
   filterTeamSessions,
+  shouldShowTeamSessions,
   groupSessionsByTeam,
   teamRowKind,
   NO_TEAM_GROUP_KEY,
@@ -24,6 +25,15 @@ function makeSession(overrides: Partial<SessionMeta> = {}): SessionMeta {
     ...overrides,
   };
 }
+
+describe('shouldShowTeamSessions', () => {
+  it('retains team-origin rows for explicit team and routine scopes', () => {
+    expect(shouldShowTeamSessions({})).toBe(false);
+    expect(shouldShowTeamSessions({ teams: true })).toBe(true);
+    expect(shouldShowTeamSessions({ routine: true })).toBe(true);
+    expect(shouldShowTeamSessions({ routine: 'nightly-review' })).toBe(true);
+  });
+});
 
 describe('classifyTeamSession', () => {
   let tmpDir: string;

--- a/apps/cli/src/lib/session/team-filter.ts
+++ b/apps/cli/src/lib/session/team-filter.ts
@@ -160,6 +160,20 @@ export interface FilterResult {
 }
 
 /**
+ * Whether a listing scope must retain team-origin sessions.
+ *
+ * A routine owns every session produced during its run, including teammates and
+ * SDK-launched children. Requiring callers to add `--teams` would make a routine
+ * catalog incomplete and can make team-heavy routines appear to have no runs.
+ */
+export function shouldShowTeamSessions(filters: {
+  teams?: boolean;
+  routine?: boolean | string;
+}): boolean {
+  return !!filters.teams || !!filters.routine;
+}
+
+/**
  * Split `sessions` into visible and hidden (team-origin) groups.
  * When `showTeams` is true every session is visible and `teamOrigin` is
  * populated on team sessions for display. When false, team sessions are


### PR DESCRIPTION
Fixes routine-session browsing for users.

## What changed

- Restores the routine-first picker and run-grouped session view for `agents sessions --routine[s]`.
- Searches routine archives across working directories instead of scoping to the inspection shell's repository.
- Includes team-origin child sessions automatically because they belong to the routine run.
- Adds a real archived-transcript regression and updates sessions/routines docs.

## Live run

The built CLI queried the existing `security-sweep` archive from this worktree and returned 553 sessions across 5 runs, including 508 team-origin sessions: [captured JSON output](https://share.agents-cli.sh/muqsitnawaz/fix-routine-session-browser-rush-2403-security-sweep-proof-6f266e2ec09d676f).

The interactive picker also opened `perf-watch` and rendered `336 sessions · 73 routine runs · newest run first`, grouped under routine run IDs.

## Verification

- `./scripts/build.sh`
- `vitest`: 82 focused routine/browser/team-filter tests passed
- `git diff --check`
- Canonical crabbox run reached provisioning, then failed before repository tests because the fresh box's Bun installer could not move its extracted binary.

## Tracking

- [RUSH-2403](https://linear.app/rush/issue/RUSH-2403/sessions-routines-opens-an-empty-repo-scoped-browser)
- Companion `.agents-system` audit found no guidance that invokes the old `--routine --all` form.