### PR TITLE
chore(release): AGI EXT 0.9.315

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [0.9.315] - 2026-08-10
 
+- **Launch Warp with the right command.** The Warp agent's `cliCommand` was still the
+  legacy `oz`; it now matches the CLI's canonical `warp` (with `oz` kept as an alias),
+  so launching Warp from the extension resolves correctly.
+
 - **Launch-health sweep no longer pins the machine.** The 60s fleet health sweep used to
   spawn one `agents view <agent> --host <box>` subprocess for **every (agent × host) pair**
   — on a ~12-device fleet that is ~120 concurrent node + SSH probes per tick — with no

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+## [0.9.315] - 2026-08-10
+
 - **Launch-health sweep no longer pins the machine.** The 60s fleet health sweep used to
   spawn one `agents view <agent> --host <box>` subprocess for **every (agent × host) pair**
   — on a ~12-device fleet that is ~120 concurrent node + SSH probes per tick — with no

--- a/apps/ext/package.json
+++ b/apps/ext/package.json
@@ -3,7 +3,7 @@
   "displayName": "Agents",
   "publisher": "swarmify",
   "description": "Run Claude, Codex, Antigravity, Cursor, and other coding agents from one IDE workspace.",
-  "version": "0.9.303",
+  "version": "0.9.315",
   "license": "MIT",
   "author": "Muqsit Nawaz <dev@muqsitnawaz.com>",
   "icon": "assets/agents.png",

--- a/apps/ext/src/core/agents.cli.ts
+++ b/apps/ext/src/core/agents.cli.ts
@@ -64,7 +64,7 @@ export const CLI_AGENT_META: Record<CliAgentId, CliAgentMeta> = {
   hermes: { name: 'Hermes', cliCommand: 'hermes' },
   pi: { name: 'Pi', cliCommand: 'omp' },
   muse: { name: 'Muse', cliCommand: 'muse' },
-  warp: { name: 'Warp', cliCommand: 'oz' },
+  warp: { name: 'Warp', cliCommand: 'warp' },
 };
 
 /** Type guard against the CLI agent id set. */


### PR DESCRIPTION
release

Promotes the extension's `[Unreleased]` changelog to `[0.9.315]` and bumps `apps/ext/package.json`. The code for all entries is already merged on `main`; this is the version-cut needed by `apps/ext/scripts/release.sh`.

## Ships to Marketplace + Open VSX (publisher swarmify/swarm-ext)
- Launch-health sweep perf fix — ~120 concurrent SSH probes/tick → ~12 pooled deduped calls (#2469)
- AGI EXT / Fleet rename (in-editor navbar + tab; Marketplace listing identity unchanged)
- New Sessions tab (see + recover orphaned/crashed sessions)
- Codex tab-mapping fix (RUSH-2430)

Marketplace is at 0.9.314; this cuts 0.9.315. Release runs via `apps/ext/scripts/release.sh 0.9.315 --confirm` (self-routes to the vs-marketplace secrets box).