### PR TITLE
chore(repo): gitignore root-only /.config/ (local muse state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ scripts/scrub-history.sh
 .refs/
 .crabbox/
 .rush/
+# Local muse state (root only; nested package .config dirs stay tracked)
+/.config/
 
 # Agents (recurisve)
 # Harness config homes written by `agents` config sync. Keep this list in step


### PR DESCRIPTION
**gitignore-only** — no runtime surface (no code, docs, test, or CHANGELOG change required).

## What
Adds a narrow, root-only rule `/.config/` to the repo-root `.gitignore` so local `.config/muse` state stops showing up in `git status`.

## Why
The root `.config/muse` directory is local machine state that agents create; it was appearing as untracked noise in `git status` on the main checkout.

## Scope guarantees (verified)
- Rule is **root-anchored** (`/.config/`), so nested package `.config` dirs stay tracked.
- Placed in the existing `# Other` root-local-state section, next to `.refs/` / `.crabbox/` / `.rush/`.
- Affects **zero tracked files**.

## Verification (run in the branch worktree)
```
$ git check-ignore -v .config/muse .config/muse/state.json
.gitignore:60:/.config/	.config/muse
.gitignore:60:/.config/	.config/muse/state.json

$ git check-ignore -v apps/cli/.config/foo apps/factory/.config ; echo rc=$?
rc=1                       # nested package .config NOT ignored

$ git ls-files ':(top).config/' | wc -l
0                          # no tracked file affected
```
