### PR TITLE
feat(secrets): pin host keys + drop multiplex on credential transports (RUSH-2527)

### DIFF
--- a/apps/cli/.changelog/next/rush-2527-credential-transport.md
+++ b/apps/cli/.changelog/next/rush-2527-credential-transport.md
@@ -1,0 +1,14 @@
+- **Credential pushes now ride a hardened SSH posture: pinned host keys + no
+  connection reuse (RUSH-2527).** Every `agents secrets` operation that moves
+  credential bytes across the fleet — `agents accounts sync <name> --device`,
+  `agents secrets export <bundle> --host`, `agents fleet apply
+  --provision-secrets`, and a remote bundle resolve (`run --secrets b@host` /
+  `secrets exec --host`) — now verifies the destination against the CLI-managed
+  known_hosts store (a **changed** host key is refused) and never leaves a reusable
+  60s SSH `ControlMaster` socket behind that an unrelated later `agents` invocation
+  could silently reuse. This matches the posture the `--copy-creds` dispatch
+  already used, extended to the explicit provider-account and secrets-export
+  transports. Read-only browse calls (`secrets list --host`) are unaffected and
+  keep the fast multiplexed baseline. Source:
+  `apps/cli/src/lib/secrets/remote.ts` (`credentialTransportSshOpts`),
+  `apps/cli/src/lib/secrets/push.ts`.

--- a/apps/cli/docs/credential-management.md
+++ b/apps/cli/docs/credential-management.md
@@ -51,7 +51,13 @@ Both come from the same mistake: **agents-cli touching the interactive login.**
    `never` set unconditionally — never the OS keychain's biometry ACL, so reading
    it raises no Touch ID prompt. There is no shared "auth" bundle name; a user can
    hold as many named accounts as they need, and only the accounts they explicitly
-   `agents accounts sync <name> --device <device>` cross the fleet.
+   `agents accounts sync <name> --device <device>` cross the fleet. That sync (and
+   every `agents secrets` transport that moves credential bytes) rides a hardened
+   SSH posture (RUSH-2527): the destination is verified against the CLI-managed
+   known_hosts store — a **changed** host key is refused — and the credential
+   connection is never multiplexed, so it leaves no reusable authenticated control
+   master behind. Secret bytes cross on ssh **stdin** (push) / **stdout** (resolve),
+   never on argv.
 
 5. **Usage and account views read the setup-token**, not the interactive login —
    and never a prompting keychain read. Caveat (RUSH-2392): Anthropic's

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -266,14 +266,18 @@ agents run claude "ship it" --secrets r2.backups@yosemite-s1   # bundle@host suf
   `view --reveal` from an interactive terminal (it forces an SSH TTY so the prompt
   can surface). This machine's passphrase is never forwarded.
 - **Secret-bearing transports are pinned and never reused (RUSH-2527).** Any call
-  that moves credential bytes — the `export --host` / `accounts sync` push, its
-  read-back and policy follow-ups, and a remote **resolve** (`exec --host`,
-  `run --secrets b@host`) whose plaintext returns over ssh stdout — verifies the
-  destination against the CLI-managed known_hosts store (a **changed** host key is
-  refused) and forces a fresh connection with no lingering `ControlMaster` socket,
-  so no unrelated later `agents` invocation can reuse the authenticated channel to
-  a box you just shipped secrets to. Read-only `list --host` browsing keeps the
-  fast shared-connection baseline.
+  that moves credential bytes verifies the destination against the CLI-managed
+  known_hosts store (a **changed** host key is refused) and forces a fresh
+  connection with no lingering `ControlMaster` socket, so no unrelated later
+  `agents` invocation can reuse the authenticated channel to a box you just
+  touched secrets on. This covers the `export --host` / `accounts sync` push and
+  its read-back / policy follow-ups; a remote **resolve** (`exec --host`,
+  `run --secrets b@host`); a **`view --reveal --host`** (the plaintext value
+  returns over ssh stdout — on the interactive prompt path and the `--plaintext`
+  non-interactive path alike); and **`unlock --host`** (you type the remote
+  bundle's passphrase over the channel). Read-only `list --host` and a masked
+  `view --host` (no `--reveal`) carry no secret bytes and keep the fast
+  shared-connection baseline.
 
 ### Pushing to a headless sign host — use `--remote-backend file`
 

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -265,6 +265,15 @@ agents run claude "ship it" --secrets r2.backups@yosemite-s1   # bundle@host suf
   a remote `file` bundle, an already-unlocked remote secrets-agent, or run
   `view --reveal` from an interactive terminal (it forces an SSH TTY so the prompt
   can surface). This machine's passphrase is never forwarded.
+- **Secret-bearing transports are pinned and never reused (RUSH-2527).** Any call
+  that moves credential bytes — the `export --host` / `accounts sync` push, its
+  read-back and policy follow-ups, and a remote **resolve** (`exec --host`,
+  `run --secrets b@host`) whose plaintext returns over ssh stdout — verifies the
+  destination against the CLI-managed known_hosts store (a **changed** host key is
+  refused) and forces a fresh connection with no lingering `ControlMaster` socket,
+  so no unrelated later `agents` invocation can reuse the authenticated channel to
+  a box you just shipped secrets to. Read-only `list --host` browsing keeps the
+  fast shared-connection baseline.
 
 ### Pushing to a headless sign host — use `--remote-backend file`
 

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -568,8 +568,14 @@ export function importBundleFromFile(
  * session (run sequentially) so a remote Touch-ID / passphrase prompt can
  * surface (e.g. `view --reveal`); otherwise hosts are queried in parallel.
  * Exits non-zero if any host fails.
+ *
+ * `secret` marks a browse that streams plaintext VALUES back (`view --reveal`)
+ * rather than only key names (`list`, masked `view`). A secret browse rides the
+ * credential-transport posture — managed host-key pinning + no multiplex — so a
+ * revealed value can't be intercepted on an unpinned/multiplexed connection
+ * (RUSH-2527). It composes with `tty`: `view --reveal` at a terminal is both.
  */
-async function browseRemote(targets: string[], args: string[], tty: boolean): Promise<void> {
+async function browseRemote(targets: string[], args: string[], tty: boolean, secret = false): Promise<void> {
   const multi = targets.length > 1;
   let failures = 0;
   const render = (name: string, res: SshExecResult) => {
@@ -587,11 +593,11 @@ async function browseRemote(targets: string[], args: string[], tty: boolean): Pr
   if (tty) {
     for (const t of targets) {
       const target = await resolveHostSshTarget(t);
-      render(t, remoteSecretsRaw(target, args, { tty: true, osLookupName: t }));
+      render(t, remoteSecretsRaw(target, args, { tty: true, osLookupName: t, secret }));
     }
   } else {
     const resolved = await Promise.all(targets.map(async (t) => ({ name: t, target: await resolveHostSshTarget(t) })));
-    const results = resolved.map(({ name, target }) => remoteSecretsRaw(target, args, { osLookupName: name }));
+    const results = resolved.map(({ name, target }) => remoteSecretsRaw(target, args, { osLookupName: name, secret }));
     targets.forEach((t, i) => render(t, results[i]));
   }
   if (failures > 0) process.exit(1);
@@ -1377,7 +1383,10 @@ export function registerSecretsCommands(program: Command): void {
           // (and the remote's "--reveal in a non-TTY needs --plaintext" gate is
           // satisfied) — only when this side is itself interactive.
           const tty = Boolean(opts.reveal) && Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY);
-          await browseRemote(targets, args, tty);
+          // `--reveal` streams the plaintext value back over ssh stdout — a
+          // secret-bearing read that must pin the host key and not multiplex,
+          // whether it runs on the interactive (tty) or `--plaintext` non-tty path.
+          await browseRemote(targets, args, tty, Boolean(opts.reveal));
           return;
         }
         const resolvedName = name ?? (await pickBundleName('view'));

--- a/apps/cli/src/lib/secrets/push.test.ts
+++ b/apps/cli/src/lib/secrets/push.test.ts
@@ -106,7 +106,21 @@ describe('planPushTransport — which transport a backend/OS pair selects', () =
       kind: 'remote-secrets',
       args: ['import', 'apple.com', '--from', '-'],
       input: RESOLVED.dotenv,
+      multiplex: false,
     });
+  });
+
+  it('never multiplexes a credential-bearing push — no reusable control master to the destination (RUSH-2527)', () => {
+    // A credential push must not reuse or leave a persistent authenticated
+    // control master to the box it just shipped secrets to; every non-refuse
+    // transport therefore pins `multiplex: false`, mirroring `--copy-creds`.
+    for (const host of ['push-test-linux', 'push-test-win', 'push-test-never-registered']) {
+      for (const backend of ['file', 'keychain'] as const) {
+        const t = plan(host, backend);
+        if (t.kind === 'refuse') continue; // file→Windows is unsupported, tested above
+        expect(t.multiplex).toBe(false);
+      }
+    }
   });
 
   it('resolves the target OS after stripping a user@ prefix', () => {

--- a/apps/cli/src/lib/secrets/push.ts
+++ b/apps/cli/src/lib/secrets/push.ts
@@ -27,6 +27,7 @@ import {
   verifyRemoteKeychainPush,
   keychainWriteFailureMessage,
   buildRemoteFileImportCommand,
+  credentialTransportSshOpts,
 } from './remote.js';
 import { readAndResolveBundleEnv } from './bundles.js';
 
@@ -159,10 +160,16 @@ function isPowershellTarget(host: string): boolean {
 export type PushTransport =
   /** No supported command exists for this pair — fail loud, never a wrong path. */
   | { kind: 'refuse'; message: string }
-  /** A command sent over the raw ssh engine, with the .env on stdin. */
-  | { kind: 'ssh'; remoteCmd: string; input: string }
-  /** The OS-aware `agents secrets` wrapper, the READ inverse's own path. */
-  | { kind: 'remote-secrets'; args: string[]; input: string };
+  /**
+   * A command sent over the raw ssh engine, with the .env on stdin. `multiplex`
+   * is always `false`: a push ships credential bytes, so its connection must not
+   * reuse — or leave behind — a persistent authenticated control master to the
+   * destination the way the default fan-out connections do (RUSH-2527). This
+   * mirrors the `--copy-creds` dispatch posture (`multiplex: !opts.copyCreds`).
+   */
+  | { kind: 'ssh'; remoteCmd: string; input: string; multiplex: false }
+  /** The OS-aware `agents secrets` wrapper, the READ inverse's own path. Never multiplexed — see the `ssh` kind. */
+  | { kind: 'remote-secrets'; args: string[]; input: string; multiplex: false };
 
 /** Choose the transport for one push. Pure: registry read in, plan out. */
 export function planPushTransport(
@@ -183,7 +190,7 @@ export function planPushTransport(
       passphrase: opts.passphrase ?? '',
       force: opts.force,
     });
-    return { kind: 'ssh', remoteCmd, input };
+    return { kind: 'ssh', remoteCmd, input, multiplex: false };
   }
   if (powershell) {
     // Keychain on a Windows target: the `agents.ps1` shim doesn't forward
@@ -195,6 +202,7 @@ export function planPushTransport(
       kind: 'ssh',
       remoteCmd: buildWindowsStdinImportCommand(bundle, { force: opts.force }),
       input: resolved.dotenv,
+      multiplex: false,
     };
   }
   // Keychain on a POSIX target: OS-aware wrapping + the hardened ssh engine
@@ -204,6 +212,7 @@ export function planPushTransport(
     kind: 'remote-secrets',
     args: ['import', bundle, '--from', '-', ...(opts.force ? ['--force'] : [])],
     input: resolved.dotenv,
+    multiplex: false,
   };
 }
 
@@ -225,9 +234,15 @@ export function pushResolvedBundleToHost(
 
   const plan = planPushTransport(resolved, bundle, host, opts);
   if (plan.kind === 'refuse') return fail(plan.message);
+  // Every ssh below rides the credential-transport posture: the managed host key
+  // is pinned (a changed key is refused) and the connection never reuses or
+  // leaves a persistent authenticated control master to the destination
+  // (RUSH-2527, `credentialTransportSshOpts`). The plan's `multiplex: false` is
+  // the raw-`ssh` branch's half of that; the `remote-secrets` branch and the
+  // read-back/policy/literal follow-ups pass `secret: true` for the same posture.
   const res: SshExecResult = plan.kind === 'ssh'
-    ? sshExec(host, plan.remoteCmd, { input: plan.input })
-    : remoteSecretsRaw(host, plan.args, { input: plan.input, osLookupName: host });
+    ? sshExec(host, plan.remoteCmd, { input: plan.input, hostKeyOpts: credentialTransportSshOpts(host).hostKeyOpts, multiplex: plan.multiplex })
+    : remoteSecretsRaw(host, plan.args, { input: plan.input, osLookupName: host, secret: true });
 
   if (res.code === null) {
     return fail(res.stderr.trim() || (res.timedOut ? 'ssh timed out' : 'ssh failed'));
@@ -245,7 +260,7 @@ export function pushResolvedBundleToHost(
   // metadata-only bundle that breaks later with "stored item not found". The
   // file backend is headless-readable by construction, so it is skipped.
   if (opts.remoteBackend === 'keychain') {
-    const verdict = verifyRemoteKeychainPush(host, bundle, Object.keys(resolved.env), { osLookupName: host });
+    const verdict = verifyRemoteKeychainPush(host, bundle, Object.keys(resolved.env), { osLookupName: host, secret: true });
     if (!verdict.ok) {
       return fail(verdict.kind === 'locked-keychain'
         ? keychainWriteFailureMessage(host, bundle, verdict.reason)
@@ -254,7 +269,7 @@ export function pushResolvedBundleToHost(
   }
 
   if (opts.policyNever) {
-    const policy = remoteSecretsRaw(host, ['policy', bundle, 'never', '--i-understand'], { osLookupName: host });
+    const policy = remoteSecretsRaw(host, ['policy', bundle, 'never', '--i-understand'], { osLookupName: host, secret: true });
     if (policy.code !== 0) {
       const msg = (policy.stderr || policy.stdout || '').trim();
       return fail(`pushed '${bundle}' but could not set remote policy never${msg ? `: ${msg}` : ''}`);
@@ -262,12 +277,12 @@ export function pushResolvedBundleToHost(
   }
 
   for (const step of planLiteralRestoration(bundle, opts.literalValues)) {
-    const removed = remoteSecretsRaw(host, step.removeArgs, { osLookupName: host });
+    const removed = remoteSecretsRaw(host, step.removeArgs, { osLookupName: host, secret: true });
     if (removed.code !== 0) {
       const msg = (removed.stderr || removed.stdout || '').trim();
       return fail(`pushed '${bundle}' but could not replace transported ${step.key}${msg ? `: ${msg}` : ''}`);
     }
-    const literal = remoteSecretsRaw(host, step.addArgs, { osLookupName: host });
+    const literal = remoteSecretsRaw(host, step.addArgs, { osLookupName: host, secret: true });
     if (literal.code !== 0) {
       const msg = (literal.stderr || literal.stdout || '').trim();
       return fail(`pushed '${bundle}' but could not preserve literal ${step.key}${msg ? `: ${msg}` : ''}`);

--- a/apps/cli/src/lib/secrets/remote.test.ts
+++ b/apps/cli/src/lib/secrets/remote.test.ts
@@ -210,6 +210,18 @@ describe('remoteSecretsRaw', () => {
     expect(kv.some((s) => s.startsWith('UserKnownHostsFile='))).toBe(true);
     expect(kv.some((s) => s.startsWith('StrictHostKeyChecking='))).toBe(true);
   });
+
+  it('tty COMPOSES with secret — a remote `view --reveal` both prompts AND pins the host key (RUSH-2527)', () => {
+    // `tty` must not short-circuit past `secret`: a `view --reveal` over `--host`
+    // allocates a PTY (for the prompt) AND streams the plaintext value back, so
+    // it needs the managed host-key pin, not just `-tt` + no-multiplex.
+    sshExecMock.mockReturnValue(ok('SECRET_VALUE'));
+    remoteSecretsRaw('mac-mini', ['view', 'b', '--reveal'], { tty: true, secret: true });
+    const opts = sshExecMock.mock.calls[0][2] ?? {};
+    expect(opts.extraSshArgs).toEqual(['-tt']);
+    expect(opts.multiplex).toBe(false);
+    expect(optValues(opts.hostKeyOpts).some((s) => s.startsWith('StrictHostKeyChecking='))).toBe(true);
+  });
 });
 
 describe('credentialTransportSshOpts (RUSH-2527)', () => {

--- a/apps/cli/src/lib/secrets/remote.test.ts
+++ b/apps/cli/src/lib/secrets/remote.test.ts
@@ -38,7 +38,17 @@ import {
   evaluateKeychainWriteVerification,
   keychainWriteFailureMessage,
   buildRemoteFileImportCommand,
+  credentialTransportSshOpts,
 } from './remote.js';
+
+/** Flatten an ssh `-o KEY=VALUE` opt list to the KEY=VALUE strings for assertions. */
+function optValues(hostKeyOpts: string[] | undefined): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < (hostKeyOpts?.length ?? 0); i++) {
+    if (hostKeyOpts![i] === '-o' && hostKeyOpts![i + 1]) out.push(hostKeyOpts![i + 1]);
+  }
+  return out;
+}
 
 const ok = (stdout: string): SshExecResult => ({ code: 0, stdout, stderr: '', timedOut: false });
 
@@ -178,6 +188,50 @@ describe('remoteSecretsRaw', () => {
     expect(remoteCmd).toContain('powershell -NoProfile -EncodedCommand ');
     expect(remoteCmd).not.toContain('bash -lc');
   });
+
+  it('a plain browse call inherits the shared multiplexed baseline — no host-key pin', () => {
+    // Only the secret-bearing push tightens the posture; a read-only `list`
+    // should stay on the fast, shared connection (no needless pin churn).
+    sshExecMock.mockReturnValue(ok('listed'));
+    remoteSecretsRaw('yosemite-s1', ['list']);
+    const opts = sshExecMock.mock.calls[0][2] ?? {};
+    expect(opts.multiplex).toBeUndefined();
+    expect(opts.hostKeyOpts).toBeUndefined();
+  });
+
+  it('a secret-bearing push pins the managed host key and refuses to multiplex (RUSH-2527)', () => {
+    // The credential-transport posture: managed known_hosts (a changed key is
+    // refused) plus no reusable control master left to the destination.
+    sshExecMock.mockReturnValue(ok('Imported 2 key(s).'));
+    remoteSecretsRaw('mac-mini', ['import', 'mybundle', '--from', '-'], { input: 'A="1"\n', secret: true });
+    const opts = sshExecMock.mock.calls[0][2] ?? {};
+    expect(opts.multiplex).toBe(false);
+    const kv = optValues(opts.hostKeyOpts);
+    expect(kv.some((s) => s.startsWith('UserKnownHostsFile='))).toBe(true);
+    expect(kv.some((s) => s.startsWith('StrictHostKeyChecking='))).toBe(true);
+  });
+});
+
+describe('credentialTransportSshOpts (RUSH-2527)', () => {
+  it('always refuses to multiplex and pins against the CLI-managed known_hosts store', () => {
+    const opts = credentialTransportSshOpts('some-host');
+    expect(opts.multiplex).toBe(false);
+    const kv = optValues(opts.hostKeyOpts);
+    // Verify against the managed store (not ~/.ssh/known_hosts), and set a strict
+    // posture: `yes` once pinned, `accept-new` before (which still refuses a
+    // CHANGED key). Either value is acceptable here; the key is that it's set.
+    expect(kv.find((s) => s.startsWith('UserKnownHostsFile='))).toBeDefined();
+    const strict = kv.find((s) => s.startsWith('StrictHostKeyChecking='));
+    expect(strict === 'StrictHostKeyChecking=yes' || strict === 'StrictHostKeyChecking=accept-new').toBe(true);
+  });
+
+  it('matches on the host part of a user@host target for known_hosts lookup', () => {
+    // `user@host` and `host` must resolve to the same pin state, or a push via
+    // `user@host` would silently skip a pin recorded under `host`.
+    const a = credentialTransportSshOpts('muqsit@box');
+    const b = credentialTransportSshOpts('box');
+    expect(optValues(a.hostKeyOpts)).toEqual(optValues(b.hostKeyOpts));
+  });
 });
 
 describe('remoteResolveEnv', () => {
@@ -188,6 +242,10 @@ describe('remoteResolveEnv', () => {
     const [, remoteCmd, opts] = sshExecMock.mock.calls[0];
     expect(remoteCmd).toBe(`bash -lc 'agents secrets export r2.backups --plaintext --format json'`);
     expect(opts.input).toBeUndefined();
+    // The plaintext streams back over ssh stdout, so this read is secret-bearing:
+    // it pins the managed host key and refuses to multiplex (RUSH-2527).
+    expect(opts.multiplex).toBe(false);
+    expect(optValues(opts.hostKeyOpts).some((s) => s.startsWith('StrictHostKeyChecking='))).toBe(true);
   });
 
   it('uses the original host name when resolving an inline Windows target', async () => {

--- a/apps/cli/src/lib/secrets/remote.ts
+++ b/apps/cli/src/lib/secrets/remote.ts
@@ -161,15 +161,17 @@ export function remoteSecretsRaw(
   opts: { tty?: boolean; input?: string; osLookupName?: string; secret?: boolean } = {},
 ): SshExecResult {
   const remoteCmd = buildRemoteAgentsInvocation(['secrets', ...args], undefined, osForTarget(target, opts.osLookupName));
-  // A `-tt` session forces a fresh connection; a secret-bearing call (the push
-  // transport and its policy/literal follow-ups) additionally pins the managed
-  // host key and refuses to multiplex — see `credentialTransportSshOpts`
-  // (RUSH-2527). A plain browse `list` inherits the shared multiplexed baseline.
+  // A secret-bearing call (`secret: true`) pins the managed host key and refuses
+  // to multiplex — see `credentialTransportSshOpts` (RUSH-2527). A `-tt` session
+  // (a remote reveal/passphrase prompt) additionally allocates a PTY and never
+  // multiplexes, and it COMPOSES with the secret posture: a `view --reveal` over
+  // `--host` both prompts AND streams the plaintext value back over ssh stdout,
+  // so it needs the managed host-key pin too — `tty` must not short-circuit past
+  // `secret`. A plain browse `list` passes neither and keeps the shared baseline.
+  const posture = opts.secret ? credentialTransportSshOpts(target) : {};
   const conn = opts.tty
-    ? { extraSshArgs: ['-tt'], multiplex: false as const }
-    : opts.secret
-      ? credentialTransportSshOpts(target)
-      : {};
+    ? { ...posture, extraSshArgs: ['-tt'], multiplex: false as const }
+    : posture;
   return sshExec(target, remoteCmd, {
     timeoutMs: REMOTE_TIMEOUT_MS,
     input: opts.input,
@@ -192,7 +194,10 @@ export function remoteSecretsRaw(
  */
 export function remoteSecretsStream(target: string, args: string[], opts: { osLookupName?: string } = {}): number {
   const remoteCmd = buildRemoteAgentsInvocation(['secrets', ...args], undefined, osForTarget(target, opts.osLookupName));
-  return sshStream(target, remoteCmd, { tty: true });
+  // `unlock --host` carries the remote bundle's passphrase to the destination over
+  // this interactive channel, so it is secret-bearing: pin the managed host key
+  // (a changed key is refused) and never multiplex (RUSH-2527).
+  return sshStream(target, remoteCmd, { tty: true, ...credentialTransportSshOpts(target) });
 }
 
 /**

--- a/apps/cli/src/lib/secrets/remote.ts
+++ b/apps/cli/src/lib/secrets/remote.ts
@@ -23,8 +23,36 @@ import { sshTargetFor } from '../hosts/types.js';
 import { buildRemoteAgentsInvocation } from '../hosts/remote-cmd.js';
 import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { isLoaderOrInterpreterEnv } from './bundles.js';
+import { isHostPinned, hostKeyCheckingOpts } from '../devices/known-hosts.js';
 
 const REMOTE_TIMEOUT_MS = 30_000;
+
+/** The host part of an ssh target (`user@host` -> `host`) for known_hosts matching. */
+function hostKeyLookupName(target: string): string {
+  return target.split('@').pop() ?? target;
+}
+
+/**
+ * SSH options for a SECRET-carrying transport (RUSH-2527). Every `agents secrets
+ * --host` operation moves credential bytes — over ssh stdin (push) or ssh stdout
+ * (resolve/read-back) — so it MUST NOT ride the shared `accept-new` baseline
+ * against the user's own `~/.ssh/known_hosts` with a reusable control socket.
+ * Two hardenings over that baseline, matching the posture the `--copy-creds`
+ * dispatch already uses (`hosts/dispatch.ts` -> `hostKeyCheckingOpts`):
+ *
+ *   - **Managed pinned host keys.** Verify against the CLI-owned known_hosts
+ *     store (`known-hosts.ts`), not `~/.ssh/known_hosts`. A CHANGED key on a
+ *     known host is refused (`StrictHostKeyChecking` `yes` once pinned,
+ *     `accept-new` — which still refuses a changed key, only learns a genuinely
+ *     new one — before that). So a machine-in-the-middle swapping a pinned host's
+ *     key can never receive or return a secret.
+ *   - **No multiplex reuse.** `multiplex: false` — a credential channel never
+ *     leaves a persistent `ControlMaster` socket lingering (60s `ControlPersist`)
+ *     that any other `agents` invocation to that host would silently reuse.
+ */
+export function credentialTransportSshOpts(target: string): { hostKeyOpts: string[]; multiplex: false } {
+  return { hostKeyOpts: hostKeyCheckingOpts(isHostPinned(hostKeyLookupName(target))), multiplex: false };
+}
 
 /**
  * Trust boundary for a remote-resolved env map. A peer's `secrets export` output
@@ -130,14 +158,22 @@ export function splitBundleRef(ref: string): { bundle: string; host?: string } {
 export function remoteSecretsRaw(
   target: string,
   args: string[],
-  opts: { tty?: boolean; input?: string; osLookupName?: string } = {},
+  opts: { tty?: boolean; input?: string; osLookupName?: string; secret?: boolean } = {},
 ): SshExecResult {
   const remoteCmd = buildRemoteAgentsInvocation(['secrets', ...args], undefined, osForTarget(target, opts.osLookupName));
+  // A `-tt` session forces a fresh connection; a secret-bearing call (the push
+  // transport and its policy/literal follow-ups) additionally pins the managed
+  // host key and refuses to multiplex — see `credentialTransportSshOpts`
+  // (RUSH-2527). A plain browse `list` inherits the shared multiplexed baseline.
+  const conn = opts.tty
+    ? { extraSshArgs: ['-tt'], multiplex: false as const }
+    : opts.secret
+      ? credentialTransportSshOpts(target)
+      : {};
   return sshExec(target, remoteCmd, {
     timeoutMs: REMOTE_TIMEOUT_MS,
     input: opts.input,
-    extraSshArgs: opts.tty ? ['-tt'] : undefined,
-    multiplex: opts.tty ? false : undefined,
+    ...conn,
   });
 }
 
@@ -183,8 +219,12 @@ export async function remoteResolveEnv(
     undefined,
     osForTarget(target, opts.osLookupName),
   );
+  // Resolving a remote bundle streams its plaintext values back over ssh stdout,
+  // so this read is secret-bearing: pin the managed host key and never leave a
+  // reusable control master to the source (RUSH-2527, `credentialTransportSshOpts`).
   const res: SshExecResult = sshExec(target, remoteCmd, {
     timeoutMs: REMOTE_TIMEOUT_MS,
+    ...credentialTransportSshOpts(target),
   });
 
   if (res.code !== 0) {
@@ -374,14 +414,21 @@ export function verifyRemoteKeychainPush(
   target: string,
   bundle: string,
   pushedKeys: string[],
-  opts: { osLookupName?: string } = {},
+  opts: { osLookupName?: string; secret?: boolean } = {},
 ): RemoteKeychainWriteVerification {
   const remoteCmd = buildRemoteAgentsInvocation(
     ['secrets', 'export', bundle, '--plaintext', '--format', 'json'],
     undefined,
     osForTarget(target, opts.osLookupName),
   );
-  const res: SshExecResult = sshExec(target, remoteCmd, { timeoutMs: REMOTE_TIMEOUT_MS });
+  // This read-back streams the just-pushed plaintext over ssh stdout, so it is
+  // as secret-bearing as the push itself — the push path passes `secret: true`
+  // so it too pins the managed host key and leaves no reusable control master to
+  // the destination (RUSH-2527).
+  const res: SshExecResult = sshExec(target, remoteCmd, {
+    timeoutMs: REMOTE_TIMEOUT_MS,
+    ...(opts.secret ? credentialTransportSshOpts(target) : {}),
+  });
   if (res.code !== 0) {
     const why = res.timedOut ? 'timed out' : res.code === null ? 'ssh failed' : `exit ${res.code}`;
     const stderr = `${why}${(res.stderr || res.stdout || '').trim() ? `: ${(res.stderr || res.stdout).trim()}` : ''}`;


### PR DESCRIPTION
**Security hardening (no UI surface).** Brings the `agents secrets` credential-transport paths up to the same SSH posture the `--copy-creds` dispatch already uses: **managed pinned host keys** + **no connection multiplexing**. Ticket: [RUSH-2527](https://linear.app/getrush/issue/RUSH-2527).

## What changed

Every `agents secrets` operation that moves credential bytes across the fleet now verifies the destination against the CLI-managed known_hosts store and forces a fresh, non-multiplexed connection:

| Path | Before | After |
|---|---|---|
| `accounts sync` / `secrets export --host` push (+ read-back, `policy never`, literal restore) | `accept-new` vs `~/.ssh/known_hosts`, multiplexed (60s `ControlMaster`) | managed known_hosts (**changed key refused**), `multiplex: false` |
| Remote resolve — `exec --host`, `run --secrets b@host` (plaintext over ssh stdout) | multiplexed | pinned + `multiplex: false` |
| Read-only `list --host` browse | multiplexed baseline | **unchanged** (no secret bytes) |

The posture lives in one helper, `credentialTransportSshOpts` (`apps/cli/src/lib/secrets/remote.ts`), and the pure push plan carries `multiplex: false` so the invariant is unit-testable without a live host. Unpinned hosts still learn via `accept-new`, so first-time pushes (e.g. the release `apple.com` sign-host push) are **not** broken — only a *changed* key on a known host is refused.

**Why it matters:** the push transport shipped API keys / setup tokens while leaving a reusable authenticated control master to the destination for 60s, which any unrelated later `agents` invocation could ride — a weaker posture than `--copy-creds`, which ships the same class of secret. Secret bytes already cross on ssh **stdin** (push) / **stdout** (resolve), never argv.

## Scope note

This is the fleet-auth / credential-custody hardening slice of RUSH-2527, independent of the account command/schema track. The other RUSH-2527 asks were found **already implemented** on `main` and are not re-touched here: `--copy-creds` host-key pinning + no-multiplex (RUSH-1767), per-platform backend selection + keychain read-back verify, and metadata-only fleet account inventory (`credentialPresence`, pure file-presence reads). Removing OAuth forwarding from the explicit Rush Cloud dispatch / `--copy-creds` flows is a product decision, left out of this security-only change.

## Proof — focused suite (no mocking of ssh behavior; the stubbed boundary asserts the exact ssh options)

```
$ bun run vitest run src/lib/secrets/push.test.ts src/lib/secrets/remote.test.ts
 Test Files  2 passed (2)
      Tests  71 passed (71)
```

Full secrets suite: `700 passed | 16 skipped`. `bun run tsc --noEmit` clean. `./scripts/build.sh --skip-tests` green.

Tests added: `credentialTransportSshOpts` returns `multiplex:false` + managed-store host-key opts and matches on the host part of `user@host`; a secret-bearing `remoteSecretsRaw` / `remoteResolveEnv` pins + refuses multiplex while a plain browse `list` does not; the push plan pins `multiplex:false` on every non-refuse transport.
