### PR TITLE
feat(usage): fleet primary publisher/subscriber usage refresh

### DIFF
--- a/apps/cli/.changelog/next/usage-primary-runtime.md
+++ b/apps/cli/.changelog/next/usage-primary-runtime.md
@@ -1,0 +1,1 @@
+- **Fleet usage primary runtime.** When `usage.primary-host` (or `interactive.host`) is set, only that device runs frequent live usage API refreshes; peers pull a token-free snapshot. Standalone mode keeps per-host refresh when no pin is set.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.22.36
 
+- **One configured host now owns fleet usage refreshes.** When
+  `usage.primary-host` is set, that daemon alone calls usage providers and
+  publishes derived usage windows plus routing headroom. Every other host imports
+  the primary's cache over the registered SSH path; the export schema contains no
+  credentials, access tokens, refresh tokens, or authorization headers. With no
+  configured primary, the existing local refresh behavior is unchanged. Source:
+  `apps/cli/src/lib/daemon-ticks.ts`, `apps/cli/src/lib/usage-fleet.ts`.
+
 - **`agents cp <src> <dst>` — first-class fleet file transfer (RUSH-2297).** New
   top-level command that copies files and directories between fleet hosts
   (local-to-remote, remote-to-local, and remote-to-remote) using the same

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -227,9 +227,14 @@ Detail in [teams.md](teams.md); the SSH transport is [ssh-transport.md](ssh-tran
 Usage and auth health are exceptions to on-demand computation. The daemon starts
 one `account-state-service` per state directory: it refreshes persisted usage
 snapshots and authentication verdicts, while command and UI readers only render
-those files. Explicit `--refresh` calls use the same device-wide lease keyed by
-provider account, so separate `agents` processes cannot duplicate a provider
-request. The lease owner atomically publishes the snapshot; waiters re-read it.
+those files. When `usage.primary-host` is configured, only that host's usage tick
+calls providers. It publishes a schema-limited envelope containing usage windows
+and routing headroom; peer ticks fetch it over the registered SSH path and merge
+it into their local caches. Tokens and credentials are never exported. Without a
+pin, the prior per-host refresh behavior remains active. Explicit `--refresh`
+calls use the same device-wide lease keyed by provider account, so separate
+`agents` processes cannot duplicate a provider request. The lease owner atomically
+publishes the snapshot; waiters re-read it.
 Local-log sources such as Codex and Grok follow the same rule because a render
 loop repeatedly scanning transcripts is still duplicate collection.
 

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -2549,6 +2549,15 @@ nothing but its own view cache.
   cross-device state is limited to safe account labels, auth verdicts, and usage
   snapshots. Named API-key/setup-token/bearer accounts retain device-local secret
   material and synchronized metadata.
+- **SING-1c (MUST).** When `usage.primary-host` is configured, only that host's
+  daemon usage tick MUST call usage providers. Every other host MUST import the
+  primary's derived usage windows and routing headroom without exporting or
+  copying credentials, access tokens, refresh tokens, or authorization headers.
+  The publisher/subscriber gate is `runUsageRefreshTick`
+  (`lib/daemon-ticks.ts`); the safe envelope is `UsageFleetExport`
+  (`lib/usage-fleet.ts`). Given a peer whose configured primary differs from its
+  machine id, when its usage tick runs, then no local provider refresh runs and
+  the primary envelope is merged into its usage/headroom caches.
 - **SING-2 (MUST NOT).** A UI surface (apps/ext, the menubar app, the iOS app)
   MUST NOT own a timer, watcher, or loop that detects a condition and performs a
   fleet-affecting action. Detection and decision MUST live in the CLI, which holds

--- a/apps/cli/src/lib/daemon-ticks.test.ts
+++ b/apps/cli/src/lib/daemon-ticks.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { isFreshFleetAuthSnapshot } from './daemon-ticks.js';
+import { usageRefreshRole } from './usage-fleet.js';
 
 describe('isFreshFleetAuthSnapshot', () => {
   const minimum = 1_000;
@@ -18,5 +19,16 @@ describe('isFreshFleetAuthSnapshot', () => {
     expect(isFreshFleetAuthSnapshot({ row, authRows: [] }, minimum)).toBe(false);
     expect(isFreshFleetAuthSnapshot({ row, authRows: [{ ...authRow, health: { ...authRow.health, checkedAt: minimum - 1 } }] }, minimum)).toBe(false);
     expect(isFreshFleetAuthSnapshot({ row, authRows: [authRow] }, minimum)).toBe(true);
+  });
+});
+
+describe('usage refresh publisher/subscriber gate', () => {
+  it('publishes locally when this host is primary or the pin is absent', () => {
+    expect(usageRefreshRole(undefined, 'zion')).toBe('publisher');
+    expect(usageRefreshRole('zion', 'zion')).toBe('publisher');
+  });
+
+  it('subscribes without provider refreshes when another host is primary', () => {
+    expect(usageRefreshRole('yosemite-s0', 'zion')).toBe('subscriber');
   });
 });

--- a/apps/cli/src/lib/daemon-ticks.ts
+++ b/apps/cli/src/lib/daemon-ticks.ts
@@ -70,9 +70,23 @@ export async function runFleetCacheWarmTick(): Promise<void> {
 /**
  * Usage refresh: keep the usage cache the `agents run` router reads
  * (RUSH-2061, readOnly hot path) fresh, WITHOUT the hot path ever fetching.
- * This host is the sole writer for its own local accounts.
+ * The configured primary host is the fleet's sole provider-facing writer;
+ * subscribers import its token-free derived cache.
  */
 export async function runUsageRefreshTick(): Promise<void> {
+  const { resolveUsagePrimaryHost } = await import('./device-config.js');
+  const { machineId } = await import('./machine-id.js');
+  // usage.primary-host, else interactive.host, else null (standalone local refresh)
+  const primaryHost = resolveUsagePrimaryHost() ?? undefined;
+
+  const self = machineId();
+  const { importUsageFleetFromHost, usageRefreshRole } = await import('./usage-fleet.js');
+  if (usageRefreshRole(primaryHost, self) === 'subscriber') {
+    const imported = await importUsageFleetFromHost(primaryHost!);
+    console.log(`usage refresh: imported ${Object.keys(imported.usage).length} account(s) from primary host ${primaryHost}`);
+    return;
+  }
+
   const { runUsageRefresh, buildLocalUsageAccounts } = await import('./usage-refresh.js');
   const { writeClaudeUsageCache } = await import('./usage.js');
   const { usageRateLimitedUntil } = await import('./usage-backoff.js');
@@ -84,7 +98,9 @@ export async function runUsageRefreshTick(): Promise<void> {
   const { listProfiles } = await import('./profiles.js');
   const { refreshDueByokUsage } = await import('./byok-usage.js');
   const byok = await refreshDueByokUsage(listProfiles());
+  const { exportUsageFleet } = await import('./usage-fleet.js');
+  const published = exportUsageFleet();
   console.log(
-    `usage refresh: ${r.refreshed} refreshed, ${r.failed} failed, ${r.skippedNotDue} not-due, ${r.skippedBackoff} backed-off, ${r.skippedCap} capped; BYOK ${byok.refreshed} refreshed, ${byok.skipped} not-due`,
+    `usage refresh: ${r.refreshed} refreshed, ${r.failed} failed, ${r.skippedNotDue} not-due, ${r.skippedBackoff} backed-off, ${r.skippedCap} capped; BYOK ${byok.refreshed} refreshed, ${byok.skipped} not-due; published ${Object.keys(published.usage).length} account(s)`,
   );
 }

--- a/apps/cli/src/lib/usage-fleet.test.ts
+++ b/apps/cli/src/lib/usage-fleet.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  exportUsageFleet,
+  importUsageFleet,
+  setUsageFleetExportPathForTest,
+} from './usage-fleet.js';
+import {
+  readHeadroomEntry,
+  setHeadroomCachePathForTest,
+  writeHeadroomEntries,
+  type HeadroomEntry,
+} from './usage-refresh.js';
+import {
+  readClaudeUsageCache,
+  setClaudeUsageCachePathForTest,
+  writeClaudeUsageCache,
+  type UsageSnapshot,
+} from './usage.js';
+
+const NOW = 1_800_000_000_000;
+const KEY = 'claude:org=fleet';
+
+describe('usage fleet export/import', () => {
+  let dir: string;
+  let oldUsage: string | null;
+  let oldHeadroom: string | null;
+  let oldExport: string | null;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-usage-fleet-'));
+    oldUsage = setClaudeUsageCachePathForTest(path.join(dir, 'publisher-usage.json'));
+    oldHeadroom = setHeadroomCachePathForTest(path.join(dir, 'publisher-headroom.json'));
+    oldExport = setUsageFleetExportPathForTest(path.join(dir, 'usage-fleet.json'));
+  });
+
+  afterEach(() => {
+    setClaudeUsageCachePathForTest(oldUsage);
+    setHeadroomCachePathForTest(oldHeadroom);
+    setUsageFleetExportPathForTest(oldExport);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('exports only derived usage and headroom, then imports both caches', () => {
+    const snapshot: UsageSnapshot = {
+      source: 'live',
+      sourceLabel: 'live',
+      capturedAt: new Date(NOW),
+      plan: 'max',
+      windows: [{
+        key: 'session', label: '5h', shortLabel: 'S', usedPercent: 42,
+        resetsAt: new Date(NOW + 60_000), windowMinutes: 300,
+      }],
+    };
+    const headroom: HeadroomEntry = {
+      status: 'available', minutesToLimit: 90, sessionUsedPercent: 42,
+      capturedAt: NOW, nextRefreshAt: NOW + 300_000,
+      callTimestamps: [NOW], computedAt: NOW,
+    };
+    writeClaudeUsageCache(KEY, snapshot);
+    writeHeadroomEntries({ [KEY]: headroom });
+
+    const payload = exportUsageFleet(NOW);
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toMatch(/access[_-]?token|refresh[_-]?token|authorization/i);
+    expect(payload.usage[KEY]?.windows[0]?.usedPercent).toBe(42);
+
+    setClaudeUsageCachePathForTest(path.join(dir, 'subscriber-usage.json'));
+    setHeadroomCachePathForTest(path.join(dir, 'subscriber-headroom.json'));
+    importUsageFleet(payload);
+
+    expect(readClaudeUsageCache(KEY, undefined, new Date(NOW))?.windows[0]?.usedPercent).toBe(42);
+    expect(readHeadroomEntry(KEY)?.minutesToLimit).toBe(90);
+  });
+
+  it('rejects an unsupported envelope instead of silently accepting it', () => {
+    expect(() => importUsageFleet({ version: 2, usage: {}, headroom: {}, publishedAt: NOW }))
+      .toThrow(/unsupported shape/);
+  });
+});

--- a/apps/cli/src/lib/usage-fleet.ts
+++ b/apps/cli/src/lib/usage-fleet.ts
@@ -1,0 +1,161 @@
+/**
+ * Token-free usage replication from the configured primary host.
+ *
+ * The publisher writes only the already-derived usage windows and routing
+ * headroom. Credentials, OAuth material, and provider responses never enter
+ * this envelope. Subscribers fetch that file over the existing SSH trust path
+ * and merge it into their local caches.
+ */
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+
+import { buildSshInvocation, writeAskpassShim } from './devices/connect.js';
+import { loadDevices } from './devices/registry.js';
+import { atomicWriteFileSync } from './fs-atomic.js';
+import { getCacheDir } from './state.js';
+import {
+  readHeadroomCache,
+  writeHeadroomEntries,
+  type HeadroomEntry,
+} from './usage-refresh.js';
+import {
+  readClaudeUsageCache,
+  writeClaudeUsageCache,
+  type UsageSnapshot,
+  type UsageWindow,
+} from './usage.js';
+
+export const USAGE_FLEET_VERSION = 1;
+export const USAGE_FLEET_FILE = '.usage-fleet.json';
+
+export interface UsageFleetWindow {
+  key: UsageWindow['key'];
+  label: string;
+  shortLabel: string;
+  usedPercent: number;
+  resetsAt: string | null;
+  windowMinutes: number | null;
+}
+
+export interface UsageFleetSnapshot {
+  capturedAt: string | null;
+  plan: string | null;
+  windows: UsageFleetWindow[];
+}
+
+export interface UsageFleetExport {
+  version: 1;
+  publishedAt: number;
+  usage: Record<string, UsageFleetSnapshot>;
+  headroom: Record<string, HeadroomEntry>;
+}
+
+/** Publisher/subscriber role selection, kept pure for the daemon gate test. */
+export function usageRefreshRole(primaryHost: string | undefined, self: string): 'publisher' | 'subscriber' {
+  return primaryHost && primaryHost !== self ? 'subscriber' : 'publisher';
+}
+
+let exportPathOverride: string | null = null;
+export function setUsageFleetExportPathForTest(value: string | null): string | null {
+  const previous = exportPathOverride;
+  exportPathOverride = value;
+  return previous;
+}
+
+function exportPath(): string {
+  return exportPathOverride ?? path.join(getCacheDir(), USAGE_FLEET_FILE);
+}
+
+function safeSnapshot(snapshot: UsageSnapshot): UsageFleetSnapshot {
+  return {
+    capturedAt: snapshot.capturedAt?.toISOString() ?? null,
+    plan: snapshot.plan ?? null,
+    windows: snapshot.windows.map((window) => ({
+      key: window.key,
+      label: window.label,
+      shortLabel: window.shortLabel,
+      usedPercent: window.usedPercent,
+      resetsAt: window.resetsAt?.toISOString() ?? null,
+      windowMinutes: window.windowMinutes,
+    })),
+  };
+}
+
+function liveSnapshot(snapshot: UsageFleetSnapshot): UsageSnapshot {
+  return {
+    source: 'last_seen',
+    sourceLabel: 'primary host cache',
+    capturedAt: snapshot.capturedAt ? new Date(snapshot.capturedAt) : null,
+    plan: snapshot.plan,
+    windows: snapshot.windows.map((window) => ({
+      ...window,
+      resetsAt: window.resetsAt ? new Date(window.resetsAt) : null,
+    })),
+  };
+}
+
+/** Build and persist the primary's safe cache envelope. */
+export function exportUsageFleet(now = Date.now()): UsageFleetExport {
+  const headroom = readHeadroomCache();
+  const usage: Record<string, UsageFleetSnapshot> = {};
+  for (const usageKey of Object.keys(headroom)) {
+    const snapshot = readClaudeUsageCache(usageKey);
+    if (snapshot) usage[usageKey] = safeSnapshot(snapshot);
+  }
+  const payload: UsageFleetExport = {
+    version: USAGE_FLEET_VERSION,
+    publishedAt: now,
+    usage,
+    headroom,
+  };
+  atomicWriteFileSync(exportPath(), JSON.stringify(payload, null, 2), 'utf-8');
+  return payload;
+}
+
+function isUsageFleetExport(value: unknown): value is UsageFleetExport {
+  if (!value || typeof value !== 'object') return false;
+  const payload = value as Partial<UsageFleetExport>;
+  return payload.version === USAGE_FLEET_VERSION
+    && typeof payload.publishedAt === 'number'
+    && !!payload.usage && typeof payload.usage === 'object'
+    && !!payload.headroom && typeof payload.headroom === 'object';
+}
+
+/** Merge a primary-host envelope into the subscriber's existing caches. */
+export function importUsageFleet(value: unknown): UsageFleetExport {
+  if (!isUsageFleetExport(value)) throw new Error('usage fleet export has an unsupported shape');
+  for (const [usageKey, snapshot] of Object.entries(value.usage)) {
+    writeClaudeUsageCache(usageKey, liveSnapshot(snapshot));
+  }
+  writeHeadroomEntries(value.headroom);
+  return value;
+}
+
+/** Fetch the primary's published envelope over the registered device SSH path. */
+export async function importUsageFleetFromHost(host: string): Promise<UsageFleetExport> {
+  const device = (await loadDevices())[host];
+  if (!device) throw new Error(`usage primary host '${host}' is not a registered device`);
+  const remoteRead = device.shell === 'powershell'
+    ? ['Get-Content', '-Raw', '(Join-Path $HOME \'.agents/.cache/.usage-fleet.json\')']
+    : ['cat', '"$HOME/.agents/.cache/.usage-fleet.json"'];
+  const { args, env } = buildSshInvocation(device, remoteRead, writeAskpassShim(), {}, { agentOnly: true });
+  const raw = await new Promise<string>((resolve, reject) => {
+    const child = spawn('ssh', args, {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve(stdout);
+      else reject(new Error(`usage primary host '${host}' export failed: ${stderr.trim() || `ssh exited ${code}`}`));
+    });
+  });
+  return importUsageFleet(JSON.parse(raw) as unknown);
+}

--- a/apps/cli/src/lib/usage-refresh.ts
+++ b/apps/cli/src/lib/usage-refresh.ts
@@ -1,15 +1,17 @@
 /**
- * Daemon-owned usage refresher (per host).
+ * Daemon-owned usage refresher (publisher host).
  *
  * The routing hot path (`agents run` → collectRunCandidates) reads usage
  * CACHE-ONLY (`getUsageInfoForIdentity`, RUSH-2061) and never blocks
  * on a provider fetch. Something still has to keep that cache fresh — this
- * module is that something, running inside the daemon on **each machine**.
+ * module is that something, running inside the daemon on the configured
+ * `usage.primary-host` (or locally when no primary is configured).
  *
  * Design:
  *
- *  - **Per-host sole writer.** Only accounts whose credentials live on THIS
- *    box are listed; no fleet-wide usage sync.
+ *  - **Fleet sole writer.** Only the configured primary lists credential-backed
+ *    accounts and calls providers. It exports derived snapshots/headroom;
+ *    subscriber hosts import that token-free envelope (`usage-fleet.ts`).
  *  - **Fixed 5-minute cadence** (`REFRESH_INTERVAL_MS`). Enough to keep
  *    balanced/`agents view` off multi-hour stale data without thrashing
  *    provider APIs when the user runs agents frequently. The delay helpers
@@ -224,7 +226,7 @@ export function nextHeadroomEntry(
   };
 }
 
-/** An account whose credentials live on THIS host — the only ones we refresh. */
+/** An account whose credentials live on the publisher host. */
 export interface LocalUsageAccount {
   usageKey: string;
   agentId: AgentId;
@@ -238,7 +240,7 @@ export interface LocalUsageAccount {
  * canonicalization `getUsageInfoByIdentity` uses). Each carries a closure that
  * live-fetches its usage. This is the daemon's `listAccounts`; because it only
  * ever lists local, signed-in accounts, each host is the sole writer for its own
- * accounts' caches — no cross-host coordination.
+ * accounts' caches. `runUsageRefreshTick` calls this only on the fleet publisher.
  */
 export async function buildLocalUsageAccounts(): Promise<LocalUsageAccount[]> {
   const accounts: LocalUsageAccount[] = [];


### PR DESCRIPTION
**What + type:** feature — fleet usage primary runtime (publisher/subscriber).

Depends on merged #2586 (`usage.primary-host` / `resolveUsagePrimaryHost`).

## What changed

- `runUsageRefreshTick` roles via `resolveUsagePrimaryHost()`: **publisher** (live refresh + export), **subscriber** (pull token-free snapshot), **standalone** (no pin → per-host as before).
- New `apps/cli/src/lib/usage-fleet.ts`: export/import/pull over SSH device path; **no tokens/credentials**.
- Docs (`architecture.md`, `specifications.md`) + CHANGELOG fragment.

## Operator pin (config only)

```bash
agents config set usage.primary-host zion
# or leave unset → defaults to interactive.host as primary
```

## Run proof (no UI surface)

```

 RUN  v4.1.9 /home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/usage-primary-runtime-land/apps/cli

 ✓ src/lib/daemon-ticks.test.ts (3 tests) 5ms
 ✓ src/lib/usage-fleet.test.ts (2 tests) 20ms

 Test Files  2 passed (2)
      Tests  5 passed (5)
   Start at  10:09:38
   Duration  1.27s (transform 1.62s, setup 50ms, import 2.24s, tests 25ms, environment 0ms)
```

## Test plan

- [x] vitest usage-fleet + daemon-ticks
- [ ] CI green
- [ ] Manual: primary exports; peer logs imported N accounts
