### PR TITLE
docs(specs): fix two stale citations left by the SING-GAP-5/6 resolution

### DIFF
--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -2566,7 +2566,7 @@ a machine-wide process sweep.)
   and the daemon's instance-registry entry. The shutdown postcondition MUST name any
   survivor and MUST NOT report success merely because the daemon process exited. The
   graceful path already attempts all six releases in `handleShutdown`
-  (`lib/daemon.ts:996-1016`); `stopDaemon` independently verifies the full inventory
+  (`lib/daemon.ts:1033-1054`); `stopDaemon` independently verifies the full inventory
   via `stopResidueArtifacts` (`lib/daemon.ts:1596-1640`), consumed at
   `lib/daemon.ts:1825-1831` on both the graceful and escalated `killTree` paths, and
   distinguishes residue from a provably dead owner (reclaimed) from state belonging to
@@ -2693,7 +2693,7 @@ a machine-wide process sweep.)
   firing and forgetting: the secrets broker via `closeServerBounded`
   (`lib/secrets/agent.ts:928-941`, `:953-973`, RUSH-2419) and the browser IPC server via
   `BrowserIPCServer.stop` (`lib/browser/ipc.ts:284-295`, bounded by
-  `IPC_CLOSE_TIMEOUT_MS = 5_000` at `ipc.ts:84`, RUSH-2421).
+  `IPC_CLOSE_TIMEOUT_MS = 5_000` at `ipc.ts:19`, RUSH-2421).
 - **SING-GAP-6 (resolved, RUSH-2418).** SING-14's restart bound was previously
   unenforced: `generateLaunchdPlist` set `KeepAlive` with no `ThrottleInterval`,
   `generateSystemdUnit` set `Restart=always` with no `StartLimitIntervalSec`/


### PR DESCRIPTION
docs-only. Audience: maintainers (internal normative spec, not end-user docs). No CHANGELOG fragment.

## What

While independently working the same SING-GAP-5/6 drift (RUSH-2418/RUSH-2421), a sibling session merged 52004ad39 first, correctly resolving both gaps. Re-verifying every citation in that merged commit against `origin/main` surfaced two it left stale — the exact defect class the whole fix was about.

## Fix 1 — SING-12a's `handleShutdown` citation

`lib/daemon.ts:996-1016` is `handleReload`, not `handleShutdown`.

```
$ git show origin/main:apps/cli/src/lib/daemon.ts | sed -n '996,1000p'
  const handleReload = () => {
    log('INFO', 'Reloading jobs (SIGHUP)');
    ...
```

`handleShutdown` is actually here:
```
$ git show origin/main:apps/cli/src/lib/daemon.ts | grep -n "const handleShutdown = async"
1033:  const handleShutdown = async () => {
$ git show origin/main:apps/cli/src/lib/daemon.ts | sed -n '1033,1054p'
  const handleShutdown = async () => {
    log('INFO', 'Daemon shutting down');
    stopScheduler();
    monitorEngine.stop();
    await browserIPC.stop();
    ...
    hostedBroker?.close();
    removeDaemonPid();
    removeHeartbeat();
    unregisterDaemonInstance();
    process.exit(0);
  };
```

## Fix 2 — SING-GAP-5's `IPC_CLOSE_TIMEOUT_MS` citation

`ipc.ts:84` is inside the unrelated `waitForSocket` helper, not the constant declaration.

```
$ git show origin/main:apps/cli/src/lib/browser/ipc.ts | grep -n "IPC_CLOSE_TIMEOUT_MS"
19:const IPC_CLOSE_TIMEOUT_MS = 5_000;
290:        const timer = setTimeout(done, IPC_CLOSE_TIMEOUT_MS);
$ git show origin/main:apps/cli/src/lib/browser/ipc.ts | sed -n '83,85p'
async function waitForSocket(_socketPath: string, timeoutMs: number): Promise<void> {
  const endpoint = getIpcEndpoint();
  const deadline = Date.now() + timeoutMs;
```

## Scope

Two one-line citation corrections in `apps/cli/docs/specifications.md`, nothing else touched. No source files touched.
