### PR TITLE
fix(routines): make isBareRelative target-aware, not host-platform-aware (RUSH-2393)

### DIFF
--- a/apps/cli/src/lib/routine-context.test.ts
+++ b/apps/cli/src/lib/routine-context.test.ts
@@ -234,6 +234,48 @@ describe('resolveRoutineExecutionContext', () => {
     expect(res.ready).toBe(true);
   });
 
+  it('an absolute Windows-shaped cwd overrides a project base instead of being misread as project-relative (RUSH-2393)', () => {
+    // isBareRelative used to check `path.isAbsolute` with the HOST's default
+    // path module. A POSIX daemon dispatching to a Windows target saw
+    // `path.isAbsolute('C:\\Users\\remoteuser\\override')` return false (posix
+    // doesn't recognize a drive letter), so the cwd was misclassified as
+    // project-relative: joined against the project base, found to escape it,
+    // and paused with cwd_not_portable — even though it is a legitimate
+    // absolute override under the target's own home.
+    const res = resolveRoutineExecutionContext({
+      name: 'r',
+      kind: 'agent',
+      mode: 'host',
+      targetHome: 'C:\\Users\\remoteuser',
+      project: 'mono',
+      cwd: 'C:\\Users\\remoteuser\\override',
+      projectResolution: { defined: true, base: '~/mono' },
+      probe: undefined,
+    });
+    expect(res.readiness?.code).not.toBe('cwd_not_portable');
+    expect(res.ready).toBe(true);
+    expect(res.resolvedCwd).toBe('~/override');
+  });
+
+  it('an absolute POSIX cwd overrides a project base the same way (regression guard, other direction)', () => {
+    // Mirrors the Windows-target case above with a POSIX target home, so a fix
+    // that swapped the posix/win32 selection (or hardcoded one flavour) would
+    // fail this the same way it would have failed the Windows case.
+    const res = resolveRoutineExecutionContext({
+      name: 'r',
+      kind: 'agent',
+      mode: 'host',
+      targetHome: '/home/remoteuser',
+      project: 'mono',
+      cwd: '/home/remoteuser/override',
+      projectResolution: { defined: true, base: '~/mono' },
+      probe: undefined,
+    });
+    expect(res.readiness?.code).not.toBe('cwd_not_portable');
+    expect(res.ready).toBe(true);
+    expect(res.resolvedCwd).toBe('~/override');
+  });
+
   it('an unwritable directory pauses with workspace_not_writable', () => {
     if (process.getuid && process.getuid() === 0) return; // root bypasses W_OK
     // Windows ignores the mode bits chmod sets, so W_OK still succeeds and there

--- a/apps/cli/src/lib/routine-context.ts
+++ b/apps/cli/src/lib/routine-context.ts
@@ -156,9 +156,16 @@ export function toTargetPortable(home: string, abs: string): string {
   return abs;
 }
 
-/** True for a bare relative path (not absolute, not home-anchored). */
-export function isBareRelative(p: string): boolean {
-  return !path.isAbsolute(p) && !p.startsWith('~') && !p.startsWith('$HOME');
+/**
+ * True for a bare relative path (not absolute, not home-anchored) ON THE TARGET.
+ *
+ * `isAbsolute` is evaluated in the TARGET's own path flavour (see
+ * {@link targetPath}), not this process's platform — a Windows-shaped absolute
+ * cwd (`C:\Users\x\override`) dispatched from a POSIX daemon must still be
+ * recognized as absolute, or it is misread as project-relative.
+ */
+export function isBareRelative(home: string, p: string): boolean {
+  return !targetPath(home).isAbsolute(p) && !p.startsWith('~') && !p.startsWith('$HOME');
 }
 
 /**
@@ -251,7 +258,7 @@ export function resolveRoutineExecutionContext(input: ExecutionContextInput): Re
       if (cwd === undefined) {
         return finalize(projBase, 'project_path_missing');
       }
-      if (isBareRelative(cwd)) {
+      if (isBareRelative(targetHome, cwd)) {
         const baseAbs = expandTargetHome(targetHome, projBase);
         // Target-side join: `path.resolve` would use this host's separator and,
         // for a target home this host does not consider absolute, prepend the


### PR DESCRIPTION
No visible surface — internal correctness fix to routine execution-context resolution logic, exercised only by unit tests (no CLI command, flag, or UI output changes). Bug fix — no CHANGELOG entry per repo convention.

## What

`isBareRelative` (`apps/cli/src/lib/routine-context.ts`) used the host-default `path` module instead of the target-aware `targetPath(home)` helper the rest of this module was already converted to use in RUSH-2290 (commit 64d953525). A daemon dispatching a routine to a target of a *different* platform shape (e.g. a Linux daemon scheduling onto a Windows host) misclassified a Windows-shaped absolute `cwd` override as a bare relative path, because POSIX's `path.isAbsolute('C:\\Users\\x\\override')` returns `false`.

That misclassification routed the cwd into the project-base-relative join branch (`routine-context.ts:254`), where `isInside(baseAbs, joinedAbs)` then classified the resolved absolute override as *escaping* the project base and paused the routine with `cwd_not_portable` — the wrong readiness code for a legitimate absolute override.

## Before / after

```ts
// before
export function isBareRelative(p: string): boolean {
  return !path.isAbsolute(p) && !p.startsWith('~') && !p.startsWith('$HOME');
}

// after
export function isBareRelative(home: string, p: string): boolean {
  return !targetPath(home).isAbsolute(p) && !p.startsWith('~') && !p.startsWith('$HOME');
}
```

Call site updated: `routine-context.ts:254` now calls `isBareRelative(targetHome, cwd)`.

## Repro — failing before, passing after

New test `an absolute Windows-shaped cwd overrides a project base instead of being misread as project-relative (RUSH-2393)`:
- project base `~/mono`, `cwd: 'C:\Users\remoteuser\override'`, `targetHome: 'C:\Users\remoteuser'`, `mode: 'host'`.
- **Old code:** `res.readiness?.code === 'cwd_not_portable'` (paused, wrong).
- **New code:** `res.ready === true`, `res.resolvedCwd === '~/override'` (correctly treated as an absolute override).

Verified by temporarily reverting just `isBareRelative` to the pre-fix implementation and re-running the suite:

```
 × ...an absolute Windows-shaped cwd overrides a project base instead of being misread as project-relative (RUSH-2393) 3ms
 ✓ ...an absolute POSIX cwd overrides a project base the same way (regression guard, other direction) 1ms
 Tests  1 failed | 27 passed (28)
```

A companion posix-target test (`an absolute POSIX cwd overrides a project base the same way`) pins the other direction so a fix that accidentally hardcoded or swapped the posix/win32 selection would fail it the same way.

## Full suite — after the fix, unchanged old tests + 2 new ones, all green

```
$ cd apps/cli && bun run vitest run src/lib/routine-context.test.ts --reporter=verbose

 ✓ resolveRoutineExecutionContext > project with a usable base and no cwd resolves the base 2ms
 ✓ resolveRoutineExecutionContext > project base + relative cwd joins inside the base 1ms
 ✓ resolveRoutineExecutionContext > rejects a project-relative cwd that escapes the base (traversal) 0ms
 ✓ resolveRoutineExecutionContext > rootless Linear project + relative cwd anchors at the target home 1ms
 ✓ resolveRoutineExecutionContext > rootless project with no cwd pauses with project_path_missing 0ms
 ✓ resolveRoutineExecutionContext > named-but-undefined project pauses with project_not_found 0ms
 ✓ resolveRoutineExecutionContext > no project + relative cwd anchors at the target home 0ms
 ✓ resolveRoutineExecutionContext > ~/ cwd resolves against the target home 0ms
 ✓ resolveRoutineExecutionContext > absolute cwd under the target home is normalized to portable ~/ form 0ms
 ✓ resolveRoutineExecutionContext > absolute cwd outside home is allowed for a local routine 0ms
 ✓ resolveRoutineExecutionContext > absolute cwd outside home is not portable to host/fleet/cloud placement 0ms
 ✓ resolveRoutineExecutionContext > missing directory pauses with cwd_missing 0ms
 ✓ resolveRoutineExecutionContext > a file (not directory) pauses with cwd_not_directory 0ms
 ✓ resolveRoutineExecutionContext > an agent routine with neither field pauses with execution_context_missing 0ms
 ✓ resolveRoutineExecutionContext > a command routine with neither field falls back to the target home 0ms
 ✓ resolveRoutineExecutionContext > resolves against a DISTINCT remote target home (deferred existence, no probe) 0ms
 ✓ resolveRoutineExecutionContext > builds the target path with the TARGET machine separator, not this host's 0ms
 ✓ resolveRoutineExecutionContext > cloud placement with a bare cwd (no project binding) pauses with cloud_context_unsupported 0ms
 ✓ resolveRoutineExecutionContext > cloud placement with a project binding is allowed 0ms
 ✓ resolveRoutineExecutionContext > an absolute Windows-shaped cwd overrides a project base instead of being misread as project-relative (RUSH-2393) 1ms
 ✓ resolveRoutineExecutionContext > an absolute POSIX cwd overrides a project base the same way (regression guard, other direction) 0ms
 ✓ resolveRoutineExecutionContext > an unwritable directory pauses with workspace_not_writable 0ms
 ✓ evaluateRoutineReadiness > short-circuits on a context blocker 0ms
 ✓ evaluateRoutineReadiness > flags an uninstalled agent 0ms
 ✓ evaluateRoutineReadiness > flags an untrusted Codex workspace 0ms
 ✓ evaluateRoutineReadiness > flags a failed live auth check 0ms
 ✓ evaluateRoutineReadiness > flags an unreachable target before harness checks 0ms
 ✓ evaluateRoutineReadiness > passes when every wired probe passes 0ms

 Test Files  1 passed (1)
      Tests  28 passed (28)
```

26 pre-existing tests unchanged and passing, plus the 2 new repro/regression tests.

`bun run build` (tsc) also passes clean — `isBareRelative` has exactly one call site in the codebase, updated in this diff.

## Scope

`apps/cli/src/lib/routine-context.ts` + `apps/cli/src/lib/routine-context.test.ts` only. No change to `isInside`, `targetPath`, `expandTargetHome`, `toTargetPortable`, or any surrounding branch semantics/docblock.

RUSH-2393
