### PR TITLE
fix(cli): stop Grok usage bars inventing 0% or keeping expired weeks

### DIFF
--- a/apps/cli/.changelog/next/grok-usage-stale-windows.md
+++ b/apps/cli/.changelog/next/grok-usage-stale-windows.md
@@ -1,0 +1,15 @@
+# Grok usage bars ignore expired / missing last-seen billing
+
+`agents view grok` reads weekly usage from each machine's local
+`.grok/logs/unified.jsonl` (`network: false`). Two bugs made the bars disagree
+across devices and lie after a weekly reset:
+
+1. A billing line with no `creditUsagePercent` was coerced to **0%**, so a fresh
+   period looked empty instead of unknown.
+2. An **expired** period (e.g. last week's 100%) was still rendered, so one box
+   showed `rate-limited` after the window had already reset.
+
+Expired windows are dropped via the same freshness check used for the Claude
+usage cache; missing percents no longer invent a bar. Live cross-device parity
+still requires a Grok session on that box to write a new billing line — there is
+no network usage probe for Grok yet.

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -395,23 +395,34 @@ describe('usage formatting', () => {
     try {
       const logDir = path.join(home, '.grok', 'logs');
       fs.mkdirSync(logDir, { recursive: true });
+      // Relative dates so the fixture stays in-period under the freshness filter
+      // (absolute Aug 2026 ends were already expired when this PR landed).
+      const now = Date.now();
+      const day = 24 * 60 * 60 * 1000;
+      const periodEnd = new Date(now + 6 * day).toISOString();
       // Two billing lines; the parser keeps the LAST one seen.
       const lines = [
         JSON.stringify({
-          ts: '2026-08-01T00:00:00.000Z',
+          ts: new Date(now - 2 * day).toISOString(),
           msg: 'billing: fetched credits config',
-          ctx: { config: { creditUsagePercent: 10, currentPeriod: { end: '2026-08-01T18:27:00Z' } }, subscriptionTier: 'X Premium' },
+          ctx: {
+            config: {
+              creditUsagePercent: 10,
+              currentPeriod: { end: new Date(now - day).toISOString() },
+            },
+            subscriptionTier: 'X Premium',
+          },
         }),
         // Real-world shape captured from ~/.grok/logs/unified.jsonl.
         JSON.stringify({
-          ts: '2026-08-02T04:00:49.628Z',
+          ts: new Date(now - 60_000).toISOString(),
           src: 'shell',
           lvl: 'info',
           msg: 'billing: fetched credits config',
           ctx: {
             config: {
               creditUsagePercent: 100.0,
-              currentPeriod: { type: 'USAGE_PERIOD_TYPE_WEEKLY', end: '2026-08-02T18:27:00.269749+00:00' },
+              currentPeriod: { type: 'USAGE_PERIOD_TYPE_WEEKLY', end: periodEnd },
               isUnifiedBillingUser: true,
             },
             subscriptionTier: 'X Premium+',
@@ -427,7 +438,40 @@ describe('usage formatting', () => {
       expect(week?.shortLabel).toBe('W');
       // Real credit consumption is surfaced, not a hardcoded 0%.
       expect(week?.usedPercent).toBe(100);
-      expect(week?.resetsAt?.toISOString()).toBe(new Date('2026-08-02T18:27:00.269749+00:00').toISOString());
+      expect(week?.resetsAt?.toISOString()).toBe(new Date(periodEnd).toISOString());
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('drops an expired Grok billing window from the real log shape', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-grok-expired-'));
+    try {
+      const logDir = path.join(home, '.grok', 'logs');
+      fs.mkdirSync(logDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(logDir, 'unified.jsonl'),
+        `${JSON.stringify({
+          ts: '2026-08-02T04:00:49.628Z',
+          msg: 'billing: fetched credits config',
+          ctx: {
+            config: {
+              creditUsagePercent: 100.0,
+              currentPeriod: {
+                type: 'USAGE_PERIOD_TYPE_WEEKLY',
+                end: '2026-08-02T18:27:00.269749+00:00',
+              },
+            },
+            subscriptionTier: 'X Premium+',
+          },
+        })}\n`
+      );
+
+      const { snapshot, error } = await getUsageInfo('grok', { home });
+      expect(error).toBeNull();
+      expect(snapshot?.plan).toBe('X Premium+');
+      expect(snapshot?.windows).toEqual([]);
+      expect(deriveUsageStatusFromSnapshot(snapshot)).toBeNull();
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -909,3 +909,99 @@ describe('getUsageInfo(codex) — usage is scoped to the current login', () => {
     expect(session?.usedPercent).toBe(42);
   });
 });
+
+describe('getUsageInfo(grok) — last-seen billing from unified.jsonl', () => {
+  let home: string;
+  const HOUR = 60 * 60 * 1000;
+  const DAY = 24 * HOUR;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-usage-'));
+  });
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeBillingLine(opts: {
+    tsMs: number;
+    percent?: number | null;
+    periodStartMs: number;
+    periodEndMs: number;
+    tier?: string;
+  }): void {
+    const logDir = path.join(home, '.grok', 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    const p = path.join(logDir, 'unified.jsonl');
+    const config: Record<string, unknown> = {
+      currentPeriod: {
+        type: 'USAGE_PERIOD_TYPE_WEEKLY',
+        start: new Date(opts.periodStartMs).toISOString(),
+        end: new Date(opts.periodEndMs).toISOString(),
+      },
+    };
+    if (opts.percent !== null && opts.percent !== undefined) {
+      config.creditUsagePercent = opts.percent;
+    }
+    const line = JSON.stringify({
+      ts: new Date(opts.tsMs).toISOString(),
+      msg: 'billing: fetched credits config',
+      ctx: { config, subscriptionTier: opts.tier ?? 'X Premium+' },
+    });
+    fs.appendFileSync(p, line + '\n');
+  }
+
+  it('renders the latest in-period creditUsagePercent as the week bar', async () => {
+    const now = Date.now();
+    writeBillingLine({
+      tsMs: now - HOUR,
+      percent: 37,
+      periodStartMs: now - DAY,
+      periodEndMs: now + 6 * DAY,
+      tier: 'SuperGrok Heavy',
+    });
+
+    const info = await getUsageInfo('grok', { home });
+    expect(info.snapshot?.plan).toBe('SuperGrok Heavy');
+    expect(info.snapshot?.source).toBe('last_seen');
+    const week = info.snapshot?.windows.find((w) => w.key === 'week');
+    expect(week?.usedPercent).toBe(37);
+  });
+
+  it('does not invent a 0% bar when creditUsagePercent is missing', async () => {
+    const now = Date.now();
+    // Prior period at 100%, then a new period line with no percent yet — the
+    // real fleet case that painted W: 0% on one box while another still
+    // showed a stale expired reading.
+    writeBillingLine({
+      tsMs: now - 2 * HOUR,
+      percent: 100,
+      periodStartMs: now - 8 * DAY,
+      periodEndMs: now - HOUR,
+    });
+    writeBillingLine({
+      tsMs: now - HOUR,
+      percent: null,
+      periodStartMs: now - HOUR,
+      periodEndMs: now + 6 * DAY,
+    });
+
+    const info = await getUsageInfo('grok', { home });
+    expect(info.snapshot?.windows).toEqual([]);
+    expect(info.snapshot?.plan).toBe('X Premium+');
+  });
+
+  it('drops expired billing windows so stale 100% is not rate-limited', async () => {
+    const now = Date.now();
+    writeBillingLine({
+      tsMs: now - DAY,
+      percent: 100,
+      periodStartMs: now - 8 * DAY,
+      periodEndMs: now - HOUR,
+      tier: 'SuperGrok Heavy',
+    });
+
+    const info = await getUsageInfo('grok', { home });
+    expect(info.snapshot?.windows).toEqual([]);
+    expect(info.snapshot?.plan).toBe('SuperGrok Heavy');
+  });
+});

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -2335,12 +2335,23 @@ async function getGrokUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
     const match = await readLatestGrokBilling(logPath);
     if (!match) return { snapshot: null, error: null };
 
+    // Grok has no live usage API (`network: false`) — bars are last-seen from
+    // this machine's unified.jsonl only. Drop windows whose billing period has
+    // already ended so a stale 100% does not paint "rate-limited" after reset,
+    // and so an expired 92% on one box cannot disagree with a fresh reading on
+    // another. Missing `creditUsagePercent` never reaches here as a 0% bar
+    // (see readLatestGrokBilling).
+    const now = new Date();
+    const windows = match.windows.filter((window) =>
+      isCachedUsageWindowFresh(window, match.capturedAt, now)
+    );
+
     return {
       snapshot: {
         source: 'last_seen',
         sourceLabel: 'last seen in Grok logs',
         capturedAt: match.capturedAt,
-        windows: match.windows,
+        windows,
         plan: match.subscriptionTier,
       },
       error: null,
@@ -2567,11 +2578,13 @@ async function readLatestGrokBilling(filePath: string): Promise<GrokBillingMatch
           const config = parsed.ctx.config;
           const windows: UsageWindow[] = [];
 
-          if (config.currentPeriod?.end) {
+          if (config.currentPeriod?.end && typeof config.creditUsagePercent === 'number') {
             // `creditUsagePercent` is Grok's weekly credit consumption (0-100);
             // the billing period's `end` is when that window resets.
-            const rawPercent =
-              typeof config.creditUsagePercent === 'number' ? config.creditUsagePercent : 0;
+            // Do NOT coerce a missing percent to 0 — a new period often lands a
+            // billing line before the gauge is populated, and inventing 0% makes
+            // `agents view` disagree across devices (and looks like a fresh week).
+            const rawPercent = config.creditUsagePercent;
             windows.push({
               key: 'week',
               label: 'Current week',


### PR DESCRIPTION
Behavior fix for `agents view grok` usage bars (not docs-only).

## Summary
- Grok usage is **last-seen from local** `.grok/logs/unified.jsonl` (`network: false`), so each device only sees billing events written on that box.
- Two bugs made the fleet view look contradictory: missing `creditUsagePercent` was coerced to **0%**, and **expired** periods (e.g. last week at 100%) were still rendered as current / `rate-limited`.
- Fix: omit the week bar when percent is absent; drop windows whose `resetsAt` has passed (reuse `isCachedUsageWindowFresh`).

## Evidence (runtime)
| Host | Before | After |
|---|---|---|
| yosemite-s0 `0.2.91` | W: 92% (reset Aug 6, expired) | no week bar |
| yosemite-s0 `0.2.82` | W: 7% (fresh) | W: 7% unchanged |
| yosemite-s1 `0.2.117` | W: 0% (missing percent) | no week bar |
| yosemite-s1 `0.2.82` | W: 100% rate-limited (expired) | no week bar |

Fresh in-period readings can still differ by device until a Grok session on that box writes a new billing line — there is still no live Grok usage API.

## Test plan
- [x] `bun run test src/lib/usage.test.ts` (57 passed, including 3 new Grok cases)
- [x] `agents view grok` on s0 / s1 before and after the patch


Made with [Cursor](https://cursor.com)