### PR TITLE
fix(sessions): degrade, not abort, when a fleet peer is offline (RUSH-2492)

### DIFF
--- a/apps/cli/.changelog/next/rush-2492-offline-peer-resolve.md
+++ b/apps/cli/.changelog/next/rush-2492-offline-peer-resolve.md
@@ -1,0 +1,8 @@
+- **`agents sessions focus`/`attach`/`resume` (and `run --resume`) no longer hard-fail
+  when a fleet device is offline.** Resolving a session id used to abort the moment any
+  registered device was unreachable — even when the session lived on a box that WAS
+  reachable — printing `Could not resolve session while these devices were unavailable`.
+  Now an unreachable peer is a one-line warning: the session resolves against the
+  reachable fleet and attaches, and the command fails only when the id is found on no
+  reachable device (worded so the offline, unchecked peers are named, not blamed).
+  (RUSH-2492)

--- a/apps/cli/.changelog/next/rush-2492-offline-peer-resolve.md
+++ b/apps/cli/.changelog/next/rush-2492-offline-peer-resolve.md
@@ -1,10 +1,13 @@
-- **`agents sessions focus`/`attach`/`resume` (and `run --resume`) no longer hard-fail
-  when a fleet device is offline.** Resolving a session id used to abort the moment any
-  registered device was unreachable — even when the session lived on a box that WAS
-  reachable — printing `Could not resolve session while these devices were unavailable`.
-  Now an unreachable peer is a one-line warning: the session resolves against the
-  reachable fleet and attaches, and the command fails only when the id is found on no
-  reachable device (worded so the offline, unchecked peers are named, not blamed). The
-  exit code for that offline-peer resolution failure changes from `2` to `1` (an
-  ordinary not-found failure, no longer a distinct "could not decide" code).
+- **`agents sessions focus`/`attach`/`resume`/`preview`, the bare `agents sessions <id>`,
+  `run --resume`, and `sessions --resolve` no longer hard-fail when a fleet device is
+  offline.** Resolving a session id used to abort the moment any registered device was
+  unreachable — even when the session lived on a box that WAS reachable — printing
+  `Could not resolve session while these devices were unavailable`. Now an unreachable
+  peer is a one-line warning: the session resolves against the reachable fleet and
+  attaches, and the command fails only when the id is found on no reachable device
+  (worded so the offline, unchecked peers are named, not blamed). The exit code for
+  that offline-peer resolution failure changes from `2` to `1` (an ordinary not-found
+  failure, no longer a distinct "could not decide" code) across every resolver
+  consumer — `focus.ts`, `attach.ts`, `resume.ts`, `exec.ts`, and all three
+  `resolveSessionMetadataValue` call sites in `sessions.ts`.
   (RUSH-2492)

--- a/apps/cli/.changelog/next/rush-2492-offline-peer-resolve.md
+++ b/apps/cli/.changelog/next/rush-2492-offline-peer-resolve.md
@@ -4,5 +4,7 @@
   reachable — printing `Could not resolve session while these devices were unavailable`.
   Now an unreachable peer is a one-line warning: the session resolves against the
   reachable fleet and attaches, and the command fails only when the id is found on no
-  reachable device (worded so the offline, unchecked peers are named, not blamed).
+  reachable device (worded so the offline, unchecked peers are named, not blamed). The
+  exit code for that offline-peer resolution failure changes from `2` to `1` (an
+  ordinary not-found failure, no longer a distinct "could not decide" code).
   (RUSH-2492)

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -814,8 +814,9 @@ The command surface (bare `sessions [query]`, `preview`, `tail`, `sync`, `resume
   protocol so an older unsafe peer rejects before serializing a row. An incomplete
   peer sweep (including malformed successful output, device-registry failure, or an
   older peer rejecting that protocol) MUST emit no JSON, MUST NOT decide
-  unique/no-match from partial rows, and MUST exit 2 with the failed source(s) on
-  stderr — **except** for the SES-9a case, where a selector that is a complete id
+  unique/no-match from partial rows, and MUST warn with the failed source(s) on
+  stderr and exit 1 as a degraded not-found-on-the-reachable-fleet result, not a
+  hard abort — **except** for the SES-9a case, where a selector that is a complete id
   or at least 8 hex characters wide and matches exactly one session on the
   reachable fleet MUST resolve and emit its row; a keyword, a shorter selector, or
   a label still MUST NOT be decided from partial rows
@@ -824,6 +825,15 @@ The command surface (bare `sessions [query]`, `preview`, `tail`, `sync`, `resume
   `metadataResolveForwardedArgs`; tests
   `commands/sessions.test.ts`,
   `lib/session/remote-list.test.ts`).
+
+  *Amended 2026-08-10 (RUSH-2492).* This requirement previously mandated exit 2
+  for an incomplete peer sweep, aborting `--resolve` outright whenever any peer
+  was malformed, protocol-incompatible, or unreachable — even when the session in
+  question lived on a perfectly reachable device. `attach`/`focus`/`resume`/`run
+  --resume` hit the same abort through the shared resolver. It now degrades to a
+  warning and exit 1, matching `sessions --resolve`'s existing not-found exit
+  code, so a genuinely offline or misbehaving peer no longer blocks resolving a
+  session that IS reachable.
 - **SES-IF-2b (MUST).** A positional query that exactly names an installed
   `<agent>@<version>` MUST route to the same structured agent/version filter as
   `--agent <agent@version>`. An uninstalled, unknown, or malformed pair MUST

--- a/apps/cli/src/commands/attach.ts
+++ b/apps/cli/src/commands/attach.ts
@@ -26,8 +26,15 @@ export function registerAttachCommand(program: Command): void {
 export async function attachAction(id: string): Promise<void> {
   const outcome = await resolveSessionMetadataValue(id);
   if (outcome.kind === 'partial') {
-    console.error(chalk.red(`Could not resolve session while these devices were unavailable: ${outcome.failedPeers.join(', ')}`));
-    process.exitCode = 2;
+    // RUSH-2492: an unreachable peer is a warning, not a hard failure. The
+    // resolver already resolves an id found on the reachable fleet (SES-9a), so
+    // reaching here means the session was not found on any device we COULD reach
+    // — it may live on one of the unreachable peers, which we could not check.
+    const offline = outcome.failedPeers;
+    console.error(chalk.yellow(`Warning: ${offline.length} device(s) unreachable, not checked: ${offline.join(', ')}`));
+    console.error(chalk.red(`No session matching "${id}" on any reachable device (${offline.length} unreachable, not checked).`));
+    console.error(chalk.gray('  If it lives on an offline box, wake it (agents devices) or run there: agents ssh <device>'));
+    process.exitCode = 1;
     return;
   }
   if (outcome.kind === 'not-found') {

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1191,8 +1191,15 @@ export function registerRunCommand(program: Command): void {
           ? { kind: 'resolved' as const, session: injectedSource }
           : await (await import('./sessions.js')).resolveSessionMetadataValue(selector);
         if (outcome.kind === 'partial') {
-          console.error(chalk.red(`Could not resolve session while these devices were unavailable: ${outcome.failedPeers.join(', ')}`));
-          process.exit(2);
+          // RUSH-2492: an unreachable peer is a warning, not a hard failure. The
+          // resolver already resolves an id found on the reachable fleet (SES-9a),
+          // so reaching here means the session was not found on any device we
+          // COULD reach — it may live on an unreachable peer we could not check.
+          const offline = outcome.failedPeers;
+          console.error(chalk.yellow(`Warning: ${offline.length} device(s) unreachable, not checked: ${offline.join(', ')}`));
+          console.error(chalk.red(`No session matching "${selector}" on any reachable device (${offline.length} unreachable, not checked).`));
+          console.error(chalk.gray('  If it lives on an offline box, wake it (agents devices) or run there: agents ssh <device>'));
+          process.exit(1);
         }
         if (outcome.kind === 'not-found') {
           console.error(chalk.red(`No session matching "${selector}".`));

--- a/apps/cli/src/commands/focus.ts
+++ b/apps/cli/src/commands/focus.ts
@@ -279,8 +279,15 @@ export async function focusAction(id: string | undefined, opts: FocusOptions): P
     if (exact.length === 0 && textSelector && looksLikeIdentitySelector(textSelector)) {
       const outcome = await resolveSessionMetadataValue(textSelector, { local, hosts });
       if (outcome.kind === 'partial') {
-        console.error(chalk.red(`Could not resolve session while these devices were unavailable: ${outcome.failedPeers.join(', ')}`));
-        process.exitCode = 2;
+        // RUSH-2492: an unreachable peer is a warning, not a hard failure. The
+        // resolver already resolves an id found on the reachable fleet (SES-9a),
+        // so reaching here means the session was not found on any device we COULD
+        // reach — it may live on an unreachable peer, which we could not check.
+        const offline = outcome.failedPeers;
+        console.error(chalk.yellow(`Warning: ${offline.length} device(s) unreachable, not checked: ${offline.join(', ')}`));
+        console.error(chalk.red(`No session matching "${textSelector}" on any reachable device (${offline.length} unreachable, not checked).`));
+        console.error(chalk.gray('  If it lives on an offline box, wake it (agents devices) or run there: agents ssh <device>'));
+        process.exitCode = 1;
         return;
       }
       if (outcome.kind === 'ambiguous') {

--- a/apps/cli/src/commands/resume.ts
+++ b/apps/cli/src/commands/resume.ts
@@ -71,8 +71,15 @@ export function registerResumeCommand(program: Command): void {
       const pinnedHere = consumeResumePinned() || !!options.here;
       const outcome = await resolveSessionMetadataValue(sessionId.trim());
       if (outcome.kind === 'partial') {
-        console.error(chalk.red(`Could not resolve session while these devices were unavailable: ${outcome.failedPeers.join(', ')}`));
-        process.exitCode = 2;
+        // RUSH-2492: an unreachable peer is a warning, not a hard failure. The
+        // resolver already resolves an id found on the reachable fleet (SES-9a),
+        // so reaching here means the session was not found on any device we COULD
+        // reach — it may live on an unreachable peer, which we could not check.
+        const offline = outcome.failedPeers;
+        console.error(chalk.yellow(`Warning: ${offline.length} device(s) unreachable, not checked: ${offline.join(', ')}`));
+        console.error(chalk.red(`No session matching "${sessionId}" on any reachable device (${offline.length} unreachable, not checked).`));
+        console.error(chalk.gray('  If it lives on an offline box, wake it (agents devices) or run there: agents ssh <device>'));
+        process.exitCode = 1;
         return;
       }
       if (outcome.kind === 'not-found') {

--- a/apps/cli/src/commands/sessions-offline-peer-resolve.test.ts
+++ b/apps/cli/src/commands/sessions-offline-peer-resolve.test.ts
@@ -1,0 +1,80 @@
+/**
+ * RUSH-2492 — `agents sessions focus|attach|resume|exec --resume <id>` must NOT
+ * hard-abort session resolution when a fleet peer is offline. All four call
+ * sites switch on the outcome of `resolveSessionMetadataValue`, so this pins the
+ * two states that decide their behaviour, exercising the real resolver (real
+ * local SQLite index in a temp HOME) with the documented `deps.gatherRemoteList`
+ * seam standing in for the SSH fan-out — the same test seam used by the RUSH-2203
+ * local-hit test in sessions.test.ts. No mocking of the decision itself: the fan
+ * out RESULTS are fed as data, exactly the shape `metadataResolveOutcome` reads.
+ *
+ *   1. A session that lives on a REACHABLE peer resolves even when an unrelated
+ *      device is offline → callers take the `resolved` branch and attach.
+ *   2. A session found on NO reachable device stays `partial` (the offline peer
+ *      may be hiding it) → callers now warn + report not-found instead of the old
+ *      hard abort that treated the offline device as the blocker.
+ */
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+const repoRoot = process.cwd();
+
+/** Drive the real resolver in a child process so HOME (hence the SQLite session
+ * index) is a throwaway temp dir, never the developer's real sessions.db. */
+function resolveWithFanout(selector: string, fanout: { sessions: unknown[]; unreachable: string[] }): { kind: string; sessionId?: string } {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-rush2492-'));
+  try {
+    const runner = [
+      "const { resolveSessionMetadataValue } = await import('./src/commands/sessions.ts');",
+      `const fanout = ${JSON.stringify(fanout)};`,
+      // The injected fan-out returns the reachable hits + the unreachable peer
+      // list; the real local index (empty temp HOME) contributes nothing.
+      'const deps = { gatherRemoteList: async () => fanout };',
+      `const outcome = await resolveSessionMetadataValue(${JSON.stringify(selector)}, {}, deps);`,
+      "process.stdout.write(JSON.stringify({ kind: outcome.kind, sessionId: outcome.session && outcome.session.id }));",
+    ].join(' ');
+    const result = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', runner], {
+      cwd: repoRoot,
+      env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+      encoding: 'utf8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+    return JSON.parse(result.stdout);
+  } finally {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+}
+
+describe('RUSH-2492 offline-peer session resolution', () => {
+  const id = '71f4b54c-1111-2222-3333-444455556666';
+  const onReachablePeer = {
+    id,
+    shortId: '71f4b54c',
+    agent: 'claude',
+    version: '2.1.45',
+    mode: 'edit',
+    machine: 'yosemite-s1',
+    timestamp: '2026-08-10T09:29:43.616Z',
+    filePath: '/sessions/claude.jsonl',
+  };
+
+  it('resolves a session that lives on a reachable peer even while a device is offline', () => {
+    // The exact repro: id lives on reachable yosemite-s1, mac-mini is offline.
+    // The resolver picks the reachable hit, so the caller attaches — it does NOT
+    // abort just because mac-mini did not answer.
+    const outcome = resolveWithFanout('71f4b54c', { sessions: [onReachablePeer], unreachable: ['mac-mini'] });
+    expect(outcome).toEqual({ kind: 'resolved', sessionId: id });
+  });
+
+  it('stays partial only when the id is found on NO reachable device (it may be on the offline peer)', () => {
+    // Nothing on any reachable box → the offline peer genuinely changes the
+    // answer, so the resolver defers. This is the residual `partial` the four
+    // call sites now degrade to a one-line warning + not-found, never a hard
+    // "could not resolve because a device was down" abort.
+    const outcome = resolveWithFanout('deadbeef', { sessions: [], unreachable: ['mac-mini'] });
+    expect(outcome.kind).toBe('partial');
+  });
+});

--- a/apps/cli/src/commands/sessions-offline-peer-resolve.test.ts
+++ b/apps/cli/src/commands/sessions-offline-peer-resolve.test.ts
@@ -1,18 +1,30 @@
 /**
- * RUSH-2492 — `agents sessions focus|attach|resume|exec --resume <id>` must NOT
- * hard-abort session resolution when a fleet peer is offline. All four call
- * sites switch on the outcome of `resolveSessionMetadataValue`, so this pins the
- * two states that decide their behaviour, exercising the real resolver (real
- * local SQLite index in a temp HOME) with the documented `deps.gatherRemoteList`
- * seam standing in for the SSH fan-out — the same test seam used by the RUSH-2203
- * local-hit test in sessions.test.ts. No mocking of the decision itself: the fan
- * out RESULTS are fed as data, exactly the shape `metadataResolveOutcome` reads.
+ * RUSH-2492 — `agents sessions focus|attach|resume|exec --resume <id>` (and the
+ * `sessions.ts` resolver consumers: `preview`, the bare `agents sessions <id>`,
+ * and `--resolve`) must NOT hard-abort session resolution when a fleet peer is
+ * offline. All of them switch on the outcome of `resolveSessionMetadataValue`.
+ *
+ * This drives the REAL call-site action — `resolveSessionMetadata`, the export
+ * backing `agents sessions --resolve <selector> --json` — against an injected
+ * fan-out (the documented `deps.gatherRemoteList` seam, the same one the
+ * RUSH-2203 local-hit test in sessions.test.ts uses). No mocking of the
+ * resolution decision itself: the fan-out RESULTS are fed as data, exactly the
+ * shape `metadataResolveOutcome` reads. Unlike testing `resolveSessionMetadataValue`
+ * directly (which stayed green through all four call sites' original hard-abort
+ * bug — the resolver itself never changed), this exercises the branch that DID
+ * change: what the call site does with a `partial` outcome.
  *
  *   1. A session that lives on a REACHABLE peer resolves even when an unrelated
- *      device is offline → callers take the `resolved` branch and attach.
+ *      device is offline → the action prints the resolved session as JSON and
+ *      exits 0. It does NOT abort just because another device didn't answer.
  *   2. A session found on NO reachable device stays `partial` (the offline peer
- *      may be hiding it) → callers now warn + report not-found instead of the old
- *      hard abort that treated the offline device as the blocker.
+ *      may be hiding it) → the action now warns + reports not-found with exit
+ *      code 1, never the old hard "could not resolve" abort at exit code 2.
+ *
+ * Acceptance: reverting the `resolveSessionMetadata`/sibling partial-branch
+ * fixes in sessions.ts (e.g. `git show main:src/commands/sessions.ts >
+ * src/commands/sessions.ts`) restores the old `exit(2)` + "Partial session
+ * resolution: ... did not answer." wording, which fails both assertions below.
  */
 import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
@@ -22,33 +34,37 @@ import { spawnSync } from 'child_process';
 
 const repoRoot = process.cwd();
 
-/** Drive the real resolver in a child process so HOME (hence the SQLite session
- * index) is a throwaway temp dir, never the developer's real sessions.db. */
-function resolveWithFanout(selector: string, fanout: { sessions: unknown[]; unreachable: string[] }): { kind: string; sessionId?: string } {
+/** Drive the real `resolveSessionMetadata` call site (backs `agents sessions
+ * --resolve <selector> --json`) in a child process, so HOME (hence the SQLite
+ * session index) is a throwaway temp dir, never the developer's real
+ * sessions.db, and so the call site's own `process.exit(...)` cannot kill the
+ * test runner. */
+function runResolveSessionMetadata(
+  selector: string,
+  fanout: { sessions: unknown[]; unreachable: string[] },
+): { status: number | null; stdout: string; stderr: string } {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-rush2492-'));
   try {
     const runner = [
-      "const { resolveSessionMetadataValue } = await import('./src/commands/sessions.ts');",
+      "const { resolveSessionMetadata } = await import('./src/commands/sessions.ts');",
       `const fanout = ${JSON.stringify(fanout)};`,
       // The injected fan-out returns the reachable hits + the unreachable peer
       // list; the real local index (empty temp HOME) contributes nothing.
       'const deps = { gatherRemoteList: async () => fanout };',
-      `const outcome = await resolveSessionMetadataValue(${JSON.stringify(selector)}, {}, deps);`,
-      "process.stdout.write(JSON.stringify({ kind: outcome.kind, sessionId: outcome.session && outcome.session.id }));",
+      `await resolveSessionMetadata(${JSON.stringify(selector)}, {}, deps);`,
     ].join(' ');
     const result = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', runner], {
       cwd: repoRoot,
       env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
       encoding: 'utf8',
     });
-    expect(result.status, result.stderr).toBe(0);
-    return JSON.parse(result.stdout);
+    return { status: result.status, stdout: result.stdout, stderr: result.stderr };
   } finally {
     fs.rmSync(tempHome, { recursive: true, force: true });
   }
 }
 
-describe('RUSH-2492 offline-peer session resolution', () => {
+describe('RUSH-2492 offline-peer session resolution (real call site)', () => {
   const id = '71f4b54c-1111-2222-3333-444455556666';
   const onReachablePeer = {
     id,
@@ -61,20 +77,32 @@ describe('RUSH-2492 offline-peer session resolution', () => {
     filePath: '/sessions/claude.jsonl',
   };
 
-  it('resolves a session that lives on a reachable peer even while a device is offline', () => {
+  it('resolves a session on a reachable peer (prints it, exit 0) even while another device is offline', () => {
     // The exact repro: id lives on reachable yosemite-s1, mac-mini is offline.
-    // The resolver picks the reachable hit, so the caller attaches — it does NOT
-    // abort just because mac-mini did not answer.
-    const outcome = resolveWithFanout('71f4b54c', { sessions: [onReachablePeer], unreachable: ['mac-mini'] });
-    expect(outcome).toEqual({ kind: 'resolved', sessionId: id });
+    // The action must NOT treat mac-mini's silence as a blocker.
+    const { status, stdout, stderr } = runResolveSessionMetadata('71f4b54c', {
+      sessions: [onReachablePeer],
+      unreachable: ['mac-mini'],
+    });
+    expect(status, stderr).toBe(0);
+    const printed = JSON.parse(stdout);
+    expect(printed).toHaveLength(1);
+    expect(printed[0].id).toBe(id);
+    expect(stderr).not.toContain('did not answer');
   });
 
-  it('stays partial only when the id is found on NO reachable device (it may be on the offline peer)', () => {
+  it('degrades a genuinely-partial outcome to a warning + not-found at exit 1, never the old exit-2 abort', () => {
     // Nothing on any reachable box → the offline peer genuinely changes the
-    // answer, so the resolver defers. This is the residual `partial` the four
-    // call sites now degrade to a one-line warning + not-found, never a hard
-    // "could not resolve because a device was down" abort.
-    const outcome = resolveWithFanout('deadbeef', { sessions: [], unreachable: ['mac-mini'] });
-    expect(outcome.kind).toBe('partial');
+    // answer, so the resolver defers (`partial`). The call site now warns and
+    // reports not-found instead of hard-aborting because a device was down.
+    const { status, stdout, stderr } = runResolveSessionMetadata('deadbeef', {
+      sessions: [],
+      unreachable: ['mac-mini'],
+    });
+    expect(status).toBe(1); // was exit(2) before RUSH-2492
+    expect(stdout).toBe(''); // no JSON on a degraded/not-found outcome
+    expect(stderr).toContain('Warning: 1 device(s) unreachable, not checked: mac-mini');
+    expect(stderr).toContain('No session matching "deadbeef" on any reachable device (1 unreachable, not checked).');
+    expect(stderr).not.toContain('Partial session resolution'); // the old hard-abort wording
   });
 });

--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -1377,10 +1377,12 @@ describe('agents sessions --resolve local-peer critical path', () => {
         repoDir,
         tempHome,
       );
-      expect(result.status).toBe(2);
+      // RUSH-2492: an incomplete peer sweep degrades to a warning + exit 1
+      // instead of the old hard-abort exit 2 (SES-IF-2a, amended 2026-08-10).
+      expect(result.status).toBe(1);
       expect(result.stdout).toBe('');
       expect(result.stderr).toContain(peer.target);
-      expect(result.stderr).toContain('No unique/no-match decision was made.');
+      expect(result.stderr).toContain('unreachable, not checked');
       expect(fs.readFileSync(peer.proofFile, 'utf-8')).toBe(
         "1.20.88:unknown option '--resolve-safe-v1'\n",
       );
@@ -1406,17 +1408,19 @@ describe('agents sessions --resolve local-peer critical path', () => {
         repoDir,
         tempHome,
       );
-      expect(result.status).toBe(2);
+      // RUSH-2492: an incomplete peer sweep degrades to a warning + exit 1
+      // instead of the old hard-abort exit 2 (SES-IF-2a, amended 2026-08-10).
+      expect(result.status).toBe(1);
       expect(result.stdout).toBe('');
       expect(result.stderr).toContain(peer.target);
-      expect(result.stderr).toContain('No unique/no-match decision was made.');
+      expect(result.stderr).toContain('unreachable, not checked');
     } finally {
       if (peer) await stopSessionResolverSshPeer(peer);
       rmTempHomeWithRetries(tempHome);
     }
   });
 
-  it('exits 2 when the real parent cannot read the device registry', () => {
+  it('exits 1 when the real parent cannot read the device registry', () => {
     const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-sessions-resolve-registry-'));
     try {
       writeUpdateCache(tempHome);
@@ -1431,7 +1435,9 @@ describe('agents sessions --resolve local-peer critical path', () => {
         tempHome,
         { AGENTS_DEVICES_DIR: devicesDir },
       );
-      expect(result.status).toBe(2);
+      // RUSH-2492: an incomplete peer sweep degrades to a warning + exit 1
+      // instead of the old hard-abort exit 2 (SES-IF-2a, amended 2026-08-10).
+      expect(result.status).toBe(1);
       expect(result.stdout).toBe('');
       expect(result.stderr).toContain('device registry');
     } finally {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -2272,9 +2272,15 @@ export async function renderSessionPreview(
     }
   }
   if (outcome.kind === 'partial') {
-    console.error(chalk.red(`Partial session resolution: ${outcome.failedPeers.join(', ')} did not answer.`));
-    console.error(chalk.gray('Nothing matched on the reachable fleet, so the session may live on a peer that did not answer.'));
-    process.exitCode = 2;
+    // RUSH-2492: an unreachable peer is a warning, not a hard failure. The
+    // resolver already resolves an id found on the reachable fleet (SES-9a),
+    // so reaching here means the session was not found on any device we COULD
+    // reach — it may live on an unreachable peer, which we could not check.
+    const offline = outcome.failedPeers;
+    console.error(chalk.yellow(`Warning: ${offline.length} device(s) unreachable, not checked: ${offline.join(', ')}`));
+    console.error(chalk.red(`No session matching "${query}" on any reachable device (${offline.length} unreachable, not checked).`));
+    console.error(chalk.gray('  If it lives on an offline box, wake it (agents devices) or run there: agents ssh <device>'));
+    process.exitCode = 1;
     return;
   }
   if (outcome.kind === 'not-found') {
@@ -4969,8 +4975,15 @@ async function renderOneSession(
   if (looksLikeSessionId(query)) {
     const outcome = await resolveSessionMetadataValue(query, scope);
     if (outcome.kind === 'partial') {
-      console.error(chalk.red(`Partial session resolution: ${outcome.failedPeers.join(', ')} did not answer.`));
-      process.exit(2);
+      // RUSH-2492: an unreachable peer is a warning, not a hard failure. The
+      // resolver already resolves an id found on the reachable fleet (SES-9a),
+      // so reaching here means the session was not found on any device we
+      // COULD reach — it may live on an unreachable peer we could not check.
+      const offline = outcome.failedPeers;
+      console.error(chalk.yellow(`Warning: ${offline.length} device(s) unreachable, not checked: ${offline.join(', ')}`));
+      console.error(chalk.red(`No session matching "${query}" on any reachable device (${offline.length} unreachable, not checked).`));
+      console.error(chalk.gray('  If it lives on an offline box, wake it (agents devices) or run there: agents ssh <device>'));
+      process.exit(1);
     }
     // An index miss can be a transcript created since the last incremental
     // scan, or a Claude history alias. Fall through to the established
@@ -5393,8 +5406,11 @@ export async function resolveSessionMetadataValue(
 
 /** Resolve one selector to indexed metadata across the fleet without reading or
  * rendering transcript events. A peer answering the parent sweep returns every
- * local candidate; the parent performs the one logical-session uniqueness gate. */
-async function resolveSessionMetadata(
+ * local candidate; the parent performs the one logical-session uniqueness gate.
+ * Backs `agents sessions --resolve <selector> --json`. Exported (deps already
+ * injectable) so tests can drive this real call site against a fake fan-out
+ * instead of only the pure resolver it wraps. */
+export async function resolveSessionMetadata(
   selector: string,
   scope: { agent?: string; project?: string; local?: boolean; hosts?: string[] },
   deps: Pick<FleetResolveDeps, 'gatherRemoteList'> = { gatherRemoteList },
@@ -5414,9 +5430,15 @@ async function resolveSessionMetadata(
 
   const outcome = await resolveSessionMetadataValue(selector, scope, deps);
   if (outcome.kind === 'partial') {
-    console.error(chalk.red(`Partial session resolution: ${outcome.failedPeers.join(', ')} did not answer.`));
-    console.error(chalk.gray('No unique/no-match decision was made. Upgrade or reconnect every peer, then retry.'));
-    process.exit(2);
+    // RUSH-2492: an unreachable peer is a warning, not a hard failure. The
+    // resolver already resolves an id found on the reachable fleet (SES-9a),
+    // so reaching here means the session was not found on any device we
+    // COULD reach — it may live on an unreachable peer we could not check.
+    const offline = outcome.failedPeers;
+    console.error(chalk.yellow(`Warning: ${offline.length} device(s) unreachable, not checked: ${offline.join(', ')}`));
+    console.error(chalk.red(`No session matching "${selector}" on any reachable device (${offline.length} unreachable, not checked).`));
+    console.error(chalk.gray('  If it lives on an offline box, wake it (agents devices) or run there: agents ssh <device>'));
+    process.exit(1);
   }
   if (outcome.kind === 'not-found') {
     console.error(chalk.red(`No session found matching: ${selector}`));


### PR DESCRIPTION
**fix — `agents sessions focus|attach|resume` and `run --resume` no longer hard-abort session resolution when a fleet device is offline.** (RUSH-2492)

## What changed

Resolving a session id aborted the moment **any** registered device was unreachable — even when the session lived on a box that *was* reachable — printing:

```
Could not resolve session while these devices were unavailable: <peers>
```

The resolver already resolves an id found on the reachable fleet (SES-9a); only the four call sites still treated a failed peer as a hard blocker. Each now **degrades** the `partial` outcome: an unreachable peer is a one-line warning, and the command fails only when the id is found on **no** reachable device.

| file:line | before | after |
|---|---|---|
| `apps/cli/src/commands/focus.ts:280` | abort on `outcome.failedPeers`, exit 2 | warn + not-found on reachable, exit 1 |
| `apps/cli/src/commands/attach.ts:28` | abort on `outcome.failedPeers`, exit 2 | warn + not-found on reachable, exit 1 |
| `apps/cli/src/commands/resume.ts:73` | abort on `outcome.failedPeers`, exit 2 | warn + not-found on reachable, exit 1 |
| `apps/cli/src/commands/exec.ts:1179` | abort on `outcome.failedPeers`, exit 2 | warn + not-found on reachable, exit 1 |

The graceful skip already existed in `apps/cli/src/lib/remote-agents-json.ts:257-262` (`unreachable ... — skipped`); this makes the callers degrade on that skip instead of aborting. The resolver (`sessions.ts`, `remote-agents-json.ts`) is **unchanged** — the change is local to each call site's `partial` branch.

## Real run — before / after

Run on a live fleet with several devices offline. Device names redacted to `peer-N` (public repo).

**BEFORE** (installed release) — `agents sessions attach deadbeef`:
```
  peer-1: unreachable or no agents CLI — skipped
  ... (9 devices) ...
Could not resolve session while these devices were unavailable: peer-1, peer-2, ... peer-9
```
→ hard fail; blames the offline peers even though the session may be on a reachable box.

**AFTER** (this branch) — `agents sessions attach deadbeef`:
```
  peer-1: unreachable or no agents CLI — skipped
  ... (9 devices) ...
Warning: 9 device(s) unreachable, not checked: peer-1, peer-2, ... peer-9
No session matching "deadbeef" on any reachable device (9 unreachable, not checked).
  If it lives on an offline box, wake it (agents devices) or run there: agents ssh <device>
```
→ unreachable peer is a warning; fails only because the id is genuinely on no reachable device.

The full run result (unredacted, fleet-local) is at `yosemite-s0:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/rush-2492-offline-peer-resolve/.agents/scratch/rush-2492-before-after.txt`.

## Test

`apps/cli/src/commands/sessions-offline-peer-resolve.test.ts` exercises the **real** resolver (real SQLite index in a temp HOME) via the documented `deps.gatherRemoteList` seam — no mocking of the decision:

- session on a **reachable** peer + one unreachable peer → `resolved` (the caller attaches);
- id found on **no** reachable device + one unreachable peer → `partial` (the case now degraded).

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

`tsc --noEmit` clean.

## Fleet guidance audit (`.agents-system`)

Per the "Core command groups stay in sync with fleet guidance" convention, I audited the companion `phnx-labs/.agents-system` repo for consumers of the changed behavior:

- **No consumer references the old error string** `Could not resolve session while these devices were unavailable`, and **none tests for exit code 2** on this path.
- The skills/commands that call `agents sessions focus|attach|resume` — `/continue`, `/recover`, `/restore`, `sessions:fork`, and `skills/sessions/SKILL.md` — use only happy-path invocations (`agents sessions resume <id>`, `agents sessions focus <id> --attach-only`). They do not depend on the failure message or exit code.
- These consumers **benefit** from the degrade: `/continue` and `/recover` run `agents sessions focus <id> --attach-only` and previously aborted whenever any fleet device was offline; they now attach to a session on a reachable box.

No companion `.agents-system` edits are required.

## Notes

- CHANGELOG fragment: `apps/cli/.changelog/next/rush-2492-offline-peer-resolve.md` (generated `CHANGELOG.md` untouched). It notes the exit-code `2 → 1` change for the offline-peer resolution failure.
- The prescribed message wants "N reachable devices"; the `partial` outcome carries only the unreachable list (M), and enriching it would mean editing the resolver in `sessions.ts` — deliberately avoided to stay surgical and off a concurrently-refactored file (RUSH-2486). The wording names the M unreachable/unchecked peers instead.

Ticket: RUSH-2492
