### PR TITLE
feat(cli,teams): resolve all project dirs at run + teams spawn paths (RUSH-2487)

### DIFF
--- a/apps/cli/src/commands/exec.test.ts
+++ b/apps/cli/src/commands/exec.test.ts
@@ -15,7 +15,7 @@
  * through the real `recordScannedKeys` store-write — so the decision, the store
  * reads (real `isHostPinned`), and the pin are all exercised without a network.
  */
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -31,11 +31,13 @@ import {
   isAlwaysFreshRepo,
   isInsideGitWorkTree,
   parseRunAccountPickerRequest,
+  projectRunAddDirs,
   runAccountPickerConflicts,
   runAutoDefaultsToAffinity,
   hostInteractiveNeedsCorrelationId,
   RUN_AUTO_KEYWORD,
 } from './exec.js';
+import { writeProjectDef } from '../lib/projects.js';
 import { isHostPinned, recordScannedKeys } from '../lib/devices/known-hosts.js';
 import { ALL_AGENT_IDS } from '../lib/agents.js';
 
@@ -656,5 +658,72 @@ describe.skipIf(process.platform === 'win32')('agents run — harness not instal
       fs.rmSync(home, { recursive: true, force: true });
       fs.rmSync(pathDir, { recursive: true, force: true });
     }
+  });
+});
+
+// RUSH-2487: `agents run --project <slug>` grants the project's SECONDARY bound
+// dirs (every bound dir except the primary/cwd) via --add-dir, deduped against
+// the user's explicit --add-dir. This is the merge that feeds options.addDir at
+// the dispatch site.
+describe('projectRunAddDirs — --project grants the secondary bound dirs', () => {
+  let projDir: string;
+  let primary: string;
+  let web: string;
+  let sys: string;
+  let missing: string;
+
+  beforeAll(() => {
+    projDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proj-run-adddirs-'));
+    process.env.AGENTS_PROJECTS_DIR = projDir;
+    // Real dirs so the local (forRemote:false) resolver keeps them; a missing
+    // one proves local drops it while remote keeps it.
+    const base = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'proj-run-dirs-')));
+    primary = path.join(base, 'agents-cli');
+    web = path.join(base, 'agents-cli-web');
+    sys = path.join(base, 'dot-system');
+    missing = path.join(base, 'never-checked-out');
+    for (const d of [primary, web, sys]) fs.mkdirSync(d, { recursive: true });
+    writeProjectDef({
+      name: 'projruntest',
+      root: primary,
+      defaultPath: primary,
+      // The primary is duplicated in repos (the real agents-cli def does this);
+      // projectDirsAbs dedups it, so it must never reappear as a secondary.
+      repos: [
+        { slug: 'a/agents-cli', path: primary },
+        { slug: 'a/agents-cli-web', path: web },
+        { slug: 'a/dot-system', path: sys },
+        { slug: 'a/never', path: missing },
+      ],
+    });
+  });
+  afterAll(() => {
+    delete process.env.AGENTS_PROJECTS_DIR;
+    fs.rmSync(projDir, { recursive: true, force: true });
+  });
+
+  it('returns the secondary dirs, primary dropped, missing dir dropped locally', () => {
+    const dirs = projectRunAddDirs('projruntest', false, []);
+    expect(dirs).toEqual([web, sys]);
+    expect(dirs).not.toContain(primary);
+    expect(dirs).not.toContain(missing);
+  });
+
+  it('dedups against the user\'s explicit --add-dir', () => {
+    expect(projectRunAddDirs('projruntest', false, [web])).toEqual([sys]);
+    expect(projectRunAddDirs('projruntest', false, [web, sys])).toEqual([]);
+  });
+
+  it('forRemote keeps a dir the local box has not checked out (home-relative)', () => {
+    // forRemote resolution never drops a missing dir — a box missing a checkout
+    // is the remote's concern. These temp dirs sit outside HOME so they stay
+    // absolute, but the missing one must still be present.
+    const dirs = projectRunAddDirs('projruntest', true, []);
+    expect(dirs).toContain(missing);
+    expect(dirs).not.toContain(primary);
+  });
+
+  it('returns [] for an unknown / convention-only project', () => {
+    expect(projectRunAddDirs('no-such-project', false, [])).toEqual([]);
   });
 });

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -34,6 +34,8 @@ import { spawnSync } from 'child_process';
 import { randomUUID } from 'crypto';
 import { isSessionTrackedAgent } from '../lib/session/types.js';
 import { applyActiveRulesPresetAtRun } from '../lib/rules/run-sync.js';
+import { loadProjectDef, projectDirsAbs } from '../lib/projects.js';
+import { parseProjectRef, toRemotePortable, expandLocalHome } from '../lib/project-root.js';
 
 interface ExecCommandActionOptions {
   mode: ExecMode;
@@ -608,6 +610,35 @@ async function resolveRunCwd(
 }
 
 /**
+ * The SECONDARY dirs a `--project` run grants as `--add-dir`: every dir the
+ * defined project binds (`projectDirsAbs`, primary first) except the primary
+ * (which is the run's cwd), deduped against dirs the user already passed via
+ * `--add-dir`. `forRemote` matches the cwd resolution — `~/…` on a `--host` run
+ * (the host re-roots them; `toRemotePortable` at the dispatch site is a no-op on
+ * a `~/…` entry), absolute locally (missing dirs already dropped by
+ * `projectDirsAbs`). Returns `[]` for a convention-only / unknown project.
+ */
+export function projectRunAddDirs(
+  projectRef: string,
+  forRemote: boolean,
+  existing: string[],
+): string[] {
+  const { slug } = parseProjectRef(projectRef);
+  const def = slug ? loadProjectDef(slug) : undefined;
+  if (!def) return [];
+  const norm = (s: string) => (forRemote ? toRemotePortable(s) : path.resolve(expandLocalHome(s)));
+  const seen = new Set(existing.map(norm));
+  const out: string[] = [];
+  for (const dir of projectDirsAbs(def, { forRemote }).slice(1)) {
+    const key = norm(dir);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(dir);
+  }
+  return out;
+}
+
+/**
  * `--terminal`: hand this run to a real terminal tab and exit.
  *
  * The terminal is detected from the user's live sessions, so a run started from
@@ -747,7 +778,7 @@ export function registerRunCommand(program: Command): void {
     .option('--cwd <dir>', 'Working directory for the agent (defaults to current directory). With --host, the directory ON the host.')
     .option(
       '-P, --project <ref>',
-      'Project shorthand <slug>[@worktree], resolved against your projects root (auto-inferred, cached). Sets the cwd locally or on --host.',
+      "Project shorthand <slug>[@worktree], resolved against your projects root (auto-inferred, cached). Sets the cwd locally or on --host. A defined project's other bound dirs are granted via --add-dir (Claude and Codex only; silently dropped for other harnesses).",
     )
     .option(
       '--add-dir <dir>',
@@ -1697,7 +1728,13 @@ export function registerRunCommand(program: Command): void {
       // it); locally it becomes an absolute path. It owns the working directory,
       // so it is mutually exclusive with both --cwd and --remote-cwd.
       if (options.project) {
-        options.cwd = await resolveRunCwd(options, { forRemote: hostGiven.length > 0 });
+        const forRemote = hostGiven.length > 0;
+        options.cwd = await resolveRunCwd(options, { forRemote });
+        // A DEFINED project binds several dirs (`projectDirsAbs`, primary first).
+        // The primary is the cwd above; grant the SECONDARY dirs as --add-dir so
+        // the agent can read the project's other bound repos, not just its cwd.
+        // Only Claude and Codex consume --add-dir (see the --project help note).
+        options.addDir.push(...projectRunAddDirs(options.project, forRemote, options.addDir));
       }
 
       if (hostGiven.length > 0) {

--- a/apps/cli/src/commands/teams.test.ts
+++ b/apps/cli/src/commands/teams.test.ts
@@ -203,3 +203,47 @@ describe('printFeedHint', () => {
     expect(out).toContain('IMPORTANT milestones');
   });
 });
+
+// RUSH-2487: `teams create --project <slug>` binds the team to a defined project
+// so `teams add` lands teammates in its primary dir with the sibling grants.
+describe('teams create --project (RUSH-2487)', () => {
+  function seedProject(home: string, slug: string): void {
+    const pdir = path.join(home, '.agents', 'projects');
+    fs.mkdirSync(pdir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pdir, `${slug}.yaml`),
+      `name: ${slug}\nroot: ~/src/${slug}\ndefaultPath: ~/src/${slug}\n`,
+    );
+  }
+
+  it('stores the project slug in the team meta and echoes it', () => {
+    const { stdout, status, home } = run(
+      ['teams', 'create', 'proj-bound', '--project', 'myproj'],
+      (home) => seedProject(home, 'myproj'),
+    );
+
+    expect(status, stdout).toBe(0);
+    expect(stdout).toContain('project: myproj');
+    const reg = JSON.parse(
+      fs.readFileSync(path.join(home, '.agents', '.history', 'teams', 'registry.json'), 'utf-8'),
+    );
+    expect(reg['proj-bound'].project).toBe('myproj');
+  });
+
+  it('rejects an undefined project loudly (fail-loud, not silent no-grant)', () => {
+    const { status, home } = run(['teams', 'create', 'proj-bad', '--project', 'no-such-project']);
+
+    expect(status).toBe(1);
+    const eventsPath = path.join(home, '.agents', 'events.jsonl');
+    const friction = fs
+      .readFileSync(eventsPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l))
+      .find((r) => r.event === 'friction' && r.failureId === 'unknown-project');
+    expect(friction).toBeDefined();
+    expect(friction.error).toContain('no-such-project');
+    // The team must NOT have been created with a bogus binding.
+    expect(fs.existsSync(path.join(home, '.agents', '.history', 'teams', 'registry.json'))).toBe(false);
+  });
+});

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -1598,8 +1598,9 @@ export function registerTeamsCommands(program: Command): void {
     .option('--devices <list>', 'Pool of machines this team may run teammates on (comma-separated). Enables distributed auto-scheduling.')
     .option('--hosts <list>', 'Alias for --devices.')
     .option('--repo <urlOrPath>', 'How each remote (--device) teammate gets the code — ONE git URL/path for the whole team (existing checkout reused, else cloned). A team is single-repo; for work across repos, make one team per repo. Defaults to this checkout origin.')
+    .option('--project <slug>', "Bind the team to a defined project (`agents projects`): a teammate added without --cwd/--worktree lands in the project's primary dir, and every local teammate is granted the project's other bound dirs via --add-dir (Claude/Codex only).")
     .option('--json', 'Output machine-readable JSON')
-    .action(async (team: string, opts: { description?: string; enableWorktrees?: boolean; useWorktree?: string; devices?: string; hosts?: string; repo?: string; json?: boolean }) => {
+    .action(async (team: string, opts: { description?: string; enableWorktrees?: boolean; useWorktree?: string; devices?: string; hosts?: string; repo?: string; project?: string; json?: boolean }) => {
       try {
         // --devices / --hosts are aliases; commander can't express a two-name
         // option that isn't a short flag, so merge them here. Split on comma,
@@ -1646,12 +1647,26 @@ export function registerTeamsCommands(program: Command): void {
           }
         }
 
+        // --project must name a DEFINED project (`agents projects`): the teammate
+        // cwd + add-dirs are resolved from its definition via projectDirsAbs, so a
+        // convention-only slug with no <slug>.yaml would silently grant nothing.
+        // Fail loud here instead of at spawn.
+        if (opts.project) {
+          const { loadProjectDef } = await import('../lib/projects.js');
+          const { parseProjectRef } = await import('../lib/project-root.js');
+          const { slug } = parseProjectRef(opts.project);
+          if (!slug || !loadProjectDef(slug)) {
+            dieFriction('teams', 'unknown-project', `No defined project '${opts.project}'. Define it with: agents projects add ${opts.project ?? '<slug>'}`);
+          }
+        }
+
         const meta = await createTeam(team, {
           description: opts.description,
           enableWorktrees: opts.enableWorktrees,
           useWorktree: opts.useWorktree,
           devices,
           repo,
+          project: opts.project,
         });
         if (isJsonMode(opts)) {
           console.log(JSON.stringify({ team, ...meta }, null, 2));
@@ -1663,6 +1678,7 @@ export function registerTeamsCommands(program: Command): void {
         if (meta.use_worktree) console.log(chalk.gray(`  worktree: ${meta.use_worktree}`));
         if (meta.devices && meta.devices.length) console.log(chalk.gray(`  devices: ${meta.devices.join(', ')}`));
         if (meta.repo) console.log(chalk.gray(`  repo: ${meta.repo}`));
+        if (meta.project) console.log(chalk.gray(`  project: ${meta.project}`));
         console.log();
         console.log(chalk.gray('Add your first teammate:'));
         if (meta.enable_worktrees) {
@@ -2049,10 +2065,24 @@ export function registerTeamsCommands(program: Command): void {
         dieFriction('teams', 'worktree-requires-enable-worktrees', `--worktree requires --enable-worktrees on the team. Recreate the team with: agents teams create ${team} --enable-worktrees`);
       }
 
+      // A team bound to a defined project (`teams create --project`) lands a
+      // teammate in the project's PRIMARY dir when neither a worktree nor --cwd
+      // pins one. Resolved locally (absolute) — a distributed teammate resolves
+      // its own dir on the host, so this only feeds the local precedence below.
+      let projectPrimary: string | undefined;
+      if (!hostName && !worktreePath && !opts.cwd && teamMeta?.project) {
+        const { loadProjectDef, projectBasePath } = await import('../lib/projects.js');
+        const { parseProjectRef } = await import('../lib/project-root.js');
+        const { slug } = parseProjectRef(teamMeta.project);
+        const def = slug ? loadProjectDef(slug) : undefined;
+        if (def) projectPrimary = projectBasePath(def, false);
+      }
+
       // Distributed teammates have no LOCAL cwd — their working dir lives on the
       // host (repoPath / the remote worktree). Local teammates default to the
-      // worktree path, then --cwd, then the current directory.
-      const cwd = hostName ? null : (worktreePath ?? opts.cwd ?? process.cwd());
+      // worktree path, then --cwd, then the project's primary dir, then the
+      // current directory.
+      const cwd = hostName ? null : (worktreePath ?? opts.cwd ?? projectPrimary ?? process.cwd());
 
       // Factory teammates: prepend the worker-skill preamble to every task
       // prompt so implementers/testers/reviewers know about the Ledger, the

--- a/apps/cli/src/lib/teams/agents.test.ts
+++ b/apps/cli/src/lib/teams/agents.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { projectTeammateAddDirs } from './agents.js';
+import { writeProjectDef, loadProjectDef, type ProjectDef } from '../projects.js';
+
+// RUSH-2487: a team bound to a defined project (`teams create --project`) grants
+// each local teammate the project's SECONDARY bound dirs via --add-dir. This is
+// the pure list `resolveProjectAddDirs` feeds into `buildCommand`.
+describe('projectTeammateAddDirs — a project-bound team grants the secondary dirs', () => {
+  let projDir: string;
+  let primary: string;
+  let web: string;
+  let sys: string;
+  let def: ProjectDef;
+
+  beforeAll(() => {
+    projDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proj-team-adddirs-'));
+    process.env.AGENTS_PROJECTS_DIR = projDir;
+    const base = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'proj-team-dirs-')));
+    primary = path.join(base, 'agents-cli');
+    web = path.join(base, 'agents-cli-web');
+    sys = path.join(base, 'dot-system');
+    for (const d of [primary, web, sys]) fs.mkdirSync(d, { recursive: true });
+    writeProjectDef({
+      name: 'projteamtest',
+      root: primary,
+      defaultPath: primary,
+      repos: [
+        { slug: 'a/agents-cli', path: primary },
+        { slug: 'a/agents-cli-web', path: web },
+        { slug: 'a/dot-system', path: sys },
+      ],
+    });
+    def = loadProjectDef('projteamtest')!;
+  });
+  afterAll(() => {
+    delete process.env.AGENTS_PROJECTS_DIR;
+    fs.rmSync(projDir, { recursive: true, force: true });
+  });
+
+  it('cwd = primary → the two secondary dirs, primary never duplicated', () => {
+    expect(projectTeammateAddDirs(def, primary)).toEqual([web, sys]);
+  });
+
+  it('cwd = a secondary → that dir is filtered out of the grants', () => {
+    expect(projectTeammateAddDirs(def, web)).toEqual([sys]);
+  });
+
+  it('cwd = a worktree outside the project dirs → all secondaries granted', () => {
+    const wt = path.join(primary, '.agents', 'worktrees', 'feat');
+    expect(projectTeammateAddDirs(def, wt)).toEqual([web, sys]);
+  });
+});

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -35,6 +35,8 @@ import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { pullRemoteLogDelta, REMOTE_MIRROR_MAX_BYTES } from '../hosts/progress.js';
 import { createRemoteWorktree, ensureRemoteRepo } from './remoteWorktree.js';
 import { getTeam, isTeamDisbanded } from './registry.js';
+import { loadProjectDef, projectDirsAbs, type ProjectDef } from '../projects.js';
+import { parseProjectRef } from '../project-root.js';
 import { resolvePlacement, classifyExclusions, NoViableDeviceError } from './scheduler.js';
 import { probePoolSignals } from './placement-probe.js';
 import { readMaxConcurrentCaps } from '../device-config.js';
@@ -560,6 +562,18 @@ export async function collectTeamsDoctorData(): Promise<Record<string, TeamsDoct
     })
   );
   return result;
+}
+
+/**
+ * The project's SECONDARY bound dirs to grant a local teammate as `--add-dir`:
+ * `projectDirsAbs` (primary first, resolved locally, missing dirs already
+ * dropped) minus the primary — filtered against the teammate's own cwd so the
+ * cwd (granted separately in `buildCommand`) is never duplicated. Only Claude
+ * and Codex consume `--add-dir`; `buildCommand` gates on that.
+ */
+export function projectTeammateAddDirs(def: ProjectDef, cwd: string): string[] {
+  const cwdAbs = path.resolve(cwd);
+  return projectDirsAbs(def, { forRemote: false }).slice(1).filter((d) => d !== cwdAbs);
 }
 
 let AGENTS_DIR: string | null = null;
@@ -2211,6 +2225,7 @@ export class AgentManager {
     // forwarded). Effort is a separate knob wired into buildReasoningFlags
     // inside buildCommand.
     const resolvedModel: string | null = agent.model ?? null;
+    const projectAddDirs = await this.resolveProjectAddDirs(agent);
     const cmd = this.buildCommand(
       agent.agentType,
       agent.prompt,
@@ -2222,6 +2237,7 @@ export class AgentManager {
       agent.version,
       agent.profileName,
       resume,
+      projectAddDirs,
     );
 
     debug(`Launching ${agent.agentType} agent ${agent.agentId} [${agent.mode}]${resume ? ' (resume)' : ''}: ${cmd.slice(0, 3).join(' ')}...`);
@@ -2747,6 +2763,25 @@ export class AgentManager {
     return args;
   }
 
+  /**
+   * The project's SECONDARY bound dirs to grant a local teammate as --add-dir.
+   *
+   * When the teammate's team is bound to a defined project
+   * (`teams create --project`), this returns `projectDirsAbs` minus the primary
+   * (the teammate's cwd), resolved locally (absolute, missing dirs dropped),
+   * deduped against the cwd. A distributed teammate (`hostName` set → `cwd` null)
+   * resolves its dirs on the host, so it gets none here. No project → `[]`.
+   */
+  private async resolveProjectAddDirs(agent: AgentProcess): Promise<string[]> {
+    if (!agent.cwd) return [];
+    const meta = await getTeam(agent.taskName);
+    if (!meta?.project) return [];
+    const { slug } = parseProjectRef(meta.project);
+    const def = slug ? loadProjectDef(slug) : undefined;
+    if (!def) return [];
+    return projectTeammateAddDirs(def, agent.cwd);
+  }
+
   private buildCommand(
     agentType: AgentType,
     prompt: string,
@@ -2758,6 +2793,7 @@ export class AgentManager {
     version: string | null = null,
     profileName: string | null = null,
     resume?: { id: string; message: string },
+    addDirs: string[] = [],
   ): string[] {
     // Route through getAgentsInvocation so a teammate launched by the compiled
     // standalone binary (#315) doesn't relaunch as `agents /$bunfs/root/agents …`
@@ -2782,6 +2818,15 @@ export class AgentManager {
     // Claude: grant access to the teammate's working directory.
     if (agentType === 'claude' && cwd) {
       cmd.push('--add-dir', cwd);
+    }
+
+    // Project-bound team (`teams create --project`): grant the project's OTHER
+    // bound dirs (projectDirsAbs minus the primary, resolved in
+    // resolveProjectAddDirs). Only Claude and Codex consume --add-dir — the
+    // inner `agents run` drops it for every other harness (exec.ts add-dir gate),
+    // so gate here to keep the command honest.
+    if (addDirs.length > 0 && (agentType === 'claude' || agentType === 'codex')) {
+      for (const dir of addDirs) cmd.push('--add-dir', dir);
     }
 
     // Codex's workspace-write sandbox blocks writes outside cwd. Factory

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -2770,7 +2770,11 @@ export class AgentManager {
    * (`teams create --project`), this returns `projectDirsAbs` minus the primary
    * (the teammate's cwd), resolved locally (absolute, missing dirs dropped),
    * deduped against the cwd. A distributed teammate (`hostName` set → `cwd` null)
-   * resolves its dirs on the host, so it gets none here. No project → `[]`.
+   * is OUT OF SCOPE: it launches via `launchRemoteProcess`/`buildRunArgv`, not
+   * `buildCommand`, and gets its code from `--repo`/its remote worktree — no
+   * project add-dirs are forwarded to it (a team is single-repo; `create
+   * --project` grants only LOCAL teammates). Returns `[]` when `cwd` is null or
+   * the team has no project.
    */
   private async resolveProjectAddDirs(agent: AgentProcess): Promise<string[]> {
     if (!agent.cwd) return [];

--- a/apps/cli/src/lib/teams/registry.ts
+++ b/apps/cli/src/lib/teams/registry.ts
@@ -35,6 +35,13 @@ export interface TeamMeta {
    * `origin` at create time. Used by `ensureRemoteRepo` to provision the repo.
    */
   repo?: string;
+  /**
+   * Defined-project slug (`agents projects`) this team is bound to. When set,
+   * a teammate added without `--cwd`/`--worktree` lands in the project's primary
+   * dir, and every local teammate is granted the project's other bound dirs via
+   * `--add-dir` (Claude/Codex). Resolved through `projectDirsAbs` at spawn.
+   */
+  project?: string;
 }
 
 /** Map of team name to team metadata. */
@@ -128,6 +135,8 @@ export interface CreateTeamOptions {
   devices?: string[];
   /** How each device gets the code (git URL to clone, or a path on the host). */
   repo?: string;
+  /** Defined-project slug bound to the team (resolves teammate cwd + add-dirs). */
+  project?: string;
 }
 
 /** Create a new team. Throws if a team with the same name already exists. */
@@ -148,6 +157,7 @@ export async function createTeam(name: string, options?: CreateTeamOptions): Pro
       ...(options?.useWorktree ? { use_worktree: options.useWorktree } : {}),
       ...(options?.devices && options.devices.length ? { devices: options.devices } : {}),
       ...(options?.repo ? { repo: options.repo } : {}),
+      ...(options?.project ? { project: options.project } : {}),
     };
     reg[name] = m;
     await saveTeams(reg);


### PR DESCRIPTION
**feat (behavior change) — resolves ALL of a project's bound dirs at both spawn paths (`agents run --project`, `agents teams`), not just the primary cwd.** RUSH-2487 track 2 of 3.

> Stacked on #2501 (track 1, `agents/projects-core`) — this PR's base is `agents/projects-core` so the diff shows only track-2 files. It consumes track 1's exported `projectDirsAbs`. **Merge after #2501; do not delete the `agents/projects-core` branch before this lands** (or I rebuild on `main`).

## What changed

Before, `agents run --project <slug>` resolved only `defaultPath ?? root` (`resolveDefinedProjectPath`), so a project's other bound repos were invisible to the spawned agent; `agents teams` had no `--project` flag at all. Now both spawn paths resolve the full bound-dir set via track 1's `projectDirsAbs`.

| File | Change |
|---|---|
| **`apps/cli/src/commands/exec.ts`** | `--project` grants the project's SECONDARY bound dirs as `--add-dir` via the new exported `projectRunAddDirs(ref, forRemote, existing)` — deduped against explicit `--add-dir`; cwd unchanged (primary stays cwd). `--host` forwards them through the existing `toRemotePortable` map (`~/…`). `--project` help now states the Claude/Codex-only limit. |
| **`apps/cli/src/commands/teams.ts`** | `teams create --project <slug>` (validated fail-loud, stored in team meta, echoed). `teams add` cwd precedence is now `worktree → --cwd → project primary → cwd`. |
| **`apps/cli/src/lib/teams/agents.ts`** | A project-bound teammate is granted the project's other dirs as `--add-dir` via the new exported `projectTeammateAddDirs(def, cwd)`, resolved in `resolveProjectAddDirs` and appended in `buildCommand` (Claude/Codex only). |
| **`apps/cli/src/lib/teams/registry.ts`** | `TeamMeta.project` / `CreateTeamOptions.project` persist the binding beside `enable_worktrees`/`use_worktree`/`repo`. |

**Honest limit (per (d)):** `--add-dir` is emitted only for Claude (native flag, `exec.ts:1269`) and Codex (folded into `workspace_roots`, `codex-policy.ts:34-42`); it is silently dropped for every other harness. No fallback invented — the help text and code comments say so.

## Verification — real output against the live `agents-cli` project (all three bound dirs)

Reproduced the exact command build the actions run (`projectRunAddDirs` + `buildExecCommand`; `projectTeammateAddDirs`), against `~/.agents/projects/agents-cli.yaml`:

```
LOCAL cwd       : /home/muqsit/src/github.com/muqsitnawaz/agents-cli
LOCAL add-dirs  : [ ".../agents-cli-web", "/home/muqsit/.agents/.system" ]
LOCAL --add-dir in built claude cmd: [ ".../agents-cli-web", "/home/muqsit/.agents/.system" ]

REMOTE cwd (~)  : ~/src/github.com/muqsitnawaz/agents-cli
REMOTE hostAddDirs (forwarded): [ "~/src/github.com/muqsitnawaz/agents-cli-web", "~/.agents/.system" ]

TEAM teammate cwd   : /home/muqsit/src/github.com/muqsitnawaz/agents-cli
TEAM teammate grants: [ ".../agents-cli-web", "/home/muqsit/.agents/.system" ]
```

cwd stays the primary; secondaries `agents-cli-web` and `.agents/.system` are granted; `--host` forwards them as `~/…` (not `/Users/muqsit/…`); the teammate lands in the primary with the sibling grants. Every success criterion met.

Tests (new, `bun vitest run`):
```
src/commands/exec.test.ts   36 passed   (incl. projectRunAddDirs: secondary/primary/missing-dir/dedup/forRemote/unknown)
src/commands/teams.test.ts  +2 passed   (teams create --project stores meta; undefined project fails loud, no bogus team)
src/lib/teams/agents.test.ts 3 passed   (projectTeammateAddDirs: cwd=primary/secondary/worktree)
```
`bunx tsc --noEmit`: clean.

## For track 1 (`projects-core`) — CHANGELOG text (docs/CHANGELOG are yours)

Under `[Unreleased] / Changed`:
> `agents run --project` and `agents teams create --project` now grant ALL of a defined project's bound dirs at spawn — the primary stays the cwd, the other bound repos are added via `--add-dir` (Claude/Codex only). Previously only the primary dir was resolved.
