### PR TITLE
fix(cli): read Codex model from turn_context fallback

### DIFF
--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -920,10 +920,11 @@ normative — a change that widens/narrows a cell is a spec change.
 ### 8. Given/When/Then scenarios
 
 **GWT-1 — Codex transcript discovered with correct harness + metadata.**
-Given a Codex JSONL at `~/.codex/sessions/**` with a `session_meta` line;
-When `agents sessions` runs; Then it appears with `agent='codex'`, cwd/gitBranch
-from `session_meta`, and `tokenCount` from the last cumulative snapshot priced
-once (`discover.ts:3477-3526`).
+Given a Codex JSONL at `~/.codex/sessions/**` with a `session_meta` line and
+per-turn `turn_context` lines; When `agents sessions` runs; Then it appears with
+`agent='codex'`, cwd/gitBranch from `session_meta`, `model` from `session_meta`
+falling back to `turn_context`, and `tokenCount` from the last cumulative snapshot
+priced once (`discover.ts:3477-3526`, `discover.ts:4242-4253`).
 
 **GWT-2 — Live copy beats backup mirror.**
 Given the same session id in the live root and a `backups/<agent>/<ts>/` mirror;

--- a/apps/cli/src/lib/session/__tests__/codex-incremental-parity.test.ts
+++ b/apps/cli/src/lib/session/__tests__/codex-incremental-parity.test.ts
@@ -203,6 +203,20 @@ describe('codex incremental parity — turn_context metadata fallback', () => {
     expect(inc.model).toBe('gpt-5-codex');
     expectScanParity(inc, full);
   });
+
+  it('falls back cwd from turn_context when session_meta omits it', async () => {
+    const chunkA = jsonl([
+      { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: 's' } },
+      { type: 'response_item', timestamp: '2026-06-28T00:01:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'turn_context', timestamp: '2026-06-28T00:02:00.000Z', payload: { model: 'gpt-5.6-sol', cwd: '/from-turn' } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.cwd).toBe('/from-turn');
+    expect(inc.model).toBe('gpt-5.6-sol');
+    expectScanParity(inc, full);
+  });
 });
 
 describe('codex incremental parity — truncation → full reparse', () => {

--- a/apps/cli/src/lib/session/__tests__/codex-incremental-parity.test.ts
+++ b/apps/cli/src/lib/session/__tests__/codex-incremental-parity.test.ts
@@ -74,7 +74,7 @@ async function replay(chunks: string[]) {
 function expectScanParity(inc: any, full: any) {
   expect(inc).toEqual(full);
   const fields = [
-    'sessionId', 'timestamp', 'cwd', 'gitBranch', 'version', 'topic',
+    'sessionId', 'timestamp', 'cwd', 'gitBranch', 'version', 'model', 'topic',
     'messageCount', 'tokenCount', 'outputTokens', 'costUsd', 'durationMs',
     'lastActivity', 'contentText', 'prUrl', 'prNumber', 'worktreeSlug',
     'ticketId', 'createdTickets', 'spawnedTeam', 'todos', 'recentDirectoriesTouched',
@@ -173,6 +173,34 @@ describe('codex incremental parity — straddled two-event patterns', () => {
     ]);
     const { inc, full } = await replay([chunkA, chunkB]);
     expect(inc.spawnedTeam).toBe('my-feature');
+    expectScanParity(inc, full);
+  });
+});
+
+describe('codex incremental parity — turn_context metadata fallback', () => {
+  it('extracts model from turn_context when session_meta omits it', async () => {
+    const chunkA = jsonl([
+      { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: 's', cwd: '/x' } },
+      { type: 'response_item', timestamp: '2026-06-28T00:01:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'turn_context', timestamp: '2026-06-28T00:02:00.000Z', payload: { model: 'gpt-5.6-sol', cwd: '/y' } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.model).toBe('gpt-5.6-sol');
+    expect(inc.cwd).toBe('/x');
+    expectScanParity(inc, full);
+  });
+
+  it('session_meta model wins over turn_context model', async () => {
+    const chunkA = jsonl([
+      { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: 's', cwd: '/x', model: 'gpt-5-codex' } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'turn_context', timestamp: '2026-06-28T00:01:00.000Z', payload: { model: 'gpt-5.6-sol' } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.model).toBe('gpt-5-codex');
     expectScanParity(inc, full);
   });
 });

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -4239,6 +4239,17 @@ export function applyCodexLine(state: CodexParseState, parsed: any): void {
     return;
   }
 
+  // Codex rollouts put per-turn metadata (including the model) on
+  // `turn_context` events. Use them as a fallback when session_meta itself
+  // does not carry the field, otherwise `agents sessions` shows blank model
+  // info for Codex.
+  if (parsed.type === 'turn_context') {
+    const payload = parsed.payload || {};
+    if (!state.model && typeof payload.model === 'string') state.model = payload.model;
+    if (!state.cwd && typeof payload.cwd === 'string') state.cwd = payload.cwd;
+    return;
+  }
+
   if (parsed.type === 'response_item' && parsed.payload?.type === 'message') {
     const role = parsed.payload.role === 'user' || parsed.payload.role === 'developer'
       ? 'user'


### PR DESCRIPTION
## Problem

For Codex agent sessions, `agents sessions` omits or leaves blank the **Model** column. Claude sessions show the model correctly.

## Root cause

Current Codex rollouts store the model in `turn_context.payload.model`, but `applyCodexLine()` in `apps/cli/src/lib/session/discover.ts` only looked at `session_meta.payload.model` and an outdated `event_msg/token_count` fallback. Because real Codex transcripts no longer include the model in those places, `state.model` stayed undefined.

## Change

Use `turn_context` as a fallback source for `model` and `cwd` when `session_meta` does not provide them. `session_meta` remains authoritative.

### Files

- `apps/cli/src/lib/session/discover.ts` — adds `turn_context` branch in `applyCodexLine()`.
- `apps/cli/src/lib/session/__tests__/codex-incremental-parity.test.ts` — adds `model` to parity checks and two tests:
  - model extracted from `turn_context` when `session_meta` omits it
  - `session_meta.model` wins over `turn_context.model`

## Validation

```
cd apps/cli
bun test src/lib/session/__tests__/codex-incremental-parity.test.ts src/lib/session/__tests__/parse-codex.test.ts --run
```

Result: **20 pass, 0 fail**.

The pre-existing e2e failure in `codex-incremental-scan-e2e.test.ts` (sessions not discovered in this environment) was verified to fail identically before and after the change.

## User-visible result

After this fix, `agents sessions --agent codex` displays the model name (e.g., `gpt-5.6-sol`) in the Model column and in the session preview pane, matching Claude behavior.
