### PR TITLE
docs(specs): close SING-GAP-5 and SING-GAP-6 — both landed on main

### DIFF
--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -2565,19 +2565,25 @@ a machine-wide process sweep.)
   socket, the daemon pid registration, the lifetime marker file, the heartbeat file,
   and the daemon's instance-registry entry. The shutdown postcondition MUST name any
   survivor and MUST NOT report success merely because the daemon process exited. The
-  graceful path already attempts all six releases in `handleShutdown`
-  (`lib/daemon.ts:996-1016`); Status: **[Intended]** for `stopDaemon` independently
-  verifying the full inventory (RUSH-2421, SING-GAP-5).
+  graceful path attempts all six releases in `handleShutdown`
+  (`lib/daemon.ts:1033-1054`); `stopDaemon` independently verifies the full
+  six-resource inventory: the daemon process, browser IPC socket, and secrets broker
+  socket (`lib/daemon.ts:1707-1813`), then the lifetime marker, heartbeat, and
+  instance-registry entry via `stopResidueArtifacts` (`lib/daemon.ts:1596-1640`,
+  invoked at `lib/daemon.ts:1825-1831`) — each reclaimed only from a provably-dead
+  owner and reported as `surviving` if reclaim fails (RUSH-2421, closes SING-GAP-5).
 - **SING-14 (MUST).** Supervised daemon restart MUST be bounded. A permanently failing
   daemon start MUST NOT cycle through unbounded rapid retries: the service manager MUST
   enforce a restart interval and burst limit, and `ensureDaemonStarted` MUST stop
   initiating starts after a bounded number of consecutive failures until the circuit
-  breaker resets. The current unbounded surfaces are launchd `KeepAlive`
-  (`lib/daemon.ts:1060-1090`), systemd `Restart=always` (`lib/daemon.ts:1106-1124`),
-  and the best-effort `ensureDaemonStarted` path (`lib/daemon.ts:1181-1202`). Status:
-  **[Intended]**: RUSH-2418 adds `ThrottleInterval`/`StartLimitBurst` service-manager
-  limits and a `consecutiveFailures` circuit breaker in `ensureDaemonStarted`
-  (SING-GAP-6).
+  breaker resets. launchd's plist sets `KeepAlive` with a `ThrottleInterval` of
+  `DAEMON_THROTTLE_SECONDS` (30s) (`lib/daemon.ts:1097-1130`, constant at
+  `lib/daemon.ts:72`); systemd's unit sets `Restart=always` bounded by
+  `StartLimitIntervalSec`/`StartLimitBurst` (`lib/daemon.ts:1145-1166`, constants at
+  `lib/daemon.ts:73-74`); and `ensureDaemonStarted` stops initiating starts once
+  `isDaemonAutostartCircuitOpen()` reads `consecutiveFailures >=
+  DAEMON_AUTOSTART_FAILURE_LIMIT` (5) (`lib/daemon.ts:1252-1262`, refusal at
+  `lib/daemon.ts:1293-1299`) (RUSH-2418, closes SING-GAP-6).
 
 ### 4. Given/When/Then scenarios
 
@@ -2676,23 +2682,34 @@ a machine-wide process sweep.)
   fingerprint. The live-daemon exclusion is re-asserted on that path
   (`lib/secrets/reaper.ts:170-172`), so auto-lock-on-sleep for a running daemon is
   untouched; `lib/secrets/reaper.test.ts:347-354` covers the predicate.
-- **SING-GAP-5 (RUSH-2421).** SING-12a's shutdown postcondition is `[Intended]`:
-  `stopDaemon` (`lib/daemon.ts:1496-1617`) today verifies only the browser IPC socket,
-  the secrets broker socket, and pid registration — not the lifetime marker, heartbeat
-  file, or instance-registry entry, which `handleShutdown`'s graceful path releases but
-  the escalated (`killTree`) path leaves stale with no postcondition check. RUSH-2421
-  extends the postcondition to the full six-resource inventory. The secrets-broker socket
-  teardown now awaits the real `net.Server` `'close'` event with a bounded 2s timeout
-  (`closeServerBounded`, `lib/secrets/agent.ts:928-941`, `:953-973`) instead of firing and
-  forgetting; the browser IPC teardown (`BrowserIPCServer.stop`, `lib/browser/ipc.ts:259-273`)
-  still calls `server.close()` fire-and-forget and remains to be converted.
-- **SING-GAP-6 (RUSH-2418).** SING-14's restart bound is `[Intended]`: `generateLaunchdPlist`
-  (`lib/daemon.ts:1060-1090`) sets `KeepAlive` with no `ThrottleInterval`, `generateSystemdUnit`
-  (`lib/daemon.ts:1106-1124`) sets `Restart=always` with no `StartLimitIntervalSec`/
-  `StartLimitBurst`, and `ensureDaemonStarted` (`lib/daemon.ts:1181-1202`) has no
-  circuit breaker reading the `consecutiveFailures` `daemon-health.ts` already tracks —
-  so a daemon that fails on every startup restarts in an unbounded ~10s cycle. RUSH-2418
-  adds the service-manager limits and wires the circuit breaker.
+- **SING-GAP-5 (resolved, RUSH-2421).** SING-12a's shutdown postcondition was
+  `[Intended]`: `stopDaemon` used to verify only the browser IPC socket, the secrets
+  broker socket, and pid registration — not the lifetime marker, heartbeat file, or
+  instance-registry entry, which `handleShutdown`'s graceful path releases
+  (`lib/daemon.ts:1033-1054`) but the escalated (`killTree`) path left stale with no
+  postcondition check. RUSH-2421 closed both halves: `stopDaemon` now verifies the
+  full six-resource inventory via `stopResidueArtifacts`
+  (`lib/daemon.ts:1596-1640`, invoked at `lib/daemon.ts:1825-1831`), reclaiming the
+  lifetime marker, heartbeat, and instance-registry entry from a provably-dead owner;
+  and both socket teardowns now await the real `net.Server` `'close'` event with a
+  bounded timeout instead of firing and forgetting — the secrets broker socket via
+  `closeServerBounded` (`lib/secrets/agent.ts:928-941`, `:953-973`) and the browser
+  IPC socket via `BrowserIPCServer.stop`'s own bounded await
+  (`lib/browser/ipc.ts:267-295`).
+- **SING-GAP-6 (resolved, RUSH-2418).** SING-14's restart bound was `[Intended]`:
+  `generateLaunchdPlist` used to set `KeepAlive` with no `ThrottleInterval`,
+  `generateSystemdUnit` used to set `Restart=always` with no
+  `StartLimitIntervalSec`/`StartLimitBurst`, and `ensureDaemonStarted` had no circuit
+  breaker reading the `consecutiveFailures` `daemon-health.ts` already tracked — so a
+  daemon that failed on every startup restarted in an unbounded ~10s cycle. RUSH-2418
+  landed the service-manager limits — launchd `ThrottleInterval` from
+  `DAEMON_THROTTLE_SECONDS` (`lib/daemon.ts:1117-1118`), systemd
+  `StartLimitIntervalSec`/`StartLimitBurst` from `DAEMON_START_LIMIT_INTERVAL_SECONDS`/
+  `DAEMON_START_LIMIT_BURST` (`lib/daemon.ts:1154-1155`), constants declared at
+  `lib/daemon.ts:72-74` — and wired the `isDaemonAutostartCircuitOpen()` circuit
+  breaker (`lib/daemon.ts:1252-1262`) into `ensureDaemonStarted`'s refusal path
+  (`lib/daemon.ts:1293-1299`), gated on `DAEMON_AUTOSTART_FAILURE_LIMIT`
+  (`lib/daemon.ts:82`).
 
 ---
 


### PR DESCRIPTION
docs-only. Audience: maintainers (internal normative spec, not end-user docs). No CHANGELOG fragment — this corrects an internal spec description, not user-visible CLI behavior.

## What

Two entries in `apps/cli/docs/specifications.md` §Scheduling & execution singularity described code as still `[Intended]`/open when it had already landed on `origin/main`. Verified every citation against `origin/main` (commit `98f481722`) before editing; no source file touched.

## Drift 1 — SING-14 / SING-GAP-6 (RUSH-2418), the daemon restart bound

**Before:**
```
- **SING-14 (MUST).** ... The current unbounded surfaces are launchd `KeepAlive`
  (`lib/daemon.ts:1060-1090`), systemd `Restart=always` (`lib/daemon.ts:1106-1124`),
  and the best-effort `ensureDaemonStarted` path (`lib/daemon.ts:1181-1202`). Status:
  **[Intended]**: RUSH-2418 adds `ThrottleInterval`/`StartLimitBurst` service-manager
  limits and a `consecutiveFailures` circuit breaker in `ensureDaemonStarted`
  (SING-GAP-6).
```

**After:**
```
- **SING-14 (MUST).** ... launchd's plist sets `KeepAlive` with a `ThrottleInterval` of
  `DAEMON_THROTTLE_SECONDS` (30s) (`lib/daemon.ts:1097-1130`, constant at
  `lib/daemon.ts:72`); systemd's unit sets `Restart=always` bounded by
  `StartLimitIntervalSec`/`StartLimitBurst` (`lib/daemon.ts:1145-1166`, constants at
  `lib/daemon.ts:73-74`); and `ensureDaemonStarted` stops initiating starts once
  `isDaemonAutostartCircuitOpen()` reads `consecutiveFailures >=
  DAEMON_AUTOSTART_FAILURE_LIMIT` (5) (`lib/daemon.ts:1252-1262`, refusal at
  `lib/daemon.ts:1293-1299`) (RUSH-2418, closes SING-GAP-6).
```

**Proof — `git show origin/main` grep output backing every citation:**
```
$ git show origin/main:apps/cli/src/lib/daemon.ts | grep -n "ThrottleInterval\|StartLimitBurst\|StartLimitIntervalSec\|DAEMON_AUTOSTART_FAILURE_LIMIT\|consecutiveFailures >=\|DAEMON_THROTTLE_SECONDS =\|DAEMON_START_LIMIT_BURST =\|DAEMON_START_LIMIT_INTERVAL_SECONDS ="
59: *    `ThrottleInterval` lets launchd relaunch on its ~10s default, so a daemon
64: * 2. **`StartLimitBurst` gives systemd a real cap** — after this many starts
72:const DAEMON_THROTTLE_SECONDS = 30;
73:const DAEMON_START_LIMIT_INTERVAL_SECONDS = 300;
74:const DAEMON_START_LIMIT_BURST = 5;
82:export const DAEMON_AUTOSTART_FAILURE_LIMIT = 5;
1117:  <key>ThrottleInterval</key>
1154:StartLimitIntervalSec=${DAEMON_START_LIMIT_INTERVAL_SECONDS}
1155:StartLimitBurst=${DAEMON_START_LIMIT_BURST}
1254: * {@link DAEMON_AUTOSTART_FAILURE_LIMIT} consecutive starts have failed to
1261:  return (health?.consecutiveFailures ?? 0) >= DAEMON_AUTOSTART_FAILURE_LIMIT;
1290:  // DAEMON_AUTOSTART_FAILURE_LIMIT consecutive failures, refuse and say why.
1295:      `[agents] daemon auto-start disabled after ${DAEMON_AUTOSTART_FAILURE_LIMIT} consecutive failed starts. ` +
```
And the docblock naming this exact commit's purpose:
```
$ git show origin/main:apps/cli/src/lib/daemon.ts | sed -n '55,71p'
 * Crash-loop prevention (RUSH-2418). Three layers, because none of them alone
 * bounds a daemon that dies during startup:
 * 1. **The OS supervisor paces the respawn.** `KeepAlive` with no
 *    `ThrottleInterval` lets launchd relaunch on its ~10s default, so a daemon
 *    that dies while booting is restarted six times a minute forever ...
 * 2. **`StartLimitBurst` gives systemd a real cap** ...
 * 3. **The application-level circuit breaker** below stops *auto*-starts from
 *    re-entering the loop from the other direction ...
```

## Drift 2 — SING-GAP-5 residual (RUSH-2421), the browser IPC teardown

**Before:**
```
- **SING-GAP-5 (RUSH-2421).** ... The secrets-broker socket teardown now awaits the real
  `net.Server` `'close'` event with a bounded 2s timeout (`closeServerBounded`,
  `lib/secrets/agent.ts:928-941`, `:953-973`) instead of firing and forgetting; the
  browser IPC teardown (`BrowserIPCServer.stop`, `lib/browser/ipc.ts:259-273`) still
  calls `server.close()` fire-and-forget and remains to be converted.
```

**After:**
```
- **SING-GAP-5 (resolved, RUSH-2421).** ... RUSH-2421 closed both halves: `stopDaemon`
  now verifies the full six-resource inventory via `stopResidueArtifacts`
  (`lib/daemon.ts:1596-1640`, invoked at `lib/daemon.ts:1825-1831`) ...; and both
  socket teardowns now await the real `net.Server` `'close'` event with a bounded
  timeout instead of firing and forgetting — the secrets broker socket via
  `closeServerBounded` (`lib/secrets/agent.ts:928-941`, `:953-973`) and the browser
  IPC socket via `BrowserIPCServer.stop`'s own bounded await
  (`lib/browser/ipc.ts:267-295`).
```

**Proof — the actual `async stop()` on `origin/main`, landed in the tip commit itself:**
```
$ git log origin/main -1 --format='%H %s' -- apps/cli/src/lib/browser/ipc.ts
98f481722aa55ef1fdbcbc827cb6a77d6cb03d21 fix(daemon): assert the state files a killed daemon leaves behind (RUSH-2421)

$ git show origin/main:apps/cli/src/lib/browser/ipc.ts | sed -n '267,295p'
  /**
   * Stop accepting, release the binding, and only then resolve.
   *
   * RUSH-2421: this used to call `server.close()` and move on. `close()` is
   * asynchronous — it stops accepting immediately but the binding is not
   * actually released until the `'close'` event fires — so `stop()` resolved
   * while the socket (or named pipe) was still held. ...
   */
  async stop(): Promise<void> {
    if (this.server) {
      const server = this.server;
      this.server = null;
      await new Promise<void>((resolve) => {
        const done = () => { clearTimeout(timer); resolve(); };
        const timer = setTimeout(done, IPC_CLOSE_TIMEOUT_MS);
        server.close(() => done());
      });
    }
    ...
```
The old citation (`lib/browser/ipc.ts:259-273`) pointed at the docblock, not the `stop()` body — also stale; corrected to `267-295`, the full method incl. docblock.

I also re-evaluated whether SING-GAP-5 has any other genuinely-open residual beyond the browser IPC teardown. It does not: `stopDaemon`'s postcondition now covers all six resources via `stopResidueArtifacts` (`lib/daemon.ts:1596-1640`), confirmed by reading `stopDaemon` in full (`lib/daemon.ts:1707-1845`) — closed the entire gap, not just the one sentence.

## Scope

- Only `apps/cli/docs/specifications.md` touched — no code changes, no other gap entries (SING-GAP-1..4 left untouched; spot-checked, no drift found in them during this pass).
- Grepped the whole file for other `RUSH-2418`/`RUSH-2421` references before and after editing — none left contradicting the new text.
