### PR TITLE
feat(resources): resolve skills/commands by declared frontmatter aliases (RUSH-2504)

### DIFF
--- a/apps/cli/.changelog/next/rush-2504-resource-aliases.md
+++ b/apps/cli/.changelog/next/rush-2504-resource-aliases.md
@@ -1,0 +1,9 @@
+- **Skills and commands can declare `aliases:` in their frontmatter.** Resource
+  resolution now matches a declared alias in addition to the canonical file/dir
+  name, so `resolveResource('skills', 'browser')` finds a skill that lists
+  `browser` among its `aliases:`. The canonical name always wins a collision — a
+  real resource named `browser` beats any resource that merely aliases it, in any
+  layer — and layer precedence (project > user > system) still applies among
+  aliases. `listResources` surfaces each resource's `aliases`. This is the
+  prerequisite for housing a resource under a plugin namespace (e.g. `agi:browser`)
+  while a bare name keeps resolving. (RUSH-2504)

--- a/apps/cli/docs/concepts.md
+++ b/apps/cli/docs/concepts.md
@@ -78,6 +78,20 @@ This means:
 
 The resolution logic lives in `src/lib/resources.ts` — `resolveResource(kind, name)` for a single winner and `listResources(kind)` for the full union with `source` annotations.
 
+### Aliases
+
+A **skill** (its `SKILL.md`) or a **command** can declare alternate names in its frontmatter, and `resolveResource(kind, name)` matches those too:
+
+```yaml
+---
+name: browser
+description: Drive a browser to automate websites
+aliases: [agi-browser, web]   # `browser` also resolves under these names
+---
+```
+
+`aliases:` accepts a YAML list or a comma/space-separated string. Resolution tries the canonical file/dir name across every layer first; only if that misses does it match `name` against declared aliases (again in layer order). So **the canonical name always wins a collision** — a real resource named `browser` beats any resource that merely aliases `browser`, in any layer. `listResources(kind)` surfaces each resource's aliases on its `aliases` field (lazily read, so listing never pays for it unless inspected). Only `skills` and `commands` support aliases today. This is what lets a future `agi` plugin house `agi:browser` while a bare `browser` still resolves via an alias.
+
 ---
 
 ## Version homes
@@ -380,6 +394,7 @@ description: Required one-line summary
 agents: [claude, cursor, codex]   # omit = all compatible agents; Cursor receives both formats
 since: "0.116.0"                  # minimum agent CLI version (inclusive)
 until: "0.117.0"                  # exclusive upper bound
+aliases: [deploy, ship]           # alternate names this command also resolves under
 ---
 ```
 

--- a/apps/cli/src/lib/commands.ts
+++ b/apps/cli/src/lib/commands.ts
@@ -13,6 +13,7 @@ import * as yaml from 'yaml';
 import { AGENTS, ensureCommandsDir, agentConfigDirName, resolveAgentName } from './agents.js';
 import { capableAgents, isCapable, supports } from './capabilities.js';
 import { isDirectoryDoc } from './resources.js';
+import { normalizeAliases } from './resource-aliases.js';
 import { markdownToToml } from './convert.js';
 import { getCommandsDir, getUserCommandsDir, getEnabledExtraRepos, getProjectAgentsDir, getSkillsDir, getTrashCommandsDir } from './state.js';
 import { getEffectiveHome, getVersionHomePath, listInstalledVersions, resolveVersion } from './versions.js';
@@ -46,6 +47,8 @@ export interface CommandMetadata {
   since?: string;
   /** Exclusive upper bound on agent CLI version for this command. */
   until?: string;
+  /** Alternate names this command also resolves under (frontmatter `aliases:`). */
+  aliases?: string[];
 }
 
 export type CommandApplyFailReason = 'unsupported' | 'agent_excluded' | 'too_old' | 'too_new';
@@ -177,6 +180,7 @@ export function parseCommandMetadata(filePath: string): CommandMetadata | null {
           agents: parseAgentsField(parsed.agents),
           since: typeof parsed.since === 'string' ? parsed.since : undefined,
           until: typeof parsed.until === 'string' ? parsed.until : undefined,
+          aliases: normalizeAliases(parsed.aliases),
         };
       }
     }

--- a/apps/cli/src/lib/resource-aliases.ts
+++ b/apps/cli/src/lib/resource-aliases.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalize a resource's frontmatter `aliases:` value into a clean list.
+ *
+ * A skill (SKILL.md) or command file may declare `aliases:` — alternate names
+ * that {@link resolveResource} matches in addition to the canonical file/dir name
+ * (the canonical name always wins a collision). The value is a YAML list or a
+ * comma/space-separated string, mirroring the command frontmatter `agents:` field.
+ *
+ * This lives in its own leaf module so `skills.ts` and `commands.ts` (which parse
+ * the frontmatter) and `resources.ts` (which resolves by alias) all share one
+ * definition without an import cycle.
+ */
+export function normalizeAliases(raw: unknown): string[] {
+  const tokens = Array.isArray(raw)
+    ? raw
+    : typeof raw === 'string'
+      ? raw.split(/[,\s]+/)
+      : [];
+  const out: string[] = [];
+  for (const token of tokens) {
+    const name = String(token).trim();
+    if (name && !out.includes(name)) out.push(name);
+  }
+  return out;
+}

--- a/apps/cli/src/lib/resources.test.ts
+++ b/apps/cli/src/lib/resources.test.ts
@@ -230,3 +230,139 @@ describe('resource resolution', () => {
     expect(parsed.resolved.snapshotSha).toBeUndefined();
   });
 });
+
+/** Write a skill directory with a SKILL.md carrying the given frontmatter. */
+function writeSkill(root: string, name: string, frontmatter: Record<string, unknown>): void {
+  const dir = path.join(root, '.agents', 'skills', name);
+  fs.mkdirSync(dir, { recursive: true });
+  const yamlLines = Object.entries({ name, ...frontmatter })
+    .map(([k, v]) => (Array.isArray(v) ? `${k}: [${v.join(', ')}]` : `${k}: ${v}`))
+    .join('\n');
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\n${yamlLines}\n---\nbody\n`);
+}
+
+describe('resource aliases (RUSH-2504)', () => {
+  it('resolves a skill by a declared alias, returning the canonical resource', () => {
+    const home = makeHome();
+    const project = makeProject();
+    writeSkill(home, 'browser', { description: 'drive a browser', aliases: ['agi-browser', 'web'] });
+
+    const result = runProbe(home, project, `
+      const { resolveResource } = await import('./src/lib/resources.ts');
+      console.log(JSON.stringify({
+        byAlias: resolveResource('skills', 'agi-browser', ${JSON.stringify(project)}),
+        byAlias2: resolveResource('skills', 'web', ${JSON.stringify(project)}),
+        byCanonical: resolveResource('skills', 'browser', ${JSON.stringify(project)}),
+        unknown: resolveResource('skills', 'nope', ${JSON.stringify(project)}),
+      }));
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    // Both aliases resolve to the canonical skill (its real name, not the alias).
+    expect(parsed.byAlias).toMatchObject({ name: 'browser', source: 'user' });
+    expect(parsed.byAlias2).toMatchObject({ name: 'browser', source: 'user' });
+    expect(parsed.byCanonical).toMatchObject({ name: 'browser', source: 'user' });
+    expect(parsed.byAlias.aliases.sort()).toEqual(['agi-browser', 'web']);
+    expect(parsed.unknown).toBeNull();
+  });
+
+  it('resolves a command by a declared alias', () => {
+    const home = makeHome();
+    const project = makeProject();
+    const dir = path.join(home, '.agents', 'commands');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'deploy.md'), '---\nname: deploy\ndescription: ship it\naliases: [ship, release]\n---\nbody\n');
+
+    const result = runProbe(home, project, `
+      const { resolveResource } = await import('./src/lib/resources.ts');
+      console.log(JSON.stringify({
+        byAlias: resolveResource('commands', 'ship', ${JSON.stringify(project)}),
+        byCanonical: resolveResource('commands', 'deploy', ${JSON.stringify(project)}),
+      }));
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.byAlias).toMatchObject({ name: 'deploy', source: 'user' });
+    expect(parsed.byCanonical).toMatchObject({ name: 'deploy', source: 'user' });
+    expect(parsed.byAlias.aliases.sort()).toEqual(['release', 'ship']);
+  });
+
+  it('canonical name always wins a collision with another resource that aliases it', () => {
+    const home = makeHome();
+    const project = makeProject();
+    // A real skill named `browser`, and a DIFFERENT skill that tries to alias `browser`.
+    writeSkill(home, 'browser', { description: 'the real browser skill' });
+    writeSkill(home, 'agi-browser', { description: 'imposter', aliases: ['browser'] });
+
+    const result = runProbe(home, project, `
+      const { resolveResource } = await import('./src/lib/resources.ts');
+      const r = resolveResource('skills', 'browser', ${JSON.stringify(project)});
+      console.log(JSON.stringify({ name: r?.name, path: r?.path }));
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    // The canonical `browser` skill wins, not the `agi-browser` skill that aliases it.
+    expect(parsed.name).toBe('browser');
+    expect(parsed.path.endsWith(path.join('skills', 'browser'))).toBe(true);
+  });
+
+  it('canonical in a lower layer still beats an alias in a higher layer', () => {
+    const home = makeHome();
+    const project = makeProject();
+    // Project layer: a skill that ALIASES `deploy`. User layer: the canonical `deploy`.
+    writeSkill(project, 'shipper', { description: 'aliaser', aliases: ['deploy'] });
+    writeSkill(home, 'deploy', { description: 'the real deploy skill' });
+
+    const result = runProbe(home, project, `
+      const { resolveResource } = await import('./src/lib/resources.ts');
+      const r = resolveResource('skills', 'deploy', ${JSON.stringify(project)});
+      console.log(JSON.stringify({ name: r?.name, source: r?.source }));
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    // Canonical `deploy` (user) wins over the project-layer alias — canonical always wins.
+    expect(parsed).toMatchObject({ name: 'deploy', source: 'user' });
+  });
+
+  it('a higher layer wins when two resources alias the same name (no canonical)', () => {
+    const home = makeHome();
+    const project = makeProject();
+    writeSkill(project, 'proj-skill', { description: 'project', aliases: ['shared'] });
+    writeSkill(home, 'user-skill', { description: 'user', aliases: ['shared'] });
+
+    const result = runProbe(home, project, `
+      const { resolveResource } = await import('./src/lib/resources.ts');
+      const r = resolveResource('skills', 'shared', ${JSON.stringify(project)});
+      console.log(JSON.stringify({ name: r?.name, source: r?.source }));
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    // Project layer is searched before user, so the project aliaser wins.
+    expect(parsed).toMatchObject({ name: 'proj-skill', source: 'project' });
+  });
+
+  it('listResources exposes the declared aliases on each resource', () => {
+    const home = makeHome();
+    const project = makeProject();
+    writeSkill(home, 'browser', { description: 'd', aliases: ['web'] });
+    writeSkill(home, 'plain', { description: 'd' });
+
+    const result = runProbe(home, project, `
+      const { listResources } = await import('./src/lib/resources.ts');
+      const listed = listResources('skills', ${JSON.stringify(project)});
+      console.log(JSON.stringify(listed.map((r) => ({ name: r.name, aliases: r.aliases }))));
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    const parsed = JSON.parse(result.stdout).sort((a, b) => a.name.localeCompare(b.name));
+    expect(parsed).toEqual([
+      { name: 'browser', aliases: ['web'] },
+      { name: 'plain', aliases: [] },
+    ]);
+  });
+});

--- a/apps/cli/src/lib/resources.test.ts
+++ b/apps/cli/src/lib/resources.test.ts
@@ -360,9 +360,11 @@ describe('resource aliases (RUSH-2504)', () => {
 
     expect(result.status, result.stderr).toBe(0);
     const parsed = JSON.parse(result.stdout).sort((a, b) => a.name.localeCompare(b.name));
+    // `aliases` is undefined (not []) when a resource declares none, mirroring
+    // snapshotSha — so JSON.stringify drops the key for the alias-less skill.
     expect(parsed).toEqual([
       { name: 'browser', aliases: ['web'] },
-      { name: 'plain', aliases: [] },
+      { name: 'plain' },
     ]);
   });
 });

--- a/apps/cli/src/lib/resources.ts
+++ b/apps/cli/src/lib/resources.ts
@@ -7,8 +7,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentId } from './types.js';
 import { AGENTS, listInstalledMcpsWithScope } from './agents.js';
-import { listInstalledCommandsWithScope } from './commands.js';
-import { listInstalledSkillsWithScope, type SkillParseError } from './skills.js';
+import { listInstalledCommandsWithScope, parseCommandMetadata } from './commands.js';
+import { listInstalledSkillsWithScope, parseSkillMetadata, type SkillParseError } from './skills.js';
 import { listOnDiskHooks } from './resource-inventory.js';
 import { listInstalledInstructionsWithScope } from './rules/rules.js';
 import { getEffectiveHome } from './versions.js';
@@ -66,14 +66,41 @@ export interface ResolvedResource {
    * repo (or has no commits).
    */
   readonly snapshotSha: string | undefined;
+  /**
+   * Alternate names this resource declares in its frontmatter `aliases:`, which
+   * {@link resolveResource} matches in addition to the canonical name. Lazily
+   * read from disk on first access and memoized, so listing resources never pays
+   * for it unless a caller inspects an alias. Empty for kinds that don't support
+   * aliases (only `skills` and `commands` do) and for resources that declare none.
+   */
+  readonly aliases: string[];
 }
 
-/** Build a ResolvedResource with a lazy, memoized `snapshotSha` getter. */
-function withProvenance(base: { name: string; path: string; source: string; repoRoot: string }): ResolvedResource {
+/**
+ * The declared frontmatter `aliases:` of a single resource, or `[]` for a kind
+ * that doesn't support aliases. Only `skills` (SKILL.md) and `commands` carry
+ * them today. `resourcePath` is the skill directory or the command file.
+ */
+export function resourceAliases(kind: ResourceKind, resourcePath: string): string[] {
+  if (kind === 'skills') return parseSkillMetadata(resourcePath)?.aliases ?? [];
+  if (kind === 'commands') return parseCommandMetadata(resourcePath)?.aliases ?? [];
+  return [];
+}
+
+/** Build a ResolvedResource with lazy, memoized `snapshotSha` and `aliases` getters. */
+function withProvenance(
+  base: { name: string; path: string; source: string; repoRoot: string },
+  kind: ResourceKind,
+): ResolvedResource {
+  let aliasesCache: string[] | undefined;
   return {
     ...base,
     get snapshotSha() {
       return resolveSnapshotSha(base.repoRoot);
+    },
+    get aliases() {
+      if (aliasesCache === undefined) aliasesCache = resourceAliases(kind, base.path);
+      return aliasesCache;
     },
   };
 }
@@ -154,7 +181,7 @@ export function resolveResource(
     const exactPath = path.join(dir, name);
     if (fs.existsSync(exactPath)) {
       if (resourceIsActive(kind, name, source)) {
-        return withProvenance({ name, path: exactPath, source, repoRoot });
+        return withProvenance({ name, path: exactPath, source, repoRoot }, kind);
       }
       continue;
     }
@@ -166,9 +193,36 @@ export function resolveResource(
       const withExt = exactPath + ext;
       if (fs.existsSync(withExt)) {
         if (resourceIsActive(kind, name, source)) {
-          return withProvenance({ name, path: withExt, source, repoRoot });
+          return withProvenance({ name, path: withExt, source, repoRoot }, kind);
         }
         continue;
+      }
+    }
+  }
+
+  // Alias fallback (skills/commands only). A resource may declare `aliases:` in
+  // its frontmatter; match `name` against those AFTER every layer's canonical
+  // lookup above has missed, so a canonical resource named `name` always wins a
+  // collision regardless of layer. Layer precedence still applies among aliases,
+  // and entries are sorted so a same-layer alias collision resolves deterministically.
+  if (kind === 'skills' || kind === 'commands') {
+    for (const [dir, source, repoRoot] of candidates) {
+      if (!fs.existsSync(dir)) continue;
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of [...entries].sort((a, b) => a.name.localeCompare(b.name))) {
+        if (entry.name.startsWith('.')) continue;
+        const rawName = entry.name.replace(/\.(md|yaml|yml)$/, '');
+        if (isDirectoryDoc(kind, rawName)) continue;
+        const resourcePath = path.join(dir, entry.name);
+        if (!resourceAliases(kind, resourcePath).includes(name)) continue;
+        if (!resourceIsActive(kind, rawName, source)) continue;
+        // Resolve to the canonical resource (its real name), not the alias.
+        return withProvenance({ name: rawName, path: resourcePath, source, repoRoot }, kind);
       }
     }
   }
@@ -249,7 +303,7 @@ export function listResources(
             path: full,
             source,
             repoRoot,
-          }));
+          }, kind));
           continue;
         }
         if (!stat.isDirectory() || HOOK_GROUP_SKIP.has(name)) continue;
@@ -282,7 +336,7 @@ export function listResources(
               path: path.join(full, script),
               source,
               repoRoot,
-            }));
+            }, kind));
           }
         } else {
           // Fixture-only directory bundle (hooks/tests/fixtures/…).
@@ -294,7 +348,7 @@ export function listResources(
             path: full,
             source,
             repoRoot,
-          }));
+          }, kind));
         }
       }
     }
@@ -324,7 +378,7 @@ export function listResources(
         path: path.join(dir, entry.name),
         source,
         repoRoot,
-      }));
+      }, kind));
     }
   }
 

--- a/apps/cli/src/lib/resources.ts
+++ b/apps/cli/src/lib/resources.ts
@@ -70,10 +70,12 @@ export interface ResolvedResource {
    * Alternate names this resource declares in its frontmatter `aliases:`, which
    * {@link resolveResource} matches in addition to the canonical name. Lazily
    * read from disk on first access and memoized, so listing resources never pays
-   * for it unless a caller inspects an alias. Empty for kinds that don't support
-   * aliases (only `skills` and `commands` do) and for resources that declare none.
+   * for it unless a caller inspects an alias. `undefined` when the resource
+   * declares none (or for a kind that doesn't support aliases — only `skills` and
+   * `commands` do), mirroring {@link snapshotSha} so a strict `toEqual` on a
+   * ResolvedResource ignores the absent field.
    */
-  readonly aliases: string[];
+  readonly aliases: string[] | undefined;
 }
 
 /**
@@ -92,6 +94,7 @@ function withProvenance(
   base: { name: string; path: string; source: string; repoRoot: string },
   kind: ResourceKind,
 ): ResolvedResource {
+  let aliasesComputed = false;
   let aliasesCache: string[] | undefined;
   return {
     ...base,
@@ -99,7 +102,13 @@ function withProvenance(
       return resolveSnapshotSha(base.repoRoot);
     },
     get aliases() {
-      if (aliasesCache === undefined) aliasesCache = resourceAliases(kind, base.path);
+      if (!aliasesComputed) {
+        const found = resourceAliases(kind, base.path);
+        // Undefined (not []) when none, so a strict toEqual on a ResolvedResource
+        // ignores it — the same convention snapshotSha uses.
+        aliasesCache = found.length > 0 ? found : undefined;
+        aliasesComputed = true;
+      }
       return aliasesCache;
     },
   };

--- a/apps/cli/src/lib/skills.ts
+++ b/apps/cli/src/lib/skills.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as yaml from 'yaml';
 import type { AgentId, SkillMetadata, InstalledSkill } from './types.js';
+import { normalizeAliases } from './resource-aliases.js';
 import { AGENTS, ensureSkillsDir, agentConfigDirName } from './agents.js';
 import { capableAgents, isCapable } from './capabilities.js';
 import { getAgentsDir, getUserSkillsDir, getSkillsDir as getSystemSkillsDir, getProjectAgentsDir, getEnabledExtraRepos, getTrashSkillsDir } from './state.js';
@@ -128,6 +129,7 @@ export function tryParseSkillMetadata(skillDir: string): SkillParseResult {
             version: parsed.version,
             license: parsed.license,
             keywords: parsed.keywords,
+            aliases: normalizeAliases(parsed.aliases),
           },
         };
       }

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -405,6 +405,8 @@ export interface SkillMetadata {
   version?: string;
   license?: string;
   keywords?: string[];
+  /** Alternate names this skill also resolves under (frontmatter `aliases:`). */
+  aliases?: string[];
 }
 
 /** Record of how a skill was installed into an agent version. */


### PR DESCRIPTION
**feat — resolve skills/commands by declared aliases** (RUSH-2504). Library/internal change, no UI surface.

## What changed

A **skill** (`SKILL.md`) or **command** can declare `aliases:` in its frontmatter, and `resolveResource(kind, name)` now matches those in addition to the canonical file/dir name:

```yaml
---
name: browser
description: Drive a browser to automate websites
aliases: [agi-browser, web]
---
```

- **Canonical always wins a collision.** Resolution tries the canonical name across *every* layer first; only if that misses does it match `name` against declared aliases (again in layer order). So a real resource named `browser` beats any resource that merely aliases `browser`, in any layer.
- **Layer precedence still applies among aliases** (project > user > system > extra), and same-layer alias collisions resolve deterministically (sorted).
- `listResources(kind)` surfaces each resource's `aliases` on a lazy getter (like `snapshotSha` — listing never pays for it unless inspected).
- Only `skills` and `commands` support aliases; `aliases:` accepts a YAML list or a comma/space string.

**Scope is narrow on purpose:** just the alias plumbing + tests + docs. No skill is moved into a plugin and no `agi` plugin is created — that is the dependent follow-up. The point is that a future `agi` plugin can house `agi:browser` while a bare `browser` still resolves via an alias.

## Files

| File | Change |
|---|---|
| `src/lib/resource-aliases.ts` | new — `normalizeAliases()` (leaf, no import cycle) |
| `src/lib/resources.ts` | `resolveResource` alias fallback; `resourceAliases()`; `ResolvedResource.aliases` lazy getter |
| `src/lib/skills.ts` / `commands.ts` / `types.ts` | parse `aliases:` into metadata |
| `src/lib/resources.test.ts` | 6 new tests |
| `docs/concepts.md` | frontmatter + resolution docs |
| `.changelog/next/` | fragment |

## Ran it — real test output

**Test run (real terminal capture):**

![resources alias tests](https://share.agents-cli.sh/muqsitnawaz/muqsit-resources-alias-tests-6f3aa945e82eeb01)


`bunx vitest run src/lib/resources.test.ts` — 6 new alias tests (resolve-by-alias for skills and commands, canonical-wins collision, canonical-in-lower-layer beats higher-layer alias, higher-layer alias wins with no canonical, `listResources` exposes aliases):

```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Frontmatter change is safe against existing parsers — `bunx vitest run src/lib/skills.test.ts src/lib/commands.test.ts`:

```
 Test Files  2 passed (2)
      Tests  36 passed (36)
```

`tsc --noEmit` clean; `verify:index` green (no command added).

Ticket: RUSH-2504 (alias prerequisite only)
EOF
