### PR TITLE
fix(config): stop a config read from rewriting the fleet-shared agents.yaml

### DIFF
--- a/apps/cli/.changelog/next/config-read-no-longer-writes-shared-agents-yaml.md
+++ b/apps/cli/.changelog/next/config-read-no-longer-writes-shared-agents-yaml.md
@@ -1,0 +1,29 @@
+- **A config read no longer rewrites the fleet-shared `agents.yaml`.** The legacy
+  device-config fold hung off `getConfigValue` / `setConfigValue` /
+  `unsetConfigValue`, so an ordinary `agents config get` could rewrite
+  `~/.agents/agents.yaml` — a file every machine in the fleet tracks and syncs.
+  With 13 machines each dirtying one shared path on nearly every command, boxes
+  stopped being able to pull at all (`yosemite-s0` sat 4 commits behind, unable to
+  fast-forward past its own local rewrite). The fold now runs only from a
+  lifecycle entry point (daemon boot, `runMigration`), never from a read or write.
+  Source: `apps/cli/src/lib/device-config.ts`.
+- **The device-config migration is additive instead of destructive.** It used to
+  `fs.rmSync` the per-device `devices/<host>/agents.yaml` and `fs.rmdirSync` its
+  directory after folding. Deleting the source mid-rollout meant a box still on the
+  previous CLI lost the config it was still reading, and a box that re-created the
+  doc got stripped again on its next command. The fold now leaves every legacy
+  store in place; the redundant copy is pruned later by one explicit operator
+  command rather than by each machine independently.
+  Source: `apps/cli/src/lib/devices/config-migration.ts`.
+- **`agents devices capture` no longer erases a peer's config.** `captureFleet`
+  rebuilt `fleet.devices` from the captured roster alone, so a device the capturing
+  box had not seen was dropped along with its `config:` block — observed for real,
+  a capture on `yosemite-s0` deleted `zion`'s entire config from the shared file. A
+  dropped device now carries its `config:` forward; the roster fields still reflect
+  live state.
+  Source: `apps/cli/src/lib/fleet/capture.ts`.
+- **Clearing the last model-tier override no longer leaves `model: {tiers: {}}`.**
+  The emptied container was written back to the shared `agents.yaml`, showing up as
+  a spurious local change on whichever box ran the command. It now drops the key,
+  matching how an emptied `hosts:` is already handled.
+  Source: `apps/cli/src/lib/model-tier-overrides.ts`.

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -265,6 +265,13 @@ let migrationDone = false;
  * and the next process retries the fold. Honors AGENTS_SKIP_MIGRATION=1, the
  * same gate bootstrap's runMigration uses (tests pin it so a fork never folds
  * the developer's real ~/.agents as a side effect).
+ *
+ * Call this ONLY from a lifecycle entry point (daemon boot, `runMigration`).
+ * It must never hang off a config read or write: `~/.agents/agents.yaml` is a
+ * tracked file shared by every machine in the fleet, so a migration on the read
+ * path means an ordinary `agents config get` can dirty the shared file. That is
+ * what left yosemite-s0 unable to pull — 13 machines each rewriting one tracked
+ * path, on nearly every command.
  */
 export function ensureDeviceConfigMigrated(): void {
   if (migrationDone || process.env.AGENTS_SKIP_MIGRATION === '1') return;
@@ -301,7 +308,6 @@ function targetDevice(opts?: ConfigTarget): string {
 
 /** Get one config key's value and the layer that set it. */
 export function getConfigValue(name: string, opts?: ConfigTarget): ConfigEntry {
-  ensureDeviceConfigMigrated();
   const spec = configKeySpec(name);
   if (spec.scope === 'user') {
     const value = readMeta().config?.[spec.yamlKey];
@@ -361,7 +367,6 @@ function unsetInCentralBlock(device: string, spec: ConfigKeySpec): void {
 
 /** Set a config key (validated). Device-scope keys target this machine unless `opts.device` names a peer. */
 export function setConfigValue(name: string, value: unknown, opts?: ConfigTarget): void {
-  ensureDeviceConfigMigrated();
   const spec = configKeySpec(name);
   assertValidValue(spec, value);
   if (spec.scope === 'user') {
@@ -373,7 +378,6 @@ export function setConfigValue(name: string, value: unknown, opts?: ConfigTarget
 
 /** Unset a config key — restores default behavior. No-op when already unset. */
 export function unsetConfigValue(name: string, opts?: ConfigTarget): void {
-  ensureDeviceConfigMigrated();
   const spec = configKeySpec(name);
   if (spec.scope === 'user') {
     updateMeta((m) => {

--- a/apps/cli/src/lib/devices/config-migration.test.ts
+++ b/apps/cli/src/lib/devices/config-migration.test.ts
@@ -47,6 +47,55 @@ afterEach(() => {
   try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
 });
 
+describe('the shared agents.yaml stays clean on read', () => {
+  /**
+   * `~/.agents/agents.yaml` is tracked and shared by every machine in the fleet.
+   * The fold used to hang off getConfigValue/setConfigValue/unsetConfigValue, so
+   * an ordinary `agents config get` rewrote that tracked file — 13 machines each
+   * dirtying one path on nearly every command. yosemite-s0 ended up unable to
+   * pull at all. A read must never write.
+   */
+  it('a config read does not create or modify the central file', async () => {
+    // The fold must be ENABLED for this to mean anything: bootstrap.ts defaults
+    // AGENTS_SKIP_MIGRATION=1, and with that set the read path is inert whether
+    // or not it calls the migration — the test would pass against the bug.
+    delete process.env.AGENTS_SKIP_MIGRATION;
+    fs.mkdirSync(path.dirname(deviceDocPath('mac-mini')), { recursive: true });
+    fs.writeFileSync(deviceDocPath('mac-mini'), 'config:\n  maxAgents: 4\n');
+
+    const { getConfigValue } = await freshModules();
+
+    // No central file yet: reading must not bring one into existence.
+    expect(fs.existsSync(centralPath())).toBe(false);
+    for (let i = 0; i < 50; i++) {
+      getConfigValue('agents.max-concurrent', { device: 'mac-mini' });
+      getConfigValue('browser.profile');
+      getConfigValue('scheduler.enabled');
+    }
+    expect(fs.existsSync(centralPath())).toBe(false);
+  });
+
+  it('repeated reads leave an existing central file byte-identical', async () => {
+    delete process.env.AGENTS_SKIP_MIGRATION;
+    fs.mkdirSync(path.dirname(deviceDocPath('mac-mini')), { recursive: true });
+    fs.writeFileSync(deviceDocPath('mac-mini'), 'config:\n  notes:\n    - legacy\n');
+    fs.mkdirSync(path.dirname(centralPath()), { recursive: true });
+    fs.writeFileSync(
+      centralPath(),
+      'fleet:\n  devices:\n    mac-mini:\n      config:\n        maxAgents: 8\n',
+    );
+    const before = readCentral();
+
+    const { getConfigValue } = await freshModules();
+    for (let i = 0; i < 50; i++) {
+      getConfigValue('agents.max-concurrent', { device: 'mac-mini' });
+      getConfigValue('daemon.enabled');
+    }
+
+    expect(readCentral()).toBe(before);
+  });
+});
+
 describe('migrateDeviceConfigToCentral', () => {
   it('folds device-doc config + defaultBrowserProfile into the central block, keeping pins', async () => {
     fs.mkdirSync(path.dirname(deviceDocPath('mac-mini')), { recursive: true });
@@ -66,20 +115,22 @@ describe('migrateDeviceConfigToCentral', () => {
     expect(getConfigValue('browser.profile', { device: 'mac-mini' }).value).toBe('comet-local');
     expect(getConfigValue('scheduler.enabled').value).toBe(false); // self (testbox)
 
-    // Pins survive in the device doc; config keys are gone from it.
+    // The fold is ADDITIVE: the legacy source is left exactly as it was. A box
+    // still on the previous CLI reads that doc, so deleting it mid-rollout would
+    // silently drop its config. The redundant copy is pruned later by one
+    // explicit operator command, not by every machine independently.
     const macDoc = fs.readFileSync(deviceDocPath('mac-mini'), 'utf-8');
     expect(macDoc).toContain('claude: 2.1.0');
-    expect(macDoc).not.toContain('maxAgents');
-    expect(macDoc).not.toContain('defaultBrowserProfile');
-    expect(macDoc).not.toContain('config:');
-    // A doc that held ONLY config is removed outright.
-    expect(fs.existsSync(deviceDocPath('testbox'))).toBe(false);
+    expect(macDoc).toContain('maxAgents');
+    expect(macDoc).toContain('defaultBrowserProfile');
+    // A doc that held ONLY config also survives.
+    expect(fs.existsSync(deviceDocPath('testbox'))).toBe(true);
 
     // The fold did not invent agent pins centrally either.
     expect(readMeta().agents?.claude).toBeUndefined();
   });
 
-  it('folds auto-launch.json flags and removes the file', async () => {
+  it('folds auto-launch.json flags and leaves the file in place', async () => {
     fs.mkdirSync(path.dirname(autoLaunchPath()), { recursive: true });
     fs.writeFileSync(
       autoLaunchPath(),
@@ -99,7 +150,7 @@ describe('migrateDeviceConfigToCentral', () => {
       zion: { enabled: false },
       'mac-mini': { preferred: true },
     });
-    expect(fs.existsSync(autoLaunchPath())).toBe(false);
+    expect(fs.existsSync(autoLaunchPath())).toBe(true);
   });
 
   it('is idempotent — a second run changes nothing', async () => {
@@ -126,8 +177,9 @@ describe('migrateDeviceConfigToCentral', () => {
     migrateDeviceConfigToCentral();
 
     expect(getConfigValue('agents.max-concurrent', { device: 'mac-mini' }).value).toBe(8);
-    // The legacy doc was still stripped (its value was folded-or-overridden).
-    expect(fs.existsSync(deviceDocPath('mac-mini'))).toBe(false);
+    // The legacy doc survives untouched — the newer central value simply wins.
+    expect(fs.existsSync(deviceDocPath('mac-mini'))).toBe(true);
+    expect(fs.readFileSync(deviceDocPath('mac-mini'), 'utf-8')).toContain('maxAgents: 4');
   });
 
   it('skips a corrupted device doc loudly and leaves it for a later retry', async () => {

--- a/apps/cli/src/lib/devices/config-migration.ts
+++ b/apps/cli/src/lib/devices/config-migration.ts
@@ -25,12 +25,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'yaml';
 import {
-  META_HEADER,
   getDevicesAutoLaunchPath,
   getUserAgentsDir,
   updateMeta,
 } from '../state.js';
-import { atomicWriteFileSync } from '../fs-atomic.js';
 import { loadDevicesSync } from './registry.js';
 import type { FleetDeviceOverride, FleetManifest } from '../fleet/types.js';
 
@@ -168,29 +166,19 @@ export function migrateDeviceConfigToCentral(): void {
     return { ...m, fleet };
   });
 
-  // 2. Strip the legacy stores. A device doc left with nothing but the folded
-  //    keys is removed; one with agent pins / routines keeps exactly those.
-  for (const { path: docPath, doc } of docs) {
-    const rest = { ...doc };
-    delete rest.config;
-    delete rest.defaultBrowserProfile;
-    try {
-      if (Object.keys(rest).length === 0) {
-        fs.rmSync(docPath, { force: true });
-        // Drop the device dir too when the doc was its only occupant.
-        try {
-          fs.rmdirSync(path.dirname(docPath));
-        } catch { /* not empty — other device-local files live here */ }
-      } else {
-        atomicWriteFileSync(docPath, META_HEADER + yaml.stringify(rest));
-      }
-    } catch (err) {
-      console.error(`device config migration: could not rewrite ${docPath} (${(err as Error).message}); a later run retries`);
-    }
-  }
-  try {
-    fs.rmSync(autoLaunchPath, { force: true });
-  } catch (err) {
-    console.error(`device config migration: could not remove ${autoLaunchPath} (${(err as Error).message}); a later run retries`);
-  }
+  // 2. The legacy stores are deliberately LEFT IN PLACE.
+  //
+  //    This migration used to delete them — `fs.rmSync` on the device doc and
+  //    `fs.rmdirSync` on its directory. Deleting is what made the fold unsafe
+  //    to run anywhere: it had to win a race against every other machine's copy
+  //    of the same shared file, and a box on an older CLI that re-created the
+  //    doc would be stripped again on the next command.
+  //
+  //    An additive fold has neither problem. The central block is written; the
+  //    source is untouched; a box still running the previous CLI keeps reading
+  //    what it always read. The now-redundant legacy copy is pruned in a later
+  //    release by one explicit operator command, not by 13 machines each
+  //    deciding to delete on their own schedule.
+  void docs;
+  void autoLaunchPath;
 }

--- a/apps/cli/src/lib/fleet/capture.test.ts
+++ b/apps/cli/src/lib/fleet/capture.test.ts
@@ -66,4 +66,30 @@ describe('captureFleet', () => {
     expect(m.secrets).toBeUndefined();
     expect(m.routines).toBeUndefined();
   });
+
+  it('keeps the config of a device missing from the captured roster', () => {
+    // `fleet.devices.<name>.config` is the operator-config store, so a capture
+    // run from a box whose registry has not seen a peer used to erase that
+    // peer's settings outright. Observed for real: capturing on yosemite-s0
+    // deleted zion's whole config block from the shared agents.yaml.
+    const prev = {
+      devices: {
+        zion: { config: { browserRemoteControl: false, defaultBrowserProfile: 'comet-local' } },
+        'mac-mini': { agents: ['claude@latest'] },
+      },
+    } as Parameters<typeof captureFleet>[0];
+
+    const m = captureFleet(prev, { devices: ['yosemite-s0'] });
+    const map = m.devices as Record<string, { agents?: string[]; config?: Record<string, unknown> }>;
+
+    // The roster still reflects live state — the captured device is present.
+    expect(map['yosemite-s0']).toBeDefined();
+    // zion's config survives even though it dropped out of the roster.
+    expect(map['zion'].config).toEqual({
+      browserRemoteControl: false,
+      defaultBrowserProfile: 'comet-local',
+    });
+    // A dropped device carries config ONLY — never its stale roster fields.
+    expect(map['mac-mini']).toBeUndefined();
+  });
 });

--- a/apps/cli/src/lib/fleet/capture.ts
+++ b/apps/cli/src/lib/fleet/capture.ts
@@ -47,7 +47,20 @@ export function captureFleet(prev: FleetManifest | undefined, inputs: CaptureInp
   // Roster: explicit map of the captured names. A hand-authored override for a
   // device that still exists is preserved; a captured agent list only fills in
   // when the manifest didn't already pin one for that device.
+  //
+  // A device absent from `inputs.devices` drops OUT of the roster — that is the
+  // intended "live state is the source of truth for WHICH devices exist". But
+  // `fleet.devices.<name>.config` is also the operator-config store, and a
+  // capture run from a box whose registry has not seen a peer would silently
+  // erase that peer's settings. Observed for real: capturing on yosemite-s0
+  // deleted zion's whole config block from the shared agents.yaml. So carry a
+  // dropped device's `config:` forward — config only, never its roster fields.
   const devices: Record<string, FleetDeviceOverride> = {};
+  for (const [name, prevOverride] of Object.entries(prevDevices)) {
+    if (inputs.devices.includes(name)) continue; // handled by the roster loop below
+    const config = prevOverride?.config;
+    if (config && Object.keys(config).length > 0) devices[name] = { config };
+  }
   for (const name of inputs.devices) {
     const prevOverride = prevDevices[name] ?? {};
     const override: FleetDeviceOverride = { ...prevOverride };

--- a/apps/cli/src/lib/model-tier-overrides.ts
+++ b/apps/cli/src/lib/model-tier-overrides.ts
@@ -129,8 +129,20 @@ export function clearTierOverride(selectorInput: string, tierInput?: string): bo
       delete tiers[parsed.selector];
       changed = true;
     }
-    model.tiers = tiers;
-    return { ...meta, model };
+    // Drop the emptied container rather than leaving `model: {tiers: {}}` in the
+    // shared agents.yaml — the same discipline lib/hosts/providers/local.ts uses
+    // for an emptied `hosts:`. A vestigial empty map is a real diff on a tracked
+    // file that every machine syncs, so clearing the last override would show up
+    // as a spurious local change on whichever box happened to run the command.
+    if (Object.keys(tiers).length > 0) {
+      model.tiers = tiers;
+      return { ...meta, model };
+    }
+    delete model.tiers;
+    if (Object.keys(model).length > 0) return { ...meta, model };
+    const { model: _dropped, ...rest } = meta;
+    void _dropped;
+    return rest;
   });
 
   return changed;

--- a/apps/cli/src/lib/shim-heal.test.ts
+++ b/apps/cli/src/lib/shim-heal.test.ts
@@ -44,7 +44,14 @@ describe('shouldSurfaceShimNotice (persistent, once per condition)', () => {
     `;
     const out = execFileSync('bun', ['-e', script], {
       cwd: process.cwd(),
-      env: { ...process.env, HOME: home },
+      // AGENTS_STATE_DIR must travel with HOME — it outranks HOME in
+      // getRuntimeStateDir(), and tests/setup.ts pins it fork-wide, so inheriting
+      // the parent's value would put the marker outside this planted HOME.
+      env: {
+        ...process.env,
+        HOME: home,
+        AGENTS_STATE_DIR: path.join(home, '.agents', '.cache', 'state'),
+      },
       stdio: ['ignore', 'pipe', 'inherit'],
     }).toString('utf-8');
     return JSON.parse(out);

--- a/apps/cli/src/lib/star-nudge.test.ts
+++ b/apps/cli/src/lib/star-nudge.test.ts
@@ -13,10 +13,16 @@ import { fileURLToPath } from 'url';
 const savedHome = process.env.HOME;
 const savedCI = process.env.CI;
 const savedOptOut = process.env.AGENTS_NO_NUDGE;
+const savedStateDir = process.env.AGENTS_STATE_DIR;
 const savedTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
 
 const TMP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-nudge-test-'));
 process.env.HOME = TMP_HOME;
+// The nudge sentinel lives under getRuntimeStateDir(), which honors
+// AGENTS_STATE_DIR ahead of HOME — and tests/setup.ts pins that fork-wide. Point
+// it back at this file's own HOME so the sentinel lands where these cases assert,
+// and so the per-case `raceHome` override below still isolates.
+process.env.AGENTS_STATE_DIR = path.join(TMP_HOME, '.agents', '.cache', 'state');
 delete process.env.CI;
 delete process.env.AGENTS_NO_NUDGE;
 
@@ -29,6 +35,8 @@ beforeAll(async () => {
 
 afterAll(() => {
   if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+  if (savedStateDir === undefined) delete process.env.AGENTS_STATE_DIR;
+  else process.env.AGENTS_STATE_DIR = savedStateDir;
   if (savedCI === undefined) delete process.env.CI; else process.env.CI = savedCI;
   if (savedOptOut === undefined) delete process.env.AGENTS_NO_NUDGE; else process.env.AGENTS_NO_NUDGE = savedOptOut;
   if (savedTTY) Object.defineProperty(process.stdout, 'isTTY', savedTTY);
@@ -118,7 +126,16 @@ describe('maybeShowStarNudge is race-safe across concurrent processes', () => {
     const runChild = () =>
       new Promise<string>((resolve, reject) => {
         const child = spawn(tsxBin, [fixture], {
-          env: { ...process.env, HOME: raceHome, CI: '', AGENTS_NO_NUDGE: '' },
+          env: {
+            ...process.env,
+            HOME: raceHome,
+            // Must travel with HOME: AGENTS_STATE_DIR outranks it, so inheriting
+            // the parent's value would point every child at the outer test's
+            // sentinel — which already exists, so no child would ever print.
+            AGENTS_STATE_DIR: path.join(raceHome, '.agents', '.cache', 'state'),
+            CI: '',
+            AGENTS_NO_NUDGE: '',
+          },
         });
         let out = '';
         child.stdout.on('data', (d) => { out += d.toString(); });

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -640,7 +640,7 @@ export function getDevicesIgnoredPath(): string { return path.join(getDevicesDir
 export function getDevicesAutoLaunchPath(): string { return path.join(getDevicesDir(), 'auto-launch.json'); }
 
 /** Dir of "pending device" sentinels (~/.agents/.cache/state/devices-pending/) — one empty-ish file per newly-discovered, not-yet-approved tailnet node. Written by the daemon probe, read by the menu-bar helper (mirrors the attention sentinel dir). */
-export function getDevicesPendingDir(): string { return path.join(RUNTIME_STATE_DIR, 'devices-pending'); }
+export function getDevicesPendingDir(): string { return path.join(getRuntimeStateDir(), 'devices-pending'); }
 
 /** Path to cloud dispatch cache (~/.agents/.cache/cloud/). */
 export function getCloudDir(): string { return CLOUD_DIR; }
@@ -676,8 +676,23 @@ export function getPerfDbPath(): string { return path.join(getPerfDir(), 'perf.d
 /** Path to the hook-shim NDJSON spool drained into perf.db on open. */
 export function getPerfSpoolPath(): string { return path.join(getPerfDir(), 'spool.jsonl'); }
 
-/** Path to per-process runtime state (~/.agents/.cache/state/). */
-export function getRuntimeStateDir(): string { return RUNTIME_STATE_DIR; }
+/**
+ * Path to per-process runtime state (~/.agents/.cache/state/).
+ *
+ * `AGENTS_STATE_DIR` redirects it in tests — the same test-isolation escape
+ * hatch as `AGENTS_DEVICES_DIR` / `AGENTS_LOGS_DIR`, and resolved at call time
+ * for the same reason (a suite pins it after this module is imported).
+ *
+ * Without it the suite writes into the operator's LIVE state. Concretely: the
+ * device registry and ignore-list already redirect via `AGENTS_DEVICES_DIR`, so
+ * under test both read empty — and any code path reaching
+ * `reconcilePendingSentinels` then computed "every tailnet node is new" and
+ * wrote those sentinels into the real `devices-pending/`, which is exactly what
+ * the menu bar renders. Running the suite on a dev machine surfaced all 20
+ * tailnet nodes as NEW DEVICES, including registered and explicitly ignored
+ * ones, and looked like the operator's ignore list had been lost.
+ */
+export function getRuntimeStateDir(): string { return process.env.AGENTS_STATE_DIR ?? RUNTIME_STATE_DIR; }
 
 /** Path to companion-extension scratch (~/.agents/.cache/companion/). */
 export function getCompanionDir(): string { return COMPANION_CACHE_DIR; }

--- a/apps/cli/tests/setup.ts
+++ b/apps/cli/tests/setup.ts
@@ -84,6 +84,13 @@ process.env.AGENTS_HOOK_SHIMS_DIR = path.join(tmp, 'hook-shims');
 process.env.AGENTS_HOOK_CACHE_DIR = path.join(tmp, 'hook-cache');
 process.env.AGENTS_LOGS_DIR = path.join(tmp, 'logs');
 process.env.AGENTS_PERF_DIR = path.join(tmp, 'perf');
+// Runtime state (~/.agents/.cache/state/) holds the devices-pending sentinels the
+// menu bar renders as "NEW DEVICES". AGENTS_DEVICES_DIR already points the device
+// registry and ignore list at tmp, so under test both read EMPTY — and any path
+// reaching reconcilePendingSentinels then concluded every tailnet node was new and
+// wrote those sentinels into the operator's LIVE dir. Running the suite on a dev
+// machine surfaced all 20 nodes as NEW DEVICES, registered and ignored alike.
+process.env.AGENTS_STATE_DIR = path.join(tmp, 'state');
 
 // Leak tripwire: the REAL events log must not grow while this fork runs.
 // CI-only — on a dev machine live agents append to it concurrently, so the
@@ -99,6 +106,18 @@ const sizeBefore = fs.existsSync(realEventsLog) ? fs.statSync(realEventsLog).siz
 const realDevicesRegistry = path.join(process.env.HOME ?? os.homedir(), '.agents', '.history', 'devices', 'registry.json');
 const devicesRegistryBefore: string | null = fs.existsSync(realDevicesRegistry)
   ? fs.readFileSync(realDevicesRegistry, 'utf-8')
+  : null;
+
+// Leak tripwire: the REAL devices-pending sentinels — the menu bar's "NEW
+// DEVICES" list — must not change while this fork runs. Same CI-only rule as
+// above: a live daemon probe legitimately reconciles this dir every ~3 min on a
+// dev machine. The AGENTS_STATE_DIR pin is the actual fix; this catches a code
+// path that resolves the sentinel dir some other way.
+const realDevicesPending = path.join(
+  process.env.HOME ?? os.homedir(), '.agents', '.cache', 'state', 'devices-pending',
+);
+const devicesPendingBefore: string | null = fs.existsSync(realDevicesPending)
+  ? fs.readdirSync(realDevicesPending).sort().join(',')
   : null;
 
 afterAll(() => {
@@ -121,6 +140,19 @@ afterAll(() => {
           `changed during this test file — a test wrote to it instead of the fork-private ` +
           `AGENTS_DEVICES_DIR. Set AGENTS_DEVICES_DIR (or use the setup default) before ` +
           `importing any state consumer.`,
+        );
+      }
+
+      const pendingAfter = fs.existsSync(realDevicesPending)
+        ? fs.readdirSync(realDevicesPending).sort().join(',')
+        : null;
+      if (pendingAfter !== devicesPendingBefore) {
+        throw new Error(
+          `hermeticity leak: the real devices-pending sentinels (${realDevicesPending}) ` +
+          `changed during this test file — a test wrote the menu bar's "NEW DEVICES" state ` +
+          `instead of the fork-private AGENTS_STATE_DIR. Because AGENTS_DEVICES_DIR makes the ` +
+          `registry and ignore list read EMPTY under test, the leaking path marks every ` +
+          `tailnet node as new and the operator's ignore list appears to have been lost.`,
         );
       }
     }


### PR DESCRIPTION
**Fix: an ordinary `agents config get` no longer rewrites the fleet-shared `agents.yaml`.** Five related fixes to stop machines dirtying state they shouldn't own.

## Why

`~/.agents/agents.yaml` is tracked and synced across 13 machines. The device-config fold added by `ed523e69` (marked wip) hung off `getConfigValue` / `setConfigValue` / `unsetConfigValue`, so **a config read could write the shared file**. With every box doing that on nearly every command, machines stopped being able to pull: `yosemite-s0` sat 4 commits behind, unable to fast-forward past its own local rewrite, and `zion` needed hand recovery.

This is the second time this class of bug has bitten. `d95c46e chore: stop tracking devices/` cured it for agent pins after 21 `chore(devices): snapshot <host>` commits deadlocked `agents sync`. Same disease, different file.

## What changed

| Change | File |
| --- | --- |
| **A config read never writes.** The fold runs only from a lifecycle entry point (daemon boot, `runMigration`) — removed from the three read/write call sites. | `lib/device-config.ts` |
| **The migration is additive, not destructive.** It used to `fs.rmSync` the per-device doc and `fs.rmdirSync` its directory after folding, so a box still on the previous CLI lost config it was actively reading. The legacy store now stays; the redundant copy is pruned later by one explicit operator command. | `lib/devices/config-migration.ts` |
| **`agents devices capture` no longer erases a peer's config.** `captureFleet` rebuilt `fleet.devices` from the captured roster alone, dropping unseen devices *and their `config:` block* — a capture on `yosemite-s0` deleted `zion`'s config outright. A dropped device now carries `config:` forward; roster fields still reflect live state. | `lib/fleet/capture.ts` |
| **Clearing the last model-tier override no longer leaves `model: {tiers: {}}`** in the shared file, matching how an emptied `hosts:` is already handled. | `lib/model-tier-overrides.ts` |
| **The test suite no longer writes the operator's live menubar state.** `getRuntimeStateDir()` now honors `AGENTS_STATE_DIR` (call-time, like `AGENTS_DEVICES_DIR`), and the suite pins it. | `lib/state.ts`, `tests/setup.ts` |

### The test-hermeticity leak is worth its own paragraph

`AGENTS_DEVICES_DIR` already redirects the device registry and ignore list, so **under test both read empty**. Any path reaching `reconcilePendingSentinels` therefore concluded *every* tailnet node was new — and wrote those sentinels into the real `~/.agents/.cache/state/devices-pending/`, which is exactly what the menu bar renders as "NEW DEVICES".

Running the suite on a dev machine surfaced all 20 tailnet nodes as new, registered and explicitly ignored ones alike, and read as though the operator's ignore list had been lost. It had not — `ignored.json` was intact the whole time.

`tests/setup.ts` already had tripwires for this exact class (the real events log, and the real device registry from RUSH-2042) but none for the sentinel dir. Added, following the same CI-only rule since a live daemon probe legitimately reconciles that dir every ~3 min on a dev box.

## Verification

The new regression test is not vacuous — it **fails on the bug and passes on the fix**. It must explicitly clear `AGENTS_SKIP_MIGRATION`, which `bootstrap.ts:67` defaults to `1`; without that it passes either way (caught and fixed while writing it).

```
## 1. With the old read-path migration restored (the bug)
     × a config read does not create or modify the central file
     × repeated reads leave an existing central file byte-identical
AssertionError: expected true to be false
      Tests  2 failed | 6 skipped (8)

## 2. With the fix (this branch)
 Test Files  4 passed (4)
      Tests  41 passed (41)

## 3. Typecheck
tsc --noEmit: exit 0
```

Full run log: https://share.agents-cli.sh/muqsitnawaz/agents-config-churn-proof-43d4c447cdb1469a

The hermeticity pin is verified against the live directory, not just asserted:

```
$ ls ~/.agents/.cache/state/devices-pending    # before
ci-runner-fsn1  mark-1
$ vitest run src/lib/devices/ tests/daemon.test.ts
 Test Files  27 passed (27)
      Tests  380 passed (380)
$ ls ~/.agents/.cache/state/devices-pending    # after
ci-runner-fsn1  mark-1                          # unchanged
```

Tests touched: `config-migration.test.ts` (new no-churn cases; the three asserting the old delete-the-source behavior now assert the additive contract), `capture.test.ts` (new peer-config carry-forward case).

### Full-suite status (honest)

A clean full run on this branch is 37 failures / 11,499 passed. **Three of those were mine** — `star-nudge` and `shim-heal` plant their own `HOME` and expect the state dir to follow it, and a fork-wide `AGENTS_STATE_DIR` pin outranks `HOME`. Those tests now carry the var alongside their planted `HOME` (including into the subprocesses they spawn) and pass 12/12.

The remaining failures are in `crabbox` pool-box, `notify.owner`, sessions-DB and `openclaw` areas this PR does not touch. I am running a clean `origin/main` baseline to confirm my failure set is a subset, and will post the comparison here. Two earlier comparisons were discarded as unusable — I had run both suites concurrently on one machine, which produced large disjoint failure sets in both directions.

## Not in this PR

The largest remaining automated writer of the shared file is the **browser profile map**: `ensureDefaultBrowserProfile` regenerates the auto `default` with a machine-specific `binary:` and port on every `agents browser start` (live proof — `agents.yaml` currently carries `/usr/bin/chromium-browser` on a fleet with three macOS boxes). That, plus `projectRoot` and the full `user | shared | machine` config tier, follow in a second PR.
