### PR TITLE
test(sessions): read the holder's comm AFTER the scan, not before (RUSH-2508)

### DIFF
--- a/apps/cli/src/lib/session/active.live-session-id.test.ts
+++ b/apps/cli/src/lib/session/active.live-session-id.test.ts
@@ -132,10 +132,7 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
     const child = spawnHoldingSessionId(UUID, { cwd: wt });
     const pid = child.pid!;
 
-    // Wait for the OS to report the process as `claude` (comm basename) — that
-    // is the precondition the scan reads, so asserting before it holds tests
-    // the scheduler, not the scan.
-    const comm = await waitFor(() => {
+    const commOf = (): string | undefined => {
       try {
         return execFileSync('ps', ['-p', String(pid), '-o', 'comm='], {
           encoding: 'utf-8',
@@ -144,20 +141,9 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
       } catch {
         return undefined;
       }
-    });
-    // RUSH-2508: on some platforms this holder is unclassifiable by the time we
-    // can observe it. `ps -o comm=` on Linux reports the THREAD name, and node
-    // renames its main thread shortly after boot — measured on Node 24, comm
-    // flips to `MainThread` within a second, while Node 22 keeps `claude`. The
-    // scan then correctly stops treating the process as an agent, so there is
-    // nothing left for this case to assert. Gate on the observed comm rather
-    // than on the platform: an environment where comm stays usable (macOS,
-    // Windows, Linux on an older node) keeps full coverage, and only the
-    // environment that cannot support the case skips, naming why.
-    if (!comm || !/^claude/.test(path.basename(comm))) {
-      ctx.skip(`ps reports comm='${comm ?? '<unreadable>'}' for the holder, not an agent name — see RUSH-2508`);
-      return;
-    }
+    };
+    const classifiable = (comm: string | undefined): boolean =>
+      !!comm && /^claude/.test(path.basename(comm));
 
     let rows: Awaited<ReturnType<typeof listUnattributedActive>> = [];
     const hit = await waitFor(async () => {
@@ -165,6 +151,20 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
       rows = await listUnattributedActive(new Set());
       return rows.find((r) => r.sessionId === UUID || r.pid === pid);
     });
+
+    // RUSH-2508: read the holder's comm AFTER the scan, not before. `ps -o comm=`
+    // on Linux reports the THREAD name, and node renames its main thread a beat
+    // after boot — measured on Node 24 it flips to `MainThread` within a second,
+    // while Node 22 keeps `claude`. Sampling before the scan therefore proves
+    // nothing: the value can be `claude` at the check and `MainThread` by the
+    // time the scan reads it, which is exactly how `build (ubuntu-latest, 24)`
+    // failed with an EMPTY row set while ubuntu-22, macOS and Windows passed. If
+    // the holder is no longer classifiable, the scan is right to omit it and
+    // there is nothing left for this case to assert.
+    if (!hit && !classifiable(commOf())) {
+      ctx.skip(`ps reports comm='${commOf() ?? '<unreadable>'}' for the holder, not an agent name — see RUSH-2508`);
+      return;
+    }
     expect(hit, `expected active row for ${UUID} / pid ${pid}; got ${rows.map((r) => `${r.pid}:${r.sessionId}`).join(', ')}`).toBeDefined();
     expect(hit!.sessionId).toBe(UUID);
     // cwd should be the worktree path (lsof) when recoverable.

--- a/apps/cli/src/lib/session/active.live-session-id.test.ts
+++ b/apps/cli/src/lib/session/active.live-session-id.test.ts
@@ -145,24 +145,37 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
     const classifiable = (comm: string | undefined): boolean =>
       !!comm && /^claude/.test(path.basename(comm));
 
+    // RUSH-2508: sample the holder's comm in LOCKSTEP with each scan attempt, and
+    // only skip when no attempt ever ran against a classifiable holder.
+    //
+    // `ps -o comm=` on Linux reports the THREAD name, and node renames its main
+    // thread a beat after boot — measured on Node 24 it flips to `MainThread`
+    // within a second, while Node 22 keeps `claude`. That rules out both simpler
+    // gates: sampling BEFORE the scan proves nothing (the value can flip before
+    // the scan reads it), and sampling AFTER `waitFor` exhausts its deadline
+    // proves less than nothing — the poll always burns its full 10s on a miss, by
+    // which point comm has flipped whatever the cause, so a REAL regression in the
+    // RUSH-2384 recovery path would report `skipped` instead of failing. A test
+    // that cannot fail is worse than a deleted one.
+    //
+    // Bracketing each attempt is what makes the distinction sound: if the holder
+    // was classifiable both immediately before and immediately after a scan that
+    // still missed it, the scan owed us that row and the failure is real.
     let rows: Awaited<ReturnType<typeof listUnattributedActive>> = [];
+    let lastComm: string | undefined;
+    let missedWhileClassifiable = false;
     const hit = await waitFor(async () => {
+      const before = commOf();
       clearActiveScanCachesForTest();
       rows = await listUnattributedActive(new Set());
-      return rows.find((r) => r.sessionId === UUID || r.pid === pid);
+      const found = rows.find((r) => r.sessionId === UUID || r.pid === pid);
+      lastComm = commOf();
+      if (!found && classifiable(before) && classifiable(lastComm)) missedWhileClassifiable = true;
+      return found;
     });
 
-    // RUSH-2508: read the holder's comm AFTER the scan, not before. `ps -o comm=`
-    // on Linux reports the THREAD name, and node renames its main thread a beat
-    // after boot — measured on Node 24 it flips to `MainThread` within a second,
-    // while Node 22 keeps `claude`. Sampling before the scan therefore proves
-    // nothing: the value can be `claude` at the check and `MainThread` by the
-    // time the scan reads it, which is exactly how `build (ubuntu-latest, 24)`
-    // failed with an EMPTY row set while ubuntu-22, macOS and Windows passed. If
-    // the holder is no longer classifiable, the scan is right to omit it and
-    // there is nothing left for this case to assert.
-    if (!hit && !classifiable(commOf())) {
-      ctx.skip(`ps reports comm='${commOf() ?? '<unreadable>'}' for the holder, not an agent name — see RUSH-2508`);
+    if (!hit && !missedWhileClassifiable) {
+      ctx.skip(`ps reports comm='${lastComm ?? '<unreadable>'}' for the holder, not an agent name — see RUSH-2508`);
       return;
     }
     expect(hit, `expected active row for ${UUID} / pid ${pid}; got ${rows.map((r) => `${r.pid}:${r.sessionId}`).join(', ')}`).toBeDefined();

--- a/apps/cli/src/lib/session/active.live-session-id.test.ts
+++ b/apps/cli/src/lib/session/active.live-session-id.test.ts
@@ -158,9 +158,18 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
     // RUSH-2384 recovery path would report `skipped` instead of failing. A test
     // that cannot fail is worse than a deleted one.
     //
-    // Bracketing each attempt is what makes the distinction sound: if the holder
-    // was classifiable both immediately before and immediately after a scan that
-    // still missed it, the scan owed us that row and the failure is real.
+    // Bracketing each attempt is what recovers the distinction WHERE COMM STAYS
+    // USABLE: if the holder was classifiable both immediately before and
+    // immediately after a scan that still missed it, the scan owed us that row
+    // and the failure is real. Verified by sabotaging the row predicate — Node 22
+    // fails, as it must.
+    //
+    // It does NOT recover the distinction on Node 24, where comm has already
+    // flipped before any scan can run: a correct implementation and a completely
+    // broken one both produce `1 skipped` there, byte-identical. So this case
+    // carries real Node-24 coverage only once RUSH-2508 gives the holder a name
+    // the scan can rely on; until then it is honest about skipping rather than
+    // failing a leg it cannot judge.
     let rows: Awaited<ReturnType<typeof listUnattributedActive>> = [];
     let lastComm: string | undefined;
     let missedWhileClassifiable = false;


### PR DESCRIPTION
**test-only** — follow-up to #2529, which did not actually fix `build (ubuntu-latest, 24)`. The 1.22.36 release branch failed on it again with the identical empty row set.

## Why the first fix missed

#2529 sampled `ps -o comm=` **before** the scan. That proves nothing: node renames its main thread a beat after boot, so the value reads `claude` at the check and `MainThread` by the time the scan reads it. The gate let the case through, the scan correctly omitted a holder it could no longer classify, and the assertion failed as before.

Reading comm once **after** `waitFor` is worse, and review caught it: the poll always burns its full 10s on a miss, and the rename happens within a second — so comm has flipped whatever the cause, and a genuine regression in the RUSH-2384 recovery path would report `skipped` instead of failing. A test that cannot fail.

## The mechanism that shipped

Each scan attempt is **bracketed** by a comm sample inside the probe. The case skips only when no attempt ever ran against a classifiable holder:

| Scan result | Holder comm around that attempt | Outcome |
|---|---|---|
| row found | — | assert as before |
| no row | classifiable before **and** after | **fail** — the scan owed us that row |
| no row | not an agent name | skip, naming the observed comm and RUSH-2508 |

## Run result

Sabotaging the row predicate to `rows.find((r) => r.pid === -1)` to simulate a regression, Node 22:

```
Tests  1 failed | 4 passed (5)
AssertionError: expected active row for f0f6cb6b-… / pid 2108009; got …,
  2108009:f0f6cb6b-3887-4f96-927e-8a929f3da418, …
```

The holder is present in the dumped rows — the scan found it; only the sabotage hid it, and the test caught that. Unsabotaged:

```
node v24.11.1  →  Tests  4 passed | 1 skipped (5)
node v22.23.1  →  Tests  5 passed (5)
```

The reviewer reproduced all of this independently in the PR worktree.

## Disclosed limitation

On Node 24 the rename beats every scan, so a correct implementation and a completely broken one both produce `1 skipped` — byte-identical output, confirmed by the reviewer running sabotaged and unsabotaged. This case therefore carries **no real Node-24 coverage** until **RUSH-2508** gives the holder a name the scan can rely on. That caveat is in the in-file comment, not only here. `main` had no reliable Node-24 coverage of it either, plus a false failure that broke the release matrix — which this removes.
