### PR TITLE
perf(cli): drop agents/versions from brand eager graph (RUSH-2331)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2331-brand-eager-graph.md
+++ b/apps/cli/.changelog/next/RUSH-2331-brand-eager-graph.md
@@ -1,0 +1,9 @@
+- **CLI bootstrap no longer loads `versions.ts` via the brand edge (RUSH-2331).**
+  Every `agents` invocation statically imports `brand.js` for `resolveBrandName` /
+  `disabledCommandsForActiveBrand`. That module used to import `agents.js` solely
+  for `reservedBrandNames()` / `validateBrandName()` (mine/setup only), and
+  `agents.js` pulls the full `versions.ts` graph — ~90ms of module evaluation on
+  the `--version` / secrets-broker / bare-help path. `brand.ts` now reads the
+  zero-dep `agent-cli-commands` leaf (pinned equal to `AGENTS[*].cliCommand` by
+  test); the self-update → primitives redirect from the same ticket remains.
+  Source: `apps/cli/src/lib/brand.ts`, `apps/cli/src/lib/agent-cli-commands.ts`.

--- a/apps/cli/src/lib/agent-cli-commands.test.ts
+++ b/apps/cli/src/lib/agent-cli-commands.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Pins AGENT_CLI_COMMANDS to AGENTS[*].cliCommand so brand reserved-name checks
+ * cannot drift from the harness registry (RUSH-2331).
+ */
+import { describe, expect, it } from 'vitest';
+import { AGENT_CLI_COMMANDS } from './agent-cli-commands.js';
+import { AGENTS, ALL_AGENT_IDS } from './agents.js';
+
+describe('AGENT_CLI_COMMANDS', () => {
+  it('matches every AGENTS[*].cliCommand exactly (set equality)', () => {
+    const fromAgents = new Set(ALL_AGENT_IDS.map((id) => AGENTS[id].cliCommand));
+    const fromLeaf = new Set(AGENT_CLI_COMMANDS);
+    expect(fromLeaf).toEqual(fromAgents);
+  });
+
+  it('has no duplicates', () => {
+    expect(new Set(AGENT_CLI_COMMANDS).size).toBe(AGENT_CLI_COMMANDS.length);
+  });
+
+  it('does not reserve the agents / ag binaries (those are added by brand.ts)', () => {
+    expect(AGENT_CLI_COMMANDS).not.toContain('agents');
+    expect(AGENT_CLI_COMMANDS).not.toContain('ag');
+  });
+});

--- a/apps/cli/src/lib/agent-cli-commands.ts
+++ b/apps/cli/src/lib/agent-cli-commands.ts
@@ -1,0 +1,31 @@
+/**
+ * Agent CLI binary names — the `cliCommand` field of each harness in AGENTS.
+ *
+ * Leaf module with zero imports. brand.ts uses this for reservedBrandNames so
+ * the eager index.ts → brand.js graph never pulls agents.ts / versions.ts on
+ * every invocation (RUSH-2331). agents.ts AGENTS[*].cliCommand values are
+ * pinned equal by agent-cli-commands.test.ts — when a harness is added or
+ * renamed, both this list and AGENTS must change together.
+ */
+
+/** Every managed harness CLI binary name (no `agents` / `ag`). */
+export const AGENT_CLI_COMMANDS: readonly string[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'cursor-agent',
+  'opencode',
+  'omp',
+  'openclaw',
+  'copilot',
+  'amp',
+  'kiro-cli',
+  'goose',
+  'agy',
+  'grok',
+  'kimi',
+  'droid',
+  'hermes',
+  'muse',
+  'oz',
+] as const;

--- a/apps/cli/src/lib/brand.bench.ts
+++ b/apps/cli/src/lib/brand.bench.ts
@@ -11,13 +11,12 @@
  *
  *   B) The eager MODULE-IMPORT cost of `import { resolveBrandName,
  *      disabledCommandsForActiveBrand } from './lib/brand.js'` at index.ts:514.
- *      brand.ts's own body is tiny, but its import pulls in agents.js:
- *      brand.ts:20 does `import { ALL_AGENT_IDS, AGENTS } from './agents.js'`
- *      (used only by reservedBrandNames()/validateBrandName(), brand.ts:52-67 —
- *      NEITHER of which is on the startup path). A grep of index.ts's own static
- *      imports shows brand.js (index.ts:514) is the SOLE eager edge that names
- *      agents.js — no other top-level `import` in index.ts references it. This is
- *      measured with real cold `node -e "await import(...)"` subprocesses, since
+ *      After RUSH-2331 brand.ts no longer imports agents.js — reservedBrandNames
+ *      reads the zero-dep AGENT_CLI_COMMANDS leaf (agent-cli-commands.ts) instead.
+ *      brand.js's remaining static imports are state.js + the leaf list (types is
+ *      type-only, erased). The agents.js/versions.js rows below stay as historical
+ *      baselines so a regression that re-introduces the agents edge is visible.
+ *      Measured with real cold `node -e "await import(...)"` subprocesses, since
  *      Node caches an ESM module for the life of a process, so an in-process
  *      second import cannot see cold cost (same method as index.bench.ts's
  *      startup-graph group on the sibling perf branches).
@@ -167,7 +166,7 @@ describe('cold module import — isolate what the brand.js edge costs (real node
     coldImport([]);
   }, COLD);
 
-  bench('import dist/lib/brand.js — brand.js + its full transitive (state.js + agents.js + types.js) into a fresh process', () => {
+  bench('import dist/lib/brand.js — brand.js + its full transitive (state.js + agent-cli-commands.js; no agents.js after RUSH-2331) into a fresh process', () => {
     coldImport([distUrl('brand.js')]);
   }, COLD);
 
@@ -175,7 +174,7 @@ describe('cold module import — isolate what the brand.js edge costs (real node
     coldImport([distUrl('state.js')]);
   }, COLD);
 
-  bench('import dist/lib/agents.js alone — the 138KB module brand.js:20 drags into every process', () => {
+  bench('import dist/lib/agents.js alone — REGRESSION BASELINE; brand no longer imports this after RUSH-2331', () => {
     coldImport([distUrl('agents.js')]);
   }, COLD);
 

--- a/apps/cli/src/lib/brand.test.ts
+++ b/apps/cli/src/lib/brand.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Brand helpers — reserved names must block agent CLI collisions without
+ * pulling agents.ts into the eager bootstrap graph (RUSH-2331).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_CLI_NAME,
+  disabledCommandsForActiveBrand,
+  reservedBrandNames,
+  resolveBrandName,
+  validateBrandName,
+} from './brand.js';
+import { AGENT_CLI_COMMANDS } from './agent-cli-commands.js';
+import { AGENTS, ALL_AGENT_IDS } from './agents.js';
+
+const brandSrcPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'brand.ts');
+
+describe('resolveBrandName', () => {
+  afterEach(() => {
+    delete process.env.AGENTS_BRAND;
+  });
+
+  it('returns agents when AGENTS_BRAND is unset', () => {
+    delete process.env.AGENTS_BRAND;
+    expect(resolveBrandName()).toBe(DEFAULT_CLI_NAME);
+  });
+
+  it('returns the brand when AGENTS_BRAND is a valid name', () => {
+    process.env.AGENTS_BRAND = 'jack';
+    expect(resolveBrandName()).toBe('jack');
+  });
+
+  it('rejects invalid brand tokens and falls back to agents', () => {
+    process.env.AGENTS_BRAND = '9bad';
+    expect(resolveBrandName()).toBe(DEFAULT_CLI_NAME);
+  });
+});
+
+describe('disabledCommandsForActiveBrand', () => {
+  afterEach(() => {
+    delete process.env.AGENTS_BRAND;
+  });
+
+  it('returns an empty set when unbranded (no readMeta)', () => {
+    delete process.env.AGENTS_BRAND;
+    expect(disabledCommandsForActiveBrand().size).toBe(0);
+  });
+});
+
+describe('eager graph (RUSH-2331)', () => {
+  it('brand.ts source does not statically import agents.js', () => {
+    const src = fs.readFileSync(brandSrcPath, 'utf-8');
+    // Strip block comments so a doc reference to agents.js does not trip this.
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    expect(code).not.toMatch(/from\s+['"]\.\/agents\.js['"]/);
+    expect(code).toMatch(/from\s+['"]\.\/agent-cli-commands\.js['"]/);
+  });
+});
+
+describe('reservedBrandNames / validateBrandName (RUSH-2331)', () => {
+  it('reserves agents, ag, and every harness cliCommand', () => {
+    const reserved = reservedBrandNames();
+    expect(reserved.has('agents')).toBe(true);
+    expect(reserved.has('ag')).toBe(true);
+    for (const cmd of AGENT_CLI_COMMANDS) {
+      expect(reserved.has(cmd)).toBe(true);
+    }
+    // Live AGENTS table must agree — the leaf list is the source for brand,
+    // but a harness rename that forgets agent-cli-commands.ts must fail here.
+    for (const id of ALL_AGENT_IDS) {
+      expect(reserved.has(AGENTS[id].cliCommand)).toBe(true);
+    }
+  });
+
+  it('rejects reserved harness CLI names', () => {
+    expect(validateBrandName('claude')).toMatch(/reserved/);
+    expect(validateBrandName('cursor-agent')).toMatch(/reserved/);
+    expect(validateBrandName('oz')).toMatch(/reserved/);
+    expect(validateBrandName('agents')).toMatch(/reserved/);
+    expect(validateBrandName('ag')).toMatch(/reserved/);
+  });
+
+  it('accepts a free name', () => {
+    expect(validateBrandName('jack')).toBeNull();
+    expect(validateBrandName('my-cli')).toBeNull();
+  });
+
+  it('rejects invalid shapes', () => {
+    expect(validateBrandName('9bad')).toMatch(/Invalid name/);
+    expect(validateBrandName('has space')).toMatch(/Invalid name/);
+  });
+});

--- a/apps/cli/src/lib/brand.ts
+++ b/apps/cli/src/lib/brand.ts
@@ -17,7 +17,13 @@
  * where the active profile is resolved brand-first.
  */
 import { readMeta, updateMeta } from './state.js';
-import { ALL_AGENT_IDS, AGENTS } from './agents.js';
+// Leaf list only — do NOT import agents.js here. index.ts imports brand on
+// every invocation (resolveBrandName / disabledCommandsForActiveBrand); a
+// static agents import pulls the full agents.ts → versions.ts graph (~90ms)
+// into --version/--help and the secrets-broker hot path (RUSH-2331).
+// reservedBrandNames is only called when minting a brand; AGENT_CLI_COMMANDS
+// is pinned equal to AGENTS[*].cliCommand by agent-cli-commands.test.ts.
+import { AGENT_CLI_COMMANDS } from './agent-cli-commands.js';
 import type { BrandConfig } from './types.js';
 
 /** The default (unbranded) program name. */
@@ -51,7 +57,7 @@ export function isBranded(): boolean {
 /** Names that would clobber an agent CLI shim or the `agents`/`ag` binary. */
 export function reservedBrandNames(): Set<string> {
   const reserved = new Set<string>([DEFAULT_CLI_NAME, 'ag']);
-  for (const id of ALL_AGENT_IDS) reserved.add(AGENTS[id].cliCommand);
+  for (const cmd of AGENT_CLI_COMMANDS) reserved.add(cmd);
   return reserved;
 }
 

--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -1190,36 +1190,13 @@ describe('installMenubarLaunchAgentOnUpgrade() — warm in-process call on THIS 
  * pulls in at load time is paid before `resolveBrandName()` can tell you which
  * case you are in.
  *
- * brand.ts:20 imports `{ ALL_AGENT_IDS, AGENTS }` from `./agents.js` (3290
- * lines, verified: `wc -l src/lib/agents.ts`) for exactly two functions,
- * `reservedBrandNames()` (brand.ts:52-56) and `validateBrandName()`
- * (brand.ts:59-67) — both reachable only from `agents mine init <name>` /
- * `agents setup mine`, never from `resolveBrandName()` or
- * `disabledCommandsForActiveBrand()`. Grepping the earlier eager imports in
- * index.ts (commander, chalk, fs/os/path/url, dev-build.js, secrets/sync-
- * commands.js, self-update.js, startup/command-registry.js, help.js, whats-
- * new.js, types.js, platform/index.js, cli-entry.js, events.js, event-
- * provenance.js, format.js, state.js — everything above index.ts:514) for
- * `from '../agents.js'` / `from './agents.js'` and their own static import
- * lists turns up none of them importing agents.js, so brand.js is genuinely
- * the FIRST thing on the eager path that drags it in — nothing upstream of
- * index.ts:514 already paid this cost.
- *
- * agents.ts:26 in turn imports `{ resolveVersion, getVersionHomePath,
- * getBinaryPath }` from `./versions.js` — a 3738-line file (`wc -l
- * src/lib/versions.ts`) that is itself the single largest static-import
- * fan-out in this package: resources.ts, resource-profiles.ts, permissions.ts,
- * mcp.ts, convert.ts, import.ts, subagents.ts, workflows.ts, hooks.ts,
- * capabilities.ts, plugins.ts, rules/compose.ts, staleness/index.ts,
- * staleness/registry.ts, memory.ts, project-resources.ts, and
- * `@inquirer/prompts` (versions.ts:17-68) — AND versions.ts:35 imports back
- * from `./agents.js`, so agents.ts <-> versions.ts is a circular pair; Node's
- * ESM loader still evaluates the whole reachable graph once, cycle or not.
- * The three rows below decompose exactly how much of brand.js's real cost is
- * "load brand.ts's own 134 lines" versus "drag in agents.js" versus "drag in
- * versions.js and everything under it" — each row's (row - FLOOR) isolates
- * one layer, since FLOOR cancels identically in every row (same coldEval
- * spawn shape, see the coldEval docblock above).
+ * RUSH-2331 cut the brand → agents → versions edge: brand.ts now imports the
+ * zero-dep `agent-cli-commands.js` leaf for reservedBrandNames(), so a cold
+ * `import('./lib/brand.js')` no longer evaluates agents.js or versions.js.
+ * The agents.js / versions.js rows below remain as regression baselines (and
+ * as isolated costs for callers that still import those modules on demand).
+ * brand.js's remaining real imports are state.js (already eager at index.ts
+ * near brand) and the leaf command-name list.
  *
  * No mocking: every row spawns a real cold `node --input-type=module`
  * process and imports the real built dist/lib/*.js artifact — the same files
@@ -1234,7 +1211,7 @@ describe('brand.js eager import (index.ts:514) — cold module import, the graph
     coldEval([BRAND_SPEC]);
   }, COLD_OPTS);
 
-  bench('lib/agents.js alone — the graph brand.ts:20 imports `{ ALL_AGENT_IDS, AGENTS }` from, for reservedBrandNames()/validateBrandName() (brand.ts:52-67), functions the unbranded fast path never calls. agents.ts is 3290 lines and itself imports versions.ts, capabilities.ts, fs-walk.ts, fuzzy.ts (agents.ts:12-27)', () => {
+  bench('lib/agents.js alone — REGRESSION BASELINE (RUSH-2331): brand.ts no longer imports this; was the sole eager edge into agents/versions. agents.ts still imports versions.ts for on-demand callers', () => {
     coldEval([AGENTS_REGISTRY_SPEC]);
   }, COLD_OPTS);
 


### PR DESCRIPTION
perf · bootstrap latency · audience: operators / agents that invoke the CLI often

## What changed

Every `agents` invocation statically imports `brand.js` for `resolveBrandName` / `disabledCommandsForActiveBrand`. That module imported `agents.js` only for `reservedBrandNames()` / `validateBrandName()` (mine/setup), and `agents.js` pulls the full `versions.ts` graph into the eager path.

`brand.ts` now reads the zero-dep `agent-cli-commands` leaf (pinned equal to `AGENTS[*].cliCommand` by test). The self-update → primitives redirect from the same ticket was already on main.

## Cold-import evidence (real built `dist/`, cold child processes)

| Module | mean ms |
| --- | --- |
| bare node floor | 18.9 |
| `agent-cli-commands.js` | 15.0 |
| `brand.js` (after fix) | **46.7** |
| `agents.js` alone | 104.6 |
| `versions.js` alone | 102.7 |

Brand no longer pays the agents/versions graph on every invocation. Remaining brand cost is mostly `state.js` (already eager on the same path).

## Tests

```
bun test src/lib/brand.test.ts src/lib/agent-cli-commands.test.ts src/commands/mine.test.ts
18 pass, 0 fail
```

Covers: reserved names match AGENTS cliCommands; brand.ts source does not import agents.js; mine white-label still rejects reserved/invalid names.

## Ticket

https://linear.app/getrush/issue/RUSH-2331/cli-bootstrap-versionsts-reaches-the-eager-graph-by-two-edges-94ms

No UI surface; CLI bootstrap change.