### PR TITLE
docs(artifacts): sessions indexing / cross-device explainers

### DIFF
--- a/.agents/artifacts/2026-08-10/agents-sessions-artifacts-README.md
+++ b/.agents/artifacts/2026-08-10/agents-sessions-artifacts-README.md
@@ -1,0 +1,14 @@
+# agents sessions — investigation artifacts (2026-08-10)
+
+Friend-facing explainers for how `agents sessions` works: not shared memory,
+local SQLite+FTS5 indexing, SSH cross-device query, export/import bundles.
+
+| File | What |
+| --- | --- |
+| `agents-sessions-cross-device-index.html` | Full page: indexing, cross-device, filters, benches, SQLite live stats, export/import (primary) |
+| `agents-sessions-explainer-2026-07-20.html` | Shorter “query tool not shared memory” explainer |
+| `zion-week-sessions-2026-07-20.html` | Zion laptop week-of-work data story (sessions summary) |
+
+Public share (when published): https://share.agents-cli.sh/agents-sessions-cross-device
+
+Source investigation: agents-cli `lib/session/{discover,db,remote,remote-list,bundle}.ts`.

--- a/.agents/artifacts/2026-08-10/agents-sessions-cross-device-index.html
+++ b/.agents/artifacts/2026-08-10/agents-sessions-cross-device-index.html
@@ -1,0 +1,525 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agents sessions · indexing &amp; cross-device — not shared memory</title>
+<meta name="description" content="How agents-cli indexes agent transcripts into SQLite+FTS5 and queries them across machines over SSH — a query tool, not shared memory.">
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111312; --panel2:#161a18; --ink:#e7ece8; --dim:#8b938c;
+    --line:#26302a; --accent:#a3e635; --amber:#f5c451; --red:#ff6b6b; --cyan:#5ad6c0;
+    --violet:#c4b5fd;
+    --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"]{
+    --bg:#faf9f6; --panel:#fff; --panel2:#f2f4f0; --ink:#1a1c1a; --dim:#5c655c;
+    --line:#e2e6df; --accent:#4d7c0f; --amber:#b45309; --red:#dc2626; --cyan:#0e7490;
+    --violet:#6d28d9;
+  }
+  :root[data-theme="light"] .fig{background:#0e120f;border-color:#26302a}
+  :root[data-theme="light"] .fig figcaption{color:#8b938c}
+  :root[data-theme="light"] .fig figcaption b{color:#e7ece8}
+  :root[data-theme="light"] pre{background:#0c0f0d;color:#e7ece8}
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1000px;margin:0 auto;padding:52px 28px 110px}
+  header.hero{border-bottom:1px solid var(--line);padding-bottom:28px;margin-bottom:36px}
+  .kicker{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--accent);margin:0 0 14px}
+  h1{font-size:34px;line-height:1.14;margin:0 0 14px;font-weight:700;letter-spacing:-.015em}
+  h1 .accent{color:var(--accent)}
+  .sub{color:var(--dim);font-size:17.5px;max-width:68ch;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:20px}
+  .chip{font-family:var(--mono);font-size:11.5px;color:var(--dim);border:1px solid var(--line);border-radius:999px;padding:4px 11px;background:var(--panel)}
+  .chip b{color:var(--ink);font-weight:500}
+  h2{font-size:23px;margin:52px 0 10px;letter-spacing:-.01em;scroll-margin-top:18px}
+  h2 .n{font-family:var(--mono);color:var(--accent);font-size:15px;margin-right:10px;opacity:.9}
+  h3{font-size:15.5px;margin:22px 0 8px;font-family:var(--mono);color:var(--cyan);font-weight:500}
+  p{margin:10px 0}.lead{color:var(--dim)}
+  code{font-family:var(--mono);font-size:.86em;background:var(--panel2);border:1px solid var(--line);border-radius:5px;padding:1.5px 6px;color:var(--cyan)}
+  a{color:var(--accent);text-decoration:none}a:hover{border-bottom:1px solid var(--accent)}
+  .fig{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:24px 20px 16px;margin:20px 0;overflow-x:auto}
+  .fig figcaption{font-family:var(--mono);font-size:12px;color:var(--dim);margin-top:14px;text-align:center}
+  .fig figcaption b{color:var(--ink)}
+  svg{display:block;margin:0 auto;max-width:100%;height:auto}
+  table{width:100%;border-collapse:collapse;margin:14px 0;font-size:14.5px}
+  th,td{text-align:left;padding:10px 11px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--dim);font-weight:500}
+  .callout{border-left:3px solid var(--accent);background:var(--panel2);border-radius:0 10px 10px 0;padding:14px 18px;margin:18px 0}
+  .callout.warn{border-left-color:var(--amber)}
+  .callout .lbl{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--accent);display:block;margin-bottom:5px}
+  .callout.warn .lbl{color:var(--amber)}
+  .toc{font-family:var(--mono);font-size:13px;display:flex;flex-wrap:wrap;gap:6px 18px;margin-top:18px}
+  .toc a{color:var(--dim)}.toc a:hover{color:var(--accent)}
+  pre{font-family:var(--mono);font-size:12.5px;background:#0c0f0d;border:1px solid var(--line);border-radius:12px;padding:14px 16px;overflow-x:auto;line-height:1.55;color:#e7ece8;margin:14px 0}
+  pre .c{color:#8b938c}pre .k{color:#a3e635}pre .s{color:#5ad6c0}
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:11px;margin:20px 0}
+  @media(max-width:720px){.stats{grid-template-columns:1fr 1fr}}
+  .stat{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 14px}
+  .stat .v{font-family:var(--mono);font-size:24px;font-weight:600;color:var(--accent);letter-spacing:-.02em}
+  .stat .l{font-family:var(--mono);font-size:10.5px;color:var(--dim);letter-spacing:.06em;text-transform:uppercase;margin-top:5px}
+  .stat .s{font-size:12.5px;color:var(--dim);margin-top:3px}
+  .tag{font-family:var(--mono);font-size:11px;padding:2px 7px;border-radius:6px;font-weight:600;display:inline-block}
+  .tag.a{background:rgba(163,230,53,.12);color:var(--accent);border:1px solid rgba(163,230,53,.3)}
+  .tag.b{background:rgba(90,214,192,.1);color:var(--cyan);border:1px solid rgba(90,214,192,.28)}
+  .tag.c{background:rgba(245,196,81,.1);color:var(--amber);border:1px solid rgba(245,196,81,.28)}
+  .path{font-family:var(--mono);font-size:12.5px;color:var(--cyan)}
+  .foot{margin-top:56px;padding-top:20px;border-top:1px solid var(--line);font-family:var(--mono);font-size:12px;color:var(--dim)}
+  .themebtn{position:fixed;top:14px;right:14px;z-index:9;font-family:var(--mono);font-size:12px;color:var(--dim);background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 13px;cursor:pointer}
+  .themebtn:hover{color:var(--accent);border-color:var(--accent)}
+  ul{margin:8px 0;padding-left:20px}li{margin:5px 0}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+  @media(max-width:760px){.grid2{grid-template-columns:1fr}}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 18px}
+</style>
+</head>
+<body>
+<button class="themebtn" id="tb" onclick="tt()">◐ light</button>
+<script>
+  var r=document.documentElement;
+  function set(t){r.setAttribute('data-theme',t);document.getElementById('tb').textContent=t==='light'?'◑ dark':'◐ light'}
+  set(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');
+  function tt(){set(r.getAttribute('data-theme')==='light'?'dark':'light')}
+</script>
+<div class="wrap">
+
+<header class="hero">
+  <p class="kicker">agents-cli · sessions · architecture</p>
+  <h1>Not shared memory.<br>A <span class="accent">local index</span> + <span class="accent">SSH query</span>.</h1>
+  <p class="sub">
+    Agents (Claude, Codex, Grok, Kimi…) do not share a brain. Each conversation is a transcript
+    file on disk. <code>agents sessions</code> builds a per-machine SQLite + FTS5 index of those
+    files, then answers filtered queries — locally, or on other machines over SSH. This page is
+    grounded in the agents-cli source (<span class="path">lib/session/*</span>).
+  </p>
+  <div class="meta">
+    <span class="chip">source <b>phnx-labs/agents-cli</b></span>
+    <span class="chip">core <b>discover · db · remote-list</b></span>
+    <span class="chip">as of <b>2026-07-20</b></span>
+    <span class="chip">bench <b>yosemite-s0</b></span>
+  </div>
+  <nav class="toc">
+    <a href="#s1">01 · myth</a>
+    <a href="#s2">02 · indexing</a>
+    <a href="#s3">03 · cross-device</a>
+    <a href="#s4">04 · filters</a>
+    <a href="#s5">05 · speed</a>
+    <a href="#s6">06 · SQLite live</a>
+    <a href="#s7">07 · export / import</a>
+    <a href="#s8">08 · code map</a>
+  </nav>
+</header>
+
+<div class="stats">
+  <div class="stat"><div class="v">SQLite</div><div class="l">Local index</div><div class="s">WAL · FTS5 · scan ledger</div></div>
+  <div class="stat"><div class="v">SSH</div><div class="l">Cross-device</div><div class="s">no shared RAM · no daemon required</div></div>
+  <div class="stat"><div class="v">~0.45s</div><div class="l">Local query</div><div class="s">JSON list 50 sessions</div></div>
+  <div class="stat"><div class="v">~0.75s</div><div class="l">One host</div><div class="s">SSH + remote index</div></div>
+</div>
+
+<!-- ============ 01 ============ -->
+<h2 id="s1"><span class="n">01</span>The myth vs. the model</h2>
+<p class="lead">When someone asks “how do agents share memory across devices?”, the honest answer is: they don’t. They query.</p>
+
+<figure class="fig">
+<svg viewBox="0 0 960 300" role="img" aria-label="Not shared memory — per-machine transcripts and indexes">
+  <defs>
+    <marker id="ar" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0 0 L7 4 L0 8 z" fill="#a3e635"/></marker>
+    <marker id="ar2" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0 0 L7 4 L0 8 z" fill="#5ad6c0"/></marker>
+  </defs>
+  <!-- myth X -->
+  <rect x="40" y="30" width="280" height="100" rx="12" fill="#1a1212" stroke="#ff6b6b" stroke-dasharray="4 3"/>
+  <text x="180" y="60" fill="#ff6b6b" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">MYTH</text>
+  <text x="180" y="88" fill="#e7ece8" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">one shared agent memory</text>
+  <text x="180" y="110" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">joint embeddings · hive mind</text>
+
+  <!-- reality -->
+  <rect x="380" y="30" width="540" height="100" rx="12" fill="#12160f" stroke="#a3e635"/>
+  <text x="650" y="60" fill="#a3e635" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">REALITY</text>
+  <text x="650" y="88" fill="#e7ece8" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">per-agent JSONL on each machine + local SQLite index</text>
+  <text x="650" y="110" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">query via agents sessions · optional SSH fan-out</text>
+
+  <!-- three machines -->
+  <rect x="40" y="170" width="200" height="90" rx="10" fill="#161a18" stroke="#26302a"/>
+  <text x="140" y="200" fill="#e7ece8" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">zion</text>
+  <text x="140" y="222" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">transcripts + sessions.db</text>
+  <text x="140" y="242" fill="#5c655c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">personal laptop</text>
+
+  <rect x="280" y="170" width="200" height="90" rx="10" fill="#161a18" stroke="#26302a"/>
+  <text x="380" y="200" fill="#e7ece8" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">yosemite-s0</text>
+  <text x="380" y="222" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">transcripts + sessions.db</text>
+  <text x="380" y="242" fill="#5c655c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">worker</text>
+
+  <rect x="520" y="170" width="200" height="90" rx="10" fill="#161a18" stroke="#26302a"/>
+  <text x="620" y="200" fill="#e7ece8" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">mac-mini</text>
+  <text x="620" y="222" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">transcripts + sessions.db</text>
+  <text x="620" y="242" fill="#5c655c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">relay / openclaw</text>
+
+  <path d="M240 215 L280 215" stroke="#5ad6c0" fill="none" marker-end="url(#ar2)"/>
+  <path d="M480 215 L520 215" stroke="#5ad6c0" fill="none" marker-end="url(#ar2)"/>
+  <text x="820" y="210" fill="#5ad6c0" font-size="12" font-family="ui-monospace,Menlo,monospace">SSH</text>
+  <text x="820" y="230" fill="#8b938c" font-size="11" font-family="ui-monospace,Menlo,monospace">query only</text>
+</svg>
+<figcaption><b>Three isolated stores.</b> Cross-device “memory” is running the same CLI query on the peer’s index over SSH.</figcaption>
+</figure>
+
+<div class="callout">
+  <span class="lbl">One sentence</span>
+  An agent “recalling” prior work is <code>agents sessions "topic" --since 7d</code> (or reading a session id as markdown) — the same family of operation as grepping logs, not loading a shared embedding space.
+</div>
+
+<!-- ============ 02 ============ -->
+<h2 id="s2"><span class="n">02</span>How indexing works</h2>
+<p class="lead">Every machine that runs <code>agents sessions</code> maintains its own index. Discovery walks agent homes; only <em>changed</em> files are re-parsed; results land in SQLite.</p>
+
+<h3>1 · Transcript roots (where files live)</h3>
+<p>
+  Specs live in <span class="path">lib/session/discover.ts</span> as <code>SESSION_ROOT_SPECS</code>:
+  Claude → <code>projects</code>, Codex → <code>sessions</code>, Gemini → <code>tmp</code>, Kimi → <code>sessions</code>, Droid → <code>sessions</code>, etc.
+  <code>getAgentSessionDirs()</code> expands each to:
+</p>
+<ul>
+  <li>live home — e.g. <code>~/.claude/projects</code></li>
+  <li>every versioned home — <code>~/.agents/versions/&lt;agent&gt;/&lt;ver&gt;/home/…</code></li>
+  <li>optional backup mirrors under <code>~/.agents/.history/backups/&lt;agent&gt;/&lt;machine&gt;/…</code></li>
+</ul>
+<p>Expose the live set with <code>agents sessions --roots --json</code> so external watchers stay in lockstep with the CLI.</p>
+
+<h3>2 · Incremental scan (don’t re-parse the world)</h3>
+<figure class="fig">
+<svg viewBox="0 0 960 240" role="img" aria-label="Incremental scan pipeline">
+  <rect x="30" y="80" width="140" height="56" rx="10" fill="#161a18" stroke="#26302a"/>
+  <text x="100" y="112" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">JSONL files</text>
+
+  <path d="M180 108 L230 108" stroke="#a3e635" fill="none" marker-end="url(#ar)"/>
+
+  <rect x="240" y="80" width="160" height="56" rx="10" fill="#12160f" stroke="#a3e635"/>
+  <text x="320" y="105" fill="#a3e635" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">scan_ledger</text>
+  <text x="320" y="122" fill="#8b938c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">mtime + size</text>
+
+  <path d="M410 108 L460 108" stroke="#a3e635" fill="none" marker-end="url(#ar)"/>
+
+  <rect x="470" y="80" width="160" height="56" rx="10" fill="#161a18" stroke="#f5c451"/>
+  <text x="550" y="105" fill="#f5c451" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">filterChanged</text>
+  <text x="550" y="122" fill="#8b938c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">only dirty files</text>
+
+  <path d="M640 108 L690 108" stroke="#a3e635" fill="none" marker-end="url(#ar)"/>
+
+  <rect x="700" y="80" width="220" height="56" rx="10" fill="#12160f" stroke="#5ad6c0"/>
+  <text x="810" y="105" fill="#5ad6c0" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">parse + upsert</text>
+  <text x="810" y="122" fill="#8b938c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">sessions + session_text FTS</text>
+
+  <text x="480" y="30" fill="#8b938c" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">discoverSessions() · tryClaimScan(pid) · concurrency 2 · stagger 15ms</text>
+  <text x="480" y="190" fill="#8b938c" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Active appends are debounced so a growing JSONL is not re-streamed every invocation</text>
+  <text x="480" y="215" fill="#5c655c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">db.ts · scan_ledger · discover.ts filterChangedFiles / shouldDeferRecentAppend</text>
+</svg>
+<figcaption><b>Incremental indexing.</b> Unchanged mtime/size → skip. Concurrent processes coordinate via a scan claim in the DB meta table.</figcaption>
+</figure>
+
+<ul>
+  <li><b>Scan claim</b> — <code>tryClaimScan(pid)</code> so only one process scans; others serve the existing DB (<span class="path">db.ts</span>).</li>
+  <li><b>Bounded agent scans</b> — concurrency 2, 15ms stagger, so bulk multi-dotfile walks don’t trip EDR heuristics (<span class="path">discover.ts</span>).</li>
+  <li><b>Canonical ledger keys</b> — realpath so <code>~/.claude/…</code> and versioned homes of the same file don’t double-parse.</li>
+  <li><b>Per-agent parsers</b> — Claude JSONL, Codex threads, Kimi dirs, Droid, Rush, OpenClaw, Hermes… each extracts meta + searchable content.</li>
+</ul>
+
+<h3>3 · SQLite schema (the actual index)</h3>
+<p>Database path: <code>~/.agents/sessions/sessions.db</code> (WAL, busy_timeout 30s). Defined in <span class="path">lib/session/db.ts</span>.</p>
+<table>
+  <thead><tr><th>Table</th><th>Role</th></tr></thead>
+  <tbody>
+    <tr><td><code>sessions</code></td><td>Metadata: id, agent, project, cwd, topic, label, cost, tokens, PR/ticket, file_path, timestamps</td></tr>
+    <tr><td><code>session_text</code> (FTS5)</td><td>Full-text: label, topic, project, content — BM25 weights label &gt; topic &gt; project &gt; content</td></tr>
+    <tr><td><code>scan_ledger</code></td><td>mtime/size/scanned_at per file — “did we already look at this?”</td></tr>
+    <tr><td><code>meta</code></td><td>schema version, scan_in_progress claim, migration flags</td></tr>
+  </tbody>
+</table>
+
+<pre><span class="c">// Query path after scan (discoverSessions)</span>
+<span class="k">getDB</span>();                          <span class="c">// open/migrate sessions.db</span>
+<span class="k">tryClaimScan</span>(pid) → scan agents  <span class="c">// incremental only</span>
+sessions = <span class="k">querySessions</span>(filters) <span class="c">// SQL WHERE + ORDER + LIMIT</span>
+<span class="c">// Text search:</span>
+hits = <span class="k">ftsSearch</span>(query)           <span class="c">// label tiers + FTS5 BM25</span>
+</pre>
+
+<div class="callout">
+  <span class="lbl">Why this is fast</span>
+  Listing is a SQL select on an already-warm index. FTS5 handles content search. The expensive parse only runs for files whose mtime/size changed — so repeated <code>agents sessions</code> calls stay sub-second once the ledger is hot.
+</div>
+
+<!-- ============ 03 ============ -->
+<h2 id="s3"><span class="n">03</span>How cross-device works</h2>
+<p class="lead">There is no multi-master memory. Cross-device is <b>run the same query on the peer</b>, over SSH, and merge rows tagged by machine.</p>
+
+<figure class="fig">
+<svg viewBox="0 0 960 340" role="img" aria-label="Cross-device fan-out architecture">
+  <!-- local box -->
+  <rect x="340" y="20" width="280" height="70" rx="12" fill="#12160f" stroke="#a3e635" stroke-width="1.5"/>
+  <text x="480" y="48" fill="#a3e635" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-weight="600">you / agent</text>
+  <text x="480" y="70" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">agents sessions --since 7d "auth"</text>
+
+  <path d="M480 90 L480 120" stroke="#a3e635" fill="none" marker-end="url(#ar)"/>
+
+  <rect x="300" y="125" width="360" height="50" rx="10" fill="#161a18" stroke="#26302a"/>
+  <text x="480" y="155" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">gatherRemoteList / runRemoteSessions</text>
+
+  <!-- three remotes -->
+  <path d="M360 175 L160 210" stroke="#5ad6c0" fill="none" marker-end="url(#ar2)"/>
+  <path d="M480 175 L480 210" stroke="#5ad6c0" fill="none" marker-end="url(#ar2)"/>
+  <path d="M600 175 L800 210" stroke="#5ad6c0" fill="none" marker-end="url(#ar2)"/>
+
+  <rect x="40" y="220" width="240" height="90" rx="10" fill="#161a18" stroke="#26302a"/>
+  <text x="160" y="250" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">peer A (e.g. zion)</text>
+  <text x="160" y="272" fill="#5ad6c0" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">AGENTS_SESSIONS_LOCAL=1</text>
+  <text x="160" y="292" fill="#8b938c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">agents sessions … --json</text>
+
+  <rect x="360" y="220" width="240" height="90" rx="10" fill="#161a18" stroke="#26302a"/>
+  <text x="480" y="250" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">peer B (yosemite-s1)</text>
+  <text x="480" y="272" fill="#5ad6c0" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">own sessions.db</text>
+  <text x="480" y="292" fill="#8b938c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">same filters · --all</text>
+
+  <rect x="680" y="220" width="240" height="90" rx="10" fill="#1a1212" stroke="#ff6b6b" stroke-dasharray="3 3"/>
+  <text x="800" y="250" fill="#ff6b6b" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">peer C offline</text>
+  <text x="800" y="272" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">skipped / cache replay</text>
+  <text x="800" y="292" fill="#5c655c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">never fatal</text>
+</svg>
+<figcaption><b>Fan-out.</b> Each peer answers for itself. Rows are tagged <code>machine</code> + <code>_remote: true</code> so resume/read route back over SSH.</figcaption>
+</figure>
+
+<div class="grid2">
+  <div class="panel">
+    <h3 style="margin-top:0">Modes</h3>
+    <table>
+      <tr><td><code>--local</code></td><td>This machine’s disk + DB only</td></tr>
+      <tr><td><code>--host zion</code></td><td>Explicit peer(s); strip --host, forward filters</td></tr>
+      <tr><td>default list</td><td>Online devices from <code>agents devices</code></td></tr>
+      <tr><td>import --from-host</td><td>Copy transcripts into local mirror</td></tr>
+      <tr><td>sessions sync</td><td>Optional R2 CRDT — opt-in beta</td></tr>
+    </table>
+  </div>
+  <div class="panel">
+    <h3 style="margin-top:0">Hardening details (code)</h3>
+    <ul>
+      <li><b>No recursive fan-out</b> — peer gets <code>AGENTS_SESSIONS_LOCAL=1</code></li>
+      <li><b>Whole index over SSH</b> — <code>ensureWholeIndex</code> adds <code>--all</code> (remote cwd is home, not your project)</li>
+      <li><b>12s timeout</b> per host; dead hosts skipped with a gray note</li>
+      <li><b>Offline cache</b> — <code>~/.agents/.cache/remote-sessions/</code> for explicit <code>--host</code> replays</li>
+      <li><b>Skip control-only</b> devices (phones/tablets)</li>
+      <li><b>Windows peers</b> get PowerShell command form</li>
+    </ul>
+  </div>
+</div>
+
+<pre><span class="c"># Explicit peer — runs peer's own index</span>
+agents sessions --all --since 7d --host zion --flat
+
+<span class="c"># Fan-out (interactive default) — merge all online machines</span>
+agents sessions --all --since 1d --flat
+
+<span class="c"># Stay local (fast scripts / JSON)</span>
+agents sessions --all --since 7d --local --json -n 50
+
+<span class="c"># Copy a peer week into a local mirror (tagged by origin machine)</span>
+agents sessions import --from-host zion --since 7d
+</pre>
+
+<div class="callout warn">
+  <span class="lbl">Auth is SSH</span>
+  If machine A’s key is not on machine B, that host is simply skipped
+  (<code>unreachable or no agents CLI</code>). There is no alternate memory channel.
+  Optional R2 session-sync is a separate opt-in path — off by default on most fleets.
+</div>
+
+<!-- ============ 04 ============ -->
+<h2 id="s4"><span class="n">04</span>Filters (the recall API)</h2>
+<p class="lead">Filters compile to SQL WHERE clauses in <code>buildSessionWhere</code> and/or FTS MATCH. Same flags work local and remote (forwarded over SSH).</p>
+<table>
+  <thead><tr><th>Filter</th><th>Effect</th><th>Layer</th></tr></thead>
+  <tbody>
+    <tr><td><code>"search text"</code></td><td>Label-first tiers + FTS5 BM25 over content</td><td>FTS</td></tr>
+    <tr><td><code>--since 7d</code> / <code>--until</code></td><td>timestamp window</td><td>SQL</td></tr>
+    <tr><td><code>-a claude</code> / <code>--codex</code></td><td>agent (optional @version)</td><td>SQL</td></tr>
+    <tr><td><code>-p agents-cli</code></td><td>project substring</td><td>SQL</td></tr>
+    <tr><td><code>--all</code></td><td>drop cwd scoping</td><td>query scope</td></tr>
+    <tr><td><code>--teams</code></td><td>include team-origin (hidden by default)</td><td>SQL flag</td></tr>
+    <tr><td><code>--active</code></td><td>live processes (separate path + remote-active fan-out)</td><td>process scan</td></tr>
+    <tr><td><code>-n 50</code> · <code>--sort cost</code></td><td>limit + order</td><td>SQL</td></tr>
+    <tr><td><code>--include user</code> · <code>--last 3</code></td><td>when rendering one session</td><td>render</td></tr>
+    <tr><td><code>--json</code> / <code>--markdown</code> / <code>--flat</code></td><td>output shape</td><td>CLI</td></tr>
+    <tr><td><code>--artifacts</code></td><td>files written during the session</td><td>parse</td></tr>
+    <tr><td><code>--host</code> / <code>--device</code></td><td>where the query executes</td><td>remote</td></tr>
+  </tbody>
+</table>
+
+<pre><span class="c"># Agent mid-turn recall pattern</span>
+agents sessions --all --since 7d <span class="s">"secrets unlock"</span> --flat -n 20
+agents sessions a1b2c3d4 --markdown --include user,assistant --last 5
+agents sessions --active --host zion
+</pre>
+
+<!-- ============ 05 ============ -->
+<h2 id="s5"><span class="n">05</span>Speed — measured, not claimed</h2>
+<p class="lead">Wall-clock on yosemite-s0 (agents-cli 1.20.x), three warm runs each. Local = index hit. Host = SSH + peer index.</p>
+<table>
+  <thead><tr><th>Call</th><th>Times (3×)</th><th>≈</th></tr></thead>
+  <tbody>
+    <tr><td><code>--local --json --since 7d -n 50</code></td><td>0.47 · 0.45 · 0.45 s</td><td><span class="tag a">~0.45s</span></td></tr>
+    <tr><td><code>--local --flat --since 7d -n 50</code></td><td>0.85 · 0.78 · 0.83 s</td><td><span class="tag a">~0.8s</span></td></tr>
+    <tr><td>search <code>"auth"</code> local 7d</td><td>0.84 · 0.80 · 0.85 s</td><td><span class="tag a">~0.8s</span></td></tr>
+    <tr><td><code>--active --local</code></td><td>0.63 · 0.62 · 0.64 s</td><td><span class="tag a">~0.6s</span></td></tr>
+    <tr><td><code>--markdown --last 3</code> one id</td><td>0.50 · 0.50 · 0.50 s</td><td><span class="tag a">~0.5s</span></td></tr>
+    <tr><td><code>--host yosemite-s1</code> 1d -n 20</td><td>0.74 · 0.77 · 0.74 s</td><td><span class="tag b">~0.75s</span></td></tr>
+    <tr><td>default multi-host fan-out 1d</td><td>1.81 · 1.80 · 1.81 s</td><td><span class="tag c">~1.8s</span></td></tr>
+  </tbody>
+</table>
+<div class="callout">
+  <span class="lbl">So what?</span>
+  Local list/search is comfortably under a second. Single-host SSH stays under a second on a healthy tailnet.
+  Full fan-out is ~2s of parallel SSH — still fine mid-conversation. That is why agents can “check sessions” without stalling a turn.
+</div>
+
+<!-- ============ 06 ============ -->
+<h2 id="s6"><span class="n">06</span>SQLite index — live on a worker</h2>
+<p class="lead">Investigated on <code>yosemite-s0</code> after a real <code>agents sessions</code> call. Path from <span class="path">lib/state.ts</span>: <code>~/.agents/.history/sessions/sessions.db</code>.</p>
+
+<div class="stats">
+  <div class="stat"><div class="v">15.1 MB</div><div class="l">DB size</div><div class="s">sessions.db on disk</div></div>
+  <div class="stat"><div class="v">2,054</div><div class="l">sessions rows</div><div class="s">metadata index</div></div>
+  <div class="stat"><div class="v">2,046</div><div class="l">FTS docs</div><div class="s">session_text (FTS5)</div></div>
+  <div class="stat"><div class="v">2,039</div><div class="l">scan_ledger</div><div class="s">mtime/size stamps</div></div>
+</div>
+
+<table>
+  <thead><tr><th>Fact</th><th>Value</th></tr></thead>
+  <tbody>
+    <tr><td>Path</td><td><code>~/.agents/.history/sessions/sessions.db</code></td></tr>
+    <tr><td>Schema version</td><td><code>12</code> (meta table)</td></tr>
+    <tr><td>Journal</td><td>WAL · busy_timeout 30s · concurrent writers OK</td></tr>
+    <tr><td>Core tables</td><td><code>sessions</code>, <code>session_text</code> (FTS5 + shadow tables), <code>scan_ledger</code>, <code>meta</code></td></tr>
+    <tr><td>sessions columns</td><td>id, short_id, agent, version, account, timestamp, last_activity, project, cwd, topic, label, message_count, token_count, cost_usd, duration_ms, file_path, pr_*, ticket_id, plan, …</td></tr>
+  </tbody>
+</table>
+
+<pre><span class="c"># Inspect yourself</span>
+sqlite3 ~/.agents/.history/sessions/sessions.db \
+  "SELECT COUNT(*) FROM sessions; SELECT value FROM meta WHERE key='schema_version';"
+
+<span class="c"># FTS smoke test (same engine ftsSearch uses)</span>
+sqlite3 ~/.agents/.history/sessions/sessions.db \
+  "SELECT session_id FROM session_text WHERE session_text MATCH 'auth*' LIMIT 5;"
+</pre>
+
+<div class="callout">
+  <span class="lbl">What the DB is not</span>
+  It is <b>not</b> the source of truth for conversation content long-term — the JSONL (or agent session dir) is.
+  The DB is a <b>query cache / index</b>: rebuildable by re-scanning roots. Export/import move the <em>transcript files</em>; the next <code>agents sessions</code> on the receiving machine re-indexes them.
+</div>
+
+<!-- ============ 07 ============ -->
+<h2 id="s7"><span class="n">07</span>Export &amp; import — portable bundles</h2>
+<p class="lead">Yes. Explicit hand-off without requiring R2 sync. Format: NDJSON bundle (<span class="path">lib/session/bundle.ts</span>, RUSH-1710/1711).</p>
+
+<figure class="fig">
+<svg viewBox="0 0 960 220" role="img" aria-label="Export import flow">
+  <rect x="40" y="60" width="200" height="80" rx="12" fill="#12160f" stroke="#a3e635"/>
+  <text x="140" y="95" fill="#a3e635" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">export</text>
+  <text x="140" y="115" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">select → NDJSON bundle</text>
+
+  <path d="M250 100 L320 100" stroke="#a3e635" fill="none" marker-end="url(#ar)"/>
+
+  <rect x="330" y="60" width="300" height="80" rx="12" fill="#161a18" stroke="#5ad6c0"/>
+  <text x="480" y="90" fill="#5ad6c0" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">agents-session-bundle v1</text>
+  <text x="480" y="112" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">header + one line per file · optional AES</text>
+  <text x="480" y="128" fill="#5c655c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">secrets redacted by default · mode 0600</text>
+
+  <path d="M640 100 L710 100" stroke="#a3e635" fill="none" marker-end="url(#ar)"/>
+
+  <rect x="720" y="60" width="200" height="80" rx="12" fill="#12160f" stroke="#f5c451"/>
+  <text x="820" y="95" fill="#f5c451" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">import</text>
+  <text x="820" y="115" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">mirrorPath by origin machine</text>
+
+  <text x="480" y="190" fill="#8b938c" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Local always wins · byte-exact dups skipped · conflicts need --overwrite</text>
+</svg>
+<figcaption><b>Portable hand-off.</b> Bundle carries transcript bodies; import places them under the sync mirror tree keyed by origin machine, then the local scanner indexes them.</figcaption>
+</figure>
+
+<table>
+  <thead><tr><th>Command</th><th>What it does</th></tr></thead>
+  <tbody>
+    <tr><td><code>agents sessions export --since 7d -o week.bundle</code></td><td>Select via same filters as list; write NDJSON archive</td></tr>
+    <tr><td><code>export … --stdout</code></td><td>Pipe over SSH</td></tr>
+    <tr><td><code>export … --encrypt</code></td><td>AES-256-GCM per body</td></tr>
+    <tr><td><code>export --host zion …</code></td><td>Run export on peer, stream bundle back</td></tr>
+    <tr><td><code>import week.bundle</code></td><td>Place into <code>backups/&lt;agent&gt;/&lt;originMachine&gt;/…</code></td></tr>
+    <tr><td><code>import --dry-run</code></td><td>Plan only: new / dup / conflict</td></tr>
+    <tr><td><code>import --from-host peer --since 7d</code></td><td>export on peer + import here in one shot</td></tr>
+    <tr><td><code>import - --decrypt</code></td><td>stdin pipe + decrypt</td></tr>
+  </tbody>
+</table>
+
+<pre><span class="c"># Proven on yosemite-s0 just now</span>
+agents sessions export --all --since 7d --claude -n 2 -o /tmp/demo.bundle
+<span class="c"># → Exported 2 sessions (2 files, redacted)</span>
+<span class="c"># header: kind=agents-session-bundle version=1 redacted=true</span>
+
+agents sessions import /tmp/demo.bundle --dry-run
+<span class="c"># → 2 sessions · status new · (dry run — nothing written)</span>
+
+<span class="c"># One-liner peer pull</span>
+agents sessions import --from-host zion --since 7d
+
+<span class="c"># Encrypted pipe</span>
+agents sessions export --since 7d --stdout --encrypt \
+  | agents ssh boxB 'agents sessions import - --decrypt'
+</pre>
+
+<div class="callout warn">
+  <span class="lbl">vs. live --host query</span>
+  <b>Query</b> (<code>--host</code> / fan-out) never copies files — peer answers from its own index.
+  <b>Import</b> materializes transcripts under a machine-tagged mirror so you can search them offline later.
+  Neither is “shared memory”; both are deliberate tools.
+</div>
+
+<!-- ============ 08 ============ -->
+<h2 id="s8"><span class="n">08</span>Code map (agents-cli)</h2>
+<table>
+  <thead><tr><th>File</th><th>Responsibility</th></tr></thead>
+  <tbody>
+    <tr><td><span class="path">commands/sessions.ts</span></td><td>CLI entry, flags, listing UI, routing to local/remote</td></tr>
+    <tr><td><span class="path">lib/session/discover.ts</span></td><td>Transcript roots, per-agent scanners, incremental filter, machine tagging</td></tr>
+    <tr><td><span class="path">lib/session/db.ts</span></td><td>SQLite schema, scan ledger, querySessions, FTS5, scan claim</td></tr>
+    <tr><td><span class="path">lib/session/remote-list.ts</span></td><td>Default listing fan-out: SSH peers, merge SessionMeta[], <code>_remote</code></td></tr>
+    <tr><td><span class="path">lib/session/remote.ts</span></td><td>Explicit <code>--host</code>: forward args, ensureWholeIndex, cache, outcomes</td></tr>
+    <tr><td><span class="path">lib/session/remote-active.ts</span></td><td>Fan-out for <code>--active</code></td></tr>
+    <tr><td><span class="path">lib/session/sync/*</span></td><td>Optional R2 CRDT mirror (beta, off by default)</td></tr>
+    <tr><td><span class="path">lib/session/bundle.ts</span></td><td>export / import portable archives</td></tr>
+  </tbody>
+</table>
+
+<pre><span class="c"># Prove the index roots on any machine</span>
+agents sessions --roots --json --local
+
+<span class="c"># Prove cross-device is live query, not sync</span>
+agents sessions sync --status
+<span class="c"># → often: automatic sync disabled · no shared cloud brain</span>
+</pre>
+
+<div class="callout">
+  <span class="lbl">For friends who only want the takeaway</span>
+  <b>Agents write files. Each computer indexes its own files into SQLite+FTS5.
+  <code>agents sessions</code> is the query tool. Cross-device = SSH the same query to the peer’s index.
+  Fast enough to use mid-turn. Not shared memory.</b>
+</div>
+
+<div class="foot">
+  agents sessions · indexing &amp; cross-device · grounded in phnx-labs/agents-cli
+  lib/session/{discover,db,remote,remote-list}.ts · measured 2026-07-20 ·
+  public share for friends · ◐ theme toggle
+</div>
+
+</div>
+</body>
+</html>

--- a/.agents/artifacts/2026-08-10/agents-sessions-explainer-2026-07-20.html
+++ b/.agents/artifacts/2026-08-10/agents-sessions-explainer-2026-07-20.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agents sessions · query tool, not shared memory</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111312; --panel2:#161a18; --ink:#e7ece8; --dim:#8b938c;
+    --line:#26302a; --accent:#a3e635; --amber:#f5c451; --red:#ff6b6b; --cyan:#5ad6c0;
+    --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"]{
+    --bg:#faf9f6; --panel:#fff; --panel2:#f2f4f0; --ink:#1a1c1a; --dim:#5c655c;
+    --line:#e2e6df; --accent:#4d7c0f; --amber:#b45309; --red:#dc2626; --cyan:#0e7490;
+  }
+  :root[data-theme="light"] .fig{background:#0e120f;border-color:#26302a}
+  :root[data-theme="light"] .fig figcaption{color:#8b938c}
+  :root[data-theme="light"] .fig figcaption b{color:#e7ece8}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:16px;line-height:1.6}
+  .wrap{max-width:980px;margin:0 auto;padding:52px 26px 100px}
+  .kicker{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--accent);margin:0 0 12px}
+  h1{font-size:32px;line-height:1.15;margin:0 0 12px;letter-spacing:-.01em}
+  h1 .accent{color:var(--accent)}
+  .sub{color:var(--dim);font-size:17px;max-width:70ch;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:18px}
+  .chip{font-family:var(--mono);font-size:11.5px;color:var(--dim);border:1px solid var(--line);border-radius:999px;padding:4px 11px;background:var(--panel)}
+  .chip b{color:var(--ink)}
+  h2{font-size:22px;margin:44px 0 8px}.n{font-family:var(--mono);color:var(--accent);font-size:14px;margin-right:8px}
+  .lead{color:var(--dim)}
+  code{font-family:var(--mono);font-size:.88em;background:var(--panel2);border:1px solid var(--line);border-radius:5px;padding:1.5px 6px;color:var(--cyan)}
+  pre{font-family:var(--mono);font-size:12.5px;background:#0c0f0d;border:1px solid var(--line);border-radius:12px;padding:14px 16px;overflow-x:auto;line-height:1.5;color:#e7ece8}
+  .fig{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:22px;margin:18px 0}
+  .fig figcaption{font-family:var(--mono);font-size:12px;color:var(--dim);margin-top:12px;text-align:center}
+  .fig figcaption b{color:var(--ink)}
+  table{width:100%;border-collapse:collapse;margin:14px 0;font-size:14px}
+  th,td{text-align:left;padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--dim);font-weight:500}
+  .callout{border-left:3px solid var(--accent);background:var(--panel2);border-radius:0 10px 10px 0;padding:14px 16px;margin:16px 0}
+  .callout .lbl{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--accent);display:block;margin-bottom:4px}
+  .callout.warn{border-left-color:var(--amber)}.callout.warn .lbl{color:var(--amber)}
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin:18px 0}
+  @media(max-width:700px){.stats{grid-template-columns:1fr 1fr}}
+  .stat{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:14px}
+  .stat .v{font-family:var(--mono);font-size:22px;color:var(--accent);font-weight:600}
+  .stat .l{font-family:var(--mono);font-size:10.5px;color:var(--dim);text-transform:uppercase;letter-spacing:.06em;margin-top:4px}
+  .toc{font-family:var(--mono);font-size:12.5px;display:flex;flex-wrap:wrap;gap:6px 16px;margin-top:16px}
+  .toc a{color:var(--dim);text-decoration:none}.toc a:hover{color:var(--accent)}
+  .foot{margin-top:48px;padding-top:18px;border-top:1px solid var(--line);font-family:var(--mono);font-size:11.5px;color:var(--dim)}
+  .themebtn{position:fixed;top:14px;right:14px;font-family:var(--mono);font-size:12px;color:var(--dim);background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 12px;cursor:pointer}
+  .tag{font-family:var(--mono);font-size:11px;padding:2px 7px;border-radius:6px;font-weight:600}
+  .tag.a{background:rgba(163,230,53,.12);color:var(--accent);border:1px solid rgba(163,230,53,.3)}
+  .tag.b{background:rgba(90,214,192,.1);color:var(--cyan);border:1px solid rgba(90,214,192,.28)}
+  .tag.c{background:rgba(245,196,81,.1);color:var(--amber);border:1px solid rgba(245,196,81,.28)}
+</style>
+</head>
+<body>
+<button class="themebtn" id="tb" onclick="tt()">◐ light</button>
+<script>
+  var r=document.documentElement;
+  function set(t){r.setAttribute('data-theme',t);document.getElementById('tb').textContent=t==='light'?'◑ dark':'◐ light'}
+  set(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');
+  function tt(){set(r.getAttribute('data-theme')==='light'?'dark':'light')}
+</script>
+<div class="wrap">
+
+<p class="kicker">agents-cli · sessions · architecture note</p>
+<h1>Not shared memory.<br><span class="accent">A query tool over transcripts.</span></h1>
+<p class="sub">Agents (Claude, Codex, Grok, Kimi…) do <b>not</b> share a brain. Each conversation is a file on disk.
+<code>agents sessions</code> is the read API: search, filter, fan out over SSH, optionally sync. Fast enough to use mid-thought.</p>
+<div class="meta">
+  <span class="chip">as of <b>2026-07-20</b></span>
+  <span class="chip">bench host <b>yosemite-s0</b></span>
+  <span class="chip">cli <b>1.20.70</b></span>
+</div>
+<nav class="toc">
+  <a href="#s1">01 · model</a>
+  <a href="#s2">02 · devices</a>
+  <a href="#s3">03 · filters</a>
+  <a href="#s4">04 · speed</a>
+  <a href="#s5">05 · cookbook</a>
+</nav>
+
+<div class="stats">
+  <div class="stat"><div class="v">~0.45s</div><div class="l">JSON list 50</div></div>
+  <div class="stat"><div class="v">~0.5s</div><div class="l">Read last 3 turns</div></div>
+  <div class="stat"><div class="v">~0.75s</div><div class="l">SSH host query</div></div>
+  <div class="stat"><div class="v">~1.8s</div><div class="l">Multi-host fan-out</div></div>
+</div>
+
+<h2 id="s1"><span class="n">01</span>The memory model</h2>
+<p class="lead">There is no cross-agent RAM. Transcripts live where each agent writes them. The CLI indexes those paths and answers questions.</p>
+
+<figure class="fig">
+<svg viewBox="0 0 920 260" role="img" aria-label="Query tool over per-agent transcript files">
+  <!-- disk files -->
+  <rect x="40" y="40" width="200" height="180" rx="12" fill="#161a18" stroke="#26302a"/>
+  <text x="140" y="70" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">ON DISK</text>
+  <text x="140" y="100" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">.claude/projects/*.jsonl</text>
+  <text x="140" y="124" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">.codex/sessions/…</text>
+  <text x="140" y="148" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">.kimi-code/sessions/</text>
+  <text x="140" y="172" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">.factory/sessions/</text>
+  <text x="140" y="196" fill="#5c655c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">per agent · per machine</text>
+
+  <path d="M250 130 L340 130" stroke="#a3e635" fill="none" marker-end="url(#ar)"/>
+  <defs><marker id="ar" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0 0 L7 4 L0 8 z" fill="#a3e635"/></marker></defs>
+
+  <!-- CLI -->
+  <rect x="350" y="70" width="220" height="120" rx="12" fill="#12160f" stroke="#a3e635" stroke-width="1.5"/>
+  <text x="460" y="115" fill="#a3e635" font-size="14" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-weight="600">agents sessions</text>
+  <text x="460" y="138" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">index · filter · render</text>
+  <text x="460" y="158" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">--host · --since · --json</text>
+
+  <path d="M580 130 L670 130" stroke="#a3e635" fill="none" marker-end="url(#ar)"/>
+
+  <!-- agents -->
+  <rect x="680" y="40" width="200" height="180" rx="12" fill="#161a18" stroke="#26302a"/>
+  <text x="780" y="70" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">CALLERS</text>
+  <text x="780" y="105" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Grok / Claude / Codex</text>
+  <text x="780" y="130" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">You in a terminal</text>
+  <text x="780" y="155" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Teams / resume / inject</text>
+  <text x="780" y="190" fill="#5ad6c0" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">query → answer · no shared RAM</text>
+</svg>
+<figcaption><b>Read path.</b> Transcripts stay local to each agent install. The CLI is the shared <em>interface</em>, not shared state.</figcaption>
+</figure>
+
+<div class="callout">
+  <span class="lbl">What “memory” actually means</span>
+  When an agent “recalls prior work,” it runs something like
+  <code>agents sessions "auth middleware" --since 7d</code>
+  (or reads a session id as markdown). That is <b>search + read</b>, the same way you’d
+  <code>grep</code> logs — not a joint embedding store, not a hive mind.
+</div>
+
+<h2 id="s2"><span class="n">02</span>How devices connect</h2>
+<p class="lead">Three layers. Default is live SSH fan-out. Nothing requires R2.</p>
+
+<figure class="fig">
+<svg viewBox="0 0 920 300" role="img" aria-label="Local, host, fan-out, optional R2 sync">
+  <!-- local -->
+  <rect x="40" y="30" width="200" height="70" rx="10" fill="#12160f" stroke="#a3e635"/>
+  <text x="140" y="60" fill="#a3e635" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">--local</text>
+  <text x="140" y="80" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">this machine only</text>
+
+  <!-- host -->
+  <rect x="280" y="30" width="200" height="70" rx="10" fill="#161a18" stroke="#5ad6c0"/>
+  <text x="380" y="60" fill="#5ad6c0" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">--host zion</text>
+  <text x="380" y="80" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">SSH → remote index</text>
+
+  <!-- fanout -->
+  <rect x="520" y="30" width="200" height="70" rx="10" fill="#161a18" stroke="#f5c451"/>
+  <text x="620" y="60" fill="#f5c451" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">default list</text>
+  <text x="620" y="80" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">fan-out all online</text>
+
+  <!-- sync optional -->
+  <rect x="760" y="30" width="120" height="70" rx="10" fill="#161a18" stroke="#26302a"/>
+  <text x="820" y="60" fill="#8b938c" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">R2 sync</text>
+  <text x="820" y="80" fill="#5c655c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">opt-in beta</text>
+
+  <!-- flow detail -->
+  <text x="40" y="140" fill="#8b938c" font-size="12" font-family="ui-monospace,Menlo,monospace">LIVE QUERY (no daemon)</text>
+  <text x="40" y="168" fill="#e7ece8" font-size="13" font-family="ui-monospace,Menlo,monospace">1. Resolve devices from  agents devices  (Tailscale registry)</text>
+  <text x="40" y="192" fill="#e7ece8" font-size="13" font-family="ui-monospace,Menlo,monospace">2. SSH to each target · run the same filter on that host’s disk</text>
+  <text x="40" y="216" fill="#e7ece8" font-size="13" font-family="ui-monospace,Menlo,monospace">3. Merge rows · label by machine · skip unreachable hosts</text>
+  <text x="40" y="250" fill="#8b938c" font-size="12" font-family="ui-monospace,Menlo,monospace">OPTIONAL MIRROR</text>
+  <text x="40" y="274" fill="#e7ece8" font-size="13" font-family="ui-monospace,Menlo,monospace">sessions import --from-host · sessions sync (R2 CRDT) · export/import bundles</text>
+</svg>
+<figcaption><b>Device layers.</b> Auth is SSH only. Unreachable hosts are skipped (e.g. key-denied), not fatal.</figcaption>
+</figure>
+
+<table>
+  <thead><tr><th>Mode</th><th>What it does</th><th>When</th></tr></thead>
+  <tbody>
+    <tr><td><code>--local</code></td><td>Scan only this machine’s transcript roots</td><td>Speed · scripting · JSON</td></tr>
+    <tr><td><code>--host / --device</code></td><td>Run the query on remote(s) over SSH</td><td>“What did zion do this week?”</td></tr>
+    <tr><td>default listing</td><td>Auto fan-out to online fleet, host column</td><td>Interactive browse</td></tr>
+    <tr><td><code>import --from-host</code></td><td>Copy remote transcripts into a local mirror (tagged by origin machine)</td><td>Offline recall later</td></tr>
+    <tr><td><code>sessions sync</code></td><td>R2 CRDT merge across machines — <b>opt-in beta, off by default</b></td><td>Always-on multi-machine archive</td></tr>
+  </tbody>
+</table>
+
+<div class="callout warn">
+  <span class="lbl">On this fleet right now</span>
+  <code>agents sessions sync --status</code> → automatic sync <b>disabled</b>, R2 credentials missing.
+  Cross-machine recall uses live <code>--host</code> / fan-out, not a shared cloud brain.
+</div>
+
+<h2 id="s3"><span class="n">03</span>Filters that matter</h2>
+<table>
+  <thead><tr><th>Filter</th><th>Purpose</th></tr></thead>
+  <tbody>
+    <tr><td><code>"search text"</code></td><td>Full-text over topic / content / paths</td></tr>
+    <tr><td><code>--since 7d</code> · <code>--until</code></td><td>Time window (relative or ISO)</td></tr>
+    <tr><td><code>-a claude</code> · <code>--codex</code> · <code>--grok</code></td><td>Agent type (optional @version)</td></tr>
+    <tr><td><code>-p agents-cli</code></td><td>Project name across dirs</td></tr>
+    <tr><td><code>--all</code></td><td>Every directory, not just cwd project</td></tr>
+    <tr><td><code>--teams</code></td><td>Include team-spawned sessions (hidden by default)</td></tr>
+    <tr><td><code>--active</code> · <code>--waiting</code></td><td>Live processes only · blocked on user input</td></tr>
+    <tr><td><code>-n 50</code> · <code>--sort cost</code></td><td>Cap + order (recent / cost / duration)</td></tr>
+    <tr><td><code>--include user</code> · <code>--last 3</code></td><td>When reading one session: roles + turn window</td></tr>
+    <tr><td><code>--json</code> · <code>--markdown</code> · <code>--flat</code></td><td>Machine / human / table output</td></tr>
+    <tr><td><code>--artifacts</code></td><td>Files written during a session</td></tr>
+    <tr><td><code>--cloud</code></td><td>Rush Cloud captured runs instead of disk</td></tr>
+  </tbody>
+</table>
+
+<pre># Typical agent recall pattern
+agents sessions --all --since 7d "secrets unlock" --flat -n 20
+agents sessions a1b2c3d4 --markdown --include user,assistant --last 5
+agents sessions --active --host zion
+agents sessions --all --since 7d --host zion --json -n 100</pre>
+
+<h2 id="s4"><span class="n">04</span>Benchmarks (measured)</h2>
+<p class="lead">Wall-clock on yosemite-s0, three warm runs, median-ish. Not synthetic — real CLI.</p>
+<table>
+  <thead><tr><th>Call</th><th>Wall times (3×)</th><th>≈</th></tr></thead>
+  <tbody>
+    <tr><td><code>--local --json --since 7d -n 50</code></td><td>0.47 · 0.45 · 0.45 s</td><td><span class="tag a">~0.45s</span></td></tr>
+    <tr><td><code>--local --flat --since 7d -n 50</code></td><td>0.85 · 0.78 · 0.83 s</td><td><span class="tag a">~0.8s</span></td></tr>
+    <tr><td>search <code>"auth"</code> local 7d</td><td>0.84 · 0.80 · 0.85 s</td><td><span class="tag a">~0.8s</span></td></tr>
+    <tr><td><code>--active --local</code></td><td>0.63 · 0.62 · 0.64 s</td><td><span class="tag a">~0.6s</span></td></tr>
+    <tr><td><code>--markdown --last 3</code> one session</td><td>0.50 · 0.50 · 0.50 s</td><td><span class="tag a">~0.5s</span></td></tr>
+    <tr><td><code>--host yosemite-s1</code> 1d -n 20</td><td>0.74 · 0.77 · 0.74 s</td><td><span class="tag b">~0.75s</span></td></tr>
+    <tr><td>default fan-out 1d -n 20</td><td>1.81 · 1.80 · 1.81 s</td><td><span class="tag c">~1.8s</span></td></tr>
+  </tbody>
+</table>
+<div class="callout">
+  <span class="lbl">Read of the numbers</span>
+  Local list/search is sub-second. Single-host SSH is still under a second on this fleet.
+  Full fan-out pays parallel SSH (~2s) — still fine mid-conversation. This is why agents
+  can “check sessions” without stalling a turn.
+</div>
+
+<h2 id="s5"><span class="n">05</span>Cookbook for the question “do agents share memory?”</h2>
+<pre># No. But any agent can:
+# 1) find related past work (any machine you can SSH to)
+agents sessions --all --since 14d "fleet visibility" --host zion --host yosemite-s0 --flat
+
+# 2) open the actual transcript slice
+agents sessions &lt;id&gt; --markdown --last 10 --include user,assistant
+
+# 3) see what's running fleet-wide right now
+agents sessions --active
+
+# 4) (optional) copy a peer's week into a local mirror
+agents sessions import --from-host zion --since 7d</pre>
+
+<div class="foot">
+  agents sessions explainer · measured on yosemite-s0 · cli 1.20.70 · 2026-07-20 ·
+  source: agents sessions --help + live bench · not a shared-memory system
+</div>
+</div>
+</body>
+</html>

--- a/.agents/artifacts/2026-08-10/zion-week-sessions-2026-07-20.html
+++ b/.agents/artifacts/2026-08-10/zion-week-sessions-2026-07-20.html
@@ -1,0 +1,434 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Zion · Week of Agent Work · Jul 14–20</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111312; --panel2:#161a18; --ink:#e7ece8; --dim:#8b938c;
+    --line:#26302a; --accent:#a3e635; --amber:#f5c451; --red:#ff6b6b; --cyan:#5ad6c0;
+    --violet:#c4b5fd; --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"]{
+    --bg:#faf9f6; --panel:#ffffff; --panel2:#f2f4f0; --ink:#1a1c1a; --dim:#5c655c;
+    --line:#e2e6df; --accent:#4d7c0f; --amber:#b45309; --red:#dc2626; --cyan:#0e7490;
+    --violet:#6d28d9;
+  }
+  :root[data-theme="light"] .fig{background:#0e120f;border-color:#26302a}
+  :root[data-theme="light"] .fig figcaption{color:#8b938c}
+  :root[data-theme="light"] .fig figcaption b{color:#e7ece8}
+
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);
+    font-size:16px;line-height:1.6;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1040px;margin:0 auto;padding:56px 28px 120px}
+  header.hero{border-bottom:1px solid var(--line);padding-bottom:28px;margin-bottom:36px}
+  .kicker{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--accent);margin:0 0 14px}
+  h1{font-size:34px;line-height:1.15;margin:0 0 12px;font-weight:700;letter-spacing:-.01em}
+  h1 .accent{color:var(--accent)}
+  .sub{color:var(--dim);font-size:17px;max-width:72ch;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:20px}
+  .chip{font-family:var(--mono);font-size:11.5px;color:var(--dim);border:1px solid var(--line);
+    border-radius:999px;padding:4px 11px;background:var(--panel)}
+  .chip b{color:var(--ink);font-weight:500}
+  h2{font-size:23px;margin:48px 0 8px;letter-spacing:-.01em;scroll-margin-top:20px}
+  h2 .n{font-family:var(--mono);color:var(--accent);font-size:15px;margin-right:10px;opacity:.85}
+  p{margin:10px 0}
+  .lead{color:var(--dim)}
+  code{font-family:var(--mono);font-size:.88em;background:var(--panel2);border:1px solid var(--line);
+    border-radius:5px;padding:1.5px 6px;color:var(--cyan)}
+  a{color:var(--accent);text-decoration:none;border-bottom:1px solid transparent}
+  a:hover{border-bottom-color:var(--accent)}
+  .fig{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:26px 22px 18px;margin:22px 0;overflow-x:auto}
+  .fig figcaption{font-family:var(--mono);font-size:12px;color:var(--dim);margin-top:14px;text-align:center}
+  .fig figcaption b{color:var(--ink)}
+  svg{display:block;margin:0 auto;max-width:100%;height:auto}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin:22px 0}
+  @media(max-width:760px){.grid2,.stats{grid-template-columns:1fr 1fr}}
+  @media(max-width:480px){.stats{grid-template-columns:1fr}}
+  .stat{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:18px 16px}
+  .stat .v{font-family:var(--mono);font-size:28px;font-weight:600;color:var(--accent);letter-spacing:-.02em;line-height:1.1}
+  .stat .l{font-family:var(--mono);font-size:11px;color:var(--dim);letter-spacing:.06em;text-transform:uppercase;margin-top:6px}
+  .stat .s{font-size:13px;color:var(--dim);margin-top:4px}
+  table{width:100%;border-collapse:collapse;margin:16px 0;font-size:14.5px}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--dim);font-weight:500}
+  .tag{font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:6px;font-weight:600;display:inline-block}
+  .tag.a{background:rgba(163,230,53,.12);color:var(--accent);border:1px solid rgba(163,230,53,.3)}
+  .tag.b{background:rgba(90,214,192,.1);color:var(--cyan);border:1px solid rgba(90,214,192,.28)}
+  .tag.c{background:rgba(245,196,81,.1);color:var(--amber);border:1px solid rgba(245,196,81,.28)}
+  .tag.d{background:rgba(196,181,253,.12);color:var(--violet);border:1px solid rgba(196,181,253,.28)}
+  .tag.e{background:rgba(255,107,107,.1);color:var(--red);border:1px solid rgba(255,107,107,.28)}
+  .callout{border-left:3px solid var(--accent);background:var(--panel2);border-radius:0 10px 10px 0;
+    padding:14px 18px;margin:18px 0}
+  .callout.warn{border-left-color:var(--amber)}
+  .callout .lbl{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;
+    color:var(--accent);display:block;margin-bottom:5px}
+  .callout.warn .lbl{color:var(--amber)}
+  .toc{font-family:var(--mono);font-size:13px;display:flex;flex-wrap:wrap;gap:6px 18px;margin-top:18px}
+  .toc a{color:var(--dim);border:0}.toc a:hover{color:var(--accent)}
+  .foot{margin-top:60px;padding-top:22px;border-top:1px solid var(--line);color:var(--dim);
+    font-family:var(--mono);font-size:12px}
+  .themebtn{position:fixed;top:16px;right:16px;z-index:9;font-family:var(--mono);font-size:12px;
+    color:var(--dim);background:var(--panel);border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;cursor:pointer}
+  .themebtn:hover{color:var(--accent);border-color:var(--accent)}
+  .theme-list{display:grid;gap:10px;margin:18px 0}
+  .theme-row{display:grid;grid-template-columns:160px 1fr 70px;gap:12px;align-items:center}
+  .theme-row .name{font-family:var(--mono);font-size:12.5px;color:var(--ink)}
+  .theme-row .bar-wrap{background:var(--panel2);border:1px solid var(--line);border-radius:8px;height:22px;overflow:hidden}
+  .theme-row .bar{height:100%;border-radius:8px;background:linear-gradient(90deg,var(--accent),var(--cyan));
+    min-width:2px;display:flex;align-items:center;padding-left:8px;font-family:var(--mono);font-size:10px;color:#0a0a0a;font-weight:600}
+  .theme-row .amt{font-family:var(--mono);font-size:12px;color:var(--dim);text-align:right}
+  .live-dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--accent);
+    box-shadow:0 0 0 0 rgba(163,230,53,.5);margin-right:6px;vertical-align:middle;
+    animation:pulse 1.8s ease infinite}
+  @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(163,230,53,.45)}70%{box-shadow:0 0 0 10px rgba(163,230,53,0)}100%{box-shadow:0 0 0 0 rgba(163,230,53,0)}}
+  @media print{.themebtn{display:none} body{background:#fff;color:#111}}
+</style>
+</head>
+<body>
+<button class="themebtn" onclick="tt()" id="tb">◐ light</button>
+<script>
+  var r=document.documentElement;
+  function set(t){r.setAttribute('data-theme',t);document.getElementById('tb').textContent=(t==='light'?'◑ dark':'◐ light')}
+  set(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');
+  function tt(){set(r.getAttribute('data-theme')==='light'?'dark':'light')}
+</script>
+<div class="wrap">
+
+<header class="hero">
+  <p class="kicker">Zion · Personal laptop · Agent sessions</p>
+  <h1>One week on <span class="accent">zion</span>:<br>the control-plane laptop</h1>
+  <p class="sub">Your Mac wasn’t idle — it was the interactive control plane for agents-cli.
+  Fleet, secrets/auth, Linear backlog, Factory/share, and a content burst. Pulled live via
+  <code>agents sessions --host zion --since 7d</code>.</p>
+  <div class="meta">
+    <span class="chip"><b>196</b>&nbsp;sessions</span>
+    <span class="chip"><b>120</b>&nbsp;substantive</span>
+    <span class="chip"><b>40</b>&nbsp;PRs touched</span>
+    <span class="chip">cost&nbsp;<b>~$3.36k</b></span>
+    <span class="chip">as of&nbsp;<b>2026-07-20</b></span>
+    <span class="chip">source: <b>agents sessions</b></span>
+  </div>
+  <nav class="toc">
+    <a href="#s1">01 · snapshot</a>
+    <a href="#s2">02 · cadence</a>
+    <a href="#s3">03 · themes</a>
+    <a href="#s4">04 · top sessions</a>
+    <a href="#s5">05 · agents mix</a>
+    <a href="#s6">06 · live now</a>
+  </nav>
+</header>
+
+<div class="stats">
+  <div class="stat"><div class="v" data-count="196">196</div><div class="l">Sessions</div><div class="s">7 days, local on zion</div></div>
+  <div class="stat"><div class="v" data-count="120">120</div><div class="l">Real work</div><div class="s">minus cron + hellos</div></div>
+  <div class="stat"><div class="v">$3.36k</div><div class="l">API cost</div><div class="s">Claude-heavy spend</div></div>
+  <div class="stat"><div class="v" data-count="40">40</div><div class="l">PRs</div><div class="s">across agents-cli &amp; monorepo</div></div>
+</div>
+
+<!-- ============ 01 ============ -->
+<h2 id="s1"><span class="n">01</span>The takeaway</h2>
+<p class="lead">Zion is where you <em>drive</em> the fleet — not where bulk tickets land. Heavy
+merge-train work fans to Yosemite; zion owns UX, secrets, fleet visibility, reviews, and content.</p>
+
+<div class="callout">
+  <span class="lbl">Single sentence</span>
+  Jul 16–20 on zion: ship the agents-cli control surfaces (fleet · secrets · auth · share),
+  clear Linear portfolio debt, and write the Go-harness / browser-use story.
+</div>
+
+<figure class="fig">
+<svg viewBox="0 0 960 280" role="img" aria-label="Zion as control plane among fleet devices">
+  <defs>
+    <marker id="ar" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0 0 L7 4 L0 8 z" fill="#a3e635"/></marker>
+    <marker id="ar2" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0 0 L7 4 L0 8 z" fill="#5ad6c0"/></marker>
+    <radialGradient id="glow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#a3e635" stop-opacity=".25"/><stop offset="100%" stop-color="#a3e635" stop-opacity="0"/></radialGradient>
+  </defs>
+  <!-- glow under zion -->
+  <circle cx="480" cy="120" r="90" fill="url(#glow)"/>
+  <!-- zion center -->
+  <rect x="390" y="88" width="180" height="64" rx="12" fill="#12160f" stroke="#a3e635" stroke-width="1.5"/>
+  <text x="480" y="114" fill="#a3e635" font-size="13" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-weight="600">ZION</text>
+  <text x="480" y="134" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">personal Mac · control plane</text>
+
+  <!-- mac-mini -->
+  <rect x="40" y="40" width="150" height="48" rx="8" fill="#161a18" stroke="#26302a"/>
+  <text x="115" y="68" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">mac-mini</text>
+  <path d="M190 64 L385 110" stroke="#5ad6c0" stroke-width="1.2" fill="none" marker-end="url(#ar2)" opacity=".85"/>
+  <text x="250" y="72" fill="#5ad6c0" font-size="10" font-family="ui-monospace,Menlo,monospace">SSH hop</text>
+
+  <!-- yosemite-s0 -->
+  <rect x="40" y="160" width="150" height="48" rx="8" fill="#161a18" stroke="#26302a"/>
+  <text x="115" y="188" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">yosemite-s0</text>
+  <path d="M190 184 L385 130" stroke="#26302a" stroke-width="1.2" stroke-dasharray="4 3" fill="none"/>
+  <text x="240" y="168" fill="#ff6b6b" font-size="10" font-family="ui-monospace,Menlo,monospace">key denied</text>
+
+  <!-- yosemite-s1 -->
+  <rect x="770" y="40" width="150" height="48" rx="8" fill="#161a18" stroke="#26302a"/>
+  <text x="845" y="68" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">yosemite-s1</text>
+  <path d="M770 64 L575 110" stroke="#a3e635" stroke-width="1.2" fill="none" opacity=".5"/>
+
+  <!-- cloud -->
+  <rect x="770" y="160" width="150" height="48" rx="8" fill="#161a18" stroke="#26302a"/>
+  <text x="845" y="188" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">rush cloud</text>
+  <path d="M770 184 L575 130" stroke="#a3e635" stroke-width="1.2" fill="none" opacity=".5"/>
+
+  <!-- bottom legend -->
+  <text x="480" y="240" fill="#8b938c" font-size="11.5" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Zion drives reviews · secrets · fleet UI · blogs — workers execute ticket loops</text>
+  <text x="480" y="260" fill="#5ad6c0" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">196 sessions · $3.36k · 40 PRs · Jul 16–20 2026</text>
+</svg>
+<figcaption><b>Fleet topology from zion’s view.</b> mac-mini can SSH into zion; yosemite-s0 cannot (key not authorized).</figcaption>
+</figure>
+
+<!-- ============ 02 ============ -->
+<h2 id="s2"><span class="n">02</span>Cadence — spend by day</h2>
+<p class="lead">Jul 17 was the peak engineering day. Jul 18 almost quiet. Today (20) is the second spike — auth + backlog + content.</p>
+
+<figure class="fig">
+<svg viewBox="0 0 960 320" role="img" aria-label="Bar chart of substantive sessions and cost by day">
+  <!-- axes -->
+  <line x1="80" y1="40" x2="80" y2="250" stroke="#26302a"/>
+  <line x1="80" y1="250" x2="900" y2="250" stroke="#26302a"/>
+  <text x="40" y="50" fill="#8b938c" font-size="10" font-family="ui-monospace,Menlo,monospace">cost</text>
+
+  <!-- grid lines -->
+  <line x1="80" y1="80" x2="900" y2="80" stroke="#1a221c" stroke-dasharray="3 4"/>
+  <line x1="80" y1="140" x2="900" y2="140" stroke="#1a221c" stroke-dasharray="3 4"/>
+  <line x1="80" y1="200" x2="900" y2="200" stroke="#1a221c" stroke-dasharray="3 4"/>
+  <text x="72" y="84" fill="#5c655c" font-size="10" text-anchor="end" font-family="ui-monospace,Menlo,monospace">$1.8k</text>
+  <text x="72" y="144" fill="#5c655c" font-size="10" text-anchor="end" font-family="ui-monospace,Menlo,monospace">$1.2k</text>
+  <text x="72" y="204" fill="#5c655c" font-size="10" text-anchor="end" font-family="ui-monospace,Menlo,monospace">$0.6k</text>
+  <text x="72" y="254" fill="#5c655c" font-size="10" text-anchor="end" font-family="ui-monospace,Menlo,monospace">$0</text>
+
+  <!-- max cost 1804 -> height 170px from baseline 250, so y = 250 - (cost/1804)*170 -->
+  <!-- Jul 16: $194, 24 sess  height=18 -->
+  <rect x="140" y="232" width="72" height="18" rx="4" fill="#5ad6c0" opacity=".9"/>
+  <text x="176" y="226" fill="#e7ece8" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">$194</text>
+  <text x="176" y="270" fill="#8b938c" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Jul 16</text>
+  <text x="176" y="286" fill="#5c655c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">24 sess</text>
+
+  <!-- Jul 17: $1804, 50  height=170 -->
+  <rect x="290" y="80" width="72" height="170" rx="4" fill="#a3e635"/>
+  <text x="326" y="74" fill="#a3e635" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-weight="600">$1.8k</text>
+  <text x="326" y="270" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Jul 17</text>
+  <text x="326" y="286" fill="#a3e635" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">50 sess · peak</text>
+
+  <!-- Jul 18: $5, 7  height=2 -->
+  <rect x="440" y="248" width="72" height="2" rx="1" fill="#5ad6c0" opacity=".7"/>
+  <text x="476" y="242" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">$5</text>
+  <text x="476" y="270" fill="#8b938c" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Jul 18</text>
+  <text x="476" y="286" fill="#5c655c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">7 sess</text>
+
+  <!-- Jul 19: $242, 17  height=23 -->
+  <rect x="590" y="227" width="72" height="23" rx="4" fill="#5ad6c0" opacity=".9"/>
+  <text x="626" y="221" fill="#e7ece8" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">$242</text>
+  <text x="626" y="270" fill="#8b938c" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Jul 19</text>
+  <text x="626" y="286" fill="#5c655c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">17 sess</text>
+
+  <!-- Jul 20: $1116, 22  height=105 -->
+  <rect x="740" y="145" width="72" height="105" rx="4" fill="#f5c451"/>
+  <text x="776" y="139" fill="#f5c451" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-weight="600">$1.1k</text>
+  <text x="776" y="270" fill="#e7ece8" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Jul 20</text>
+  <text x="776" y="286" fill="#f5c451" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">22 sess · today</text>
+
+  <text x="480" y="312" fill="#5c655c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Substantive sessions only · cost bars scaled to Jul 17 peak ($1,804)</text>
+</svg>
+<figcaption><b>Daily burn.</b> Two spikes: platform surface day (17) and auth/backlog/content day (20).</figcaption>
+</figure>
+
+<table>
+  <thead><tr><th>Day</th><th>Sessions</th><th>Cost</th><th>Character</th></tr></thead>
+  <tbody>
+    <tr><td>Jul 16</td><td>24</td><td>$194</td><td>Merge train, droid usage bars, secrets hold, hosts-as-run-options</td></tr>
+    <tr><td><b>Jul 17</b></td><td><b>50</b></td><td><b>$1.8k</b></td><td>Fleet cockpit/arcade/visibility · monitors · routines · SEO · Touch ID · cycle-20</td></tr>
+    <tr><td>Jul 18</td><td>7</td><td>$5</td><td>Quiet — fleet queries, X feed, agi-cli-web audit</td></tr>
+    <tr><td>Jul 19</td><td>17</td><td>$242</td><td>Ghostty SSH, secrets daemon, public share, Pranjal review, menu bar</td></tr>
+    <tr><td><b>Jul 20</b></td><td><b>22</b></td><td><b>$1.1k</b></td><td>Auth health · secrets unlock · login warning · backlog leak · blogs · factory UI</td></tr>
+  </tbody>
+</table>
+
+<!-- ============ 03 ============ -->
+<h2 id="s3"><span class="n">03</span>Where the money went — themes</h2>
+<p class="lead">Clustered by topic (substantive cost). Fleet + auth alone are over $1k — the laptop’s real job this week.</p>
+
+<div class="theme-list">
+  <div class="theme-row"><div class="name">Fleet / SSH / devices</div><div class="bar-wrap"><div class="bar" style="width:100%">$572</div></div><div class="amt">$572</div></div>
+  <div class="theme-row"><div class="name">Auth / secrets / login</div><div class="bar-wrap"><div class="bar" style="width:94%;background:linear-gradient(90deg,#f5c451,#a3e635)">$536</div></div><div class="amt">$536</div></div>
+  <div class="theme-row"><div class="name">Linear / backlog</div><div class="bar-wrap"><div class="bar" style="width:77%;background:linear-gradient(90deg,#ff6b6b,#f5c451)">$443</div></div><div class="amt">$443</div></div>
+  <div class="theme-row"><div class="name">Factory / cloud / Rush</div><div class="bar-wrap"><div class="bar" style="width:74%;background:linear-gradient(90deg,#5ad6c0,#a3e635)">$426</div></div><div class="amt">$426</div></div>
+  <div class="theme-row"><div class="name">Monitors / routines</div><div class="bar-wrap"><div class="bar" style="width:65%;background:linear-gradient(90deg,#c4b5fd,#5ad6c0)">$374</div></div><div class="amt">$374</div></div>
+  <div class="theme-row"><div class="name">Other shipping (PRs)</div><div class="bar-wrap"><div class="bar" style="width:61%">$347</div></div><div class="amt">$347</div></div>
+  <div class="theme-row"><div class="name">Web / SEO / share</div><div class="bar-wrap"><div class="bar" style="width:57%;background:linear-gradient(90deg,#5ad6c0,#c4b5fd)">$328</div></div><div class="amt">$328</div></div>
+  <div class="theme-row"><div class="name">Content / blogs</div><div class="bar-wrap"><div class="bar" style="width:18%;background:#5ad6c0">$104</div></div><div class="amt">$104</div></div>
+  <div class="theme-row"><div class="name">PR review / merge</div><div class="bar-wrap"><div class="bar" style="width:10%;background:#8b938c">$55</div></div><div class="amt">$55</div></div>
+</div>
+
+<figure class="fig">
+<svg viewBox="0 0 960 340" role="img" aria-label="Theme map as connected nodes">
+  <defs>
+    <marker id="dot" markerWidth="6" markerHeight="6" refX="3" refY="3"><circle cx="3" cy="3" r="2" fill="#a3e635"/></marker>
+  </defs>
+  <!-- center -->
+  <circle cx="480" cy="170" r="52" fill="#12160f" stroke="#a3e635" stroke-width="1.5"/>
+  <text x="480" y="166" fill="#a3e635" font-size="12" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-weight="600">agents-cli</text>
+  <text x="480" y="184" fill="#8b938c" font-size="10" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">on zion</text>
+
+  <!-- spokes -->
+  <line x1="480" y1="118" x2="480" y2="48" stroke="#26302a"/>
+  <rect x="400" y="18" width="160" height="36" rx="8" fill="#161a18" stroke="#a3e635"/>
+  <text x="480" y="40" fill="#e7ece8" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Fleet $572</text>
+
+  <line x1="430" y1="130" x2="220" y2="70" stroke="#26302a"/>
+  <rect x="100" y="50" width="160" height="36" rx="8" fill="#161a18" stroke="#f5c451"/>
+  <text x="180" y="72" fill="#e7ece8" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Auth $536</text>
+
+  <line x1="530" y1="130" x2="740" y2="70" stroke="#26302a"/>
+  <rect x="700" y="50" width="160" height="36" rx="8" fill="#161a18" stroke="#ff6b6b"/>
+  <text x="780" y="72" fill="#e7ece8" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Linear $443</text>
+
+  <line x1="430" y1="210" x2="220" y2="270" stroke="#26302a"/>
+  <rect x="100" y="254" width="160" height="36" rx="8" fill="#161a18" stroke="#5ad6c0"/>
+  <text x="180" y="276" fill="#e7ece8" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Factory $426</text>
+
+  <line x1="530" y1="210" x2="740" y2="270" stroke="#26302a"/>
+  <rect x="700" y="254" width="160" height="36" rx="8" fill="#161a18" stroke="#c4b5fd"/>
+  <text x="780" y="276" fill="#e7ece8" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Monitors $374</text>
+
+  <line x1="480" y1="222" x2="480" y2="300" stroke="#26302a"/>
+  <rect x="390" y="300" width="180" height="28" rx="8" fill="#161a18" stroke="#26302a"/>
+  <text x="480" y="318" fill="#8b938c" font-size="11" text-anchor="middle" font-family="ui-monospace,Menlo,monospace">Web · content · reviews</text>
+</svg>
+<figcaption><b>Theme map.</b> Everything orbits agents-cli; the five heavy nodes are fleet, auth, Linear, factory, monitors.</figcaption>
+</figure>
+
+<!-- ============ 04 ============ -->
+<h2 id="s4"><span class="n">04</span>Top sessions by cost</h2>
+<table>
+  <thead><tr><th>Cost</th><th>Session</th><th>Work</th><th>Track</th></tr></thead>
+  <tbody>
+    <tr><td><code>$295</code></td><td><code>83e4626c</code></td><td>linear-backlog-leak-investigation</td><td><span class="tag e">RUSH-899</span> PR#1258</td></tr>
+    <tr><td><code>$211</code></td><td><code>0cabd0e6</code></td><td>script-mode-routines-llm</td><td><span class="tag a">PR#1159</span></td></tr>
+    <tr><td><code>$190</code></td><td><code>b6be8e98</code></td><td>fleet-visibility-consistency-fixes</td><td><span class="tag c">RUSH-1753</span></td></tr>
+    <tr><td><code>$163</code></td><td><code>29835911</code></td><td>agents-monitors-watchers</td><td><span class="tag c">RUSH-1415</span></td></tr>
+    <tr><td><code>$150</code></td><td><code>4bdcbde4</code></td><td>Screenshots → product visuals</td><td><span class="tag b">PR#2</span></td></tr>
+    <tr><td><code>$148</code></td><td><code>f2314c23</code></td><td>persist-secrets-unlock-state</td><td><span class="tag d">AES-256</span> PR#1293</td></tr>
+    <tr><td><code>$139</code></td><td><code>6c0c111d</code></td><td>agi-cli-seo-automation</td><td><span class="tag b">PR#2</span></td></tr>
+    <tr><td><code>$138</code></td><td><code>fc7b3fdf</code></td><td>show-agent-login-state-warning</td><td><span class="tag d">AES-256</span> PR#1284</td></tr>
+    <tr><td><code>$138</code></td><td><code>d77f2823</code></td><td>cycle-20-ticket-portfolio-clear</td><td><span class="tag c">RUSH-1776</span></td></tr>
+    <tr><td><code>$129</code></td><td><code>77ef9e0a</code></td><td>live-auth-health-check</td><td><span class="tag a">PR#1285</span></td></tr>
+    <tr><td><code>$123</code></td><td><code>c32e4ca2</code></td><td>Plan next steps</td><td><span class="tag a">PR#1193</span></td></tr>
+    <tr><td><code>$119</code></td><td><code>a1523d2b</code></td><td>cloudflare-r2-share-command</td><td><span class="tag a">PR#1220</span></td></tr>
+  </tbody>
+</table>
+
+<div class="callout warn">
+  <span class="lbl">Noise filter</span>
+  ~76 of 196 sessions are Rush hourly competitive-watch cron jobs or 2-message hellos/byes.
+  Cost above is almost entirely Claude on real engineering threads.
+</div>
+
+<!-- ============ 05 ============ -->
+<h2 id="s5"><span class="n">05</span>Agent mix</h2>
+
+<figure class="fig">
+<svg viewBox="0 0 960 220" role="img" aria-label="Agent session counts as proportional bars">
+  <!-- Claude 110/196 = 56% -->
+  <text x="40" y="42" fill="#8b938c" font-size="12" font-family="ui-monospace,Menlo,monospace">claude</text>
+  <rect x="120" y="26" width="540" height="24" rx="6" fill="#a3e635"/>
+  <text x="670" y="42" fill="#e7ece8" font-size="12" font-family="ui-monospace,Menlo,monospace">110 · ~$3.36k</text>
+
+  <text x="40" y="82" fill="#8b938c" font-size="12" font-family="ui-monospace,Menlo,monospace">rush</text>
+  <rect x="120" y="66" width="289" height="24" rx="6" fill="#f5c451"/>
+  <text x="420" y="82" fill="#e7ece8" font-size="12" font-family="ui-monospace,Menlo,monospace">59 · cron watches</text>
+
+  <text x="40" y="122" fill="#8b938c" font-size="12" font-family="ui-monospace,Menlo,monospace">kimi</text>
+  <rect x="120" y="106" width="69" height="24" rx="6" fill="#c4b5fd"/>
+  <text x="200" y="122" fill="#e7ece8" font-size="12" font-family="ui-monospace,Menlo,monospace">14</text>
+
+  <text x="40" y="162" fill="#8b938c" font-size="12" font-family="ui-monospace,Menlo,monospace">codex</text>
+  <rect x="120" y="146" width="54" height="24" rx="6" fill="#5ad6c0"/>
+  <text x="185" y="162" fill="#e7ece8" font-size="12" font-family="ui-monospace,Menlo,monospace">11</text>
+
+  <text x="40" y="202" fill="#8b938c" font-size="12" font-family="ui-monospace,Menlo,monospace">droid</text>
+  <rect x="120" y="186" width="10" height="24" rx="4" fill="#8b938c"/>
+  <text x="145" y="202" fill="#e7ece8" font-size="12" font-family="ui-monospace,Menlo,monospace">2</text>
+</svg>
+<figcaption><b>Session count by agent.</b> Claude does the expensive work; Rush session count is inflated by hourly watches.</figcaption>
+</figure>
+
+<div class="grid2">
+  <div>
+    <h3 style="margin-top:0;font-size:15px;color:var(--dim);font-family:var(--mono)">Shipped surfaces (sample)</h3>
+    <ul>
+      <li>Fleet visibility, arcade status, iOS cockpit</li>
+      <li>Secrets unlock + login warning + live auth health</li>
+      <li>Touch ID noise, R2 share, factory UI</li>
+      <li>Monitors/watchers, script-mode routines</li>
+      <li>Go harness + browser-use blogs, SMB value prop</li>
+    </ul>
+  </div>
+  <div>
+    <h3 style="margin-top:0;font-size:15px;color:var(--dim);font-family:var(--mono)">Notable PR band</h3>
+    <ul>
+      <li><code>agents-cli</code> #1159 · #1209 · #1212 · #1220 · #1223</li>
+      <li>#1258 · #1283–#1293 · #1302 · #1308–#1310</li>
+      <li>monorepo blogs #1168 · #1170 · #1172 · logo #1169</li>
+      <li>system: arcade #92 · Clify #108 · SEO #2</li>
+    </ul>
+  </div>
+</div>
+
+<!-- ============ 06 ============ -->
+<h2 id="s6"><span class="n">06</span><span class="live-dot"></span>Live on zion (when rendered)</h2>
+<p class="lead">Snapshot from <code>agents sessions --active --local</code> on zion around render time — ~14 active across codium + tmux.</p>
+
+<table>
+  <thead><tr><th>State</th><th>Agent</th><th>Work</th></tr></thead>
+  <tbody>
+    <tr><td><span class="tag a">working</span></td><td>Claude <code>83e4626c</code></td><td>linear-backlog-leak-investigation · RUSH-899</td></tr>
+    <tr><td><span class="tag a">working</span></td><td>Codex <code>019f7e5a</code></td><td>team /root agent</td></tr>
+    <tr><td><span class="tag c">idle</span></td><td>Claude · codium</td><td>Clify plugin · blogs · SMB value prop · API auth</td></tr>
+    <tr><td><span class="tag c">idle</span></td><td>Claude · tmux</td><td>YouTube-on-Mac-Mini · review sessions last week</td></tr>
+    <tr><td><span class="tag b">cron</span></td><td>Rush</td><td>Hourly competitive watch (background)</td></tr>
+  </tbody>
+</table>
+
+<div class="callout">
+  <span class="lbl">How to re-query</span>
+  From a machine that can SSH to zion (mac-mini works; yosemite-s0 currently key-denied):
+  <br><code>agents sessions --all --since 7d --host zion --flat</code>
+  · <code>agents sessions --active --host zion</code>
+</div>
+
+<div class="foot">
+  zion-week-sessions · data from agents sessions --local on zion · window Jul 16–20 2026 ·
+  rendered 2026-07-20 · Grok on yosemite-s0 via mac-mini hop · self-contained HTML · ◐ toggles theme
+</div>
+
+</div>
+<script>
+  // Count-up only in interactive browsers (print/webdriver keeps baked values)
+  if (!navigator.webdriver) {
+    document.querySelectorAll('.stat .v[data-count]').forEach(function(el){
+      var target = parseInt(el.getAttribute('data-count'), 10);
+      if (!target) return;
+      var start = 0, t0 = null, dur = 700;
+      function step(ts){
+        if (!t0) t0 = ts;
+        var p = Math.min(1, (ts - t0) / dur);
+        el.textContent = Math.round(start + (target - start) * (1 - Math.pow(1-p, 3)));
+        if (p < 1) requestAnimationFrame(step);
+      }
+      requestAnimationFrame(step);
+    });
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Checks in the self-contained HTML explainers for how `agents sessions` works (not shared memory — local SQLite+FTS5 index + SSH cross-device query + export/import), under `.agents/artifacts/2026-08-10/`.

## Files
- `agents-sessions-cross-device-index.html` — primary (indexing, fan-out, filters, benches, SQLite live stats, export/import)
- `agents-sessions-explainer-2026-07-20.html` — shorter explainer
- `zion-week-sessions-2026-07-20.html` — zion week data story
- `agents-sessions-artifacts-README.md` — index of the set

Public share: https://share.agents-cli.sh/agents-sessions-cross-device

## Test plan
- [x] Artifacts open offline (self-contained HTML)
- [x] Paths match repo convention `.agents/artifacts/<yyyy-mm-dd>/`