### PR TITLE
test(session): de-flake active.live-session-id real-process test (unblocks releases)

### DIFF
--- a/apps/cli/src/lib/session/active.live-session-id.test.ts
+++ b/apps/cli/src/lib/session/active.live-session-id.test.ts
@@ -165,6 +165,30 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
       rows = await listUnattributedActive(new Set());
       return rows.find((r) => r.sessionId === UUID || r.pid === pid);
     });
+    // RUSH-2508 (cont.): the comm-name guard above is a point-in-time read, but on
+    // Node 24 the holder's comm flips from `claude` to `MainThread` within ~1s of
+    // boot. It can pass the guard and then become unclassifiable BEFORE the scan
+    // observes it, so `listUnattributedActive` correctly returns nothing — the same
+    // skip case, reached a moment later. Measured: this raced green on ubuntu-22 /
+    // macOS / Windows but failed on the loaded `ubuntu-latest, 24` release runner.
+    // On a timeout, re-read comm: if the holder is no longer an agent name, skip
+    // (nothing left to assert); only fail when it is STILL `claude`, i.e. the scan
+    // genuinely missed a classifiable process.
+    if (!hit) {
+      let commNow: string | undefined;
+      try {
+        commNow = execFileSync('ps', ['-p', String(pid), '-o', 'comm='], {
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+      } catch {
+        commNow = undefined;
+      }
+      if (!commNow || !/^claude/.test(path.basename(commNow))) {
+        ctx.skip(`holder comm flipped to '${commNow ?? '<gone>'}' before the scan observed it — see RUSH-2508`);
+        return;
+      }
+    }
     expect(hit, `expected active row for ${UUID} / pid ${pid}; got ${rows.map((r) => `${r.pid}:${r.sessionId}`).join(', ')}`).toBeDefined();
     expect(hit!.sessionId).toBe(UUID);
     // cwd should be the worktree path (lsof) when recoverable.


### PR DESCRIPTION
test-only.

## What
De-flakes `src/lib/session/active.live-session-id.test.ts` > "listUnattributedActive attributes a worktree-cwd process by its live --session-id", which has been **failing `build (ubuntu-latest, 24)` on every release-CI run** and blocking the merge gate (observed repeatedly on release PR #2522).

## Root cause
The existing RUSH-2508 `ctx.skip` guard reads the holder process`s `comm` name **once, before** the scan loop. On Node 24, node renames its main thread so `ps -o comm=` flips from `claude` to `MainThread` within ~1s of boot. The holder can pass the guard and then become unclassifiable **before** `listUnattributedActive` observes it — the scan then correctly returns nothing, `waitFor` times out, and the single-shot `expect(hit).toBeDefined()` fails on timing, not behavior. It passed ubuntu-22 / macOS / Windows, red only on the loaded ubuntu-24 runner.

## Fix
On the timeout path, re-read `comm`: if the holder is no longer an agent name (the same RUSH-2508 condition, reached a moment later), `ctx.skip` — nothing left to assert. Still fully asserts when `comm` stays `claude`, so coverage on macOS / Node 22 is unchanged. No production code touched.

## Verification
Ran locally 3× on Linux (yosemite-s0): `Tests 5 passed (5)` each time, deterministic.

Unblocks: release 1.22.36 (PR #2522) and every future release.