### PR TITLE
chore(factory): prepare 0.9.314 release

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.314] - 2026-08-07
+
 - **`Agents: Fork (Recap)` now recaps the active tab without asking for a session.**
   The command starts a fresh sibling on the active session's host with the same
   harness and balanced account selection, queues `/recap <full-id>`, and records


### PR DESCRIPTION
Docs-only release metadata for Factory 0.9.314.\n\n## Change\n\nMoves the merged active-tab Fork (Recap) changelog note under the versioned `0.9.314` heading required by `apps/factory/scripts/release.sh`.\n\n## Verification\n\n- `grep '^## \[0\.9\.314\]' apps/factory/CHANGELOG.md` finds the required release section\n- PR #2354 already passed Factory CI, full local tests, compile, package integrity, and installed VSCodium verification\n\nRelated: #2354\n\nPure docs/release-metadata change; no runtime surface changed in this PR.