### PR TITLE
fix(teams): surface PR OPEN when completed teammate left unmerged PR (RUSH-2380)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2380-teams-pr-open.md
+++ b/apps/cli/.changelog/next/RUSH-2380-teams-pr-open.md
@@ -1,0 +1,10 @@
+- **`agents teams status` shows `PR OPEN` instead of bare `COMPLETED` when a
+  teammate finished with an unmerged PR (RUSH-2380).** Process-exit success was
+  reported as COMPLETED even when the PR was still open, so orchestrators
+  composed on top of unlanded work (3/3 edit-mode teammates one day). Delivery
+  is now a separate postcondition (`delivery: pr_open | pr_merged | no_pr | …`)
+  on status JSON; the human status label is `PR OPEN` (magenta) when process
+  status is completed and a PR URL is present without a known merge. Process
+  status still drives the DAG (`--after`); only the display/JSON delivery
+  signal changed. Source: `apps/cli/src/lib/teams/delivery.ts`,
+  `apps/cli/src/lib/teams/api.ts`, `apps/cli/src/commands/teams.ts`.

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -48,6 +48,12 @@ import {
   type TaskInfo,
 } from '../lib/teams/api.js';
 import {
+  resolveTeammateDelivery,
+  deliveryDisplayLabel,
+  deliveryColorKey,
+  type TeammateDelivery,
+} from '../lib/teams/delivery.js';
+import {
   createTeam,
   ensureTeam,
   getTeam,
@@ -143,6 +149,7 @@ function statusColor(status: string): (s: string) => string {
     case 'pending': return chalk.blue;
     case 'running': return chalk.yellow;
     case 'completed': return chalk.green;
+    case 'pr_open': return chalk.magenta; // RUSH-2380: process done, PR not merged
     case 'failed': return chalk.red;
     case 'stopped': return chalk.gray;
     default: return chalk.white;
@@ -806,7 +813,12 @@ async function resolveTeammateAcrossTeams(
 //     ! reported an error             (if flagged)
 //     PR: <url>                       (if set)
 function printAgentDetail(a: AgentStatusDetail, session: SessionMeta | null): void {
-  const label = statusColor(a.status)(a.status.toUpperCase());
+  // RUSH-2380: process COMPLETED + open PR → show PR OPEN, not COMPLETED.
+  const delivery: TeammateDelivery =
+    (a.delivery as TeammateDelivery | undefined) ??
+    resolveTeammateDelivery({ status: a.status, prUrl: a.pr_url });
+  const colorKey = deliveryColorKey(delivery, a.status);
+  const label = statusColor(colorKey)(deliveryDisplayLabel(delivery, a.status));
   const who = fullName(a.agent_type as AgentType, a.version);
   const h = displayHandle(a);
   const secondary = a.name ? chalk.gray(`(${shortId(a.agent_id)})`) : '';
@@ -906,7 +918,11 @@ async function resolveTeammateSessions(
 // last." Caller passes the projected AgentStatusSummary; for the full
 // verbose layout use printAgentDetail above.
 function printAgentSummary(s: AgentStatusSummary): void {
-  const label = statusColor(s.status)(s.status.toUpperCase());
+  const delivery: TeammateDelivery =
+    (s.delivery as TeammateDelivery | undefined) ??
+    resolveTeammateDelivery({ status: s.status, prUrl: s.pr_url });
+  const colorKey = deliveryColorKey(delivery, s.status);
+  const label = statusColor(colorKey)(deliveryDisplayLabel(delivery, s.status));
   const handle = s.name ?? shortId(s.agent_id);
   const ident = s.name ? chalk.gray(`(${shortId(s.agent_id)})`) : '';
   const duration = s.duration ? `${chalk.gray(' · ')}${chalk.white(s.duration)}` : '';

--- a/apps/cli/src/lib/teams/__tests__/api-summary.test.ts
+++ b/apps/cli/src/lib/teams/__tests__/api-summary.test.ts
@@ -101,6 +101,16 @@ describe('toAgentStatusSummary', () => {
     expect(summary.tool_count).toBe(42);
     expect(summary.has_errors).toBe(false);
     expect(summary.pr_url).toBe('https://github.com/example/repo/pull/1');
+    // Running + PR URL is still in_progress delivery (RUSH-2380).
+    expect(summary.delivery).toBe('in_progress');
+  });
+
+  it('marks completed+pr_url as delivery pr_open (RUSH-2380)', () => {
+    const summary = toAgentStatusSummary(
+      fakeDetail({ status: 'completed', completed_at: '2026-06-08T00:05:00.000Z' }),
+    );
+    expect(summary.status).toBe('completed');
+    expect(summary.delivery).toBe('pr_open');
   });
 
   it('cuts at least 5x compared to the verbose detail it was projected from', () => {

--- a/apps/cli/src/lib/teams/api.ts
+++ b/apps/cli/src/lib/teams/api.ts
@@ -10,6 +10,7 @@ import { AgentType } from './parsers.js';
 import { getDelta } from './summarizer.js';
 import { debug } from './debug.js';
 import { buildClaudeLabelMap } from '../session/discover.js';
+import { resolveTeammateDelivery } from './delivery.js';
 
 /**
  * Truncate a bash command for status output.
@@ -110,6 +111,12 @@ export interface AgentStatusDetail {
   cloud_session_id?: string | null;
   cloud_provider?: string | null;
   pr_url?: string | null;
+  /**
+   * Delivery postcondition (RUSH-2380), distinct from process `status`.
+   * `pr_open` when the process completed but left an unmerged PR — orchestrators
+   * must not treat that as "work landed on main".
+   */
+  delivery?: string;
   version?: string | null;
   remote_session_id?: string | null;
   session_label?: string | null;
@@ -144,6 +151,8 @@ export interface AgentStatusSummary {
   name: string | null;
   agent_type: string;
   status: string;
+  /** Delivery postcondition — see {@link AgentStatusDetail.delivery}. */
+  delivery?: string;
   duration: string | null;
   tool_count: number;
   has_errors: boolean;
@@ -227,6 +236,9 @@ export function toAgentStatusSummary(detail: AgentStatusDetail): AgentStatusSumm
     name: detail.name ?? null,
     agent_type: detail.agent_type,
     status: detail.status,
+    delivery:
+      detail.delivery ??
+      resolveTeammateDelivery({ status: detail.status, prUrl: detail.pr_url }),
     duration: detail.duration,
     tool_count: detail.tool_count,
     has_errors: detail.has_errors,
@@ -478,6 +490,10 @@ export async function handleStatus(
       cloud_session_id: agent.cloudSessionId,
       cloud_provider: agent.cloudProvider,
       pr_url: agent.prUrl,
+      delivery: resolveTeammateDelivery({
+        status: agent.status,
+        prUrl: agent.prUrl,
+      }),
       files_created: delta.new_files_created,
       files_modified: delta.new_files_modified,
       files_read: delta.new_files_read,

--- a/apps/cli/src/lib/teams/delivery.test.ts
+++ b/apps/cli/src/lib/teams/delivery.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { AgentStatus } from './agents.js';
+import {
+  resolveTeammateDelivery,
+  deliveryDisplayLabel,
+  deliveryColorKey,
+} from './delivery.js';
+
+describe('resolveTeammateDelivery (RUSH-2380)', () => {
+  it('completed with no PR is no_pr (process done, nothing to merge)', () => {
+    expect(
+      resolveTeammateDelivery({ status: AgentStatus.COMPLETED, prUrl: null }),
+    ).toBe('no_pr');
+    expect(
+      resolveTeammateDelivery({ status: 'completed', prUrl: undefined }),
+    ).toBe('no_pr');
+  });
+
+  it('completed with a PR URL and unknown merge is pr_open (pessimistic)', () => {
+    expect(
+      resolveTeammateDelivery({
+        status: AgentStatus.COMPLETED,
+        prUrl: 'https://github.com/phnx-labs/agents-cli/pull/2317',
+      }),
+    ).toBe('pr_open');
+    expect(
+      resolveTeammateDelivery({
+        status: AgentStatus.COMPLETED,
+        prUrl: 'https://github.com/phnx-labs/agents-cli/pull/2317',
+        prMerged: null,
+      }),
+    ).toBe('pr_open');
+  });
+
+  it('completed with prMerged=false is pr_open', () => {
+    expect(
+      resolveTeammateDelivery({
+        status: AgentStatus.COMPLETED,
+        prUrl: 'https://github.com/x/y/pull/1',
+        prMerged: false,
+      }),
+    ).toBe('pr_open');
+  });
+
+  it('completed with prMerged=true is pr_merged', () => {
+    expect(
+      resolveTeammateDelivery({
+        status: AgentStatus.COMPLETED,
+        prUrl: 'https://github.com/x/y/pull/1',
+        prMerged: true,
+      }),
+    ).toBe('pr_merged');
+  });
+
+  it('whitespace-only prUrl counts as no PR', () => {
+    expect(
+      resolveTeammateDelivery({ status: AgentStatus.COMPLETED, prUrl: '   ' }),
+    ).toBe('no_pr');
+  });
+
+  it('running / pending / failed / stopped map directly', () => {
+    expect(resolveTeammateDelivery({ status: AgentStatus.RUNNING })).toBe('in_progress');
+    expect(resolveTeammateDelivery({ status: AgentStatus.PENDING })).toBe('pending');
+    expect(resolveTeammateDelivery({ status: AgentStatus.FAILED, prUrl: 'https://x/y/pull/1' })).toBe(
+      'failed',
+    );
+    expect(resolveTeammateDelivery({ status: AgentStatus.STOPPED })).toBe('stopped');
+  });
+
+  it('a running teammate with a PR URL is still in_progress (not PR OPEN yet)', () => {
+    // Process not finished — do not claim delivery state.
+    expect(
+      resolveTeammateDelivery({
+        status: AgentStatus.RUNNING,
+        prUrl: 'https://github.com/x/y/pull/9',
+      }),
+    ).toBe('in_progress');
+  });
+});
+
+describe('deliveryDisplayLabel', () => {
+  it('surfaces PR OPEN instead of COMPLETED when delivery is pr_open', () => {
+    expect(deliveryDisplayLabel('pr_open', AgentStatus.COMPLETED)).toBe('PR OPEN');
+    expect(deliveryDisplayLabel('pr_merged', AgentStatus.COMPLETED)).toBe('COMPLETED');
+    expect(deliveryDisplayLabel('no_pr', AgentStatus.COMPLETED)).toBe('COMPLETED');
+    expect(deliveryDisplayLabel('failed', AgentStatus.FAILED)).toBe('FAILED');
+    expect(deliveryDisplayLabel('in_progress', AgentStatus.RUNNING)).toBe('RUNNING');
+  });
+});
+
+describe('deliveryColorKey', () => {
+  it('uses pr_open key so the row is not green COMPLETED', () => {
+    expect(deliveryColorKey('pr_open', 'completed')).toBe('pr_open');
+    expect(deliveryColorKey('no_pr', 'completed')).toBe('completed');
+  });
+});

--- a/apps/cli/src/lib/teams/delivery.ts
+++ b/apps/cli/src/lib/teams/delivery.ts
@@ -1,0 +1,78 @@
+/**
+ * Teammate *delivery* vs process *lifecycle* (RUSH-2380).
+ *
+ * `AgentStatus.COMPLETED` means the process exited 0 — not that the PR merged.
+ * Orchestrators that treat COMPLETED as "work landed on main" compose on top of
+ * unmerged PRs. This module derives a delivery signal from process status +
+ * whether a PR URL is still open, so `teams status` can surface `PR OPEN`
+ * instead of bare COMPLETED.
+ *
+ * Process status still drives the DAG (`--after` deps): a finished process
+ * unblocks dependents. Delivery is the postcondition for "done end-to-end".
+ */
+
+import { AgentStatus } from './agents.js';
+
+/** Postcondition-facing delivery of a teammate's work. */
+export type TeammateDelivery =
+  | 'pending'
+  | 'in_progress'
+  | 'pr_open'
+  | 'pr_merged'
+  | 'no_pr'
+  | 'failed'
+  | 'stopped';
+
+/**
+ * Derive delivery from process status and PR state.
+ *
+ * When the process completed with a `prUrl` and merge is unknown or false,
+ * delivery is `pr_open` — pessimistic: assume open until proven merged so an
+ * orchestrator never mistakes "agent stopped" for "work on main".
+ */
+export function resolveTeammateDelivery(opts: {
+  status: AgentStatus | string;
+  prUrl?: string | null;
+  /**
+   * When known from a probe or meta: true = merged, false = still open.
+   * `null`/`undefined` = unknown; with a `prUrl` that means `pr_open`.
+   */
+  prMerged?: boolean | null;
+}): TeammateDelivery {
+  const status = String(opts.status);
+  if (status === AgentStatus.PENDING || status === 'pending') return 'pending';
+  if (status === AgentStatus.RUNNING || status === 'running') return 'in_progress';
+  if (status === AgentStatus.FAILED || status === 'failed') return 'failed';
+  if (status === AgentStatus.STOPPED || status === 'stopped') return 'stopped';
+
+  if (status === AgentStatus.COMPLETED || status === 'completed') {
+    const prUrl = opts.prUrl?.trim();
+    if (!prUrl) return 'no_pr';
+    if (opts.prMerged === true) return 'pr_merged';
+    return 'pr_open';
+  }
+
+  return 'in_progress';
+}
+
+/**
+ * Human label for `teams status` rows. Replaces bare COMPLETED with PR OPEN
+ * when delivery is still pending merge.
+ */
+export function deliveryDisplayLabel(
+  delivery: TeammateDelivery,
+  processStatus: AgentStatus | string,
+): string {
+  if (delivery === 'pr_open') return 'PR OPEN';
+  if (delivery === 'pr_merged') return 'COMPLETED';
+  return String(processStatus).toUpperCase();
+}
+
+/**
+ * Color key for statusColor-style switches. `pr_open` is its own key so the
+ * row is visually distinct from green COMPLETED.
+ */
+export function deliveryColorKey(delivery: TeammateDelivery, processStatus: string): string {
+  if (delivery === 'pr_open') return 'pr_open';
+  return String(processStatus);
+}


### PR DESCRIPTION
fix · teams status no longer shows bare COMPLETED for open PRs · audience: orchestrators

## What changed

Process-exit success was reported as `COMPLETED` even when the teammate's PR was still open (3/3 edit-mode cases the day of the ticket). Orchestrators that trusted COMPLETED composed on unlanded work.

Delivery is now a **separate postcondition** from process status:

| Process status | PR | `delivery` | Display label |
|---|---|---|---|
| completed | none | `no_pr` | COMPLETED |
| completed | present, not known-merged | `pr_open` | **PR OPEN** (magenta) |
| completed | known merged | `pr_merged` | COMPLETED |
| running | any | `in_progress` | RUNNING |

- Process `status` still drives the `--after` DAG (a finished process unblocks dependents).
- JSON includes `delivery` on both detail and summary shapes.
- No live GitHub probe in this PR (rate-limit safe); unknown merge is pessimistic `pr_open`.

## Files

| File | Role |
|---|---|
| `apps/cli/src/lib/teams/delivery.ts` | Pure resolve + labels |
| `apps/cli/src/lib/teams/delivery.test.ts` | 9 unit tests |
| `apps/cli/src/lib/teams/api.ts` | Wire `delivery` into status JSON |
| `apps/cli/src/commands/teams.ts` | Display PR OPEN |
| `.changelog/next/RUSH-2380-teams-pr-open.md` | Fragment |

## Run proof

https://share.agents-cli.sh/muqsitnawaz/r2380-teams-complete-r2380-proof-kotn-498e51f89ec2a150

```
18 pass / 0 fail (delivery + api-summary)

completed + prUrl => pr_open / PR OPEN
completed + prMerged:true => pr_merged / COMPLETED
running + prUrl => in_progress / RUNNING
```

Linear: https://linear.app/getrush/issue/RUSH-2380