### PR TITLE
docs(artifacts): redact home paths on main, commit today's stranded plans

### DIFF
--- a/.agents/artifacts/2026-08-10/plan-dev-install-no-shadow.html
+++ b/.agents/artifacts/2026-08-10/plan-dev-install-no-shadow.html
@@ -120,7 +120,7 @@ command. Every one is verified against this machine, not inferred.</p>
 <tbody><tr>
 <td>1</td>
 <td>The global rule tells every agent to install globally, and this repo carves out no exception</td>
-<td><code>/home/muqsit/.claude/CLAUDE.md:455</code> — <em>"No locally built CLIs. Install globally (<code>npm i -g</code>…)"</em>. npm prefix is <code>/home/muqsit/.local</code>, so <code>npm i -g .</code> lands on the real install.</td>
+<td><code>/home/you/.claude/CLAUDE.md:455</code> — <em>"No locally built CLIs. Install globally (<code>npm i -g</code>…)"</em>. npm prefix is <code>/home/you/.local</code>, so <code>npm i -g .</code> lands on the real install.</td>
 </tr>
 <tr>
 <td>2</td>
@@ -146,15 +146,15 @@ That is true about the npm prefix and false about the command you actually type.
 
 ```console
 $ ls -la ~/.local/bin/agents ~/.local/bin/ag ~/.local/bin/browser
-agents  -&gt; /home/muqsit/.local/agents-cli-dev/bin/agents
-ag      -&gt; /home/muqsit/.local/agents-cli-dev/bin/ag
-browser -&gt; /home/muqsit/.local/agents-cli-dev/bin/browser
+agents  -&gt; /home/you/.local/agents-cli-dev/bin/agents
+ag      -&gt; /home/you/.local/agents-cli-dev/bin/ag
+browser -&gt; /home/you/.local/agents-cli-dev/bin/browser
 
 $ ls ~/.local/agents-cli-dev/lib/node_modules/@phnx-labs/
                                      # empty - the dev prefix was cleaned
 
 $ ~/.local/bin/agents --version
-zsh: no such file or directory: /home/muqsit/.local/bin/agents
+zsh: no such file or directory: /home/you/.local/bin/agents
 
 $ pgrep -af __daemon-run
 4163347 bun .agents/worktrees/rush-2431-binary-shadow/apps/cli/dist/index.js __daemon-run
@@ -169,13 +169,13 @@ Any shell that puts `~/.local/bin` first gets a broken `agents`.
 
 ```console
 $ bash scripts/install.sh --skip-tests
-  bin:    /home/muqsit/.local/bin/agents-dev
+  bin:    /home/you/.local/bin/agents-dev
   Removed stale dev link: ~/.local/bin/agents -&gt; ~/.local/agents-cli-dev/bin/agents
   Removed stale dev link: ~/.local/bin/ag     -&gt; ~/.local/agents-cli-dev/bin/ag
   Removed stale dev link: ~/.local/bin/browser -&gt; ~/.local/agents-cli-dev/bin/browser
   Shared daemon left on production code (secrets broker, browser IPC, routines).
   Ready
-  /home/muqsit/.local/bin/agents-dev (0.0.0-dev.41ae41f60-dirty)
+  /home/you/.local/bin/agents-dev (0.0.0-dev.41ae41f60-dirty)
   Run 'agents-dev '. Your installed 'agents' is untouched.
 
 $ ls ~/.local/bin/agents ~/.local/bin/ag ~/.local/bin/browser

--- a/.agents/artifacts/2026-08-10/plan-dev-install-no-shadow.md
+++ b/.agents/artifacts/2026-08-10/plan-dev-install-no-shadow.md
@@ -104,7 +104,7 @@ command. Every one is verified against this machine, not inferred.
 
 | # | Mechanism | Evidence |
 | --- | --- | --- |
-| 1 | The global rule tells every agent to install globally, and this repo carves out no exception | `/home/muqsit/.claude/CLAUDE.md:455` — *"No locally built CLIs. Install globally (`npm i -g`…)"*. npm prefix is `/home/muqsit/.local`, so `npm i -g .` lands on the real install. |
+| 1 | The global rule tells every agent to install globally, and this repo carves out no exception | `/home/you/.claude/CLAUDE.md:455` — *"No locally built CLIs. Install globally (`npm i -g`…)"*. npm prefix is `/home/you/.local`, so `npm i -g .` lands on the real install. |
 | 2 | `install.sh` links the dev build under the production names | `apps/cli/scripts/install.sh:141-146` — `for bin in agents ag browser; do ln -sf "$src" "$LINK_DIR/$bin"` |
 | 3 | `install.sh` restarts the shared daemon pinned to the dev binary | `install.sh:196` `AGENTS_INSTALL_BIN="$LINKED_PATH"` → `install.sh:205` `d.startDaemon?.(bin)` → `apps/cli/src/lib/daemon.ts:1313` |
 
@@ -124,15 +124,15 @@ That is true about the npm prefix and false about the command you actually type.
 
 ```console
 $ ls -la ~/.local/bin/agents ~/.local/bin/ag ~/.local/bin/browser
-agents  -> /home/muqsit/.local/agents-cli-dev/bin/agents
-ag      -> /home/muqsit/.local/agents-cli-dev/bin/ag
-browser -> /home/muqsit/.local/agents-cli-dev/bin/browser
+agents  -> /home/you/.local/agents-cli-dev/bin/agents
+ag      -> /home/you/.local/agents-cli-dev/bin/ag
+browser -> /home/you/.local/agents-cli-dev/bin/browser
 
 $ ls ~/.local/agents-cli-dev/lib/node_modules/@phnx-labs/
                                      # empty - the dev prefix was cleaned
 
 $ ~/.local/bin/agents --version
-zsh: no such file or directory: /home/muqsit/.local/bin/agents
+zsh: no such file or directory: /home/you/.local/bin/agents
 
 $ pgrep -af __daemon-run
 4163347 bun .agents/worktrees/rush-2431-binary-shadow/apps/cli/dist/index.js __daemon-run
@@ -147,13 +147,13 @@ Any shell that puts `~/.local/bin` first gets a broken `agents`.
 
 ```console
 $ bash scripts/install.sh --skip-tests
-  bin:    /home/muqsit/.local/bin/agents-dev
+  bin:    /home/you/.local/bin/agents-dev
   Removed stale dev link: ~/.local/bin/agents -> ~/.local/agents-cli-dev/bin/agents
   Removed stale dev link: ~/.local/bin/ag     -> ~/.local/agents-cli-dev/bin/ag
   Removed stale dev link: ~/.local/bin/browser -> ~/.local/agents-cli-dev/bin/browser
   Shared daemon left on production code (secrets broker, browser IPC, routines).
   Ready
-  /home/muqsit/.local/bin/agents-dev (0.0.0-dev.41ae41f60-dirty)
+  /home/you/.local/bin/agents-dev (0.0.0-dev.41ae41f60-dirty)
   Run 'agents-dev <args>'. Your installed 'agents' is untouched.
 
 $ ls ~/.local/bin/agents ~/.local/bin/ag ~/.local/bin/browser

--- a/.agents/artifacts/2026-08-10/plan-events-one-engine.html
+++ b/.agents/artifacts/2026-08-10/plan-events-one-engine.html
@@ -1,0 +1,474 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>One event engine — events is truth; audit and logs are aliases</title>
+<style>
+:root{--font-body:Inter,Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;--font-display:Inter,Inter,system-ui,sans-serif;--font-mono:"JetBrains Mono","JetBrains Mono","SFMono-Regular",Consolas,monospace;}
+@page{margin:24px}
+:root{color-scheme:light;--bg:#faf9f6;--surface:#ffffff;--surface-alt:#f2f4f0;--line:#e2e6df;--text:#1a1c1a;--muted:#5c655c;--accent:#4d7c0f;--accent-alt:#0e7490;--warn:#b45309;--danger:#dc2626;--content-width:980px;--page-padding:24px;--mobile-page-padding:16px;--hero-top:40px;--hero-bottom:28px;--section-spacing:36px;--figure-spacing:22px;--panel-padding:16px;--footer-spacing:64px;--print-margin:24px;--code:#0c0f0d;--code-text:#e7ece8;--radius:10px}
+@media(prefers-color-scheme:dark){:root:not([data-theme]){color-scheme:dark;--bg:#0a0a0a;--surface:#111312;--surface-alt:#161a18;--line:#26302a;--text:#e7ece8;--muted:#8b938c;--accent:#a3e635;--accent-alt:#5ad6c0;--warn:#f5c451;--danger:#ff6b6b;}}
+:root[data-theme="light"]{color-scheme:light;--bg:#faf9f6;--surface:#ffffff;--surface-alt:#f2f4f0;--line:#e2e6df;--text:#1a1c1a;--muted:#5c655c;--accent:#4d7c0f;--accent-alt:#0e7490;--warn:#b45309;--danger:#dc2626;}
+:root[data-theme="dark"]{color-scheme:dark;--bg:#0a0a0a;--surface:#111312;--surface-alt:#161a18;--line:#26302a;--text:#e7ece8;--muted:#8b938c;--accent:#a3e635;--accent-alt:#5ad6c0;--warn:#f5c451;--danger:#ff6b6b;}
+@media print{:root,:root[data-theme="light"],:root[data-theme="dark"]{color-scheme:light;--bg:#faf9f6;--surface:#ffffff;--surface-alt:#f2f4f0;--line:#e2e6df;--text:#1a1c1a;--muted:#5c655c;--accent:#4d7c0f;--accent-alt:#0e7490;--warn:#b45309;--danger:#dc2626;}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-body);line-height:1.6;-webkit-font-smoothing:antialiased;transition:background-color .15s ease,color .15s ease}main{width:100%;max-width:var(--content-width);min-width:0;margin:0 auto;padding:24px var(--page-padding) 80px}.document-header{display:flex;align-items:center;justify-content:flex-end;min-height:42px;border-bottom:1px solid var(--line);color:var(--muted);font-family:var(--font-mono);font-size:12px}.header-label{min-width:0;margin-right:auto;padding-right:12px;overflow-wrap:anywhere;color:var(--text);font-weight:650}.theme-toggle{display:inline-flex;flex:0 0 auto;align-items:center;gap:6px;height:30px;padding:0 12px;border:1px solid var(--line);border-radius:999px;background:var(--surface);color:var(--muted);font:500 12px/1 var(--font-mono);cursor:pointer}.theme-toggle:hover{color:var(--accent);border-color:var(--accent)}.theme-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px}.hero{padding:var(--hero-top) 0 var(--hero-bottom);border-bottom:1px solid var(--line)}.kicker{display:flex;flex-wrap:wrap;align-items:center;gap:8px 10px;font-family:var(--font-mono);font-size:12px;text-transform:uppercase;letter-spacing:.14em;color:var(--accent);font-weight:500}.kicker-part{color:var(--accent)}.kicker-separator{color:var(--muted);padding:0 2px}.status-badge{display:inline-flex;align-items:center;height:22px;padding:0 9px;border-radius:999px;border:1px solid color-mix(in srgb,var(--warn) 40%,var(--line));background:color-mix(in srgb,var(--warn) 14%,transparent);color:var(--warn);font-family:var(--font-mono);font-size:10.5px;font-weight:650;letter-spacing:.1em;text-transform:uppercase;line-height:1}.status-badge.status-implementing,.status-badge.status-in-progress,.status-badge.status-review,.status-badge.status-done,.status-badge.status-complete{border-color:color-mix(in srgb,var(--accent) 40%,var(--line));background:color-mix(in srgb,var(--accent) 12%,transparent);color:var(--accent)}.hero h1{font-family:var(--font-display);font-size:clamp(30px,4vw,44px);line-height:1.1;margin:12px 0 14px;letter-spacing:-.01em}.summary{max-width:760px;color:var(--muted);font-size:17px;margin:0}.meta{display:grid;gap:14px;margin-top:20px}.facts-line{margin:0;color:var(--muted);font-family:var(--font-mono);font-size:12.5px;line-height:1.7}.meta-block{display:grid;gap:8px}.meta-label{font-family:var(--font-mono);font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);font-weight:500}.meta-row{display:flex;flex-wrap:wrap;gap:8px;list-style:none;margin:0;padding:0}.chip{display:inline-flex;align-items:center;gap:4px;max-width:100%;border:1px solid var(--line);background:var(--surface);border-radius:999px;padding:4px 11px;color:var(--muted);font-family:var(--font-mono);font-size:11.5px;line-height:1.5}.chip-value{color:var(--text);overflow-wrap:anywhere}.chip-icon{display:inline-block;width:12px;height:12px;margin-right:5px;vertical-align:-1.5px;fill:currentColor;flex:0 0 auto}.chip-favicon{display:inline-block;width:12px;height:12px;margin-right:5px;vertical-align:-1.5px;border-radius:2px;object-fit:contain;flex:0 0 auto}.chip-value a{color:inherit;text-decoration:none}.chip-value a:hover{text-decoration:underline}.provenance-line{margin:0;color:var(--muted);font-family:var(--font-mono);font-size:12.5px;line-height:1.7}.provenance-line a{color:var(--accent-alt);text-decoration:none}.provenance-line a:hover{text-decoration:underline}.provenance-part{color:var(--muted)}.meta-sep{margin:0 7px;opacity:.45}.toc{display:grid;gap:5px;margin:24px 0 8px;font-family:var(--font-mono);font-size:13px}.code-diff{margin:var(--figure-spacing) 0;border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;background:var(--code)}.code-diff-pre{margin:0;padding:10px 0;background:none;border:none;border-radius:0;overflow-x:auto;font-family:var(--font-mono);font-size:12.5px;line-height:1.55;color:var(--code-text)}.cd-line{display:block;white-space:pre;padding:0 14px}.cd-sign{display:inline-block;width:1.4ch;color:var(--muted);user-select:none}.cd-add{background:color-mix(in srgb,var(--accent) 15%,transparent)}.cd-add .cd-sign{color:var(--accent)}.cd-del{background:color-mix(in srgb,var(--danger) 15%,transparent)}.cd-del .cd-sign{color:var(--danger)}.cd-hunk,.cd-meta{color:var(--muted);opacity:.8}.checklist{margin:var(--figure-spacing) 0;border:1px solid var(--line);border-radius:var(--radius);background:var(--surface);padding:var(--panel-padding)}.checklist-head{font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:.1em;color:var(--muted);margin-bottom:10px}.checklist-items{list-style:none;margin:0;padding:0;display:grid;gap:7px}.cl-item{display:flex;align-items:baseline;gap:9px}.cl-box{flex:0 0 auto;font-family:var(--font-mono);font-size:.95em}.cl-done .cl-box{color:var(--accent)}.cl-todo .cl-box{color:var(--muted)}.cl-done .cl-text{color:var(--muted);text-decoration:line-through;text-decoration-color:var(--line)}.toc a{color:var(--muted);text-decoration:none}.toc a:hover{color:var(--accent)}.toc a:focus-visible{outline:2px solid var(--accent);outline-offset:2px}.toc-index{color:var(--accent);font-family:var(--font-mono);font-size:.9em}.artifact-body{min-width:0;padding-top:18px;counter-reset:section}h2{font-size:24px;margin:var(--section-spacing) 0 12px;line-height:1.2;letter-spacing:-.01em}.artifact-body>h2{counter-increment:section}.artifact-body>h2::before{content:counter(section,decimal-leading-zero);font-family:var(--font-mono);font-size:.62em;color:var(--accent);margin-right:10px;opacity:.85}h3{font-size:17px;margin:calc(var(--section-spacing) * .78) 0 10px}a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}p,li,dd,figcaption{overflow-wrap:anywhere}pre{background:var(--code);color:var(--code-text);padding:var(--panel-padding);border-radius:12px;overflow:auto;border:1px solid var(--line)}code{font-family:var(--font-mono);font-size:.88em;background:var(--surface-alt);border:1px solid var(--line);border-radius:5px;padding:1.5px 6px;color:var(--accent-alt)}pre code{background:none;border:none;padding:0;color:inherit}table{width:100%;border-collapse:collapse;margin:18px 0}th,td{border-bottom:1px solid var(--line);padding:10px;text-align:left;vertical-align:top}th{font-family:var(--font-mono);font-size:11.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);font-weight:500}blockquote{border-left:3px solid var(--accent);padding-left:var(--panel-padding);color:var(--muted);margin-left:0}img{display:block;max-width:100%;height:auto}svg{max-width:100%;height:auto}.artifact-body>p>img{margin:var(--figure-spacing) auto}.artifact-grid{display:grid;gap:var(--panel-padding);margin:var(--figure-spacing) 0}.artifact-grid-2{grid-template-columns:repeat(2,minmax(0,1fr))}.artifact-grid-3{grid-template-columns:repeat(3,minmax(0,1fr))}.artifact-panel,.artifact-stat{min-width:0;border:1px solid var(--line);border-radius:var(--radius);background:var(--surface);padding:var(--panel-padding)}.artifact-panel h3{margin:10px 0 8px;font-size:16px}.artifact-stat-value,.artifact-stat-label{display:block}.artifact-stat-value{color:var(--text);font-family:var(--font-display);font-size:24px;line-height:1.15}.artifact-stat-label{margin-top:6px;color:var(--muted);font-size:13px}.artifact-tag{display:inline-block;--tag-color:var(--muted);background:color-mix(in srgb,var(--tag-color) 12%,transparent);border:1px solid color-mix(in srgb,var(--tag-color) 30%,transparent);border-radius:6px;padding:2px 8px;color:var(--tag-color);font-family:var(--font-mono);font-size:11px;font-weight:600;text-transform:uppercase}.artifact-tag-accent{--tag-color:var(--accent)}.artifact-callout{margin:var(--figure-spacing) 0;border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:0 var(--radius) var(--radius) 0;background:var(--surface-alt);padding:var(--panel-padding)}.artifact-callout-warn{border-left-color:var(--warn)}.artifact-callout-danger{border-left-color:var(--danger)}.artifact-callout strong{color:var(--text)}.artifact-figure{margin:var(--figure-spacing) 0;border:1px solid var(--line);border-radius:var(--radius);background:var(--surface);padding:var(--panel-padding);overflow-x:auto}.artifact-figure>img,.artifact-image{width:auto;max-width:100%;height:auto;margin:0 auto}.artifact-figure-diagram{background:#0e120f;border-color:#26302a}.artifact-diagram{display:block;width:100%;height:auto;margin:0 auto}.artifact-figure-tall{width:100%;max-width:394px;margin-left:auto;margin-right:auto}.artifact-figure figcaption{margin-top:12px;color:var(--muted);font-family:var(--font-mono);font-size:12px;text-align:center}.artifact-figure.artifact-figure-diagram figcaption{color:#8b938c}.artifact-legend{display:flex;flex-wrap:wrap;gap:8px 16px;margin:12px 0;color:var(--muted);font-family:var(--font-mono);font-size:11.5px}.document-footer{margin-top:var(--footer-spacing);padding-top:18px;border-top:1px solid var(--line);color:var(--muted);font-family:var(--font-mono);font-size:12px}
+@media(max-width:720px){main{padding:32px var(--mobile-page-padding) 64px}.artifact-grid-2,.artifact-grid-3{grid-template-columns:1fr}.artifact-figure{padding:min(12px,var(--panel-padding))}.artifact-figure-wide .artifact-diagram{min-width:640px}table{display:block;max-width:100%;overflow-x:auto}th,td{min-width:140px;overflow-wrap:anywhere}pre{white-space:pre-wrap;overflow-wrap:anywhere}}
+@media print{body{transition:none;-webkit-print-color-adjust:exact;print-color-adjust:exact}.toc,.theme-toggle{display:none}.document-header-empty{display:none}main{max-width:none;padding:0}:root[data-pdf-layout="poster"] main{max-width:var(--content-width);margin:0 auto;padding:var(--print-margin)}.chip{background:var(--surface)}.chip-value{color:var(--text)}.provenance-line,.provenance-line a,.facts-line{color:var(--text)}.status-badge{color:var(--text);border-color:var(--line)}h2,h3{break-after:avoid-page}.artifact-figure,.artifact-grid,.artifact-panel,.artifact-stat,.artifact-callout,pre,table,blockquote,.meta{break-inside:avoid}.artifact-figure-wide .artifact-diagram{min-width:0}.artifact-figure-tall{max-width:330px}pre{white-space:pre-wrap;overflow-wrap:anywhere}a{color:var(--text);text-decoration:underline}}
+</style>
+</head>
+<body>
+<main>
+<header class="document-header document-header-empty"><button class="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false" title="Toggle color theme"><span aria-hidden="true">&#9680;</span> theme</button></header>
+<section class="hero">
+<div class="kicker"><span class="kicker-part">agents-cli</span><span class="kicker-separator" aria-hidden="true">&middot;</span><span class="kicker-part">plan</span><span class="status-badge status-awaiting-go">awaiting-go</span></div>
+<h1>One event engine — events is truth; audit and logs are aliases</h1>
+<p class="summary">Collapse agents events, agents logs, and agents audit onto a single EventRecord store and a single read/write engine. audit and logs become thin wrappers with fixed filters. Sessions-style --include/--exclude filters the one stream. Bare events stays full; teach --exclude commands for noise.
+</p>
+<div class="meta" aria-label="Artifact metadata"><p class="facts-line">Decision: one source of truth, one engine<span class="meta-sep" aria-hidden="true">·</span>Decision: audit and logs are aliases only — no separate implementations<span class="meta-sep" aria-hidden="true">·</span>Decision: bare events stays full stream; teach --exclude commands<span class="meta-sep" aria-hidden="true">·</span>Today: logs audit already calls runEventsCommand; audit list is a separate store<span class="meta-sep" aria-hidden="true">·</span>Today: agent.run.end already exists as EventType; hash-chain audit is a parallel product</p><p class="provenance-line" aria-label="Provenance"><span class="provenance-part"><a href="https://github.com/phnx-labs/agents-cli" target="_blank" rel="noopener">phnx-labs/agents-cli</a></span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">main</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">events/logs/audit consolidation</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">Grok</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">Muqsit</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">yosemite-s0</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">989a55d9</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">2026-08-10</span></p></div>
+</section>
+<nav class="toc" aria-label="Artifact sections"><a href="#focus-for-review"><span class="toc-index">01&nbsp;&middot;&nbsp;</span>Focus for review</a><a href="#intent"><span class="toc-index">02&nbsp;&middot;&nbsp;</span>Intent</a><a href="#current-vs-proposed-what-you-type"><span class="toc-index">03&nbsp;&middot;&nbsp;</span>Current vs proposed (what you type)</a><a href="#architecture-before-after"><span class="toc-index">04&nbsp;&middot;&nbsp;</span>Architecture: before → after</a><a href="#purpose"><span class="toc-index">05&nbsp;&middot;&nbsp;</span>Purpose</a><a href="#public-interface"><span class="toc-index">06&nbsp;&middot;&nbsp;</span>Public interface</a><a href="#run-dispatch-rows-absorb-audit-list"><span class="toc-index">07&nbsp;&middot;&nbsp;</span>Run-dispatch rows (absorb audit list)</a><a href="#proposed-changes"><span class="toc-index">08&nbsp;&middot;&nbsp;</span>Proposed Changes</a><a href="#implementation-plan"><span class="toc-index">09&nbsp;&middot;&nbsp;</span>Implementation plan</a><a href="#key-files"><span class="toc-index">10&nbsp;&middot;&nbsp;</span>Key files</a><a href="#validation"><span class="toc-index">11&nbsp;&middot;&nbsp;</span>Validation</a><a href="#risks"><span class="toc-index">12&nbsp;&middot;&nbsp;</span>Risks</a><a href="#plan-checklist"><span class="toc-index">13&nbsp;&middot;&nbsp;</span>Plan checklist</a></nav><article class="artifact-body"><h1>One event engine: <code>events</code> is truth; <code>audit</code> and <code>logs</code> are aliases</h1>
+<h2 id="focus-for-review">Focus for review</h2>
+<ol>
+<li><strong>Single store + single engine</strong> — ops, activity, and former run-dispatch audit rows all become <code>EventRecord</code>s through one <code>emit</code> / <code>query</code> / <code>readUnifiedEvents</code> path.</li>
+<li><strong><code>audit</code> and <code>logs</code> are wrappers only</strong> — fixed flag presets over <code>agents events</code>, zero independent logic.</li>
+<li><strong>Hash chain</strong> — fold onto run events in the same engine (<code>events verify</code>) <strong>or</strong> drop verify as a product. No second file under <code>.history/audit/</code>.</li>
+<li><strong><code>logs [id]</code> content path</strong> — transcripts/host stdout leave this product; they stay on <code>sessions</code> / <code>hosts logs</code>.</li>
+<li><strong>Default noise</strong> — bare <code>events</code> stays full; <code>--exclude commands</code> is the taught path.</li>
+</ol>
+<h2 id="intent">Intent</h2>
+<p>You looked at <code>agents audit list</code> and <code>agents events</code> and saw three similar commands with three implementations. Your direction:</p>
+<ul>
+<li>One source of truth for logs, events, and audit.</li>
+<li>One engine for read and write.</li>
+<li><code>audit</code> is a bare-bones alias/wrapper over <code>events</code>.</li>
+<li>Same for <code>logs</code>.</li>
+<li>Track broadly by default; filter with sessions-style <code>--include</code> / <code>--exclude</code>.</li>
+</ul>
+<p>This plan follows that. Earlier drafts that kept three stores are rejected.</p>
+<h2 id="current-vs-proposed-what-you-type">Current vs proposed (what you type)</h2>
+<section class="artifact-grid artifact-grid-2">
+<article class="artifact-panel">
+<figcaption><strong>Current:</strong> three nouns, two stores, wall of command noise, wrong verb fails.</figcaption>
+
+```text
+$ agents events
+2026-08-10 … command.end  sessions
+2026-08-10 … command.end  sessions
+… (×40) …
+
+$ agents audit list
+3055  2026-08-08 … plan fail exit=1  /
+
+$ agents logs audit
+# ops-only events — same reader as events --audit
+# but lives under a different parent command
+
+$ agents events list
+error: too many arguments for 'events'
+```
+</article>
+
+<article class="artifact-panel">
+<figcaption><strong>Proposed:</strong> one engine; three nouns are the same command with defaults; filters kill noise.</figcaption>
+
+```text
+$ agents events --exclude commands --limit 5
+2026-08-10 … secrets.get   bundle=share
+2026-08-10 … pr.opened     https://github.com/…
+
+$ agents audit
+# ≡ agents events --include runs
+3055  2026-08-08 … agent.run.end  plan fail exit=1
+
+$ agents logs
+# ≡ agents events
+
+$ agents events stats
+$ agents events rotate --days 7
+$ agents sessions a1b2c3d4   # transcript content (not events)
+```
+</article>
+</section><h2 id="architecture-before-after">Architecture: before → after</h2>
+<figure class="artifact-figure artifact-figure-diagram artifact-figure-wide">
+<svg class="artifact-diagram" viewBox="0 0 1080 420" role="img" xmlns="http://www.w3.org/2000/svg">
+  <title id="ev-title">Before three stores; after one EventRecord engine</title>
+  <desc id="ev-desc">Left side shows three write paths and three CLIs. Right side shows one emit/query engine with events primary and audit/logs as aliases.</desc>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#a3e635"></path></marker>
+  </defs>
+
+  <text x="40" y="32" fill="#f87171" font-family="Inter,system-ui" font-size="14" font-weight="700">BEFORE — three products</text>
+
+  <rect x="30" y="52" width="200" height="70" rx="10" fill="#111827" stroke="#f87171" stroke-width="2"></rect>
+  <text x="48" y="82" fill="#f8fafc" font-family="JetBrains Mono,monospace" font-size="13">events/*.jsonl</text>
+  <text x="48" y="104" fill="#94a3b8" font-family="Inter,system-ui" font-size="11">ops emit()</text>
+
+  <rect x="30" y="138" width="200" height="70" rx="10" fill="#111827" stroke="#f87171" stroke-width="2"></rect>
+  <text x="48" y="168" fill="#f8fafc" font-family="JetBrains Mono,monospace" font-size="13">activity/*.jsonl</text>
+  <text x="48" y="190" fill="#94a3b8" font-family="Inter,system-ui" font-size="11">milestones</text>
+
+  <rect x="30" y="224" width="200" height="70" rx="10" fill="#111827" stroke="#f87171" stroke-width="2"></rect>
+  <text x="48" y="254" fill="#f8fafc" font-family="JetBrains Mono,monospace" font-size="13">audit/log.jsonl</text>
+  <text x="48" y="276" fill="#94a3b8" font-family="Inter,system-ui" font-size="11">hash chain (separate)</text>
+
+  <path d="M230 87H300" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arr)"></path>
+  <path d="M230 173H300" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arr)"></path>
+  <path d="M230 259H300" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arr)"></path>
+
+  <rect x="300" y="52" width="170" height="50" rx="8" fill="#1e293b" stroke="#475569"></rect>
+  <text x="318" y="82" fill="#e2e8f0" font-family="JetBrains Mono,monospace" font-size="12">agents events</text>
+  <rect x="300" y="148" width="170" height="50" rx="8" fill="#1e293b" stroke="#475569"></rect>
+  <text x="318" y="178" fill="#e2e8f0" font-family="JetBrains Mono,monospace" font-size="12">agents logs …</text>
+  <rect x="300" y="244" width="170" height="50" rx="8" fill="#1e293b" stroke="#475569"></rect>
+  <text x="318" y="274" fill="#e2e8f0" font-family="JetBrains Mono,monospace" font-size="12">agents audit</text>
+
+  <text x="30" y="340" fill="#94a3b8" font-family="Inter,system-ui" font-size="12">logs audit already aliases events — the outlier is audit/log.jsonl + logs[id] content</text>
+  <text x="30" y="362" fill="#94a3b8" font-family="Inter,system-ui" font-size="12">Transcripts stay on sessions / hosts logs (not this product)</text>
+
+  <text x="560" y="32" fill="#a3e635" font-family="Inter,system-ui" font-size="14" font-weight="700">AFTER — one engine</text>
+
+  <rect x="560" y="52" width="240" height="200" rx="12" fill="#111827" stroke="#a3e635" stroke-width="2"></rect>
+  <text x="580" y="88" fill="#a3e635" font-family="Inter,system-ui" font-size="13" font-weight="700">EventRecord engine</text>
+  <text x="580" y="118" fill="#f8fafc" font-family="JetBrains Mono,monospace" font-size="12">emit() / query()</text>
+  <text x="580" y="142" fill="#f8fafc" font-family="JetBrains Mono,monospace" font-size="12">readUnifiedEvents()</text>
+  <text x="580" y="174" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">ops + activity + run rows</text>
+  <text x="580" y="198" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">same schema, one filter layer</text>
+  <text x="580" y="222" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">stats · rotate · follow · verify?</text>
+
+  <path d="M800 152H860" stroke="#a3e635" stroke-width="3" fill="none" marker-end="url(#arr)"></path>
+
+  <rect x="860" y="60" width="190" height="48" rx="8" fill="#14532d" stroke="#a3e635" stroke-width="2"></rect>
+  <text x="878" y="90" fill="#ecfccb" font-family="JetBrains Mono,monospace" font-size="12">events (primary)</text>
+
+  <rect x="860" y="128" width="190" height="48" rx="8" fill="#1e293b" stroke="#64748b"></rect>
+  <text x="878" y="150" fill="#e2e8f0" font-family="JetBrains Mono,monospace" font-size="12">audit</text>
+  <text x="878" y="168" fill="#94a3b8" font-family="Inter,system-ui" font-size="11">≡ --include runs</text>
+
+  <rect x="860" y="196" width="190" height="48" rx="8" fill="#1e293b" stroke="#64748b"></rect>
+  <text x="878" y="218" fill="#e2e8f0" font-family="JetBrains Mono,monospace" font-size="12">logs</text>
+  <text x="878" y="236" fill="#94a3b8" font-family="Inter,system-ui" font-size="11">≡ events (passthrough)</text>
+
+  <text x="560" y="300" fill="#a3e635" font-family="Inter,system-ui" font-size="13" font-weight="700">Families</text>
+  <text x="560" y="328" fill="#cbd5e1" font-family="JetBrains Mono,monospace" font-size="12">ops · activity · commands · runs · security</text>
+  <text x="560" y="354" fill="#94a3b8" font-family="Inter,system-ui" font-size="12">--include / --exclude (mutex, like sessions roles)</text>
+  <text x="560" y="380" fill="#94a3b8" font-family="Inter,system-ui" font-size="12">run.dispatched / agent.run.end absorb old audit list rows</text>
+</svg>
+<figcaption>One write/read engine. CLI nouns are entry points, not products. Content viewing stays on sessions/hosts.</figcaption>
+</figure><div class="artifact-callout"><strong>Core rule:</strong> if it is a timestamped fleet fact, it is an <code>EventRecord</code> and goes through the events engine. If it is a session transcript or host task stdout, it is not this product — use <code>sessions</code> / <code>hosts logs</code>.</div><h2 id="purpose">Purpose</h2>
+<p>Three top-level commands print similar rows from different writers. Operators and agents guess wrong (<code>events list</code> fails; <code>logs audit</code> vs <code>audit list</code> are different products that share a name). Half the surface already shares an engine (<code>logs audit</code> → <code>runEventsCommand</code>). The outliers are the hash-chain file and the misnamed content viewer under <code>logs [id]</code>.</p>
+<p>The fix is one pipeline — not better help text.</p>
+<h2 id="public-interface">Public interface</h2>
+<h3>Primary: <code>agents events</code></h3>
+<pre><code># Full stream (default)
+agents events
+agents events --limit 0 --json
+
+# Sessions-style families
+agents events --exclude commands              # drop command.start/end noise
+agents events --include activity              # milestones only
+agents events --include ops                   # operational only
+agents events --include runs                  # what audit list used to show
+agents events --include security              # level=audit / secrets sugar
+
+# Existing field filters (keep)
+agents events --module secrets --bundle share
+agents events --event pr.opened --since 7d
+agents events --session &lt;id&gt;
+agents events -f
+
+# Housekeeping (moved off logs)
+agents events stats [--since 7d] [--json]
+agents events rotate [--days 7] [--max-mb 50]
+agents events emit --source factory &lt; batch.jsonl
+# optional if chain retained:
+agents events verify [--json]
+</code></pre>
+<h3>Families</h3>
+<table>
+<thead>
+<tr>
+<th>Family</th>
+<th>Definition</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>ops</code></td>
+<td>Operational log rows (module ≠ activity)</td>
+</tr>
+<tr>
+<td><code>activity</code></td>
+<td>Agent milestones (module = activity)</td>
+</tr>
+<tr>
+<td><code>commands</code></td>
+<td><code>command.start</code> + <code>command.end</code> only</td>
+</tr>
+<tr>
+<td><code>runs</code></td>
+<td>Run-dispatch outcomes (<code>agent.run.end</code> / <code>run.dispatched</code>)</td>
+</tr>
+<tr>
+<td><code>security</code></td>
+<td>level <code>audit</code> and/or secrets.* (sugar)</td>
+</tr>
+</tbody></table>
+<p><code>--include</code> and <code>--exclude</code> are mutually exclusive, same rule as <code>sessions</code>.</p>
+<h3>Aliases (zero independent logic)</h3>
+<table>
+<thead>
+<tr>
+<th>Command</th>
+<th>Expands to</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>agents audit</code></td>
+<td><code>agents events --include runs</code></td>
+</tr>
+<tr>
+<td><code>agents audit list</code></td>
+<td>same</td>
+</tr>
+<tr>
+<td><code>agents audit verify</code></td>
+<td><code>agents events verify</code> (if H1) or removed (if H2)</td>
+</tr>
+<tr>
+<td><code>agents logs</code></td>
+<td><code>agents events</code></td>
+</tr>
+<tr>
+<td><code>agents logs audit</code></td>
+<td><code>agents events --include ops</code></td>
+</tr>
+<tr>
+<td><code>agents logs stats</code></td>
+<td><code>agents events stats</code></td>
+</tr>
+<tr>
+<td><code>agents logs rotate</code></td>
+<td><code>agents events rotate</code></td>
+</tr>
+</tbody></table>
+<p>Implementation pattern: one <code>runEventsCommand</code>; aliases only set default opts.</p>
+<h3>Leaves this surface</h3>
+<table>
+<thead>
+<tr>
+<th>Old</th>
+<th>New home</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>agents logs &lt;session-id&gt;</code> transcript</td>
+<td><code>agents sessions &lt;id&gt;</code> / <code>sessions tail</code></td>
+</tr>
+<tr>
+<td><code>agents logs &lt;task-id&gt;</code> host stdout</td>
+<td><code>agents hosts logs &lt;id&gt;</code></td>
+</tr>
+</tbody></table>
+<p>If <code>agents logs &lt;id&gt;</code> is kept for muscle memory, it <strong>redirects</strong> with a clear message — it does not reimplement content viewing.</p>
+<h2 id="run-dispatch-rows-absorb-audit-list">Run-dispatch rows (absorb <code>audit list</code>)</h2>
+<p>Today <code>audit list</code> shows: index, ts, agent@version, mode, ok/fail, exit, repo.</p>
+<p>At the exec chokepoint that currently calls <code>recordDispatchedRun</code>:</p>
+<div class="code-diff"><pre class="code-diff-pre"><span class="cd-line cd-del"><span class="cd-sign">-</span><span class="cd-code"> appendAuditRecord({ ts, agent, version, repo, mode, outcome, exit })</span></span><span class="cd-line cd-add"><span class="cd-sign">+</span><span class="cd-code"> emit('agent.run.end', { agent, version, repo, mode, outcome, exit })</span></span><span class="cd-line cd-ctx"><span class="cd-sign"></span><span class="cd-code"> // or 'run.dispatched' if end is too overloaded</span></span></pre></div><p><code>--include runs</code> (and thus <code>agents audit</code>) can use a <strong>row format</strong> tuned like the old audit table. Presentation is not a second engine.</p>
+<h3>Hash chain (pick at implement start)</h3>
+<table>
+<thead>
+<tr>
+<th>Option</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>H1</strong></td>
+<td><code>prevHash</code>/<code>hash</code> on run rows only; <code>events verify</code> walks them in the same stream</td>
+</tr>
+<tr>
+<td><strong>H2</strong></td>
+<td>Drop chain product; just emit outcomes; delete verify</td>
+</tr>
+</tbody></table>
+<p>Recommendation: H1 only if something still gates on <code>audit verify</code> in CI; else H2. Either way <strong>no separate <code>audit/log.jsonl</code> product.</strong></p>
+<h2 id="proposed-changes">Proposed Changes</h2>
+<table>
+<thead>
+<tr>
+<th>Change</th>
+<th>What happens</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>One EventRecord engine</td>
+<td>All timeline writes go through <code>emit()</code>; all reads through <code>query</code> / <code>readUnifiedEvents</code> + family filters</td>
+</tr>
+<tr>
+<td><code>--include</code> / <code>--exclude</code></td>
+<td>Sessions-style family filters: ops, activity, commands, runs, security</td>
+</tr>
+<tr>
+<td><code>agents audit</code></td>
+<td>Thin alias of <code>agents events --include runs</code> — no second store</td>
+</tr>
+<tr>
+<td><code>agents logs</code></td>
+<td>Thin alias of <code>agents events</code>; stats/rotate re-dispatch; <code>logs [id]</code> redirects to sessions/hosts</td>
+</tr>
+<tr>
+<td>Run-dispatch rows</td>
+<td><code>recordDispatchedRun</code> becomes <code>emit('agent.run.end'…)</code> (or <code>run.dispatched</code>)</td>
+</tr>
+<tr>
+<td>Retire <code>audit/log.jsonl</code></td>
+<td>Stop writing the hash-chain file for new runs; optional H1 verify on run rows or H2 drop</td>
+</tr>
+</tbody></table>
+<h3>Diff sketch — alias not peer product</h3>
+<div class="code-diff"><pre class="code-diff-pre"><span class="cd-line cd-ctx"><span class="cd-sign"></span><span class="cd-code">// commands/audit.ts</span></span><span class="cd-line cd-del"><span class="cd-sign">-</span><span class="cd-code"> readAuditLog() + custom renderRow for AuditRecord</span></span><span class="cd-line cd-add"><span class="cd-sign">+</span><span class="cd-code"> runEventsCommand({ ...opts, include: 'runs' })</span></span></pre></div><h3>Diff sketch — run end writes events</h3>
+<div class="code-diff"><pre class="code-diff-pre"><span class="cd-line cd-ctx"><span class="cd-sign"></span><span class="cd-code">// exec dispatch end</span></span><span class="cd-line cd-del"><span class="cd-sign">-</span><span class="cd-code"> appendAuditRecord({ ts, agent, version, repo, mode, outcome, exit })</span></span><span class="cd-line cd-add"><span class="cd-sign">+</span><span class="cd-code"> emit('agent.run.end', { agent, version, repo, mode, outcome, exit })</span></span></pre></div><h2 id="implementation-plan">Implementation plan</h2>
+<h3>Phase 1 — families on the existing engine</h3>
+<ul>
+<li>Add <code>--include</code> / <code>--exclude</code> family parser in the events option surface (mutex).</li>
+<li>Map families → <code>includeActivity</code> + eventTypes / level inside <code>readUnifiedEvents</code> (no second scan).</li>
+<li>Help leads with <code>--exclude commands</code>.</li>
+<li>Tests: family filters, mutex, interaction with <code>--module</code> / <code>--event</code>.</li>
+</ul>
+<h3>Phase 2 — collapse CLIs onto one handler</h3>
+<ul>
+<li><code>registerAuditCommands</code> → thin alias (default <code>--include runs</code>).</li>
+<li><code>registerLogsCommand</code> → thin alias of events; stats/rotate re-dispatch.</li>
+<li>Remove independent <code>readAuditLog</code> list renderer from the audit command tree.</li>
+<li><code>logs [id]</code> → redirect to sessions/hosts.</li>
+<li>Deprecation one-liners for one train if needed.</li>
+</ul>
+<h3>Phase 3 — absorb run-dispatch into emit</h3>
+<ul>
+<li>At run end: <code>emit(...)</code> with fields audit list needed.</li>
+<li>Stop appending to <code>audit/log.jsonl</code> for new runs.</li>
+<li>Optional migration of historical chain rows into events JSONL.</li>
+<li>Gut or delete <code>lib/audit/log.ts</code> once no writers remain.</li>
+<li>H1 or H2 for verify.</li>
+</ul>
+<h3>Phase 4 — docs + fleet guidance</h3>
+<ul>
+<li>Rewrite <code>apps/cli/docs/observability.md</code> table.</li>
+<li>CHANGELOG under next version.</li>
+<li>Companion <code>.agents-system</code> skills/rules that teach old names — linked PR if consumers exist.</li>
+</ul>
+<h2 id="key-files">Key files</h2>
+<table>
+<thead>
+<tr>
+<th>Area</th>
+<th>Path</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Types + emit + query + stats + rotate</td>
+<td><code>apps/cli/src/lib/events.ts</code></td>
+</tr>
+<tr>
+<td>Unified reader</td>
+<td><code>apps/cli/src/lib/event-stream.ts</code></td>
+</tr>
+<tr>
+<td>Events CLI + shared handler</td>
+<td><code>apps/cli/src/commands/events.ts</code></td>
+</tr>
+<tr>
+<td>Audit CLI → alias</td>
+<td><code>apps/cli/src/commands/audit.ts</code></td>
+</tr>
+<tr>
+<td>Logs CLI → alias</td>
+<td><code>apps/cli/src/commands/logs.ts</code></td>
+</tr>
+<tr>
+<td>Hash chain (retire)</td>
+<td><code>apps/cli/src/lib/audit/log.ts</code></td>
+</tr>
+<tr>
+<td>Run end write site</td>
+<td>exec dispatch / <code>recordDispatchedRun</code> call sites</td>
+</tr>
+<tr>
+<td>Docs</td>
+<td><code>apps/cli/docs/observability.md</code></td>
+</tr>
+</tbody></table>
+<h2 id="validation">Validation</h2>
+<pre><code># same engine answers all three nouns
+agents events --include runs --limit 5 --json
+agents audit --limit 5 --json          # identical records
+agents logs --include runs --limit 5 --json
+
+agents events --exclude commands --limit 10
+agents events stats --json
+agents events rotate --days 7 --max-mb 50
+
+# content is not events
+agents sessions &lt;id&gt; --markdown
+agents hosts logs &lt;task-id&gt;
+</code></pre>
+<h2 id="risks">Risks</h2>
+<table>
+<thead>
+<tr>
+<th>Risk</th>
+<th>Mitigation</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Scripts call <code>audit list</code> / <code>logs audit</code></td>
+<td>Wrappers keep flags/JSON working</td>
+</tr>
+<tr>
+<td>Hash-chain consumers</td>
+<td>H1 keeps verify on same stream; or document drop</td>
+</tr>
+<tr>
+<td><code>logs &lt;id&gt;</code> muscle memory</td>
+<td>Explicit redirect to sessions/hosts</td>
+</tr>
+<tr>
+<td>Activity still sharded on disk</td>
+<td>Same schema + one reader; write split is internal</td>
+</tr>
+<tr>
+<td>Bare events still noisy</td>
+<td>Teach <code>--exclude commands</code> (locked decision)</td>
+</tr>
+</tbody></table>
+<h2 id="plan-checklist">Plan checklist</h2>
+<div class="checklist"><div class="checklist-head">0 / 6 done</div><ul class="checklist-items"><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Confirm H1 vs H2 for hash chain at implement start</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Phase 1: <code>--include</code> / <code>--exclude</code> on events engine</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Phase 2: audit + logs as aliases; move stats/rotate; redirect logs [id]</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Phase 3: emit run outcomes into events; retire <code>audit/log.jsonl</code> writer</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Phase 4: docs, CHANGELOG, companion guidance</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Prove: three CLI nouns → one query path; new runs never open the old audit file</span></li></ul></div>
+</article>
+
+</main>
+<script type="application/json" id="artifacts-source">{"encoding":"base64","markdown":"LS0tCmtpbmQ6IHBsYW4KdGVtcGxhdGU6IHBsYW4udjEKc3VyZmFjZTogY2xpCnRpdGxlOiBPbmUgZXZlbnQgZW5naW5lIOKAlCBldmVudHMgaXMgdHJ1dGg7IGF1ZGl0IGFuZCBsb2dzIGFyZSBhbGlhc2VzCnN1bW1hcnk6ID4KICBDb2xsYXBzZSBhZ2VudHMgZXZlbnRzLCBhZ2VudHMgbG9ncywgYW5kIGFnZW50cyBhdWRpdCBvbnRvIGEgc2luZ2xlIEV2ZW50UmVjb3JkCiAgc3RvcmUgYW5kIGEgc2luZ2xlIHJlYWQvd3JpdGUgZW5naW5lLiBhdWRpdCBhbmQgbG9ncyBiZWNvbWUgdGhpbiB3cmFwcGVycyB3aXRoCiAgZml4ZWQgZmlsdGVycy4gU2Vzc2lvbnMtc3R5bGUgLS1pbmNsdWRlLy0tZXhjbHVkZSBmaWx0ZXJzIHRoZSBvbmUgc3RyZWFtLgogIEJhcmUgZXZlbnRzIHN0YXlzIGZ1bGw7IHRlYWNoIC0tZXhjbHVkZSBjb21tYW5kcyBmb3Igbm9pc2UuCnN0YXR1czogYXdhaXRpbmctZ28KdHJhY2tpbmc6ICJldmVudHMvbG9ncy9hdWRpdCBjb25zb2xpZGF0aW9uIgpwcm9qZWN0OiBhZ2VudHMtY2xpCnJlcG9zaXRvcnk6IHBobngtbGFicy9hZ2VudHMtY2xpCmJyYW5jaDogbWFpbgpob3N0OiB5b3NlbWl0ZS1zMApkYXRlOiAnMjAyNi0wOC0xMCcKZmFjdHM6CiAgLSAiRGVjaXNpb246IG9uZSBzb3VyY2Ugb2YgdHJ1dGgsIG9uZSBlbmdpbmUiCiAgLSAiRGVjaXNpb246IGF1ZGl0IGFuZCBsb2dzIGFyZSBhbGlhc2VzIG9ubHkg4oCUIG5vIHNlcGFyYXRlIGltcGxlbWVudGF0aW9ucyIKICAtICJEZWNpc2lvbjogYmFyZSBldmVudHMgc3RheXMgZnVsbCBzdHJlYW07IHRlYWNoIC0tZXhjbHVkZSBjb21tYW5kcyIKICAtICJUb2RheTogbG9ncyBhdWRpdCBhbHJlYWR5IGNhbGxzIHJ1bkV2ZW50c0NvbW1hbmQ7IGF1ZGl0IGxpc3QgaXMgYSBzZXBhcmF0ZSBzdG9yZSIKICAtICJUb2RheTogYWdlbnQucnVuLmVuZCBhbHJlYWR5IGV4aXN0cyBhcyBFdmVudFR5cGU7IGhhc2gtY2hhaW4gYXVkaXQgaXMgYSBwYXJhbGxlbCBwcm9kdWN0IgotLS0KCiMgT25lIGV2ZW50IGVuZ2luZTogYGV2ZW50c2AgaXMgdHJ1dGg7IGBhdWRpdGAgYW5kIGBsb2dzYCBhcmUgYWxpYXNlcwoKIyMgRm9jdXMgZm9yIHJldmlldwoKMS4gKipTaW5nbGUgc3RvcmUgKyBzaW5nbGUgZW5naW5lKiog4oCUIG9wcywgYWN0aXZpdHksIGFuZCBmb3JtZXIgcnVuLWRpc3BhdGNoIGF1ZGl0IHJvd3MgYWxsIGJlY29tZSBgRXZlbnRSZWNvcmRgcyB0aHJvdWdoIG9uZSBgZW1pdGAgLyBgcXVlcnlgIC8gYHJlYWRVbmlmaWVkRXZlbnRzYCBwYXRoLgoyLiAqKmBhdWRpdGAgYW5kIGBsb2dzYCBhcmUgd3JhcHBlcnMgb25seSoqIOKAlCBmaXhlZCBmbGFnIHByZXNldHMgb3ZlciBgYWdlbnRzIGV2ZW50c2AsIHplcm8gaW5kZXBlbmRlbnQgbG9naWMuCjMuICoqSGFzaCBjaGFpbioqIOKAlCBmb2xkIG9udG8gcnVuIGV2ZW50cyBpbiB0aGUgc2FtZSBlbmdpbmUgKGBldmVudHMgdmVyaWZ5YCkgKipvcioqIGRyb3AgdmVyaWZ5IGFzIGEgcHJvZHVjdC4gTm8gc2Vjb25kIGZpbGUgdW5kZXIgYC5oaXN0b3J5L2F1ZGl0L2AuCjQuICoqYGxvZ3MgW2lkXWAgY29udGVudCBwYXRoKiog4oCUIHRyYW5zY3JpcHRzL2hvc3Qgc3Rkb3V0IGxlYXZlIHRoaXMgcHJvZHVjdDsgdGhleSBzdGF5IG9uIGBzZXNzaW9uc2AgLyBgaG9zdHMgbG9nc2AuCjUuICoqRGVmYXVsdCBub2lzZSoqIOKAlCBiYXJlIGBldmVudHNgIHN0YXlzIGZ1bGw7IGAtLWV4Y2x1ZGUgY29tbWFuZHNgIGlzIHRoZSB0YXVnaHQgcGF0aC4KCiMjIEludGVudAoKWW91IGxvb2tlZCBhdCBgYWdlbnRzIGF1ZGl0IGxpc3RgIGFuZCBgYWdlbnRzIGV2ZW50c2AgYW5kIHNhdyB0aHJlZSBzaW1pbGFyIGNvbW1hbmRzIHdpdGggdGhyZWUgaW1wbGVtZW50YXRpb25zLiBZb3VyIGRpcmVjdGlvbjoKCi0gT25lIHNvdXJjZSBvZiB0cnV0aCBmb3IgbG9ncywgZXZlbnRzLCBhbmQgYXVkaXQuCi0gT25lIGVuZ2luZSBmb3IgcmVhZCBhbmQgd3JpdGUuCi0gYGF1ZGl0YCBpcyBhIGJhcmUtYm9uZXMgYWxpYXMvd3JhcHBlciBvdmVyIGBldmVudHNgLgotIFNhbWUgZm9yIGBsb2dzYC4KLSBUcmFjayBicm9hZGx5IGJ5IGRlZmF1bHQ7IGZpbHRlciB3aXRoIHNlc3Npb25zLXN0eWxlIGAtLWluY2x1ZGVgIC8gYC0tZXhjbHVkZWAuCgpUaGlzIHBsYW4gZm9sbG93cyB0aGF0LiBFYXJsaWVyIGRyYWZ0cyB0aGF0IGtlcHQgdGhyZWUgc3RvcmVzIGFyZSByZWplY3RlZC4KCiMjIEN1cnJlbnQgdnMgcHJvcG9zZWQgKHdoYXQgeW91IHR5cGUpCgo8c2VjdGlvbiBjbGFzcz0iYXJ0aWZhY3QtZ3JpZCBhcnRpZmFjdC1ncmlkLTIiPgo8YXJ0aWNsZSBjbGFzcz0iYXJ0aWZhY3QtcGFuZWwiIGRhdGEtc3RhdGU9ImN1cnJlbnQiIGRhdGEtZXZpZGVuY2U9ImNhcHR1cmUiPgo8ZmlnY2FwdGlvbj48c3Ryb25nPkN1cnJlbnQ6PC9zdHJvbmc+IHRocmVlIG5vdW5zLCB0d28gc3RvcmVzLCB3YWxsIG9mIGNvbW1hbmQgbm9pc2UsIHdyb25nIHZlcmIgZmFpbHMuPC9maWdjYXB0aW9uPgoKYGBgdGV4dAokIGFnZW50cyBldmVudHMKMjAyNi0wOC0xMCDigKYgY29tbWFuZC5lbmQgIHNlc3Npb25zCjIwMjYtMDgtMTAg4oCmIGNvbW1hbmQuZW5kICBzZXNzaW9ucwrigKYgKMOXNDApIOKApgoKJCBhZ2VudHMgYXVkaXQgbGlzdAozMDU1ICAyMDI2LTA4LTA4IOKApiBwbGFuIGZhaWwgZXhpdD0xICAvCgokIGFnZW50cyBsb2dzIGF1ZGl0CiMgb3BzLW9ubHkgZXZlbnRzIOKAlCBzYW1lIHJlYWRlciBhcyBldmVudHMgLS1hdWRpdAojIGJ1dCBsaXZlcyB1bmRlciBhIGRpZmZlcmVudCBwYXJlbnQgY29tbWFuZAoKJCBhZ2VudHMgZXZlbnRzIGxpc3QKZXJyb3I6IHRvbyBtYW55IGFyZ3VtZW50cyBmb3IgJ2V2ZW50cycKYGBgCjwvYXJ0aWNsZT4KCjxhcnRpY2xlIGNsYXNzPSJhcnRpZmFjdC1wYW5lbCIgZGF0YS1zdGF0ZT0icHJvcG9zZWQiIGRhdGEtZXZpZGVuY2U9Im1vY2t1cCI+CjxmaWdjYXB0aW9uPjxzdHJvbmc+UHJvcG9zZWQ6PC9zdHJvbmc+IG9uZSBlbmdpbmU7IHRocmVlIG5vdW5zIGFyZSB0aGUgc2FtZSBjb21tYW5kIHdpdGggZGVmYXVsdHM7IGZpbHRlcnMga2lsbCBub2lzZS48L2ZpZ2NhcHRpb24+CgpgYGB0ZXh0CiQgYWdlbnRzIGV2ZW50cyAtLWV4Y2x1ZGUgY29tbWFuZHMgLS1saW1pdCA1CjIwMjYtMDgtMTAg4oCmIHNlY3JldHMuZ2V0ICAgYnVuZGxlPXNoYXJlCjIwMjYtMDgtMTAg4oCmIHByLm9wZW5lZCAgICAgaHR0cHM6Ly9naXRodWIuY29tL+KApgoKJCBhZ2VudHMgYXVkaXQKIyDiiaEgYWdlbnRzIGV2ZW50cyAtLWluY2x1ZGUgcnVucwozMDU1ICAyMDI2LTA4LTA4IOKApiBhZ2VudC5ydW4uZW5kICBwbGFuIGZhaWwgZXhpdD0xCgokIGFnZW50cyBsb2dzCiMg4omhIGFnZW50cyBldmVudHMKCiQgYWdlbnRzIGV2ZW50cyBzdGF0cwokIGFnZW50cyBldmVudHMgcm90YXRlIC0tZGF5cyA3CiQgYWdlbnRzIHNlc3Npb25zIGExYjJjM2Q0ICAgIyB0cmFuc2NyaXB0IGNvbnRlbnQgKG5vdCBldmVudHMpCmBgYAo8L2FydGljbGU+Cjwvc2VjdGlvbj4KCiMjIEFyY2hpdGVjdHVyZTogYmVmb3JlIOKGkiBhZnRlcgoKPGZpZ3VyZSBjbGFzcz0iYXJ0aWZhY3QtZmlndXJlIGFydGlmYWN0LWZpZ3VyZS1kaWFncmFtIGFydGlmYWN0LWZpZ3VyZS13aWRlIj4KPHN2ZyBjbGFzcz0iYXJ0aWZhY3QtZGlhZ3JhbSIgdmlld0JveD0iMCAwIDEwODAgNDIwIiByb2xlPSJpbWciIGFyaWEtbGFiZWxsZWRieT0iZXYtdGl0bGUgZXYtZGVzYyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8dGl0bGUgaWQ9ImV2LXRpdGxlIj5CZWZvcmUgdGhyZWUgc3RvcmVzOyBhZnRlciBvbmUgRXZlbnRSZWNvcmQgZW5naW5lPC90aXRsZT4KICA8ZGVzYyBpZD0iZXYtZGVzYyI+TGVmdCBzaWRlIHNob3dzIHRocmVlIHdyaXRlIHBhdGhzIGFuZCB0aHJlZSBDTElzLiBSaWdodCBzaWRlIHNob3dzIG9uZSBlbWl0L3F1ZXJ5IGVuZ2luZSB3aXRoIGV2ZW50cyBwcmltYXJ5IGFuZCBhdWRpdC9sb2dzIGFzIGFsaWFzZXMuPC9kZXNjPgogIDxkZWZzPgogICAgPG1hcmtlciBpZD0iYXJyIiB2aWV3Qm94PSIwIDAgMTAgMTAiIHJlZlg9IjkiIHJlZlk9IjUiIG1hcmtlcldpZHRoPSI3IiBtYXJrZXJIZWlnaHQ9IjciIG9yaWVudD0iYXV0by1zdGFydC1yZXZlcnNlIj48cGF0aCBkPSJNMCAwTDEwIDVMMCAxMHoiIGZpbGw9IiNhM2U2MzUiLz48L21hcmtlcj4KICA8L2RlZnM+CgogIDx0ZXh0IHg9IjQwIiB5PSIzMiIgZmlsbD0iI2Y4NzE3MSIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxNCIgZm9udC13ZWlnaHQ9IjcwMCI+QkVGT1JFIOKAlCB0aHJlZSBwcm9kdWN0czwvdGV4dD4KCiAgPHJlY3QgeD0iMzAiIHk9IjUyIiB3aWR0aD0iMjAwIiBoZWlnaHQ9IjcwIiByeD0iMTAiIGZpbGw9IiMxMTE4MjciIHN0cm9rZT0iI2Y4NzE3MSIgc3Ryb2tlLXdpZHRoPSIyIi8+CiAgPHRleHQgeD0iNDgiIHk9IjgyIiBmaWxsPSIjZjhmYWZjIiBmb250LWZhbWlseT0iSmV0QnJhaW5zIE1vbm8sbW9ub3NwYWNlIiBmb250LXNpemU9IjEzIj5ldmVudHMvKi5qc29ubDwvdGV4dD4KICA8dGV4dCB4PSI0OCIgeT0iMTA0IiBmaWxsPSIjOTRhM2I4IiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjExIj5vcHMgZW1pdCgpPC90ZXh0PgoKICA8cmVjdCB4PSIzMCIgeT0iMTM4IiB3aWR0aD0iMjAwIiBoZWlnaHQ9IjcwIiByeD0iMTAiIGZpbGw9IiMxMTE4MjciIHN0cm9rZT0iI2Y4NzE3MSIgc3Ryb2tlLXdpZHRoPSIyIi8+CiAgPHRleHQgeD0iNDgiIHk9IjE2OCIgZmlsbD0iI2Y4ZmFmYyIgZm9udC1mYW1pbHk9IkpldEJyYWlucyBNb25vLG1vbm9zcGFjZSIgZm9udC1zaXplPSIxMyI+YWN0aXZpdHkvKi5qc29ubDwvdGV4dD4KICA8dGV4dCB4PSI0OCIgeT0iMTkwIiBmaWxsPSIjOTRhM2I4IiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjExIj5taWxlc3RvbmVzPC90ZXh0PgoKICA8cmVjdCB4PSIzMCIgeT0iMjI0IiB3aWR0aD0iMjAwIiBoZWlnaHQ9IjcwIiByeD0iMTAiIGZpbGw9IiMxMTE4MjciIHN0cm9rZT0iI2Y4NzE3MSIgc3Ryb2tlLXdpZHRoPSIyIi8+CiAgPHRleHQgeD0iNDgiIHk9IjI1NCIgZmlsbD0iI2Y4ZmFmYyIgZm9udC1mYW1pbHk9IkpldEJyYWlucyBNb25vLG1vbm9zcGFjZSIgZm9udC1zaXplPSIxMyI+YXVkaXQvbG9nLmpzb25sPC90ZXh0PgogIDx0ZXh0IHg9IjQ4IiB5PSIyNzYiIGZpbGw9IiM5NGEzYjgiIGZvbnQtZmFtaWx5PSJJbnRlcixzeXN0ZW0tdWkiIGZvbnQtc2l6ZT0iMTEiPmhhc2ggY2hhaW4gKHNlcGFyYXRlKTwvdGV4dD4KCiAgPHBhdGggZD0iTTIzMCA4N0gzMDAiIHN0cm9rZT0iIzY0NzQ4YiIgc3Ryb2tlLXdpZHRoPSIyIiBmaWxsPSJub25lIiBtYXJrZXItZW5kPSJ1cmwoI2FycikiLz4KICA8cGF0aCBkPSJNMjMwIDE3M0gzMDAiIHN0cm9rZT0iIzY0NzQ4YiIgc3Ryb2tlLXdpZHRoPSIyIiBmaWxsPSJub25lIiBtYXJrZXItZW5kPSJ1cmwoI2FycikiLz4KICA8cGF0aCBkPSJNMjMwIDI1OUgzMDAiIHN0cm9rZT0iIzY0NzQ4YiIgc3Ryb2tlLXdpZHRoPSIyIiBmaWxsPSJub25lIiBtYXJrZXItZW5kPSJ1cmwoI2FycikiLz4KCiAgPHJlY3QgeD0iMzAwIiB5PSI1MiIgd2lkdGg9IjE3MCIgaGVpZ2h0PSI1MCIgcng9IjgiIGZpbGw9IiMxZTI5M2IiIHN0cm9rZT0iIzQ3NTU2OSIvPgogIDx0ZXh0IHg9IjMxOCIgeT0iODIiIGZpbGw9IiNlMmU4ZjAiIGZvbnQtZmFtaWx5PSJKZXRCcmFpbnMgTW9ubyxtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTIiPmFnZW50cyBldmVudHM8L3RleHQ+CiAgPHJlY3QgeD0iMzAwIiB5PSIxNDgiIHdpZHRoPSIxNzAiIGhlaWdodD0iNTAiIHJ4PSI4IiBmaWxsPSIjMWUyOTNiIiBzdHJva2U9IiM0NzU1NjkiLz4KICA8dGV4dCB4PSIzMTgiIHk9IjE3OCIgZmlsbD0iI2UyZThmMCIgZm9udC1mYW1pbHk9IkpldEJyYWlucyBNb25vLG1vbm9zcGFjZSIgZm9udC1zaXplPSIxMiI+YWdlbnRzIGxvZ3Mg4oCmPC90ZXh0PgogIDxyZWN0IHg9IjMwMCIgeT0iMjQ0IiB3aWR0aD0iMTcwIiBoZWlnaHQ9IjUwIiByeD0iOCIgZmlsbD0iIzFlMjkzYiIgc3Ryb2tlPSIjNDc1NTY5Ii8+CiAgPHRleHQgeD0iMzE4IiB5PSIyNzQiIGZpbGw9IiNlMmU4ZjAiIGZvbnQtZmFtaWx5PSJKZXRCcmFpbnMgTW9ubyxtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTIiPmFnZW50cyBhdWRpdDwvdGV4dD4KCiAgPHRleHQgeD0iMzAiIHk9IjM0MCIgZmlsbD0iIzk0YTNiOCIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxMiI+bG9ncyBhdWRpdCBhbHJlYWR5IGFsaWFzZXMgZXZlbnRzIOKAlCB0aGUgb3V0bGllciBpcyBhdWRpdC9sb2cuanNvbmwgKyBsb2dzW2lkXSBjb250ZW50PC90ZXh0PgogIDx0ZXh0IHg9IjMwIiB5PSIzNjIiIGZpbGw9IiM5NGEzYjgiIGZvbnQtZmFtaWx5PSJJbnRlcixzeXN0ZW0tdWkiIGZvbnQtc2l6ZT0iMTIiPlRyYW5zY3JpcHRzIHN0YXkgb24gc2Vzc2lvbnMgLyBob3N0cyBsb2dzIChub3QgdGhpcyBwcm9kdWN0KTwvdGV4dD4KCiAgPHRleHQgeD0iNTYwIiB5PSIzMiIgZmlsbD0iI2EzZTYzNSIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxNCIgZm9udC13ZWlnaHQ9IjcwMCI+QUZURVIg4oCUIG9uZSBlbmdpbmU8L3RleHQ+CgogIDxyZWN0IHg9IjU2MCIgeT0iNTIiIHdpZHRoPSIyNDAiIGhlaWdodD0iMjAwIiByeD0iMTIiIGZpbGw9IiMxMTE4MjciIHN0cm9rZT0iI2EzZTYzNSIgc3Ryb2tlLXdpZHRoPSIyIi8+CiAgPHRleHQgeD0iNTgwIiB5PSI4OCIgZmlsbD0iI2EzZTYzNSIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxMyIgZm9udC13ZWlnaHQ9IjcwMCI+RXZlbnRSZWNvcmQgZW5naW5lPC90ZXh0PgogIDx0ZXh0IHg9IjU4MCIgeT0iMTE4IiBmaWxsPSIjZjhmYWZjIiBmb250LWZhbWlseT0iSmV0QnJhaW5zIE1vbm8sbW9ub3NwYWNlIiBmb250LXNpemU9IjEyIj5lbWl0KCkgLyBxdWVyeSgpPC90ZXh0PgogIDx0ZXh0IHg9IjU4MCIgeT0iMTQyIiBmaWxsPSIjZjhmYWZjIiBmb250LWZhbWlseT0iSmV0QnJhaW5zIE1vbm8sbW9ub3NwYWNlIiBmb250LXNpemU9IjEyIj5yZWFkVW5pZmllZEV2ZW50cygpPC90ZXh0PgogIDx0ZXh0IHg9IjU4MCIgeT0iMTc0IiBmaWxsPSIjY2JkNWUxIiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjEyIj5vcHMgKyBhY3Rpdml0eSArIHJ1biByb3dzPC90ZXh0PgogIDx0ZXh0IHg9IjU4MCIgeT0iMTk4IiBmaWxsPSIjY2JkNWUxIiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjEyIj5zYW1lIHNjaGVtYSwgb25lIGZpbHRlciBsYXllcjwvdGV4dD4KICA8dGV4dCB4PSI1ODAiIHk9IjIyMiIgZmlsbD0iI2NiZDVlMSIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxMiI+c3RhdHMgwrcgcm90YXRlIMK3IGZvbGxvdyDCtyB2ZXJpZnk/PC90ZXh0PgoKICA8cGF0aCBkPSJNODAwIDE1Mkg4NjAiIHN0cm9rZT0iI2EzZTYzNSIgc3Ryb2tlLXdpZHRoPSIzIiBmaWxsPSJub25lIiBtYXJrZXItZW5kPSJ1cmwoI2FycikiLz4KCiAgPHJlY3QgeD0iODYwIiB5PSI2MCIgd2lkdGg9IjE5MCIgaGVpZ2h0PSI0OCIgcng9IjgiIGZpbGw9IiMxNDUzMmQiIHN0cm9rZT0iI2EzZTYzNSIgc3Ryb2tlLXdpZHRoPSIyIi8+CiAgPHRleHQgeD0iODc4IiB5PSI5MCIgZmlsbD0iI2VjZmNjYiIgZm9udC1mYW1pbHk9IkpldEJyYWlucyBNb25vLG1vbm9zcGFjZSIgZm9udC1zaXplPSIxMiI+ZXZlbnRzIChwcmltYXJ5KTwvdGV4dD4KCiAgPHJlY3QgeD0iODYwIiB5PSIxMjgiIHdpZHRoPSIxOTAiIGhlaWdodD0iNDgiIHJ4PSI4IiBmaWxsPSIjMWUyOTNiIiBzdHJva2U9IiM2NDc0OGIiLz4KICA8dGV4dCB4PSI4NzgiIHk9IjE1MCIgZmlsbD0iI2UyZThmMCIgZm9udC1mYW1pbHk9IkpldEJyYWlucyBNb25vLG1vbm9zcGFjZSIgZm9udC1zaXplPSIxMiI+YXVkaXQ8L3RleHQ+CiAgPHRleHQgeD0iODc4IiB5PSIxNjgiIGZpbGw9IiM5NGEzYjgiIGZvbnQtZmFtaWx5PSJJbnRlcixzeXN0ZW0tdWkiIGZvbnQtc2l6ZT0iMTEiPuKJoSAtLWluY2x1ZGUgcnVuczwvdGV4dD4KCiAgPHJlY3QgeD0iODYwIiB5PSIxOTYiIHdpZHRoPSIxOTAiIGhlaWdodD0iNDgiIHJ4PSI4IiBmaWxsPSIjMWUyOTNiIiBzdHJva2U9IiM2NDc0OGIiLz4KICA8dGV4dCB4PSI4NzgiIHk9IjIxOCIgZmlsbD0iI2UyZThmMCIgZm9udC1mYW1pbHk9IkpldEJyYWlucyBNb25vLG1vbm9zcGFjZSIgZm9udC1zaXplPSIxMiI+bG9nczwvdGV4dD4KICA8dGV4dCB4PSI4NzgiIHk9IjIzNiIgZmlsbD0iIzk0YTNiOCIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxMSI+4omhIGV2ZW50cyAocGFzc3Rocm91Z2gpPC90ZXh0PgoKICA8dGV4dCB4PSI1NjAiIHk9IjMwMCIgZmlsbD0iI2EzZTYzNSIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxMyIgZm9udC13ZWlnaHQ9IjcwMCI+RmFtaWxpZXM8L3RleHQ+CiAgPHRleHQgeD0iNTYwIiB5PSIzMjgiIGZpbGw9IiNjYmQ1ZTEiIGZvbnQtZmFtaWx5PSJKZXRCcmFpbnMgTW9ubyxtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTIiPm9wcyDCtyBhY3Rpdml0eSDCtyBjb21tYW5kcyDCtyBydW5zIMK3IHNlY3VyaXR5PC90ZXh0PgogIDx0ZXh0IHg9IjU2MCIgeT0iMzU0IiBmaWxsPSIjOTRhM2I4IiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjEyIj4tLWluY2x1ZGUgLyAtLWV4Y2x1ZGUgKG11dGV4LCBsaWtlIHNlc3Npb25zIHJvbGVzKTwvdGV4dD4KICA8dGV4dCB4PSI1NjAiIHk9IjM4MCIgZmlsbD0iIzk0YTNiOCIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxMiI+cnVuLmRpc3BhdGNoZWQgLyBhZ2VudC5ydW4uZW5kIGFic29yYiBvbGQgYXVkaXQgbGlzdCByb3dzPC90ZXh0Pgo8L3N2Zz4KPGZpZ2NhcHRpb24+T25lIHdyaXRlL3JlYWQgZW5naW5lLiBDTEkgbm91bnMgYXJlIGVudHJ5IHBvaW50cywgbm90IHByb2R1Y3RzLiBDb250ZW50IHZpZXdpbmcgc3RheXMgb24gc2Vzc2lvbnMvaG9zdHMuPC9maWdjYXB0aW9uPgo8L2ZpZ3VyZT4KCjxkaXYgY2xhc3M9ImFydGlmYWN0LWNhbGxvdXQiPjxzdHJvbmc+Q29yZSBydWxlOjwvc3Ryb25nPiBpZiBpdCBpcyBhIHRpbWVzdGFtcGVkIGZsZWV0IGZhY3QsIGl0IGlzIGFuIDxjb2RlPkV2ZW50UmVjb3JkPC9jb2RlPiBhbmQgZ29lcyB0aHJvdWdoIHRoZSBldmVudHMgZW5naW5lLiBJZiBpdCBpcyBhIHNlc3Npb24gdHJhbnNjcmlwdCBvciBob3N0IHRhc2sgc3Rkb3V0LCBpdCBpcyBub3QgdGhpcyBwcm9kdWN0IOKAlCB1c2UgPGNvZGU+c2Vzc2lvbnM8L2NvZGU+IC8gPGNvZGU+aG9zdHMgbG9nczwvY29kZT4uPC9kaXY+CgojIyBQdXJwb3NlCgpUaHJlZSB0b3AtbGV2ZWwgY29tbWFuZHMgcHJpbnQgc2ltaWxhciByb3dzIGZyb20gZGlmZmVyZW50IHdyaXRlcnMuIE9wZXJhdG9ycyBhbmQgYWdlbnRzIGd1ZXNzIHdyb25nIChgZXZlbnRzIGxpc3RgIGZhaWxzOyBgbG9ncyBhdWRpdGAgdnMgYGF1ZGl0IGxpc3RgIGFyZSBkaWZmZXJlbnQgcHJvZHVjdHMgdGhhdCBzaGFyZSBhIG5hbWUpLiBIYWxmIHRoZSBzdXJmYWNlIGFscmVhZHkgc2hhcmVzIGFuIGVuZ2luZSAoYGxvZ3MgYXVkaXRgIOKGkiBgcnVuRXZlbnRzQ29tbWFuZGApLiBUaGUgb3V0bGllcnMgYXJlIHRoZSBoYXNoLWNoYWluIGZpbGUgYW5kIHRoZSBtaXNuYW1lZCBjb250ZW50IHZpZXdlciB1bmRlciBgbG9ncyBbaWRdYC4KClRoZSBmaXggaXMgb25lIHBpcGVsaW5lIOKAlCBub3QgYmV0dGVyIGhlbHAgdGV4dC4KCiMjIFB1YmxpYyBpbnRlcmZhY2UKCiMjIyBQcmltYXJ5OiBgYWdlbnRzIGV2ZW50c2AKCmBgYGJhc2gKIyBGdWxsIHN0cmVhbSAoZGVmYXVsdCkKYWdlbnRzIGV2ZW50cwphZ2VudHMgZXZlbnRzIC0tbGltaXQgMCAtLWpzb24KCiMgU2Vzc2lvbnMtc3R5bGUgZmFtaWxpZXMKYWdlbnRzIGV2ZW50cyAtLWV4Y2x1ZGUgY29tbWFuZHMgICAgICAgICAgICAgICMgZHJvcCBjb21tYW5kLnN0YXJ0L2VuZCBub2lzZQphZ2VudHMgZXZlbnRzIC0taW5jbHVkZSBhY3Rpdml0eSAgICAgICAgICAgICAgIyBtaWxlc3RvbmVzIG9ubHkKYWdlbnRzIGV2ZW50cyAtLWluY2x1ZGUgb3BzICAgICAgICAgICAgICAgICAgICMgb3BlcmF0aW9uYWwgb25seQphZ2VudHMgZXZlbnRzIC0taW5jbHVkZSBydW5zICAgICAgICAgICAgICAgICAgIyB3aGF0IGF1ZGl0IGxpc3QgdXNlZCB0byBzaG93CmFnZW50cyBldmVudHMgLS1pbmNsdWRlIHNlY3VyaXR5ICAgICAgICAgICAgICAjIGxldmVsPWF1ZGl0IC8gc2VjcmV0cyBzdWdhcgoKIyBFeGlzdGluZyBmaWVsZCBmaWx0ZXJzIChrZWVwKQphZ2VudHMgZXZlbnRzIC0tbW9kdWxlIHNlY3JldHMgLS1idW5kbGUgc2hhcmUKYWdlbnRzIGV2ZW50cyAtLWV2ZW50IHByLm9wZW5lZCAtLXNpbmNlIDdkCmFnZW50cyBldmVudHMgLS1zZXNzaW9uIDxpZD4KYWdlbnRzIGV2ZW50cyAtZgoKIyBIb3VzZWtlZXBpbmcgKG1vdmVkIG9mZiBsb2dzKQphZ2VudHMgZXZlbnRzIHN0YXRzIFstLXNpbmNlIDdkXSBbLS1qc29uXQphZ2VudHMgZXZlbnRzIHJvdGF0ZSBbLS1kYXlzIDddIFstLW1heC1tYiA1MF0KYWdlbnRzIGV2ZW50cyBlbWl0IC0tc291cmNlIGZhY3RvcnkgPCBiYXRjaC5qc29ubAojIG9wdGlvbmFsIGlmIGNoYWluIHJldGFpbmVkOgphZ2VudHMgZXZlbnRzIHZlcmlmeSBbLS1qc29uXQpgYGAKCiMjIyBGYW1pbGllcwoKfCBGYW1pbHkgfCBEZWZpbml0aW9uIHwKfCAtLS0gfCAtLS0gfAp8IGBvcHNgIHwgT3BlcmF0aW9uYWwgbG9nIHJvd3MgKG1vZHVsZSDiiaAgYWN0aXZpdHkpIHwKfCBgYWN0aXZpdHlgIHwgQWdlbnQgbWlsZXN0b25lcyAobW9kdWxlID0gYWN0aXZpdHkpIHwKfCBgY29tbWFuZHNgIHwgYGNvbW1hbmQuc3RhcnRgICsgYGNvbW1hbmQuZW5kYCBvbmx5IHwKfCBgcnVuc2AgfCBSdW4tZGlzcGF0Y2ggb3V0Y29tZXMgKGBhZ2VudC5ydW4uZW5kYCAvIGBydW4uZGlzcGF0Y2hlZGApIHwKfCBgc2VjdXJpdHlgIHwgbGV2ZWwgYGF1ZGl0YCBhbmQvb3Igc2VjcmV0cy4qIChzdWdhcikgfAoKYC0taW5jbHVkZWAgYW5kIGAtLWV4Y2x1ZGVgIGFyZSBtdXR1YWxseSBleGNsdXNpdmUsIHNhbWUgcnVsZSBhcyBgc2Vzc2lvbnNgLgoKIyMjIEFsaWFzZXMgKHplcm8gaW5kZXBlbmRlbnQgbG9naWMpCgp8IENvbW1hbmQgfCBFeHBhbmRzIHRvIHwKfCAtLS0gfCAtLS0gfAp8IGBhZ2VudHMgYXVkaXRgIHwgYGFnZW50cyBldmVudHMgLS1pbmNsdWRlIHJ1bnNgIHwKfCBgYWdlbnRzIGF1ZGl0IGxpc3RgIHwgc2FtZSB8CnwgYGFnZW50cyBhdWRpdCB2ZXJpZnlgIHwgYGFnZW50cyBldmVudHMgdmVyaWZ5YCAoaWYgSDEpIG9yIHJlbW92ZWQgKGlmIEgyKSB8CnwgYGFnZW50cyBsb2dzYCB8IGBhZ2VudHMgZXZlbnRzYCB8CnwgYGFnZW50cyBsb2dzIGF1ZGl0YCB8IGBhZ2VudHMgZXZlbnRzIC0taW5jbHVkZSBvcHNgIHwKfCBgYWdlbnRzIGxvZ3Mgc3RhdHNgIHwgYGFnZW50cyBldmVudHMgc3RhdHNgIHwKfCBgYWdlbnRzIGxvZ3Mgcm90YXRlYCB8IGBhZ2VudHMgZXZlbnRzIHJvdGF0ZWAgfAoKSW1wbGVtZW50YXRpb24gcGF0dGVybjogb25lIGBydW5FdmVudHNDb21tYW5kYDsgYWxpYXNlcyBvbmx5IHNldCBkZWZhdWx0IG9wdHMuCgojIyMgTGVhdmVzIHRoaXMgc3VyZmFjZQoKfCBPbGQgfCBOZXcgaG9tZSB8CnwgLS0tIHwgLS0tIHwKfCBgYWdlbnRzIGxvZ3MgPHNlc3Npb24taWQ+YCB0cmFuc2NyaXB0IHwgYGFnZW50cyBzZXNzaW9ucyA8aWQ+YCAvIGBzZXNzaW9ucyB0YWlsYCB8CnwgYGFnZW50cyBsb2dzIDx0YXNrLWlkPmAgaG9zdCBzdGRvdXQgfCBgYWdlbnRzIGhvc3RzIGxvZ3MgPGlkPmAgfAoKSWYgYGFnZW50cyBsb2dzIDxpZD5gIGlzIGtlcHQgZm9yIG11c2NsZSBtZW1vcnksIGl0ICoqcmVkaXJlY3RzKiogd2l0aCBhIGNsZWFyIG1lc3NhZ2Ug4oCUIGl0IGRvZXMgbm90IHJlaW1wbGVtZW50IGNvbnRlbnQgdmlld2luZy4KCiMjIFJ1bi1kaXNwYXRjaCByb3dzIChhYnNvcmIgYGF1ZGl0IGxpc3RgKQoKVG9kYXkgYGF1ZGl0IGxpc3RgIHNob3dzOiBpbmRleCwgdHMsIGFnZW50QHZlcnNpb24sIG1vZGUsIG9rL2ZhaWwsIGV4aXQsIHJlcG8uCgpBdCB0aGUgZXhlYyBjaG9rZXBvaW50IHRoYXQgY3VycmVudGx5IGNhbGxzIGByZWNvcmREaXNwYXRjaGVkUnVuYDoKCmBgYGRpZmYKLSBhcHBlbmRBdWRpdFJlY29yZCh7IHRzLCBhZ2VudCwgdmVyc2lvbiwgcmVwbywgbW9kZSwgb3V0Y29tZSwgZXhpdCB9KQorIGVtaXQoJ2FnZW50LnJ1bi5lbmQnLCB7IGFnZW50LCB2ZXJzaW9uLCByZXBvLCBtb2RlLCBvdXRjb21lLCBleGl0IH0pCiAgLy8gb3IgJ3J1bi5kaXNwYXRjaGVkJyBpZiBlbmQgaXMgdG9vIG92ZXJsb2FkZWQKYGBgCgpgLS1pbmNsdWRlIHJ1bnNgIChhbmQgdGh1cyBgYWdlbnRzIGF1ZGl0YCkgY2FuIHVzZSBhICoqcm93IGZvcm1hdCoqIHR1bmVkIGxpa2UgdGhlIG9sZCBhdWRpdCB0YWJsZS4gUHJlc2VudGF0aW9uIGlzIG5vdCBhIHNlY29uZCBlbmdpbmUuCgojIyMgSGFzaCBjaGFpbiAocGljayBhdCBpbXBsZW1lbnQgc3RhcnQpCgp8IE9wdGlvbiB8IEJlaGF2aW9yIHwKfCAtLS0gfCAtLS0gfAp8ICoqSDEqKiB8IGBwcmV2SGFzaGAvYGhhc2hgIG9uIHJ1biByb3dzIG9ubHk7IGBldmVudHMgdmVyaWZ5YCB3YWxrcyB0aGVtIGluIHRoZSBzYW1lIHN0cmVhbSB8CnwgKipIMioqIHwgRHJvcCBjaGFpbiBwcm9kdWN0OyBqdXN0IGVtaXQgb3V0Y29tZXM7IGRlbGV0ZSB2ZXJpZnkgfAoKUmVjb21tZW5kYXRpb246IEgxIG9ubHkgaWYgc29tZXRoaW5nIHN0aWxsIGdhdGVzIG9uIGBhdWRpdCB2ZXJpZnlgIGluIENJOyBlbHNlIEgyLiBFaXRoZXIgd2F5ICoqbm8gc2VwYXJhdGUgYGF1ZGl0L2xvZy5qc29ubGAgcHJvZHVjdC4qKgoKCiMjIFByb3Bvc2VkIENoYW5nZXMKCnwgQ2hhbmdlIHwgV2hhdCBoYXBwZW5zIHwKfCAtLS0gfCAtLS0gfAp8IE9uZSBFdmVudFJlY29yZCBlbmdpbmUgfCBBbGwgdGltZWxpbmUgd3JpdGVzIGdvIHRocm91Z2ggYGVtaXQoKWA7IGFsbCByZWFkcyB0aHJvdWdoIGBxdWVyeWAgLyBgcmVhZFVuaWZpZWRFdmVudHNgICsgZmFtaWx5IGZpbHRlcnMgfAp8IGAtLWluY2x1ZGVgIC8gYC0tZXhjbHVkZWAgfCBTZXNzaW9ucy1zdHlsZSBmYW1pbHkgZmlsdGVyczogb3BzLCBhY3Rpdml0eSwgY29tbWFuZHMsIHJ1bnMsIHNlY3VyaXR5IHwKfCBgYWdlbnRzIGF1ZGl0YCB8IFRoaW4gYWxpYXMgb2YgYGFnZW50cyBldmVudHMgLS1pbmNsdWRlIHJ1bnNgIOKAlCBubyBzZWNvbmQgc3RvcmUgfAp8IGBhZ2VudHMgbG9nc2AgfCBUaGluIGFsaWFzIG9mIGBhZ2VudHMgZXZlbnRzYDsgc3RhdHMvcm90YXRlIHJlLWRpc3BhdGNoOyBgbG9ncyBbaWRdYCByZWRpcmVjdHMgdG8gc2Vzc2lvbnMvaG9zdHMgfAp8IFJ1bi1kaXNwYXRjaCByb3dzIHwgYHJlY29yZERpc3BhdGNoZWRSdW5gIGJlY29tZXMgYGVtaXQoJ2FnZW50LnJ1bi5lbmQn4oCmKWAgKG9yIGBydW4uZGlzcGF0Y2hlZGApIHwKfCBSZXRpcmUgYGF1ZGl0L2xvZy5qc29ubGAgfCBTdG9wIHdyaXRpbmcgdGhlIGhhc2gtY2hhaW4gZmlsZSBmb3IgbmV3IHJ1bnM7IG9wdGlvbmFsIEgxIHZlcmlmeSBvbiBydW4gcm93cyBvciBIMiBkcm9wIHwKCiMjIyBEaWZmIHNrZXRjaCDigJQgYWxpYXMgbm90IHBlZXIgcHJvZHVjdAoKYGBgZGlmZgovLyBjb21tYW5kcy9hdWRpdC50cwotIHJlYWRBdWRpdExvZygpICsgY3VzdG9tIHJlbmRlclJvdyBmb3IgQXVkaXRSZWNvcmQKKyBydW5FdmVudHNDb21tYW5kKHsgLi4ub3B0cywgaW5jbHVkZTogJ3J1bnMnIH0pCmBgYAoKIyMjIERpZmYgc2tldGNoIOKAlCBydW4gZW5kIHdyaXRlcyBldmVudHMKCmBgYGRpZmYKLy8gZXhlYyBkaXNwYXRjaCBlbmQKLSBhcHBlbmRBdWRpdFJlY29yZCh7IHRzLCBhZ2VudCwgdmVyc2lvbiwgcmVwbywgbW9kZSwgb3V0Y29tZSwgZXhpdCB9KQorIGVtaXQoJ2FnZW50LnJ1bi5lbmQnLCB7IGFnZW50LCB2ZXJzaW9uLCByZXBvLCBtb2RlLCBvdXRjb21lLCBleGl0IH0pCmBgYAoKIyMgSW1wbGVtZW50YXRpb24gcGxhbgoKIyMjIFBoYXNlIDEg4oCUIGZhbWlsaWVzIG9uIHRoZSBleGlzdGluZyBlbmdpbmUKCi0gQWRkIGAtLWluY2x1ZGVgIC8gYC0tZXhjbHVkZWAgZmFtaWx5IHBhcnNlciBpbiB0aGUgZXZlbnRzIG9wdGlvbiBzdXJmYWNlIChtdXRleCkuCi0gTWFwIGZhbWlsaWVzIOKGkiBgaW5jbHVkZUFjdGl2aXR5YCArIGV2ZW50VHlwZXMgLyBsZXZlbCBpbnNpZGUgYHJlYWRVbmlmaWVkRXZlbnRzYCAobm8gc2Vjb25kIHNjYW4pLgotIEhlbHAgbGVhZHMgd2l0aCBgLS1leGNsdWRlIGNvbW1hbmRzYC4KLSBUZXN0czogZmFtaWx5IGZpbHRlcnMsIG11dGV4LCBpbnRlcmFjdGlvbiB3aXRoIGAtLW1vZHVsZWAgLyBgLS1ldmVudGAuCgojIyMgUGhhc2UgMiDigJQgY29sbGFwc2UgQ0xJcyBvbnRvIG9uZSBoYW5kbGVyCgotIGByZWdpc3RlckF1ZGl0Q29tbWFuZHNgIOKGkiB0aGluIGFsaWFzIChkZWZhdWx0IGAtLWluY2x1ZGUgcnVuc2ApLgotIGByZWdpc3RlckxvZ3NDb21tYW5kYCDihpIgdGhpbiBhbGlhcyBvZiBldmVudHM7IHN0YXRzL3JvdGF0ZSByZS1kaXNwYXRjaC4KLSBSZW1vdmUgaW5kZXBlbmRlbnQgYHJlYWRBdWRpdExvZ2AgbGlzdCByZW5kZXJlciBmcm9tIHRoZSBhdWRpdCBjb21tYW5kIHRyZWUuCi0gYGxvZ3MgW2lkXWAg4oaSIHJlZGlyZWN0IHRvIHNlc3Npb25zL2hvc3RzLgotIERlcHJlY2F0aW9uIG9uZS1saW5lcnMgZm9yIG9uZSB0cmFpbiBpZiBuZWVkZWQuCgojIyMgUGhhc2UgMyDigJQgYWJzb3JiIHJ1bi1kaXNwYXRjaCBpbnRvIGVtaXQKCi0gQXQgcnVuIGVuZDogYGVtaXQoLi4uKWAgd2l0aCBmaWVsZHMgYXVkaXQgbGlzdCBuZWVkZWQuCi0gU3RvcCBhcHBlbmRpbmcgdG8gYGF1ZGl0L2xvZy5qc29ubGAgZm9yIG5ldyBydW5zLgotIE9wdGlvbmFsIG1pZ3JhdGlvbiBvZiBoaXN0b3JpY2FsIGNoYWluIHJvd3MgaW50byBldmVudHMgSlNPTkwuCi0gR3V0IG9yIGRlbGV0ZSBgbGliL2F1ZGl0L2xvZy50c2Agb25jZSBubyB3cml0ZXJzIHJlbWFpbi4KLSBIMSBvciBIMiBmb3IgdmVyaWZ5LgoKIyMjIFBoYXNlIDQg4oCUIGRvY3MgKyBmbGVldCBndWlkYW5jZQoKLSBSZXdyaXRlIGBhcHBzL2NsaS9kb2NzL29ic2VydmFiaWxpdHkubWRgIHRhYmxlLgotIENIQU5HRUxPRyB1bmRlciBuZXh0IHZlcnNpb24uCi0gQ29tcGFuaW9uIGAuYWdlbnRzLXN5c3RlbWAgc2tpbGxzL3J1bGVzIHRoYXQgdGVhY2ggb2xkIG5hbWVzIOKAlCBsaW5rZWQgUFIgaWYgY29uc3VtZXJzIGV4aXN0LgoKIyMgS2V5IGZpbGVzCgp8IEFyZWEgfCBQYXRoIHwKfCAtLS0gfCAtLS0gfAp8IFR5cGVzICsgZW1pdCArIHF1ZXJ5ICsgc3RhdHMgKyByb3RhdGUgfCBgYXBwcy9jbGkvc3JjL2xpYi9ldmVudHMudHNgIHwKfCBVbmlmaWVkIHJlYWRlciB8IGBhcHBzL2NsaS9zcmMvbGliL2V2ZW50LXN0cmVhbS50c2AgfAp8IEV2ZW50cyBDTEkgKyBzaGFyZWQgaGFuZGxlciB8IGBhcHBzL2NsaS9zcmMvY29tbWFuZHMvZXZlbnRzLnRzYCB8CnwgQXVkaXQgQ0xJIOKGkiBhbGlhcyB8IGBhcHBzL2NsaS9zcmMvY29tbWFuZHMvYXVkaXQudHNgIHwKfCBMb2dzIENMSSDihpIgYWxpYXMgfCBgYXBwcy9jbGkvc3JjL2NvbW1hbmRzL2xvZ3MudHNgIHwKfCBIYXNoIGNoYWluIChyZXRpcmUpIHwgYGFwcHMvY2xpL3NyYy9saWIvYXVkaXQvbG9nLnRzYCB8CnwgUnVuIGVuZCB3cml0ZSBzaXRlIHwgZXhlYyBkaXNwYXRjaCAvIGByZWNvcmREaXNwYXRjaGVkUnVuYCBjYWxsIHNpdGVzIHwKfCBEb2NzIHwgYGFwcHMvY2xpL2RvY3Mvb2JzZXJ2YWJpbGl0eS5tZGAgfAoKIyMgVmFsaWRhdGlvbgoKYGBgYmFzaAojIHNhbWUgZW5naW5lIGFuc3dlcnMgYWxsIHRocmVlIG5vdW5zCmFnZW50cyBldmVudHMgLS1pbmNsdWRlIHJ1bnMgLS1saW1pdCA1IC0tanNvbgphZ2VudHMgYXVkaXQgLS1saW1pdCA1IC0tanNvbiAgICAgICAgICAjIGlkZW50aWNhbCByZWNvcmRzCmFnZW50cyBsb2dzIC0taW5jbHVkZSBydW5zIC0tbGltaXQgNSAtLWpzb24KCmFnZW50cyBldmVudHMgLS1leGNsdWRlIGNvbW1hbmRzIC0tbGltaXQgMTAKYWdlbnRzIGV2ZW50cyBzdGF0cyAtLWpzb24KYWdlbnRzIGV2ZW50cyByb3RhdGUgLS1kYXlzIDcgLS1tYXgtbWIgNTAKCiMgY29udGVudCBpcyBub3QgZXZlbnRzCmFnZW50cyBzZXNzaW9ucyA8aWQ+IC0tbWFya2Rvd24KYWdlbnRzIGhvc3RzIGxvZ3MgPHRhc2staWQ+CmBgYAoKIyMgUmlza3MKCnwgUmlzayB8IE1pdGlnYXRpb24gfAp8IC0tLSB8IC0tLSB8CnwgU2NyaXB0cyBjYWxsIGBhdWRpdCBsaXN0YCAvIGBsb2dzIGF1ZGl0YCB8IFdyYXBwZXJzIGtlZXAgZmxhZ3MvSlNPTiB3b3JraW5nIHwKfCBIYXNoLWNoYWluIGNvbnN1bWVycyB8IEgxIGtlZXBzIHZlcmlmeSBvbiBzYW1lIHN0cmVhbTsgb3IgZG9jdW1lbnQgZHJvcCB8CnwgYGxvZ3MgPGlkPmAgbXVzY2xlIG1lbW9yeSB8IEV4cGxpY2l0IHJlZGlyZWN0IHRvIHNlc3Npb25zL2hvc3RzIHwKfCBBY3Rpdml0eSBzdGlsbCBzaGFyZGVkIG9uIGRpc2sgfCBTYW1lIHNjaGVtYSArIG9uZSByZWFkZXI7IHdyaXRlIHNwbGl0IGlzIGludGVybmFsIHwKfCBCYXJlIGV2ZW50cyBzdGlsbCBub2lzeSB8IFRlYWNoIGAtLWV4Y2x1ZGUgY29tbWFuZHNgIChsb2NrZWQgZGVjaXNpb24pIHwKCiMjIFBsYW4gY2hlY2tsaXN0CgotIFsgXSBDb25maXJtIEgxIHZzIEgyIGZvciBoYXNoIGNoYWluIGF0IGltcGxlbWVudCBzdGFydAotIFsgXSBQaGFzZSAxOiBgLS1pbmNsdWRlYCAvIGAtLWV4Y2x1ZGVgIG9uIGV2ZW50cyBlbmdpbmUKLSBbIF0gUGhhc2UgMjogYXVkaXQgKyBsb2dzIGFzIGFsaWFzZXM7IG1vdmUgc3RhdHMvcm90YXRlOyByZWRpcmVjdCBsb2dzIFtpZF0KLSBbIF0gUGhhc2UgMzogZW1pdCBydW4gb3V0Y29tZXMgaW50byBldmVudHM7IHJldGlyZSBgYXVkaXQvbG9nLmpzb25sYCB3cml0ZXIKLSBbIF0gUGhhc2UgNDogZG9jcywgQ0hBTkdFTE9HLCBjb21wYW5pb24gZ3VpZGFuY2UKLSBbIF0gUHJvdmU6IHRocmVlIENMSSBub3VucyDihpIgb25lIHF1ZXJ5IHBhdGg7IG5ldyBydW5zIG5ldmVyIG9wZW4gdGhlIG9sZCBhdWRpdCBmaWxlCg=="}</script>
+<script>
+(() => {
+  const root = document.documentElement;
+  const button = document.querySelector('.theme-toggle');
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  const configured = "system";
+  const stored = () => { try { const value = localStorage.getItem('artifacts-theme'); return value === 'light' || value === 'dark' ? value : null; } catch { return null; } };
+  const preferred = () => stored() || (configured === 'system' ? (media.matches ? 'dark' : 'light') : configured);
+  const apply = (theme, persist) => {
+    root.dataset.theme = theme;
+    root.style.colorScheme = theme;
+    const next = theme === 'dark' ? 'light' : 'dark';
+    button.setAttribute('aria-label', 'Switch to ' + next + ' theme');
+    button.setAttribute('title', 'Switch to ' + next + ' theme');
+    button.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+    if (persist) { try { localStorage.setItem('artifacts-theme', theme); } catch {} }
+  };
+  apply(preferred(), false);
+  button.addEventListener('click', () => apply(root.dataset.theme === 'dark' ? 'light' : 'dark', true));
+  media.addEventListener('change', () => { if (configured === 'system' && !stored()) apply(media.matches ? 'dark' : 'light', false); });
+})();
+</script>
+</body>
+</html>

--- a/.agents/artifacts/2026-08-10/plan-events-one-engine.md
+++ b/.agents/artifacts/2026-08-10/plan-events-one-engine.md
@@ -1,0 +1,365 @@
+---
+kind: plan
+template: plan.v1
+surface: cli
+title: One event engine — events is truth; audit and logs are aliases
+summary: >
+  Collapse agents events, agents logs, and agents audit onto a single EventRecord
+  store and a single read/write engine. audit and logs become thin wrappers with
+  fixed filters. Sessions-style --include/--exclude filters the one stream.
+  Bare events stays full; teach --exclude commands for noise.
+status: awaiting-go
+tracking: "events/logs/audit consolidation"
+project: agents-cli
+repository: phnx-labs/agents-cli
+branch: main
+host: yosemite-s0
+date: '2026-08-10'
+facts:
+  - "Decision: one source of truth, one engine"
+  - "Decision: audit and logs are aliases only — no separate implementations"
+  - "Decision: bare events stays full stream; teach --exclude commands"
+  - "Today: logs audit already calls runEventsCommand; audit list is a separate store"
+  - "Today: agent.run.end already exists as EventType; hash-chain audit is a parallel product"
+---
+
+# One event engine: `events` is truth; `audit` and `logs` are aliases
+
+## Focus for review
+
+1. **Single store + single engine** — ops, activity, and former run-dispatch audit rows all become `EventRecord`s through one `emit` / `query` / `readUnifiedEvents` path.
+2. **`audit` and `logs` are wrappers only** — fixed flag presets over `agents events`, zero independent logic.
+3. **Hash chain** — fold onto run events in the same engine (`events verify`) **or** drop verify as a product. No second file under `.history/audit/`.
+4. **`logs [id]` content path** — transcripts/host stdout leave this product; they stay on `sessions` / `hosts logs`.
+5. **Default noise** — bare `events` stays full; `--exclude commands` is the taught path.
+
+## Intent
+
+You looked at `agents audit list` and `agents events` and saw three similar commands with three implementations. Your direction:
+
+- One source of truth for logs, events, and audit.
+- One engine for read and write.
+- `audit` is a bare-bones alias/wrapper over `events`.
+- Same for `logs`.
+- Track broadly by default; filter with sessions-style `--include` / `--exclude`.
+
+This plan follows that. Earlier drafts that kept three stores are rejected.
+
+## Current vs proposed (what you type)
+
+<section class="artifact-grid artifact-grid-2">
+<article class="artifact-panel" data-state="current" data-evidence="capture">
+<figcaption><strong>Current:</strong> three nouns, two stores, wall of command noise, wrong verb fails.</figcaption>
+
+```text
+$ agents events
+2026-08-10 … command.end  sessions
+2026-08-10 … command.end  sessions
+… (×40) …
+
+$ agents audit list
+3055  2026-08-08 … plan fail exit=1  /
+
+$ agents logs audit
+# ops-only events — same reader as events --audit
+# but lives under a different parent command
+
+$ agents events list
+error: too many arguments for 'events'
+```
+</article>
+
+<article class="artifact-panel" data-state="proposed" data-evidence="mockup">
+<figcaption><strong>Proposed:</strong> one engine; three nouns are the same command with defaults; filters kill noise.</figcaption>
+
+```text
+$ agents events --exclude commands --limit 5
+2026-08-10 … secrets.get   bundle=share
+2026-08-10 … pr.opened     https://github.com/…
+
+$ agents audit
+# ≡ agents events --include runs
+3055  2026-08-08 … agent.run.end  plan fail exit=1
+
+$ agents logs
+# ≡ agents events
+
+$ agents events stats
+$ agents events rotate --days 7
+$ agents sessions a1b2c3d4   # transcript content (not events)
+```
+</article>
+</section>
+
+## Architecture: before → after
+
+<figure class="artifact-figure artifact-figure-diagram artifact-figure-wide">
+<svg class="artifact-diagram" viewBox="0 0 1080 420" role="img" aria-labelledby="ev-title ev-desc" xmlns="http://www.w3.org/2000/svg">
+  <title id="ev-title">Before three stores; after one EventRecord engine</title>
+  <desc id="ev-desc">Left side shows three write paths and three CLIs. Right side shows one emit/query engine with events primary and audit/logs as aliases.</desc>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#a3e635"/></marker>
+  </defs>
+
+  <text x="40" y="32" fill="#f87171" font-family="Inter,system-ui" font-size="14" font-weight="700">BEFORE — three products</text>
+
+  <rect x="30" y="52" width="200" height="70" rx="10" fill="#111827" stroke="#f87171" stroke-width="2"/>
+  <text x="48" y="82" fill="#f8fafc" font-family="JetBrains Mono,monospace" font-size="13">events/*.jsonl</text>
+  <text x="48" y="104" fill="#94a3b8" font-family="Inter,system-ui" font-size="11">ops emit()</text>
+
+  <rect x="30" y="138" width="200" height="70" rx="10" fill="#111827" stroke="#f87171" stroke-width="2"/>
+  <text x="48" y="168" fill="#f8fafc" font-family="JetBrains Mono,monospace" font-size="13">activity/*.jsonl</text>
+  <text x="48" y="190" fill="#94a3b8" font-family="Inter,system-ui" font-size="11">milestones</text>
+
+  <rect x="30" y="224" width="200" height="70" rx="10" fill="#111827" stroke="#f87171" stroke-width="2"/>
+  <text x="48" y="254" fill="#f8fafc" font-family="JetBrains Mono,monospace" font-size="13">audit/log.jsonl</text>
+  <text x="48" y="276" fill="#94a3b8" font-family="Inter,system-ui" font-size="11">hash chain (separate)</text>
+
+  <path d="M230 87H300" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arr)"/>
+  <path d="M230 173H300" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arr)"/>
+  <path d="M230 259H300" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arr)"/>
+
+  <rect x="300" y="52" width="170" height="50" rx="8" fill="#1e293b" stroke="#475569"/>
+  <text x="318" y="82" fill="#e2e8f0" font-family="JetBrains Mono,monospace" font-size="12">agents events</text>
+  <rect x="300" y="148" width="170" height="50" rx="8" fill="#1e293b" stroke="#475569"/>
+  <text x="318" y="178" fill="#e2e8f0" font-family="JetBrains Mono,monospace" font-size="12">agents logs …</text>
+  <rect x="300" y="244" width="170" height="50" rx="8" fill="#1e293b" stroke="#475569"/>
+  <text x="318" y="274" fill="#e2e8f0" font-family="JetBrains Mono,monospace" font-size="12">agents audit</text>
+
+  <text x="30" y="340" fill="#94a3b8" font-family="Inter,system-ui" font-size="12">logs audit already aliases events — the outlier is audit/log.jsonl + logs[id] content</text>
+  <text x="30" y="362" fill="#94a3b8" font-family="Inter,system-ui" font-size="12">Transcripts stay on sessions / hosts logs (not this product)</text>
+
+  <text x="560" y="32" fill="#a3e635" font-family="Inter,system-ui" font-size="14" font-weight="700">AFTER — one engine</text>
+
+  <rect x="560" y="52" width="240" height="200" rx="12" fill="#111827" stroke="#a3e635" stroke-width="2"/>
+  <text x="580" y="88" fill="#a3e635" font-family="Inter,system-ui" font-size="13" font-weight="700">EventRecord engine</text>
+  <text x="580" y="118" fill="#f8fafc" font-family="JetBrains Mono,monospace" font-size="12">emit() / query()</text>
+  <text x="580" y="142" fill="#f8fafc" font-family="JetBrains Mono,monospace" font-size="12">readUnifiedEvents()</text>
+  <text x="580" y="174" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">ops + activity + run rows</text>
+  <text x="580" y="198" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">same schema, one filter layer</text>
+  <text x="580" y="222" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">stats · rotate · follow · verify?</text>
+
+  <path d="M800 152H860" stroke="#a3e635" stroke-width="3" fill="none" marker-end="url(#arr)"/>
+
+  <rect x="860" y="60" width="190" height="48" rx="8" fill="#14532d" stroke="#a3e635" stroke-width="2"/>
+  <text x="878" y="90" fill="#ecfccb" font-family="JetBrains Mono,monospace" font-size="12">events (primary)</text>
+
+  <rect x="860" y="128" width="190" height="48" rx="8" fill="#1e293b" stroke="#64748b"/>
+  <text x="878" y="150" fill="#e2e8f0" font-family="JetBrains Mono,monospace" font-size="12">audit</text>
+  <text x="878" y="168" fill="#94a3b8" font-family="Inter,system-ui" font-size="11">≡ --include runs</text>
+
+  <rect x="860" y="196" width="190" height="48" rx="8" fill="#1e293b" stroke="#64748b"/>
+  <text x="878" y="218" fill="#e2e8f0" font-family="JetBrains Mono,monospace" font-size="12">logs</text>
+  <text x="878" y="236" fill="#94a3b8" font-family="Inter,system-ui" font-size="11">≡ events (passthrough)</text>
+
+  <text x="560" y="300" fill="#a3e635" font-family="Inter,system-ui" font-size="13" font-weight="700">Families</text>
+  <text x="560" y="328" fill="#cbd5e1" font-family="JetBrains Mono,monospace" font-size="12">ops · activity · commands · runs · security</text>
+  <text x="560" y="354" fill="#94a3b8" font-family="Inter,system-ui" font-size="12">--include / --exclude (mutex, like sessions roles)</text>
+  <text x="560" y="380" fill="#94a3b8" font-family="Inter,system-ui" font-size="12">run.dispatched / agent.run.end absorb old audit list rows</text>
+</svg>
+<figcaption>One write/read engine. CLI nouns are entry points, not products. Content viewing stays on sessions/hosts.</figcaption>
+</figure>
+
+<div class="artifact-callout"><strong>Core rule:</strong> if it is a timestamped fleet fact, it is an <code>EventRecord</code> and goes through the events engine. If it is a session transcript or host task stdout, it is not this product — use <code>sessions</code> / <code>hosts logs</code>.</div>
+
+## Purpose
+
+Three top-level commands print similar rows from different writers. Operators and agents guess wrong (`events list` fails; `logs audit` vs `audit list` are different products that share a name). Half the surface already shares an engine (`logs audit` → `runEventsCommand`). The outliers are the hash-chain file and the misnamed content viewer under `logs [id]`.
+
+The fix is one pipeline — not better help text.
+
+## Public interface
+
+### Primary: `agents events`
+
+```bash
+# Full stream (default)
+agents events
+agents events --limit 0 --json
+
+# Sessions-style families
+agents events --exclude commands              # drop command.start/end noise
+agents events --include activity              # milestones only
+agents events --include ops                   # operational only
+agents events --include runs                  # what audit list used to show
+agents events --include security              # level=audit / secrets sugar
+
+# Existing field filters (keep)
+agents events --module secrets --bundle share
+agents events --event pr.opened --since 7d
+agents events --session <id>
+agents events -f
+
+# Housekeeping (moved off logs)
+agents events stats [--since 7d] [--json]
+agents events rotate [--days 7] [--max-mb 50]
+agents events emit --source factory < batch.jsonl
+# optional if chain retained:
+agents events verify [--json]
+```
+
+### Families
+
+| Family | Definition |
+| --- | --- |
+| `ops` | Operational log rows (module ≠ activity) |
+| `activity` | Agent milestones (module = activity) |
+| `commands` | `command.start` + `command.end` only |
+| `runs` | Run-dispatch outcomes (`agent.run.end` / `run.dispatched`) |
+| `security` | level `audit` and/or secrets.* (sugar) |
+
+`--include` and `--exclude` are mutually exclusive, same rule as `sessions`.
+
+### Aliases (zero independent logic)
+
+| Command | Expands to |
+| --- | --- |
+| `agents audit` | `agents events --include runs` |
+| `agents audit list` | same |
+| `agents audit verify` | `agents events verify` (if H1) or removed (if H2) |
+| `agents logs` | `agents events` |
+| `agents logs audit` | `agents events --include ops` |
+| `agents logs stats` | `agents events stats` |
+| `agents logs rotate` | `agents events rotate` |
+
+Implementation pattern: one `runEventsCommand`; aliases only set default opts.
+
+### Leaves this surface
+
+| Old | New home |
+| --- | --- |
+| `agents logs <session-id>` transcript | `agents sessions <id>` / `sessions tail` |
+| `agents logs <task-id>` host stdout | `agents hosts logs <id>` |
+
+If `agents logs <id>` is kept for muscle memory, it **redirects** with a clear message — it does not reimplement content viewing.
+
+## Run-dispatch rows (absorb `audit list`)
+
+Today `audit list` shows: index, ts, agent@version, mode, ok/fail, exit, repo.
+
+At the exec chokepoint that currently calls `recordDispatchedRun`:
+
+```diff
+- appendAuditRecord({ ts, agent, version, repo, mode, outcome, exit })
++ emit('agent.run.end', { agent, version, repo, mode, outcome, exit })
+  // or 'run.dispatched' if end is too overloaded
+```
+
+`--include runs` (and thus `agents audit`) can use a **row format** tuned like the old audit table. Presentation is not a second engine.
+
+### Hash chain (pick at implement start)
+
+| Option | Behavior |
+| --- | --- |
+| **H1** | `prevHash`/`hash` on run rows only; `events verify` walks them in the same stream |
+| **H2** | Drop chain product; just emit outcomes; delete verify |
+
+Recommendation: H1 only if something still gates on `audit verify` in CI; else H2. Either way **no separate `audit/log.jsonl` product.**
+
+
+## Proposed Changes
+
+| Change | What happens |
+| --- | --- |
+| One EventRecord engine | All timeline writes go through `emit()`; all reads through `query` / `readUnifiedEvents` + family filters |
+| `--include` / `--exclude` | Sessions-style family filters: ops, activity, commands, runs, security |
+| `agents audit` | Thin alias of `agents events --include runs` — no second store |
+| `agents logs` | Thin alias of `agents events`; stats/rotate re-dispatch; `logs [id]` redirects to sessions/hosts |
+| Run-dispatch rows | `recordDispatchedRun` becomes `emit('agent.run.end'…)` (or `run.dispatched`) |
+| Retire `audit/log.jsonl` | Stop writing the hash-chain file for new runs; optional H1 verify on run rows or H2 drop |
+
+### Diff sketch — alias not peer product
+
+```diff
+// commands/audit.ts
+- readAuditLog() + custom renderRow for AuditRecord
++ runEventsCommand({ ...opts, include: 'runs' })
+```
+
+### Diff sketch — run end writes events
+
+```diff
+// exec dispatch end
+- appendAuditRecord({ ts, agent, version, repo, mode, outcome, exit })
++ emit('agent.run.end', { agent, version, repo, mode, outcome, exit })
+```
+
+## Implementation plan
+
+### Phase 1 — families on the existing engine
+
+- Add `--include` / `--exclude` family parser in the events option surface (mutex).
+- Map families → `includeActivity` + eventTypes / level inside `readUnifiedEvents` (no second scan).
+- Help leads with `--exclude commands`.
+- Tests: family filters, mutex, interaction with `--module` / `--event`.
+
+### Phase 2 — collapse CLIs onto one handler
+
+- `registerAuditCommands` → thin alias (default `--include runs`).
+- `registerLogsCommand` → thin alias of events; stats/rotate re-dispatch.
+- Remove independent `readAuditLog` list renderer from the audit command tree.
+- `logs [id]` → redirect to sessions/hosts.
+- Deprecation one-liners for one train if needed.
+
+### Phase 3 — absorb run-dispatch into emit
+
+- At run end: `emit(...)` with fields audit list needed.
+- Stop appending to `audit/log.jsonl` for new runs.
+- Optional migration of historical chain rows into events JSONL.
+- Gut or delete `lib/audit/log.ts` once no writers remain.
+- H1 or H2 for verify.
+
+### Phase 4 — docs + fleet guidance
+
+- Rewrite `apps/cli/docs/observability.md` table.
+- CHANGELOG under next version.
+- Companion `.agents-system` skills/rules that teach old names — linked PR if consumers exist.
+
+## Key files
+
+| Area | Path |
+| --- | --- |
+| Types + emit + query + stats + rotate | `apps/cli/src/lib/events.ts` |
+| Unified reader | `apps/cli/src/lib/event-stream.ts` |
+| Events CLI + shared handler | `apps/cli/src/commands/events.ts` |
+| Audit CLI → alias | `apps/cli/src/commands/audit.ts` |
+| Logs CLI → alias | `apps/cli/src/commands/logs.ts` |
+| Hash chain (retire) | `apps/cli/src/lib/audit/log.ts` |
+| Run end write site | exec dispatch / `recordDispatchedRun` call sites |
+| Docs | `apps/cli/docs/observability.md` |
+
+## Validation
+
+```bash
+# same engine answers all three nouns
+agents events --include runs --limit 5 --json
+agents audit --limit 5 --json          # identical records
+agents logs --include runs --limit 5 --json
+
+agents events --exclude commands --limit 10
+agents events stats --json
+agents events rotate --days 7 --max-mb 50
+
+# content is not events
+agents sessions <id> --markdown
+agents hosts logs <task-id>
+```
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Scripts call `audit list` / `logs audit` | Wrappers keep flags/JSON working |
+| Hash-chain consumers | H1 keeps verify on same stream; or document drop |
+| `logs <id>` muscle memory | Explicit redirect to sessions/hosts |
+| Activity still sharded on disk | Same schema + one reader; write split is internal |
+| Bare events still noisy | Teach `--exclude commands` (locked decision) |
+
+## Plan checklist
+
+- [ ] Confirm H1 vs H2 for hash chain at implement start
+- [ ] Phase 1: `--include` / `--exclude` on events engine
+- [ ] Phase 2: audit + logs as aliases; move stats/rotate; redirect logs [id]
+- [ ] Phase 3: emit run outcomes into events; retire `audit/log.jsonl` writer
+- [ ] Phase 4: docs, CHANGELOG, companion guidance
+- [ ] Prove: three CLI nouns → one query path; new runs never open the old audit file

--- a/.agents/artifacts/2026-08-10/plan-project-dirs.html
+++ b/.agents/artifacts/2026-08-10/plan-project-dirs.html
@@ -310,7 +310,7 @@ agents teams create my-feature --project agents-cli     # NEW flag on teams
 </tr>
 <tr>
 <td><code>--host yosemite-s0</code></td>
-<td>Forwarded paths are <code>~/…</code>, not <code>/Users/muqsit/…</code></td>
+<td>Forwarded paths are <code>~/…</code>, not <code>/Users/you/…</code></td>
 </tr>
 <tr>
 <td><code>agents teams create … --project agents-cli</code></td>

--- a/.agents/artifacts/2026-08-10/plan-project-dirs.md
+++ b/.agents/artifacts/2026-08-10/plan-project-dirs.md
@@ -293,7 +293,7 @@ Steps 1 through 3 are the spine. Steps 4 and 5 are independent consumers of step
 | `agents projects view agents-cli` | Three `repo` lines, each with its own path |
 | `agents run claude --project agents-cli` | cwd is `agents-cli`; two `--add-dir` flags for the siblings |
 | Grant is real | Inside the spawned agent, read a file under `~/.agents/.system` and edit one under `agents-cli-web` |
-| `--host yosemite-s0` | Forwarded paths are `~/…`, not `/Users/muqsit/…` |
+| `--host yosemite-s0` | Forwarded paths are `~/…`, not `/Users/you/…` |
 | `agents teams create … --project agents-cli` | Teammate lands in the primary dir with sibling grants |
 | Extension Cmd-Shift-A | Terminal shows `agents run <agent> --interactive --project agents-cli` |
 | Fleet | `projects view` matches on one Linux worker and one Mac; a box missing `agents-cli-web` skips it without error |

--- a/.agents/artifacts/2026-08-10/plan-unified-accounts.html
+++ b/.agents/artifacts/2026-08-10/plan-unified-accounts.html
@@ -1,0 +1,397 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Unify native logins and provider credentials as named accounts</title>
+<style>
+:root{--font-body:Inter,Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;--font-display:Inter,Inter,system-ui,sans-serif;--font-mono:"JetBrains Mono","JetBrains Mono","SFMono-Regular",Consolas,monospace;}
+@page{margin:24px}
+:root{color-scheme:light;--bg:#faf9f6;--surface:#ffffff;--surface-alt:#f2f4f0;--line:#e2e6df;--text:#1a1c1a;--muted:#5c655c;--accent:#4d7c0f;--accent-alt:#0e7490;--warn:#b45309;--danger:#dc2626;--content-width:980px;--page-padding:24px;--mobile-page-padding:16px;--hero-top:40px;--hero-bottom:28px;--section-spacing:36px;--figure-spacing:22px;--panel-padding:16px;--footer-spacing:64px;--print-margin:24px;--code:#0c0f0d;--code-text:#e7ece8;--radius:10px}
+@media(prefers-color-scheme:dark){:root:not([data-theme]){color-scheme:dark;--bg:#0a0a0a;--surface:#111312;--surface-alt:#161a18;--line:#26302a;--text:#e7ece8;--muted:#8b938c;--accent:#a3e635;--accent-alt:#5ad6c0;--warn:#f5c451;--danger:#ff6b6b;}}
+:root[data-theme="light"]{color-scheme:light;--bg:#faf9f6;--surface:#ffffff;--surface-alt:#f2f4f0;--line:#e2e6df;--text:#1a1c1a;--muted:#5c655c;--accent:#4d7c0f;--accent-alt:#0e7490;--warn:#b45309;--danger:#dc2626;}
+:root[data-theme="dark"]{color-scheme:dark;--bg:#0a0a0a;--surface:#111312;--surface-alt:#161a18;--line:#26302a;--text:#e7ece8;--muted:#8b938c;--accent:#a3e635;--accent-alt:#5ad6c0;--warn:#f5c451;--danger:#ff6b6b;}
+@media print{:root,:root[data-theme="light"],:root[data-theme="dark"]{color-scheme:light;--bg:#faf9f6;--surface:#ffffff;--surface-alt:#f2f4f0;--line:#e2e6df;--text:#1a1c1a;--muted:#5c655c;--accent:#4d7c0f;--accent-alt:#0e7490;--warn:#b45309;--danger:#dc2626;}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-body);line-height:1.6;-webkit-font-smoothing:antialiased;transition:background-color .15s ease,color .15s ease}main{width:100%;max-width:var(--content-width);min-width:0;margin:0 auto;padding:24px var(--page-padding) 80px}.document-header{display:flex;align-items:center;justify-content:flex-end;min-height:42px;border-bottom:1px solid var(--line);color:var(--muted);font-family:var(--font-mono);font-size:12px}.header-label{min-width:0;margin-right:auto;padding-right:12px;overflow-wrap:anywhere;color:var(--text);font-weight:650}.theme-toggle{display:inline-flex;flex:0 0 auto;align-items:center;gap:6px;height:30px;padding:0 12px;border:1px solid var(--line);border-radius:999px;background:var(--surface);color:var(--muted);font:500 12px/1 var(--font-mono);cursor:pointer}.theme-toggle:hover{color:var(--accent);border-color:var(--accent)}.theme-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px}.hero{padding:var(--hero-top) 0 var(--hero-bottom);border-bottom:1px solid var(--line)}.kicker{display:flex;flex-wrap:wrap;align-items:center;gap:8px 10px;font-family:var(--font-mono);font-size:12px;text-transform:uppercase;letter-spacing:.14em;color:var(--accent);font-weight:500}.kicker-part{color:var(--accent)}.kicker-separator{color:var(--muted);padding:0 2px}.status-badge{display:inline-flex;align-items:center;height:22px;padding:0 9px;border-radius:999px;border:1px solid color-mix(in srgb,var(--warn) 40%,var(--line));background:color-mix(in srgb,var(--warn) 14%,transparent);color:var(--warn);font-family:var(--font-mono);font-size:10.5px;font-weight:650;letter-spacing:.1em;text-transform:uppercase;line-height:1}.status-badge.status-implementing,.status-badge.status-in-progress,.status-badge.status-review,.status-badge.status-done,.status-badge.status-complete{border-color:color-mix(in srgb,var(--accent) 40%,var(--line));background:color-mix(in srgb,var(--accent) 12%,transparent);color:var(--accent)}.hero h1{font-family:var(--font-display);font-size:clamp(30px,4vw,44px);line-height:1.1;margin:12px 0 14px;letter-spacing:-.01em}.summary{max-width:760px;color:var(--muted);font-size:17px;margin:0}.meta{display:grid;gap:14px;margin-top:20px}.facts-line{margin:0;color:var(--muted);font-family:var(--font-mono);font-size:12.5px;line-height:1.7}.meta-block{display:grid;gap:8px}.meta-label{font-family:var(--font-mono);font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);font-weight:500}.meta-row{display:flex;flex-wrap:wrap;gap:8px;list-style:none;margin:0;padding:0}.chip{display:inline-flex;align-items:center;gap:4px;max-width:100%;border:1px solid var(--line);background:var(--surface);border-radius:999px;padding:4px 11px;color:var(--muted);font-family:var(--font-mono);font-size:11.5px;line-height:1.5}.chip-value{color:var(--text);overflow-wrap:anywhere}.chip-icon{display:inline-block;width:12px;height:12px;margin-right:5px;vertical-align:-1.5px;fill:currentColor;flex:0 0 auto}.chip-favicon{display:inline-block;width:12px;height:12px;margin-right:5px;vertical-align:-1.5px;border-radius:2px;object-fit:contain;flex:0 0 auto}.chip-value a{color:inherit;text-decoration:none}.chip-value a:hover{text-decoration:underline}.provenance-line{margin:0;color:var(--muted);font-family:var(--font-mono);font-size:12.5px;line-height:1.7}.provenance-line a{color:var(--accent-alt);text-decoration:none}.provenance-line a:hover{text-decoration:underline}.provenance-part{color:var(--muted)}.meta-sep{margin:0 7px;opacity:.45}.toc{display:grid;gap:5px;margin:24px 0 8px;font-family:var(--font-mono);font-size:13px}.code-diff{margin:var(--figure-spacing) 0;border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;background:var(--code)}.code-diff-pre{margin:0;padding:10px 0;background:none;border:none;border-radius:0;overflow-x:auto;font-family:var(--font-mono);font-size:12.5px;line-height:1.55;color:var(--code-text)}.cd-line{display:block;white-space:pre;padding:0 14px}.cd-sign{display:inline-block;width:1.4ch;color:var(--muted);user-select:none}.cd-add{background:color-mix(in srgb,var(--accent) 15%,transparent)}.cd-add .cd-sign{color:var(--accent)}.cd-del{background:color-mix(in srgb,var(--danger) 15%,transparent)}.cd-del .cd-sign{color:var(--danger)}.cd-hunk,.cd-meta{color:var(--muted);opacity:.8}.checklist{margin:var(--figure-spacing) 0;border:1px solid var(--line);border-radius:var(--radius);background:var(--surface);padding:var(--panel-padding)}.checklist-head{font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:.1em;color:var(--muted);margin-bottom:10px}.checklist-items{list-style:none;margin:0;padding:0;display:grid;gap:7px}.cl-item{display:flex;align-items:baseline;gap:9px}.cl-box{flex:0 0 auto;font-family:var(--font-mono);font-size:.95em}.cl-done .cl-box{color:var(--accent)}.cl-todo .cl-box{color:var(--muted)}.cl-done .cl-text{color:var(--muted);text-decoration:line-through;text-decoration-color:var(--line)}.toc a{color:var(--muted);text-decoration:none}.toc a:hover{color:var(--accent)}.toc a:focus-visible{outline:2px solid var(--accent);outline-offset:2px}.toc-index{color:var(--accent);font-family:var(--font-mono);font-size:.9em}.artifact-body{min-width:0;padding-top:18px;counter-reset:section}h2{font-size:24px;margin:var(--section-spacing) 0 12px;line-height:1.2;letter-spacing:-.01em}.artifact-body>h2{counter-increment:section}.artifact-body>h2::before{content:counter(section,decimal-leading-zero);font-family:var(--font-mono);font-size:.62em;color:var(--accent);margin-right:10px;opacity:.85}h3{font-size:17px;margin:calc(var(--section-spacing) * .78) 0 10px}a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}p,li,dd,figcaption{overflow-wrap:anywhere}pre{background:var(--code);color:var(--code-text);padding:var(--panel-padding);border-radius:12px;overflow:auto;border:1px solid var(--line)}code{font-family:var(--font-mono);font-size:.88em;background:var(--surface-alt);border:1px solid var(--line);border-radius:5px;padding:1.5px 6px;color:var(--accent-alt)}pre code{background:none;border:none;padding:0;color:inherit}table{width:100%;border-collapse:collapse;margin:18px 0}th,td{border-bottom:1px solid var(--line);padding:10px;text-align:left;vertical-align:top}th{font-family:var(--font-mono);font-size:11.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);font-weight:500}blockquote{border-left:3px solid var(--accent);padding-left:var(--panel-padding);color:var(--muted);margin-left:0}img{display:block;max-width:100%;height:auto}svg{max-width:100%;height:auto}.artifact-body>p>img{margin:var(--figure-spacing) auto}.artifact-grid{display:grid;gap:var(--panel-padding);margin:var(--figure-spacing) 0}.artifact-grid-2{grid-template-columns:repeat(2,minmax(0,1fr))}.artifact-grid-3{grid-template-columns:repeat(3,minmax(0,1fr))}.artifact-panel,.artifact-stat{min-width:0;border:1px solid var(--line);border-radius:var(--radius);background:var(--surface);padding:var(--panel-padding)}.artifact-panel h3{margin:10px 0 8px;font-size:16px}.artifact-stat-value,.artifact-stat-label{display:block}.artifact-stat-value{color:var(--text);font-family:var(--font-display);font-size:24px;line-height:1.15}.artifact-stat-label{margin-top:6px;color:var(--muted);font-size:13px}.artifact-tag{display:inline-block;--tag-color:var(--muted);background:color-mix(in srgb,var(--tag-color) 12%,transparent);border:1px solid color-mix(in srgb,var(--tag-color) 30%,transparent);border-radius:6px;padding:2px 8px;color:var(--tag-color);font-family:var(--font-mono);font-size:11px;font-weight:600;text-transform:uppercase}.artifact-tag-accent{--tag-color:var(--accent)}.artifact-callout{margin:var(--figure-spacing) 0;border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:0 var(--radius) var(--radius) 0;background:var(--surface-alt);padding:var(--panel-padding)}.artifact-callout-warn{border-left-color:var(--warn)}.artifact-callout-danger{border-left-color:var(--danger)}.artifact-callout strong{color:var(--text)}.artifact-figure{margin:var(--figure-spacing) 0;border:1px solid var(--line);border-radius:var(--radius);background:var(--surface);padding:var(--panel-padding);overflow-x:auto}.artifact-figure>img,.artifact-image{width:auto;max-width:100%;height:auto;margin:0 auto}.artifact-figure-diagram{background:#0e120f;border-color:#26302a}.artifact-diagram{display:block;width:100%;height:auto;margin:0 auto}.artifact-figure-tall{width:100%;max-width:394px;margin-left:auto;margin-right:auto}.artifact-figure figcaption{margin-top:12px;color:var(--muted);font-family:var(--font-mono);font-size:12px;text-align:center}.artifact-figure.artifact-figure-diagram figcaption{color:#8b938c}.artifact-legend{display:flex;flex-wrap:wrap;gap:8px 16px;margin:12px 0;color:var(--muted);font-family:var(--font-mono);font-size:11.5px}.document-footer{margin-top:var(--footer-spacing);padding-top:18px;border-top:1px solid var(--line);color:var(--muted);font-family:var(--font-mono);font-size:12px}
+@media(max-width:720px){main{padding:32px var(--mobile-page-padding) 64px}.artifact-grid-2,.artifact-grid-3{grid-template-columns:1fr}.artifact-figure{padding:min(12px,var(--panel-padding))}.artifact-figure-wide .artifact-diagram{min-width:640px}table{display:block;max-width:100%;overflow-x:auto}th,td{min-width:140px;overflow-wrap:anywhere}pre{white-space:pre-wrap;overflow-wrap:anywhere}}
+@media print{body{transition:none;-webkit-print-color-adjust:exact;print-color-adjust:exact}.toc,.theme-toggle{display:none}.document-header-empty{display:none}main{max-width:none;padding:0}:root[data-pdf-layout="poster"] main{max-width:var(--content-width);margin:0 auto;padding:var(--print-margin)}.chip{background:var(--surface)}.chip-value{color:var(--text)}.provenance-line,.provenance-line a,.facts-line{color:var(--text)}.status-badge{color:var(--text);border-color:var(--line)}h2,h3{break-after:avoid-page}.artifact-figure,.artifact-grid,.artifact-panel,.artifact-stat,.artifact-callout,pre,table,blockquote,.meta{break-inside:avoid}.artifact-figure-wide .artifact-diagram{min-width:0}.artifact-figure-tall{max-width:330px}pre{white-space:pre-wrap;overflow-wrap:anywhere}a{color:var(--text);text-decoration:underline}}
+</style>
+</head>
+<body>
+<main>
+<header class="document-header document-header-empty"><button class="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false" title="Toggle color theme"><span aria-hidden="true">&#9680;</span> theme</button></header>
+<section class="hero">
+<div class="kicker"><span class="kicker-part">agents-cli</span><span class="kicker-separator" aria-hidden="true">&middot;</span><span class="kicker-part">plan</span><span class="status-badge status-awaiting-go">awaiting-go</span></div>
+<h1>Unify native logins and provider credentials as named accounts</h1>
+<p class="summary">Give native OAuth identities and portable provider credentials one account catalog, then bind named accounts to native installations and custom harnesses with positional commands. Native OAuth remains owned by each harness and never enters the agents-cli keychain; portable secrets move only through an explicit, verified sync operation.</p>
+<div class="meta" aria-label="Artifact metadata"><p class="facts-line">Provider accounts already use canonical secrets bundles with stable UUIDs and policy never.<span class="meta-sep" aria-hidden="true">·</span>Native identities are currently discovered read-only and labels are not rendered in agents view.<span class="meta-sep" aria-hidden="true">·</span>Direct run, routines, custom harnesses, native installations, and fleet sync do not yet share one account resolver.</p><p class="provenance-line" aria-label="Provenance"><span class="provenance-part"><a href="https://github.com/phnx-labs/agents-cli" target="_blank" rel="noopener">phnx-labs/agents-cli</a></span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">main</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">Account unification follow-up</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">Codex</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">Muqsit</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">yosemite-s0</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">019fdef4</span><span class="meta-sep" aria-hidden="true">·</span><span class="provenance-part">2026-08-10</span></p></div>
+</section>
+<nav class="toc" aria-label="Artifact sections"><a href="#focus-for-review"><span class="toc-index">01&nbsp;&middot;&nbsp;</span>Focus for review</a><a href="#intent"><span class="toc-index">02&nbsp;&middot;&nbsp;</span>Intent</a><a href="#current-architecture"><span class="toc-index">03&nbsp;&middot;&nbsp;</span>Current architecture</a><a href="#purpose"><span class="toc-index">04&nbsp;&middot;&nbsp;</span>Purpose</a><a href="#public-interface"><span class="toc-index">05&nbsp;&middot;&nbsp;</span>Public Interface</a><a href="#proposed-changes"><span class="toc-index">06&nbsp;&middot;&nbsp;</span>Proposed Changes</a><a href="#plan"><span class="toc-index">07&nbsp;&middot;&nbsp;</span>Plan</a><a href="#validation"><span class="toc-index">08&nbsp;&middot;&nbsp;</span>Validation</a><a href="#risks"><span class="toc-index">09&nbsp;&middot;&nbsp;</span>Risks</a><a href="#tracking"><span class="toc-index">10&nbsp;&middot;&nbsp;</span>Tracking</a><a href="#delta-spec"><span class="toc-index">11&nbsp;&middot;&nbsp;</span>Delta Spec</a></nav><article class="artifact-body"><h1>Unify native logins and provider credentials as named accounts</h1>
+<h2 id="focus-for-review">Focus for review</h2>
+<ul>
+<li>Is the positional grammar natural: <code>name &lt;source&gt; &lt;name&gt;</code> and <code>attach &lt;account&gt; &lt;target&gt;</code>?</li>
+<li>Should a native OAuth alias be attachable only where that same harness-owned login already exists? This plan says yes.</li>
+<li>Should portable provider credentials be copied only by an explicit <code>accounts sync</code> command? This plan says yes.</li>
+</ul>
+<h2 id="intent">Intent</h2>
+<p>Manage a Claude, Codex, Cursor, or other native login separately from the installed CLI version, give it a memorable name such as <code>work</code>, and connect it to one or more installations. Use the same model for OpenRouter, DeepInfra, and other API-key or long-lived-token providers without making native OAuth credentials pass through agents-cli storage.</p>
+<div class="artifact-callout"><strong>Core rule:</strong> an account is a named identity. A native account stores only identity metadata and a binding to a harness-owned login. A provider account stores a portable credential in the existing secrets backend. Attaching never copies a native OAuth token.</div><h2 id="current-architecture">Current architecture</h2>
+<section class="artifact-grid artifact-grid-2">
+<article class="artifact-panel">
+<figcaption><strong>Current:</strong> the name command reports success, but <code>agents view</code> still shows only the email and version.</figcaption>
+
+```text
+$ agents accounts name work --from claude@2.1.220
+Named the claude account 'work'.
+
+$ agents view claude
+2.1.220  default  user@example.com
+```
+</article>
+
+<article class="artifact-panel">
+<figcaption><strong>Proposed:</strong> the source and target are positional, and the name is visible everywhere the identity appears.</figcaption>
+
+```text
+$ agents accounts name claude@2.1.220 work
+Named claude@2.1.220 as work.
+
+$ agents accounts attach work claude@2.1.225
+Attached work to claude@2.1.225.
+
+$ agents view claude
+2.1.225  opus[1m]  work · user@example.com  Max
+2.1.220  default   work · user@example.com  Max
+```
+</article>
+</section><figure class="artifact-figure artifact-figure-diagram artifact-figure-wide">
+<svg class="artifact-diagram" viewBox="0 0 1040 350" role="img" xmlns="http://www.w3.org/2000/svg">
+  <title id="account-title">Unified account catalog and binding flow</title>
+  <desc id="account-desc">Native aliases point to harness-owned OAuth state while provider accounts point to portable secret bundles. Both resolve through bindings to installations and custom harnesses.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#a3e635"></path></marker>
+  </defs>
+  <text x="30" y="28" fill="#a3e635" font-family="Inter,system-ui" font-size="14" font-weight="700">ACCOUNT CATALOG</text>
+  <rect x="30" y="48" width="260" height="105" rx="12" fill="#111827" stroke="#a3e635" stroke-width="2"></rect><text x="50" y="79" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">native · work</text><text x="50" y="104" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">identity fingerprint + label</text><text x="50" y="128" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">secret stays in Claude/Codex/Cursor</text>
+  <rect x="30" y="190" width="260" height="105" rx="12" fill="#111827" stroke="#a3e635" stroke-width="2"></rect><text x="50" y="221" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">provider · openrouter-work</text><text x="50" y="246" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">provider + auth type + stable UUID</text><text x="50" y="270" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">secret bundle, policy never</text>
+  <path d="M290 100H405" stroke="#a3e635" stroke-width="3" fill="none" marker-end="url(#arrow)"></path><path d="M290 242H405" stroke="#a3e635" stroke-width="3" fill="none" marker-end="url(#arrow)"></path>
+  <text x="420" y="28" fill="#a3e635" font-family="Inter,system-ui" font-size="14" font-weight="700">BINDINGS</text>
+  <rect x="405" y="48" width="260" height="247" rx="12" fill="#111827" stroke="#475569" stroke-width="2"></rect><text x="430" y="84" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">work → claude@2.1.220</text><text x="430" y="121" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">work → claude@2.1.225</text><text x="430" y="176" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">openrouter-work → codex@0.145.0</text><text x="430" y="213" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">openrouter-work → cursor@latest</text><text x="430" y="268" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">openrouter-work → deepseek</text>
+  <path d="M665 170H780" stroke="#a3e635" stroke-width="3" fill="none" marker-end="url(#arrow)"></path>
+  <text x="795" y="28" fill="#a3e635" font-family="Inter,system-ui" font-size="14" font-weight="700">EXECUTION</text>
+  <rect x="780" y="48" width="230" height="247" rx="12" fill="#111827" stroke="#475569" stroke-width="2"></rect><text x="805" y="92" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">native installation</text><text x="805" y="120" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">validate existing login</text><text x="805" y="166" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">custom harness</text><text x="805" y="194" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">inject provider credential</text><text x="805" y="240" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">remote fleet run</text><text x="805" y="268" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">resolve account on target</text>
+</svg>
+<figcaption>One catalog and one resolver, with different custody rules for native and portable credentials.</figcaption>
+</figure><h2 id="purpose">Purpose</h2>
+<p>The existing account work has two disconnected concepts. Provider credentials are durable account bundles, while native OAuth identities are read-only discovery rows. The old label path records a label outside the rendered catalog, so <code>agents view</code> cannot show it. Account selection also differs between direct runs, routines, custom harnesses, and remote dispatch.</p>
+<p>The change standardizes the user model without pretending every harness supports the same authentication mechanics.</p>
+<h2 id="public-interface">Public Interface</h2>
+<h3>Command grammar</h3>
+<table>
+<thead>
+<tr>
+<th>Intent</th>
+<th>Command</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Name a discovered native login</td>
+<td><code>agents accounts name claude@2.1.220 work</code></td>
+<td>Create or update native account <code>work</code> from the login found in that installation</td>
+</tr>
+<tr>
+<td>Add a portable provider credential</td>
+<td><code>agents accounts add openrouter-work --provider openrouter --auth api-key</code></td>
+<td>Create provider account and securely prompt for its key</td>
+</tr>
+<tr>
+<td>Attach an account</td>
+<td><code>agents accounts attach work claude@2.1.225</code></td>
+<td>Bind the named account to an exact native installation</td>
+</tr>
+<tr>
+<td>Attach to a custom harness</td>
+<td><code>agents accounts attach openrouter-work deepseek</code></td>
+<td>Bind the provider account to the named custom harness</td>
+</tr>
+<tr>
+<td>Detach</td>
+<td><code>agents accounts detach work claude@2.1.225</code></td>
+<td>Remove exactly that binding</td>
+</tr>
+<tr>
+<td>Inspect</td>
+<td><code>agents accounts view work</code></td>
+<td>Show identity metadata, credential custody, bindings, and availability</td>
+</tr>
+<tr>
+<td>Rename</td>
+<td><code>agents accounts rename work rush-work</code></td>
+<td>Rename the account while retaining its stable ID and bindings</td>
+</tr>
+<tr>
+<td>Remove</td>
+<td><code>agents accounts remove rush-work</code></td>
+<td>Refuse while bindings/defaults still reference it; explain how to detach</td>
+</tr>
+<tr>
+<td>Copy portable credentials</td>
+<td><code>agents accounts sync openrouter-work zion</code></td>
+<td>Explicitly provision the same stable provider account on another device</td>
+</tr>
+</tbody></table>
+<p><code>--from</code> and <code>--to</code> are removed from the proposed API. Flags remain for optional attributes and behavior, such as <code>--provider</code>, <code>--auth</code>, <code>--json</code>, <code>--force</code>, and <code>--default</code>.</p>
+<h3>Complete happy paths</h3>
+<p>Native OAuth account:</p>
+<pre><code>agents accounts name claude@2.1.220 work
+agents accounts attach work claude@2.1.225
+agents accounts view work
+agents run claude@2.1.225
+</code></pre>
+<p>Portable provider account:</p>
+<pre><code>agents accounts add openrouter-work --provider openrouter --auth api-key
+agents accounts attach openrouter-work codex@0.145.0
+agents accounts attach openrouter-work cursor@latest
+agents accounts attach openrouter-work deepseek
+agents accounts sync openrouter-work zion
+</code></pre>
+<h3>Output contract</h3>
+<pre><code>$ agents accounts view work
+work
+  kind        native login
+  identity    user@example.com
+  provider    Anthropic
+  custody     Claude Code (not stored by agents-cli)
+  scope       version
+  available   yes
+  attached    claude@2.1.220, claude@2.1.225
+</code></pre>
+<pre><code>$ agents accounts view openrouter-work
+openrouter-work
+  kind        provider credential
+  provider    OpenRouter
+  auth        API key
+  custody     agents secrets (no biometric ACL)
+  available   this device, zion
+  attached    codex@0.145.0, cursor@latest, deepseek
+</code></pre>
+<p>Every human-readable account row uses <code>name · identity</code> when both exist. Every command that emits account data supports <code>--json</code> and returns the stable account ID, kind, display name, identity metadata, custody, availability, and bindings.</p>
+<h2 id="proposed-changes">Proposed Changes</h2>
+<h3>1. One typed catalog, two credential custody models</h3>
+<p>Extend the existing account registry rather than add a second store:</p>
+<pre><code>type Account =
+  | {
+      id: string;
+      name: string;
+      kind: "native";
+      agent: AgentId;
+      identityKey: string;
+      identityLabel?: string;
+      authScope: "version" | "device";
+    }
+  | {
+      id: string;
+      name: string;
+      kind: "provider";
+      provider: AccountProviderId;
+      authType: "api-key" | "token";
+      bundle: string;
+    };
+
+type AccountBinding = {
+  accountId: string;
+  target: string;
+};
+</code></pre>
+<p>Native records contain no OAuth access token, refresh token, auth file, or keychain reference. Provider records continue to use the canonical secrets bundle with stable UUID and <code>policy: never</code>.</p>
+<h3>2. One target parser and resolver</h3>
+<p>Parse the second positional argument into either an exact native installation (<code>claude@2.1.225</code>, <code>codex@0.145.0</code>, <code>cursor@latest</code>) or a custom harness (<code>deepseek</code>). Resolve accounts in this order:</p>
+<ol>
+<li>explicit run account;</li>
+<li>exact target binding;</li>
+<li>bare-agent default;</li>
+<li>current native or balanced selection.</li>
+</ol>
+<p>The same resolver is used by direct runs, routines, teams, local dispatch, and remote fleet dispatch. Cloud/lease runs fail clearly for device-local native accounts. They do not export native OAuth automatically.</p>
+<h3>3. Capability registry keeps harness claims truthful</h3>
+<table>
+<thead>
+<tr>
+<th>Capability</th>
+<th>Harnesses / handling</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Version-scoped native identity</td>
+<td>Claude, Codex, Grok; Muse when identity inspection is strong</td>
+</tr>
+<tr>
+<td>Device-scoped native identity</td>
+<td>Cursor after correcting false XDG isolation; Antigravity, Kimi, Droid, OpenCode where their auth is device-global</td>
+</tr>
+<tr>
+<td>Requires inspector work before attach</td>
+<td>Copilot</td>
+</tr>
+<tr>
+<td>Discovery only / legacy</td>
+<td>Gemini</td>
+</tr>
+<tr>
+<td>Unsupported until modeled</td>
+<td>Pi, OpenClaw, Amp, Kiro, Goose, Hermes, Warp</td>
+</tr>
+<tr>
+<td>Portable provider credential</td>
+<td>Registry-driven adapters only; unsupported provider/harness pairs fail loud</td>
+</tr>
+</tbody></table>
+<p>For a native account, <code>attach</code> validates that the target already exposes the same identity fingerprint. It never logs in, copies, or rewrites OAuth state. A device-scoped harness rejects an exact-version attachment and explains that the account applies to the device.</p>
+<h3>4. Labels render everywhere</h3>
+<p>Use one account renderer in <code>accounts</code>, <code>agents view</code>, <code>harness view</code>, run banners, pickers, routines, and fleet inventory. Recover archived fingerprint labels transactionally where the identity still matches. Do not auto-merge opaque identities.</p>
+<h3>5. Explicit and verifiable portable sync</h3>
+<p><code>accounts sync &lt;account&gt; &lt;device&gt;</code> applies only to provider accounts. The destination import is one atomic transaction with rollback and read-back verification. Transport requirements:</p>
+<ul>
+<li>pinned managed SSH host key; reject unknown or changed keys;</li>
+<li>no SSH multiplex reuse for the credential transfer;</li>
+<li>secret bytes only on stdin, never argv, environment, logs, or config;</li>
+<li>no persistent plaintext or reusable secret fingerprint;</li>
+<li>same name with a different stable account ID fails unless explicitly forced;</li>
+<li>macOS uses a silent, non-biometric Keychain item; Linux uses the encrypted file backend; Windows uses Credential Manager.</li>
+</ul>
+<p>Sync provisions the same logical account ID on another device. Attaching one account to several harnesses does not clone it into several logical accounts.</p>
+<h3>6. No Touch ID noise in normal operation</h3>
+<p>Normal <code>accounts</code>, <code>view</code>, routing, attachment validation, and usage inspection read only native metadata or provider bundle metadata. They never read native OAuth secrets. Provider accounts use non-biometric secret policy, so headless execution does not trigger Touch ID. A secret read occurs only when launching a harness that requires the selected portable credential or during explicit sync.</p>
+<h2 id="plan">Plan</h2>
+<div class="checklist"><div class="checklist-head">0 / 9 done</div><ul class="checklist-items"><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Add native account metadata and binding schema; migrate matching archived labels.</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Replace relationship flags with positional <code>name</code>, <code>attach</code>, <code>detach</code>, <code>view</code>, and <code>sync</code> grammars plus workflow-first help.</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Add the capability registry and identity validation for every supported native harness.</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Route custom harnesses, native installations, direct runs, routines, teams, and SSH dispatch through one account resolver.</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Render names, custody, availability, and bindings consistently in text and JSON.</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Remove ordinary cloud/lease native OAuth export and enforce device-local errors.</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Harden provider sync with pinned hosts, atomic import, rollback, and equality verification.</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Update CLI docs, specifications, README, CHANGELOG, and audit companion <code>.agents-system</code> consumers.</span></li><li class="cl-item cl-todo"><span class="cl-box">○</span><span class="cl-text">Run focused account tests, full remote tests, and installed-CLI E2E on macOS, Linux, and Windows credential backends.</span></li></ul></div>
+<h2 id="validation">Validation</h2>
+<table>
+<thead>
+<tr>
+<th>Scenario</th>
+<th>Required result</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Name Claude login</td>
+<td><code>accounts view work</code> and <code>agents view claude</code> show <code>work · email</code></td>
+</tr>
+<tr>
+<td>Attach native alias to matching login</td>
+<td>Binding succeeds without reading or copying OAuth secrets</td>
+</tr>
+<tr>
+<td>Attach native alias to different identity</td>
+<td>Nonzero error names both identities; no state changes</td>
+</tr>
+<tr>
+<td>Attach provider to Codex/Cursor/custom harness</td>
+<td>Each installed target resolves the same stable provider account</td>
+</tr>
+<tr>
+<td>Normal view/routing</td>
+<td>No biometric prompt and no native secret access</td>
+</tr>
+<tr>
+<td>Remote run</td>
+<td>Destination resolves the account locally; no implicit secret transfer</td>
+</tr>
+<tr>
+<td>Explicit provider sync</td>
+<td>Atomic destination import verifies and reports availability on both devices</td>
+</tr>
+<tr>
+<td>Native sync attempt</td>
+<td>Refused with <code>native login credentials remain owned by &lt;harness&gt;</code></td>
+</tr>
+<tr>
+<td>Unsupported harness</td>
+<td>Clear nonzero capability error, never a silent no-op</td>
+</tr>
+</tbody></table>
+<pre><code>cd apps/cli
+./scripts/build.sh --skip-tests
+bun run test:remote
+agents accounts name claude@2.1.220 work
+agents accounts attach work claude@2.1.225
+agents accounts view work --json
+agents view claude
+</code></pre>
+<h2 id="risks">Risks</h2>
+<table>
+<thead>
+<tr>
+<th>Risk</th>
+<th>Handling</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>A label points at the wrong human identity</td>
+<td>Bind by stable fingerprint; never email text alone; opaque identities do not auto-merge</td>
+</tr>
+<tr>
+<td>Cursor isolation is overstated</td>
+<td>Mark Cursor device-scoped until its runtime behavior is corrected and verified</td>
+</tr>
+<tr>
+<td>Removing <code>--from</code> / <code>--to</code> breaks unreleased examples</td>
+<td>Change code, help, docs, and companion guidance together; do not add a compatibility shim unless a shipped version requires it</td>
+</tr>
+<tr>
+<td>Account removal leaves dangling consumers</td>
+<td>Refuse removal while bindings, defaults, profiles, harnesses, or routines reference the ID</td>
+</tr>
+<tr>
+<td>Sync exposes a reusable credential</td>
+<td>Explicit command only, pinned transport, stdin-only atomic import, no native OAuth path</td>
+</tr>
+<tr>
+<td>Provider adapter claims exceed real support</td>
+<td>Registry completeness tests pin every supported pair and require clear unsupported errors</td>
+</tr>
+</tbody></table>
+<h2 id="tracking">Tracking</h2>
+<p>The implementation should use one account-unification ticket and link this rendered plan from that ticket. Any prerequisite harness inspector work should be a linked subtask and referenced back here before implementation begins.</p>
+<h2 id="delta-spec">Delta Spec</h2>
+<ul>
+<li>Account names MUST be unique across native and provider accounts and MUST resolve through stable IDs.</li>
+<li><code>accounts name &lt;source&gt; &lt;name&gt;</code> MUST create only native metadata and MUST NOT read or store native OAuth credentials.</li>
+<li><code>accounts attach &lt;account&gt; &lt;target&gt;</code> MUST use positional arguments and MUST validate compatibility before changing bindings.</li>
+<li>A native attachment MUST reference a harness-owned login already present at the target scope; it MUST NOT migrate credentials.</li>
+<li>A provider attachment MAY bind one portable account to multiple compatible native installations and custom harnesses.</li>
+<li>Normal inspection, routing, and status commands MUST NOT trigger biometric prompts.</li>
+<li>Portable credential sync MUST be explicit, destination-authenticated, atomic, rollback-safe, and verifiable without persisting plaintext.</li>
+<li>Remote execution MUST resolve the account on the destination. It MUST NOT transfer credentials implicitly.</li>
+<li>Text and JSON account renderers MUST expose the same account identity, custody, availability, and binding facts.</li>
+<li>Unsupported harness or provider combinations MUST fail nonzero with the missing capability named.</li>
+</ul>
+</article>
+
+</main>
+<script type="application/json" id="artifacts-source">{"encoding":"base64","markdown":"LS0tCmtpbmQ6IHBsYW4KdGVtcGxhdGU6IHBsYW4udjEKc3VyZmFjZTogY2xpCnRpdGxlOiBVbmlmeSBuYXRpdmUgbG9naW5zIGFuZCBwcm92aWRlciBjcmVkZW50aWFscyBhcyBuYW1lZCBhY2NvdW50cwpzdW1tYXJ5OiBHaXZlIG5hdGl2ZSBPQXV0aCBpZGVudGl0aWVzIGFuZCBwb3J0YWJsZSBwcm92aWRlciBjcmVkZW50aWFscyBvbmUgYWNjb3VudCBjYXRhbG9nLCB0aGVuIGJpbmQgbmFtZWQgYWNjb3VudHMgdG8gbmF0aXZlIGluc3RhbGxhdGlvbnMgYW5kIGN1c3RvbSBoYXJuZXNzZXMgd2l0aCBwb3NpdGlvbmFsIGNvbW1hbmRzLiBOYXRpdmUgT0F1dGggcmVtYWlucyBvd25lZCBieSBlYWNoIGhhcm5lc3MgYW5kIG5ldmVyIGVudGVycyB0aGUgYWdlbnRzLWNsaSBrZXljaGFpbjsgcG9ydGFibGUgc2VjcmV0cyBtb3ZlIG9ubHkgdGhyb3VnaCBhbiBleHBsaWNpdCwgdmVyaWZpZWQgc3luYyBvcGVyYXRpb24uCnN0YXR1czogYXdhaXRpbmctZ28KdHJhY2tpbmc6ICJBY2NvdW50IHVuaWZpY2F0aW9uIGZvbGxvdy11cCIKcHJvamVjdDogYWdlbnRzLWNsaQpyZXBvc2l0b3J5OiBwaG54LWxhYnMvYWdlbnRzLWNsaQpicmFuY2g6IG1haW4KaGFybmVzczogY29kZXgKYWdlbnQ6IENvZGV4Cmh1bWFuOiBNdXFzaXQKaG9zdDogeW9zZW1pdGUtczAKc2Vzc2lvbjogMDE5ZmRlZjQKZGF0ZTogJzIwMjYtMDgtMTAnCmZhY3RzOgogIC0gUHJvdmlkZXIgYWNjb3VudHMgYWxyZWFkeSB1c2UgY2Fub25pY2FsIHNlY3JldHMgYnVuZGxlcyB3aXRoIHN0YWJsZSBVVUlEcyBhbmQgcG9saWN5IG5ldmVyLgogIC0gTmF0aXZlIGlkZW50aXRpZXMgYXJlIGN1cnJlbnRseSBkaXNjb3ZlcmVkIHJlYWQtb25seSBhbmQgbGFiZWxzIGFyZSBub3QgcmVuZGVyZWQgaW4gYWdlbnRzIHZpZXcuCiAgLSBEaXJlY3QgcnVuLCByb3V0aW5lcywgY3VzdG9tIGhhcm5lc3NlcywgbmF0aXZlIGluc3RhbGxhdGlvbnMsIGFuZCBmbGVldCBzeW5jIGRvIG5vdCB5ZXQgc2hhcmUgb25lIGFjY291bnQgcmVzb2x2ZXIuCi0tLQoKIyBVbmlmeSBuYXRpdmUgbG9naW5zIGFuZCBwcm92aWRlciBjcmVkZW50aWFscyBhcyBuYW1lZCBhY2NvdW50cwoKIyMgRm9jdXMgZm9yIHJldmlldwoKLSBJcyB0aGUgcG9zaXRpb25hbCBncmFtbWFyIG5hdHVyYWw6IGBuYW1lIDxzb3VyY2U+IDxuYW1lPmAgYW5kIGBhdHRhY2ggPGFjY291bnQ+IDx0YXJnZXQ+YD8KLSBTaG91bGQgYSBuYXRpdmUgT0F1dGggYWxpYXMgYmUgYXR0YWNoYWJsZSBvbmx5IHdoZXJlIHRoYXQgc2FtZSBoYXJuZXNzLW93bmVkIGxvZ2luIGFscmVhZHkgZXhpc3RzPyBUaGlzIHBsYW4gc2F5cyB5ZXMuCi0gU2hvdWxkIHBvcnRhYmxlIHByb3ZpZGVyIGNyZWRlbnRpYWxzIGJlIGNvcGllZCBvbmx5IGJ5IGFuIGV4cGxpY2l0IGBhY2NvdW50cyBzeW5jYCBjb21tYW5kPyBUaGlzIHBsYW4gc2F5cyB5ZXMuCgojIyBJbnRlbnQKCk1hbmFnZSBhIENsYXVkZSwgQ29kZXgsIEN1cnNvciwgb3Igb3RoZXIgbmF0aXZlIGxvZ2luIHNlcGFyYXRlbHkgZnJvbSB0aGUgaW5zdGFsbGVkIENMSSB2ZXJzaW9uLCBnaXZlIGl0IGEgbWVtb3JhYmxlIG5hbWUgc3VjaCBhcyBgd29ya2AsIGFuZCBjb25uZWN0IGl0IHRvIG9uZSBvciBtb3JlIGluc3RhbGxhdGlvbnMuIFVzZSB0aGUgc2FtZSBtb2RlbCBmb3IgT3BlblJvdXRlciwgRGVlcEluZnJhLCBhbmQgb3RoZXIgQVBJLWtleSBvciBsb25nLWxpdmVkLXRva2VuIHByb3ZpZGVycyB3aXRob3V0IG1ha2luZyBuYXRpdmUgT0F1dGggY3JlZGVudGlhbHMgcGFzcyB0aHJvdWdoIGFnZW50cy1jbGkgc3RvcmFnZS4KCjxkaXYgY2xhc3M9ImFydGlmYWN0LWNhbGxvdXQiPjxzdHJvbmc+Q29yZSBydWxlOjwvc3Ryb25nPiBhbiBhY2NvdW50IGlzIGEgbmFtZWQgaWRlbnRpdHkuIEEgbmF0aXZlIGFjY291bnQgc3RvcmVzIG9ubHkgaWRlbnRpdHkgbWV0YWRhdGEgYW5kIGEgYmluZGluZyB0byBhIGhhcm5lc3Mtb3duZWQgbG9naW4uIEEgcHJvdmlkZXIgYWNjb3VudCBzdG9yZXMgYSBwb3J0YWJsZSBjcmVkZW50aWFsIGluIHRoZSBleGlzdGluZyBzZWNyZXRzIGJhY2tlbmQuIEF0dGFjaGluZyBuZXZlciBjb3BpZXMgYSBuYXRpdmUgT0F1dGggdG9rZW4uPC9kaXY+CgojIyBDdXJyZW50IGFyY2hpdGVjdHVyZQoKPHNlY3Rpb24gY2xhc3M9ImFydGlmYWN0LWdyaWQgYXJ0aWZhY3QtZ3JpZC0yIj4KPGFydGljbGUgY2xhc3M9ImFydGlmYWN0LXBhbmVsIiBkYXRhLXN0YXRlPSJjdXJyZW50IiBkYXRhLWV2aWRlbmNlPSJjYXB0dXJlIj4KPGZpZ2NhcHRpb24+PHN0cm9uZz5DdXJyZW50Ojwvc3Ryb25nPiB0aGUgbmFtZSBjb21tYW5kIHJlcG9ydHMgc3VjY2VzcywgYnV0IDxjb2RlPmFnZW50cyB2aWV3PC9jb2RlPiBzdGlsbCBzaG93cyBvbmx5IHRoZSBlbWFpbCBhbmQgdmVyc2lvbi48L2ZpZ2NhcHRpb24+CgpgYGB0ZXh0CiQgYWdlbnRzIGFjY291bnRzIG5hbWUgd29yayAtLWZyb20gY2xhdWRlQDIuMS4yMjAKTmFtZWQgdGhlIGNsYXVkZSBhY2NvdW50ICd3b3JrJy4KCiQgYWdlbnRzIHZpZXcgY2xhdWRlCjIuMS4yMjAgIGRlZmF1bHQgIG11cXNpdEBnZXRydXNoLmFpCmBgYAo8L2FydGljbGU+Cgo8YXJ0aWNsZSBjbGFzcz0iYXJ0aWZhY3QtcGFuZWwiIGRhdGEtc3RhdGU9InByb3Bvc2VkIiBkYXRhLWV2aWRlbmNlPSJtb2NrdXAiPgo8ZmlnY2FwdGlvbj48c3Ryb25nPlByb3Bvc2VkOjwvc3Ryb25nPiB0aGUgc291cmNlIGFuZCB0YXJnZXQgYXJlIHBvc2l0aW9uYWwsIGFuZCB0aGUgbmFtZSBpcyB2aXNpYmxlIGV2ZXJ5d2hlcmUgdGhlIGlkZW50aXR5IGFwcGVhcnMuPC9maWdjYXB0aW9uPgoKYGBgdGV4dAokIGFnZW50cyBhY2NvdW50cyBuYW1lIGNsYXVkZUAyLjEuMjIwIHdvcmsKTmFtZWQgY2xhdWRlQDIuMS4yMjAgYXMgd29yay4KCiQgYWdlbnRzIGFjY291bnRzIGF0dGFjaCB3b3JrIGNsYXVkZUAyLjEuMjI1CkF0dGFjaGVkIHdvcmsgdG8gY2xhdWRlQDIuMS4yMjUuCgokIGFnZW50cyB2aWV3IGNsYXVkZQoyLjEuMjI1ICBvcHVzWzFtXSAgd29yayDCtyBtdXFzaXRAZ2V0cnVzaC5haSAgTWF4CjIuMS4yMjAgIGRlZmF1bHQgICB3b3JrIMK3IG11cXNpdEBnZXRydXNoLmFpICBNYXgKYGBgCjwvYXJ0aWNsZT4KPC9zZWN0aW9uPgoKPGZpZ3VyZSBjbGFzcz0iYXJ0aWZhY3QtZmlndXJlIGFydGlmYWN0LWZpZ3VyZS1kaWFncmFtIGFydGlmYWN0LWZpZ3VyZS13aWRlIj4KPHN2ZyBjbGFzcz0iYXJ0aWZhY3QtZGlhZ3JhbSIgdmlld0JveD0iMCAwIDEwNDAgMzUwIiByb2xlPSJpbWciIGFyaWEtbGFiZWxsZWRieT0iYWNjb3VudC10aXRsZSBhY2NvdW50LWRlc2MiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHRpdGxlIGlkPSJhY2NvdW50LXRpdGxlIj5VbmlmaWVkIGFjY291bnQgY2F0YWxvZyBhbmQgYmluZGluZyBmbG93PC90aXRsZT4KICA8ZGVzYyBpZD0iYWNjb3VudC1kZXNjIj5OYXRpdmUgYWxpYXNlcyBwb2ludCB0byBoYXJuZXNzLW93bmVkIE9BdXRoIHN0YXRlIHdoaWxlIHByb3ZpZGVyIGFjY291bnRzIHBvaW50IHRvIHBvcnRhYmxlIHNlY3JldCBidW5kbGVzLiBCb3RoIHJlc29sdmUgdGhyb3VnaCBiaW5kaW5ncyB0byBpbnN0YWxsYXRpb25zIGFuZCBjdXN0b20gaGFybmVzc2VzLjwvZGVzYz4KICA8ZGVmcz4KICAgIDxtYXJrZXIgaWQ9ImFycm93IiB2aWV3Qm94PSIwIDAgMTAgMTAiIHJlZlg9IjkiIHJlZlk9IjUiIG1hcmtlcldpZHRoPSI3IiBtYXJrZXJIZWlnaHQ9IjciIG9yaWVudD0iYXV0by1zdGFydC1yZXZlcnNlIj48cGF0aCBkPSJNMCAwTDEwIDVMMCAxMHoiIGZpbGw9IiNhM2U2MzUiLz48L21hcmtlcj4KICA8L2RlZnM+CiAgPHRleHQgeD0iMzAiIHk9IjI4IiBmaWxsPSIjYTNlNjM1IiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjE0IiBmb250LXdlaWdodD0iNzAwIj5BQ0NPVU5UIENBVEFMT0c8L3RleHQ+CiAgPHJlY3QgeD0iMzAiIHk9IjQ4IiB3aWR0aD0iMjYwIiBoZWlnaHQ9IjEwNSIgcng9IjEyIiBmaWxsPSIjMTExODI3IiBzdHJva2U9IiNhM2U2MzUiIHN0cm9rZS13aWR0aD0iMiIvPjx0ZXh0IHg9IjUwIiB5PSI3OSIgZmlsbD0iI2Y4ZmFmYyIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxNSI+bmF0aXZlIMK3IHdvcms8L3RleHQ+PHRleHQgeD0iNTAiIHk9IjEwNCIgZmlsbD0iI2NiZDVlMSIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxMiI+aWRlbnRpdHkgZmluZ2VycHJpbnQgKyBsYWJlbDwvdGV4dD48dGV4dCB4PSI1MCIgeT0iMTI4IiBmaWxsPSIjY2JkNWUxIiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjEyIj5zZWNyZXQgc3RheXMgaW4gQ2xhdWRlL0NvZGV4L0N1cnNvcjwvdGV4dD4KICA8cmVjdCB4PSIzMCIgeT0iMTkwIiB3aWR0aD0iMjYwIiBoZWlnaHQ9IjEwNSIgcng9IjEyIiBmaWxsPSIjMTExODI3IiBzdHJva2U9IiNhM2U2MzUiIHN0cm9rZS13aWR0aD0iMiIvPjx0ZXh0IHg9IjUwIiB5PSIyMjEiIGZpbGw9IiNmOGZhZmMiIGZvbnQtZmFtaWx5PSJJbnRlcixzeXN0ZW0tdWkiIGZvbnQtc2l6ZT0iMTUiPnByb3ZpZGVyIMK3IG9wZW5yb3V0ZXItd29yazwvdGV4dD48dGV4dCB4PSI1MCIgeT0iMjQ2IiBmaWxsPSIjY2JkNWUxIiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjEyIj5wcm92aWRlciArIGF1dGggdHlwZSArIHN0YWJsZSBVVUlEPC90ZXh0Pjx0ZXh0IHg9IjUwIiB5PSIyNzAiIGZpbGw9IiNjYmQ1ZTEiIGZvbnQtZmFtaWx5PSJJbnRlcixzeXN0ZW0tdWkiIGZvbnQtc2l6ZT0iMTIiPnNlY3JldCBidW5kbGUsIHBvbGljeSBuZXZlcjwvdGV4dD4KICA8cGF0aCBkPSJNMjkwIDEwMEg0MDUiIHN0cm9rZT0iI2EzZTYzNSIgc3Ryb2tlLXdpZHRoPSIzIiBmaWxsPSJub25lIiBtYXJrZXItZW5kPSJ1cmwoI2Fycm93KSIvPjxwYXRoIGQ9Ik0yOTAgMjQySDQwNSIgc3Ryb2tlPSIjYTNlNjM1IiBzdHJva2Utd2lkdGg9IjMiIGZpbGw9Im5vbmUiIG1hcmtlci1lbmQ9InVybCgjYXJyb3cpIi8+CiAgPHRleHQgeD0iNDIwIiB5PSIyOCIgZmlsbD0iI2EzZTYzNSIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxNCIgZm9udC13ZWlnaHQ9IjcwMCI+QklORElOR1M8L3RleHQ+CiAgPHJlY3QgeD0iNDA1IiB5PSI0OCIgd2lkdGg9IjI2MCIgaGVpZ2h0PSIyNDciIHJ4PSIxMiIgZmlsbD0iIzExMTgyNyIgc3Ryb2tlPSIjNDc1NTY5IiBzdHJva2Utd2lkdGg9IjIiLz48dGV4dCB4PSI0MzAiIHk9Ijg0IiBmaWxsPSIjZjhmYWZjIiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjE1Ij53b3JrIOKGkiBjbGF1ZGVAMi4xLjIyMDwvdGV4dD48dGV4dCB4PSI0MzAiIHk9IjEyMSIgZmlsbD0iI2Y4ZmFmYyIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxNSI+d29yayDihpIgY2xhdWRlQDIuMS4yMjU8L3RleHQ+PHRleHQgeD0iNDMwIiB5PSIxNzYiIGZpbGw9IiNmOGZhZmMiIGZvbnQtZmFtaWx5PSJJbnRlcixzeXN0ZW0tdWkiIGZvbnQtc2l6ZT0iMTUiPm9wZW5yb3V0ZXItd29yayDihpIgY29kZXhAMC4xNDUuMDwvdGV4dD48dGV4dCB4PSI0MzAiIHk9IjIxMyIgZmlsbD0iI2Y4ZmFmYyIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxNSI+b3BlbnJvdXRlci13b3JrIOKGkiBjdXJzb3JAbGF0ZXN0PC90ZXh0Pjx0ZXh0IHg9IjQzMCIgeT0iMjY4IiBmaWxsPSIjZjhmYWZjIiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjE1Ij5vcGVucm91dGVyLXdvcmsg4oaSIGRlZXBzZWVrPC90ZXh0PgogIDxwYXRoIGQ9Ik02NjUgMTcwSDc4MCIgc3Ryb2tlPSIjYTNlNjM1IiBzdHJva2Utd2lkdGg9IjMiIGZpbGw9Im5vbmUiIG1hcmtlci1lbmQ9InVybCgjYXJyb3cpIi8+CiAgPHRleHQgeD0iNzk1IiB5PSIyOCIgZmlsbD0iI2EzZTYzNSIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxNCIgZm9udC13ZWlnaHQ9IjcwMCI+RVhFQ1VUSU9OPC90ZXh0PgogIDxyZWN0IHg9Ijc4MCIgeT0iNDgiIHdpZHRoPSIyMzAiIGhlaWdodD0iMjQ3IiByeD0iMTIiIGZpbGw9IiMxMTE4MjciIHN0cm9rZT0iIzQ3NTU2OSIgc3Ryb2tlLXdpZHRoPSIyIi8+PHRleHQgeD0iODA1IiB5PSI5MiIgZmlsbD0iI2Y4ZmFmYyIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxNSI+bmF0aXZlIGluc3RhbGxhdGlvbjwvdGV4dD48dGV4dCB4PSI4MDUiIHk9IjEyMCIgZmlsbD0iI2NiZDVlMSIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxMiI+dmFsaWRhdGUgZXhpc3RpbmcgbG9naW48L3RleHQ+PHRleHQgeD0iODA1IiB5PSIxNjYiIGZpbGw9IiNmOGZhZmMiIGZvbnQtZmFtaWx5PSJJbnRlcixzeXN0ZW0tdWkiIGZvbnQtc2l6ZT0iMTUiPmN1c3RvbSBoYXJuZXNzPC90ZXh0Pjx0ZXh0IHg9IjgwNSIgeT0iMTk0IiBmaWxsPSIjY2JkNWUxIiBmb250LWZhbWlseT0iSW50ZXIsc3lzdGVtLXVpIiBmb250LXNpemU9IjEyIj5pbmplY3QgcHJvdmlkZXIgY3JlZGVudGlhbDwvdGV4dD48dGV4dCB4PSI4MDUiIHk9IjI0MCIgZmlsbD0iI2Y4ZmFmYyIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxNSI+cmVtb3RlIGZsZWV0IHJ1bjwvdGV4dD48dGV4dCB4PSI4MDUiIHk9IjI2OCIgZmlsbD0iI2NiZDVlMSIgZm9udC1mYW1pbHk9IkludGVyLHN5c3RlbS11aSIgZm9udC1zaXplPSIxMiI+cmVzb2x2ZSBhY2NvdW50IG9uIHRhcmdldDwvdGV4dD4KPC9zdmc+CjxmaWdjYXB0aW9uPk9uZSBjYXRhbG9nIGFuZCBvbmUgcmVzb2x2ZXIsIHdpdGggZGlmZmVyZW50IGN1c3RvZHkgcnVsZXMgZm9yIG5hdGl2ZSBhbmQgcG9ydGFibGUgY3JlZGVudGlhbHMuPC9maWdjYXB0aW9uPgo8L2ZpZ3VyZT4KCiMjIFB1cnBvc2UKClRoZSBleGlzdGluZyBhY2NvdW50IHdvcmsgaGFzIHR3byBkaXNjb25uZWN0ZWQgY29uY2VwdHMuIFByb3ZpZGVyIGNyZWRlbnRpYWxzIGFyZSBkdXJhYmxlIGFjY291bnQgYnVuZGxlcywgd2hpbGUgbmF0aXZlIE9BdXRoIGlkZW50aXRpZXMgYXJlIHJlYWQtb25seSBkaXNjb3Zlcnkgcm93cy4gVGhlIG9sZCBsYWJlbCBwYXRoIHJlY29yZHMgYSBsYWJlbCBvdXRzaWRlIHRoZSByZW5kZXJlZCBjYXRhbG9nLCBzbyBgYWdlbnRzIHZpZXdgIGNhbm5vdCBzaG93IGl0LiBBY2NvdW50IHNlbGVjdGlvbiBhbHNvIGRpZmZlcnMgYmV0d2VlbiBkaXJlY3QgcnVucywgcm91dGluZXMsIGN1c3RvbSBoYXJuZXNzZXMsIGFuZCByZW1vdGUgZGlzcGF0Y2guCgpUaGUgY2hhbmdlIHN0YW5kYXJkaXplcyB0aGUgdXNlciBtb2RlbCB3aXRob3V0IHByZXRlbmRpbmcgZXZlcnkgaGFybmVzcyBzdXBwb3J0cyB0aGUgc2FtZSBhdXRoZW50aWNhdGlvbiBtZWNoYW5pY3MuCgojIyBQdWJsaWMgSW50ZXJmYWNlCgojIyMgQ29tbWFuZCBncmFtbWFyCgp8IEludGVudCB8IENvbW1hbmQgfCBNZWFuaW5nIHwKfCAtLS0gfCAtLS0gfCAtLS0gfAp8IE5hbWUgYSBkaXNjb3ZlcmVkIG5hdGl2ZSBsb2dpbiB8IGBhZ2VudHMgYWNjb3VudHMgbmFtZSBjbGF1ZGVAMi4xLjIyMCB3b3JrYCB8IENyZWF0ZSBvciB1cGRhdGUgbmF0aXZlIGFjY291bnQgYHdvcmtgIGZyb20gdGhlIGxvZ2luIGZvdW5kIGluIHRoYXQgaW5zdGFsbGF0aW9uIHwKfCBBZGQgYSBwb3J0YWJsZSBwcm92aWRlciBjcmVkZW50aWFsIHwgYGFnZW50cyBhY2NvdW50cyBhZGQgb3BlbnJvdXRlci13b3JrIC0tcHJvdmlkZXIgb3BlbnJvdXRlciAtLWF1dGggYXBpLWtleWAgfCBDcmVhdGUgcHJvdmlkZXIgYWNjb3VudCBhbmQgc2VjdXJlbHkgcHJvbXB0IGZvciBpdHMga2V5IHwKfCBBdHRhY2ggYW4gYWNjb3VudCB8IGBhZ2VudHMgYWNjb3VudHMgYXR0YWNoIHdvcmsgY2xhdWRlQDIuMS4yMjVgIHwgQmluZCB0aGUgbmFtZWQgYWNjb3VudCB0byBhbiBleGFjdCBuYXRpdmUgaW5zdGFsbGF0aW9uIHwKfCBBdHRhY2ggdG8gYSBjdXN0b20gaGFybmVzcyB8IGBhZ2VudHMgYWNjb3VudHMgYXR0YWNoIG9wZW5yb3V0ZXItd29yayBkZWVwc2Vla2AgfCBCaW5kIHRoZSBwcm92aWRlciBhY2NvdW50IHRvIHRoZSBuYW1lZCBjdXN0b20gaGFybmVzcyB8CnwgRGV0YWNoIHwgYGFnZW50cyBhY2NvdW50cyBkZXRhY2ggd29yayBjbGF1ZGVAMi4xLjIyNWAgfCBSZW1vdmUgZXhhY3RseSB0aGF0IGJpbmRpbmcgfAp8IEluc3BlY3QgfCBgYWdlbnRzIGFjY291bnRzIHZpZXcgd29ya2AgfCBTaG93IGlkZW50aXR5IG1ldGFkYXRhLCBjcmVkZW50aWFsIGN1c3RvZHksIGJpbmRpbmdzLCBhbmQgYXZhaWxhYmlsaXR5IHwKfCBSZW5hbWUgfCBgYWdlbnRzIGFjY291bnRzIHJlbmFtZSB3b3JrIHJ1c2gtd29ya2AgfCBSZW5hbWUgdGhlIGFjY291bnQgd2hpbGUgcmV0YWluaW5nIGl0cyBzdGFibGUgSUQgYW5kIGJpbmRpbmdzIHwKfCBSZW1vdmUgfCBgYWdlbnRzIGFjY291bnRzIHJlbW92ZSBydXNoLXdvcmtgIHwgUmVmdXNlIHdoaWxlIGJpbmRpbmdzL2RlZmF1bHRzIHN0aWxsIHJlZmVyZW5jZSBpdDsgZXhwbGFpbiBob3cgdG8gZGV0YWNoIHwKfCBDb3B5IHBvcnRhYmxlIGNyZWRlbnRpYWxzIHwgYGFnZW50cyBhY2NvdW50cyBzeW5jIG9wZW5yb3V0ZXItd29yayB6aW9uYCB8IEV4cGxpY2l0bHkgcHJvdmlzaW9uIHRoZSBzYW1lIHN0YWJsZSBwcm92aWRlciBhY2NvdW50IG9uIGFub3RoZXIgZGV2aWNlIHwKCmAtLWZyb21gIGFuZCBgLS10b2AgYXJlIHJlbW92ZWQgZnJvbSB0aGUgcHJvcG9zZWQgQVBJLiBGbGFncyByZW1haW4gZm9yIG9wdGlvbmFsIGF0dHJpYnV0ZXMgYW5kIGJlaGF2aW9yLCBzdWNoIGFzIGAtLXByb3ZpZGVyYCwgYC0tYXV0aGAsIGAtLWpzb25gLCBgLS1mb3JjZWAsIGFuZCBgLS1kZWZhdWx0YC4KCiMjIyBDb21wbGV0ZSBoYXBweSBwYXRocwoKTmF0aXZlIE9BdXRoIGFjY291bnQ6CgpgYGBiYXNoCmFnZW50cyBhY2NvdW50cyBuYW1lIGNsYXVkZUAyLjEuMjIwIHdvcmsKYWdlbnRzIGFjY291bnRzIGF0dGFjaCB3b3JrIGNsYXVkZUAyLjEuMjI1CmFnZW50cyBhY2NvdW50cyB2aWV3IHdvcmsKYWdlbnRzIHJ1biBjbGF1ZGVAMi4xLjIyNQpgYGAKClBvcnRhYmxlIHByb3ZpZGVyIGFjY291bnQ6CgpgYGBiYXNoCmFnZW50cyBhY2NvdW50cyBhZGQgb3BlbnJvdXRlci13b3JrIC0tcHJvdmlkZXIgb3BlbnJvdXRlciAtLWF1dGggYXBpLWtleQphZ2VudHMgYWNjb3VudHMgYXR0YWNoIG9wZW5yb3V0ZXItd29yayBjb2RleEAwLjE0NS4wCmFnZW50cyBhY2NvdW50cyBhdHRhY2ggb3BlbnJvdXRlci13b3JrIGN1cnNvckBsYXRlc3QKYWdlbnRzIGFjY291bnRzIGF0dGFjaCBvcGVucm91dGVyLXdvcmsgZGVlcHNlZWsKYWdlbnRzIGFjY291bnRzIHN5bmMgb3BlbnJvdXRlci13b3JrIHppb24KYGBgCgojIyMgT3V0cHV0IGNvbnRyYWN0CgpgYGB0ZXh0CiQgYWdlbnRzIGFjY291bnRzIHZpZXcgd29yawp3b3JrCiAga2luZCAgICAgICAgbmF0aXZlIGxvZ2luCiAgaWRlbnRpdHkgICAgbXVxc2l0QGdldHJ1c2guYWkKICBwcm92aWRlciAgICBBbnRocm9waWMKICBjdXN0b2R5ICAgICBDbGF1ZGUgQ29kZSAobm90IHN0b3JlZCBieSBhZ2VudHMtY2xpKQogIHNjb3BlICAgICAgIHZlcnNpb24KICBhdmFpbGFibGUgICB5ZXMKICBhdHRhY2hlZCAgICBjbGF1ZGVAMi4xLjIyMCwgY2xhdWRlQDIuMS4yMjUKYGBgCgpgYGB0ZXh0CiQgYWdlbnRzIGFjY291bnRzIHZpZXcgb3BlbnJvdXRlci13b3JrCm9wZW5yb3V0ZXItd29yawogIGtpbmQgICAgICAgIHByb3ZpZGVyIGNyZWRlbnRpYWwKICBwcm92aWRlciAgICBPcGVuUm91dGVyCiAgYXV0aCAgICAgICAgQVBJIGtleQogIGN1c3RvZHkgICAgIGFnZW50cyBzZWNyZXRzIChubyBiaW9tZXRyaWMgQUNMKQogIGF2YWlsYWJsZSAgIHRoaXMgZGV2aWNlLCB6aW9uCiAgYXR0YWNoZWQgICAgY29kZXhAMC4xNDUuMCwgY3Vyc29yQGxhdGVzdCwgZGVlcHNlZWsKYGBgCgpFdmVyeSBodW1hbi1yZWFkYWJsZSBhY2NvdW50IHJvdyB1c2VzIGBuYW1lIMK3IGlkZW50aXR5YCB3aGVuIGJvdGggZXhpc3QuIEV2ZXJ5IGNvbW1hbmQgdGhhdCBlbWl0cyBhY2NvdW50IGRhdGEgc3VwcG9ydHMgYC0tanNvbmAgYW5kIHJldHVybnMgdGhlIHN0YWJsZSBhY2NvdW50IElELCBraW5kLCBkaXNwbGF5IG5hbWUsIGlkZW50aXR5IG1ldGFkYXRhLCBjdXN0b2R5LCBhdmFpbGFiaWxpdHksIGFuZCBiaW5kaW5ncy4KCiMjIFByb3Bvc2VkIENoYW5nZXMKCiMjIyAxLiBPbmUgdHlwZWQgY2F0YWxvZywgdHdvIGNyZWRlbnRpYWwgY3VzdG9keSBtb2RlbHMKCkV4dGVuZCB0aGUgZXhpc3RpbmcgYWNjb3VudCByZWdpc3RyeSByYXRoZXIgdGhhbiBhZGQgYSBzZWNvbmQgc3RvcmU6CgpgYGB0cwp0eXBlIEFjY291bnQgPQogIHwgewogICAgICBpZDogc3RyaW5nOwogICAgICBuYW1lOiBzdHJpbmc7CiAgICAgIGtpbmQ6ICJuYXRpdmUiOwogICAgICBhZ2VudDogQWdlbnRJZDsKICAgICAgaWRlbnRpdHlLZXk6IHN0cmluZzsKICAgICAgaWRlbnRpdHlMYWJlbD86IHN0cmluZzsKICAgICAgYXV0aFNjb3BlOiAidmVyc2lvbiIgfCAiZGV2aWNlIjsKICAgIH0KICB8IHsKICAgICAgaWQ6IHN0cmluZzsKICAgICAgbmFtZTogc3RyaW5nOwogICAgICBraW5kOiAicHJvdmlkZXIiOwogICAgICBwcm92aWRlcjogQWNjb3VudFByb3ZpZGVySWQ7CiAgICAgIGF1dGhUeXBlOiAiYXBpLWtleSIgfCAidG9rZW4iOwogICAgICBidW5kbGU6IHN0cmluZzsKICAgIH07Cgp0eXBlIEFjY291bnRCaW5kaW5nID0gewogIGFjY291bnRJZDogc3RyaW5nOwogIHRhcmdldDogc3RyaW5nOwp9OwpgYGAKCk5hdGl2ZSByZWNvcmRzIGNvbnRhaW4gbm8gT0F1dGggYWNjZXNzIHRva2VuLCByZWZyZXNoIHRva2VuLCBhdXRoIGZpbGUsIG9yIGtleWNoYWluIHJlZmVyZW5jZS4gUHJvdmlkZXIgcmVjb3JkcyBjb250aW51ZSB0byB1c2UgdGhlIGNhbm9uaWNhbCBzZWNyZXRzIGJ1bmRsZSB3aXRoIHN0YWJsZSBVVUlEIGFuZCBgcG9saWN5OiBuZXZlcmAuCgojIyMgMi4gT25lIHRhcmdldCBwYXJzZXIgYW5kIHJlc29sdmVyCgpQYXJzZSB0aGUgc2Vjb25kIHBvc2l0aW9uYWwgYXJndW1lbnQgaW50byBlaXRoZXIgYW4gZXhhY3QgbmF0aXZlIGluc3RhbGxhdGlvbiAoYGNsYXVkZUAyLjEuMjI1YCwgYGNvZGV4QDAuMTQ1LjBgLCBgY3Vyc29yQGxhdGVzdGApIG9yIGEgY3VzdG9tIGhhcm5lc3MgKGBkZWVwc2Vla2ApLiBSZXNvbHZlIGFjY291bnRzIGluIHRoaXMgb3JkZXI6CgoxLiBleHBsaWNpdCBydW4gYWNjb3VudDsKMi4gZXhhY3QgdGFyZ2V0IGJpbmRpbmc7CjMuIGJhcmUtYWdlbnQgZGVmYXVsdDsKNC4gY3VycmVudCBuYXRpdmUgb3IgYmFsYW5jZWQgc2VsZWN0aW9uLgoKVGhlIHNhbWUgcmVzb2x2ZXIgaXMgdXNlZCBieSBkaXJlY3QgcnVucywgcm91dGluZXMsIHRlYW1zLCBsb2NhbCBkaXNwYXRjaCwgYW5kIHJlbW90ZSBmbGVldCBkaXNwYXRjaC4gQ2xvdWQvbGVhc2UgcnVucyBmYWlsIGNsZWFybHkgZm9yIGRldmljZS1sb2NhbCBuYXRpdmUgYWNjb3VudHMuIFRoZXkgZG8gbm90IGV4cG9ydCBuYXRpdmUgT0F1dGggYXV0b21hdGljYWxseS4KCiMjIyAzLiBDYXBhYmlsaXR5IHJlZ2lzdHJ5IGtlZXBzIGhhcm5lc3MgY2xhaW1zIHRydXRoZnVsCgp8IENhcGFiaWxpdHkgfCBIYXJuZXNzZXMgLyBoYW5kbGluZyB8CnwgLS0tIHwgLS0tIHwKfCBWZXJzaW9uLXNjb3BlZCBuYXRpdmUgaWRlbnRpdHkgfCBDbGF1ZGUsIENvZGV4LCBHcm9rOyBNdXNlIHdoZW4gaWRlbnRpdHkgaW5zcGVjdGlvbiBpcyBzdHJvbmcgfAp8IERldmljZS1zY29wZWQgbmF0aXZlIGlkZW50aXR5IHwgQ3Vyc29yIGFmdGVyIGNvcnJlY3RpbmcgZmFsc2UgWERHIGlzb2xhdGlvbjsgQW50aWdyYXZpdHksIEtpbWksIERyb2lkLCBPcGVuQ29kZSB3aGVyZSB0aGVpciBhdXRoIGlzIGRldmljZS1nbG9iYWwgfAp8IFJlcXVpcmVzIGluc3BlY3RvciB3b3JrIGJlZm9yZSBhdHRhY2ggfCBDb3BpbG90IHwKfCBEaXNjb3Zlcnkgb25seSAvIGxlZ2FjeSB8IEdlbWluaSB8CnwgVW5zdXBwb3J0ZWQgdW50aWwgbW9kZWxlZCB8IFBpLCBPcGVuQ2xhdywgQW1wLCBLaXJvLCBHb29zZSwgSGVybWVzLCBXYXJwIHwKfCBQb3J0YWJsZSBwcm92aWRlciBjcmVkZW50aWFsIHwgUmVnaXN0cnktZHJpdmVuIGFkYXB0ZXJzIG9ubHk7IHVuc3VwcG9ydGVkIHByb3ZpZGVyL2hhcm5lc3MgcGFpcnMgZmFpbCBsb3VkIHwKCkZvciBhIG5hdGl2ZSBhY2NvdW50LCBgYXR0YWNoYCB2YWxpZGF0ZXMgdGhhdCB0aGUgdGFyZ2V0IGFscmVhZHkgZXhwb3NlcyB0aGUgc2FtZSBpZGVudGl0eSBmaW5nZXJwcmludC4gSXQgbmV2ZXIgbG9ncyBpbiwgY29waWVzLCBvciByZXdyaXRlcyBPQXV0aCBzdGF0ZS4gQSBkZXZpY2Utc2NvcGVkIGhhcm5lc3MgcmVqZWN0cyBhbiBleGFjdC12ZXJzaW9uIGF0dGFjaG1lbnQgYW5kIGV4cGxhaW5zIHRoYXQgdGhlIGFjY291bnQgYXBwbGllcyB0byB0aGUgZGV2aWNlLgoKIyMjIDQuIExhYmVscyByZW5kZXIgZXZlcnl3aGVyZQoKVXNlIG9uZSBhY2NvdW50IHJlbmRlcmVyIGluIGBhY2NvdW50c2AsIGBhZ2VudHMgdmlld2AsIGBoYXJuZXNzIHZpZXdgLCBydW4gYmFubmVycywgcGlja2Vycywgcm91dGluZXMsIGFuZCBmbGVldCBpbnZlbnRvcnkuIFJlY292ZXIgYXJjaGl2ZWQgZmluZ2VycHJpbnQgbGFiZWxzIHRyYW5zYWN0aW9uYWxseSB3aGVyZSB0aGUgaWRlbnRpdHkgc3RpbGwgbWF0Y2hlcy4gRG8gbm90IGF1dG8tbWVyZ2Ugb3BhcXVlIGlkZW50aXRpZXMuCgojIyMgNS4gRXhwbGljaXQgYW5kIHZlcmlmaWFibGUgcG9ydGFibGUgc3luYwoKYGFjY291bnRzIHN5bmMgPGFjY291bnQ+IDxkZXZpY2U+YCBhcHBsaWVzIG9ubHkgdG8gcHJvdmlkZXIgYWNjb3VudHMuIFRoZSBkZXN0aW5hdGlvbiBpbXBvcnQgaXMgb25lIGF0b21pYyB0cmFuc2FjdGlvbiB3aXRoIHJvbGxiYWNrIGFuZCByZWFkLWJhY2sgdmVyaWZpY2F0aW9uLiBUcmFuc3BvcnQgcmVxdWlyZW1lbnRzOgoKLSBwaW5uZWQgbWFuYWdlZCBTU0ggaG9zdCBrZXk7IHJlamVjdCB1bmtub3duIG9yIGNoYW5nZWQga2V5czsKLSBubyBTU0ggbXVsdGlwbGV4IHJldXNlIGZvciB0aGUgY3JlZGVudGlhbCB0cmFuc2ZlcjsKLSBzZWNyZXQgYnl0ZXMgb25seSBvbiBzdGRpbiwgbmV2ZXIgYXJndiwgZW52aXJvbm1lbnQsIGxvZ3MsIG9yIGNvbmZpZzsKLSBubyBwZXJzaXN0ZW50IHBsYWludGV4dCBvciByZXVzYWJsZSBzZWNyZXQgZmluZ2VycHJpbnQ7Ci0gc2FtZSBuYW1lIHdpdGggYSBkaWZmZXJlbnQgc3RhYmxlIGFjY291bnQgSUQgZmFpbHMgdW5sZXNzIGV4cGxpY2l0bHkgZm9yY2VkOwotIG1hY09TIHVzZXMgYSBzaWxlbnQsIG5vbi1iaW9tZXRyaWMgS2V5Y2hhaW4gaXRlbTsgTGludXggdXNlcyB0aGUgZW5jcnlwdGVkIGZpbGUgYmFja2VuZDsgV2luZG93cyB1c2VzIENyZWRlbnRpYWwgTWFuYWdlci4KClN5bmMgcHJvdmlzaW9ucyB0aGUgc2FtZSBsb2dpY2FsIGFjY291bnQgSUQgb24gYW5vdGhlciBkZXZpY2UuIEF0dGFjaGluZyBvbmUgYWNjb3VudCB0byBzZXZlcmFsIGhhcm5lc3NlcyBkb2VzIG5vdCBjbG9uZSBpdCBpbnRvIHNldmVyYWwgbG9naWNhbCBhY2NvdW50cy4KCiMjIyA2LiBObyBUb3VjaCBJRCBub2lzZSBpbiBub3JtYWwgb3BlcmF0aW9uCgpOb3JtYWwgYGFjY291bnRzYCwgYHZpZXdgLCByb3V0aW5nLCBhdHRhY2htZW50IHZhbGlkYXRpb24sIGFuZCB1c2FnZSBpbnNwZWN0aW9uIHJlYWQgb25seSBuYXRpdmUgbWV0YWRhdGEgb3IgcHJvdmlkZXIgYnVuZGxlIG1ldGFkYXRhLiBUaGV5IG5ldmVyIHJlYWQgbmF0aXZlIE9BdXRoIHNlY3JldHMuIFByb3ZpZGVyIGFjY291bnRzIHVzZSBub24tYmlvbWV0cmljIHNlY3JldCBwb2xpY3ksIHNvIGhlYWRsZXNzIGV4ZWN1dGlvbiBkb2VzIG5vdCB0cmlnZ2VyIFRvdWNoIElELiBBIHNlY3JldCByZWFkIG9jY3VycyBvbmx5IHdoZW4gbGF1bmNoaW5nIGEgaGFybmVzcyB0aGF0IHJlcXVpcmVzIHRoZSBzZWxlY3RlZCBwb3J0YWJsZSBjcmVkZW50aWFsIG9yIGR1cmluZyBleHBsaWNpdCBzeW5jLgoKIyMgUGxhbgoKLSBbIF0gQWRkIG5hdGl2ZSBhY2NvdW50IG1ldGFkYXRhIGFuZCBiaW5kaW5nIHNjaGVtYTsgbWlncmF0ZSBtYXRjaGluZyBhcmNoaXZlZCBsYWJlbHMuCi0gWyBdIFJlcGxhY2UgcmVsYXRpb25zaGlwIGZsYWdzIHdpdGggcG9zaXRpb25hbCBgbmFtZWAsIGBhdHRhY2hgLCBgZGV0YWNoYCwgYHZpZXdgLCBhbmQgYHN5bmNgIGdyYW1tYXJzIHBsdXMgd29ya2Zsb3ctZmlyc3QgaGVscC4KLSBbIF0gQWRkIHRoZSBjYXBhYmlsaXR5IHJlZ2lzdHJ5IGFuZCBpZGVudGl0eSB2YWxpZGF0aW9uIGZvciBldmVyeSBzdXBwb3J0ZWQgbmF0aXZlIGhhcm5lc3MuCi0gWyBdIFJvdXRlIGN1c3RvbSBoYXJuZXNzZXMsIG5hdGl2ZSBpbnN0YWxsYXRpb25zLCBkaXJlY3QgcnVucywgcm91dGluZXMsIHRlYW1zLCBhbmQgU1NIIGRpc3BhdGNoIHRocm91Z2ggb25lIGFjY291bnQgcmVzb2x2ZXIuCi0gWyBdIFJlbmRlciBuYW1lcywgY3VzdG9keSwgYXZhaWxhYmlsaXR5LCBhbmQgYmluZGluZ3MgY29uc2lzdGVudGx5IGluIHRleHQgYW5kIEpTT04uCi0gWyBdIFJlbW92ZSBvcmRpbmFyeSBjbG91ZC9sZWFzZSBuYXRpdmUgT0F1dGggZXhwb3J0IGFuZCBlbmZvcmNlIGRldmljZS1sb2NhbCBlcnJvcnMuCi0gWyBdIEhhcmRlbiBwcm92aWRlciBzeW5jIHdpdGggcGlubmVkIGhvc3RzLCBhdG9taWMgaW1wb3J0LCByb2xsYmFjaywgYW5kIGVxdWFsaXR5IHZlcmlmaWNhdGlvbi4KLSBbIF0gVXBkYXRlIENMSSBkb2NzLCBzcGVjaWZpY2F0aW9ucywgUkVBRE1FLCBDSEFOR0VMT0csIGFuZCBhdWRpdCBjb21wYW5pb24gYC5hZ2VudHMtc3lzdGVtYCBjb25zdW1lcnMuCi0gWyBdIFJ1biBmb2N1c2VkIGFjY291bnQgdGVzdHMsIGZ1bGwgcmVtb3RlIHRlc3RzLCBhbmQgaW5zdGFsbGVkLUNMSSBFMkUgb24gbWFjT1MsIExpbnV4LCBhbmQgV2luZG93cyBjcmVkZW50aWFsIGJhY2tlbmRzLgoKIyMgVmFsaWRhdGlvbgoKfCBTY2VuYXJpbyB8IFJlcXVpcmVkIHJlc3VsdCB8CnwgLS0tIHwgLS0tIHwKfCBOYW1lIENsYXVkZSBsb2dpbiB8IGBhY2NvdW50cyB2aWV3IHdvcmtgIGFuZCBgYWdlbnRzIHZpZXcgY2xhdWRlYCBzaG93IGB3b3JrIMK3IGVtYWlsYCB8CnwgQXR0YWNoIG5hdGl2ZSBhbGlhcyB0byBtYXRjaGluZyBsb2dpbiB8IEJpbmRpbmcgc3VjY2VlZHMgd2l0aG91dCByZWFkaW5nIG9yIGNvcHlpbmcgT0F1dGggc2VjcmV0cyB8CnwgQXR0YWNoIG5hdGl2ZSBhbGlhcyB0byBkaWZmZXJlbnQgaWRlbnRpdHkgfCBOb256ZXJvIGVycm9yIG5hbWVzIGJvdGggaWRlbnRpdGllczsgbm8gc3RhdGUgY2hhbmdlcyB8CnwgQXR0YWNoIHByb3ZpZGVyIHRvIENvZGV4L0N1cnNvci9jdXN0b20gaGFybmVzcyB8IEVhY2ggaW5zdGFsbGVkIHRhcmdldCByZXNvbHZlcyB0aGUgc2FtZSBzdGFibGUgcHJvdmlkZXIgYWNjb3VudCB8CnwgTm9ybWFsIHZpZXcvcm91dGluZyB8IE5vIGJpb21ldHJpYyBwcm9tcHQgYW5kIG5vIG5hdGl2ZSBzZWNyZXQgYWNjZXNzIHwKfCBSZW1vdGUgcnVuIHwgRGVzdGluYXRpb24gcmVzb2x2ZXMgdGhlIGFjY291bnQgbG9jYWxseTsgbm8gaW1wbGljaXQgc2VjcmV0IHRyYW5zZmVyIHwKfCBFeHBsaWNpdCBwcm92aWRlciBzeW5jIHwgQXRvbWljIGRlc3RpbmF0aW9uIGltcG9ydCB2ZXJpZmllcyBhbmQgcmVwb3J0cyBhdmFpbGFiaWxpdHkgb24gYm90aCBkZXZpY2VzIHwKfCBOYXRpdmUgc3luYyBhdHRlbXB0IHwgUmVmdXNlZCB3aXRoIGBuYXRpdmUgbG9naW4gY3JlZGVudGlhbHMgcmVtYWluIG93bmVkIGJ5IDxoYXJuZXNzPmAgfAp8IFVuc3VwcG9ydGVkIGhhcm5lc3MgfCBDbGVhciBub256ZXJvIGNhcGFiaWxpdHkgZXJyb3IsIG5ldmVyIGEgc2lsZW50IG5vLW9wIHwKCmBgYGJhc2gKY2QgYXBwcy9jbGkKLi9zY3JpcHRzL2J1aWxkLnNoIC0tc2tpcC10ZXN0cwpidW4gcnVuIHRlc3Q6cmVtb3RlCmFnZW50cyBhY2NvdW50cyBuYW1lIGNsYXVkZUAyLjEuMjIwIHdvcmsKYWdlbnRzIGFjY291bnRzIGF0dGFjaCB3b3JrIGNsYXVkZUAyLjEuMjI1CmFnZW50cyBhY2NvdW50cyB2aWV3IHdvcmsgLS1qc29uCmFnZW50cyB2aWV3IGNsYXVkZQpgYGAKCiMjIFJpc2tzCgp8IFJpc2sgfCBIYW5kbGluZyB8CnwgLS0tIHwgLS0tIHwKfCBBIGxhYmVsIHBvaW50cyBhdCB0aGUgd3JvbmcgaHVtYW4gaWRlbnRpdHkgfCBCaW5kIGJ5IHN0YWJsZSBmaW5nZXJwcmludDsgbmV2ZXIgZW1haWwgdGV4dCBhbG9uZTsgb3BhcXVlIGlkZW50aXRpZXMgZG8gbm90IGF1dG8tbWVyZ2UgfAp8IEN1cnNvciBpc29sYXRpb24gaXMgb3ZlcnN0YXRlZCB8IE1hcmsgQ3Vyc29yIGRldmljZS1zY29wZWQgdW50aWwgaXRzIHJ1bnRpbWUgYmVoYXZpb3IgaXMgY29ycmVjdGVkIGFuZCB2ZXJpZmllZCB8CnwgUmVtb3ZpbmcgYC0tZnJvbWAgLyBgLS10b2AgYnJlYWtzIHVucmVsZWFzZWQgZXhhbXBsZXMgfCBDaGFuZ2UgY29kZSwgaGVscCwgZG9jcywgYW5kIGNvbXBhbmlvbiBndWlkYW5jZSB0b2dldGhlcjsgZG8gbm90IGFkZCBhIGNvbXBhdGliaWxpdHkgc2hpbSB1bmxlc3MgYSBzaGlwcGVkIHZlcnNpb24gcmVxdWlyZXMgaXQgfAp8IEFjY291bnQgcmVtb3ZhbCBsZWF2ZXMgZGFuZ2xpbmcgY29uc3VtZXJzIHwgUmVmdXNlIHJlbW92YWwgd2hpbGUgYmluZGluZ3MsIGRlZmF1bHRzLCBwcm9maWxlcywgaGFybmVzc2VzLCBvciByb3V0aW5lcyByZWZlcmVuY2UgdGhlIElEIHwKfCBTeW5jIGV4cG9zZXMgYSByZXVzYWJsZSBjcmVkZW50aWFsIHwgRXhwbGljaXQgY29tbWFuZCBvbmx5LCBwaW5uZWQgdHJhbnNwb3J0LCBzdGRpbi1vbmx5IGF0b21pYyBpbXBvcnQsIG5vIG5hdGl2ZSBPQXV0aCBwYXRoIHwKfCBQcm92aWRlciBhZGFwdGVyIGNsYWltcyBleGNlZWQgcmVhbCBzdXBwb3J0IHwgUmVnaXN0cnkgY29tcGxldGVuZXNzIHRlc3RzIHBpbiBldmVyeSBzdXBwb3J0ZWQgcGFpciBhbmQgcmVxdWlyZSBjbGVhciB1bnN1cHBvcnRlZCBlcnJvcnMgfAoKIyMgVHJhY2tpbmcKClRoZSBpbXBsZW1lbnRhdGlvbiBzaG91bGQgdXNlIG9uZSBhY2NvdW50LXVuaWZpY2F0aW9uIHRpY2tldCBhbmQgbGluayB0aGlzIHJlbmRlcmVkIHBsYW4gZnJvbSB0aGF0IHRpY2tldC4gQW55IHByZXJlcXVpc2l0ZSBoYXJuZXNzIGluc3BlY3RvciB3b3JrIHNob3VsZCBiZSBhIGxpbmtlZCBzdWJ0YXNrIGFuZCByZWZlcmVuY2VkIGJhY2sgaGVyZSBiZWZvcmUgaW1wbGVtZW50YXRpb24gYmVnaW5zLgoKIyMgRGVsdGEgU3BlYwoKLSBBY2NvdW50IG5hbWVzIE1VU1QgYmUgdW5pcXVlIGFjcm9zcyBuYXRpdmUgYW5kIHByb3ZpZGVyIGFjY291bnRzIGFuZCBNVVNUIHJlc29sdmUgdGhyb3VnaCBzdGFibGUgSURzLgotIGBhY2NvdW50cyBuYW1lIDxzb3VyY2U+IDxuYW1lPmAgTVVTVCBjcmVhdGUgb25seSBuYXRpdmUgbWV0YWRhdGEgYW5kIE1VU1QgTk9UIHJlYWQgb3Igc3RvcmUgbmF0aXZlIE9BdXRoIGNyZWRlbnRpYWxzLgotIGBhY2NvdW50cyBhdHRhY2ggPGFjY291bnQ+IDx0YXJnZXQ+YCBNVVNUIHVzZSBwb3NpdGlvbmFsIGFyZ3VtZW50cyBhbmQgTVVTVCB2YWxpZGF0ZSBjb21wYXRpYmlsaXR5IGJlZm9yZSBjaGFuZ2luZyBiaW5kaW5ncy4KLSBBIG5hdGl2ZSBhdHRhY2htZW50IE1VU1QgcmVmZXJlbmNlIGEgaGFybmVzcy1vd25lZCBsb2dpbiBhbHJlYWR5IHByZXNlbnQgYXQgdGhlIHRhcmdldCBzY29wZTsgaXQgTVVTVCBOT1QgbWlncmF0ZSBjcmVkZW50aWFscy4KLSBBIHByb3ZpZGVyIGF0dGFjaG1lbnQgTUFZIGJpbmQgb25lIHBvcnRhYmxlIGFjY291bnQgdG8gbXVsdGlwbGUgY29tcGF0aWJsZSBuYXRpdmUgaW5zdGFsbGF0aW9ucyBhbmQgY3VzdG9tIGhhcm5lc3Nlcy4KLSBOb3JtYWwgaW5zcGVjdGlvbiwgcm91dGluZywgYW5kIHN0YXR1cyBjb21tYW5kcyBNVVNUIE5PVCB0cmlnZ2VyIGJpb21ldHJpYyBwcm9tcHRzLgotIFBvcnRhYmxlIGNyZWRlbnRpYWwgc3luYyBNVVNUIGJlIGV4cGxpY2l0LCBkZXN0aW5hdGlvbi1hdXRoZW50aWNhdGVkLCBhdG9taWMsIHJvbGxiYWNrLXNhZmUsIGFuZCB2ZXJpZmlhYmxlIHdpdGhvdXQgcGVyc2lzdGluZyBwbGFpbnRleHQuCi0gUmVtb3RlIGV4ZWN1dGlvbiBNVVNUIHJlc29sdmUgdGhlIGFjY291bnQgb24gdGhlIGRlc3RpbmF0aW9uLiBJdCBNVVNUIE5PVCB0cmFuc2ZlciBjcmVkZW50aWFscyBpbXBsaWNpdGx5LgotIFRleHQgYW5kIEpTT04gYWNjb3VudCByZW5kZXJlcnMgTVVTVCBleHBvc2UgdGhlIHNhbWUgYWNjb3VudCBpZGVudGl0eSwgY3VzdG9keSwgYXZhaWxhYmlsaXR5LCBhbmQgYmluZGluZyBmYWN0cy4KLSBVbnN1cHBvcnRlZCBoYXJuZXNzIG9yIHByb3ZpZGVyIGNvbWJpbmF0aW9ucyBNVVNUIGZhaWwgbm9uemVybyB3aXRoIHRoZSBtaXNzaW5nIGNhcGFiaWxpdHkgbmFtZWQuCg=="}</script>
+<script>
+(() => {
+  const root = document.documentElement;
+  const button = document.querySelector('.theme-toggle');
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  const configured = "system";
+  const stored = () => { try { const value = localStorage.getItem('artifacts-theme'); return value === 'light' || value === 'dark' ? value : null; } catch { return null; } };
+  const preferred = () => stored() || (configured === 'system' ? (media.matches ? 'dark' : 'light') : configured);
+  const apply = (theme, persist) => {
+    root.dataset.theme = theme;
+    root.style.colorScheme = theme;
+    const next = theme === 'dark' ? 'light' : 'dark';
+    button.setAttribute('aria-label', 'Switch to ' + next + ' theme');
+    button.setAttribute('title', 'Switch to ' + next + ' theme');
+    button.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+    if (persist) { try { localStorage.setItem('artifacts-theme', theme); } catch {} }
+  };
+  apply(preferred(), false);
+  button.addEventListener('click', () => apply(root.dataset.theme === 'dark' ? 'light' : 'dark', true));
+  media.addEventListener('change', () => { if (configured === 'system' && !stored()) apply(media.matches ? 'dark' : 'light', false); });
+})();
+</script>
+</body>
+</html>

--- a/.agents/artifacts/2026-08-10/plan-unified-accounts.md
+++ b/.agents/artifacts/2026-08-10/plan-unified-accounts.md
@@ -1,0 +1,303 @@
+---
+kind: plan
+template: plan.v1
+surface: cli
+title: Unify native logins and provider credentials as named accounts
+summary: Give native OAuth identities and portable provider credentials one account catalog, then bind named accounts to native installations and custom harnesses with positional commands. Native OAuth remains owned by each harness and never enters the agents-cli keychain; portable secrets move only through an explicit, verified sync operation.
+status: awaiting-go
+tracking: "Account unification follow-up"
+project: agents-cli
+repository: phnx-labs/agents-cli
+branch: main
+harness: codex
+agent: Codex
+human: Muqsit
+host: yosemite-s0
+session: 019fdef4
+date: '2026-08-10'
+facts:
+  - Provider accounts already use canonical secrets bundles with stable UUIDs and policy never.
+  - Native identities are currently discovered read-only and labels are not rendered in agents view.
+  - Direct run, routines, custom harnesses, native installations, and fleet sync do not yet share one account resolver.
+---
+
+# Unify native logins and provider credentials as named accounts
+
+## Focus for review
+
+- Is the positional grammar natural: `name <source> <name>` and `attach <account> <target>`?
+- Should a native OAuth alias be attachable only where that same harness-owned login already exists? This plan says yes.
+- Should portable provider credentials be copied only by an explicit `accounts sync` command? This plan says yes.
+
+## Intent
+
+Manage a Claude, Codex, Cursor, or other native login separately from the installed CLI version, give it a memorable name such as `work`, and connect it to one or more installations. Use the same model for OpenRouter, DeepInfra, and other API-key or long-lived-token providers without making native OAuth credentials pass through agents-cli storage.
+
+<div class="artifact-callout"><strong>Core rule:</strong> an account is a named identity. A native account stores only identity metadata and a binding to a harness-owned login. A provider account stores a portable credential in the existing secrets backend. Attaching never copies a native OAuth token.</div>
+
+## Current architecture
+
+<section class="artifact-grid artifact-grid-2">
+<article class="artifact-panel" data-state="current" data-evidence="capture">
+<figcaption><strong>Current:</strong> the name command reports success, but <code>agents view</code> still shows only the email and version.</figcaption>
+
+```text
+$ agents accounts name work --from claude@2.1.220
+Named the claude account 'work'.
+
+$ agents view claude
+2.1.220  default  user@example.com
+```
+</article>
+
+<article class="artifact-panel" data-state="proposed" data-evidence="mockup">
+<figcaption><strong>Proposed:</strong> the source and target are positional, and the name is visible everywhere the identity appears.</figcaption>
+
+```text
+$ agents accounts name claude@2.1.220 work
+Named claude@2.1.220 as work.
+
+$ agents accounts attach work claude@2.1.225
+Attached work to claude@2.1.225.
+
+$ agents view claude
+2.1.225  opus[1m]  work · user@example.com  Max
+2.1.220  default   work · user@example.com  Max
+```
+</article>
+</section>
+
+<figure class="artifact-figure artifact-figure-diagram artifact-figure-wide">
+<svg class="artifact-diagram" viewBox="0 0 1040 350" role="img" aria-labelledby="account-title account-desc" xmlns="http://www.w3.org/2000/svg">
+  <title id="account-title">Unified account catalog and binding flow</title>
+  <desc id="account-desc">Native aliases point to harness-owned OAuth state while provider accounts point to portable secret bundles. Both resolve through bindings to installations and custom harnesses.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#a3e635"/></marker>
+  </defs>
+  <text x="30" y="28" fill="#a3e635" font-family="Inter,system-ui" font-size="14" font-weight="700">ACCOUNT CATALOG</text>
+  <rect x="30" y="48" width="260" height="105" rx="12" fill="#111827" stroke="#a3e635" stroke-width="2"/><text x="50" y="79" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">native · work</text><text x="50" y="104" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">identity fingerprint + label</text><text x="50" y="128" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">secret stays in Claude/Codex/Cursor</text>
+  <rect x="30" y="190" width="260" height="105" rx="12" fill="#111827" stroke="#a3e635" stroke-width="2"/><text x="50" y="221" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">provider · openrouter-work</text><text x="50" y="246" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">provider + auth type + stable UUID</text><text x="50" y="270" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">secret bundle, policy never</text>
+  <path d="M290 100H405" stroke="#a3e635" stroke-width="3" fill="none" marker-end="url(#arrow)"/><path d="M290 242H405" stroke="#a3e635" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+  <text x="420" y="28" fill="#a3e635" font-family="Inter,system-ui" font-size="14" font-weight="700">BINDINGS</text>
+  <rect x="405" y="48" width="260" height="247" rx="12" fill="#111827" stroke="#475569" stroke-width="2"/><text x="430" y="84" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">work → claude@2.1.220</text><text x="430" y="121" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">work → claude@2.1.225</text><text x="430" y="176" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">openrouter-work → codex@0.145.0</text><text x="430" y="213" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">openrouter-work → cursor@latest</text><text x="430" y="268" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">openrouter-work → deepseek</text>
+  <path d="M665 170H780" stroke="#a3e635" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+  <text x="795" y="28" fill="#a3e635" font-family="Inter,system-ui" font-size="14" font-weight="700">EXECUTION</text>
+  <rect x="780" y="48" width="230" height="247" rx="12" fill="#111827" stroke="#475569" stroke-width="2"/><text x="805" y="92" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">native installation</text><text x="805" y="120" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">validate existing login</text><text x="805" y="166" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">custom harness</text><text x="805" y="194" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">inject provider credential</text><text x="805" y="240" fill="#f8fafc" font-family="Inter,system-ui" font-size="15">remote fleet run</text><text x="805" y="268" fill="#cbd5e1" font-family="Inter,system-ui" font-size="12">resolve account on target</text>
+</svg>
+<figcaption>One catalog and one resolver, with different custody rules for native and portable credentials.</figcaption>
+</figure>
+
+## Purpose
+
+The existing account work has two disconnected concepts. Provider credentials are durable account bundles, while native OAuth identities are read-only discovery rows. The old label path records a label outside the rendered catalog, so `agents view` cannot show it. Account selection also differs between direct runs, routines, custom harnesses, and remote dispatch.
+
+The change standardizes the user model without pretending every harness supports the same authentication mechanics.
+
+## Public Interface
+
+### Command grammar
+
+| Intent | Command | Meaning |
+| --- | --- | --- |
+| Name a discovered native login | `agents accounts name claude@2.1.220 work` | Create or update native account `work` from the login found in that installation |
+| Add a portable provider credential | `agents accounts add openrouter-work --provider openrouter --auth api-key` | Create provider account and securely prompt for its key |
+| Attach an account | `agents accounts attach work claude@2.1.225` | Bind the named account to an exact native installation |
+| Attach to a custom harness | `agents accounts attach openrouter-work deepseek` | Bind the provider account to the named custom harness |
+| Detach | `agents accounts detach work claude@2.1.225` | Remove exactly that binding |
+| Inspect | `agents accounts view work` | Show identity metadata, credential custody, bindings, and availability |
+| Rename | `agents accounts rename work rush-work` | Rename the account while retaining its stable ID and bindings |
+| Remove | `agents accounts remove rush-work` | Refuse while bindings/defaults still reference it; explain how to detach |
+| Copy portable credentials | `agents accounts sync openrouter-work zion` | Explicitly provision the same stable provider account on another device |
+
+`--from` and `--to` are removed from the proposed API. Flags remain for optional attributes and behavior, such as `--provider`, `--auth`, `--json`, `--force`, and `--default`.
+
+### Complete happy paths
+
+Native OAuth account:
+
+```bash
+agents accounts name claude@2.1.220 work
+agents accounts attach work claude@2.1.225
+agents accounts view work
+agents run claude@2.1.225
+```
+
+Portable provider account:
+
+```bash
+agents accounts add openrouter-work --provider openrouter --auth api-key
+agents accounts attach openrouter-work codex@0.145.0
+agents accounts attach openrouter-work cursor@latest
+agents accounts attach openrouter-work deepseek
+agents accounts sync openrouter-work zion
+```
+
+### Output contract
+
+```text
+$ agents accounts view work
+work
+  kind        native login
+  identity    user@example.com
+  provider    Anthropic
+  custody     Claude Code (not stored by agents-cli)
+  scope       version
+  available   yes
+  attached    claude@2.1.220, claude@2.1.225
+```
+
+```text
+$ agents accounts view openrouter-work
+openrouter-work
+  kind        provider credential
+  provider    OpenRouter
+  auth        API key
+  custody     agents secrets (no biometric ACL)
+  available   this device, zion
+  attached    codex@0.145.0, cursor@latest, deepseek
+```
+
+Every human-readable account row uses `name · identity` when both exist. Every command that emits account data supports `--json` and returns the stable account ID, kind, display name, identity metadata, custody, availability, and bindings.
+
+## Proposed Changes
+
+### 1. One typed catalog, two credential custody models
+
+Extend the existing account registry rather than add a second store:
+
+```ts
+type Account =
+  | {
+      id: string;
+      name: string;
+      kind: "native";
+      agent: AgentId;
+      identityKey: string;
+      identityLabel?: string;
+      authScope: "version" | "device";
+    }
+  | {
+      id: string;
+      name: string;
+      kind: "provider";
+      provider: AccountProviderId;
+      authType: "api-key" | "token";
+      bundle: string;
+    };
+
+type AccountBinding = {
+  accountId: string;
+  target: string;
+};
+```
+
+Native records contain no OAuth access token, refresh token, auth file, or keychain reference. Provider records continue to use the canonical secrets bundle with stable UUID and `policy: never`.
+
+### 2. One target parser and resolver
+
+Parse the second positional argument into either an exact native installation (`claude@2.1.225`, `codex@0.145.0`, `cursor@latest`) or a custom harness (`deepseek`). Resolve accounts in this order:
+
+1. explicit run account;
+2. exact target binding;
+3. bare-agent default;
+4. current native or balanced selection.
+
+The same resolver is used by direct runs, routines, teams, local dispatch, and remote fleet dispatch. Cloud/lease runs fail clearly for device-local native accounts. They do not export native OAuth automatically.
+
+### 3. Capability registry keeps harness claims truthful
+
+| Capability | Harnesses / handling |
+| --- | --- |
+| Version-scoped native identity | Claude, Codex, Grok; Muse when identity inspection is strong |
+| Device-scoped native identity | Cursor after correcting false XDG isolation; Antigravity, Kimi, Droid, OpenCode where their auth is device-global |
+| Requires inspector work before attach | Copilot |
+| Discovery only / legacy | Gemini |
+| Unsupported until modeled | Pi, OpenClaw, Amp, Kiro, Goose, Hermes, Warp |
+| Portable provider credential | Registry-driven adapters only; unsupported provider/harness pairs fail loud |
+
+For a native account, `attach` validates that the target already exposes the same identity fingerprint. It never logs in, copies, or rewrites OAuth state. A device-scoped harness rejects an exact-version attachment and explains that the account applies to the device.
+
+### 4. Labels render everywhere
+
+Use one account renderer in `accounts`, `agents view`, `harness view`, run banners, pickers, routines, and fleet inventory. Recover archived fingerprint labels transactionally where the identity still matches. Do not auto-merge opaque identities.
+
+### 5. Explicit and verifiable portable sync
+
+`accounts sync <account> <device>` applies only to provider accounts. The destination import is one atomic transaction with rollback and read-back verification. Transport requirements:
+
+- pinned managed SSH host key; reject unknown or changed keys;
+- no SSH multiplex reuse for the credential transfer;
+- secret bytes only on stdin, never argv, environment, logs, or config;
+- no persistent plaintext or reusable secret fingerprint;
+- same name with a different stable account ID fails unless explicitly forced;
+- macOS uses a silent, non-biometric Keychain item; Linux uses the encrypted file backend; Windows uses Credential Manager.
+
+Sync provisions the same logical account ID on another device. Attaching one account to several harnesses does not clone it into several logical accounts.
+
+### 6. No Touch ID noise in normal operation
+
+Normal `accounts`, `view`, routing, attachment validation, and usage inspection read only native metadata or provider bundle metadata. They never read native OAuth secrets. Provider accounts use non-biometric secret policy, so headless execution does not trigger Touch ID. A secret read occurs only when launching a harness that requires the selected portable credential or during explicit sync.
+
+## Plan
+
+- [ ] Add native account metadata and binding schema; migrate matching archived labels.
+- [ ] Replace relationship flags with positional `name`, `attach`, `detach`, `view`, and `sync` grammars plus workflow-first help.
+- [ ] Add the capability registry and identity validation for every supported native harness.
+- [ ] Route custom harnesses, native installations, direct runs, routines, teams, and SSH dispatch through one account resolver.
+- [ ] Render names, custody, availability, and bindings consistently in text and JSON.
+- [ ] Remove ordinary cloud/lease native OAuth export and enforce device-local errors.
+- [ ] Harden provider sync with pinned hosts, atomic import, rollback, and equality verification.
+- [ ] Update CLI docs, specifications, README, CHANGELOG, and audit companion `.agents-system` consumers.
+- [ ] Run focused account tests, full remote tests, and installed-CLI E2E on macOS, Linux, and Windows credential backends.
+
+## Validation
+
+| Scenario | Required result |
+| --- | --- |
+| Name Claude login | `accounts view work` and `agents view claude` show `work · email` |
+| Attach native alias to matching login | Binding succeeds without reading or copying OAuth secrets |
+| Attach native alias to different identity | Nonzero error names both identities; no state changes |
+| Attach provider to Codex/Cursor/custom harness | Each installed target resolves the same stable provider account |
+| Normal view/routing | No biometric prompt and no native secret access |
+| Remote run | Destination resolves the account locally; no implicit secret transfer |
+| Explicit provider sync | Atomic destination import verifies and reports availability on both devices |
+| Native sync attempt | Refused with `native login credentials remain owned by <harness>` |
+| Unsupported harness | Clear nonzero capability error, never a silent no-op |
+
+```bash
+cd apps/cli
+./scripts/build.sh --skip-tests
+bun run test:remote
+agents accounts name claude@2.1.220 work
+agents accounts attach work claude@2.1.225
+agents accounts view work --json
+agents view claude
+```
+
+## Risks
+
+| Risk | Handling |
+| --- | --- |
+| A label points at the wrong human identity | Bind by stable fingerprint; never email text alone; opaque identities do not auto-merge |
+| Cursor isolation is overstated | Mark Cursor device-scoped until its runtime behavior is corrected and verified |
+| Removing `--from` / `--to` breaks unreleased examples | Change code, help, docs, and companion guidance together; do not add a compatibility shim unless a shipped version requires it |
+| Account removal leaves dangling consumers | Refuse removal while bindings, defaults, profiles, harnesses, or routines reference the ID |
+| Sync exposes a reusable credential | Explicit command only, pinned transport, stdin-only atomic import, no native OAuth path |
+| Provider adapter claims exceed real support | Registry completeness tests pin every supported pair and require clear unsupported errors |
+
+## Tracking
+
+The implementation should use one account-unification ticket and link this rendered plan from that ticket. Any prerequisite harness inspector work should be a linked subtask and referenced back here before implementation begins.
+
+## Delta Spec
+
+- Account names MUST be unique across native and provider accounts and MUST resolve through stable IDs.
+- `accounts name <source> <name>` MUST create only native metadata and MUST NOT read or store native OAuth credentials.
+- `accounts attach <account> <target>` MUST use positional arguments and MUST validate compatibility before changing bindings.
+- A native attachment MUST reference a harness-owned login already present at the target scope; it MUST NOT migrate credentials.
+- A provider attachment MAY bind one portable account to multiple compatible native installations and custom harnesses.
+- Normal inspection, routing, and status commands MUST NOT trigger biometric prompts.
+- Portable credential sync MUST be explicit, destination-authenticated, atomic, rollback-safe, and verifiable without persisting plaintext.
+- Remote execution MUST resolve the account on the destination. It MUST NOT transfer credentials implicitly.
+- Text and JSON account renderers MUST expose the same account identity, custody, availability, and binding facts.
+- Unsupported harness or provider combinations MUST fail nonzero with the missing capability named.


### PR DESCRIPTION
**Docs-only — no code, no CLI surface.** Two follow-ups to the `.agents/artifacts` consolidation, both found by scanning what actually landed on `main` rather than trusting the merge.

## 1. Real home paths were already committed to `main`

Sibling sessions landed artifacts carrying absolute home paths into a public repo. `AGENTS.md` asks for this scrub before a file lands, but these branches predate anyone reading it:

| File | Leak |
|---|---|
| `2026-08-10/plan-dev-install-no-shadow.{md,html}` | `/home/muqsit` ×8 each |
| `2026-08-10/plan-project-dirs.{md,html}` | `/Users/muqsit` |

Redacted to `/home/you` / `/Users/you`, the convention already used across the consolidated artifacts.

## 2. Four plans were stranded untracked

`plan-events-one-engine.{md,html}` and `plan-unified-accounts.{md,html}` sat untracked in the working tree since 04:33–07:02 today. They were already in the correct dated directory — they were untracked only because `.agents/artifacts/` stopped being gitignored *after* their sessions wrote them. `plan-unified-accounts` named a real account in a pasted `agents view claude` block; now `user@example.com`.

## Verification

A scan across **every** committed file under `.agents/artifacts/` for `/home/muqsit`, `/Users/muqsit`, and `@getrush.ai|@gmail.com|@prix.dev|@icloud.com|@swarmify.co` returns nothing after this change. Before it, the four files above matched.

The only remaining matches are two `.png` binaries under `2026-08-03/harness-first-class/`, which grep can't read — one of those was redacted in-image in #2465 and both were reviewed visually then.

## Related

This is the content half of the same drift #2576 fixes structurally. #2576 stops the retired *directories* coming back; nothing yet stops an artifact landing with a home path in it. That gap is worth a follow-up guard, but it needs a scan that tolerates false positives (a doc legitimately discussing `/home/<user>` paths), so it is not folded in here.
