### PR TITLE
docs(spec): mark SING-14 restart bound implemented, retire SING-GAP-6 (RUSH-2418)

### DIFF
--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -2572,12 +2572,14 @@ a machine-wide process sweep.)
   daemon start MUST NOT cycle through unbounded rapid retries: the service manager MUST
   enforce a restart interval and burst limit, and `ensureDaemonStarted` MUST stop
   initiating starts after a bounded number of consecutive failures until the circuit
-  breaker resets. The current unbounded surfaces are launchd `KeepAlive`
-  (`lib/daemon.ts:1060-1090`), systemd `Restart=always` (`lib/daemon.ts:1106-1124`),
-  and the best-effort `ensureDaemonStarted` path (`lib/daemon.ts:1181-1202`). Status:
-  **[Intended]**: RUSH-2418 adds `ThrottleInterval`/`StartLimitBurst` service-manager
-  limits and a `consecutiveFailures` circuit breaker in `ensureDaemonStarted`
-  (SING-GAP-6).
+  breaker resets. Enforced at all three restart layers (RUSH-2418): `generateLaunchdPlist`
+  pairs `KeepAlive` with a 30s `ThrottleInterval` (`lib/daemon.ts:1115-1118`);
+  `generateSystemdUnit` caps respawns with `StartLimitIntervalSec=300`/`StartLimitBurst=5`
+  in its `[Unit]` section alongside `Restart=always` (`lib/daemon.ts:1154-1160`); and the
+  application-level auto-start path `ensureDaemonStarted` (`lib/daemon.ts:1274-1299`)
+  refuses to launch once `isDaemonAutostartCircuitOpen` (`lib/daemon.ts:1259-1262`) reads
+  `DAEMON_AUTOSTART_FAILURE_LIMIT` (5) consecutive failed starts from the persisted
+  `daemon-health.ts` record, pointing the operator at `agents daemon doctor` (SING-GAP-6).
 
 ### 4. Given/When/Then scenarios
 
@@ -2686,13 +2688,22 @@ a machine-wide process sweep.)
   (`closeServerBounded`, `lib/secrets/agent.ts:928-941`, `:953-973`) instead of firing and
   forgetting; the browser IPC teardown (`BrowserIPCServer.stop`, `lib/browser/ipc.ts:259-273`)
   still calls `server.close()` fire-and-forget and remains to be converted.
-- **SING-GAP-6 (RUSH-2418).** SING-14's restart bound is `[Intended]`: `generateLaunchdPlist`
-  (`lib/daemon.ts:1060-1090`) sets `KeepAlive` with no `ThrottleInterval`, `generateSystemdUnit`
-  (`lib/daemon.ts:1106-1124`) sets `Restart=always` with no `StartLimitIntervalSec`/
-  `StartLimitBurst`, and `ensureDaemonStarted` (`lib/daemon.ts:1181-1202`) has no
-  circuit breaker reading the `consecutiveFailures` `daemon-health.ts` already tracks —
-  so a daemon that fails on every startup restarts in an unbounded ~10s cycle. RUSH-2418
-  adds the service-manager limits and wires the circuit breaker.
+- **SING-GAP-6 (resolved, RUSH-2418).** SING-14's restart bound was `[Intended]`:
+  `generateLaunchdPlist` set `KeepAlive` with no `ThrottleInterval`, `generateSystemdUnit`
+  set `Restart=always` with no `StartLimitIntervalSec`/`StartLimitBurst`, and
+  `ensureDaemonStarted` had no circuit breaker reading the `consecutiveFailures`
+  `daemon-health.ts` already tracks — so a daemon that failed on every startup restarted
+  in an unbounded ~10s cycle. All three layers are now bounded: launchd carries a 30s
+  `ThrottleInterval` (`generateLaunchdPlist`, `lib/daemon.ts:1117-1118`), the systemd unit
+  carries `StartLimitIntervalSec=300`/`StartLimitBurst=5` in its `[Unit]` section
+  (`generateSystemdUnit`, `lib/daemon.ts:1154-1155`), and `ensureDaemonStarted`
+  (`lib/daemon.ts:1274-1299`) refuses to relaunch once `isDaemonAutostartCircuitOpen`
+  (`lib/daemon.ts:1259-1262`) sees `DAEMON_AUTOSTART_FAILURE_LIMIT` consecutive failed
+  starts — the application-level loop the OS supervisor's throttle cannot see, because
+  each attempt is a fresh service start rather than a respawn. Covered by
+  `lib/daemon.test.ts:167` (launchd `ThrottleInterval`), `:185`/`:199` (systemd
+  `StartLimitBurst` in `[Unit]`), and the `daemon auto-start circuit breaker (RUSH-2418)`
+  suite (`lib/daemon.test.ts:1254-1393`).
 
 ---
 


### PR DESCRIPTION
**docs-only** — reconciles `apps/cli/docs/specifications.md` with code that already merged. Audience: maintainers. No runnable surface (spec text only). Ticket: RUSH-2418.

## What was lying

RUSH-2418 landed the daemon crash-loop bound as commit `2bf3e0c7f` (daemon.ts, daemon-health.ts, index.ts, tests, changelog) but never touched the spec. So on `main` the spec still claimed the bound was **not** implemented:

- **SING-14** was marked `Status: [Intended]` and listed "current unbounded surfaces" at stale line refs (`lib/daemon.ts:1060-1090` / `1106-1124` / `1181-1202`).
- **SING-GAP-6** still asserted `generateLaunchdPlist` "sets `KeepAlive` with no `ThrottleInterval`", `generateSystemdUnit` "sets `Restart=always` with no `StartLimitIntervalSec`/`StartLimitBurst`", and `ensureDaemonStarted` "has no circuit breaker" — all false on `main`.

## What changed

- **SING-14** — dropped `[Intended]`, replaced the "unbounded surfaces" sentence with the enforced-by citations, matching the no-status convention of the already-implemented SING-11/SING-11b/SING-12. The existing Given/When/Then for the bound was already accurate and is left as-is.
- **SING-GAP-6** — rewritten in the file's `(resolved, RUSH-XXXX)` past-tense style (same shape as SING-GAP-4), with a test-coverage citation.
- Corrected every stale `lib/daemon.ts` line reference.

Deliberately **not** touched: SING-GAP-5 / SING-12a (RUSH-2421 spec territory, still stale on main — flagged separately), and no genuinely-open gap was weakened.

## Verification — every new citation checked against `origin/main`

```
$ grep -nE 'ThrottleInterval|StartLimitIntervalSec|StartLimitBurst|KeepAlive|Restart=always|DAEMON_AUTOSTART_FAILURE_LIMIT' src/lib/daemon.ts
72:const DAEMON_THROTTLE_SECONDS = 30;
73:const DAEMON_START_LIMIT_INTERVAL_SECONDS = 300;
74:const DAEMON_START_LIMIT_BURST = 5;
82:export const DAEMON_AUTOSTART_FAILURE_LIMIT = 5;
1115:  <key>KeepAlive</key>
1117:  <key>ThrottleInterval</key>
1154:StartLimitIntervalSec=${DAEMON_START_LIMIT_INTERVAL_SECONDS}
1155:StartLimitBurst=${DAEMON_START_LIMIT_BURST}
1160:Restart=always
1261:  return (health?.consecutiveFailures ?? 0) >= DAEMON_AUTOSTART_FAILURE_LIMIT;
1290:  // ... after DAEMON_AUTOSTART_FAILURE_LIMIT consecutive failures, refuse and say why.
```

`generateLaunchdPlist` (`:1097`) now pairs `KeepAlive` (`:1115`) with `ThrottleInterval` (`:1117-1118`); `generateSystemdUnit` (`:1145`) sets `StartLimitIntervalSec`/`StartLimitBurst` (`:1154-1155`) in `[Unit]` alongside `Restart=always` (`:1160`); `ensureDaemonStarted` (`:1274-1299`) refuses to launch once `isDaemonAutostartCircuitOpen` (`:1259-1262`) sees the limit. Tests: `daemon.test.ts:167` (`ThrottleInterval`), `:185`/`:199` (systemd `[Unit]`), and the `daemon auto-start circuit breaker (RUSH-2418)` suite (`:1254-1393`).

Follows the precedent of `095aaa901` (`docs(spec): retire SING-GAP-4 …`) — docs-only, no changelog fragment.
