### PR TITLE
fix(sessions): reap the helper processes an exited agent leaves behind (RUSH-2521)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2521.md
+++ b/apps/cli/.changelog/next/RUSH-2521.md
@@ -1,0 +1,23 @@
+- **Agent helper processes are reaped when the agent exits (RUSH-2521).** An interactive
+  agent runs as the leaf of a detached tmux pane, and tearing that pane down only SIGHUPs
+  its foreground process group — so an MCP server or a harness background daemon that had
+  moved out of that group survived its session and kept its memory indefinitely. Measured
+  on the fleet: one pane holding 2.5 GB of Claude Code background daemons 22 days after
+  its session ended, and 34 orphaned `cgraph-mcp --daemon` processes on one worker.
+  `agents sessions reap` and the routines daemon's 5-minute sweep now terminate those
+  helpers as well as the dead panes, and `killSession` collects a session's helpers as it
+  tears the session down. A helper is attributed to its session through the
+  `AGENT_TMUX_SESSION_NAME` the pane exports and every descendant inherits — the one
+  handle that survives reparenting — and is killed only when that session is gone, or has
+  no attached client AND its agent process has exited. A harness that detaches its
+  daemons from the environment (Claude Code's `daemon run`) is matched instead on the
+  spawner pid it declares in its own argv, and reaped only once that pid is dead.
+  `agents sessions reap --dry-run` lists what would be collected without killing
+  anything. Source: `apps/cli/src/lib/tmux/orphan-reap.ts`,
+  `apps/cli/src/lib/tmux/session.ts`, `apps/cli/src/commands/sessions-reap.ts`.
+- **`sessions migrate --host` stops leaving `remain-on-exit` on server-wide (RUSH-2521).**
+  The remote launch set the tmux server default to `on` and never put it back, so every
+  later pane on that box — user splits included — retained a dead corpse when its command
+  finished. It now keeps the option on the migrated agent's own pane (which the liveness
+  probe reads) and restores the server default to `off`, matching `createSession`.
+  Source: `apps/cli/src/commands/sessions-migrate.ts`.

--- a/apps/cli/docs/command-index.json
+++ b/apps/cli/docs/command-index.json
@@ -23901,13 +23901,22 @@
           "name": "reap",
           "path": "sessions reap",
           "aliases": [],
-          "description": "Kill tmux sessions whose panes are all dead.",
+          "description": "Kill tmux sessions whose panes are all dead, and the helper processes their agents left behind.",
           "args": [],
           "options": [
             {
               "flags": "--json",
               "description": "Emit a JSON result object instead of human output.",
               "long": "--json",
+              "required": false,
+              "optional": false,
+              "variadic": false,
+              "negate": false
+            },
+            {
+              "flags": "--dry-run",
+              "description": "List what would be reaped without killing anything.",
+              "long": "--dry-run",
               "required": false,
               "optional": false,
               "variadic": false,
@@ -23933,8 +23942,8 @@
               "negate": false
             }
           ],
-          "examples": "# Reap dead sessions interactively\nagents sessions reap\n\n# JSON output (for scripts)\nagents sessions reap --json",
-          "notes": "Sessions stay open after their process exits because `remain-on-exit on` is set\nso the harness can inspect exit status. This command cleans them up on demand.\n\nSafety: sessions with at least one live pane are never touched.",
+          "examples": "# Reap dead sessions and orphaned helper processes\nagents sessions reap\n\n# See what would be reaped, without killing anything\nagents sessions reap --dry-run\n\n# JSON output (for scripts)\nagents sessions reap --json",
+          "notes": "Sessions stay open after their process exits because `remain-on-exit on` is set\nso the harness can inspect exit status. Killing the pane only SIGHUPs its\nforeground process group, so MCP servers and harness background daemons that\nmoved out of that group outlive the agent. This command collects both.\n\nSafety: sessions with at least one live pane are never touched, and a helper\nprocess is killed only when its owning tmux session is gone, or that session\nhas no attached client AND its agent process has exited.\n\nThe routines daemon runs the same sweep every 5 minutes.",
           "subcommands": []
         },
         {

--- a/apps/cli/docs/command-index.md
+++ b/apps/cli/docs/command-index.md
@@ -821,7 +821,7 @@ agents sessions migrate [session-id]        Relocate a running session onto anot
 agents sessions migrations                  Show the migration ledger — sessions handed off to/from other machines.
 agents sessions optimize                    Compact the session search index (FTS5), reclaiming bloat from repeated re-indexing
 agents sessions preview <id>                Show one rich session card without rendering the full transcript
-agents sessions reap                        Kill tmux sessions whose panes are all dead.
+agents sessions reap                        Kill tmux sessions whose panes are all dead, and the helper processes their agents left behind.
 agents sessions reconnect [session-id]      Re-enter a dropped agent terminal: attach the live pane if it survived, else resume the session
 agents sessions render <selectors...>       Render one or more sessions as readable, redacted Markdown for review or sharing.
 agents sessions resume [query]              Reopen one session by canonical identity, or multi-select history into terminal tabs/splits.

--- a/apps/cli/docs/command-reference.html
+++ b/apps/cli/docs/command-reference.html
@@ -2804,21 +2804,39 @@ pass --decrypt &lt;key&gt;). It is the inverse of &#39;sessions export --to-r2&#
       agents sessions preview 407b8dd5 --device zion</code></pre><h4>Notes</h4><p class="notes">- Full UUIDs are globally unique and may stop the fleet lookup at the first exact hit.
       - Short IDs wait for every selected device so ambiguity is never hidden.
       - Active status is refreshed through the bounded live-state TTL; transcript-derived details use the durable session index.</p></article>
-<article id="sessions-reap" data-search="reap sessions reap  kill tmux sessions whose panes are all dead. --json emit a json result object instead of human output. --socket &lt;path&gt; path to the tmux server socket (default: agents helper socket). -h, --help show help # reap dead sessions interactively
+<article id="sessions-reap" data-search="reap sessions reap  kill tmux sessions whose panes are all dead, and the helper processes their agents left behind. --json emit a json result object instead of human output. --dry-run list what would be reaped without killing anything. --socket &lt;path&gt; path to the tmux server socket (default: agents helper socket). -h, --help show help # reap dead sessions and orphaned helper processes
 agents sessions reap
+
+# see what would be reaped, without killing anything
+agents sessions reap --dry-run
 
 # json output (for scripts)
 agents sessions reap --json sessions stay open after their process exits because `remain-on-exit on` is set
-so the harness can inspect exit status. this command cleans them up on demand.
+so the harness can inspect exit status. killing the pane only sighups its
+foreground process group, so mcp servers and harness background daemons that
+moved out of that group outlive the agent. this command collects both.
 
-safety: sessions with at least one live pane are never touched."><div class="command-head"><h3><code>agents sessions reap</code></h3></div><p>Kill tmux sessions whose panes are all dead.</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>--json</code></td><td>Emit a JSON result object instead of human output.</td><td></td><td></td></tr><tr><td><code>--socket &lt;path&gt;</code></td><td>Path to the tmux server socket (default: agents helper socket).</td><td></td><td></td></tr><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table><h4>Examples</h4><pre><code># Reap dead sessions interactively
+safety: sessions with at least one live pane are never touched, and a helper
+process is killed only when its owning tmux session is gone, or that session
+has no attached client and its agent process has exited.
+
+the routines daemon runs the same sweep every 5 minutes."><div class="command-head"><h3><code>agents sessions reap</code></h3></div><p>Kill tmux sessions whose panes are all dead, and the helper processes their agents left behind.</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>--json</code></td><td>Emit a JSON result object instead of human output.</td><td></td><td></td></tr><tr><td><code>--dry-run</code></td><td>List what would be reaped without killing anything.</td><td></td><td></td></tr><tr><td><code>--socket &lt;path&gt;</code></td><td>Path to the tmux server socket (default: agents helper socket).</td><td></td><td></td></tr><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table><h4>Examples</h4><pre><code># Reap dead sessions and orphaned helper processes
 agents sessions reap
+
+# See what would be reaped, without killing anything
+agents sessions reap --dry-run
 
 # JSON output (for scripts)
 agents sessions reap --json</code></pre><h4>Notes</h4><p class="notes">Sessions stay open after their process exits because `remain-on-exit on` is set
-so the harness can inspect exit status. This command cleans them up on demand.
+so the harness can inspect exit status. Killing the pane only SIGHUPs its
+foreground process group, so MCP servers and harness background daemons that
+moved out of that group outlive the agent. This command collects both.
 
-Safety: sessions with at least one live pane are never touched.</p></article>
+Safety: sessions with at least one live pane are never touched, and a helper
+process is killed only when its owning tmux session is gone, or that session
+has no attached client AND its agent process has exited.
+
+The routines daemon runs the same sweep every 5 minutes.</p></article>
 <article id="sessions-reconnect" data-search="reconnect sessions reconnect  re-enter a dropped agent terminal: attach the live pane if it survived, else resume the session session-id session id/prefix to reconnect (default: the most recent session started here) -h, --help show help # reconnect the session that just dropped in this shell (most recent here)
       agents reconnect
 

--- a/apps/cli/docs/sessions.md
+++ b/apps/cli/docs/sessions.md
@@ -1235,6 +1235,56 @@ whether it is `background` or `parked` is decided live from the recorded pid plu
 start-time fingerprint (which defeats PID reuse). Ad-hoc headless runs and cloud/team
 rows carry no presence — they are not on this axis.
 
+## Reaping what an exited agent left behind (`sessions reap`)
+
+An interactive agent is the leaf of a detached tmux pane, and the pane is created
+with `remain-on-exit on` so the harness can read the agent's exit status and
+capture its final output. Two things then accumulate:
+
+- **Dead panes.** A retained pane whose agent exited is diagnostic state; nothing
+  in the attach path collects it when the client that launched it is gone (an SSH
+  drop, a closed terminal).
+- **Helper processes.** Destroying a pane SIGHUPs only its FOREGROUND process
+  group. An MCP server or a harness background daemon that moved itself into its
+  own process group survives, reparents to init, and holds its memory forever.
+  Measured on the fleet: one pane holding 2.5 GB of Claude Code background daemons
+  22 days after its session ended, and 34 orphaned `cgraph-mcp --daemon`
+  processes on a single worker (RUSH-2521).
+
+```bash
+agents sessions reap             # collect both
+agents sessions reap --dry-run   # list what would be collected, kill nothing
+agents sessions reap --json      # { reaped, sessions, details, processes, processDetails }
+```
+
+The routines daemon runs the same sweep every 5 minutes
+([`src/lib/daemon.ts`](../src/lib/daemon.ts) `runDeadPaneReap`), and `killSession`
+collects a session's helpers as it tears that session down, so an agent that exits
+normally leaves nothing behind without waiting for a tick.
+
+**How a helper is attributed to its session.** Every OS handle that names the pane
+is destroyed by the exit itself — ppid ancestry is replaced by init, the
+controlling terminal is disassociated from the whole POSIX session when its leader
+exits, and the surviving helpers are precisely the ones that left the pane's
+process group. What does survive is the environment: the pane exports
+`AGENT_TMUX_SESSION_NAME` and every descendant inherits it, reparented or not. A
+process carrying that marker is reaped when its tmux session no longer exists, or
+when that session has **no attached client AND** its agent pane process has exited.
+A live agent or an attached client protects everything it owns, and the routines
+daemon, the secrets broker, and the reaping process's own ancestry are never
+candidates.
+
+A harness that starts its background daemons with a scrubbed environment is matched
+on the owner it declares in its own argv instead — Claude Code's
+`daemon run --spawned-by {…,"pid":N}` pool is reaped, with its `bg-pty-host` /
+`bg-spare` workers, once pid `N` is dead. Those rules live in
+`DETACHED_HELPER_RULES` ([`src/lib/tmux/orphan-reap.ts`](../src/lib/tmux/orphan-reap.ts)),
+one entry per harness.
+
+Note that this collects **everything** a session's agent spawned, not only MCP
+servers — a server the agent deliberately backgrounded inside its pane is torn down
+with the session too.
+
 ## Lost hosts: `crashed` and `orphaned`
 
 Every other liveness signal answers "is the agent process alive". None of them answer

--- a/apps/cli/src/commands/sessions-migrate.ts
+++ b/apps/cli/src/commands/sessions-migrate.ts
@@ -495,12 +495,23 @@ async function resumeOnTarget(
   // carries spaces or backticks (the rehydrate prompt) reaches the agent as one
   // clean argument — an unquoted join would let the target shell split it and
   // run its backticks.
+  //
+  // The pane exports AGENT_TMUX_SESSION_NAME the way a local `createSession`
+  // pane does, so the target's reaper can attribute the helpers this agent
+  // spawns and collect them when it exits (RUSH-2521,
+  // `lib/tmux/orphan-reap.ts`).
   const sessionName = `migrate-${source.shortId}`;
-  const inner = iLoginShell(`exec ${command!.map(quoteArg).join(' ')}`);
+  const inner = iLoginShell(`export AGENT_TMUX_SESSION_NAME=${sessionName}; exec ${command!.map(quoteArg).join(' ')}`);
   const argv = ['tmux', 'set-option', '-g', 'remain-on-exit', 'on', ';', 'new-session', '-d', '-s', sessionName];
   const cwd = remoteCwd ?? source.cwd;
   if (cwd && cwd !== '~') argv.push('-c', cwd);
   argv.push(inner);
+  // Mirror createSession's second half: keep remain-on-exit on THIS pane (the
+  // liveness probe below reads `pane_dead`), then put the server-wide default
+  // back to off. Leaving `-g on` set made every later pane on the target — user
+  // splits included — retain a corpse when its command finished.
+  argv.push(';', 'set-option', '-t', sessionName, '-p', 'remain-on-exit', 'on');
+  argv.push(';', 'set-option', '-g', 'remain-on-exit', 'off');
   const launch = sshExec(sshTarget, argv.map(shellQuote).join(' '), { timeoutMs: 60000 });
   if (launch.code !== 0) {
     console.log(chalk.red(`  Resume on ${sshTarget} failed: ${launch.stderr.trim().split('\n').pop() || `tmux exited ${launch.code}`}`));

--- a/apps/cli/src/commands/sessions-reap.ts
+++ b/apps/cli/src/commands/sessions-reap.ts
@@ -2,30 +2,42 @@ import chalk from 'chalk';
 import type { Command } from 'commander';
 import { setHelpSections } from '../lib/help.js';
 import { reapDeadTmuxPanes } from '../lib/tmux/session.js';
+import { reapOrphanAgentProcesses } from '../lib/tmux/orphan-reap.js';
 import { getDefaultSocketPath } from '../lib/tmux/paths.js';
 
 interface ReapOptions {
   json?: boolean;
   socket?: string;
+  dryRun?: boolean;
 }
 
 export function registerSessionsReapCommand(sessionsCmd: Command): void {
   const cmd = sessionsCmd
     .command('reap')
-    .description('Kill tmux sessions whose panes are all dead.')
+    .description('Kill tmux sessions whose panes are all dead, and the helper processes their agents left behind.')
     .option('--json', 'Emit a JSON result object instead of human output.')
+    .option('--dry-run', 'List what would be reaped without killing anything.')
     .option('--socket <path>', 'Path to the tmux server socket (default: agents helper socket).');
 
   setHelpSections(cmd, {
     notes: [
       'Sessions stay open after their process exits because `remain-on-exit on` is set',
-      'so the harness can inspect exit status. This command cleans them up on demand.',
+      'so the harness can inspect exit status. Killing the pane only SIGHUPs its',
+      'foreground process group, so MCP servers and harness background daemons that',
+      'moved out of that group outlive the agent. This command collects both.',
       '',
-      'Safety: sessions with at least one live pane are never touched.',
+      'Safety: sessions with at least one live pane are never touched, and a helper',
+      'process is killed only when its owning tmux session is gone, or that session',
+      'has no attached client AND its agent process has exited.',
+      '',
+      'The routines daemon runs the same sweep every 5 minutes.',
     ].join('\n'),
     examples: [
-      '# Reap dead sessions interactively',
+      '# Reap dead sessions and orphaned helper processes',
       'agents sessions reap',
+      '',
+      '# See what would be reaped, without killing anything',
+      'agents sessions reap --dry-run',
       '',
       '# JSON output (for scripts)',
       'agents sessions reap --json',
@@ -34,21 +46,33 @@ export function registerSessionsReapCommand(sessionsCmd: Command): void {
 
   cmd.action(async (options: ReapOptions) => {
     const socket = options.socket ?? getDefaultSocketPath();
-    const result = await reapDeadTmuxPanes(socket);
+    const dryRun = options.dryRun === true;
+    const result = await reapDeadTmuxPanes(socket, { dryRun });
 
     if (options.json) {
-      console.log(JSON.stringify({ reaped: result.reaped, sessions: result.sessions, details: result.details }));
+      console.log(JSON.stringify({
+        dryRun,
+        reaped: result.reaped,
+        sessions: result.sessions,
+        details: result.details,
+        processes: result.processes,
+        processDetails: result.processDetails,
+      }));
       return;
     }
 
-    if (result.reaped === 0) {
-      console.log(chalk.gray('No dead tmux sessions to reap.'));
+    if (result.reaped === 0 && result.processes === 0) {
+      console.log(chalk.gray('No dead tmux sessions or orphaned processes to reap.'));
       return;
     }
 
-    for (const d of result.details) {
-      console.log(chalk.green('reaped') + ' ' + d);
-    }
-    console.log(chalk.gray(`\n${result.reaped} session${result.reaped === 1 ? '' : 's'} reaped.`));
+    const verb = dryRun ? chalk.yellow('would kill') : chalk.green('killed');
+    for (const d of result.processDetails) console.log(`${verb} ${d}`);
+    for (const d of result.details) console.log(`${verb} session ${d}`);
+
+    const parts: string[] = [];
+    if (result.reaped > 0) parts.push(`${result.reaped} session${result.reaped === 1 ? '' : 's'}`);
+    if (result.processes > 0) parts.push(`${result.processes} orphaned process${result.processes === 1 ? '' : 'es'}`);
+    console.log(chalk.gray(`\n${parts.join(' and ')} ${dryRun ? 'would be reaped.' : 'reaped.'}`));
   });
 }

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -705,6 +705,10 @@ async function runKeychainReap(): Promise<void> {
 
 /**
  * RUSH-2501: kill tmux sessions on the helper socket whose panes are ALL dead.
+ * RUSH-2521: and terminate the helper processes (MCP servers, harness background
+ * daemons) whose owning agent has exited — killing the pane only SIGHUPs its
+ * foreground process group, so anything that left that group outlives it.
+ *
  * Runs every DEAD_PANE_REAP_TICK_MS (5 min). The daemon is the single executor
  * so no UI surface can race it.
  */
@@ -715,9 +719,13 @@ async function runDeadPaneReap(): Promise<void> {
     const { reapDeadTmuxPanes } = await import('./tmux/session.js');
     const { getDefaultSocketPath } = await import('./tmux/paths.js');
     const result = await reapDeadTmuxPanes(getDefaultSocketPath());
+    if (result.processes > 0) {
+      log('INFO', `Dead-pane reaper: terminated ${result.processes} orphaned helper process(es)`);
+      for (const d of result.processDetails) log('INFO', `  ${d}`);
+    }
     if (result.reaped > 0) {
       log('INFO', `Dead-pane reaper: reaped ${result.reaped} session(s)`);
-      for (const d of result.details) log('INFO', `  ${d}`);
+      for (const d of result.details) log('INFO', `  killed ${d}`);
     }
   } catch (err) {
     log('ERROR', `Dead-pane reaper failed: ${(err as Error).message}`);

--- a/apps/cli/src/lib/tmux/orphan-reap.test.ts
+++ b/apps/cli/src/lib/tmux/orphan-reap.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for the agent-helper orphan reaper (RUSH-2521).
+ *
+ * The integration block spawns a REAL tmux pane whose command starts a REAL
+ * helper process that ignores SIGHUP — the exact shape that leaks in production
+ * — then exits, and asserts the reaper collects it. Nothing on that path is
+ * mocked: real tmux, real processes, real signals.
+ *
+ * The selector block covers the decision logic with process tables captured from
+ * the fleet, including the verbatim argv of a leaked Claude Code daemon.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { isTmuxInstalled, runTmux } from './binary.js';
+import { createSession, hasSession, killAll, killSession, reapDeadTmuxPanes } from './session.js';
+import {
+  DETACHED_HELPER_RULES,
+  TMUX_SESSION_ENV,
+  descendantsOf,
+  isProtectedAgentsService,
+  parsePaneOwners,
+  parseProcessRows,
+  parseTmuxSessionMarker,
+  selectOrphanProcesses,
+  type AgentProcess,
+  type PaneOwner,
+} from './orphan-reap.js';
+
+const posix = process.platform !== 'win32';
+const skipReason = !posix ? 'POSIX-only' : (isTmuxInstalled() ? null : 'tmux not installed');
+
+const proc = (pid: number, ppid: number, args: string, tmuxSession?: string): AgentProcess =>
+  ({ pid, ppid, args, tmuxSession });
+
+const owners = (entries: Array<[string, PaneOwner]>): Map<string, PaneOwner> => new Map(entries);
+
+const noneProtected = { protectedPids: new Set<number>() };
+
+describe('parseProcessRows', () => {
+  it('splits pid/ppid and keeps the full argv, spaces included', () => {
+    const rows = parseProcessRows([
+      '  201357  201227 /home/me/.local/bin/cgraph-mcp --root /home/me/src/agents-cli --daemon',
+      '       1       0 /sbin/init',
+      'garbage line with no pids',
+      '',
+    ].join('\n'));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ pid: 201357, ppid: 201227 });
+    expect(rows[0].args).toContain('--root /home/me/src/agents-cli --daemon');
+    expect(rows[1]).toMatchObject({ pid: 1, ppid: 0, args: '/sbin/init' });
+  });
+});
+
+describe('parseTmuxSessionMarker', () => {
+  it('reads the marker out of a NUL-separated /proc/<pid>/environ blob', () => {
+    const environ = ['PATH=/usr/bin', `${TMUX_SESSION_ENV}=ag-codex-ff55f79f`, 'HOME=/home/me'].join('\0') + '\0';
+    expect(parseTmuxSessionMarker(environ)).toBe('ag-codex-ff55f79f');
+  });
+
+  it('reads the marker out of the space-separated tail macOS `ps -E` appends', () => {
+    const line = `node /opt/agents/dist/index.js PATH=/usr/bin ${TMUX_SESSION_ENV}=ag-claude-8f89aab4 SHELL=/bin/zsh`;
+    expect(parseTmuxSessionMarker(line)).toBe('ag-claude-8f89aab4');
+  });
+
+  it('does not match a variable that merely ends with the marker name', () => {
+    expect(parseTmuxSessionMarker(`MY_${TMUX_SESSION_ENV}=ag-claude-1234abcd`)).toBeUndefined();
+  });
+
+  it('is undefined when no marker is present', () => {
+    expect(parseTmuxSessionMarker('PATH=/usr/bin\0HOME=/home/me\0')).toBeUndefined();
+  });
+});
+
+describe('parsePaneOwners', () => {
+  it('treats a session as owned while ANY of its panes has a live agent', () => {
+    const alive = (pid: number) => pid === 100;
+    const map = parsePaneOwners(['ag-claude-aaaa\t100\t0', 'ag-claude-aaaa\t101\t0'].join('\n'), alive);
+    expect(map.get('ag-claude-aaaa')).toEqual({ agentAlive: true, attached: false });
+  });
+
+  it('marks a session attached when any pane reports a client', () => {
+    const map = parsePaneOwners(['ag-claude-bbbb\t200\t1'].join('\n'), () => false);
+    expect(map.get('ag-claude-bbbb')).toEqual({ agentAlive: false, attached: true });
+  });
+});
+
+describe('selectOrphanProcesses', () => {
+  it('reaps a helper whose tmux session no longer exists', () => {
+    const table = [proc(500, 1, 'cgraph-mcp --daemon', 'ag-codex-ff55f79f')];
+    const picked = selectOrphanProcesses(table, owners([]), noneProtected);
+    expect(picked).toEqual([{ pid: 500, args: 'cgraph-mcp --daemon', reason: 'tmux-session-gone', tmuxSession: 'ag-codex-ff55f79f' }]);
+  });
+
+  it('reaps a helper whose session exists but whose agent pane process has exited', () => {
+    const table = [proc(500, 1, 'cgraph-mcp --daemon', 'ag-claude-dead')];
+    const picked = selectOrphanProcesses(table, owners([['ag-claude-dead', { agentAlive: false, attached: false }]]), noneProtected);
+    expect(picked.map(c => c.reason)).toEqual(['tmux-agent-exited']);
+  });
+
+  it('NEVER reaps a helper whose agent is still running', () => {
+    const table = [proc(500, 400, 'cgraph-mcp --daemon', 'ag-claude-live')];
+    const picked = selectOrphanProcesses(table, owners([['ag-claude-live', { agentAlive: true, attached: false }]]), noneProtected);
+    expect(picked).toEqual([]);
+  });
+
+  it('NEVER reaps a helper of a session that has a client attached, even with a dead pane', () => {
+    const table = [proc(500, 1, 'cgraph-mcp --daemon', 'ag-claude-watched')];
+    const picked = selectOrphanProcesses(table, owners([['ag-claude-watched', { agentAlive: false, attached: true }]]), noneProtected);
+    expect(picked).toEqual([]);
+  });
+
+  it('NEVER reaps the routines daemon or the secrets broker, marker or not', () => {
+    const table = [
+      proc(600, 1, 'node dist/index.js __daemon-run', 'ag-claude-gone'),
+      proc(601, 1, 'node dist/index.js secrets _agent-run', 'ag-claude-gone'),
+    ];
+    expect(selectOrphanProcesses(table, owners([]), noneProtected)).toEqual([]);
+    expect(isProtectedAgentsService('node dist/index.js __daemon-run')).toBe(true);
+  });
+
+  it('NEVER reaps the reaping process itself or its ancestors', () => {
+    const table = [proc(700, 699, 'node dist/index.js sessions reap', 'ag-claude-gone')];
+    expect(selectOrphanProcesses(table, owners([]), { protectedPids: new Set([700]) })).toEqual([]);
+  });
+
+  it('reaps a detached harness daemon whose declared spawner is dead, and its workers', () => {
+    // Verbatim argv measured on yosemite-s1: a Claude Code daemon still holding
+    // 2.5 GB of bg workers 22 days after the claude that spawned it exited.
+    const daemonArgs = '/home/me/.agents/.history/versions/claude/2.1.207/node_modules/@anthropic-ai/claude-code/bin/claude.exe '
+      + 'daemon run --origin transient --spawned-by {"label":"claude","cwd":"/home/me/src/agents-cli","pid":3834601}';
+    const table = [
+      proc(3868250, 1, daemonArgs),
+      proc(3868356, 3868250, 'claude bg-pty-host --bg-pty-host /tmp/cc-daemon-1000/cbb199fb/spare/0d113ea8.pty.sock'),
+      proc(3868404, 3868356, 'claude bg-spare --bg-spare /tmp/cc-daemon-1000/cbb199fb/spare/0d113ea8.claim.sock'),
+      proc(999, 1, 'unrelated-process'),
+    ];
+    const picked = selectOrphanProcesses(table, owners([]), { ...noneProtected, isAlive: () => false });
+    expect(picked.map(c => c.pid).sort((a, b) => a - b)).toEqual([3868250, 3868356, 3868404]);
+    expect(picked.every(c => c.reason === 'detached-helper')).toBe(true);
+  });
+
+  it('NEVER reaps a detached harness daemon whose declared spawner is still alive', () => {
+    const daemonArgs = 'claude.exe daemon run --origin transient --spawned-by {"label":"claude","pid":3834601}';
+    const table = [
+      proc(3868250, 3834601, daemonArgs),
+      proc(3868356, 3868250, 'claude bg-pty-host --bg-pty-host /tmp/cc-daemon-1000/cbb199fb/spare/x.pty.sock'),
+    ];
+    const picked = selectOrphanProcesses(table, owners([]), { ...noneProtected, isAlive: pid => pid === 3834601 });
+    expect(picked).toEqual([]);
+  });
+
+  it('claude rule ignores a non-daemon claude command line', () => {
+    const rule = DETACHED_HELPER_RULES.find(r => r.agent === 'claude')!;
+    expect(rule.spawnerPid('/home/me/.../.bin/claude --permission-mode plan --session-id 978673a2')).toBeUndefined();
+    expect(rule.spawnerPid('claude.exe daemon run --spawned-by {"pid":42}')).toBe(42);
+  });
+});
+
+describe('descendantsOf', () => {
+  it('returns the seeds plus everything reachable through ppid links', () => {
+    const table = [proc(10, 1, 'a'), proc(11, 10, 'b'), proc(12, 11, 'c'), proc(20, 1, 'other')];
+    expect(descendantsOf(table, [10]).sort((a, b) => a - b)).toEqual([10, 11, 12]);
+  });
+
+  it('terminates on a cyclic ppid chain instead of spinning', () => {
+    const table = [proc(30, 31, 'a'), proc(31, 30, 'b')];
+    expect(descendantsOf(table, [30]).sort((a, b) => a - b)).toEqual([30, 31]);
+  });
+});
+
+describe.skipIf(skipReason)('reaping a real leaked helper', () => {
+  let socket: string;
+  let tempDir: string;
+  const spawned: number[] = [];
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-orphan-reap-'));
+    socket = path.join(tempDir, 'test.sock');
+  });
+
+  afterEach(async () => {
+    await killAll(socket).catch(() => {});
+    for (const pid of spawned.splice(0)) {
+      try { process.kill(pid, 'SIGKILL'); } catch { /* already reaped — the point of the test */ }
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Launch a pane that exports the session marker (as the real pane env file
+   * does), starts a SIGHUP-immune helper, records its pid, and exits — the
+   * production leak, reproduced.
+   */
+  async function launchLeakingSession(name: string, agentCmd: string): Promise<number> {
+    const pidFile = path.join(tempDir, `${name}.pid`);
+    const cmd = `export ${TMUX_SESSION_ENV}=${name}; sh -c 'trap "" HUP; exec sleep 300' & echo $! > ${pidFile}; ${agentCmd}`;
+    await createSession({ name, cmd, socket });
+    for (let i = 0; i < 100 && !fs.existsSync(pidFile); i += 1) await wait(50);
+    const pid = parseInt(fs.readFileSync(pidFile, 'utf8').trim(), 10);
+    expect(Number.isFinite(pid)).toBe(true);
+    spawned.push(pid);
+    return pid;
+  }
+
+  it('kills the helper an exited agent left behind, and leaves no dead session', async () => {
+    const name = `orph-dead-${process.pid}`;
+    const helper = await launchLeakingSession(name, 'exec sleep 0.3');
+    await waitForPaneDead(name, socket, 8000);
+
+    // The leak, before the fix does anything: the agent is gone, the helper is not.
+    expect(alive(helper)).toBe(true);
+    expect(markerOf(helper)).toBe(name);
+
+    const result = await reapDeadTmuxPanes(socket);
+
+    expect(result.processes).toBeGreaterThanOrEqual(1);
+    expect(result.processDetails.join('\n')).toContain(String(helper));
+    expect(await waitForGone(helper, 6000)).toBe(true);
+    expect(await hasSession(name, socket)).toBe(false);
+  }, 30_000);
+
+  it('does NOT kill the helper of a session whose agent is still running', async () => {
+    const name = `orph-live-${process.pid}`;
+    const helper = await launchLeakingSession(name, 'exec sleep 120');
+
+    const result = await reapDeadTmuxPanes(socket);
+
+    expect(result.processDetails.join('\n')).not.toContain(String(helper));
+    expect(alive(helper)).toBe(true);
+    expect(await hasSession(name, socket)).toBe(true);
+  }, 30_000);
+
+  it('killSession tears the session helpers down with the session', async () => {
+    const name = `orph-kill-${process.pid}`;
+    const helper = await launchLeakingSession(name, 'exec sleep 120');
+    expect(alive(helper)).toBe(true);
+
+    await killSession(name, socket);
+
+    expect(await waitForGone(helper, 6000)).toBe(true);
+  }, 30_000);
+});
+
+function alive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+/** The pane marker a live process actually carries, read the way the reaper reads it. */
+function markerOf(pid: number): string | undefined {
+  if (!fs.existsSync('/proc/self/environ')) return undefined; // macOS reads it via `ps -E`
+  try {
+    return parseTmuxSessionMarker(fs.readFileSync(`/proc/${pid}/environ`, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+async function waitForGone(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!alive(pid)) return true;
+    await wait(100);
+  }
+  return !alive(pid);
+}
+
+/** Poll until the session's agent pane reports `pane_dead=1`. */
+async function waitForPaneDead(name: string, socket: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const res = await runTmux({ socket, args: ['list-panes', '-t', `=${name}`, '-F', '#{pane_dead}'], throwOnError: false });
+    if (res.code === 0 && res.stdout.trim().split('\n')[0] === '1') return;
+    await wait(100);
+  }
+  throw new Error(`pane for ${name} never died within ${timeoutMs}ms`);
+}

--- a/apps/cli/src/lib/tmux/orphan-reap.ts
+++ b/apps/cli/src/lib/tmux/orphan-reap.ts
@@ -1,0 +1,481 @@
+/**
+ * Reap the helper processes an exited agent leaves behind (RUSH-2521).
+ *
+ * ## The leak
+ *
+ * An interactive agent runs as the leaf of a detached tmux pane
+ * (`runInTmux` → `createSession`, [`../exec.ts`](../exec.ts)). Anything the
+ * harness spawns — MCP servers, background daemons, `exec` helper trees — is a
+ * child of that pane. When the agent exits, the kernel SIGHUPs the pane's
+ * FOREGROUND process group only. A helper that put itself in its own process
+ * group, or that ignores SIGHUP, survives: it reparents to init and keeps its
+ * memory forever. Measured on the fleet: one pane holding 2.5 GB of Claude Code
+ * background daemons 22 days after its session ended, and 34 orphaned
+ * `cgraph-mcp --daemon` processes on a single worker.
+ *
+ * ## Why attribution is by ENVIRONMENT, not by pid ancestry / tty / pgid
+ *
+ * Every obvious OS handle is destroyed by exactly the event we are detecting:
+ *
+ * - **ppid ancestry** — an orphan is reparented to init the instant its parent
+ *   dies, so the chain back to the pane is gone.
+ * - **controlling terminal** — POSIX disassociates the controlling terminal from
+ *   every process in a session when the session leader exits, so the orphan's
+ *   `tty` reads `?`. Verified on Linux: an orphan under a dead pane leader shows
+ *   `tty=?` while its own pane still reports `pane_tty=/dev/pts/6`.
+ * - **process group** — the helpers that survive are precisely the ones that
+ *   left the pane's process group (that is why they survived the SIGHUP).
+ * - **POSIX session id** — durable and correct, but not portable: `ps -o sid=`
+ *   exists on Linux and does not exist on macOS (`ps: sid: keyword not found`),
+ *   `ps -o sess=` reports 0 there, and `pgrep -s` is Linux-only.
+ *
+ * What DOES survive all of it is the process environment. `runInTmux` stamps
+ * `AGENT_TMUX_SESSION_NAME` into the pane env ([`../exec.ts`](../exec.ts)), and
+ * every descendant inherits it — including a reparented one. So a process
+ * carrying `AGENT_TMUX_SESSION_NAME=<name>` is attributable to that tmux session
+ * with no heuristics at all, and tmux itself is the liveness oracle for whether
+ * that session's agent is still running.
+ *
+ * ## The second tier: harness daemons that scrub the environment
+ *
+ * Claude Code's background pool (`claude … daemon run`, which owns the
+ * `bg-pty-host` / `bg-spare` processes) starts with a clean environment, so tier
+ * one cannot see it. It does, however, declare its owner in its own argv:
+ * `daemon run --origin transient --spawned-by {"label":"claude",…,"pid":3834601}`.
+ * A pool whose declared spawner pid is dead is unowned, so it and its descendants
+ * are reaped. That rule lives in {@link DETACHED_HELPER_RULES} rather than an
+ * inline `if (agent === 'claude')`, so another harness that detaches helpers the
+ * same way is one table entry.
+ *
+ * ## Safety
+ *
+ * Nothing is killed without positive proof its owner is gone:
+ *
+ * - a tmux session that still exists AND whose agent pane process is alive
+ *   protects every process it owns;
+ * - a tmux session with a client attached protects every process it owns,
+ *   whatever the pane state;
+ * - the reaping process itself, its ancestors, pid 1, and every long-lived
+ *   agents-cli service ({@link isProtectedAgentsService}) are never candidates.
+ */
+
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/** Ceiling on the `ps` snapshot so a wedged `ps` can never stall the daemon tick. */
+const PS_TIMEOUT_MS = 10_000;
+
+/** Grace between SIGTERM and SIGKILL for a reaped orphan. */
+export const REAP_GRACE_MS = 2_000;
+
+/** Env var `runInTmux` stamps into the pane, inherited by every descendant. */
+export const TMUX_SESSION_ENV = 'AGENT_TMUX_SESSION_NAME';
+
+/** One process, with the fields the reaper attributes on. */
+export interface AgentProcess {
+  pid: number;
+  ppid: number;
+  /** Full command line (`ps -o args=`). */
+  args: string;
+  /** Value of {@link TMUX_SESSION_ENV} inherited from the pane, when present. */
+  tmuxSession?: string;
+}
+
+/** Liveness of the tmux session that owns a set of processes. */
+export interface PaneOwner {
+  /** The session's agent pane process is still running. */
+  agentAlive: boolean;
+  /** A client is attached to the session — a human is looking at it. */
+  attached: boolean;
+}
+
+/** Why a process was selected, for human output and tests. */
+export type OrphanReason = 'tmux-session-gone' | 'tmux-agent-exited' | 'detached-helper';
+
+export interface OrphanCandidate {
+  pid: number;
+  args: string;
+  reason: OrphanReason;
+  /** Owning tmux session, when the process carried the marker. */
+  tmuxSession?: string;
+}
+
+export interface OrphanReapResult {
+  /** Processes signalled (SIGTERM, escalated to SIGKILL when they ignore it). */
+  killed: number;
+  /** One human-readable line per reaped process. */
+  details: string[];
+  /** Selected candidates, whether or not they were killed (`dryRun`). */
+  candidates: OrphanCandidate[];
+}
+
+/**
+ * A harness that detaches helper daemons from the session environment, and the
+ * pid it records as their owner.
+ *
+ * Registry rather than per-agent branches: a second harness with the same shape
+ * is one entry, and the completeness of the table is what a reviewer checks.
+ */
+export interface DetachedHelperRule {
+  /** Harness id, for the reap detail line. */
+  agent: string;
+  /** Owner pid the helper declares in its own argv, or undefined when it is not this rule's process. */
+  spawnerPid(args: string): number | undefined;
+}
+
+/**
+ * Claude Code's background daemon pool. Its argv carries a JSON `--spawned-by`
+ * blob naming the claude process that started it, e.g.
+ * `claude.exe daemon run --origin transient --spawned-by {"label":"claude","cwd":"/…","pid":3834601}`.
+ * The `bg-pty-host` / `bg-spare` workers are its children and are reaped as
+ * descendants rather than matched individually — they carry no owner of their own.
+ */
+const CLAUDE_BG_DAEMON: DetachedHelperRule = {
+  agent: 'claude',
+  spawnerPid(args: string): number | undefined {
+    if (!/\bdaemon\s+run\b/.test(args)) return undefined;
+    const m = /--spawned-by\s+.*?"pid"\s*:\s*(\d+)/.exec(args);
+    if (!m) return undefined;
+    const pid = parseInt(m[1], 10);
+    return Number.isFinite(pid) && pid > 1 ? pid : undefined;
+  },
+};
+
+export const DETACHED_HELPER_RULES: DetachedHelperRule[] = [CLAUDE_BG_DAEMON];
+
+/**
+ * Long-lived agents-cli services that must never be reaped, even when they
+ * inherited a pane's environment because the CLI invocation that started them
+ * happened to run inside an agent pane.
+ *
+ * This is a safety invariant, not a fallback: the routines daemon runs this very
+ * reaper, so killing it would make the reaper delete its own executor, and the
+ * secrets broker holds the keychain session every live agent depends on.
+ */
+export function isProtectedAgentsService(args: string): boolean {
+  return /\b__daemon-run\b/.test(args)
+    || /\bsecrets\s+_agent-run\b/.test(args)
+    || /\bMenubarHelper\b/.test(args)
+    || /\bAgents CLI\.app\b/.test(args);
+}
+
+/** Is this pid currently running? Signal-0 probe, matching `platform/process.ts`. */
+function livePid(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the process exists but belongs to another user — alive.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Pure. Select the processes whose owning agent is provably gone.
+ *
+ * `owners` maps a tmux session name to its liveness; a name ABSENT from the map
+ * is a session tmux no longer has, which is the strongest orphan signal there is.
+ */
+export function selectOrphanProcesses(
+  procs: AgentProcess[],
+  owners: Map<string, PaneOwner>,
+  opts: { protectedPids: Set<number>; isAlive?: (pid: number) => boolean },
+): OrphanCandidate[] {
+  const isAlive = opts.isAlive ?? livePid;
+  const eligible = (p: AgentProcess): boolean =>
+    p.pid > 1 && !opts.protectedPids.has(p.pid) && !isProtectedAgentsService(p.args);
+
+  const out: OrphanCandidate[] = [];
+  const seen = new Set<number>();
+  const push = (p: AgentProcess, reason: OrphanReason): void => {
+    if (seen.has(p.pid)) return;
+    seen.add(p.pid);
+    out.push({ pid: p.pid, args: p.args, reason, tmuxSession: p.tmuxSession });
+  };
+
+  // Tier 1 — inherited pane marker with a dead owner.
+  for (const p of procs) {
+    if (!p.tmuxSession || !eligible(p)) continue;
+    const owner = owners.get(p.tmuxSession);
+    if (!owner) {
+      push(p, 'tmux-session-gone');
+      continue;
+    }
+    // An attached client or a live agent pane process is a hard exclusion.
+    if (owner.attached || owner.agentAlive) continue;
+    push(p, 'tmux-agent-exited');
+  }
+
+  // Tier 2 — a detached helper daemon whose declared spawner is dead, plus the
+  // workers it owns. Its own descendants are pulled in because they carry no
+  // owner declaration of their own.
+  const seeds: AgentProcess[] = [];
+  for (const p of procs) {
+    if (!eligible(p)) continue;
+    for (const rule of DETACHED_HELPER_RULES) {
+      const spawner = rule.spawnerPid(p.args);
+      if (spawner === undefined || isAlive(spawner)) continue;
+      seeds.push(p);
+      break;
+    }
+  }
+  if (seeds.length > 0) {
+    const byPid = new Map(procs.map(p => [p.pid, p]));
+    for (const seed of descendantsOf(procs, seeds.map(s => s.pid))) {
+      const p = byPid.get(seed);
+      if (p && eligible(p)) push(p, 'detached-helper');
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Pure. `seeds` plus every process reachable from them through ppid links.
+ * Depth is bounded by the table size, so a ppid cycle (which the kernel cannot
+ * produce, but a malformed snapshot could) terminates.
+ */
+export function descendantsOf(procs: AgentProcess[], seeds: number[]): number[] {
+  const children = new Map<number, number[]>();
+  for (const p of procs) {
+    const list = children.get(p.ppid);
+    if (list) list.push(p.pid);
+    else children.set(p.ppid, [p.pid]);
+  }
+  const out: number[] = [];
+  const seen = new Set<number>();
+  const stack = [...seeds];
+  while (stack.length > 0) {
+    const pid = stack.pop()!;
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    out.push(pid);
+    for (const child of children.get(pid) ?? []) stack.push(child);
+  }
+  return out;
+}
+
+/** Pure. Parse `ps -A -o pid=,ppid=,args=` output. */
+export function parseProcessRows(stdout: string): AgentProcess[] {
+  const rows: AgentProcess[] = [];
+  for (const line of stdout.split('\n')) {
+    const m = /^\s*(\d+)\s+(\d+)\s+(.+)$/.exec(line);
+    if (!m) continue;
+    const pid = parseInt(m[1], 10);
+    const ppid = parseInt(m[2], 10);
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+    rows.push({ pid, ppid, args: m[3].trim() });
+  }
+  return rows;
+}
+
+/**
+ * Pure. Extract the pane marker from a blob that contains the process
+ * environment — a NUL-separated `/proc/<pid>/environ` on Linux, or the
+ * space-separated `KEY=VALUE` tail macOS `ps -E` appends after the command.
+ * Session names are `[A-Za-z0-9_-]` ({@link ../tmux/session.ts} `VALID_NAME`),
+ * so the value ends at the first character outside that set.
+ */
+export function parseTmuxSessionMarker(blob: string): string | undefined {
+  const m = new RegExp(`(?:^|[\\s\\0])${TMUX_SESSION_ENV}=([A-Za-z0-9_-]{1,64})`).exec(blob);
+  return m ? m[1] : undefined;
+}
+
+/** Pure. Parse `tmux list-panes -a -F '#{session_name}\t#{pane_pid}\t#{session_attached}'`. */
+export function parsePaneOwners(stdout: string, isAlive: (pid: number) => boolean = livePid): Map<string, PaneOwner> {
+  const owners = new Map<string, PaneOwner>();
+  for (const line of stdout.split('\n')) {
+    const parts = line.trim().split('\t');
+    if (parts.length < 3) continue;
+    const name = parts[0];
+    if (!name) continue;
+    const panePid = parseInt(parts[1], 10);
+    const attached = parts[2].trim() !== '0';
+    const prev = owners.get(name);
+    const agentAlive = Number.isFinite(panePid) && isAlive(panePid);
+    owners.set(name, {
+      agentAlive: (prev?.agentAlive ?? false) || agentAlive,
+      attached: (prev?.attached ?? false) || attached,
+    });
+  }
+  return owners;
+}
+
+/**
+ * Snapshot the process table with each process's pane marker.
+ *
+ * Two readers because no single command works on both platforms: Linux exposes
+ * `/proc/<pid>/environ` (one cheap read per pid), while macOS has no `/proc` and
+ * instead lets `ps -E` print a process's own-uid environment after its command.
+ * Windows has no tmux integration at all, so it returns an empty table rather
+ * than pretending to reap.
+ */
+export async function readAgentProcesses(): Promise<AgentProcess[]> {
+  if (process.platform === 'win32') return [];
+  const hasProc = fs.existsSync('/proc/self/environ');
+  const args = hasProc ? ['-A', '-o', 'pid=,ppid=,args='] : ['-A', '-E', '-o', 'pid=,ppid=,args='];
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync('ps', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024, timeout: PS_TIMEOUT_MS }));
+  } catch {
+    return [];
+  }
+  const rows = parseProcessRows(stdout);
+  if (!hasProc) {
+    // `ps -E` already appended the environment to the args column.
+    for (const row of rows) row.tmuxSession = parseTmuxSessionMarker(row.args);
+    return rows;
+  }
+  for (const row of rows) {
+    let blob: string;
+    try {
+      blob = fs.readFileSync(`/proc/${row.pid}/environ`, 'utf8');
+    } catch {
+      continue; // exited between ps and the read, or not ours to inspect
+    }
+    row.tmuxSession = parseTmuxSessionMarker(blob);
+  }
+  return rows;
+}
+
+/** Read every tmux session's ownership state from one socket. */
+export async function readPaneOwners(socket: string): Promise<Map<string, PaneOwner>> {
+  if (!fs.existsSync(socket)) return new Map();
+  const { runTmux } = await import('./binary.js');
+  const res = await runTmux({
+    socket,
+    args: ['list-panes', '-a', '-F', '#{session_name}\t#{pane_pid}\t#{session_attached}'],
+    throwOnError: false,
+  }).catch(() => null);
+  if (!res || res.code !== 0) return new Map();
+  return parsePaneOwners(res.stdout);
+}
+
+/**
+ * Ownership across every socket that could own a marked process, merged so a
+ * session that is live on ANY of them protects its processes.
+ *
+ * The union is load bearing, not defensive: the process table is machine-wide,
+ * so a reap driven from a non-default socket (`agents sessions reap --socket`,
+ * or a test's temp socket) would otherwise see every real agent's marker with no
+ * matching session and classify a whole box's live helpers as orphans.
+ */
+async function readAllPaneOwners(socket: string): Promise<Map<string, PaneOwner>> {
+  const { getDefaultSocketPath } = await import('./paths.js');
+  const merged = new Map<string, PaneOwner>();
+  for (const sock of new Set([socket, getDefaultSocketPath()].filter(Boolean))) {
+    for (const [name, owner] of await readPaneOwners(sock)) {
+      const prev = merged.get(name);
+      merged.set(name, {
+        agentAlive: (prev?.agentAlive ?? false) || owner.agentAlive,
+        attached: (prev?.attached ?? false) || owner.attached,
+      });
+    }
+  }
+  return merged;
+}
+
+/** Pids the reaper must never signal: itself and its whole ancestor chain. */
+function selfProtectedPids(procs: AgentProcess[]): Set<number> {
+  const byPid = new Map(procs.map(p => [p.pid, p]));
+  const out = new Set<number>([process.pid]);
+  let cursor = process.ppid;
+  // Bounded by the table size — an ancestor walk cannot exceed it.
+  for (let i = 0; i <= procs.length && cursor > 1; i += 1) {
+    out.add(cursor);
+    cursor = byPid.get(cursor)?.ppid ?? 0;
+  }
+  return out;
+}
+
+/** SIGTERM every candidate, then SIGKILL whatever ignored it. */
+async function terminate(candidates: OrphanCandidate[], graceMs: number): Promise<number> {
+  let signalled = 0;
+  for (const c of candidates) {
+    try {
+      process.kill(c.pid, 'SIGTERM');
+      signalled += 1;
+    } catch { /* already gone */ }
+  }
+  if (signalled === 0) return 0;
+  await new Promise(resolve => setTimeout(resolve, graceMs));
+  for (const c of candidates) {
+    if (!livePid(c.pid)) continue;
+    try { process.kill(c.pid, 'SIGKILL'); } catch { /* already gone */ }
+  }
+  return signalled;
+}
+
+function describe(c: OrphanCandidate): string {
+  const where = c.tmuxSession ? ` [${c.tmuxSession}]` : '';
+  return `pid ${c.pid}${where} (${c.reason}): ${c.args.slice(0, 120)}`;
+}
+
+/**
+ * Reap every helper process whose owning agent has exited.
+ *
+ * Called from the daemon's periodic tick and from `agents sessions reap`. Panes
+ * are read BEFORE processes so a session that disappears mid-scan is treated as
+ * gone (reapable) rather than as a live owner.
+ */
+export async function reapOrphanAgentProcesses(
+  opts: { socket: string; dryRun?: boolean; graceMs?: number } = { socket: '' },
+): Promise<OrphanReapResult> {
+  const result: OrphanReapResult = { killed: 0, details: [], candidates: [] };
+  if (process.platform === 'win32') return result;
+
+  const owners = await readAllPaneOwners(opts.socket);
+  const procs = await readAgentProcesses();
+  if (procs.length === 0) return result;
+
+  const candidates = selectOrphanProcesses(procs, owners, { protectedPids: selfProtectedPids(procs) });
+  result.candidates = candidates;
+  if (candidates.length === 0) return result;
+
+  result.details = candidates.map(describe);
+  if (opts.dryRun) return result;
+  result.killed = await terminate(candidates, opts.graceMs ?? REAP_GRACE_MS);
+  return result;
+}
+
+/**
+ * Reap the helper processes belonging to ONE tmux session, on the teardown path.
+ *
+ * `killSession` calls this so an agent's helpers die with the session that owned
+ * them instead of waiting for the next daemon tick. The tmux session is being
+ * destroyed by the caller, so ownership needs no liveness check — anything still
+ * carrying this session's marker is leftover by definition.
+ */
+export async function reapProcessesForTmuxSession(
+  name: string,
+  opts: { dryRun?: boolean; graceMs?: number } = {},
+): Promise<OrphanReapResult> {
+  const result: OrphanReapResult = { killed: 0, details: [], candidates: [] };
+  if (process.platform === 'win32') return result;
+
+  const procs = await readAgentProcesses();
+  if (procs.length === 0) return result;
+
+  const protectedPids = selfProtectedPids(procs);
+  const byPid = new Map(procs.map(p => [p.pid, p]));
+  const owned = procs.filter(p => p.tmuxSession === name);
+  // Descendants too: a helper that scrubbed its own environment (so it carries
+  // no marker) is still attributable through the marked process that spawned it.
+  const candidates: OrphanCandidate[] = [];
+  for (const pid of descendantsOf(procs, owned.map(p => p.pid))) {
+    const p = byPid.get(pid);
+    if (!p || p.pid <= 1 || protectedPids.has(p.pid) || isProtectedAgentsService(p.args)) continue;
+    candidates.push({ pid: p.pid, args: p.args, reason: 'tmux-agent-exited', tmuxSession: name });
+  }
+  result.candidates = candidates;
+  if (candidates.length === 0) return result;
+
+  result.details = candidates.map(describe);
+  if (opts.dryRun) return result;
+  result.killed = await terminate(candidates, opts.graceMs ?? REAP_GRACE_MS);
+  return result;
+}

--- a/apps/cli/src/lib/tmux/session.ts
+++ b/apps/cli/src/lib/tmux/session.ts
@@ -186,8 +186,22 @@ export async function createSession(opts: CreateSessionOptions): Promise<Session
   return meta;
 }
 
-/** Kill one named session. Idempotent — killing a non-existent session is a no-op. */
-export async function killSession(name: string, socket?: string): Promise<boolean> {
+/**
+ * Kill one named session. Idempotent — killing a non-existent session is a no-op.
+ *
+ * Destroying the tmux session only SIGHUPs each pane's FOREGROUND process group,
+ * so a helper the agent put in its own process group (an MCP server, a harness
+ * background daemon) survives and reparents to init. `reapOrphans` therefore
+ * defaults ON: the session's leftover helpers are terminated with it rather than
+ * waiting for the daemon's next sweep (RUSH-2521). {@link reapDeadTmuxPanes}
+ * passes `false` because it sweeps every session's leftovers in one pass instead
+ * of re-snapshotting the process table per session.
+ */
+export async function killSession(
+  name: string,
+  socket?: string,
+  opts: { reapOrphans?: boolean } = {},
+): Promise<boolean> {
   assertValidSessionName(name);
   const sock = socket ?? getDefaultSocketPath();
   const existed = await hasSession(name, sock);
@@ -203,6 +217,10 @@ export async function killSession(name: string, socket?: string): Promise<boolea
     } else {
       throw err;
     }
+  }
+  if (opts.reapOrphans !== false) {
+    const { reapProcessesForTmuxSession } = await import('./orphan-reap.js');
+    await reapProcessesForTmuxSession(name).catch(() => ({ killed: 0, details: [], candidates: [] }));
   }
   removeSessionMeta(name);
   return true;
@@ -242,22 +260,49 @@ export interface ReapDeadPanesResult {
   sessions: string[];
   /** Human-readable lines describing each reap, for log output. */
   details: string[];
+  /** Orphaned helper processes terminated (MCP servers, harness background daemons). */
+  processes: number;
+  /** One human-readable line per terminated helper process. */
+  processDetails: string[];
 }
 
 /**
- * Kill every tmux session whose panes are ALL dead (`pane_dead=1`).
+ * Kill every tmux session whose panes are ALL dead (`pane_dead=1`), and
+ * terminate the helper processes whose owning agent has exited.
  *
  * Dead panes accumulate because `remain-on-exit on` is intentionally set
  * per-pane so the harness can inspect exit status. Without a periodic sweep
  * they pile up indefinitely — e.g. 48 of 127 sessions dead on yosemite-s0
  * (RUSH-2501).
  *
+ * Killing the pane is not enough on its own: it SIGHUPs only the pane's
+ * FOREGROUND process group, so an MCP server or harness background daemon that
+ * moved itself out of that group survives the session that spawned it and keeps
+ * its memory forever (RUSH-2521). The process sweep runs FIRST, while the dead
+ * sessions still exist, so every leftover is attributed to a named session
+ * rather than to a session tmux has already forgotten.
+ *
  * Safety invariant: a session with ANY live pane (`pane_dead=0`) is never
- * touched. Only all-dead sessions are reaped.
+ * touched, and neither are the processes belonging to a session whose agent is
+ * still running or that has a client attached.
+ *
+ * `dryRun` reports both halves without killing anything.
  */
-export async function reapDeadTmuxPanes(socket?: string): Promise<ReapDeadPanesResult> {
+export async function reapDeadTmuxPanes(
+  socket?: string,
+  opts: { dryRun?: boolean } = {},
+): Promise<ReapDeadPanesResult> {
   const sock = socket ?? getDefaultSocketPath();
-  const result: ReapDeadPanesResult = { reaped: 0, sessions: [], details: [] };
+  const result: ReapDeadPanesResult = { reaped: 0, sessions: [], details: [], processes: 0, processDetails: [] };
+
+  // The process sweep runs even with no server on this socket: a torn-down
+  // server (`killAll` unlinks the socket) is the strongest orphan signal there
+  // is, and skipping it here would strand exactly those leftovers forever.
+  const { reapOrphanAgentProcesses } = await import('./orphan-reap.js');
+  const orphans = await reapOrphanAgentProcesses({ socket: sock, dryRun: opts.dryRun });
+  result.processes = opts.dryRun ? orphans.candidates.length : orphans.killed;
+  result.processDetails = orphans.details;
+
   if (!fs.existsSync(sock)) return result;
 
   const res = await runTmux({
@@ -283,10 +328,12 @@ export async function reapDeadTmuxPanes(socket?: string): Promise<ReapDeadPanesR
   for (const [name, flags] of sessionFlags) {
     if (flags.length === 0 || !flags.every(d => d)) continue;
     try {
-      await killSession(name, sock);
+      // The one process-table sweep above already collected this session's
+      // leftovers; a per-session reap here would re-snapshot `ps` N times.
+      if (!opts.dryRun) await killSession(name, sock, { reapOrphans: false });
       result.reaped++;
       result.sessions.push(name);
-      result.details.push(`killed ${name} (${flags.length} dead pane${flags.length === 1 ? '' : 's'})`);
+      result.details.push(`${name} (${flags.length} dead pane${flags.length === 1 ? '' : 's'})`);
     } catch {
       // Best-effort: session may already be gone by the time we hit it.
     }


### PR DESCRIPTION
**Bug fix — agent helper processes (MCP servers, harness background daemons) are now reaped when the agent exits.** RUSH-2521.

## The bug

An interactive agent is the leaf of a detached tmux pane. Tearing that pane down only SIGHUPs its **foreground** process group, so a helper that moved itself out of that group survives the session, reparents to init, and holds its memory forever. Measured on the fleet on 2026-08-10:

| Box | Leak |
|---|---|
| yosemite-s1 | one pane holding **2.5 GB** of `claude bg-spare` / `bg-pty-host` daemons, 22 days after its session ended |
| yosemite-s0 | 34 orphaned `cgraph-mcp --daemon`; multi-GB `droid exec` trees 8–10 days old |

`reapDeadTmuxPanes` (`apps/cli/src/lib/tmux/session.ts:258` on main) only killed tmux **sessions** whose panes were all dead, so neither `agents sessions reap` nor the daemon's 5-minute tick (`apps/cli/src/lib/daemon.ts:711`) ever touched the process trees.

## Run result — before / after

Full capture: **https://share.agents-cli.sh/muqsitnawaz/muqsit-rush2521-demo-ee42171c0b3d16d1**

The pane is built the way `createSession` builds one (`remain-on-exit on`, the `AGENT_TMUX_SESSION_NAME` marker exported into the pane env); the helper puts itself out of reach of the pane's SIGHUP the way an MCP server does. BEFORE runs `tmux kill-session`, which is all main's reaper does.

```
======== BEFORE (main: the reaper only closes the pane) ========
agent exited:
  tmux pane : pane_dead=1 agent_pid=3310639 clients_attached=0
  helper    : 3310640       1 sleep 900   <-- STILL RUNNING

$ tmux kill-session -t ag-claude-before2521      # what reapDeadTmuxPanes does today
after:
  tmux pane : session gone
  helper    : 3310640       1 sleep 900   <-- STILL RUNNING

======== AFTER (this branch) ========
agent exited:
  tmux pane : pane_dead=1 agent_pid=3318292 clients_attached=0
  helper    : 3318294       1 sleep 900   <-- STILL RUNNING

$ agents-dev sessions reap --socket /tmp/rush2521-demo/ag-claude-after2521.sock
killed pid 3318294 [ag-claude-after2521] (tmux-agent-exited): sleep 900
killed session ag-claude-after2521 (1 dead pane)

1 session and 1 orphaned process reaped.
after:
  tmux pane : session gone
  helper    : pid 3318294 is gone

======== SAFETY: a live agent's helper is never touched ========
agent still running:
  tmux pane : pane_dead=0 agent_pid=3338407 clients_attached=0
  helper    : 3338409 3338407 sleep 900   <-- STILL RUNNING

$ agents-dev sessions reap --socket .../ag-claude-live2521.sock --dry-run
No dead tmux sessions or orphaned processes to reap.
$ agents-dev sessions reap --socket .../ag-claude-live2521.sock
No dead tmux sessions or orphaned processes to reap.
after:
  tmux pane : pane_dead=0 agent_pid=3338407 clients_attached=0
  helper    : 3338409 3338407 sleep 900   <-- STILL RUNNING
```

## Why attribution is by ENVIRONMENT

Every obvious OS handle is destroyed by exactly the event being detected — each of these was measured, not assumed:

| Handle | Why it fails |
|---|---|
| ppid ancestry | the orphan is reparented to init the instant its parent dies |
| controlling terminal | POSIX disassociates it from every process in a session when the leader exits — the orphan's `tty` reads `?` while its pane still reports `pane_tty=/dev/pts/6` |
| process group | the helpers that survive are precisely the ones that left the pane's group |
| POSIX session id | correct but not portable: `ps -o sid=` is Linux-only (`ps: sid: keyword not found` on macOS 26.4, `sess` reports 0, `pgrep -s` is Linux-only) |

What survives is the process environment. `runInTmux` stamps `AGENT_TMUX_SESSION_NAME` into the pane (`apps/cli/src/lib/exec.ts:1664`) and every descendant inherits it, reparented or not — verified on a live orphan: `AGENT_TMUX_SESSION_NAME=ag-codex-ff55f79f` in a `cgraph-mcp` whose pane leader was long dead. tmux is then the liveness oracle. Linux reads `/proc/<pid>/environ`; macOS has no `/proc` and uses `ps -E`, which appends a process's own-uid environment after its command (verified on zion).

**A marked process is killed only when** its tmux session no longer exists, **or** that session has no attached client **and** its agent pane process has exited. A live agent or an attached client protects everything it owns; the routines daemon, the secrets broker, and the reaping process's own ancestry are never candidates.

**Second tier — harnesses that scrub the environment.** Claude Code's background pool starts clean, so tier one cannot see it, but it declares its owner in its own argv: `claude.exe daemon run --origin transient --spawned-by {"label":"claude",…,"pid":3834601}`. When that pid is dead the pool and its `bg-pty-host` / `bg-spare` children are reaped. That lives in `DETACHED_HELPER_RULES` (`apps/cli/src/lib/tmux/orphan-reap.ts`), one entry per harness — not an inline `if (agent === 'claude')`.

## What changed

| File | Change |
|---|---|
| `apps/cli/src/lib/tmux/orphan-reap.ts` (new) | attribution + selection (pure) and the SIGTERM→grace→SIGKILL driver |
| `apps/cli/src/lib/tmux/session.ts` | `reapDeadTmuxPanes` sweeps processes as well as panes and takes `dryRun`; `killSession` reaps its own session's helpers so a normal exit leaves nothing behind |
| `apps/cli/src/commands/sessions-reap.ts` | reports processes; new `--dry-run`; `--json` gains `processes` / `processDetails` / `dryRun` |
| `apps/cli/src/lib/daemon.ts` | the 5-minute tick logs the helper processes it collected |
| `apps/cli/src/commands/sessions-migrate.ts` | stops leaving `remain-on-exit` set **server-wide** on the migration target (every later pane there retained a corpse), and exports the marker so the target's reaper can attribute that agent's helpers |
| `apps/cli/docs/sessions.md` | new "Reaping what an exited agent left behind" section |
| `apps/cli/.changelog/next/RUSH-2521.md` | release note |

## Tests

`apps/cli/src/lib/tmux/orphan-reap.test.ts` — 21 passing, nothing mocked on the critical path. Three of them spawn a **real** tmux pane whose command starts a **real** SIGHUP-immune helper and then exits, and assert the reaper collects it, spares it while the agent lives, and that `killSession` collects it. The selector tests run against process tables captured from the fleet, including the verbatim argv of the leaked Claude Code daemon.

```
 ✓ reaping a real leaked helper > kills the helper an exited agent left behind, and leaves no dead session 2604ms
 ✓ reaping a real leaked helper > does NOT kill the helper of a session whose agent is still running 225ms
 ✓ reaping a real leaked helper > killSession tears the session helpers down with the session 2217ms
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

## Scope notes for the reviewer

- **Not cross-harness in the registry sense.** Tier one is harness-agnostic (it keys on the pane marker every harness inherits). `DETACHED_HELPER_RULES` has one entry today because Claude Code is the only harness measured to detach helpers with a scrubbed environment; another harness is one table entry.
- **Windows is a no-op** — there is no tmux integration there, and the reaper returns an empty result rather than pretending.
- **This collects everything the session's agent spawned**, not only MCP servers: a server the agent deliberately backgrounded inside its pane is torn down with the session. Documented in `docs/sessions.md`.
- `.agents-system` audit: no hook, skill, command, or rule in the companion repo invokes `agents sessions reap`, so there is no companion edit to land with this.

Ticket: RUSH-2521 — https://linear.app/getrush/issue/RUSH-2521
