### PR TITLE
fix(inspect): exclude directory-doc files from repo resource listing

### DIFF
--- a/apps/cli/src/commands/inspect.test.ts
+++ b/apps/cli/src/commands/inspect.test.ts
@@ -120,6 +120,20 @@ describe('collectRepoKind', () => {
     const repo = resolveRepoTarget(root)!;
     expect(collectRepoKind(repo, 'commands').map(c => c.name)).toEqual(['plain', 'ship']);
   });
+
+  it('skips directory-doc files (README/AGENTS/CLAUDE/GEMINI), including symlinks', () => {
+    const root = makeProjectRepo();
+    const commandsDir = path.join(root, '.agents', 'commands');
+    // Every resource dir carries README.md + AGENTS.md by convention, with
+    // CLAUDE.md/GEMINI.md symlinked to AGENTS.md. None is a command.
+    fs.writeFileSync(path.join(commandsDir, 'README.md'), '# Commands\n');
+    fs.writeFileSync(path.join(commandsDir, 'AGENTS.md'), '# Maintenance\n');
+    fs.symlinkSync('AGENTS.md', path.join(commandsDir, 'CLAUDE.md'));
+    fs.symlinkSync('AGENTS.md', path.join(commandsDir, 'GEMINI.md'));
+    const repo = resolveRepoTarget(root)!;
+    // Only the real commands remain — the four doc files are filtered out.
+    expect(collectRepoKind(repo, 'commands').map(c => c.name)).toEqual(['plain', 'ship']);
+  });
 });
 
 describe('repoManifestSummary', () => {

--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -41,6 +41,7 @@ import { getVersionHomePath,
 import { getShimsDir, getVersionedAliasPath } from '../lib/shims.js';
 import {
   getAgentResources,
+  isDirectoryDoc,
   listResources,
   type ResourceEntry,
   type SkillResourceEntry,
@@ -384,9 +385,14 @@ export function collectRepoKind(repo: RepoTarget, kind: DrillableKind): Resource
     if (entry.name.startsWith('.')) continue;
     // Build/tooling caches are never resources — they only inflate counts.
     if (entry.name === '__pycache__' || entry.name === 'node_modules') continue;
+    const name = entry.name.replace(/\.(md|yaml|yml|toml|json)$/, '');
+    // README/AGENTS/CLAUDE/GEMINI describe the directory, not resources of this
+    // kind. CLAUDE.md/GEMINI.md are symlinks to AGENTS.md, so a Dirent reports
+    // isFile() === false — use !isDirectory() to catch them (mirrors resources.ts).
+    if (!entry.isDirectory() && isDirectoryDoc(kind, name)) continue;
     const p = path.join(dir, entry.name);
     items.push({
-      name: entry.name.replace(/\.(md|yaml|yml|toml|json)$/, ''),
+      name,
       source: repo.label,
       path: p,
       linkTarget: linkTarget(p),


### PR DESCRIPTION
**bug fix** — no user-facing UI; proof is the CLI run output below.

## Problem
`agents inspect <repo> --commands` listed the directory-doc files — `README`, `AGENTS`, and their `CLAUDE`/`GEMINI` symlinks — as if they were commands, inflating the count and showing a bogus `/README` "command":

```
.system  commands (32)
  [.system]  AGENTS   commands/ — maintenance contract
  [.system]  CLAUDE   commands/ — maintenance contract
  [.system]  GEMINI   ...
  [.system]  README   Commands
```

`collectRepoKind` (`apps/cli/src/commands/inspect.ts`) raw-read the kind dir and skipped only dotfiles and build caches — it never applied `isDirectoryDoc`, unlike the sibling enumerators in `resources.ts` (e.g. `resources.ts:318`).

## Fix
Apply the shared `isDirectoryDoc` filter, guarded by `!entry.isDirectory()` so the `CLAUDE.md`/`GEMINI.md` **symlinks** (whose `Dirent` reports `isFile() === false`) are caught too — mirroring the resources.ts enumerator exactly.

## Proof (ran the fixed code against the real `.system` repo)
```
command count: 28
doc files still leaking: NONE
first few: clean, commit, continue, debug, dispatch, done
```

## Test
`apps/cli/src/commands/inspect.test.ts` — new case writes `README.md` + `AGENTS.md` and `CLAUDE.md`/`GEMINI.md` **symlinks** into a commands dir and asserts only the real commands remain. Full file: **30 passed**.

Note: the `prix/code-reviewer` is paused (#1767); a non-author subagent review is attached below per AGENTS.md fallback.
