### PR TITLE
fix(monitors): mode:every stays silent on an empty observation (RUSH-2488)

### DIFF
--- a/apps/cli/.changelog/next/monitor-every-empty-observation.md
+++ b/apps/cli/.changelog/next/monitor-every-empty-observation.md
@@ -1,0 +1,9 @@
+- **Monitor `condition: { mode: every }` no longer fires on an empty observation (RUSH-2488).** `every`
+  previously returned `fire: true` for every tick regardless of the observation, so a poll whose
+  command produced no rows still dispatched the action with an empty `{event}`. It now stays silent on
+  an empty or whitespace-only observation and fires on every tick that carries real output. This gives
+  a poll-driven monitor the "re-fire while the watched set is non-empty" semantics that a
+  silently-failed action dispatch needs to be retried — an action failure leaves the same non-empty
+  observation next tick, so `every` re-fires (bounded by `rateLimit`), where `match`/`on-change` would
+  dedupe and never retry. No shipped monitor used `every`, so there is no behavior change to an existing
+  monitor. Source: `apps/cli/src/lib/monitors/engine.ts`, `apps/cli/src/lib/monitors/engine.test.ts`.

--- a/apps/cli/src/lib/monitors/engine.test.ts
+++ b/apps/cli/src/lib/monitors/engine.test.ts
@@ -29,12 +29,22 @@ afterEach(() => {
 });
 
 describe('decideFire — every mode', () => {
-  it('always fires', () => {
+  it('fires on every non-empty observation', () => {
     const m = monitor({ name: uniq('every'), condition: { mode: 'every' } });
     const d = decideFire(m, { raw: 'anything' });
     expect(d.fire).toBe(true);
     expect(d.event).not.toBeNull();
     expect(d.persist).toBe(false);
+  });
+
+  it('does NOT fire on an empty or whitespace-only observation (RUSH-2488)', () => {
+    const m = monitor({ name: uniq('every-empty'), condition: { mode: 'every' } });
+    for (const raw of ['', '   ', '\n', ' \t\n ']) {
+      const d = decideFire(m, { raw });
+      expect(d.fire).toBe(false);
+      expect(d.event).toBeNull();
+      expect(d.persist).toBe(false);
+    }
   });
 });
 

--- a/apps/cli/src/lib/monitors/engine.ts
+++ b/apps/cli/src/lib/monitors/engine.ts
@@ -96,6 +96,15 @@ export function decideFire(monitor: MonitorConfig, observation: Observation): Fi
   const dedupeKey = cond.dedupeKey;
 
   if (cond.mode === 'every') {
+    // Fire on every tick that carries a real observation. An empty (or
+    // whitespace-only) observation means "nothing to report": firing an action
+    // with an empty {event} is never useful, and skipping it lets a poll whose
+    // command yields no rows (e.g. no mergeable PR) stay silent while still
+    // re-firing every tick the set is non-empty — the retry semantics a
+    // silently-failed action dispatch needs (RUSH-2488).
+    if (raw.trim() === '') {
+      return { fire: false, value: raw, dedupeKey, persist: false, event: null };
+    }
     return {
       fire: true,
       value: raw,


### PR DESCRIPTION
**What + type:** bug fix (monitor engine). Fixes RUSH-2488.

## What changed
`decideFire` for `condition: { mode: every }` (`apps/cli/src/lib/monitors/engine.ts`) previously returned `fire: true` for **every** tick regardless of the observation — so a poll whose command produced no rows still dispatched the action with an empty `{event}`. It now returns `fire: false` on an empty or whitespace-only observation, and fires on every tick that carries real output.

## Why
This gives a poll-driven monitor the **"re-fire while the watched set is non-empty"** semantics a silently-failed action dispatch needs. If a dispatched action fails silently (transient error, box down, agent crashes before completing), the same non-empty observation recurs next tick, so `every` re-fires — bounded by `rateLimit` — where `match`/`on-change` would dedupe on the unchanged value and never retry. That "no-op forever after a silent failure" is exactly the anti-pattern the built-in `pr-merge-on-green` monitor hit (it will switch `match`→`every` in a companion .agents-system PR).

No shipped monitor used `every`, so there is no behavior change to an existing monitor.

## Evidence (ran it)
`bunx vitest run src/lib/monitors/` on the branch:
```
Test Files  ... passed
     Tests  11 passed (11)
```
New test `does NOT fire on an empty or whitespace-only observation (RUSH-2488)` covers `''`, `'   '`, `'\n'`, `' \t\n '`; the existing `fires on every non-empty observation` still passes.