### PR TITLE
fix(sessions): pass boolean global routine scope

### DIFF
--- a/apps/cli/.changelog/next/routine-index-global-boolean.md
+++ b/apps/cli/.changelog/next/routine-index-global-boolean.md
@@ -1,0 +1,1 @@
+`agents sessions --routine <name>` now passes a real boolean global-scope flag to the indexed session reader, so routine runs outside the invoking directory appear without requiring `--all`.

--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -112,6 +112,44 @@ describe('routine session catalog', () => {
       fs.rmSync(tempHome, { recursive: true, force: true });
     }
   });
+
+  it('passes a boolean global scope to the real indexed routine query', () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-routine-index-scope-'));
+    try {
+      writeUpdateCache(tempHome);
+      const invokingCwd = path.join(tempHome, 'work', 'unrelated-repo');
+      const routineCwd = path.join(tempHome, 'work', 'scheduled-repo');
+      const sessionId = 'face2403-2222-4222-8333-444455556666';
+      const filePath = path.join(tempHome, `${sessionId}.jsonl`);
+      fs.mkdirSync(invokingCwd, { recursive: true });
+      fs.writeFileSync(filePath, '', 'utf-8');
+      const seed = [
+        "import { upsertSession, closeDB } from './src/lib/session/db.ts';",
+        `upsertSession(${JSON.stringify({
+          id: sessionId, shortId: sessionId.slice(0, 8), agent: 'claude',
+          timestamp: '2026-08-08T03:00:00.000Z', filePath, cwd: routineCwd,
+          origin: 'routine', routineName: 'nightly-review',
+        })}, '');`,
+        'closeDB();',
+      ].join(' ');
+      const seeded = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', seed], {
+        cwd: repoRoot,
+        env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+        encoding: 'utf8',
+      });
+      expect(seeded.status, seeded.stderr).toBe(0);
+
+      const result = runAgents(
+        ['sessions', '--routine', 'nightly-review', '--json', '--local'],
+        invokingCwd,
+        tempHome,
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect((JSON.parse(result.stdout) as SessionMeta[]).map((row) => row.id)).toEqual([sessionId]);
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('positional installed agent version filters', () => {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -2621,7 +2621,7 @@ async function sessionsAction(
       // --in-team spans directories by construction: a team's teammates run in
       // their own worktrees, so scoping to the current cwd hides most of the
       // lineage the flag exists to show.
-      all: pathFilter ? undefined : options.all || wantsWholeTeam || wantsWholeRoutine || toolSpansDevices,
+      all: pathFilter ? undefined : !!options.all || wantsWholeTeam || wantsWholeRoutine || toolSpansDevices,
       cwd: process.cwd(),
       // Default overview scopes to the current repo SUBTREE (prefix match), so a
       // monorepo shows its sub-projects grouped instead of collapsing to the one


### PR DESCRIPTION
## What changed

Fixes the installed `agents sessions --routine <name>` path so the global discovery flag is the boolean `true`, not the routine-name string. This restores routine runs outside the invoking directory without requiring `--all`.

## Run result

No UI surface. Real SQLite-index regression test added.

- `bunx vitest run src/commands/sessions.test.ts -t "routine session catalog" --reporter=verbose` — 4 passed
- `bunx tsc --noEmit` — passed
- Pre-fix installed 1.22.33: `--routine perf-watch` returned 0, while `--all --routine perf-watch` returned 49.

## Tracking

Follow-up to RUSH-2403 and release PR #2365.