### PR TITLE
docs(accounts): align public docs with the canonical account-bundle model (RUSH-2509)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Also available as `ag` -- all commands work with both `agents` and `ag`.
 - [Plugins](#plugins)
 - [Make it yours](#make-it-yours)
 - [Browser](#browser)
+- [Accounts](#accounts)
 - [Secrets](#secrets)
 - [Routines](#routines)
 - [Monitors](#monitors)
@@ -499,10 +500,10 @@ agents add codex@latest       # Install latest
 agents add codex@oldest       # Install the oldest published version
 agents view                   # See everything installed
 agents accounts add work --provider anthropic --auth setup-token
-agents accounts add gateway --provider openrouter --auth api-key --from-secrets openrouter.ai:OPENROUTER_API_KEY
-agents run claude --account work
 agents run claude --account work
 ```
+
+Multiple provider accounts to juggle? See [Accounts](#accounts) below.
 
 ---
 
@@ -958,6 +959,26 @@ agents browser profiles create cloud \
   --browser chrome \
   --endpoint "wss://connect.browserbase.com?apiKey=..."
 ```
+
+---
+
+## Accounts
+
+Give a provider credential a durable name once, reuse it everywhere -- across harnesses, across machines.
+
+```bash
+agents accounts add work --provider anthropic --auth setup-token
+agents accounts add gateway --provider openrouter --auth api-key \
+  --from-secrets openrouter.ai:OPENROUTER_API_KEY  # import from an existing secrets bundle
+
+agents accounts set-default claude work   # claude uses `work` when --account is omitted
+agents accounts sync work --device yosemite-s0   # explicitly copy the bundle to a worker device
+agents run claude --account work
+```
+
+One provider account **is** one `agents secrets` bundle -- `agents accounts add` creates it with secrets policy `never`, so a background agent launch on that account never raises Touch ID. `agents accounts` (no subcommand) lists provider bundles next to harness-native signed-in identities so you see both kinds of credential together; `accounts list` / `inspect <name>` / `set-key <name>` (rotate) / `rename` / `remove` manage a bundle by its stable id, independent of its current label.
+
+Harness-native OAuth logins (Claude Code's own `/login`, `codex login`, and so on) stay exactly where the harness put them -- agents-cli discovers and displays them but never copies, renames, or converts them into a provider bundle. `accounts sync <name> --device <device>` is the only way a provider account crosses machines, and it's explicit: nothing syncs automatically. Selection order for a run is explicit `--account`, then `accounts set-default` for that harness, then the harness's native/balanced account behavior.
 
 ---
 

--- a/apps/cli/docs/QUICKSTART.md
+++ b/apps/cli/docs/QUICKSTART.md
@@ -82,6 +82,14 @@ agents doctor claude@default                                   # per-resource re
 agents run claude "Reply with exactly PINGOK" --mode plan       # headless read-only ping
 ```
 
+Need a credential that isn't a browser login — a setup-token, an API key for a
+BYOK gateway, a team's shared key? `agents accounts add <name> --provider <p>
+--auth <type>` stores it as a named, Touch-ID-free bundle you select with
+`agents run <agent> --account <name>` or make the default with `agents
+accounts set-default <agent> <name>`; `agents accounts sync <name> --device
+<device>` copies it to another machine. See [Accounts](../../../README.md#accounts)
+in the root README.
+
 `--mode plan` is read-only (safe to run against anything); `edit` lets the
 agent write files, `auto` auto-approves safe operations and prompts for risky
 ones, `skip` bypasses all permission prompts. Omit the prompt argument for an

--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -46,7 +46,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 | [Secrets](secrets.md) | Keychain-backed env-var bundles. Inject into runs via `agents run --secrets <name>`. 1Password import/export, encrypted push/pull. |
 | [Secrets-agent process model](secrets-agent-process-model.md) | Design decision: fold the secrets broker into a hardened, always-on daemon — make the host reliable enough to carry the critical service rather than routing around it. |
 | [Secrets trust boundaries](secrets-trust-boundaries.md) | Design record: the plaintext data-flow — exactly which commands inject into a child process vs materialize a value into the agent's context/transcript. |
-| [Credential management](credential-management.md) | Design record: the fleet auth model — the interactive/rotating login is untouchable, only a deliberate setup-token is shareable across devices, and the per-harness Touch ID fix. |
+| [Credential management](credential-management.md) | Design record: the fleet auth model — the interactive/rotating login is untouchable, only a deliberate account bundle (`agents accounts add`, policy `never`) is shareable across devices, and the per-harness Touch ID fix. |
 
 ## Orchestration
 

--- a/apps/cli/docs/credential-management.md
+++ b/apps/cli/docs/credential-management.md
@@ -38,17 +38,20 @@ Both come from the same mistake: **agents-cli touching the interactive login.**
    by us and never copied across devices. It stays on the box that minted it and
    refreshes itself there.
 
-3. **The only credential agents-cli manages is a deliberate setup-token.** A
-   long-lived, **non-rotating** OAuth setup-token / device-login token / API key
+3. **The only credential agents-cli manages is a deliberate, durable credential.** A
+   long-lived, **non-rotating** OAuth setup-token / API key / bearer token
    (`claude setup-token`, `OPENAI_API_KEY`, `XAI_API_KEY`, `FACTORY_API_KEY`, …).
    Valid until explicitly revoked → **safe to reuse on many devices, no repeated
    logouts, no revocation cascade.** That safety property is the whole reason it, and
    only it, is shareable.
 
-4. **Setup-tokens live file-based, in a reserved "auth" bundle.** They are stored in
-   the **file-based** secrets mechanism (never the OS keychain), under a reserved
-   bundle name (the `auth` bundle), and synced across the fleet by the existing
-   file-based secrets sync. No Touch ID, because no keychain ACL.
+4. **Shipped (RUSH-2470): each provider account is its own named `agents secrets`
+   bundle, not one reserved bundle.** `agents accounts add <name> --provider <p>
+   --auth <type>` creates a bundle named after the account, with secrets policy
+   `never` set unconditionally — never the OS keychain's biometry ACL, so reading
+   it raises no Touch ID prompt. There is no shared "auth" bundle name; a user can
+   hold as many named accounts as they need, and only the accounts they explicitly
+   `agents accounts sync <name> --device <device>` cross the fleet.
 
 5. **Usage and account views read the setup-token**, not the interactive login —
    and never a prompting keychain read. Caveat (RUSH-2392): Anthropic's
@@ -68,23 +71,26 @@ Both come from the same mistake: **agents-cli touching the interactive login.**
 | ingredient | where | shared across fleet? | why safe |
 |---|---|---|---|
 | Interactive OAuth login | the box that minted it, in its own config home / the harness's own keychain item | **No — never touched by us** | rotates/revokes on cross-use; leaving it alone is the fix |
-| Setup-token (API key / long-lived OAuth) | file-based `auth` secrets bundle | **Yes — synced** | non-rotating, revoke-only; reuse never invalidates another holder |
+| Setup-token / API key (durable) | a named `agents accounts add` bundle, secrets policy `never` | **Yes — synced, explicitly** | non-rotating, revoke-only; reuse never invalidates another holder |
 | daemon / CLI | — | — | hold nothing |
 
-The only thing that crosses the fleet is the reserved `auth` bundle (file-based
-setup-tokens the user deliberately placed). Nothing rotating is ever copied.
+The only thing that crosses the fleet is a provider account bundle the user
+deliberately created with `agents accounts add` and explicitly pushed with
+`agents accounts sync <name> --device <device>`. Nothing rotating is ever copied.
 
 ## How each surface changes
 
 - **`agents apply`** stops copying login files. `FLEET_AUTH_FILES` loses its copy
   role; the `push-login` / `--recv-auth` login-materialize path is removed. Per
   agent per box `apply` surfaces: "logged in" / "log in on this box" (interactive or
-  `agents fleet login`) / "seed the `auth` bundle" — driven by whether the box has
-  its own login or a declared setup-token, never by agent identity.
+  `agents fleet login`) / "add or sync a provider account (`agents accounts add` /
+  `sync`)" — driven by whether the box has its own login or a declared account
+  bundle, never by agent identity.
 - **`agents fleet login`** (per-box device-code over SSH, writes the credential on
   the box, never transports it) stays as the per-machine login path. Onboarding a
-  new device seeds the reserved `auth` bundle instead of copying logins.
-- **`ag view` / usage** (`usage.ts`) reads the setup-token from the file-based `auth`
+  new device syncs the needed provider account bundle (`agents accounts sync`)
+  instead of copying logins.
+- **`ag view` / usage** (`usage.ts`) reads the setup-token from its named account
   bundle. It never reads the harness's ACL-bound keychain login. No no-ACL cache of
   the interactive token is needed because the interactive token is never read.
   When Anthropic returns 403 `user:profile` on that token, the probe sets
@@ -119,7 +125,7 @@ Resolved open items:
 - **Kimi has no env-var auth** (config.toml only) — a real limitation; its
   file-based OAuth login stays per-box, no shareable token.
 - **Droid**: `FACTORY_API_KEY` is real but agents-cli wires nothing — a gap to
-  close if we want droid in the `auth` bundle.
+  close if we want droid selectable as an `agents accounts` provider.
 
 ## The Touch ID fix (concrete)
 
@@ -127,30 +133,36 @@ Only the **token-acquisition step** changes — no endpoint/header change (the u
 endpoint takes any `sk-ant-oat01-` bearer, `usage.ts:624,957`):
 
 - In `loadClaudeOauth` (and its callers `probeClaudeStatus` / `getClaudeUsageInfo`,
-  `usage.ts:604,938`), **resolve `CLAUDE_CODE_OAUTH_TOKEN` from the file-based `auth`
-  bundle (or env) BEFORE the keychain read** (`usage.ts:1348-1353`). If a setup-token
-  is present → use it as the bearer and skip `getKeychainToken` entirely → no
-  `/usr/bin/security` call → no Touch ID.
+  `usage.ts:604,938`), **resolve `CLAUDE_CODE_OAUTH_TOKEN` from the named account
+  bundle (or env) BEFORE the keychain-ACL read** (`usage.ts:1348-1353`). If a
+  setup-token is present → use it as the bearer and skip `getKeychainToken`
+  entirely → no ACL-gated `/usr/bin/security` call → no Touch ID.
 - Same for the daemon's every-3-min `probeLocalFleetAuth` (`auth-health.ts:391-410`)
-  — the real storm source — so its warm loop reads the file-based setup-token, never
-  the keychain.
-- The setup-token lives in a **file-based** bundle (`--backend file`,
-  `~/.agents/.cache/secrets/`, no biometry). Populated by the user OR **self-minted**
-  by the agent (`claude setup-token` via pty + computer-use), stored file-backed.
+  — the real storm source — so its warm loop reads the account bundle's
+  setup-token, never the ACL-bound keychain login.
+- The setup-token lives in a bundle written by `agents accounts add`, which
+  always sets secrets policy `never` — a no-biometry-ACL item (keychain on
+  macOS, the platform default elsewhere), never the harness's own ACL'd login.
+  Populated by the user OR **self-minted** by the agent (`claude setup-token`
+  via pty + computer-use).
 
 ## Migration (priority order — Touch ID first, it's the live pain)
 
 1. Daemon holds nothing (done, #1583).
-2. **Claude usage/probe read the file-based setup-token, not the keychain** → kills
-   the Touch ID storm. Self-mint + store the setup-token per account file-based.
-   **Enforcement landed:** `loadClaudeOauth`'s `accessTokenCache` path
-   (`usage.ts`) now returns `null` when no setup-token is provisioned instead of
-   falling through to the interactive keychain / `.credentials.json` — so the
-   daemon's usage (~60s) and auth-health (~3min) warms can never read or transmit
-   the interactive OAuth login (the transitional fallback + its no-ACL cache are
-   removed). An unprovisioned account reads as `unconfigured` (benign for
-   rotation) and shows "usage pending"; seed a setup-token to restore usage.
+2. **Claude usage/probe read the account bundle's setup-token, not the ACL'd
+   keychain login** → kills the Touch ID storm. Self-mint + store the setup-token
+   per account. **Enforcement landed:** `loadClaudeOauth`'s `accessTokenCache`
+   path (`usage.ts`) now returns `null` when no setup-token is provisioned
+   instead of falling through to the interactive keychain / `.credentials.json`
+   — so the daemon's usage (~60s) and auth-health (~3min) warms can never read
+   or transmit the interactive OAuth login (the transitional fallback + its
+   no-ACL cache are removed). An unprovisioned account reads as `unconfigured`
+   (benign for rotation) and shows "usage pending"; seed a setup-token to
+   restore usage.
 3. `apply` stops copying rotating login files (Gap B).
-4. Reserved file-based `auth` bundle + fleet sync (via `vault.age`/`secrets
-   push-pull`, not `apply`) — onboarding + headless.
+4. **Shipped (RUSH-2470):** `agents accounts add <name>` creates a named,
+   policy-`never` bundle per account; `agents accounts sync <name> --device
+   <device>` copies it explicitly to a worker device (encrypted file backend on
+   Linux, Credential Manager on Windows). No reserved bundle name — every
+   account the user creates is independently named and independently synced.
 5. Fleet upgrade + verify **zero Touch ID** on a real macOS box (the proof).


### PR DESCRIPTION
**docs-only.** No behavior change — aligns public documentation with the account-bundle model PR #2470 already shipped.

## What changed, for whom

For anyone reading agents-cli's public docs (README, QUICKSTART, credential-management design record) about credentials/accounts:

- **Fixed a duplicated command** in the root README's "Pin versions per project" snippet (`agents run claude --account work` appeared twice).
- **Added a task-oriented `## Accounts` section** to the root README (also the published package README) documenting the concrete, shipped contract:
  - one provider account **is** one `agents secrets` bundle, always created with secrets policy `never` (`agents accounts add`)
  - selected per-run with `--account`, or defaulted per harness with `accounts set-default`
  - copied to another machine only explicitly, with `accounts sync <name> --device <device>`
  - harness-native OAuth logins stay harness-owned and device-local — never copied or converted into a bundle
- **Pointed `QUICKSTART.md`** at the same flow from the "add harnesses and log in" step.
- **Fixed `docs/credential-management.md`**, a design record that predates PR #2470 and still claimed setup-tokens live in one reserved `auth` bundle and are stored file-based. Both are stale: the shipped model is one named, policy-`never` bundle per account (verified against `apps/cli/src/commands/accounts.ts` and `apps/cli/src/lib/account-registry.ts`), on whichever backend the platform default resolves to (no-ACL keychain item on macOS, not exclusively file-based). Marked the relevant invariant and migration step as **Shipped (RUSH-2470)**.
- **Updated `docs/README.md`**'s one-line description of `credential-management.md` to name the shipped mechanism.

No `AGENTS_SECRETS_PASSPHRASE` claim was added to the account flow anywhere — `agents accounts sync` uses an auto-provisioned machine-local key on the encrypted file backend, not the shared passphrase.

## Verification

```
$ cd apps/cli && bun run verify-docs
$ scripts/verify-docs.sh
✓ docs/AGENT-CHEATSHEET.md exists
  ✓ covers: The three DotAgents repos
  ✓ covers: `AGENTS.md` is the canonical memory file
  ✓ covers: Capability table gates
  ✓ covers: Version homes
  ✓ covers: Two unrelated things are called
✓ AGENTS.md links to AGENT-CHEATSHEET.md
✓ docs/README.md links to AGENT-CHEATSHEET.md
✓ Docs verification passed
```

All new/changed relative links (`README.md#accounts`, `../../../README.md#accounts`) checked by hand against the anchors and directory depth of neighboring links in the same files.

RUSH-2509 · builds on merged agents-cli #2470