### PR TITLE
fix(factory): batch + bound + singleflight the launch-health sweep (fixes #2469)

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Launch-health sweep no longer pins the machine.** The 60s fleet health sweep used to
+  spawn one `agents view <agent> --host <box>` subprocess for **every (agent × host) pair**
+  — on a ~12-device fleet that is ~120 concurrent node + SSH probes per tick — with no
+  concurrency cap and no guard against a fire-and-forget sweep stacking on a still-draining
+  one, which drove CPU to a runaway load (100–447) and starved the UI. The sweep now makes
+  **one batched `agents view --host <box> --json` call per host** (deriving every agent's
+  usable-version flag from that single payload, the remote analog of the existing local
+  batching), **bounds the per-device fan-out** to a small concurrency pool, and
+  **singleflights** so overlapping ticks can't pile a second full sweep on top. A
+  ~120-process burst becomes ~12 pooled, deduped calls. Fixes phnx-labs/agents-cli#2469.
+
 - **New Sessions tab — see and recover every session you own.** A dense, virtualized
   Sessions surface is now the first subtab on the Floor (before Agents). It lists every
   session across projects — local and remote, active and **orphaned** — and its whole

--- a/apps/factory/src/core/launchHost.test.ts
+++ b/apps/factory/src/core/launchHost.test.ts
@@ -10,6 +10,8 @@ import {
   resolveBalancePool,
   DeviceLoad,
   VersionHealth,
+  parseAgentVersionsByAgent,
+  computeUsableAgents,
 } from './launchHost';
 
 test('pickLeastBusyDevice: returns null when nothing is online', () => {
@@ -315,4 +317,62 @@ test('pickBestHost: all devices SSH-unreachable (online:false) → returns null 
       { name: 'b', online: false, running: 0 },
     ]),
   ).toBeNull();
+});
+
+// #2469: the launch-health sweep now makes ONE `agents view --host <host> --json`
+// call per host and derives every agent's usable flag from that single payload,
+// instead of one `view <agent> --host` subprocess per (agent, host) pair. These
+// pin the parse + reduce that make the single-call form correct.
+
+test('parseAgentVersionsByAgent: whole-host array → by-agent version map', () => {
+  const raw = JSON.stringify([
+    { agent: 'claude', versions: [{ signedIn: true, usageStatus: 'available' }] },
+    { agent: 'codex', versions: [{ signedIn: false }] },
+  ]);
+  expect(parseAgentVersionsByAgent(raw)).toEqual({
+    claude: [{ signedIn: true, usageStatus: 'available' }],
+    codex: [{ signedIn: false }],
+  });
+});
+
+test('parseAgentVersionsByAgent: a single {agent,versions} object (one-agent host) is accepted, not just arrays', () => {
+  const raw = JSON.stringify({ agent: 'grok', versions: [{ signedIn: true }] });
+  expect(parseAgentVersionsByAgent(raw)).toEqual({ grok: [{ signedIn: true }] });
+});
+
+test('parseAgentVersionsByAgent: malformed / empty input yields {} (probe failure is unusable, never a throw)', () => {
+  expect(parseAgentVersionsByAgent('not json')).toEqual({});
+  expect(parseAgentVersionsByAgent('')).toEqual({});
+  expect(parseAgentVersionsByAgent('null')).toEqual({});
+  // entries missing agent/versions are dropped, not partially kept
+  expect(parseAgentVersionsByAgent(JSON.stringify([{ agent: 'x' }, { versions: [] }]))).toEqual({});
+});
+
+test('computeUsableAgents: one signed-in non-throttled version = usable; throttled/signed-out/absent = not', () => {
+  const byAgent: Record<string, VersionHealth[]> = {
+    claude: [{ signedIn: true, usageStatus: 'available' }],
+    codex: [{ signedIn: true, usageStatus: 'rate_limited' }],
+    grok: [{ signedIn: false }],
+  };
+  // 'kimi' is absent from the map (not installed / probe failed) — must be false.
+  expect(computeUsableAgents(byAgent, ['claude', 'codex', 'grok', 'kimi'])).toEqual({
+    claude: true,
+    codex: false,
+    grok: false,
+    kimi: false,
+  });
+});
+
+test('computeUsableAgents: batched map for all keys matches per-agent deviceHasUsableVersion (behavior parity with the old fan-out)', () => {
+  const byAgent: Record<string, VersionHealth[]> = {
+    claude: [{ signedIn: false }, { signedIn: true, usageStatus: 'available' }],
+    codex: [{ signedIn: true, usageStatus: 'out_of_credits' }],
+  };
+  const keys = ['claude', 'codex', 'gemini'];
+  const batched = computeUsableAgents(byAgent, keys);
+  // The old code computed each cell as deviceHasUsableVersion(versionsForThatAgent);
+  // the batched path must produce the identical per-key result.
+  for (const k of keys) {
+    expect(batched[k]).toBe(deviceHasUsableVersion(byAgent[k] ?? []));
+  }
 });

--- a/apps/factory/src/core/launchHost.ts
+++ b/apps/factory/src/core/launchHost.ts
@@ -58,6 +58,51 @@ export function deviceHasUsableVersion(versions: VersionHealth[]): boolean {
   );
 }
 
+/**
+ * Parse `agents view --host <host> --json` (the whole-host form, no agent arg)
+ * into a by-agent map of version health. That form returns an array of
+ * `{ agent, versions }` (a single object for a one-agent host); malformed input
+ * yields an empty map. This is the batched analog of parsing one
+ * `view <agent> --host` response per agent — it lets the launch-health sweep make
+ * ONE CLI call per host instead of one per (agent, host) pair, the fleet-wide
+ * fan-out that pinned CPU (phnx-labs/agents-cli#2469).
+ */
+export function parseAgentVersionsByAgent(rawJson: string): Record<string, VersionHealth[]> {
+  let data: unknown;
+  try {
+    data = JSON.parse(rawJson);
+  } catch {
+    return {};
+  }
+  const entries = Array.isArray(data) ? data : [data];
+  const out: Record<string, VersionHealth[]> = {};
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as { agent?: unknown; versions?: unknown };
+    if (typeof e.agent !== 'string' || !Array.isArray(e.versions)) continue;
+    out[e.agent] = e.versions.filter((v): v is VersionHealth => !!v && typeof v === 'object');
+  }
+  return out;
+}
+
+/**
+ * Reduce a by-agent version map (see parseAgentVersionsByAgent) to the
+ * usable-version flag the launch-health cache stores per agent. An agent absent
+ * from the map (not installed on the host, or the probe failed) is reported
+ * unusable — matching the old per-agent probe, whose failure returned an empty
+ * version list.
+ */
+export function computeUsableAgents(
+  byAgent: Record<string, VersionHealth[]>,
+  agentKeys: string[],
+): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const key of agentKeys) {
+    out[key] = deviceHasUsableVersion(byAgent[key] ?? []);
+  }
+  return out;
+}
+
 // Pick the least-busy online device — fewest running agents, ties broken by
 // input order (first declared wins), offline devices skipped. Returns null when
 // no candidate is online, so the caller can fall back to the local machine.

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -15,7 +15,7 @@ import * as git from './git.vscode';
 import { AgentSettings, hasLoginEnabled, PromptEntry, QUICK_LAUNCH_SLOT_KEYS, getQuickLaunchSlot, QuickLaunchSlot, QuickLaunchSlotKey } from '../core/settings';
 import { listRegisteredDevices, countRunningAgents, fetchDeviceStats, probeReachable } from './deviceHealth.vscode';
 import { normalizeHost } from '../core/remoteSessions';
-import { pickBestHost, cappedOutDevices, noHostReason, deviceHasUsableVersion, resolveBalancePool, DeviceLoad } from '../core/launchHost';
+import { pickBestHost, cappedOutDevices, noHostReason, deviceHasUsableVersion, resolveBalancePool, DeviceLoad, VersionHealth, parseAgentVersionsByAgent, computeUsableAgents } from '../core/launchHost';
 import {
   LAUNCH_HEALTH_KEY,
   LAUNCH_HISTORY_KEY,
@@ -34,7 +34,7 @@ import { startWatchdogBridge } from '../mcp/watchdog-bridge';
 import { ensureWatchdogMcpInstalled } from '../mcp/watchdogInstall';
 import * as notifications from './notifications.vscode';
 import * as terminals from './terminals.vscode';
-import { fetchLocalSessions, fetchRemoteSessionLabelSource, fetchSessionIdentity, fetchRecapSessions, LOCAL_LABEL, LOCAL_MACHINE_ID } from './remoteSessions.vscode';
+import { fetchLocalSessions, fetchRemoteSessionLabelSource, fetchSessionIdentity, fetchRecapSessions, LOCAL_LABEL, LOCAL_MACHINE_ID, mapWithConcurrency } from './remoteSessions.vscode';
 import * as sessionTracker from './sessionTracker';
 import { runRecapHeadless, isRecapSupported } from './recap.vscode';
 import { buildAgentTerminalEnv } from '../core/terminals';
@@ -370,12 +370,40 @@ const AUTO_HOST_AGENT_KEYS = new Set(
   BUILT_IN_AGENTS.filter((agent) => agent.key !== 'shell' && agent.key !== 'droid').map((agent) => agent.key),
 );
 
+// Cap concurrent per-device probes in the launch-health sweep. Each online device
+// fires 3 shell-outs (stats + running + one batched `view --host`), so a fleet of
+// N devices ran up to N*3 concurrent node+SSH processes at once — an unbounded
+// fan-out that pinned CPU to a runaway load (phnx-labs/agents-cli#2469). A small
+// pool keeps the sweep's peak process count flat regardless of fleet size.
+const LAUNCH_HEALTH_PROBE_CONCURRENCY = 4;
+
+// Fetch EVERY installed agent's version health from a host in ONE
+// `agents view --host <host> --json` call (the whole-host form returns an array
+// of { agent, versions }). This is the remote analog of fetchAgentInventories'
+// local batching: the launch-health sweep needs the usable-version flag for all
+// AUTO_HOST_AGENT_KEYS on each host, and one call answers for every agent instead
+// of spawning one `view <agent> --host` subprocess per agent — the per-(agent,host)
+// fan-out that pinned CPU (phnx-labs/agents-cli#2469).
+async function fetchHostAgentVersions(host: string): Promise<Record<string, VersionHealth[]>> {
+  const { runAgents } = await import('../core/agentsBin');
+  try {
+    const { stdout } = await runAgents(`view --host ${shquote(host)} --json`, {
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 15_000,
+    });
+    return parseAgentVersionsByAgent(stdout);
+  } catch {
+    return {};
+  }
+}
+
 async function refreshLaunchHealthCache(context: vscode.ExtensionContext): Promise<void> {
   const devices = await listRegisteredDevices();
   const localName = normalizeHost(os.hostname());
-  const health = await Promise.all(devices
-    .filter((device) => normalizeHost(device.name) !== localName)
-    .map(async (device) => {
+  const targets = devices.filter((device) => normalizeHost(device.name) !== localName);
+  // Bounded fan-out: at most LAUNCH_HEALTH_PROBE_CONCURRENCY devices probed at once
+  // (each is 3 shell-outs) so the sweep can't spawn a fleet-sized process storm.
+  const health = await mapWithConcurrency(targets, LAUNCH_HEALTH_PROBE_CONCURRENCY, async (device) => {
       if (!device.online) {
         return {
           name: device.name,
@@ -386,10 +414,12 @@ async function refreshLaunchHealthCache(context: vscode.ExtensionContext): Promi
           fetchedAt: Date.now(),
         };
       }
-      const [stats, running, usable] = await Promise.all([
+      const [stats, running, hostAgents] = await Promise.all([
         fetchDeviceStats(device.host, { isLocal: false }),
         countRunningAgents(device.name, { isLocal: false }),
-        Promise.all([...AUTO_HOST_AGENT_KEYS].map(async (agentKey) => [agentKey, await hostHasUsableVersion(device.name, agentKey)] as const)),
+        // ONE `view --host` call answers the usable-version question for every
+        // agent, replacing the per-(agent,host) subprocess fan-out (#2469).
+        fetchHostAgentVersions(device.name),
       ]);
       return {
         name: device.name,
@@ -400,15 +430,24 @@ async function refreshLaunchHealthCache(context: vscode.ExtensionContext): Promi
         running: running ?? 0,
         loadAvg1: stats.loadAvg1,
         memPercent: stats.memPercent,
-        usableAgents: Object.fromEntries(usable),
+        usableAgents: computeUsableAgents(hostAgents, [...AUTO_HOST_AGENT_KEYS]),
         fetchedAt: stats.fetchedAt,
       };
-    }));
+    });
   await context.globalState.update(LAUNCH_HEALTH_KEY, { devices: health, refreshedAt: Date.now() } satisfies LaunchHealthCache);
 }
 
+// Singleflight guard: only one fleet sweep may run at a time. The 60s timer,
+// startup warm-up, and post-launch refresh all call this; without the guard an
+// overdue sweep (slow SSH on an already-loaded box) got a fresh full sweep piled
+// on top every tick, compounding to runaway load (phnx-labs/agents-cli#2469).
+// Overlapping callers are dropped — the in-flight sweep updates the cache shortly.
+let launchHealthInflight: Promise<void> | null = null;
 function refreshLaunchHealthCacheInBackground(context: vscode.ExtensionContext): void {
-  void refreshLaunchHealthCache(context).catch((err) => console.error('[launchAgent] health-cache refresh failed:', err));
+  if (launchHealthInflight) return;
+  launchHealthInflight = refreshLaunchHealthCache(context)
+    .catch((err) => console.error('[launchAgent] health-cache refresh failed:', err))
+    .finally(() => { launchHealthInflight = null; });
 }
 
 function resolveCachedAutoHost(context: vscode.ExtensionContext, agentKey: string): string | undefined {

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -370,11 +370,13 @@ const AUTO_HOST_AGENT_KEYS = new Set(
   BUILT_IN_AGENTS.filter((agent) => agent.key !== 'shell' && agent.key !== 'droid').map((agent) => agent.key),
 );
 
-// Cap concurrent per-device probes in the launch-health sweep. Each online device
-// fires 3 shell-outs (stats + running + one batched `view --host`), so a fleet of
-// N devices ran up to N*3 concurrent node+SSH processes at once — an unbounded
-// fan-out that pinned CPU to a runaway load (phnx-labs/agents-cli#2469). A small
-// pool keeps the sweep's peak process count flat regardless of fleet size.
+// Cap concurrent per-device probes in the launch-health sweep. Before this fix
+// each online device fired 2 + one-per-agent shell-outs (stats + running + one
+// `view <agent> --host` per AUTO_HOST_AGENT_KEYS), so a ~12-device fleet ran ~120
+// concurrent node+SSH processes at once — the unbounded fan-out that pinned CPU
+// (phnx-labs/agents-cli#2469). Batching (below) drops each device to 3 shell-outs,
+// and this pool caps how many devices probe at once, so the sweep's peak process
+// count stays flat regardless of fleet size.
 const LAUNCH_HEALTH_PROBE_CONCURRENCY = 4;
 
 // Fetch EVERY installed agent's version health from a host in ONE
@@ -383,7 +385,11 @@ const LAUNCH_HEALTH_PROBE_CONCURRENCY = 4;
 // local batching: the launch-health sweep needs the usable-version flag for all
 // AUTO_HOST_AGENT_KEYS on each host, and one call answers for every agent instead
 // of spawning one `view <agent> --host` subprocess per agent — the per-(agent,host)
-// fan-out that pinned CPU (phnx-labs/agents-cli#2469).
+// fan-out that pinned CPU (phnx-labs/agents-cli#2469). Tradeoff of the single call:
+// a failed/timed-out probe marks EVERY agent on that host unusable for the tick
+// (vs the old per-agent isolation), but that self-heals — a host with a stale/empty
+// read just drops out of the auto-pick pool until the next successful sweep
+// (LAUNCH_HEALTH_MAX_AGE_MS), never a stuck state.
 async function fetchHostAgentVersions(host: string): Promise<Record<string, VersionHealth[]>> {
   const { runAgents } = await import('../core/agentsBin');
   try {
@@ -438,9 +444,9 @@ async function refreshLaunchHealthCache(context: vscode.ExtensionContext): Promi
 }
 
 // Singleflight guard: only one fleet sweep may run at a time. The 60s timer,
-// startup warm-up, and post-launch refresh all call this; without the guard an
-// overdue sweep (slow SSH on an already-loaded box) got a fresh full sweep piled
-// on top every tick, compounding to runaway load (phnx-labs/agents-cli#2469).
+// startup warm-up, and the cold-cache pre-launch warm all call this; without the
+// guard an overdue sweep (slow SSH on an already-loaded box) got a fresh full sweep
+// piled on top every tick, compounding to runaway load (phnx-labs/agents-cli#2469).
 // Overlapping callers are dropped — the in-flight sweep updates the cache shortly.
 let launchHealthInflight: Promise<void> | null = null;
 function refreshLaunchHealthCacheInBackground(context: vscode.ExtensionContext): void {


### PR DESCRIPTION
**fix (perf / fleet fan-out) — no UI surface.** Fixes #2469. Audience: maintainers.

**Run output (captured from this branch):**

![bun test + tsc runs: 36/36 launchHost tests, full suite 1625 pass (baseline-parity fails), tsc 0 errors](https://share.agents-cli.sh/muqsitnawaz/muqsit-ext-fanout-verification-047852fdb03e4f1f)

The Factory extension's 60s launch-health sweep spawned **one `agents view <agent> --host <box>` subprocess per (agent × host) pair** — on a ~12-device fleet that's ~120 concurrent node + SSH probes per tick — with no concurrency cap and a fire-and-forget refresh that stacked a fresh full sweep on top of one still draining. On an already-loaded Mac this compounded to a runaway CPU load and starved the UI (typing lag). Full profiling + root cause in #2469.

## What changed (`apps/factory`)

| # | Fix | Where |
|---|---|---|
| 1 | **Batch** — one `agents view --host <box> --json` per host answers the usable-version question for *every* agent, replacing the per-(agent,host) fan-out. New pure `parseAgentVersionsByAgent` + `computeUsableAgents`. | `src/core/launchHost.ts`, called from `refreshLaunchHealthCache` in `src/vscode/extension.ts` |
| 2 | **Bound** — per-device fan-out runs through the existing `mapWithConcurrency` (cap 4) so peak process count is flat regardless of fleet size. | `src/vscode/extension.ts:refreshLaunchHealthCache` |
| 3 | **Singleflight** — `refreshLaunchHealthCacheInBackground` drops overlapping calls while a sweep is in flight, so the 60s timer + startup + post-launch can't pile sweeps. | `src/vscode/extension.ts` |

Net: a ~120-subprocess/60s burst → **~12 pooled, deduped calls**. The batching is the remote analog of the local batching `fetchAgentInventories` already documents (*"single `agents view --json` call… 3-5x faster than one process per agent"*).

`listAgentVersions` / `hostHasUsableVersion` are kept — the on-demand launch-time pickers still use them (rare, user-initiated); only the 60s runaway poll is changed. No scope creep.

## Verification

**Behavioral parity (the risk):** the batched map must equal the old per-agent result. Unit-tested directly, plus array/single/malformed parse edges:

```
$ bun test src/core/launchHost.test.ts
 36 pass  0 fail  55 expect() calls   (was 31; +5 new)
```

**Full ext suite — no regressions:**

```
$ bun test
 1625 pass   15 fail   10 errors
```

The 15 fail / 10 errors are **pre-existing** (a `happy-dom` module missing + `warp`/`oz` snapshot drift) — identical to the origin/main baseline quoted in #2477. My change adds 5 passing tests and regresses none.

**`tsc --noEmit -p apps/factory/tsconfig.json`: clean (0 errors).**

No screenshot: this is a no-UI performance fix (the sweep is a background poll; its only user-visible effect is that the machine stops thrashing). The live before/after load numbers are in #2469.

## Note for the reviewer

This lands on `main` against `apps/factory/...`. The in-flight rename #2477 (`apps/factory` → `apps/ext`) is orthogonal and will carry this via git rename detection. A reasonable follow-up: point the launch-time picker at `resolveAutoAgentKey` (extension.ts, `Promise.all(all.map(hostHasUsableVersion))` for one host) at the same batched call — lower priority since it's user-initiated, not the 60s runaway.
