### PR TITLE
fix(factory): restore Warp registry parity

### DIFF
--- a/apps/factory/src/core/agents.cli.ts
+++ b/apps/factory/src/core/agents.cli.ts
@@ -32,6 +32,7 @@ export const CLI_AGENT_IDS = [
   'hermes',
   'pi',
   'muse',
+  'warp',
 ] as const;
 
 /** Mirror of the CLI's AgentId union. */
@@ -63,6 +64,7 @@ export const CLI_AGENT_META: Record<CliAgentId, CliAgentMeta> = {
   hermes: { name: 'Hermes', cliCommand: 'hermes' },
   pi: { name: 'Pi', cliCommand: 'omp' },
   muse: { name: 'Muse', cliCommand: 'muse' },
+  warp: { name: 'Warp', cliCommand: 'oz' },
 };
 
 /** Type guard against the CLI agent id set. */


### PR DESCRIPTION
Fixes a release-blocking registry drift in Factory.

## What changed
- Add `warp` to Factory’s mirrored CLI agent ID registry.
- Mirror the canonical Warp display name and `oz` command.

## Verification
No UI surface changes; this restores an internal registry snapshot.

`bun test src/core/agents.cli.test.ts`

Result: 2 pass, 0 fail.