### PR TITLE
docs(spec): fix two citation errors from PR #2402's own review

### DIFF
--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -2691,9 +2691,9 @@ a machine-wide process sweep.)
   (`daemon.test.ts` covers both the escalated-reclaim case and the live-owner-protection
   case). Both socket teardowns now await the real `net.Server` `'close'` event instead of
   firing and forgetting: the secrets broker via `closeServerBounded`
-  (`lib/secrets/agent.ts:928-941`, `:953-973`, RUSH-2419) and the browser IPC server via
+  (`lib/secrets/agent.ts:928-941`, `:953-973`, RUSH-2421) and the browser IPC server via
   `BrowserIPCServer.stop` (`lib/browser/ipc.ts:284-295`, bounded by
-  `IPC_CLOSE_TIMEOUT_MS = 5_000` at `ipc.ts:84`, RUSH-2421).
+  `IPC_CLOSE_TIMEOUT_MS = 5_000` at `ipc.ts:19`, RUSH-2421).
 - **SING-GAP-6 (resolved, RUSH-2418).** SING-14's restart bound was previously
   unenforced: `generateLaunchdPlist` set `KeepAlive` with no `ThrottleInterval`,
   `generateSystemdUnit` set `Restart=always` with no `StartLimitIntervalSec`/


### PR DESCRIPTION
docs-only — no behavior change.

## What
A non-author review of #2402 (which itself fixed stale spec citations for SING-GAP-5/6) caught two errors in that very fix:

- `IPC_CLOSE_TIMEOUT_MS = 5_000` was cited at `ipc.ts:84` (actually `const endpoint = getIpcEndpoint();` — unrelated). Correct line, verified against current `origin/main`, is `ipc.ts:19`.
- The secrets-broker `closeServerBounded` await-close was attributed to RUSH-2419. It's RUSH-2421 — confirmed via the introducing commit (`78b729973`, which splits its own subject into the RUSH-2419 reaper half and the RUSH-2421 close-await half) and PR #2388's own description.

Both re-verified against the current checked-out `origin/main` before this commit.

## Tracking
Follow-up to #2402. Review: https://github.com/phnx-labs/agents-cli/pull/2402#issuecomment-5225646864