### PR TITLE
fix(cli): compare shadow binaries by file identity

### DIFF
--- a/apps/cli/src/lib/binary-shadow.test.ts
+++ b/apps/cli/src/lib/binary-shadow.test.ts
@@ -49,7 +49,7 @@ describe('detectAgentsBinaryShadows', () => {
     try {
       const shadows = detectAgentsBinaryShadows(realAgents, []);
       expect(shadows).toHaveLength(1);
-      expect(shadows[0].path).toBe(shadowAgents);
+      expect(fs.realpathSync(shadows[0].path)).toBe(fs.realpathSync(shadowAgents));
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/apps/cli/src/lib/binary-shadow.test.ts
+++ b/apps/cli/src/lib/binary-shadow.test.ts
@@ -12,14 +12,25 @@ describe('detectAgentsBinaryShadows', () => {
   });
 
   function withSystemPath(tmpDir: string): string {
-    // Keep the system `which` binary available.
-    return `${tmpDir}${path.delimiter}/usr/bin${path.delimiter}/bin`;
+    // Keep the platform resolver (`which` / `where`) available.
+    return `${tmpDir}${path.delimiter}${savedPath ?? ''}`;
+  }
+
+  function binaryPath(tmpDir: string, name: string): string {
+    return path.join(tmpDir, process.platform === 'win32' ? `${name}.cmd` : name);
+  }
+
+  function writeBinary(file: string, output: string): void {
+    const contents = process.platform === 'win32'
+      ? `@echo off\r\necho ${output}\r\n`
+      : `#!/bin/sh\necho ${output}\n`;
+    fs.writeFileSync(file, contents, { mode: 0o755 });
   }
 
   it('returns empty when only the current agents binary exists', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-shadow-one-'));
-    const agents = path.join(tmpDir, 'agents');
-    fs.writeFileSync(agents, '#!/bin/sh\necho current\n', { mode: 0o755 });
+    const agents = binaryPath(tmpDir, 'agents');
+    writeBinary(agents, 'current');
     process.env.PATH = withSystemPath(tmpDir);
     try {
       expect(detectAgentsBinaryShadows(agents, [])).toEqual([]);
@@ -30,10 +41,10 @@ describe('detectAgentsBinaryShadows', () => {
 
   it('detects a shadowing binary earlier on PATH', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-shadow-path-'));
-    const realAgents = path.join(tmpDir, 'real-agents');
-    const shadowAgents = path.join(tmpDir, 'agents');
-    fs.writeFileSync(realAgents, '#!/bin/sh\necho real\n', { mode: 0o755 });
-    fs.writeFileSync(shadowAgents, '#!/bin/sh\necho shadow\n', { mode: 0o755 });
+    const realAgents = binaryPath(tmpDir, 'real-agents');
+    const shadowAgents = binaryPath(tmpDir, 'agents');
+    writeBinary(realAgents, 'real');
+    writeBinary(shadowAgents, 'shadow');
     process.env.PATH = withSystemPath(tmpDir);
     try {
       const shadows = detectAgentsBinaryShadows(realAgents, []);
@@ -46,12 +57,12 @@ describe('detectAgentsBinaryShadows', () => {
 
   it('detects a latent shadow in a well-known install directory', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-shadow-wellknown-'));
-    const realAgents = path.join(tmpDir, 'agents');
+    const realAgents = binaryPath(tmpDir, 'agents');
     const shadowDir = path.join(tmpDir, 'extra-bin');
-    const shadowAgents = path.join(shadowDir, 'agents');
-    fs.writeFileSync(realAgents, '#!/bin/sh\necho real\n', { mode: 0o755 });
+    const shadowAgents = binaryPath(shadowDir, 'agents');
+    writeBinary(realAgents, 'real');
     fs.mkdirSync(shadowDir, { recursive: true });
-    fs.writeFileSync(shadowAgents, '#!/bin/sh\necho shadow\n', { mode: 0o755 });
+    writeBinary(shadowAgents, 'shadow');
     process.env.PATH = withSystemPath(tmpDir);
     try {
       const shadows = detectAgentsBinaryShadows(realAgents, [shadowDir]);

--- a/apps/cli/src/lib/binary-shadow.ts
+++ b/apps/cli/src/lib/binary-shadow.ts
@@ -24,6 +24,21 @@ function safeRealpath(p: string): string {
   catch { return p; }
 }
 
+/** Whether two path spellings identify the same file. */
+function sameFile(a: string, b: string): boolean {
+  try {
+    const aStat = fs.statSync(a);
+    const bStat = fs.statSync(b);
+    if (aStat.dev === bStat.dev && aStat.ino === bStat.ino) return true;
+  } catch { /* compare their resolved path spellings below */ }
+
+  const aReal = safeRealpath(a);
+  const bReal = safeRealpath(b);
+  return process.platform === 'win32'
+    ? aReal.toLowerCase() === bReal.toLowerCase()
+    : aReal === bReal;
+}
+
 /**
  * Find `agents` installs that are NOT the currently running binary.
  *
@@ -47,7 +62,7 @@ export function detectAgentsBinaryShadows(
   function addIfShadow(candidate: string): void {
     if (seen.has(candidate)) return;
     seen.add(candidate);
-    if (safeRealpath(candidate) === currentReal) return;
+    if (sameFile(candidate, currentReal)) return;
     let version: string | undefined;
     try {
       version = execFileSync(candidate, ['--version'], { encoding: 'utf-8', env: process.env })
@@ -64,7 +79,7 @@ export function detectAgentsBinaryShadows(
       .split(/\r?\n/)
       .map((s) => s.trim())
       .filter(Boolean)[0];
-    if (pathAgents && safeRealpath(pathAgents) !== currentReal) {
+    if (pathAgents && !sameFile(pathAgents, currentReal)) {
       addIfShadow(pathAgents);
     }
   } catch { /* no `agents` resolved on PATH */ }


### PR DESCRIPTION
Fixes the Windows path-alias bug exposed while unblocking accounts PR #2470.

## What changed

- Compares resolved executables by filesystem identity (`dev` + `ino`) before comparing path spellings.
- Case-folds the final path comparison on Windows.
- Makes the assertion accept equivalent Windows path spellings.

## Actual runs

![Captured binary-shadow test run](https://share.agents-cli.sh/muqsitnawaz/binary-shadow-windows-1786350885105-7bf24e7726a4cb0c)

- [Raw captured log](https://share.agents-cli.sh/muqsitnawaz/binary-shadow-windows-binary-shadow-test-de610ae0bbbeb882): 1 file passed, 3 tests passed.
- `win-mini`, exact commit `f1a43b1ac`: 1 file passed, 3 tests passed in 695ms.
- GitHub Windows failure reproduced the issue as `RUNNER~1` versus `runneradmin`; 10,797 unrelated Windows tests passed.

No new command or user-facing surface.