### PR TITLE
feat(config): move machine-local config out of the fleet-shared agents.yaml

### DIFF
--- a/apps/cli/.changelog/next/machine-local-config-tier.md
+++ b/apps/cli/.changelog/next/machine-local-config-tier.md
@@ -1,0 +1,26 @@
+- **Per-machine config no longer lives in the fleet-shared `agents.yaml`.** Every
+  device-scope config key now declares `visibility`, which asks who READS it.
+  `shared` keys stay in the synced `fleet.devices.<name>.config` because a peer
+  resolves them — the ssh fields and `platform` are needed to dial a box before it
+  is reachable, `agents.max-concurrent` drives teams placement, `auto-launch.*`
+  and `notes` feed fleet views. `machine` keys — `browser.profile`,
+  `browser.remote-control`, `scheduler.enabled`, `daemon.enabled` — move to that
+  box's own `~/.agents/devices/<machine>/agents.yaml`, which is gitignored. That
+  is what stops 13 machines writing one tracked path.
+  Source: `apps/cli/src/lib/device-config.ts`, `apps/cli/src/lib/state.ts`.
+- **`browser.remote-control` was a consent leak.** It gates whether OTHER machines
+  may drive this box's browser, and its own help text promised "device-local,
+  never synced" — but it was stored in the file the fleet syncs, so one box's
+  opt-in propagated to the rest on pull. It is now machine-local, and setting or
+  reading a machine-local key for a peer is refused outright with the
+  `agents ssh <device>` form to use instead.
+  Source: `apps/cli/src/lib/device-config.ts`.
+- **A new config key cannot silently pick the wrong home.** `ConfigKeySpec` is a
+  discriminated union, so omitting `visibility` on a device-scope key is a COMPILE
+  error — the same discipline `META_KEY_SCOPE` already applies to `Meta`. The
+  migration no longer folds machine-local keys at all: they already sit where the
+  new read path looks, and copying a peer's would spread that consent flag
+  fleet-wide. Values an older CLI wrote centrally are still honored until
+  overwritten, so a mixed-version fleet keeps working.
+  Source: `apps/cli/src/lib/config-machine-keys.ts`,
+  `apps/cli/src/lib/devices/config-migration.ts`.

--- a/apps/cli/src/commands/daemon.test.ts
+++ b/apps/cli/src/commands/daemon.test.ts
@@ -134,11 +134,18 @@ describeDaemon('agents daemon', () => {
     expect(payload.state).toBe('disabled');
     expect(payload.daemonEnabled).toBe(false);
 
-    // Persisted to disk, not just in-process — a fresh CLI invocation (the
-    // status call above) reads it back from the central fleet.devices block.
+    // Persisted to disk, not just in-process — the status call above is a fresh
+    // CLI invocation that read it back. It lands in THIS machine's own doc, not
+    // the fleet-shared agents.yaml: the kill switch is machine-local, so syncing
+    // it would disable the daemon on every box that pulls.
+    // The doc is keyed by this machine's id, which the test does not pin — read
+    // whichever device dir the CLI created rather than hardcoding a name.
+    const devicesDir = path.join(home, '.agents', 'devices');
+    const [machineDir] = fs.readdirSync(devicesDir);
+    const localDoc = fs.readFileSync(path.join(devicesDir, machineDir, 'agents.yaml'), 'utf-8');
+    expect(localDoc).toContain('daemonEnabled: false');
     const central = fs.readFileSync(path.join(home, '.agents', 'agents.yaml'), 'utf-8');
-    expect(central).toContain('daemonEnabled: false');
-    expect(central).toContain('fleet:');
+    expect(central).not.toContain('daemonEnabled');
   });
 
   it('enable clears the kill switch again', () => {

--- a/apps/cli/src/commands/ssh.device-config.test.ts
+++ b/apps/cli/src/commands/ssh.device-config.test.ts
@@ -65,13 +65,18 @@ describe('devices config', () => {
     const set = run(['devices', 'config', 'mac-mini', 'agents.max-concurrent', '4']);
     expect(set.status, set.stderr).toBe(0);
     expect(set.stdout).toContain('agents.max-concurrent = 4');
-    expect(run(['devices', 'config', 'mac-mini', 'scheduler.enabled', 'off']).status).toBe(0);
+    // scheduler.enabled is machine-local: only mac-mini reads it, so it cannot
+    // be set from here at all. The refusal names the ssh form to use instead.
+    const peerMachineKey = run(['devices', 'config', 'mac-mini', 'scheduler.enabled', 'off']);
+    expect(peerMachineKey.status).toBe(1);
+    expect(peerMachineKey.stderr).toContain('machine-local');
 
     const central = centralDoc();
     expect(central).toContain('fleet:');
     expect(central).toContain('mac-mini:');
     expect(central).toContain('maxAgents: 4');
-    expect(central).toContain('schedulerEnabled: false');
+    // ...and it never reached the fleet-shared file.
+    expect(central).not.toContain('schedulerEnabled');
 
     const got = run(['devices', 'config', 'mac-mini', 'agents.max-concurrent', '--json']);
     expect(got.status).toBe(0);
@@ -119,7 +124,7 @@ describe('devices config', () => {
 
     expect(run(['devices', 'config', 'mac-mini', 'agents.max-concurrent', 'four']).status).toBe(1);
     expect(run(['devices', 'config', 'mac-mini', 'agents.max-concurrent', '0']).status).toBe(1);
-    const badBool = run(['devices', 'config', 'mac-mini', 'scheduler.enabled', 'maybe']);
+    const badBool = run(['devices', 'config', 'mac-mini', 'auto-launch.enabled', 'maybe']);
     expect(badBool.status).toBe(1);
     expect(badBool.stderr).toContain('on/off');
     const unknown = run(['devices', 'config', 'mac-mini', 'nope.nope', '1']);
@@ -150,25 +155,28 @@ describe('retired-subcommand tombstones', () => {
     guardedHome();
     addDevice('mac-mini', 'muqsit@192.0.2.2');
 
-    const set = run(['devices', 'configure', 'mac-mini', '--max-agents', '4', '--scheduler', 'off']);
+    const set = run(['devices', 'configure', 'mac-mini', '--max-agents', '4']);
     expect(set.status, set.stderr).toBe(0);
     expect(set.stderr).toContain('Deprecated');
     expect(set.stderr).toContain('devices config');
     expect(set.stdout).not.toContain('Deprecated');
     expect(set.stdout).toContain('agents.max-concurrent = 4');
 
+    // `--scheduler` against a PEER is refused now that scheduler.enabled is
+    // machine-local — the tombstone forwards to config, which rejects it.
+    const peerScheduler = run(['devices', 'configure', 'mac-mini', '--scheduler', 'off']);
+    expect(peerScheduler.status).toBe(1);
+    expect(peerScheduler.stderr).toContain('machine-local');
+
     const central = centralDoc();
     expect(central).toContain('maxAgents: 4');
-    expect(central).toContain('schedulerEnabled: false');
+    expect(central).not.toContain('schedulerEnabled');
 
     const got = run(['devices', 'configure', 'mac-mini', '--json']);
     expect(got.status).toBe(0);
     const parsed = JSON.parse(got.stdout);
     expect(parsed.device).toBe('mac-mini');
-    expect(parsed.config).toMatchObject({
-      'agents.max-concurrent': 4,
-      'scheduler.enabled': false,
-    });
+    expect(parsed.config).toMatchObject({ 'agents.max-concurrent': 4 });
 
     const show = run(['devices', 'configure', 'mac-mini']);
     expect(show.status).toBe(0);

--- a/apps/cli/src/lib/config-machine-keys.ts
+++ b/apps/cli/src/lib/config-machine-keys.ts
@@ -1,0 +1,17 @@
+/**
+ * The YAML keys of every machine-visibility config key — the ones that live in
+ * the owning box's own `devices/<machine>/agents.yaml` and must never reach the
+ * fleet-shared `agents.yaml`.
+ *
+ * This is a ZERO-DEPENDENCY leaf on purpose. The authority is `CONFIG_KEYS` in
+ * `lib/device-config.ts`, but that module imports `devices/config-migration.ts`,
+ * so the migration cannot import it back without a cycle. Same shape as the
+ * `agent-cli-commands` leaf: duplicated here, pinned equal to the registry by a
+ * test (`device-config.test.ts`), so the two cannot drift silently.
+ */
+export const MACHINE_LOCAL_YAML_KEYS: ReadonlySet<string> = new Set([
+  'defaultBrowserProfile', // browser.profile
+  'browserRemoteControl',  // browser.remote-control — a consent flag; syncing it is a leak
+  'schedulerEnabled',      // scheduler.enabled
+  'daemonEnabled',         // daemon.enabled
+]);

--- a/apps/cli/src/lib/device-config.test.ts
+++ b/apps/cli/src/lib/device-config.test.ts
@@ -83,8 +83,10 @@ describe('device-scope keys (central fleet.devices.<name>.config block)', () => 
     expect(central).toContain('fleet:');
     expect(central).toContain('testbox:');
     expect(central).toContain('maxAgents: 4');
-    expect(central).toContain('schedulerEnabled: false');
     expect(central).toContain('- runs the releases');
+    // scheduler.enabled is machine-visibility: only this box reads it, so it
+    // stays in this box's own doc and never enters the synced file.
+    expect(central).not.toContain('schedulerEnabled');
     // Device scope never lands in the user-scope config: block.
     expect(central).not.toContain('interactiveHost');
 
@@ -109,7 +111,8 @@ describe('device-scope keys (central fleet.devices.<name>.config block)', () => 
     expect(central).toContain('mac-mini:');
     expect(central).toContain('maxAgents: 2');
     expect(central).toContain('- do not reboot');
-    // No per-device doc is created anywhere.
+    // Both are shared-visibility, so a peer's values live centrally and no
+    // per-device doc is needed for them.
     expect(fs.existsSync(path.join(TMP, '.agents', 'devices'))).toBe(false);
 
     expect(getConfigValue('agents.max-concurrent', { device: 'mac-mini' }).value).toBe(2);
@@ -118,7 +121,7 @@ describe('device-scope keys (central fleet.devices.<name>.config block)', () => 
     unsetConfigValue('agents.max-concurrent', { device: 'mac-mini' });
     expect(getConfigValue('agents.max-concurrent', { device: 'mac-mini' }).value).toBeUndefined();
     // Unsetting a key that was never set is a no-op — no block created.
-    unsetConfigValue('scheduler.enabled', { device: 'ghost' });
+    unsetConfigValue('agents.max-concurrent', { device: 'ghost' });
     expect(readCentral()).not.toContain('ghost');
   });
 
@@ -126,12 +129,14 @@ describe('device-scope keys (central fleet.devices.<name>.config block)', () => 
     writeCentral('fleet:\n  devices:\n    mac-mini:\n      agents:\n        - claude@latest\n');
     const { setConfigValue, getConfigValue } = await freshModules();
 
-    setConfigValue('scheduler.enabled', false, { device: 'mac-mini' });
+    // A shared-visibility key, because a peer's machine-local key is refused by
+    // design — the point here is that the write preserves sibling fields.
+    setConfigValue('agents.max-concurrent', 3, { device: 'mac-mini' });
 
     const central = readCentral();
     expect(central).toContain('- claude@latest');
-    expect(central).toContain('schedulerEnabled: false');
-    expect(getConfigValue('scheduler.enabled', { device: 'mac-mini' }).value).toBe(false);
+    expect(central).toContain('maxAgents: 3');
+    expect(getConfigValue('agents.max-concurrent', { device: 'mac-mini' }).value).toBe(3);
   });
 
   it('upgrades fleet.devices: all to an explicit roster map on a config write', async () => {
@@ -172,23 +177,26 @@ describe('device-scope keys (central fleet.devices.<name>.config block)', () => 
   it('drops the fleet block entirely when an unset empties a block it created', async () => {
     const { setConfigValue, unsetConfigValue } = await freshModules();
 
-    setConfigValue('scheduler.enabled', false, { device: 'mac-mini' });
+    setConfigValue('agents.max-concurrent', 2, { device: 'mac-mini' });
     expect(readCentral()).toContain('fleet:');
 
-    unsetConfigValue('scheduler.enabled', { device: 'mac-mini' });
+    unsetConfigValue('agents.max-concurrent', { device: 'mac-mini' });
     expect(readCentral()).not.toContain('fleet:');
   });
 });
 
-describe('browser.profile is a device-scope key in the central block', () => {
-  it('set/get/unset land under fleet.devices.<self>.config.defaultBrowserProfile', async () => {
+describe('browser.profile is machine-local', () => {
+  it('set/get/unset land in this machine\'s own doc, never the synced file', async () => {
     const { setConfigValue, getConfigValue, unsetConfigValue } = await freshModules();
 
     setConfigValue('browser.profile', 'comet-local');
 
-    const central = readCentral();
-    expect(central).toContain('defaultBrowserProfile: comet-local');
-    expect(central).toContain('testbox:');
+    // Nothing off-box resolves another machine's default browser profile, so it
+    // belongs in the gitignored per-machine doc — keeping it out of the file all
+    // 13 machines share.
+    const localPath = path.join(TMP, '.agents', 'devices', 'testbox', 'agents.yaml');
+    expect(fs.readFileSync(localPath, 'utf-8')).toContain('defaultBrowserProfile: comet-local');
+    expect(readCentral()).not.toContain('defaultBrowserProfile');
 
     const got = getConfigValue('browser.profile');
     expect(got.value).toBe('comet-local');
@@ -196,7 +204,6 @@ describe('browser.profile is a device-scope key in the central block', () => {
 
     unsetConfigValue('browser.profile');
     expect(getConfigValue('browser.profile').value).toBeUndefined();
-    expect(readCentral()).not.toContain('defaultBrowserProfile');
   });
 });
 
@@ -316,9 +323,12 @@ describe('scheduler gate (scheduler.enabled=false on this device)', () => {
     );
   });
 
-  it('a peer device’s scheduler.enabled does not gate this machine', async () => {
+  it('cannot be set for a peer at all — it is machine-local', async () => {
     const { isSchedulerEnabled, setConfigValue } = await freshModules();
-    setConfigValue('scheduler.enabled', false, { device: 'mac-mini' });
+    // Previously this was settable for a peer and simply ignored locally. Now it
+    // is refused outright, so a peer's value can never gate this machine.
+    expect(() => setConfigValue('scheduler.enabled', false, { device: 'mac-mini' }))
+      .toThrow(/machine-local/);
     expect(isSchedulerEnabled()).toBe(true);
   });
 });
@@ -367,5 +377,105 @@ describe('auto-launch accessors', () => {
     setAutoLaunchPreferred('mac-mini', false);
     expect(loadAutoLaunchPreferences()).toEqual({});
     expect(readCentral()).not.toContain('autoLaunch');
+  });
+});
+
+describe('every device-scope key declares who reads it', () => {
+  /**
+   * The discriminated union already makes a missing `visibility` a COMPILE
+   * error. This is the runtime backstop plus the record of intent: a key's tier
+   * decides whether it lands in the fleet-shared agents.yaml or the owning box's
+   * own doc, and getting it wrong is how operator config drifted into the shared
+   * file twice (once for agent pins, once for device config).
+   */
+  it('assigns a valid visibility to every device key, and none to user keys', async () => {
+    const { CONFIG_KEYS } = await freshModules();
+    for (const spec of CONFIG_KEYS) {
+      if (spec.scope === 'device') {
+        expect(['shared', 'machine'], `${spec.name} must declare a visibility`).toContain(spec.visibility);
+      } else {
+        expect(spec.visibility, `${spec.name} is user-scope and must not declare one`).toBeUndefined();
+      }
+    }
+  });
+
+  it('keeps the self-read keys machine-local — browser.remote-control is a consent flag', async () => {
+    const { CONFIG_KEYS } = await freshModules();
+    const vis = (name: string) => CONFIG_KEYS.find((s: { name: string }) => s.name === name)?.visibility;
+
+    // Nothing off-box reads these; storing them centrally syncs one machine's
+    // choice to the rest. For browser.remote-control that is a security bug —
+    // the flag gates whether OTHER machines may drive this box's browser.
+    for (const name of ['browser.remote-control', 'browser.profile', 'scheduler.enabled', 'daemon.enabled']) {
+      expect(vis(name), `${name} must be machine-local`).toBe('machine');
+    }
+
+    // A peer resolves these BEFORE it can dial the box, so they cannot be
+    // machine-local — there is no way to ask the box for them first.
+    for (const name of ['ssh.user', 'ssh.auth', 'platform', 'agents.max-concurrent']) {
+      expect(vis(name), `${name} is read by peers and must be shared`).toBe('shared');
+    }
+  });
+});
+
+describe('machine-visibility keys never reach the fleet-shared file', () => {
+  it('writes browser.remote-control to the local doc, not agents.yaml', async () => {
+    const { setConfigValue, getConfigValue } = await freshModules();
+
+    setConfigValue('browser.remote-control', true);
+
+    // The consent flag gates whether OTHER machines may drive this box's
+    // browser. It lands in this machine's gitignored doc; if it reached the
+    // synced agents.yaml, one box's opt-in would propagate to the fleet on pull.
+    expect(readCentral()).not.toContain('browserRemoteControl');
+    const localDoc = fs.readFileSync(
+      path.join(TMP, '.agents', 'devices', 'testbox', 'agents.yaml'), 'utf-8',
+    );
+    expect(localDoc).toContain('browserRemoteControl: true');
+    expect(getConfigValue('browser.remote-control').value).toBe(true);
+  });
+
+  it('still writes a shared key centrally so peers can read it', async () => {
+    const { setConfigValue } = await freshModules();
+    setConfigValue('ssh.user', 'muqsit', { device: 'mac-mini' });
+    // A peer resolves ssh.user BEFORE it can dial mac-mini, so this one must
+    // stay in the synced file.
+    expect(readCentral()).toContain('sshUser: muqsit');
+  });
+
+  it('refuses to read or set a machine-local key for a peer, and names the fix', async () => {
+    const { getConfigValue, setConfigValue } = await freshModules();
+    expect(() => getConfigValue('browser.remote-control', { device: 'mac-mini' }))
+      .toThrow(/machine-local/);
+    expect(() => setConfigValue('browser.remote-control', true, { device: 'mac-mini' }))
+      .toThrow(/agents ssh mac-mini/);
+  });
+
+  it('honors a value an older CLI left centrally until it is overwritten', async () => {
+    // The migration is additive, so a pre-upgrade central value must keep working
+    // rather than silently reverting to the default on the first read.
+    fs.mkdirSync(path.join(TMP, '.agents'), { recursive: true });
+    fs.writeFileSync(
+      path.join(TMP, '.agents', 'agents.yaml'),
+      'fleet:\n  devices:\n    testbox:\n      config:\n        browserRemoteControl: true\n',
+    );
+    const { getConfigValue } = await freshModules();
+    expect(getConfigValue('browser.remote-control').value).toBe(true);
+  });
+});
+
+describe('the machine-local key leaf stays pinned to the registry', () => {
+  it('MACHINE_LOCAL_YAML_KEYS equals the machine-visibility keys in CONFIG_KEYS', async () => {
+    // devices/config-migration.ts cannot import CONFIG_KEYS (device-config imports
+    // it, so that would cycle), so the set is duplicated in a zero-dep leaf. This
+    // is the pin that stops the two drifting — a new machine-visibility key that
+    // is not added to the leaf would still be folded into the shared file.
+    const { CONFIG_KEYS } = await freshModules();
+    const { MACHINE_LOCAL_YAML_KEYS } = await import('./config-machine-keys.js');
+    const fromRegistry = CONFIG_KEYS
+      .filter((s: { scope: string; visibility?: string }) => s.scope === 'device' && s.visibility === 'machine')
+      .map((s: { yamlKey: string }) => s.yamlKey)
+      .sort();
+    expect([...MACHINE_LOCAL_YAML_KEYS].sort()).toEqual(fromRegistry);
   });
 });

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -2,14 +2,23 @@
  * Device/user config keys — typed read/write over the central agents.yaml store.
  *
  * One registry (`CONFIG_KEYS`) maps each CLI dotted name to where it lives:
- *   - user scope   → central `~/.agents/agents.yaml` under `config:` (syncs
- *                    fleet-wide via `agents repo push/pull`)
- *   - device scope → central `~/.agents/agents.yaml` under
- *                    `fleet.devices.<name>.config` — the ONE store for
- *                    per-device operator settings. Central means a setting is
- *                    readable/writable from any box, syncs with the repo, and
- *                    is backed up with it. Names and non-secret values only
- *                    (a secrets-bundle NAME is fine; a credential never is).
+ *   - user scope     → central `~/.agents/agents.yaml` under `config:` (syncs
+ *                      fleet-wide via `agents repo push/pull`)
+ *   - device scope   → split by `visibility`, which asks WHO READS IT:
+ *       · `shared`   → central `fleet.devices.<name>.config`, because a PEER
+ *                      reads it (the ssh keys and platform to dial the box,
+ *                      agents.max-concurrent for placement, auto-launch and
+ *                      notes for fleet views). Names and non-secret values only
+ *                      (a secrets-bundle NAME is fine; a credential never is).
+ *       · `machine`  → the owning box's own doc, never the shared file, because
+ *                      nothing off-box reads it (browser.profile,
+ *                      browser.remote-control, scheduler.enabled,
+ *                      daemon.enabled).
+ *
+ * That split exists because "central for everything" put 13 machines on one
+ * tracked path and they stopped being able to pull. `browser.remote-control` is
+ * also a consent flag — syncing one box's opt-in to the rest was a security bug,
+ * not just churn.
  *
  * The device registry (`~/.agents/.history/devices/registry.json`) stays the
  * DISCOVERY cache (address, tailscale snapshot, reachability); the profile
@@ -32,16 +41,34 @@ import { fleetDevicesMapForWrite, migrateDeviceConfigToCentral } from './devices
 /** Which tier of the agents.yaml store a key lives in. */
 export type ConfigScope = 'user' | 'device';
 
+/**
+ * For a device-scope key: WHO READS IT, which is what decides where it is stored.
+ *
+ * - `shared`  — a PEER reads it, so it must be visible fleet-wide and lives in the
+ *   tracked `fleet.devices.<name>.config`. `ssh.*` and `platform` are the
+ *   load-bearing cases: machine A resolves them to build the ssh target for B
+ *   (`lib/devices/resolve-profile.ts`), so it cannot ask B for them.
+ * - `machine` — only the owning box ever reads it, so it belongs in that box's
+ *   own gitignored doc and must never reach the fleet-shared file. Storing these
+ *   centrally is what makes 13 machines write one tracked path.
+ *
+ * Declaring this is MANDATORY for a device-scope key — the union below makes
+ * omitting it a compile error, mirroring how `META_KEY_SCOPE` (lib/state.ts) uses
+ * an exhaustive `Record<keyof Meta, ...>`. Before this, a new key picked its home
+ * by hand with no signal, which is how operator config drifted into the shared
+ * file twice.
+ */
+export type ConfigVisibility = 'shared' | 'machine';
+
 /** Value type of a config key — drives validation and `--json` rendering. */
 export type ConfigType = 'string' | 'int' | 'bool' | 'string-list';
 
-/** One known config key. */
-export interface ConfigKeySpec {
+/** Fields every key carries, regardless of scope. */
+interface ConfigKeySpecBase {
   /** CLI dotted name, e.g. `interactive.host`. */
   name: string;
   /** camelCase key under the YAML config block. */
   yamlKey: string;
-  scope: ConfigScope;
   type: ConfigType;
   /** One-line description for help/list output. */
   description: string;
@@ -50,6 +77,14 @@ export interface ConfigKeySpec {
   /** Extra validation beyond the type check; return an error string or null. */
   validate?: (value: unknown) => string | null;
 }
+
+/**
+ * One known config key. A device-scope key MUST declare its `visibility`; a
+ * user-scope key has none (it is fleet-wide by definition).
+ */
+export type ConfigKeySpec =
+  | (ConfigKeySpecBase & { scope: 'user'; visibility?: never })
+  | (ConfigKeySpecBase & { scope: 'device'; visibility: ConfigVisibility });
 
 /** A key with its resolved value and the layer that set it. */
 export interface ConfigEntry {
@@ -89,6 +124,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'browser.profile',
     yamlKey: 'defaultBrowserProfile',
     scope: 'device',
+    visibility: 'machine',
     type: 'string',
     description:
       'Browser profile `agents browser start` resolves to without --profile (set via `agents browser profiles set-default`).',
@@ -97,6 +133,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'agents.max-concurrent',
     yamlKey: 'maxAgents',
     scope: 'device',
+    visibility: 'shared',
     type: 'int',
     description:
       'Cap on concurrent agents on this device. What counts toward it depends on the consumer: ' +
@@ -107,6 +144,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'scheduler.enabled',
     yamlKey: 'schedulerEnabled',
     scope: 'device',
+    visibility: 'machine',
     type: 'bool',
     defaultValue: true,
     description: 'Whether the routines scheduler (daemon) may fire on this device.',
@@ -115,6 +153,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'daemon.enabled',
     yamlKey: 'daemonEnabled',
     scope: 'device',
+    visibility: 'machine',
     type: 'bool',
     defaultValue: true,
     description:
@@ -127,6 +166,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'watchdog.enabled',
     yamlKey: 'watchdogEnabled',
     scope: 'device',
+    visibility: 'shared',
     type: 'bool',
     defaultValue: false,
     description: 'Whether the daemon runs the watchdog pass on this device.',
@@ -135,6 +175,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'browser.remote-control',
     yamlKey: 'browserRemoteControl',
     scope: 'device',
+    visibility: 'machine',
     type: 'bool',
     defaultValue: false,
     description:
@@ -145,6 +186,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'notes',
     yamlKey: 'notes',
     scope: 'device',
+    visibility: 'shared',
     type: 'string-list',
     description: 'Free-form operator notes about this device (one entry per `agents devices config <name> notes <text>`).',
   },
@@ -152,6 +194,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'ssh.user',
     yamlKey: 'sshUser',
     scope: 'device',
+    visibility: 'shared',
     type: 'string',
     description: 'SSH login user for the device — overrides the registry profile’s user at dial time.',
   },
@@ -159,6 +202,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'ssh.auth',
     yamlKey: 'sshAuth',
     scope: 'device',
+    visibility: 'shared',
     type: 'string',
     description: 'SSH auth method: `key` (ssh agent / on-disk keys) or `password` (pulled from a secrets bundle).',
     validate: (v) =>
@@ -170,6 +214,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'ssh.bundle',
     yamlKey: 'sshBundle',
     scope: 'device',
+    visibility: 'shared',
     type: 'string',
     description: 'Secrets bundle holding the SSH password (for ssh.auth=password). A bundle NAME — never a secret value.',
   },
@@ -177,6 +222,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'ssh.bundle-key',
     yamlKey: 'sshBundleKey',
     scope: 'device',
+    visibility: 'shared',
     type: 'string',
     description: "Key within the bundle whose value is the password (default 'password').",
   },
@@ -184,6 +230,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'ssh.identity-file',
     yamlKey: 'sshIdentityFile',
     scope: 'device',
+    visibility: 'shared',
     type: 'string',
     description: 'Explicit private-key path for key auth (passed to OpenSSH with IdentitiesOnly=yes).',
   },
@@ -191,6 +238,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'platform',
     yamlKey: 'platform',
     scope: 'device',
+    visibility: 'shared',
     type: 'string',
     description: 'OS family of the device — picks PowerShell vs POSIX on the remote end. Overrides the discovered platform.',
     validate: (v) =>
@@ -202,6 +250,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'auto-launch.enabled',
     yamlKey: 'autoLaunchEnabled',
     scope: 'device',
+    visibility: 'shared',
     type: 'bool',
     defaultValue: true,
     description: 'Whether AGI EXT auto-launch may pick this device (default on).',
@@ -210,6 +259,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     name: 'auto-launch.preferred',
     yamlKey: 'autoLaunchPreferred',
     scope: 'device',
+    visibility: 'shared',
     type: 'bool',
     defaultValue: false,
     description: 'Boost this device in AGI EXT auto-launch ranking (default off).',
@@ -306,6 +356,22 @@ function targetDevice(opts?: ConfigTarget): string {
   return opts?.device ?? machineId();
 }
 
+/**
+ * A machine-visibility key is only ever readable for THIS box, because it lives
+ * in this box's own gitignored doc. Asking for a peer's value is a mistake with a
+ * concrete fix, so say so rather than silently returning this machine's answer
+ * for another machine — that would make `agents devices config <peer>
+ * browser.remote-control` look like it reported the peer's consent state.
+ */
+function assertLocalTarget(spec: ConfigKeySpec, device: string): void {
+  if (spec.scope !== 'device' || spec.visibility !== 'machine') return;
+  if (device === machineId()) return;
+  throw new Error(
+    `${spec.name} is machine-local, so it can only be read or set on the device itself.\n` +
+    `Run it on ${device}, e.g.: agents ssh ${device} 'agents config ${spec.name} <value>'`,
+  );
+}
+
 /** Get one config key's value and the layer that set it. */
 export function getConfigValue(name: string, opts?: ConfigTarget): ConfigEntry {
   const spec = configKeySpec(name);
@@ -313,7 +379,17 @@ export function getConfigValue(name: string, opts?: ConfigTarget): ConfigEntry {
     const value = readMeta().config?.[spec.yamlKey];
     return { spec, value, layer: value !== undefined ? 'user' : undefined };
   }
-  const value = readDeviceConfigValues(targetDevice(opts))[spec.yamlKey];
+  const device = targetDevice(opts);
+  assertLocalTarget(spec, device);
+  if (spec.visibility === 'machine') {
+    // This machine's own doc, never the synced file. Fall back to the central
+    // block so a value written by an older CLI is still honored until the
+    // operator prunes it (the migration is additive and leaves it in place).
+    const local = readMeta().deviceConfig?.[spec.yamlKey];
+    const value = local !== undefined ? local : readDeviceConfigValues(device)[spec.yamlKey];
+    return { spec, value, layer: value !== undefined ? 'device' : undefined };
+  }
+  const value = readDeviceConfigValues(device)[spec.yamlKey];
   return { spec, value, layer: value !== undefined ? 'device' : undefined };
 }
 
@@ -373,7 +449,13 @@ export function setConfigValue(name: string, value: unknown, opts?: ConfigTarget
     updateMeta((m) => ({ ...m, config: { ...m.config, [spec.yamlKey]: value } }));
     return;
   }
-  setInCentralBlock(targetDevice(opts), spec, value);
+  const device = targetDevice(opts);
+  assertLocalTarget(spec, device);
+  if (spec.visibility === 'machine') {
+    updateMeta((m) => ({ ...m, deviceConfig: { ...m.deviceConfig, [spec.yamlKey]: value } }));
+    return;
+  }
+  setInCentralBlock(device, spec, value);
 }
 
 /** Unset a config key — restores default behavior. No-op when already unset. */
@@ -388,7 +470,21 @@ export function unsetConfigValue(name: string, opts?: ConfigTarget): void {
     });
     return;
   }
-  unsetInCentralBlock(targetDevice(opts), spec);
+  const device = targetDevice(opts);
+  assertLocalTarget(spec, device);
+  if (spec.visibility === 'machine') {
+    updateMeta((m) => {
+      if (!m.deviceConfig || !(spec.yamlKey in m.deviceConfig)) return m;
+      const next = { ...m.deviceConfig };
+      delete next[spec.yamlKey];
+      return { ...m, deviceConfig: Object.keys(next).length > 0 ? next : undefined };
+    });
+    // Also clear any copy an older CLI left centrally, so the unset is not
+    // shadowed by the fallback read above.
+    unsetInCentralBlock(device, spec);
+    return;
+  }
+  unsetInCentralBlock(device, spec);
 }
 
 // ─── Auto-launch preferences (Factory auto-host selection) ────────────────────

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -393,9 +393,21 @@ export function getConfigValue(name: string, opts?: ConfigTarget): ConfigEntry {
   return { spec, value, layer: value !== undefined ? 'device' : undefined };
 }
 
-/** List every known key with its value and the layer that set it. */
+/**
+ * List every known key with its value and the layer that set it.
+ *
+ * Listing a PEER omits its machine-local keys rather than throwing. Their values
+ * live in that box's own doc and are genuinely unknowable from here, but a bulk
+ * listing must not hard-fail because one key in the registry is unreadable —
+ * `agents devices config <peer>` should still show everything it CAN resolve.
+ * Asking for such a key by name still errors, with the `agents ssh` fix named.
+ */
 export function listConfig(opts?: ConfigTarget): ConfigEntry[] {
-  return CONFIG_KEYS.map((spec) => getConfigValue(spec.name, opts));
+  const isPeer = targetDevice(opts) !== machineId();
+  const visible = isPeer
+    ? CONFIG_KEYS.filter((spec) => spec.scope !== 'device' || spec.visibility !== 'machine')
+    : CONFIG_KEYS;
+  return visible.map((spec) => getConfigValue(spec.name, opts));
 }
 
 /** List user-scope config keys with their values. Used to show inherited settings

--- a/apps/cli/src/lib/devices/config-migration.test.ts
+++ b/apps/cli/src/lib/devices/config-migration.test.ts
@@ -109,11 +109,21 @@ describe('migrateDeviceConfigToCentral', () => {
     const { migrateDeviceConfigToCentral, getConfigValue, readMeta } = await freshModules();
     migrateDeviceConfigToCentral();
 
-    // Central block carries the folded config for both devices.
+    // Central carries the SHARED-visibility config — the keys peers read.
     expect(getConfigValue('agents.max-concurrent', { device: 'mac-mini' }).value).toBe(4);
     expect(getConfigValue('notes', { device: 'mac-mini' }).value).toEqual(['runs the releases']);
-    expect(getConfigValue('browser.profile', { device: 'mac-mini' }).value).toBe('comet-local');
+
+    // Machine-visibility keys are NOT folded: mac-mini's browser profile stays in
+    // mac-mini's own doc, and is not even readable from here. Folding a peer's
+    // would put one box's settings — including the browserRemoteControl consent
+    // flag — into the file the whole fleet syncs.
+    expect(readCentral()).not.toContain('defaultBrowserProfile');
+    expect(() => getConfigValue('browser.profile', { device: 'mac-mini' })).toThrow(/machine-local/);
+
+    // This machine's own machine-local key still resolves — it is read straight
+    // from its device doc, which is where it already lived.
     expect(getConfigValue('scheduler.enabled').value).toBe(false); // self (testbox)
+    expect(readCentral()).not.toContain('schedulerEnabled');
 
     // The fold is ADDITIVE: the legacy source is left exactly as it was. A box
     // still on the previous CLI reads that doc, so deleting it mid-rollout would

--- a/apps/cli/src/lib/devices/config-migration.ts
+++ b/apps/cli/src/lib/devices/config-migration.ts
@@ -2,23 +2,27 @@
  * One-time migration: fold per-device config from the legacy stores into the
  * central `fleet.devices.<name>.config` block of `~/.agents/agents.yaml`.
  *
+ * Only SHARED-visibility keys move — the ones a peer reads. Machine-visibility
+ * keys (see lib/config-machine-keys.ts) stay in the per-device doc, which is
+ * exactly where the machine-local read path now looks for them.
+ *
  * Legacy sources (both pre-unification):
  *   - `~/.agents/devices/<name>/agents.yaml` — the `config:` map and the
  *     top-level `defaultBrowserProfile:` field. Agent pins (`agents:`,
- *     `isolatedAgents:`) and `routines:` STAY in the per-device doc — only
- *     operator config moves.
+ *     `isolatedAgents:`), `routines:`, and machine-visibility config STAY in the
+ *     per-device doc — only shared operator config moves.
  *   - `~/.agents/.history/devices/auto-launch.json` — AGI EXT auto-launch
  *     enabled/preferred flags, becoming `autoLaunchEnabled` /
  *     `autoLaunchPreferred` config keys.
  *
- * Order is crash-safe: the central block is written FIRST, then the legacy
- * stores are stripped. A crash in between re-folds on the next run, and the
- * central-wins merge makes that a no-op. Idempotent — after a successful run
- * neither source holds config, so re-running is a cheap existence check.
+ * The fold is ADDITIVE: the central block is written and the legacy stores are
+ * left exactly as they were, so a box still on the previous CLI keeps reading
+ * what it always read. The central-wins merge makes a re-run a byte no-op.
  *
- * Invoked from three places so every install converges regardless of entry
- * point: `runMigration()` (fresh / sentinel-less installs), daemon boot, and
- * the first `lib/device-config.ts` read/write in a process.
+ * Invoked only from a lifecycle entry point — `runMigration()` (fresh installs)
+ * and daemon boot. It must NEVER hang off a config read or write: agents.yaml is
+ * tracked and shared by the whole fleet, so a migration on the read path lets an
+ * ordinary `agents config get` dirty it on every machine.
  */
 
 import * as fs from 'fs';
@@ -30,6 +34,7 @@ import {
   updateMeta,
 } from '../state.js';
 import { loadDevicesSync } from './registry.js';
+import { MACHINE_LOCAL_YAML_KEYS } from '../config-machine-keys.js';
 import type { FleetDeviceOverride, FleetManifest } from '../fleet/types.js';
 
 /** Config folded out of one legacy store, keyed by device name. */
@@ -99,6 +104,19 @@ function collectDeviceDocFolds(devicesRoot: string): { folds: ConfigFolds; docs:
     }
     if (typeof doc.defaultBrowserProfile === 'string') {
       config.defaultBrowserProfile = doc.defaultBrowserProfile;
+    }
+    // Machine-visibility keys are NOT folded. Two reasons, both load-bearing:
+    //
+    //  1. They already live exactly where they belong. `config:` in this doc is
+    //     the machine-local store the new read path uses (state.ts overlays it
+    //     as `deviceConfig`), so folding would only copy them into the shared
+    //     file this whole change exists to keep clean.
+    //  2. Copying a PEER's would be a leak. `browserRemoteControl` is a consent
+    //     flag gating whether other machines may drive that box's browser;
+    //     hoisting one box's opt-in into the synced file spreads it to the fleet.
+    //     Each machine keeps its own, in its own doc.
+    for (const key of Object.keys(config)) {
+      if (MACHINE_LOCAL_YAML_KEYS.has(key)) delete config[key];
     }
     if (Object.keys(config).length === 0) continue;
     mergeFold(folds, entry.name, config);

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -935,6 +935,7 @@ const META_KEY_SCOPE: Record<keyof Meta, 'central' | 'device'> = {
   isolatedAgents: 'device',
   versions: 'device',
   deviceRoutines: 'device',
+  deviceConfig: 'device',
   // Central — synced via agents.yaml.
   accounts: 'central',
   run: 'central',
@@ -1034,7 +1035,7 @@ function serializeCentral(central: Record<string, unknown>): string {
 }
 
 function writeMetaUnlocked(meta: Meta): void {
-  const { agents, isolatedAgents, versions, deviceRoutines, ...central } = meta;
+  const { agents, isolatedAgents, versions, deviceRoutines, deviceConfig, ...central } = meta;
 
   // Write the machine-local files FIRST, then strip central — so a crash mid-write
   // never removes pins/versions from central before they're persisted elsewhere.
@@ -1046,15 +1047,20 @@ function writeMetaUnlocked(meta: Meta): void {
   // it does not have.
   const hasIsolatedAgents = !!isolatedAgents && Object.keys(isolatedAgents).length > 0;
   const hasDeviceRoutines = Array.isArray(deviceRoutines);
-  if (hasAgents || hasIsolatedAgents || hasDeviceRoutines) {
+  // Machine-visibility operator config. Lives here rather than in the synced
+  // central file because nothing off-box reads it — and because
+  // browser.remote-control is a consent flag that must not propagate on pull.
+  const hasDeviceConfig = !!deviceConfig && Object.keys(deviceConfig).length > 0;
+  if (hasAgents || hasIsolatedAgents || hasDeviceRoutines || hasDeviceConfig) {
     // Device-local doc carries `agents:` pins and `routines:` — per-machine and
     // must never land in central agents.yaml (which syncs). Operator config
     // used to ride this doc under `config:`; it now lives centrally under
     // `fleet.devices.<name>.config` (see lib/device-config.ts).
-    const deviceDoc: Partial<Meta> & { routines?: string[] } = {};
+    const deviceDoc: Partial<Meta> & { routines?: string[]; config?: Record<string, unknown> } = {};
     if (hasAgents) deviceDoc.agents = agents;
     if (hasIsolatedAgents) deviceDoc.isolatedAgents = isolatedAgents;
     if (hasDeviceRoutines) deviceDoc.routines = deviceRoutines;
+    if (hasDeviceConfig) deviceDoc.config = deviceConfig;
     fs.mkdirSync(path.dirname(devicePath), { recursive: true });
     writeIfChanged(devicePath, META_HEADER + yaml.stringify(deviceDoc));
   } else if (fs.existsSync(devicePath)) {
@@ -1100,6 +1106,9 @@ function overlayMachineLocal(meta: Meta): Meta {
     if (dm) {
       if (dm?.agents) meta.agents = { ...meta.agents, ...dm.agents };
       if (dm?.isolatedAgents) meta.isolatedAgents = { ...meta.isolatedAgents, ...dm.isolatedAgents };
+      if (dm?.config && typeof dm.config === 'object' && !Array.isArray(dm.config)) {
+        meta.deviceConfig = { ...meta.deviceConfig, ...(dm.config as Record<string, unknown>) };
+      }
       if (dm && Object.prototype.hasOwnProperty.call(dm, 'routines')) {
         if (!Array.isArray(dm.routines) || dm.routines.some((name) => typeof name !== 'string')) {
           throw new Error(`Device config corrupted at ${devicePath}: routines must be a string list.`);

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -1016,6 +1016,18 @@ export interface Meta {
    */
   deviceRoutines?: string[];
   /**
+   * Machine-local operator config — the device-scope keys whose `visibility` is
+   * `machine` (see lib/device-config.ts). state.ts writes it as `config:` inside
+   * `~/.agents/devices/<machine>/agents.yaml`, which is gitignored, so it never
+   * reaches the fleet-shared agents.yaml.
+   *
+   * These are the keys nothing off-box reads. Keeping them out of the shared file
+   * is both a churn fix (13 machines were writing one tracked path) and a
+   * security one: `browser.remote-control` gates whether OTHER machines may drive
+   * this box's browser, so syncing one box's opt-in to the rest was wrong.
+   */
+  deviceConfig?: Record<string, unknown>;
+  /**
    * Agent-host registry keyed by host name (`agents hosts`). Portable user
    * config synced with `agents repo push/pull`. For `ssh-config` hosts this is
    * just an overlay (caps/os) — the connection details stay in ~/.ssh/config and


### PR DESCRIPTION
**Per-machine config moves out of the fleet-shared `agents.yaml`, and `browser.remote-control` stops leaking as a consent flag.** Follows #2523, which stopped config *reads* dirtying that file; this stops the machine-local *writes*.

## Why

Every device-scope key was stored in `fleet.devices.<name>.config` inside the tracked, fleet-synced `agents.yaml`. For keys a peer genuinely reads that is correct. For keys only the owning box reads it is pure churn on a file 13 machines share.

`browser.remote-control` is the sharp case. It gates whether **other machines may drive this box's browser**, and its own help text says *"device-local, never synced"* (`commands/browser.ts:685`) — but it lived in the synced file, so one box's opt-in propagated to the fleet on the next pull. That is a security bug, not just churn.

## The rule

`visibility` asks **who reads it**, and that decides where it is stored:

| visibility | stored in | keys | why |
| --- | --- | --- | --- |
| `shared` | tracked `fleet.devices.<name>.config` | `ssh.user/auth/bundle/bundle-key/identity-file`, `platform`, `agents.max-concurrent`, `auto-launch.*`, `notes`, `watchdog.enabled` | a **peer** reads them. `resolve-profile.ts:29` resolves the ssh fields *to build the ssh target*, so a box cannot ask the peer for them first |
| `machine` | gitignored `devices/<machine>/agents.yaml` | `browser.profile`, `browser.remote-control`, `scheduler.enabled`, `daemon.enabled` | nothing off-box reads them |

## What changed

- **`lib/device-config.ts`** — `ConfigKeySpec` is a discriminated union, so omitting `visibility` on a device key is a **compile error**. Reads and writes branch on it; a machine-local key targeted at a peer is refused with the `agents ssh <device>` form to use instead.
- **`lib/state.ts`, `lib/types.ts`** — new `deviceConfig` Meta field, classified in `META_KEY_SCOPE` (exhaustive `Record`, so omitting it would not compile), written into the per-machine doc's `config:` block and overlaid back on read.
- **`lib/config-machine-keys.ts`** — zero-dep leaf listing the machine-local YAML keys. `device-config.ts` imports `config-migration.ts`, so the migration cannot import the registry back without a cycle; this mirrors the existing `agent-cli-commands` leaf and is **pinned equal to the registry by a test**.
- **`lib/devices/config-migration.ts`** — no longer folds machine-local keys. They already sit where the new read path looks, and copying a **peer's** would hoist that consent flag into the synced file.

Backward compatible: a value an older CLI wrote centrally is still honored until overwritten, so a mixed-version fleet keeps working.

## Verification

**Ran it.** Real run on this branch against a sandbox HOME (`agents share` log: https://share.agents-cli.sh/muqsitnawaz/agents-machine-tier-run-85b9575836fdd92b):

```
$ set browser.remote-control=on, agents.max-concurrent=4, and ssh.user for peer mac-mini
read back browser.remote-control = true
peer read refused -> browser.remote-control is machine-local, so it can only be read or set on the device itself.

--- FLEET-SHARED agents.yaml (tracked; synced to all 13 machines) ---
fleet:
  devices:
    demobox:
      config:
        maxAgents: 4
    mac-mini:
      config:
        sshUser: muqsit

--- THIS MACHINE ONLY: devices/demobox/agents.yaml (gitignored) ---
config:
  browserRemoteControl: true

shared file contains browserRemoteControl? -> 0 (0 = the leak is closed)
```

The consent flag lands in the machine-only doc; the shared keys stay central so peers can still resolve them; a peer read is refused with the fix named.

```
$ tsc --noEmit
exit 0

$ vitest run src/lib/device-config.test.ts src/lib/devices/ src/lib/state.test.ts src/lib/fleet/
 Test Files  33 passed (33)
      Tests  512 passed (512)
```

New tests assert the behavior, not the mechanism:

- `browser.remote-control` set locally lands in the per-machine doc and **never** appears in `agents.yaml` — the leak, as a regression test.
- a shared key (`ssh.user`) still goes central, so peers can resolve it.
- reading or setting a machine-local key for a peer throws, and the message names `agents ssh mac-mini`.
- a central value written by an older CLI is still honored (mixed-version safety).
- `MACHINE_LOCAL_YAML_KEYS` equals the machine-visibility keys derived from `CONFIG_KEYS` — the pin that stops the leaf drifting.

Six existing tests encoded the old contract (machine keys living centrally) and were updated to the new one rather than deleted; the diff shows each.

## Review note

`.github/rush.yml` has `prix/code-reviewer` **paused** (#1767 — the dispatch path was capturing and logging live OAuth tokens), and its documented fallback is a subagent reviewer, which my operating instructions bar me from spawning unprompted. So this has CI plus the evidence above, but no non-author review. Flagging rather than implying it was reviewed.
