### PR TITLE
fix(cli): compare Windows binaries by native identity

### DIFF
--- a/apps/cli/src/lib/binary-shadow.test.ts
+++ b/apps/cli/src/lib/binary-shadow.test.ts
@@ -16,6 +16,10 @@ describe('detectAgentsBinaryShadows', () => {
     return `${tmpDir}${path.delimiter}${savedPath ?? ''}`;
   }
 
+  function makeTmp(prefix: string): string {
+    return fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+  }
+
   function binaryPath(tmpDir: string, name: string): string {
     return path.join(tmpDir, process.platform === 'win32' ? `${name}.cmd` : name);
   }
@@ -27,8 +31,18 @@ describe('detectAgentsBinaryShadows', () => {
     fs.writeFileSync(file, contents, { mode: 0o755 });
   }
 
+  function samePath(a: string, b: string): boolean {
+    try {
+      return fs.realpathSync.native(a) === fs.realpathSync.native(b);
+    } catch {
+      return process.platform === 'win32'
+        ? path.resolve(a).toLowerCase() === path.resolve(b).toLowerCase()
+        : path.resolve(a) === path.resolve(b);
+    }
+  }
+
   it('returns empty when only the current agents binary exists', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-shadow-one-'));
+    const tmpDir = makeTmp('agents-shadow-one-');
     const agents = binaryPath(tmpDir, 'agents');
     writeBinary(agents, 'current');
     process.env.PATH = withSystemPath(tmpDir);
@@ -40,7 +54,7 @@ describe('detectAgentsBinaryShadows', () => {
   });
 
   it('detects a shadowing binary earlier on PATH', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-shadow-path-'));
+    const tmpDir = makeTmp('agents-shadow-path-');
     const realAgents = binaryPath(tmpDir, 'real-agents');
     const shadowAgents = binaryPath(tmpDir, 'agents');
     writeBinary(realAgents, 'real');
@@ -49,14 +63,14 @@ describe('detectAgentsBinaryShadows', () => {
     try {
       const shadows = detectAgentsBinaryShadows(realAgents, []);
       expect(shadows).toHaveLength(1);
-      expect(fs.realpathSync(shadows[0].path)).toBe(fs.realpathSync(shadowAgents));
+      expect(samePath(shadows[0].path, shadowAgents)).toBe(true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
   it('detects a latent shadow in a well-known install directory', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-shadow-wellknown-'));
+    const tmpDir = makeTmp('agents-shadow-wellknown-');
     const realAgents = binaryPath(tmpDir, 'agents');
     const shadowDir = path.join(tmpDir, 'extra-bin');
     const shadowAgents = binaryPath(shadowDir, 'agents');
@@ -66,7 +80,7 @@ describe('detectAgentsBinaryShadows', () => {
     process.env.PATH = withSystemPath(tmpDir);
     try {
       const shadows = detectAgentsBinaryShadows(realAgents, [shadowDir]);
-      expect(shadows.some((s) => s.path === shadowAgents)).toBe(true);
+      expect(shadows.some((s) => samePath(s.path, shadowAgents))).toBe(true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/apps/cli/src/lib/binary-shadow.ts
+++ b/apps/cli/src/lib/binary-shadow.ts
@@ -18,25 +18,30 @@ export interface AgentsBinaryShadow {
   version?: string;
 }
 
-/** Realpath of `p`, or `p` itself if it cannot be resolved. */
-function safeRealpath(p: string): string {
-  try { return fs.realpathSync(p); }
-  catch { return p; }
-}
-
 /** Whether two path spellings identify the same file. */
 function sameFile(a: string, b: string): boolean {
   try {
+    if (fs.realpathSync.native(a) === fs.realpathSync.native(b)) return true;
+  } catch { /* compare file identity and normalized spellings below */ }
+
+  try {
     const aStat = fs.statSync(a);
     const bStat = fs.statSync(b);
-    if (aStat.dev === bStat.dev && aStat.ino === bStat.ino) return true;
-  } catch { /* compare their resolved path spellings below */ }
+    if (aStat.ino !== 0 && aStat.dev === bStat.dev && aStat.ino === bStat.ino) return true;
+  } catch { /* compare normalized spellings below */ }
 
-  const aReal = safeRealpath(a);
-  const bReal = safeRealpath(b);
   return process.platform === 'win32'
-    ? aReal.toLowerCase() === bReal.toLowerCase()
-    : aReal === bReal;
+    ? path.resolve(a).toLowerCase() === path.resolve(b).toLowerCase()
+    : path.resolve(a) === path.resolve(b);
+}
+
+/** Stable de-duplication key for a candidate path. */
+function pathKey(candidate: string): string {
+  try { return fs.realpathSync.native(candidate); }
+  catch {
+    const resolved = path.resolve(candidate);
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+  }
 }
 
 /**
@@ -54,15 +59,14 @@ export function detectAgentsBinaryShadows(
   currentBin: string = getAgentsBinPath(),
   extraDirs: readonly string[] = defaultWellKnownDirs(),
 ): AgentsBinaryShadow[] {
-  const currentReal = safeRealpath(currentBin);
-
   const seen = new Set<string>();
   const shadows: AgentsBinaryShadow[] = [];
 
   function addIfShadow(candidate: string): void {
-    if (seen.has(candidate)) return;
-    seen.add(candidate);
-    if (sameFile(candidate, currentReal)) return;
+    const key = pathKey(candidate);
+    if (seen.has(key)) return;
+    seen.add(key);
+    if (sameFile(candidate, currentBin)) return;
     let version: string | undefined;
     try {
       version = execFileSync(candidate, ['--version'], { encoding: 'utf-8', env: process.env })
@@ -79,7 +83,7 @@ export function detectAgentsBinaryShadows(
       .split(/\r?\n/)
       .map((s) => s.trim())
       .filter(Boolean)[0];
-    if (pathAgents && !sameFile(pathAgents, currentReal)) {
+    if (pathAgents && !sameFile(pathAgents, currentBin)) {
       addIfShadow(pathAgents);
     }
   } catch { /* no `agents` resolved on PATH */ }


### PR DESCRIPTION
Fixes Windows binary-shadow detection after `where.exe` expands 8.3 temp paths.

## What changed

- Resolve candidate paths with `realpathSync.native` before comparison and de-duplication.
- Use device/inode identity only when Windows reports a non-zero inode.
- Make real-path tests tolerate Windows short/long path spellings.

## Run result

Focused real-path suite: **3 passed, 0 failed**.

![Focused binary-shadow suite: 3 passed, 0 failed](https://share.agents-cli.sh/muqsitnawaz/agents-cli-binary-shadow-native-test-0c252eda85f52747)

[Raw test output](https://share.agents-cli.sh/muqsitnawaz/binary-shadow-native-binary-shadow-native-test-5c17c5aaacab5f41)

## Context

Follow-up to #2481. The full Windows run exposed both the current-binary false positive and short/long assertion mismatch while refreshing #2470.

No user-facing command or config change; docs and CHANGELOG are unchanged.