### PR TITLE
fix(dispatch): restore Grok pick-host diagnostics

### DIFF
--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1925,6 +1925,11 @@ export function registerRunCommand(program: Command): void {
             const isRaw = options.raw || options.tmux === false || options.disableTmux === true;
             const { modeForRemoteDispatch } = await import('../lib/codex-policy.js');
             const forwardedMode = modeForRemoteDispatch(options.mode, command.getOptionValueSource('mode'));
+            if (process.env.AGENTS_DISPATCH_DEBUG || options.verbose) {
+              process.stderr.write(chalk.gray(
+                `[hosts] dispatch interactive ${runAgent}${runVersion ? `@${runVersion}` : ''} -> ${host.name}\n`,
+              ));
+            }
             const exitCode = await runInteractiveOnHost(host, {
               agent: runAgent,
               version: resumeId ? undefined : runVersion,
@@ -2015,6 +2020,11 @@ export function registerRunCommand(program: Command): void {
           // registration all live in the shared helper (lib/hosts/run-target.ts).
           const { modeForRemoteDispatch } = await import('../lib/codex-policy.js');
           const forwardedMode = modeForRemoteDispatch(options.mode, command.getOptionValueSource('mode'));
+          if (process.env.AGENTS_DISPATCH_DEBUG || options.verbose) {
+            process.stderr.write(chalk.gray(
+              `[hosts] dispatch headless ${runAgent}${runVersion ? `@${runVersion}` : ''} -> ${host.name}\n`,
+            ));
+          }
           const { task, exitCode } = await dispatchPromptToHost(host, {
             agent: runAgent,
             version: resumeId ? undefined : runVersion,

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -32,7 +32,8 @@ function runDispatchDiagnostic(debug: boolean): ReturnType<typeof spawnSync> {
   return spawnSync('bun', [
     '-e',
     "import { buildRunForwardedArgs } from './apps/cli/src/lib/hosts/dispatch.ts'; " +
-      "buildRunForwardedArgs({ agent: 'grok', prompt: 'rotate sk-live-secret', mode: 'auto' });",
+      "buildRunForwardedArgs({ agent: 'grok', prompt: 'rotate sk-live-prompt', mode: 'auto', " +
+      "env: ['API_TOKEN=sk-live-env'], passthroughArgs: ['--api-key', 'sk-live-arg'] });",
   ], { cwd: REPO_ROOT, env, encoding: 'utf8' });
 }
 
@@ -41,8 +42,13 @@ describe('dispatch diagnostics', () => {
     const result = runDispatchDiagnostic(true);
     expect(result.status).toBe(0);
     expect(result.stderr).toContain('[dispatch:headless] agent=grok');
-    expect(result.stderr).toContain('["run","grok","<prompt>","--quiet","--mode","auto"]');
-    expect(result.stderr).not.toContain('sk-live-secret');
+    expect(result.stderr).toContain(
+      '["run","grok","<prompt>","--quiet","--mode","auto","--env","API_TOKEN=<redacted>",' +
+        '"--","<passthrough redacted>"]',
+    );
+    expect(result.stderr).not.toContain('sk-live-prompt');
+    expect(result.stderr).not.toContain('sk-live-env');
+    expect(result.stderr).not.toContain('sk-live-arg');
   });
 
   it('emits no diagnostic when AGENTS_DISPATCH_DEBUG is unset', () => {

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -32,7 +32,7 @@ function runDispatchDiagnostic(debug: boolean): ReturnType<typeof spawnSync> {
   return spawnSync('bun', [
     '-e',
     "import { buildRunForwardedArgs } from './apps/cli/src/lib/hosts/dispatch.ts'; " +
-      "buildRunForwardedArgs({ agent: 'grok', prompt: 'rotate sk-live-prompt', mode: 'auto', " +
+      "buildRunForwardedArgs({ agent: 'grok', prompt: '--token=sk-live-prompt', mode: 'auto', " +
       "env: ['API_TOKEN=sk-live-env'], passthroughArgs: ['--api-key', 'sk-live-arg'] });",
   ], { cwd: REPO_ROOT, env, encoding: 'utf8' });
 }

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -23,6 +23,34 @@ import { resetActorCache } from '../actor.js';
 import type { HostTask } from './tasks.js';
 
 const LOCAL_HOME = process.env.HOME ?? os.homedir();
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../../../..');
+
+function runDispatchDiagnostic(debug: boolean): ReturnType<typeof spawnSync> {
+  const env = { ...process.env };
+  if (debug) env.AGENTS_DISPATCH_DEBUG = '1';
+  else delete env.AGENTS_DISPATCH_DEBUG;
+  return spawnSync('bun', [
+    '-e',
+    "import { buildRunForwardedArgs } from './apps/cli/src/lib/hosts/dispatch.ts'; " +
+      "buildRunForwardedArgs({ agent: 'grok', prompt: 'rotate sk-live-secret', mode: 'auto' });",
+  ], { cwd: REPO_ROOT, env, encoding: 'utf8' });
+}
+
+describe('dispatch diagnostics', () => {
+  it('redacts the headless prompt while retaining the complete forwarded argv', () => {
+    const result = runDispatchDiagnostic(true);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('[dispatch:headless] agent=grok');
+    expect(result.stderr).toContain('["run","grok","<prompt>","--quiet","--mode","auto"]');
+    expect(result.stderr).not.toContain('sk-live-secret');
+  });
+
+  it('emits no diagnostic when AGENTS_DISPATCH_DEBUG is unset', () => {
+    const result = runDispatchDiagnostic(false);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+  });
+});
 
 function decodeWindows(command: string): string {
   const encoded = command.match(/-EncodedCommand (\S+)$/)?.[1];

--- a/apps/cli/src/lib/hosts/dispatch.test.ts
+++ b/apps/cli/src/lib/hosts/dispatch.test.ts
@@ -31,9 +31,11 @@ function runDispatchDiagnostic(debug: boolean): ReturnType<typeof spawnSync> {
   else delete env.AGENTS_DISPATCH_DEBUG;
   return spawnSync('bun', [
     '-e',
-    "import { buildRunForwardedArgs } from './apps/cli/src/lib/hosts/dispatch.ts'; " +
+    "import { buildRunForwardedArgs, buildInteractiveRunForwardedArgs } from './apps/cli/src/lib/hosts/dispatch.ts'; " +
       "buildRunForwardedArgs({ agent: 'grok', prompt: '--token=sk-live-prompt', mode: 'auto', " +
-      "env: ['API_TOKEN=sk-live-env'], passthroughArgs: ['--api-key', 'sk-live-arg'] });",
+      "env: ['API_TOKEN=sk-live-env'], passthroughArgs: ['--api-key', 'sk-live-arg'] }); " +
+      "buildInteractiveRunForwardedArgs({ agent: 'grok', prompt: '--token=sk-live-interactive', " +
+      "forceInteractive: true });",
   ], { cwd: REPO_ROOT, env, encoding: 'utf8' });
 }
 
@@ -49,6 +51,8 @@ describe('dispatch diagnostics', () => {
     expect(result.stderr).not.toContain('sk-live-prompt');
     expect(result.stderr).not.toContain('sk-live-env');
     expect(result.stderr).not.toContain('sk-live-arg');
+    expect(result.stderr).toContain('[dispatch:interactive] agent=grok args=["run","grok","<prompt>","--interactive"]');
+    expect(result.stderr).not.toContain('sk-live-interactive');
   });
 
   it('emits no diagnostic when AGENTS_DISPATCH_DEBUG is unset', () => {

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -40,6 +40,16 @@ export function logForwardedArgs(kind: string, agent: string, version: string | 
   if (safeArgs[0] === 'run' && safeArgs[2] && !safeArgs[2].startsWith('--')) {
     safeArgs[2] = '<prompt>';
   }
+  for (let i = 0; i < safeArgs.length; i++) {
+    if (safeArgs[i] === '--env' && safeArgs[i + 1]) {
+      const key = safeArgs[i + 1].split('=', 1)[0];
+      safeArgs[i + 1] = `${key}=<redacted>`;
+      i++;
+    } else if (safeArgs[i] === '--') {
+      safeArgs.splice(i + 1, safeArgs.length - i - 1, '<passthrough redacted>');
+      break;
+    }
+  }
   process.stderr.write(
     `[dispatch:${kind}] agent=${agent}${version ? `@${version}` : ''} args=${JSON.stringify(safeArgs)}\n`,
   );

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -30,6 +30,17 @@ import { RUN_AUTO_KEYWORD, RUN_AUTO_HOST_RESOLVED_ENV } from '../types.js';
 // here so existing `hosts/dispatch.js` importers and tests keep resolving them.
 export { deriveMirroredCwd, homeRemainder, remoteCdPrefix };
 
+/**
+ * Diagnostic helper for RUSH-2441: log the requested agent and initial remote
+ * `agents run` argv without changing normal command output.
+ */
+function logForwardedArgs(kind: string, agent: string, version: string | undefined, args: string[]): void {
+  if (!process.env.AGENTS_DISPATCH_DEBUG) return;
+  process.stderr.write(
+    `[dispatch:${kind}] agent=${agent}${version ? `@${version}` : ''} args=${JSON.stringify(args)}\n`,
+  );
+}
+
 // Use $HOME (not ~) so the path is correct whether or not it's quoted and
 // regardless of the run's cwd. Task ids are 8 hex chars, so these paths are
 // injection-safe to interpolate unquoted into remote commands.
@@ -461,6 +472,7 @@ export interface DispatchOptions {
 export function buildRunForwardedArgs(opts: DispatchOptions): string[] {
   const agentArg = opts.version ? `${opts.agent}@${opts.version}` : opts.agent;
   const args = ['run', agentArg, opts.prompt, '--quiet'];
+  logForwardedArgs('headless', opts.agent, opts.version, args);
   if (opts.mode) args.push('--mode', opts.mode);
   if (opts.model) args.push('--model', opts.model);
   // 'auto' is the remote default — forwarding it would only add noise.
@@ -544,6 +556,7 @@ export interface InteractiveDispatchOptions {
 export function buildInteractiveRunForwardedArgs(opts: InteractiveDispatchOptions): string[] {
   const agentArg = opts.version ? `${opts.agent}@${opts.version}` : opts.agent;
   const args = ['run', agentArg];
+  logForwardedArgs('interactive', opts.agent, opts.version, args);
   if (opts.prompt && opts.forceInteractive) args.push(opts.prompt);
   if (opts.forceInteractive) args.push('--interactive');
   if (opts.mode) args.push('--mode', opts.mode);

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -34,10 +34,16 @@ export { deriveMirroredCwd, homeRemainder, remoteCdPrefix };
  * Diagnostic helper for RUSH-2441: log the requested agent and initial remote
  * `agents run` argv without changing normal command output.
  */
-export function logForwardedArgs(kind: string, agent: string, version: string | undefined, args: string[]): void {
+export function logForwardedArgs(
+  kind: string,
+  agent: string,
+  version: string | undefined,
+  args: string[],
+  hasPrompt: boolean,
+): void {
   if (!process.env.AGENTS_DISPATCH_DEBUG) return;
   const safeArgs = [...args];
-  if (safeArgs[0] === 'run' && safeArgs[2] && (kind === 'headless' || !safeArgs[2].startsWith('--'))) {
+  if (safeArgs[0] === 'run' && safeArgs[2] && hasPrompt) {
     safeArgs[2] = '<prompt>';
   }
   for (let i = 0; i < safeArgs.length; i++) {
@@ -512,7 +518,7 @@ export function buildRunForwardedArgs(opts: DispatchOptions): string[] {
   else if (opts.sessionId) args.push('--session-id', opts.sessionId);
   if (opts.emitSessionId) args.push('--emit-session-id');
   if (opts.passthroughArgs && opts.passthroughArgs.length > 0) args.push('--', ...opts.passthroughArgs);
-  logForwardedArgs('headless', opts.agent, opts.version, args);
+  logForwardedArgs('headless', opts.agent, opts.version, args, true);
   return args;
 }
 
@@ -594,7 +600,7 @@ export function buildInteractiveRunForwardedArgs(opts: InteractiveDispatchOption
   if (opts.passthroughArgs && opts.passthroughArgs.length > 0) {
     args.push('--', ...opts.passthroughArgs);
   }
-  logForwardedArgs('interactive', opts.agent, opts.version, args);
+  logForwardedArgs('interactive', opts.agent, opts.version, args, Boolean(opts.prompt && opts.forceInteractive));
   return args;
 }
 

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -34,10 +34,14 @@ export { deriveMirroredCwd, homeRemainder, remoteCdPrefix };
  * Diagnostic helper for RUSH-2441: log the requested agent and initial remote
  * `agents run` argv without changing normal command output.
  */
-function logForwardedArgs(kind: string, agent: string, version: string | undefined, args: string[]): void {
+export function logForwardedArgs(kind: string, agent: string, version: string | undefined, args: string[]): void {
   if (!process.env.AGENTS_DISPATCH_DEBUG) return;
+  const safeArgs = [...args];
+  if (safeArgs[0] === 'run' && safeArgs[2] && !safeArgs[2].startsWith('--')) {
+    safeArgs[2] = '<prompt>';
+  }
   process.stderr.write(
-    `[dispatch:${kind}] agent=${agent}${version ? `@${version}` : ''} args=${JSON.stringify(args)}\n`,
+    `[dispatch:${kind}] agent=${agent}${version ? `@${version}` : ''} args=${JSON.stringify(safeArgs)}\n`,
   );
 }
 
@@ -472,7 +476,6 @@ export interface DispatchOptions {
 export function buildRunForwardedArgs(opts: DispatchOptions): string[] {
   const agentArg = opts.version ? `${opts.agent}@${opts.version}` : opts.agent;
   const args = ['run', agentArg, opts.prompt, '--quiet'];
-  logForwardedArgs('headless', opts.agent, opts.version, args);
   if (opts.mode) args.push('--mode', opts.mode);
   if (opts.model) args.push('--model', opts.model);
   // 'auto' is the remote default — forwarding it would only add noise.
@@ -499,6 +502,7 @@ export function buildRunForwardedArgs(opts: DispatchOptions): string[] {
   else if (opts.sessionId) args.push('--session-id', opts.sessionId);
   if (opts.emitSessionId) args.push('--emit-session-id');
   if (opts.passthroughArgs && opts.passthroughArgs.length > 0) args.push('--', ...opts.passthroughArgs);
+  logForwardedArgs('headless', opts.agent, opts.version, args);
   return args;
 }
 
@@ -556,7 +560,6 @@ export interface InteractiveDispatchOptions {
 export function buildInteractiveRunForwardedArgs(opts: InteractiveDispatchOptions): string[] {
   const agentArg = opts.version ? `${opts.agent}@${opts.version}` : opts.agent;
   const args = ['run', agentArg];
-  logForwardedArgs('interactive', opts.agent, opts.version, args);
   if (opts.prompt && opts.forceInteractive) args.push(opts.prompt);
   if (opts.forceInteractive) args.push('--interactive');
   if (opts.mode) args.push('--mode', opts.mode);
@@ -581,6 +584,7 @@ export function buildInteractiveRunForwardedArgs(opts: InteractiveDispatchOption
   if (opts.passthroughArgs && opts.passthroughArgs.length > 0) {
     args.push('--', ...opts.passthroughArgs);
   }
+  logForwardedArgs('interactive', opts.agent, opts.version, args);
   return args;
 }
 

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -37,7 +37,7 @@ export { deriveMirroredCwd, homeRemainder, remoteCdPrefix };
 export function logForwardedArgs(kind: string, agent: string, version: string | undefined, args: string[]): void {
   if (!process.env.AGENTS_DISPATCH_DEBUG) return;
   const safeArgs = [...args];
-  if (safeArgs[0] === 'run' && safeArgs[2] && !safeArgs[2].startsWith('--')) {
+  if (safeArgs[0] === 'run' && safeArgs[2] && (kind === 'headless' || !safeArgs[2].startsWith('--'))) {
     safeArgs[2] = '<prompt>';
   }
   for (let i = 0; i < safeArgs.length; i++) {

--- a/apps/factory/src/core/agents.test.ts
+++ b/apps/factory/src/core/agents.test.ts
@@ -357,6 +357,14 @@ describe('launch contract — every runner is balanced', () => {
       'claude', null, undefined, undefined, '1.2.3', 'balanced', undefined, { local: true },
     )).toBe('agents run claude@1.2.3 --interactive --mode auto');
   });
+
+  test('grok (Pick Host) never emits cursor-agent', () => {
+    const cmd = buildAgentLaunchCommand(
+      'grok', null, undefined, undefined, undefined, 'balanced', undefined, { host: 'yosemite-s1' },
+    );
+    expect(cmd).toBe("agents run grok --interactive --host 'yosemite-s1' --strategy balanced --mode auto");
+    expect(cmd).not.toContain('cursor-agent');
+  });
 });
 
 describe('buildAgentLaunchCommand', () => {


### PR DESCRIPTION
Restores the lost RUSH-2441 host-dispatch diagnostics and Grok Pick Host regression coverage.

## Changes

- Logs the selected harness and target host for interactive and headless dispatches when `AGENTS_DISPATCH_DEBUG` or `--verbose` is enabled.
- Logs the initial forwarded `agents run` argv under `AGENTS_DISPATCH_DEBUG`.
- Pins Factory's Grok Pick Host command to `agents run grok` and rejects `cursor-agent`.

## Verification

No visible UI surface; this is diagnostic instrumentation plus regression coverage.

- Focused test run: [116 pass, 1 remote-only skip, 0 fail](https://gist.github.com/muqsitnawaz/810a1902ac961bbc16c486ae351542ad)
- Fleet-local run artifact: `yosemite-s0:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/scratch/rush-2441-focused-tests.log`

![Focused test run](https://gist.githubusercontent.com/muqsitnawaz/6324038ac428b226d0ab2905342ae43a/raw/rush-2441-focused-tests.svg)

Tracking: RUSH-2441
