### PR TITLE
feat(routines): interactive browser on bare `agents routines` (RUSH-2503)

### DIFF
--- a/apps/cli/.changelog/next/rush-2503-routines-browser.md
+++ b/apps/cli/.changelog/next/rush-2503-routines-browser.md
@@ -1,0 +1,7 @@
+- **`agents routines` is now an interactive browser.** On a terminal, the bare
+  command opens a filterable, grouped picker (reusing the same picker primitive
+  behind `agents sessions`) instead of printing nothing but help. The project /
+  device group headers show as inline dividers, and selecting a routine drills into
+  four blocks — Definition, Next fire, Recent runs, Stats. `agents routines --json`
+  and any non-interactive shell keep the exact `agents routines list` output, so
+  pipes and the menu bar are unaffected. (RUSH-2503)

--- a/apps/cli/docs/routines.md
+++ b/apps/cli/docs/routines.md
@@ -102,6 +102,8 @@ What happens on enable/sync:
 
 `agents routines list` groups terminal output by effective device/host scope so it is clear what runs on the current machine, the fleet, cloud, named devices, and named hosts. Use `agents routines list --flat` for the legacy single table, or `--json` for the flat machine-readable payload. Project-sourced routines still show the source repo (and `@branch` when known) in the Repo column; `--json` includes `source`, `sourceRepo`, `sourceBranch`, `hostStrategy`, `oneShot`, and `expired`.
 
+The bare `agents routines` command (no subcommand) opens an **interactive browser** on a terminal — a filterable, grouped picker (built on the same picker primitive as `agents sessions`). The project/device group headers render as inline dividers, typing filters the rows (keeping only groups with a match), and the detail pane / drilling into a routine shows four blocks: Definition, Next fire, Recent runs, and Stats. It falls back to the static `agents routines list` output — byte-for-byte — under `--json` or in any non-interactive shell (a pipe, the menu bar, CI), and `--flat` keeps the legacy table. Separately, `agents inspect <target> --routines` lists routine *definitions* (name, last run, devices, schedule) through the inspect resource view; add a name to drill into one.
+
 A project may also declare `routines: { enable: true }` in its own `agents.yaml` as a documentation signal; daemon firing still requires the explicit `enable-project` allowlist step so consent is materialised into the user layer.
 
 ### Host placement strategy

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -1891,3 +1891,51 @@ describeRoutines('routines list --json projects and projectGroup fields', () => 
     }
   });
 });
+
+// The bare `agents routines` command (RUSH-2503): on a TTY it opens the interactive
+// browser, but with --json or in a non-interactive shell it MUST reproduce the
+// static `routines list` output byte-for-byte. spawnSync gives the child no TTY, so
+// these exercise the static fall-through path.
+describeRoutines('bare routines command routing', () => {
+  it('bare `routines --json` matches `routines list --json` byte-for-byte', () => {
+    const home = makeHome({ jobs: [baseJob, { ...baseJob, name: 'other-job', projects: ['*'] }] });
+    try {
+      const bare = run(home, ['--json']);
+      const list = run(home, ['list', '--json']);
+      expect(bare.status, bare.stderr).toBe(0);
+      expect(list.status, list.stderr).toBe(0);
+      expect(bare.stdout).toBe(list.stdout);
+      // And it is real JSON, not the table.
+      expect(() => JSON.parse(bare.stdout.trim())).not.toThrow();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('bare `routines` in a non-interactive shell prints the static list, not the browser', () => {
+    const home = makeHome({ jobs: [baseJob] });
+    try {
+      const bare = run(home, []);
+      const list = run(home, ['list']);
+      expect(bare.status, bare.stderr).toBe(0);
+      // Same rendered table as `routines list`.
+      expect(bare.stdout).toBe(list.stdout);
+      expect(bare.stdout).toContain('Scheduled Jobs');
+      expect(bare.stdout).toContain('test-job');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('bare `routines --flat` stays on the static flat table', () => {
+    const home = makeHome({ jobs: [baseJob] });
+    try {
+      const bare = run(home, ['--flat']);
+      const list = run(home, ['list', '--flat']);
+      expect(bare.status, bare.stderr).toBe(0);
+      expect(bare.stdout).toBe(list.stdout);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -832,6 +832,12 @@ function buildRoutineDetail(job: JobConfig, scheduler: JobScheduler, now: Date):
  * dividers, with a live four-block detail pane and a full drill-in on select.
  */
 async function runRoutinesBrowser(options: RoutinesListOptions): Promise<void> {
+  // Same --group-by validation as the static list, so a bad value fails the same
+  // way on a TTY as it does under --json / a pipe (rather than silently defaulting).
+  if (options.groupBy && options.groupBy !== 'device' && options.groupBy !== 'project') {
+    console.error(chalk.red(`Unsupported --group-by '${options.groupBy}'. Use: project (default) or device`));
+    process.exit(1);
+  }
   try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
   const jobs = listAllJobs(process.cwd());
   if (jobs.length === 0) {

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -80,6 +80,8 @@ import { JobScheduler } from '../lib/scheduler.js';
 import { detectOverdueJobs } from '../lib/overdue.js';
 import { runCatchup } from '../lib/catchup.js';
 import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
+import { itemPicker } from '../lib/picker.js';
+import { Separator } from '@inquirer/core';
 import { setHelpSections } from '../lib/help.js';
 import { loadDevices, loadDevicesSync } from '../lib/devices/registry.js';
 import type { DeviceRegistry } from '../lib/devices/registry.js';
@@ -643,6 +645,258 @@ async function parseAndValidateDevices(raw: string): Promise<string[]> {
   return names;
 }
 
+interface RoutinesListOptions {
+  json?: boolean;
+  groupBy?: string;
+  flat?: boolean;
+}
+
+/**
+ * The static routines table. Shared verbatim by `agents routines list` and the
+ * non-interactive fall-through of the bare `agents routines` command, so both emit
+ * byte-identical `--json` and text output.
+ */
+function runRoutinesList(options: RoutinesListOptions): void {
+  if (options.groupBy && options.groupBy !== 'device' && options.groupBy !== 'project') {
+    console.error(chalk.red(`Unsupported --group-by '${options.groupBy}'. Use: project (default) or device`));
+    process.exit(1);
+  }
+  if (options.json) {
+    process.stdout.write(JSON.stringify(buildRoutineListJson()) + '\n');
+    return;
+  }
+  try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
+  const jobs = listAllJobs(process.cwd());
+  if (jobs.length === 0) {
+    console.log(chalk.gray('No jobs configured'));
+    console.log(chalk.gray('  Add a job: agents routines add <path-to-job.yml>'));
+    return;
+  }
+
+  const scheduler = new JobScheduler(async () => {});
+  scheduler.loadAll();
+
+  // Build a quick lookup: which jobs are currently overdue?
+  const overdueSet = new Set<string>();
+  try {
+    for (const j of detectOverdueJobs()) overdueSet.add(j.name);
+  } catch {
+    // Best-effort indicator; never block the list on detection errors.
+  }
+
+  console.log(chalk.bold('Scheduled Jobs\n'));
+
+  // OSC 8 hyperlink helper — renders as a clickable link in supporting terminals.
+  // Guarded on process.stdout.isTTY so that piped/redirected output never
+  // contains raw ESC ] 8 ;; ... BEL escape sequences.
+  const link = (label: string, url: string | null): string =>
+    url && process.stdout.isTTY ? `\x1b]8;;${url}\x07${label}\x1b]8;;\x07` : label;
+
+  const now = new Date();
+  if (options.flat) {
+    renderRoutineRows({ jobs, scheduler, overdueSet, link, now });
+  } else if (options.groupBy === 'device') {
+    let registry: DeviceRegistry = {};
+    try {
+      registry = loadDevicesSync();
+    } catch (err) {
+      console.error(chalk.yellow(`Could not read device registry: ${(err as Error).message}`));
+    }
+    const groups = groupRoutineJobsByDevice(jobs, registry);
+    for (const group of groups) {
+      console.log(chalk.bold(`\n${group.title}`));
+      renderRoutineRows({ jobs: group.jobs, scheduler, overdueSet, link, now, local: group.local });
+    }
+    if (groups.some((group) => !group.local)) {
+      console.log();
+      console.log(chalk.gray('  Last Status is per-device: rows under another device show "-" — read it there with: agents routines list --device <name>'));
+    }
+  } else {
+    // Default: group by project
+    const knownProjectNames = new Set(listProjectDefs().map((p) => p.name));
+    const groups = groupRoutineJobsByProject(jobs, knownProjectNames);
+    for (const group of groups) {
+      console.log(chalk.bold(`\n${group.title}`));
+      renderRoutineRows({ jobs: group.jobs, scheduler, overdueSet, link, now });
+    }
+  }
+
+  if (overdueSet.size > 0) {
+    console.log();
+    console.log(chalk.yellow(`  ${overdueSet.size} routine(s) overdue — catch up with: agents routines catchup`));
+  }
+
+  scheduler.stopAll();
+  console.log();
+}
+
+/** True when a routine matches the browser's live filter query. */
+function routineMatchesQuery(job: JobConfig, q: string): boolean {
+  const kind = job.command ? 'command' : job.workflow ? `wf:${job.workflow}` : job.agent ?? '';
+  return [job.name, kind, fireConditionLabel(job), (job.projects ?? []).join(' ')]
+    .join(' ')
+    .toLowerCase()
+    .includes(q);
+}
+
+/** One compact routine row for the browser list: name · kind · schedule · next · last. */
+function routineBrowserRow(
+  job: JobConfig,
+  scheduler: JobScheduler,
+  overdueSet: Set<string>,
+  now: Date,
+): string {
+  const kind = job.command ? 'command' : job.workflow ? `wf:${job.workflow}` : job.agent ?? '?';
+  const name = job.name.length > 24 ? job.name.slice(0, 23) + '…' : job.name.padEnd(24);
+  const enabled = job.enabled === false ? chalk.gray('paused') : chalk.green('on');
+  const latest = localLatestRun(job);
+  const last = latest
+    ? latest.status === 'completed'
+      ? chalk.green('ok')
+      : latest.status === 'failed' || latest.status === 'timeout'
+        ? chalk.red(latest.status)
+        : chalk.yellow(latest.status)
+    : chalk.gray('—');
+  const next = overdueSet.has(job.name)
+    ? chalk.yellow('overdue')
+    : chalk.gray(nextRunLabel(job, scheduler, now));
+  return `${chalk.bold(name)} ${chalk.cyan(kind.padEnd(12))} ${enabled.padEnd(6)} ${chalk.gray(scheduleLabel(job)).padEnd(24)} next ${next} · last ${last}`;
+}
+
+/**
+ * The four-block routine detail — Definition, Next fire, Recent runs, Stats — shown
+ * both live in the picker's preview pane and, in full, when a routine is selected.
+ */
+function buildRoutineDetail(job: JobConfig, scheduler: JobScheduler, now: Date): string {
+  const lines: string[] = [];
+
+  // 1. Definition
+  lines.push(chalk.bold.underline('Definition'));
+  const kind = job.command
+    ? `command: ${job.command}`
+    : job.workflow
+      ? `workflow: ${job.workflow}`
+      : `agent: ${job.agent ?? '?'}`;
+  lines.push(`  ${kind}`);
+  lines.push(`  schedule: ${fireConditionLabel(job)}${isOneShotRoutine(job) ? ' (one-shot)' : ''}`);
+  const devices = devicesWithRoutineEnabled(job.name);
+  lines.push(`  devices: ${devices.length > 0 ? devices.join(', ') : chalk.gray('none (paused)')}`);
+  if (job.timezone) lines.push(`  timezone: ${job.timezone}`);
+  if (job.repo) lines.push(`  repo: ${job.repo}`);
+  if (job.prompt) {
+    const oneLine = job.prompt.replace(/\s+/g, ' ').trim();
+    lines.push(`  prompt: ${oneLine.length > 120 ? oneLine.slice(0, 119) + '…' : oneLine}`);
+  }
+
+  // 2. Next fire
+  lines.push('');
+  lines.push(chalk.bold.underline('Next fire'));
+  const nextDate = nextRunForDisplay(job, scheduler);
+  lines.push(`  ${nextRunLabel(job, scheduler, now)}${nextDate ? chalk.gray(`  (${nextDate.toISOString()})`) : ''}`);
+
+  // 3. Recent runs (most recent last, like `routines runs`)
+  lines.push('');
+  lines.push(chalk.bold.underline('Recent runs'));
+  const runs = listRuns(job.name).slice(-5);
+  if (runs.length === 0) {
+    lines.push(chalk.gray('  no runs yet'));
+  } else {
+    for (const run of runs) {
+      const status = run.status === 'completed'
+        ? chalk.green(run.status)
+        : run.status === 'failed' || run.status === 'timeout'
+          ? chalk.red(run.status)
+          : chalk.yellow(run.status);
+      const dur = run.completedAt ? ` ${formatRunDuration(run.startedAt, run.completedAt)}` : '';
+      lines.push(`  ${run.startedAt}  ${status}${dur}`);
+    }
+  }
+
+  // 4. Stats
+  lines.push('');
+  lines.push(chalk.bold.underline('Stats'));
+  const stats = routineStats(job.name);
+  if (stats.count === 0) {
+    lines.push(chalk.gray('  no completed runs'));
+  } else {
+    lines.push(`  runs ${stats.count} · failed ${stats.failed} · missed ${stats.missed}`);
+    lines.push(`  avg ${stats.avgMs}ms · p50 ${stats.p50}ms · p95 ${stats.p95}ms`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Interactive routines browser behind the bare `agents routines` command on a TTY.
+ * Reuses {@link itemPicker}, keeping the project/device group headers as inline
+ * dividers, with a live four-block detail pane and a full drill-in on select.
+ */
+async function runRoutinesBrowser(options: RoutinesListOptions): Promise<void> {
+  try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
+  const jobs = listAllJobs(process.cwd());
+  if (jobs.length === 0) {
+    console.log(chalk.gray('No jobs configured'));
+    console.log(chalk.gray('  Add a job: agents routines add <path-to-job.yml>'));
+    return;
+  }
+
+  const scheduler = new JobScheduler(async () => {});
+  scheduler.loadAll();
+  try {
+    const now = new Date();
+    const overdueSet = new Set<string>();
+    try {
+      for (const j of detectOverdueJobs()) overdueSet.add(j.name);
+    } catch { /* best-effort indicator */ }
+
+    // Group with the same headers the static list uses, so the picker's dividers
+    // read identically to `routines list`.
+    let groups: RoutineListGroup[];
+    if (options.groupBy === 'device') {
+      let registry: DeviceRegistry = {};
+      try { registry = loadDevicesSync(); } catch { /* headers still render without state */ }
+      groups = groupRoutineJobsByDevice(jobs, registry);
+    } else {
+      const knownProjectNames = new Set(listProjectDefs().map((p) => p.name));
+      groups = groupRoutineJobsByProject(jobs, knownProjectNames);
+    }
+
+    const filter = (query: string): Array<JobConfig | Separator> => {
+      const q = query.trim().toLowerCase();
+      const rows: Array<JobConfig | Separator> = [];
+      for (const group of groups) {
+        const matched = q ? group.jobs.filter((j) => routineMatchesQuery(j, q)) : group.jobs;
+        if (matched.length === 0) continue;
+        rows.push(new Separator(chalk.bold(`── ${group.title} ──`)));
+        rows.push(...matched);
+      }
+      return rows;
+    };
+
+    const picked = await itemPicker<JobConfig>({
+      message: 'Routines',
+      subtitle: chalk.gray('type to filter · ↑↓ navigate · space toggles detail · ⏎ open'),
+      items: filter(''),
+      filter,
+      labelFor: (job) => routineBrowserRow(job, scheduler, overdueSet, now),
+      buildPreview: (job) => buildRoutineDetail(job, scheduler, now),
+      shortIdFor: (job) => job.name,
+      pageSize: 15,
+      enterHint: 'open',
+      emptyMessage: 'No routines match.',
+    });
+
+    if (picked) {
+      // Drill-in: print the full, untruncated four-block detail for the selection.
+      console.log();
+      console.log(chalk.bold(picked.item.name));
+      console.log(buildRoutineDetail(picked.item, scheduler, now));
+    }
+  } finally {
+    scheduler.stopAll();
+  }
+}
+
 /** Register the `agents routines` command tree. */
 export function registerRoutinesCommands(program: Command): void {
   const routinesCmd = program
@@ -714,88 +968,34 @@ export function registerRoutinesCommands(program: Command): void {
     `,
   });
 
+  // Bare `agents routines`: a HIDDEN default subcommand carries the bare-command's
+  // own --json/--group-by/--flat. It must be a subcommand rather than options on the
+  // parent `routines`, because commander binds a same-named PARENT option first and
+  // would shadow the identical --json on every sibling (`add`/`run`/`runs`/`list`/…).
+  // On a TTY it opens the interactive browser; with --json, --flat, or in a
+  // non-interactive shell it prints the exact static `routines list` output.
+  routinesCmd
+    .command('browse', { isDefault: true, hidden: true })
+    .description('Interactive routines browser (the default for a bare `agents routines`)')
+    .option('--json', 'Emit machine-readable JSON instead of the browser (matches `routines list --json`)')
+    .option('--group-by <field>', 'Group by field: project (default) or device', 'project')
+    .option('--flat', 'Print the legacy flat table instead of the interactive browser')
+    .action(async (options: RoutinesListOptions) => {
+      if (options.json || options.flat || !isInteractiveTerminal()) {
+        runRoutinesList(options);
+        return;
+      }
+      await runRoutinesBrowser(options);
+    });
+
   routinesCmd
     .command('list')
     .description('See all scheduled jobs, when they run next, and their last execution status')
     .option('--json', 'Emit machine-readable JSON instead of the table (used by the menu bar helper)')
     .option('--group-by <field>', 'Group output by field: project (default) or device', 'project')
     .option('--flat', 'Print the legacy flat table instead of grouped sections')
-    .action((options: { json?: boolean; groupBy?: string; flat?: boolean }) => {
-      if (options.groupBy && options.groupBy !== 'device' && options.groupBy !== 'project') {
-        console.error(chalk.red(`Unsupported --group-by '${options.groupBy}'. Use: project (default) or device`));
-        process.exit(1);
-      }
-      if (options.json) {
-        process.stdout.write(JSON.stringify(buildRoutineListJson()) + '\n');
-        return;
-      }
-      try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
-      const jobs = listAllJobs(process.cwd());
-      if (jobs.length === 0) {
-        if (options.json) {
-          process.stdout.write('[]\n');
-          return;
-        }
-        console.log(chalk.gray('No jobs configured'));
-        console.log(chalk.gray('  Add a job: agents routines add <path-to-job.yml>'));
-        return;
-      }
-
-      const scheduler = new JobScheduler(async () => {});
-      scheduler.loadAll();
-
-      // Build a quick lookup: which jobs are currently overdue?
-      const overdueSet = new Set<string>();
-      try {
-        for (const j of detectOverdueJobs()) overdueSet.add(j.name);
-      } catch {
-        // Best-effort indicator; never block the list on detection errors.
-      }
-
-      console.log(chalk.bold('Scheduled Jobs\n'));
-
-      // OSC 8 hyperlink helper — renders as a clickable link in supporting terminals.
-      // Guarded on process.stdout.isTTY so that piped/redirected output never
-      // contains raw ESC ] 8 ;; ... BEL escape sequences.
-      const link = (label: string, url: string | null): string =>
-        url && process.stdout.isTTY ? `\x1b]8;;${url}\x07${label}\x1b]8;;\x07` : label;
-
-      const now = new Date();
-      if (options.flat) {
-        renderRoutineRows({ jobs, scheduler, overdueSet, link, now });
-      } else if (options.groupBy === 'device') {
-        let registry: DeviceRegistry = {};
-        try {
-          registry = loadDevicesSync();
-        } catch (err) {
-          console.error(chalk.yellow(`Could not read device registry: ${(err as Error).message}`));
-        }
-        const groups = groupRoutineJobsByDevice(jobs, registry);
-        for (const group of groups) {
-          console.log(chalk.bold(`\n${group.title}`));
-          renderRoutineRows({ jobs: group.jobs, scheduler, overdueSet, link, now, local: group.local });
-        }
-        if (groups.some((group) => !group.local)) {
-          console.log();
-          console.log(chalk.gray('  Last Status is per-device: rows under another device show "-" — read it there with: agents routines list --device <name>'));
-        }
-      } else {
-        // Default: group by project
-        const knownProjectNames = new Set(listProjectDefs().map((p) => p.name));
-        const groups = groupRoutineJobsByProject(jobs, knownProjectNames);
-        for (const group of groups) {
-          console.log(chalk.bold(`\n${group.title}`));
-          renderRoutineRows({ jobs: group.jobs, scheduler, overdueSet, link, now });
-        }
-      }
-
-      if (overdueSet.size > 0) {
-        console.log();
-        console.log(chalk.yellow(`  ${overdueSet.size} routine(s) overdue — catch up with: agents routines catchup`));
-      }
-
-      scheduler.stopAll();
-      console.log();
+    .action((options: RoutinesListOptions) => {
+      runRoutinesList(options);
     });
 
   routinesCmd

--- a/apps/cli/src/lib/picker.test.ts
+++ b/apps/cli/src/lib/picker.test.ts
@@ -364,3 +364,103 @@ describe('hotkeyToken', () => {
     expect(shifted.name).toBe('r');
   });
 });
+
+/**
+ * Group dividers: an itemPicker fed Separator rows renders them as non-selectable
+ * headers. The cursor never rests on one — it starts below a leading divider, and
+ * up/down navigation jumps over one — so enter always resolves a real row. This is
+ * what lets the routines browser show project/device group headers inline (RUSH-2503).
+ */
+describe('itemPicker group separators', () => {
+  const pickerUrl = pathToFileURL(path.resolve('src/lib/picker.ts')).href;
+
+  /** Spawn a tiny itemPicker program, send keys once its first frame lands, and read `PICKED:<id>`. */
+  async function drivePicker(programBody: string, keysAfterFirstFrame: string): Promise<string> {
+    const child = spawn(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', programBody], {
+      cols: 80,
+      rows: 24,
+      cwd: process.cwd(),
+      env: { ...process.env, TERM: 'xterm-256color' },
+    });
+    return await new Promise<string>((resolve, reject) => {
+      let captured = '';
+      let sentKeys = false;
+      const timeout = setTimeout(() => {
+        child.kill();
+        reject(new Error(`picker did not resolve:\n${stripVTControlCharacters(captured)}`));
+      }, 10_000);
+      child.onData((data) => {
+        captured += data;
+        // First frame renders the group header; only then are the rows on screen.
+        if (!sentKeys && captured.includes('Group A')) {
+          sentKeys = true;
+          child.write(keysAfterFirstFrame);
+        }
+        if (!captured.includes('PICKED:')) return;
+        clearTimeout(timeout);
+        child.kill();
+        resolve(stripVTControlCharacters(captured));
+      });
+    });
+  }
+
+  it('starts the cursor below a leading divider and enter selects the first real row', async () => {
+    const program = `
+      import { itemPicker } from ${JSON.stringify(pickerUrl)};
+      import { Separator } from '@inquirer/core';
+      const rows = [new Separator('Group A'), { id: 'a' }, { id: 'b' }];
+      const r = await itemPicker({
+        message: 'Pick:',
+        items: rows,
+        filter: () => rows,
+        labelFor: (it) => 'row ' + it.id,
+      });
+      console.log('PICKED:' + (r ? r.item.id : 'null'));
+    `;
+    const out = await drivePicker(program, '\r');
+    expect(out).toContain('Group A');
+    expect(out).toContain('PICKED:a');
+  });
+
+  it('skips a divider between rows so down-arrow never lands on it', async () => {
+    const program = `
+      import { itemPicker } from ${JSON.stringify(pickerUrl)};
+      import { Separator } from '@inquirer/core';
+      const rows = [{ id: 'a' }, new Separator('Group B'), { id: 'b' }];
+      const r = await itemPicker({
+        message: 'Pick:',
+        items: rows,
+        filter: () => rows,
+        labelFor: (it) => 'row ' + it.id,
+      });
+      console.log('PICKED:' + (r ? r.item.id : 'null'));
+    `;
+    // Header text differs, so wait on the always-present 'row a' frame instead.
+    const child = spawn(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', program], {
+      cols: 80,
+      rows: 24,
+      cwd: process.cwd(),
+      env: { ...process.env, TERM: 'xterm-256color' },
+    });
+    const out = await new Promise<string>((resolve, reject) => {
+      let captured = '';
+      let sent = false;
+      const timeout = setTimeout(() => {
+        child.kill();
+        reject(new Error(`picker did not resolve:\n${stripVTControlCharacters(captured)}`));
+      }, 10_000);
+      child.onData((data) => {
+        captured += data;
+        if (!sent && captured.includes('row a')) {
+          sent = true;
+          child.write('\x1b[B\r'); // down (skips the divider), then enter
+        }
+        if (!captured.includes('PICKED:')) return;
+        clearTimeout(timeout);
+        child.kill();
+        resolve(stripVTControlCharacters(captured));
+      });
+    });
+    expect(out).toContain('PICKED:b');
+  });
+});

--- a/apps/cli/src/lib/picker.ts
+++ b/apps/cli/src/lib/picker.ts
@@ -39,8 +39,12 @@ export interface PickerConfig<T> {
   message: string;
   /** Optional dim hint line rendered directly under the header (above the rows). */
   subtitle?: string;
-  items: T[];
-  filter: (query: string) => T[];
+  /**
+   * The row pool. A {@link Separator} entry renders as a non-selectable divider
+   * (used for group headers) — navigation skips it and it is never returned.
+   */
+  items: Array<T | Separator>;
+  filter: (query: string) => Array<T | Separator>;
   labelFor: (item: T, query: string) => string;
   buildPreview?: (item: T) => string;
   shortIdFor?: (item: T) => string;
@@ -229,19 +233,42 @@ export function itemPicker<T>(config: PickerConfig<T>): Promise<PickedItem<T> | 
 
     const results = useMemo(() => {
       const filtered = cfg.filter(searchTerm).slice(0, 50);
-      return filtered.map<Choice<T>>((item) => ({
-        value: item,
-        label: cfg.labelFor(item, searchTerm),
-      }));
+      return filtered.map<Choice<T> | Separator>((item) =>
+        Separator.isSeparator(item)
+          ? item
+          : { value: item, label: cfg.labelFor(item, searchTerm) },
+      );
     }, [searchTerm]);
+
+    // A row is selectable unless it is a divider (Separator). Navigation and the
+    // initial cursor skip dividers, and enter never resolves one.
+    const isSelectable = (i: number): boolean =>
+      i >= 0 && i < results.length && !Separator.isSeparator(results[i]);
+    const firstSelectable = (): number => {
+      for (let i = 0; i < results.length; i++) if (isSelectable(i)) return i;
+      return -1;
+    };
+    const nextSelectable = (from: number, dir: 1 | -1): number => {
+      if (results.length === 0) return -1;
+      let i = from;
+      for (let n = 0; n < results.length; n++) {
+        i = (i + dir + results.length) % results.length;
+        if (isSelectable(i)) return i;
+      }
+      return -1;
+    };
 
     const [active, setActive] = useState(0);
 
+    // Keep the cursor on a selectable row: after a filter change the old index can
+    // land past the end or on a divider, so snap to the first selectable row.
     useEffect(() => {
-      if (active >= results.length) setActive(0);
+      if (!isSelectable(active)) setActive(firstSelectable());
     }, [results]);
 
-    const selected = results[active];
+    const activeRow = results[active];
+    const selected =
+      activeRow && !Separator.isSeparator(activeRow) ? (activeRow as Choice<T>) : undefined;
 
     useKeypress((key, rl) => {
       if (isEnterKey(key)) {
@@ -260,17 +287,15 @@ export function itemPicker<T>(config: PickerConfig<T>): Promise<PickedItem<T> | 
 
       if (isUpKey(key)) {
         rl.clearLine(0);
-        if (results.length > 0) {
-          setActive((active - 1 + results.length) % results.length);
-        }
+        const target = nextSelectable(active, -1);
+        if (target >= 0) setActive(target);
         return;
       }
 
       if (isDownKey(key)) {
         rl.clearLine(0);
-        if (results.length > 0) {
-          setActive((active + 1) % results.length);
-        }
+        const target = nextSelectable(active, 1);
+        if (target >= 0) setActive(target);
         return;
       }
 


### PR DESCRIPTION
**feat — interactive routines browser** (RUSH-2503). On a TTY, the bare `agents routines` command now opens a filterable, grouped picker instead of printing help.

## What changed (behavior)

- **`agents routines` on a terminal → interactive browser.** Reuses the existing `itemPicker` primitive (the one behind `agents sessions`). Project / device group headers render as inline **dividers**; typing filters the rows and drops groups with no match; the detail pane / selecting a routine shows four blocks in order: **Definition · Next fire · Recent runs · Stats**.
- **`agents routines --json` and any non-interactive shell → the exact static `agents routines list` output, byte-for-byte.** Pipes, scripts, and the menu bar are unaffected. `--flat` and `--group-by` also stay static.
- **`itemPicker` gains real `Separator` support** — dividers are non-selectable and up/down/enter skip them (the picker's render branch for separators was previously dead). No behavior change for its existing callers.

## Why a hidden default subcommand

The bare command's own `--json` / `--group-by` / `--flat` live on a **hidden default subcommand**, not on the parent `routines`. Commander binds a same-named *parent* option first, so declaring `--json` on the parent silently shadowed the identical `--json` on every sibling (`add` / `run` / `runs` / `list` / …) — caught by the existing suite. The hidden default keeps bare-command flags working while leaving every subcommand's `--json` intact.

## Ran it — real output

Captured against this branch's source (`node --import tsx src/index.ts routines`) in an isolated HOME with seeded routines:

**The browser (grouped dividers + live four-block detail pane; note the red `failed` last-status):**

![routines browser](https://share.agents-cli.sh/muqsitnawaz/muqsit-routines-browser-0cf396459a02aa96)

**Drill-in — selecting a routine prints the full four blocks:**

![routines drill-in](https://share.agents-cli.sh/muqsitnawaz/muqsit-routines-browser-drill-2a229483fc80e6f6)

## Tests

- `picker.test.ts` — new: a leading divider is skipped so the cursor starts on a real row; a mid-list divider is jumped by down-arrow (22 pass).
- `routines.test.ts` — new: bare `routines --json` == `routines list --json` byte-for-byte; bare `routines` (non-TTY) == `routines list`; `--flat` stays static (63 pass).
- Full `routines` + `picker` suites: **85 passed**. `npm run verify:index` green; changelog fragment added under `.changelog/next/`.

Docs: `docs/routines.md` updated. Note `agents inspect --routines` already shipped separately (`05980b1ce`) and is unchanged here.

Ticket: RUSH-2503
EOF
