### PR TITLE
test(cli): identify the shadow binary by contents, not path spelling

### DIFF
--- a/apps/cli/.changelog/next/binary-shadow-windows-83.md
+++ b/apps/cli/.changelog/next/binary-shadow-windows-83.md
@@ -1,0 +1,8 @@
+- **Fixed a Windows-only CI failure in the binary-shadow test.** `detectAgentsBinaryShadows`
+  was already comparing files by identity, but its test still compared two path
+  spellings through `fs.realpathSync`. On Windows `realpathSync` does not expand an
+  8.3 short name, so a `where`-resolved path and one built from `os.tmpdir()` compare
+  unequal even when they name the same file — which is why every PR touching
+  `apps/cli` saw `windows` fail on a GitHub runner (`C:\Users\RUNNER~1\...` vs
+  `C:\Users\runneradmin\...`). The test now identifies the file by basename plus
+  contents, which is spelling-independent and asserts the stronger property.

--- a/apps/cli/src/lib/binary-shadow.test.ts
+++ b/apps/cli/src/lib/binary-shadow.test.ts
@@ -49,7 +49,15 @@ describe('detectAgentsBinaryShadows', () => {
     try {
       const shadows = detectAgentsBinaryShadows(realAgents, []);
       expect(shadows).toHaveLength(1);
-      expect(fs.realpathSync(shadows[0].path)).toBe(fs.realpathSync(shadowAgents));
+      // Identify the file by its contents, not by path spelling. On Windows the
+      // runner's TMP is an 8.3 short name (C:\Users\RUNNER~1\...) and
+      // fs.realpathSync expands it for a `where`-resolved path but leaves it
+      // short for the path we built from os.tmpdir(), so comparing the two
+      // spellings fails even though both name the same file. `writeBinary` gives
+      // the shadow and the real binary distinct output, so this asserts the
+      // stronger property anyway: the shadow we found is the shadow we wrote.
+      expect(path.basename(shadows[0].path)).toBe(path.basename(shadowAgents));
+      expect(fs.readFileSync(shadows[0].path, 'utf8')).toBe(fs.readFileSync(shadowAgents, 'utf8'));
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
**test-only.** Unblocks every `apps/cli` PR in the repo — the `windows` job currently fails on `binary-shadow.test.ts` for everyone, which fails the required `test` gate.

## The bug

#2486 fixed the *source* to compare binaries by file identity (`sameFile`), but the *test* still compared two path spellings through `fs.realpathSync`. **On Windows, `realpathSync` does not expand an 8.3 short name.** So a `where`-resolved path and one built from `os.tmpdir()` compare unequal even though both name the same file:

```
Expected: "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\agents-shadow-path-CeFQwx\\agents.cmd"
Received: "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\agents-shadow-path-CeFQwx\\agents.cmd"
 ❯ src/lib/binary-shadow.test.ts:52
```

Seen right now on #2488 and #2482 (different authors), so it is not one branch's problem.

## Verified on real Windows, not assumed

Ran on `win-mini` (node v24.18.0) with a >8-char temp dir, which forces the 8.3 alias exactly like the runner's `runneradmin` → `RUNNER~1`:

```
long : ...\Temp\averylongdirname-dgTdKf\agents.cmd
short: ...\Temp\AVERYL~1\agents.cmd
realpath(long)  : ...\Temp\averylongdirname-dgTdKf\agents.cmd
realpath(short) : ...\Temp\AVERYL~1\agents.cmd        <- NOT expanded
OLD assertion realpath(a)===realpath(b) -> FAIL  <-- the bug
NEW assertion basename+content          -> PASS  <-- the fix
```

## The fix

Identify the file by basename + contents instead of path spelling. `writeBinary` already writes distinct output for the shadow (`shadow`) and the real binary (`real`), so this is spelling-independent **and** a stronger assertion than before: it proves the shadow that was found is the shadow that was written, where a path comparison only proved a string matched.

`bunx vitest run src/lib/binary-shadow.test.ts` → 3 passed on Linux; the mechanism above covers Windows.

No source change, so nothing about shadow detection's behavior moves.