### PR TITLE
test(cli): compare shadow binaries by file identity on Windows too

### DIFF
--- a/apps/cli/src/lib/binary-shadow.test.ts
+++ b/apps/cli/src/lib/binary-shadow.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { detectAgentsBinaryShadows } from './binary-shadow.js';
+import { detectAgentsBinaryShadows, sameFile } from './binary-shadow.js';
 
 describe('detectAgentsBinaryShadows', () => {
   const savedPath = process.env.PATH;
@@ -49,7 +49,7 @@ describe('detectAgentsBinaryShadows', () => {
     try {
       const shadows = detectAgentsBinaryShadows(realAgents, []);
       expect(shadows).toHaveLength(1);
-      expect(fs.realpathSync(shadows[0].path)).toBe(fs.realpathSync(shadowAgents));
+      expect(sameFile(shadows[0].path, shadowAgents)).toBe(true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/apps/cli/src/lib/binary-shadow.ts
+++ b/apps/cli/src/lib/binary-shadow.ts
@@ -24,8 +24,16 @@ function safeRealpath(p: string): string {
   catch { return p; }
 }
 
-/** Whether two path spellings identify the same file. */
-function sameFile(a: string, b: string): boolean {
+/**
+ * Whether two path spellings identify the same file.
+ *
+ * Two spellings of one file rarely compare equal on Windows: `realpathSync` does
+ * not expand 8.3 short names, so a path rooted at `os.tmpdir()`
+ * (`C:\Users\RUNNER~1\...` on a GitHub runner) never matches the long form
+ * (`C:\Users\runneradmin\...`) that `where` reports. Compare by device+inode
+ * first and fall back to case-insensitive resolved spellings.
+ */
+export function sameFile(a: string, b: string): boolean {
   try {
     const aStat = fs.statSync(a);
     const bStat = fs.statSync(b);

--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -85,6 +85,11 @@ describe('classifyCiScope', () => {
     'apps/cli/src/lib/hooks/loader.ts',
     'apps/cli/src/lib/platform/paths.ts',
     'apps/cli/src/lib/shims-windows.ts',
+    // binary-shadow compares paths case-insensitively and resolves agents.exe /
+    // agents.cmd only on win32, so a change there must run the Windows job — it
+    // did not, which is how a Windows-only assertion failure reached main.
+    'apps/cli/src/lib/binary-shadow.ts',
+    'apps/cli/src/lib/binary-shadow.test.ts',
     'apps/cli/hooks/session-start.sh',
     'apps/cli/src/lib/hosts/dispatch.ts',
   ])('marks %s as Windows-sensitive', (file) => {

--- a/scripts/ci-scope.ts
+++ b/scripts/ci-scope.ts
@@ -30,6 +30,7 @@ function isWindowsSensitive(file: string): boolean {
     || file.startsWith('apps/cli/src/lib/hooks/')
     || file.startsWith('apps/cli/src/lib/platform/')
     || /^apps\/cli\/src\/lib\/shims[^/]*\.ts$/.test(file)
+    || /^apps\/cli\/src\/lib\/binary-shadow(\.test)?\.ts$/.test(file)
     || file.startsWith('apps/cli/hooks/')
     || file.startsWith('apps/cli/src/lib/hosts/');
 }


### PR DESCRIPTION
**test-only** (plus a one-word `export`) — no behavior change. Unblocks the required `test` check on every open PR.

## The problem

The `windows` CI job is failing on `binary-shadow.test.ts`, and `windows` gates the required `test` check. Three independent open PRs are red on it right now — **#2488, #2482, #2335** — none of which touch this file.

```
FAIL src/lib/binary-shadow.test.ts > detectAgentsBinaryShadows > detects a shadowing binary earlier on PATH
AssertionError: expected 'C:\Users\runneradmin\AppData\Local\Te…'
              to be 'C:\Users\RUNNER~1\AppData\Local\Temp\…'
Test Files  1 failed | 793 passed | 36 skipped (831)
```
<sub>run <a href="https://github.com/phnx-labs/agents-cli/actions/runs/31372321072">31372321072</a>, PR #2488</sub>

## Why #2486 didn't fix it

#2486 added `sameFile()` — device+inode first, case-insensitive resolved paths second — and routed the **production** path through it. The test kept comparing raw `realpathSync` spellings:

```ts
expect(fs.realpathSync(shadows[0].path)).toBe(fs.realpathSync(shadowAgents));
```

`realpathSync` does **not** expand Windows 8.3 short names. On a GitHub runner `os.tmpdir()` is `C:\Users\RUNNER~1\...`, while `where` reports the long `C:\Users\runneradmin\...` form — so the two spellings of one file never compare equal. `f7c6d3f6b` is an ancestor of both `main` and #2488's branch, and #2488 still failed on that exact sha, which is what pointed here.

## The change

Export `sameFile` and assert through it, so the test asks the same question production does instead of re-implementing a weaker version of it:

```diff
-  expect(fs.realpathSync(shadows[0].path)).toBe(fs.realpathSync(shadowAgents));
+  expect(sameFile(shadows[0].path, shadowAgents)).toBe(true);
```

## Verification

Linux `binary-shadow.test.ts`: 3 passed. Linux was always green — **the real proof is this PR's own `windows` job**, since that is the only place the failure reproduces. Merging on that check, not on the local run.

No CHANGELOG entry: test-only, no user-visible surface.

---

## Second commit: why this escaped in the first place

The first revision of this PR had `windows: skipping` — the scope gate does not consider `binary-shadow` Windows-sensitive:

```ts
function isWindowsSensitive(file: string): boolean {
  return file === 'apps/cli/src/lib/hooks.ts'
    || file.startsWith('apps/cli/src/lib/hooks/')
    || file.startsWith('apps/cli/src/lib/platform/')
    || /^apps\/cli\/src\/lib\/shims[^/]*\.ts$/.test(file)
    || file.startsWith('apps/cli/hooks/')
    || file.startsWith('apps/cli/src/lib/hosts/');
}
```
<sub>`scripts/ci-scope.ts:28-35` before this PR</sub>

But `binary-shadow.ts` branches on `process.platform === 'win32'` **four** times — the case-insensitive comparison (`:37`), the `where`/`which` resolver (`:77`), the `agents.exe`/`agents.cmd` candidate list (`:102`), and the well-known-dir scan (`:107`). So #2486 shipped a Windows path fix that never ran the Windows job, and this PR would have merged the same way.

Added `binary-shadow(.test)?.ts` to `isWindowsSensitive`, with two cases in the existing `test.each` (`bun test scripts/ci-scope.test.ts` → 16 pass). **This is what makes this PR's own `windows` job the real proof rather than a skipped check.**

Worth a follow-up, not fixed here: `scripts/ci-scope.test.ts` is at the repo root, outside `apps/cli`'s vitest `include` (`scripts/**/*.test.ts` resolves to `apps/cli/scripts/`), and no workflow invokes it — so it appears not to run in CI at all.
