### PR TITLE
feat(config): add usage primary host pin

### DIFF
--- a/apps/cli/.changelog/next/usage-primary-host.md
+++ b/apps/cli/.changelog/next/usage-primary-host.md
@@ -1,0 +1,5 @@
+---
+type: feature
+---
+
+Add `usage.primary-host`, a user-scope `agents config` key that pins the device authoritative for fleet usage while falling back to `interactive.host` when unset.

--- a/apps/cli/docs/command-index.json
+++ b/apps/cli/docs/command-index.json
@@ -5661,7 +5661,7 @@
           "negate": false
         }
       ],
-      "examples": "agents config set run.claude@*.model best\n      agents config set run.claude@*.tier.best claude-opus-4-8\n      agents config set run.claude@2.1.45.model claude-opus-4-8\n      agents config set run.claude@*.mode auto\n      agents config set interactive.host zion\n      agents config set browser.profile work\n      agents config set project.root ~/src/github.com/<you>\n      agents config set devices.mac-mini.max-agents 4\n      agents config get run.claude@*.model\n      agents config unset run.claude@*.tier.best\n      agents config list",
+      "examples": "agents config set run.claude@*.model best\n      agents config set run.claude@*.tier.best claude-opus-4-8\n      agents config set run.claude@2.1.45.model claude-opus-4-8\n      agents config set run.claude@*.mode auto\n      agents config set interactive.host zion\n      agents config set usage.primary-host zion\n      agents config set browser.profile work\n      agents config set project.root ~/src/github.com/<you>\n      agents config set devices.mac-mini.max-agents 4\n      agents config get run.claude@*.model\n      agents config get usage.primary-host\n      agents config unset run.claude@*.tier.best\n      agents config unset usage.primary-host\n      agents config list",
       "notes": "Every agent/harness reference uses agent@version. Use * for all versions.\n      Tier overrides are part of the run namespace: run.<agent@version>.tier.<tier>.\n      Project root is auto-inferred from the current Git repository when unset.",
       "subcommands": [
         {

--- a/apps/cli/docs/command-reference.html
+++ b/apps/cli/docs/command-reference.html
@@ -292,11 +292,14 @@ agents bench results --json</code></pre><h4>Notes</h4><p class="notes">Task defi
       agents config set run.claude@2.1.45.model claude-opus-4-8
       agents config set run.claude@*.mode auto
       agents config set interactive.host zion
+      agents config set usage.primary-host zion
       agents config set browser.profile work
       agents config set project.root ~/src/github.com/&lt;you&gt;
       agents config set devices.mac-mini.max-agents 4
       agents config get run.claude@*.model
+      agents config get usage.primary-host
       agents config unset run.claude@*.tier.best
+      agents config unset usage.primary-host
       agents config list every agent/harness reference uses agent@version. use * for all versions.
       tier overrides are part of the run namespace: run.&lt;agent@version&gt;.tier.&lt;tier&gt;.
       project root is auto-inferred from the current git repository when unset."><div class="command-head"><h3><code>agents config</code></h3></div><p>Get, set, list, and unset run defaults, tier overrides, the projects root, and device options.</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table><h4>Examples</h4><pre><code>agents config set run.claude@*.model best
@@ -304,11 +307,14 @@ agents bench results --json</code></pre><h4>Notes</h4><p class="notes">Task defi
       agents config set run.claude@2.1.45.model claude-opus-4-8
       agents config set run.claude@*.mode auto
       agents config set interactive.host zion
+      agents config set usage.primary-host zion
       agents config set browser.profile work
       agents config set project.root ~/src/github.com/&lt;you&gt;
       agents config set devices.mac-mini.max-agents 4
       agents config get run.claude@*.model
+      agents config get usage.primary-host
       agents config unset run.claude@*.tier.best
+      agents config unset usage.primary-host
       agents config list</code></pre><h4>Notes</h4><p class="notes">Every agent/harness reference uses agent@version. Use * for all versions.
       Tier overrides are part of the run namespace: run.&lt;agent@version&gt;.tier.&lt;tier&gt;.
       Project root is auto-inferred from the current Git repository when unset.</p></article>

--- a/apps/cli/docs/concepts.md
+++ b/apps/cli/docs/concepts.md
@@ -212,9 +212,14 @@ registry stays the **discovery cache** (address, tailscale snapshot,
 reachability); the config's `ssh.*` / `platform` / user values overlay the
 registry profile at dial time (`src/lib/devices/resolve-profile.ts`), so
 `agents ssh`, the ssh_config render, host dispatch, and the `devices list`
-table all honor them. The one user-scope key, `interactive.host`
+table all honor them. The user-scope key `interactive.host`
 (`config.interactiveHost`), names the device agents show YOU artifacts on
 (browser opens, dashboards), so skills stop guessing "the online macOS box".
+Usage collection has a separate user-scope pin, `usage.primary-host`
+(`config.usagePrimaryHost`), operated only through `agents config set|get|unset|list`.
+`resolveUsagePrimaryHost()` resolves the explicit usage pin first, then falls back to
+`interactive.host`, then to no primary host. The interactive host answers where the
+user sees artifacts; it does not by itself declare that device authoritative for usage.
 The interactive host is marked `★ interactive` in `agents devices list`;
 `list --json` carries each row's effective profile plus its `config` block and
 an `interactive` flag. The retired subcommands (`configure`, `note`, `set`,

--- a/apps/cli/src/commands/config.test.ts
+++ b/apps/cli/src/commands/config.test.ts
@@ -74,6 +74,16 @@ describe('config command', () => {
     expect(getOut).toContain('zion');
   });
 
+  it('round-trips and lists the usage primary host', () => {
+    runAgents(home, ['config', 'set', 'usage.primary-host', 'zion']);
+    expect(runAgents(home, ['config', 'get', 'usage.primary-host'])).toContain('zion');
+    expect(runAgents(home, ['config', 'list'])).toContain('usage.primary-host');
+
+    runAgents(home, ['config', 'unset', 'usage.primary-host']);
+    expect(runAgents(home, ['config', 'get', 'usage.primary-host'])).toContain('(unset)');
+    expect(runAgents(home, ['config', 'list'])).not.toContain('usage.primary-host');
+  });
+
   it('sets, gets, and unsets the projects root', () => {
     const root = path.join(home, 'src', 'github.com', 'example');
     runAgents(home, ['config', 'set', 'project.root', root]);

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -5,6 +5,7 @@
  *   - run defaults (model, mode, effort)
  *   - tier overrides (folded into the run namespace)
  *   - interactive host
+ *   - usage primary host
  *   - browser profile
  *   - local projects root
  *   - per-device config keys
@@ -70,6 +71,8 @@ function parseValue(key: string, parsed: ParsedConfigKey, raw: string): unknown 
       return raw.trim();
     case 'interactive':
       return raw.trim();
+    case 'usage':
+      return raw.trim();
     case 'browser':
       return raw.trim();
     case 'project':
@@ -117,6 +120,10 @@ function setConfig(parsed: ParsedConfigKey, value: unknown): void {
       setConfigValue('interactive.host', value as string);
       return;
     }
+    case 'usage': {
+      setConfigValue('usage.primary-host', value as string);
+      return;
+    }
     case 'browser': {
       // Device-local default lives in the central fleet.devices.<name>.config
       // block (same store `agents devices config` / getConfigValue use). Bare
@@ -160,6 +167,11 @@ function unsetConfig(parsed: ParsedConfigKey): boolean {
       unsetConfigValue('interactive.host');
       return had;
     }
+    case 'usage': {
+      const had = getConfigValue('usage.primary-host').value !== undefined;
+      unsetConfigValue('usage.primary-host');
+      return had;
+    }
     case 'browser': {
       const target = parsed.device ? { device: parsed.device } : undefined;
       const had = getConfigValue('browser.profile', target).value !== undefined;
@@ -195,6 +207,8 @@ function getConfig(parsed: ParsedConfigKey): unknown {
     }
     case 'interactive':
       return getConfigValue('interactive.host').value;
+    case 'usage':
+      return getConfigValue('usage.primary-host').value;
     case 'browser': {
       return getConfigValue(
         'browser.profile',
@@ -251,6 +265,9 @@ function* listCentralConfigEntries(): Generator<{ key: string; value: unknown; h
   const meta = readMeta();
   if (meta.config?.interactiveHost !== undefined) {
     yield { key: 'interactive.host', value: meta.config.interactiveHost, hint: 'config.interactiveHost' };
+  }
+  if (meta.config?.usagePrimaryHost !== undefined) {
+    yield { key: 'usage.primary-host', value: meta.config.usagePrimaryHost, hint: 'config.usagePrimaryHost' };
   }
   if (meta.projectRoot !== undefined) {
     yield { key: 'project.root', value: meta.projectRoot, hint: 'devices.<self>.projectRoot' };
@@ -314,11 +331,14 @@ export function registerConfigCommand(program: Command): void {
       agents config set run.claude@2.1.45.model claude-opus-4-8
       agents config set run.claude@*.mode auto
       agents config set interactive.host zion
+      agents config set usage.primary-host zion
       agents config set browser.profile work
       agents config set project.root ~/src/github.com/<you>
       agents config set devices.mac-mini.max-agents 4
       agents config get run.claude@*.model
+      agents config get usage.primary-host
       agents config unset run.claude@*.tier.best
+      agents config unset usage.primary-host
       agents config list
     `,
     notes: `

--- a/apps/cli/src/lib/config-keys.test.ts
+++ b/apps/cli/src/lib/config-keys.test.ts
@@ -53,6 +53,10 @@ describe('config-keys', () => {
       expect(parseConfigKey('interactive.host')).toEqual({ scope: 'interactive', property: 'host' });
     });
 
+    it('parses usage primary host', () => {
+      expect(parseConfigKey('usage.primary-host')).toEqual({ scope: 'usage', property: 'primary-host' });
+    });
+
     it('parses browser profile', () => {
       expect(parseConfigKey('browser.profile')).toEqual({ scope: 'browser', property: 'profile' });
     });
@@ -115,6 +119,7 @@ describe('config-keys', () => {
         'run.claude@*.model',
         'run.claude@2.1.45.tier.best',
         'interactive.host',
+        'usage.primary-host',
         'browser.profile',
         'devices.mac-mini.max-agents',
       ]) {
@@ -141,6 +146,7 @@ describe('config-keys', () => {
       expect(keys).toContain('run.<agent@version>.model');
       expect(keys).toContain('run.<agent@version>.tier.best');
       expect(keys).toContain('interactive.host');
+      expect(keys).toContain('usage.primary-host');
       expect(keys).toContain('browser.profile');
       expect(keys).toContain('devices.<name>.max-agents');
     });
@@ -153,6 +159,12 @@ describe('config-keys', () => {
       );
       expect(configKeyStorageHint(parseConfigKey('run.claude@*.tier.best'))).toBe(
         'model.tiers.claude:*.best',
+      );
+    });
+
+    it('describes where the usage primary host is stored', () => {
+      expect(configKeyStorageHint(parseConfigKey('usage.primary-host'))).toBe(
+        'config.usagePrimaryHost',
       );
     });
   });

--- a/apps/cli/src/lib/config-keys.ts
+++ b/apps/cli/src/lib/config-keys.ts
@@ -13,7 +13,7 @@ import { MODEL_TIERS, type ModelTier } from './model-tiers.js';
 import { VERSION_RE } from './run-defaults.js';
 
 /** The top-level scope of a unified config key. */
-export type ConfigScope = 'run' | 'interactive' | 'browser' | 'project' | 'device';
+export type ConfigScope = 'run' | 'interactive' | 'usage' | 'browser' | 'project' | 'device';
 
 /** A run-time default key: model, mode, effort, or tier override. */
 export interface ParsedRunConfigKey {
@@ -28,6 +28,12 @@ export interface ParsedRunConfigKey {
 export interface ParsedInteractiveConfigKey {
   scope: 'interactive';
   property: 'host';
+}
+
+/** The host whose usage snapshots are authoritative for fleet-wide reporting. */
+export interface ParsedUsageConfigKey {
+  scope: 'usage';
+  property: 'primary-host';
 }
 
 /** The default browser profile (device-scope, self or peer). */
@@ -52,6 +58,7 @@ export interface ParsedDeviceConfigKey {
 export type ParsedConfigKey =
   | ParsedRunConfigKey
   | ParsedInteractiveConfigKey
+  | ParsedUsageConfigKey
   | ParsedBrowserConfigKey
   | ParsedProjectConfigKey
   | ParsedDeviceConfigKey;
@@ -107,6 +114,7 @@ export function formatAgentVersion(agent: AgentId, version: string): string {
  *   run.<agent@version>.effort
  *   run.<agent@version>.tier.<cheap|default|best|ultra>
  *   interactive.host
+ *   usage.primary-host
  *   browser.profile
  *   project.root
  *   devices.<name>.max-agents
@@ -137,6 +145,10 @@ export function parseConfigKey(key: string): ParsedConfigKey {
     return { scope: 'interactive', property: 'host' };
   }
 
+  if (raw === 'usage.primary-host') {
+    return { scope: 'usage', property: 'primary-host' };
+  }
+
   if (raw === 'browser.profile') {
     return { scope: 'browser', property: 'profile' };
   }
@@ -165,6 +177,9 @@ export function parseConfigKey(key: string): ParsedConfigKey {
   if (raw.startsWith('interactive.')) {
     throw new Error(`Invalid interactive config key '${key}'. Use interactive.host.`);
   }
+  if (raw.startsWith('usage.')) {
+    throw new Error(`Invalid usage config key '${key}'. Use usage.primary-host.`);
+  }
   if (raw.startsWith('browser.')) {
     throw new Error(`Invalid browser config key '${key}'. Use browser.profile.`);
   }
@@ -178,7 +193,7 @@ export function parseConfigKey(key: string): ParsedConfigKey {
   }
 
   throw new Error(
-    `Unknown config scope in '${key}'. Use one of: run, interactive, browser, project, devices.`,
+    `Unknown config scope in '${key}'. Use one of: run, interactive, usage, browser, project, devices.`,
   );
 }
 
@@ -192,6 +207,8 @@ export function formatConfigKey(parsed: ParsedConfigKey): string {
       return `run.${formatAgentVersion(parsed.agent, parsed.version)}.${parsed.property}`;
     case 'interactive':
       return 'interactive.host';
+    case 'usage':
+      return 'usage.primary-host';
     case 'browser':
       return parsed.device ? `devices.${parsed.device}.browser.profile` : 'browser.profile';
     case 'project':
@@ -212,7 +229,7 @@ export function listKnownConfigKeys(): string[] {
   for (const tier of MODEL_TIERS) {
     keys.push(`run.<agent@version>.tier.${tier}`);
   }
-  keys.push('interactive.host', 'browser.profile', 'project.root');
+  keys.push('interactive.host', 'usage.primary-host', 'browser.profile', 'project.root');
   for (const prop of DEVICE_CONFIG_PROPERTIES) {
     keys.push(`devices.<name>.${prop}`);
   }
@@ -256,6 +273,8 @@ export function configKeyStorageHint(parsed: ParsedConfigKey): string {
       return `run.defaults.${parsed.agent}:${parsed.version}.${parsed.property}`;
     case 'interactive':
       return 'config.interactiveHost';
+    case 'usage':
+      return 'config.usagePrimaryHost';
     case 'browser':
       return parsed.device
         ? `fleet.devices.${parsed.device}.config.defaultBrowserProfile`

--- a/apps/cli/src/lib/device-config.test.ts
+++ b/apps/cli/src/lib/device-config.test.ts
@@ -38,6 +38,18 @@ afterEach(() => {
 });
 
 describe('user-scope keys (interactive.host)', () => {
+  it('resolves the usage primary override, interactive fallback, and null default', async () => {
+    const { resolveUsagePrimaryHost, setConfigValue, unsetConfigValue } = await freshModules();
+
+    expect(resolveUsagePrimaryHost()).toBeNull();
+    setConfigValue('interactive.host', 'zion');
+    expect(resolveUsagePrimaryHost()).toBe('zion');
+    setConfigValue('usage.primary-host', 'mac-mini');
+    expect(resolveUsagePrimaryHost()).toBe('mac-mini');
+    unsetConfigValue('usage.primary-host');
+    expect(resolveUsagePrimaryHost()).toBe('zion');
+  });
+
   it('round-trips through central agents.yaml under config:, never the fleet block', async () => {
     const { setConfigValue, getConfigValue, unsetConfigValue } = await freshModules();
 
@@ -306,6 +318,7 @@ describe('listConfig', () => {
       'ssh.bundle-key',
       'ssh.identity-file',
       'ssh.user',
+      'usage.primary-host',
       'watchdog.enabled',
     ]);
     expect(byName['interactive.host']).toMatchObject({ value: 'zion', layer: 'user' });

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -121,6 +121,21 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     },
   },
   {
+    name: 'usage.primary-host',
+    yamlKey: 'usagePrimaryHost',
+    scope: 'user',
+    type: 'string',
+    description: 'Device whose usage snapshots are authoritative for fleet-wide usage reporting.',
+    validate: (v) => {
+      try {
+        assertValidDeviceName(v as string);
+        return null;
+      } catch (err: any) {
+        return err?.message ?? String(err);
+      }
+    },
+  },
+  {
     name: 'browser.profile',
     yamlKey: 'defaultBrowserProfile',
     scope: 'device',
@@ -414,6 +429,13 @@ export function listConfig(opts?: ConfigTarget): ConfigEntry[] {
  * in per-device views without implying those keys are device-local. */
 export function listUserConfig(): ConfigEntry[] {
   return CONFIG_KEYS.filter((spec) => spec.scope === 'user').map((spec) => getConfigValue(spec.name));
+}
+
+/** Resolve the explicit usage host, falling back to the user's interactive host. */
+export function resolveUsagePrimaryHost(): string | null {
+  return (getConfigValue('usage.primary-host').value as string | undefined)
+    ?? (getConfigValue('interactive.host').value as string | undefined)
+    ?? null;
 }
 
 // ─── Writes ───────────────────────────────────────────────────────────────────

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -1019,7 +1019,8 @@ export interface Meta {
   /**
    * User-scope config block (`config:` in central agents.yaml). Holds the
    * user-scope keys from the device-config registry (`lib/device-config.ts`) —
-   * today just `interactiveHost`. Syncs fleet-wide via `agents repo push/pull`.
+   * currently `interactiveHost` and `usagePrimaryHost`. Syncs fleet-wide via
+   * `agents repo push/pull`.
    * Device-scope keys live under `fleet.devices.<name>.config` instead (see
    * {@link Meta.fleet}).
    */


### PR DESCRIPTION
Adds a user-scope `usage.primary-host` key operated exclusively through `agents config`.

## What changed

- Registers `usage.primary-host` as `config.usagePrimaryHost` with device-name validation.
- Extends config parsing, formatting, storage hints, list/get/set/unset, and help examples.
- Exports `resolveUsagePrimaryHost()` with explicit pin → `interactive.host` → `null` resolution.
- Documents the semantic difference between the interactive and usage-primary hosts and adds a changelog fragment.

## Verification

No graphical UI surface; this changes CLI output and config storage. Run screenshot: `yosemite-s0:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/scratch/usage-primary-config-run.png`. Uploaded text log: https://gist.github.com/muqsitnawaz/5dc7d80b659078ab87b6945b06d6befc

- `bun run test -- src/lib/config-keys.test.ts src/lib/device-config.test.ts src/commands/config.test.ts` — 63 passed.
- `bun run build` — passed.
- Real CLI `set → get → list → unset → get` flow — passed.