### PR TITLE
fix(sessions): close 4 live-kill gaps in the orphan reaper (RUSH-2521)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2521.md
+++ b/apps/cli/.changelog/next/RUSH-2521.md
@@ -6,18 +6,32 @@
   its session ended, and 34 orphaned `cgraph-mcp --daemon` processes on one worker.
   `agents sessions reap` and the routines daemon's 5-minute sweep now terminate those
   helpers as well as the dead panes, and `killSession` collects a session's helpers as it
-  tears the session down. A helper is attributed to its session through the
+  tears the session down. A helper is attributed to its session (tier 1) through the
   `AGENT_TMUX_SESSION_NAME` the pane exports and every descendant inherits — the one
   handle that survives reparenting — and is killed only when that session is gone, or has
-  no attached client AND its agent process has exited. A harness that detaches its
-  daemons from the environment (Claude Code's `daemon run`) is matched instead on the
-  spawner pid it declares in its own argv, and reaped only once that pid is dead.
-  `agents sessions reap --dry-run` lists what would be collected without killing
-  anything. Source: `apps/cli/src/lib/tmux/orphan-reap.ts`,
-  `apps/cli/src/lib/tmux/session.ts`, `apps/cli/src/commands/sessions-reap.ts`.
-- **`sessions migrate --host` stops leaving `remain-on-exit` on server-wide (RUSH-2521).**
-  The remote launch set the tmux server default to `on` and never put it back, so every
-  later pane on that box — user splits included — retained a dead corpse when its command
-  finished. It now keeps the option on the migrated agent's own pane (which the liveness
-  probe reads) and restores the server default to `off`, matching `createSession`.
-  Source: `apps/cli/src/commands/sessions-migrate.ts`.
+  no attached client AND its agent process has exited; a tmux query that never actually
+  answered (missing/unsupported tmux, a spawn failure, a timed-out server) disables tier 1
+  for that sweep entirely rather than being treated as "no sessions", and
+  `agents sessions reap --json`'s `warnings` array (plus a daemon log line) says when that
+  happens. Tier 1 needs another process's environment, which is a plain `/proc` read on
+  Linux; on macOS, modern `ps -E` no longer exposes it at all, so tier 1 safely finds
+  nothing there today (known gap, not a regression — only tier 2 reaps on macOS). A
+  harness that detaches its daemons from the environment (Claude Code's `daemon run`) is
+  matched instead (tier 2) on the spawner pid it declares in its own argv, anchored on the
+  process's real executable rather than a substring match anywhere in its command line,
+  and excludes anything still owned by a live/attached pane — so a `grep`/`cat`/pager (or
+  an agent's own prompt) quoting this exact pattern can never become a kill seed. Reaped
+  only once the declared spawner pid is dead. `agents sessions reap --dry-run` lists what
+  would be collected without killing anything. Source:
+  `apps/cli/src/lib/tmux/orphan-reap.ts`, `apps/cli/src/lib/tmux/session.ts`,
+  `apps/cli/src/commands/sessions-reap.ts`.
+- **`sessions migrate --host` stops leaving `remain-on-exit` on server-wide, and lands the
+  migrated session where its reaper can see it (RUSH-2521).** The remote launch set the
+  tmux server default to `on` and never put it back, so every later pane on that box —
+  user splits included — retained a dead corpse when its command finished; it now keeps
+  the option on the migrated agent's own pane (which the liveness probe reads) and
+  restores the server default to `off`, matching `createSession`. Separately, the remote
+  session was created on tmux's bare default OS socket instead of the target's agents
+  socket, so the reaper above never found it and killed the just-migrated, still-live
+  agent as `tmux-session-gone` on its next tick — it now targets the same agents socket the
+  reaper queries. Source: `apps/cli/src/commands/sessions-migrate.ts`.

--- a/apps/cli/docs/sessions.md
+++ b/apps/cli/docs/sessions.md
@@ -1254,7 +1254,7 @@ capture its final output. Two things then accumulate:
 ```bash
 agents sessions reap             # collect both
 agents sessions reap --dry-run   # list what would be collected, kill nothing
-agents sessions reap --json      # { reaped, sessions, details, processes, processDetails }
+agents sessions reap --json      # { reaped, sessions, details, processes, processDetails, warnings }
 ```
 
 The routines daemon runs the same sweep every 5 minutes
@@ -1262,24 +1262,41 @@ The routines daemon runs the same sweep every 5 minutes
 collects a session's helpers as it tears that session down, so an agent that exits
 normally leaves nothing behind without waiting for a tick.
 
-**How a helper is attributed to its session.** Every OS handle that names the pane
-is destroyed by the exit itself — ppid ancestry is replaced by init, the
-controlling terminal is disassociated from the whole POSIX session when its leader
-exits, and the surviving helpers are precisely the ones that left the pane's
-process group. What does survive is the environment: the pane exports
-`AGENT_TMUX_SESSION_NAME` and every descendant inherits it, reparented or not. A
-process carrying that marker is reaped when its tmux session no longer exists, or
-when that session has **no attached client AND** its agent pane process has exited.
-A live agent or an attached client protects everything it owns, and the routines
-daemon, the secrets broker, and the reaping process's own ancestry are never
-candidates.
+**How a helper is attributed to its session (tier 1 — Linux only today).** Every
+OS handle that names the pane is destroyed by the exit itself — ppid ancestry is
+replaced by init, the controlling terminal is disassociated from the whole POSIX
+session when its leader exits, and the surviving helpers are precisely the ones
+that left the pane's process group. What does survive is the environment: the pane
+exports `AGENT_TMUX_SESSION_NAME` and every descendant inherits it, reparented or
+not. A process carrying that marker is reaped when its tmux session no longer
+exists, or when that session has **no attached client AND** its agent pane process
+has exited. A live agent or an attached client protects everything it owns, and the
+routines daemon, the secrets broker, and the reaping process's own ancestry are
+never candidates. Reading that marker needs another process's environment, which is
+a plain `/proc/<pid>/environ` file read on Linux but has no working equivalent on
+macOS: modern `ps -E` no longer prints another process's environment at all
+(verified on macOS Sequoia), so `readAgentProcesses()` returns every macOS process
+with no marker and tier 1 correctly finds nothing to do there — safe, not
+effective. Only tier 2 (below) reaps anything on macOS today.
+
+**When tmux itself can't be asked.** Tier 1 only trusts an ABSENT session as proof
+of "gone" when the tmux query that built that answer actually completed — a query
+that threw (tmux missing/unsupported version, a spawn failure, or a timed-out
+server) skips tier 1 entirely for that tick rather than treating "we don't know" as
+"there's nothing here". `agents sessions reap --json`'s `warnings` array (and a
+`WARN`-level daemon log line) says so when it happens; tier 2 is unaffected, since
+it never consults tmux at all.
 
 A harness that starts its background daemons with a scrubbed environment is matched
-on the owner it declares in its own argv instead — Claude Code's
+on the owner it declares in its own argv instead (tier 2) — Claude Code's
 `daemon run --spawned-by {…,"pid":N}` pool is reaped, with its `bg-pty-host` /
 `bg-spare` workers, once pid `N` is dead. Those rules live in
 `DETACHED_HELPER_RULES` ([`src/lib/tmux/orphan-reap.ts`](../src/lib/tmux/orphan-reap.ts)),
-one entry per harness.
+one entry per harness, and are anchored on the process's REAL executable (argv[0]'s
+basename) rather than a substring match anywhere in its command line — a `grep`,
+`cat`, or pager viewing this rule's own source, or an agent whose prompt happens to
+quote it, must never become a kill seed. A process still owned by a live or
+attached pane is excluded from seeding tier 2 too, whatever its own argv says.
 
 Note that this collects **everything** a session's agent spawned, not only MCP
 servers — a server the agent deliberately backgrounded inside its pane is torn down
@@ -1522,7 +1539,11 @@ The flow reuses existing primitives rather than reinventing transport or resume:
    starts the server a fresh worker/box lacks — the generic `new-window` backend needs a
    live server), then confirm the pane is *live* (not merely created) before proceeding.
    For an ephemeral box, migrate git-clones the repo and checks out the (WIP) branch first
-   so the cwd resolves.
+   so the cwd resolves. The session is created on the target's **agents socket** — the
+   same one its own reaper queries (`readAllPaneOwners`, see "Reaping what an exited
+   agent left behind" above) — not tmux's bare default OS socket; landing on the wrong
+   socket made the migrated agent invisible to its own reaper, which killed it as
+   `tmux-session-gone` on the next tick (RUSH-2521).
 7. **Stop the source** (`killSession`) — but only after the target session is confirmed
    live. `--keep` skips this (copy, not move).
 

--- a/apps/cli/src/commands/sessions-migrate.test.ts
+++ b/apps/cli/src/commands/sessions-migrate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { effectiveMode, rehydrateCommand } from './sessions-migrate.js';
+import { effectiveMode, rehydrateCommand, buildMigrateResumeCommands } from './sessions-migrate.js';
 import { buildResumeCommand } from './sessions.js';
 import { AGENTS } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
@@ -66,5 +66,50 @@ describe('effectiveMode — harness parity gate', () => {
         expect(downgraded).toBe(true);
       }
     }
+  });
+});
+
+describe('buildMigrateResumeCommands — the migrated session must land on the AGENTS socket (RUSH-2521)', () => {
+  const base = { sessionName: 'migrate-abcd1234', homeRelSocketPath: '.agents/.cache/helpers/tmux/server.sock', inner: 'exec claude' };
+
+  it('every tmux invocation in the launch command carries -S <agents socket>, never bare `tmux`', () => {
+    const { launchCmd } = buildMigrateResumeCommands(base);
+    // The old bug: `tmux set-option ...` with no -S landed the session on
+    // tmux's own default OS socket — invisible to readAllPaneOwners, so the
+    // reaper's next tick killed the migrated agent's helpers as
+    // 'tmux-session-gone'. Assert that exact bare-invocation shape is absent
+    // (the mkdir path also contains the substring "tmux", so this checks the
+    // COMMAND shape, not a bare substring match).
+    expect(launchCmd).not.toContain('tmux set-option');
+    expect(launchCmd).toContain('tmux -S "$HOME/.agents/.cache/helpers/tmux/server.sock" set-option');
+  });
+
+  it('$HOME is left as a literal, unresolved token for the REMOTE shell to expand', () => {
+    const { launchCmd, probeCmd } = buildMigrateResumeCommands(base);
+    // Must never be pre-resolved to a LOCAL absolute path (the local and
+    // remote HOME can differ — different user, different OS).
+    expect(launchCmd).toContain('$HOME/');
+    expect(probeCmd).toContain('$HOME/');
+  });
+
+  it('creates the socket parent directory before tmux tries to bind there', () => {
+    const { launchCmd } = buildMigrateResumeCommands(base);
+    const mkdirIdx = launchCmd.indexOf('mkdir -p');
+    const tmuxIdx = launchCmd.indexOf('tmux -S');
+    expect(mkdirIdx).toBeGreaterThanOrEqual(0);
+    expect(mkdirIdx).toBeLessThan(tmuxIdx);
+    expect(launchCmd).toContain('mkdir -p "$HOME/.agents/.cache/helpers/tmux"');
+  });
+
+  it('the liveness probe queries has-session and list-panes on the SAME agents socket as the launch', () => {
+    const { launchCmd, probeCmd, socketFlag } = buildMigrateResumeCommands(base);
+    expect(launchCmd).toContain(socketFlag);
+    expect(probeCmd).toContain(`tmux ${socketFlag} has-session`);
+    expect(probeCmd).toContain(`tmux ${socketFlag} list-panes`);
+  });
+
+  it('threads a custom remote cwd into the new-session invocation', () => {
+    const { launchCmd } = buildMigrateResumeCommands({ ...base, cwd: '/home/worker/repo' });
+    expect(launchCmd).toContain('-c /home/worker/repo');
   });
 });

--- a/apps/cli/src/commands/sessions-migrate.ts
+++ b/apps/cli/src/commands/sessions-migrate.ts
@@ -42,6 +42,7 @@ import { injectIntoTerminal } from '../lib/terminal/index.js';
 import { iLoginShell } from '../lib/terminal/shell.js';
 import { shellQuote as quoteArg } from '../lib/terminal/quote.js';
 import { killSession } from '../lib/tmux/session.js';
+import { getDefaultSocketPath } from '../lib/tmux/paths.js';
 
 import { listAllHosts, resolveHost } from '../lib/hosts/registry.js';
 import type { Host } from '../lib/hosts/types.js';
@@ -471,6 +472,49 @@ function prepareEphemeralCwd(sshTarget: string, source: SessionMeta, branch: str
 }
 
 /**
+ * Pure. The remote shell commands that create the target's tmux session on the
+ * SAME socket its reaper queries, and that probe its liveness afterward.
+ *
+ * `homeRelSocketPath` is `getDefaultSocketPath()` expressed relative to the
+ * LOCAL home dir (`path.relative(os.homedir(), getDefaultSocketPath())`) — a
+ * portable suffix, not a resolved absolute path, because the local and remote
+ * HOME can differ (different user, different OS). It is spliced in after a
+ * literal, unquoted `$HOME/` so the REMOTE shell resolves it; `$HOME` MUST
+ * NEVER be resolved locally (see AGENTS.md's remote-path guidance).
+ *
+ * Extracted as a pure function so the "does the migrated session land on the
+ * agents socket, not tmux's bare default socket" invariant is unit-testable
+ * without an SSH round-trip (RUSH-2521 review — a bare `tmux` here made the
+ * migrated agent's helpers invisible to `readAllPaneOwners`, so the reaper's
+ * next tick killed the still-live, just-migrated agent as `tmux-session-gone`).
+ */
+export function buildMigrateResumeCommands(opts: {
+  sessionName: string;
+  homeRelSocketPath: string;
+  inner: string;
+  cwd?: string;
+}): { launchCmd: string; probeCmd: string; socketFlag: string } {
+  const socketDirRelToHome = path.dirname(opts.homeRelSocketPath);
+  const socketFlag = `-S "$HOME/${opts.homeRelSocketPath}"`;
+  const argv = ['set-option', '-g', 'remain-on-exit', 'on', ';', 'new-session', '-d', '-s', opts.sessionName];
+  if (opts.cwd && opts.cwd !== '~') argv.push('-c', opts.cwd);
+  argv.push(opts.inner);
+  // Mirror createSession's second half: keep remain-on-exit on THIS pane (the
+  // liveness probe below reads `pane_dead`), then put the server-wide default
+  // back to off. Leaving `-g on` set made every later pane on the target — user
+  // splits included — retain a corpse when its command finished.
+  argv.push(';', 'set-option', '-t', opts.sessionName, '-p', 'remain-on-exit', 'on');
+  argv.push(';', 'set-option', '-g', 'remain-on-exit', 'off');
+  // Unlike tmux's own scratch dir (auto-created under /tmp), the agents socket's
+  // parent may not exist yet on a fresh worker or ephemeral box that never ran a
+  // tmux-backed `agents` command — `mkdir -p` it before tmux tries to bind there.
+  const launchCmd = `mkdir -p "$HOME/${socketDirRelToHome}" && tmux ${socketFlag} ` + argv.map(shellQuote).join(' ');
+  const q = shellQuote(opts.sessionName);
+  const probeCmd = `sleep 3; tmux ${socketFlag} has-session -t ${q} 2>/dev/null || exit 3; test "$(tmux ${socketFlag} list-panes -t ${q} -F '#{pane_dead}' 2>/dev/null | head -n1)" = 0 || exit 4`;
+  return { launchCmd, probeCmd, socketFlag };
+}
+
+/**
  * Resume the session on the target through the SAME host path as
  * `sessions resume --host` (tmux backend). Returns true when the resume launched.
  */
@@ -498,21 +542,15 @@ async function resumeOnTarget(
   //
   // The pane exports AGENT_TMUX_SESSION_NAME the way a local `createSession`
   // pane does, so the target's reaper can attribute the helpers this agent
-  // spawns and collect them when it exits (RUSH-2521,
-  // `lib/tmux/orphan-reap.ts`).
+  // spawns and collect them when it exits (RUSH-2521, `lib/tmux/orphan-reap.ts`)
+  // — see {@link buildMigrateResumeCommands} for why the session MUST land on
+  // the agents socket rather than tmux's bare default socket.
   const sessionName = `migrate-${source.shortId}`;
+  const homeRelSocketPath = path.relative(os.homedir(), getDefaultSocketPath());
   const inner = iLoginShell(`export AGENT_TMUX_SESSION_NAME=${sessionName}; exec ${command!.map(quoteArg).join(' ')}`);
-  const argv = ['tmux', 'set-option', '-g', 'remain-on-exit', 'on', ';', 'new-session', '-d', '-s', sessionName];
   const cwd = remoteCwd ?? source.cwd;
-  if (cwd && cwd !== '~') argv.push('-c', cwd);
-  argv.push(inner);
-  // Mirror createSession's second half: keep remain-on-exit on THIS pane (the
-  // liveness probe below reads `pane_dead`), then put the server-wide default
-  // back to off. Leaving `-g on` set made every later pane on the target — user
-  // splits included — retain a corpse when its command finished.
-  argv.push(';', 'set-option', '-t', sessionName, '-p', 'remain-on-exit', 'on');
-  argv.push(';', 'set-option', '-g', 'remain-on-exit', 'off');
-  const launch = sshExec(sshTarget, argv.map(shellQuote).join(' '), { timeoutMs: 60000 });
+  const { launchCmd, probeCmd } = buildMigrateResumeCommands({ sessionName, homeRelSocketPath, inner, cwd });
+  const launch = sshExec(sshTarget, launchCmd, { timeoutMs: 60000 });
   if (launch.code !== 0) {
     console.log(chalk.red(`  Resume on ${sshTarget} failed: ${launch.stderr.trim().split('\n').pop() || `tmux exited ${launch.code}`}`));
     return false;
@@ -520,9 +558,7 @@ async function resumeOnTarget(
   // Liveness gate for the invariant: give the agent a moment to boot, then require
   // the pane to be ALIVE (not merely the session to exist) before the caller may
   // stop the source. An agent that dies on launch → we refuse to move.
-  const q = shellQuote(sessionName);
-  const probe = `sleep 3; tmux has-session -t ${q} 2>/dev/null || exit 3; test "$(tmux list-panes -t ${q} -F '#{pane_dead}' 2>/dev/null | head -n1)" = 0 || exit 4`;
-  const check = sshExec(sshTarget, probe, { timeoutMs: 30000 });
+  const check = sshExec(sshTarget, probeCmd, { timeoutMs: 30000 });
   if (check.code !== 0) {
     const why = check.code === 4 ? 'the agent exited immediately on the target'
       : check.code === 3 ? 'the session did not start'

--- a/apps/cli/src/commands/sessions-reap.ts
+++ b/apps/cli/src/commands/sessions-reap.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import type { Command } from 'commander';
 import { setHelpSections } from '../lib/help.js';
 import { reapDeadTmuxPanes } from '../lib/tmux/session.js';
-import { reapOrphanAgentProcesses } from '../lib/tmux/orphan-reap.js';
 import { getDefaultSocketPath } from '../lib/tmux/paths.js';
 
 interface ReapOptions {
@@ -57,9 +56,12 @@ export function registerSessionsReapCommand(sessionsCmd: Command): void {
         details: result.details,
         processes: result.processes,
         processDetails: result.processDetails,
+        warnings: result.warnings,
       }));
       return;
     }
+
+    for (const w of result.warnings) console.log(chalk.yellow(`warning: ${w}`));
 
     if (result.reaped === 0 && result.processes === 0) {
       console.log(chalk.gray('No dead tmux sessions or orphaned processes to reap.'));

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -737,6 +737,7 @@ async function runDeadPaneReap(): Promise<void> {
     const { reapDeadTmuxPanes } = await import('./tmux/session.js');
     const { getDefaultSocketPath } = await import('./tmux/paths.js');
     const result = await reapDeadTmuxPanes(getDefaultSocketPath());
+    for (const w of result.warnings) log('WARN', `Dead-pane reaper: ${w}`);
     if (result.processes > 0) {
       log('INFO', `Dead-pane reaper: terminated ${result.processes} orphaned helper process(es)`);
       for (const d of result.processDetails) log('INFO', `  ${d}`);

--- a/apps/cli/src/lib/tmux/orphan-reap.test.ts
+++ b/apps/cli/src/lib/tmux/orphan-reap.test.ts
@@ -24,6 +24,7 @@ import {
   parsePaneOwners,
   parseProcessRows,
   parseTmuxSessionMarker,
+  readPaneOwners,
   selectOrphanProcesses,
   type AgentProcess,
   type PaneOwner,
@@ -157,6 +158,68 @@ describe('selectOrphanProcesses', () => {
     expect(rule.spawnerPid('/home/me/.../.bin/claude --permission-mode plan --session-id 978673a2')).toBeUndefined();
     expect(rule.spawnerPid('claude.exe daemon run --spawned-by {"pid":42}')).toBe(42);
   });
+
+  // Blocker 2 (RUSH-2521 review): a tmux query that failed to answer must not
+  // be treated as "genuinely no sessions" — an absent map entry is only proof
+  // of anything when the map is known-complete.
+  it('NEVER runs tier 1 when the owners read is unreliable — even a process with no matching session survives', () => {
+    const table = [proc(500, 1, 'cgraph-mcp --daemon', 'ag-codex-ff55f79f')];
+    // Same inputs as the very first test in this block (which DOES reap this
+    // process when owners is reliable) — only `ownersReliable` differs.
+    const reliable = selectOrphanProcesses(table, owners([]), { ...noneProtected, ownersReliable: true });
+    const unreliable = selectOrphanProcesses(table, owners([]), { ...noneProtected, ownersReliable: false });
+    expect(reliable).toHaveLength(1);
+    expect(unreliable).toEqual([]);
+  });
+
+  it('an unreliable owners read does not block tier 2 (the detached-helper registry is independent of tmux)', () => {
+    const daemonArgs = 'claude.exe daemon run --origin transient --spawned-by {"label":"claude","pid":3834601}';
+    const table = [proc(3868250, 1, daemonArgs)];
+    const picked = selectOrphanProcesses(table, owners([]), { ...noneProtected, ownersReliable: false, isAlive: () => false });
+    expect(picked.map(c => c.pid)).toEqual([3868250]);
+  });
+
+  it('ownersReliable defaults to true (unchanged behavior for every existing direct caller)', () => {
+    const table = [proc(500, 1, 'cgraph-mcp --daemon', 'ag-codex-ff55f79f')];
+    const picked = selectOrphanProcesses(table, owners([]), noneProtected);
+    expect(picked).toHaveLength(1);
+  });
+
+  // Blocker 4 (RUSH-2521 review): tier 2 must not fire on a substring match
+  // anywhere in argv — only the REAL executable, and never a process still
+  // owned by a live/attached pane.
+  it('NEVER seeds tier 2 from a process whose argv merely QUOTES the daemon-run pattern (as this file\'s own docblock does)', () => {
+    // The exact shape this file's docblock and test fixtures contain — a real
+    // `cat`/`grep`/pager viewing this source, or a coding agent's own tool-call
+    // argv, could carry this verbatim text without being the daemon at all.
+    const quotedText = 'daemon run --origin transient --spawned-by {"label":"claude","cwd":"/home/me/src/agents-cli","pid":3834601}';
+    const table = [
+      proc(9001, 1, `/usr/bin/cat orphan-reap.ts ${quotedText}`),
+      proc(9002, 1, `/usr/bin/grep -n "${quotedText}" orphan-reap.ts`),
+    ];
+    const picked = selectOrphanProcesses(table, owners([]), { ...noneProtected, isAlive: () => false });
+    expect(picked).toEqual([]);
+  });
+
+  it('NEVER seeds tier 2 from a process still owned by a LIVE or attached pane, whatever its argv says', () => {
+    // A live interactive claude process whose own prompt/tool-args happen to
+    // contain the daemon-run + dead-pid shape (e.g. discussing THIS bug) must
+    // never become a kill seed for its own subtree.
+    const daemonShapedPrompt = 'claude --print "please fix daemon run --spawned-by handling for pid 3834601"';
+    const table = [proc(4200, 1, daemonShapedPrompt, 'ag-claude-live')];
+    const live = owners([['ag-claude-live', { agentAlive: true, attached: false }]]);
+    const picked = selectOrphanProcesses(table, live, { ...noneProtected, isAlive: () => false });
+    expect(picked).toEqual([]);
+  });
+
+  it('argv0Basename anchor: a real claude daemon nested deep in a quoting process is still reaped', () => {
+    // Sanity check the anchor doesn't over-correct: the ACTUAL daemon (argv[0]
+    // really is claude/claude.exe) is unaffected.
+    const daemonArgs = 'claude.exe daemon run --origin transient --spawned-by {"label":"claude","pid":3834601}';
+    const table = [proc(3868250, 1, daemonArgs)];
+    const picked = selectOrphanProcesses(table, owners([]), { ...noneProtected, isAlive: () => false });
+    expect(picked.map(c => c.pid)).toEqual([3868250]);
+  });
 });
 
 describe('descendantsOf', () => {
@@ -168,6 +231,36 @@ describe('descendantsOf', () => {
   it('terminates on a cyclic ppid chain instead of spinning', () => {
     const table = [proc(30, 31, 'a'), proc(31, 30, 'b')];
     expect(descendantsOf(table, [30]).sort((a, b) => a - b)).toEqual([30, 31]);
+  });
+});
+
+describe('readPaneOwners', () => {
+  it('a socket that was never created is a reliable, confident EMPTY read (tmux unlinks its own socket on exit)', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-orphan-reap-owners-'));
+    try {
+      const neverCreated = path.join(tempDir, 'never-existed.sock');
+      const read = await readPaneOwners(neverCreated);
+      expect(read).toEqual({ ok: true, owners: new Map() });
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(skipReason)('a socket file that exists but answers with a real, completed nonzero exit is still a reliable EMPTY read', async () => {
+    // A stale/garbage file at the socket path is NOT a listening tmux server —
+    // real tmux connects, fails, and EXITS (a completed process, not a thrown
+    // error). That is tmux itself answering "nothing here", which must stay
+    // distinct from "tmux never answered at all" (a thrown/rejected query).
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-orphan-reap-owners-'));
+    try {
+      const garbage = path.join(tempDir, 'not-a-socket.sock');
+      fs.writeFileSync(garbage, 'not a unix socket');
+      const read = await readPaneOwners(garbage);
+      expect(read.ok).toBe(true);
+      expect(read.owners.size).toBe(0);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -214,7 +307,11 @@ describe.skipIf(skipReason)('reaping a real leaked helper', () => {
     expect(alive(helper)).toBe(true);
     expect(markerOf(helper)).toBe(name);
 
-    const result = await reapDeadTmuxPanes(socket);
+    // `pids` scopes the reap's process-table read to JUST the fixture's own
+    // helper — never the machine-wide `-A` a bare call would use — so this
+    // test can never select or signal a real, unrelated process on a shared
+    // box (RUSH-2521 review).
+    const result = await reapDeadTmuxPanes(socket, { pids: [helper] });
 
     expect(result.processes).toBeGreaterThanOrEqual(1);
     expect(result.processDetails.join('\n')).toContain(String(helper));
@@ -226,7 +323,7 @@ describe.skipIf(skipReason)('reaping a real leaked helper', () => {
     const name = `orph-live-${process.pid}`;
     const helper = await launchLeakingSession(name, 'exec sleep 120');
 
-    const result = await reapDeadTmuxPanes(socket);
+    const result = await reapDeadTmuxPanes(socket, { pids: [helper] });
 
     expect(result.processDetails.join('\n')).not.toContain(String(helper));
     expect(alive(helper)).toBe(true);

--- a/apps/cli/src/lib/tmux/orphan-reap.ts
+++ b/apps/cli/src/lib/tmux/orphan-reap.ts
@@ -57,6 +57,34 @@
  *   whatever the pane state;
  * - the reaping process itself, its ancestors, pid 1, and every long-lived
  *   agents-cli service ({@link isProtectedAgentsService}) are never candidates.
+ * - an UNRELIABLE read of tmux's session state (the query threw, timed out, or
+ *   tmux itself never answered) disables tier 1 for that sweep entirely — an
+ *   absent map entry proves a session is gone only when the map is known-good.
+ *   Distinguishing "tmux answered: no such session" (a completed, if nonzero,
+ *   exit — genuinely nothing there) from "tmux did not answer" (a thrown
+ *   error/timeout — unknown) is exactly this: a completed process is a real
+ *   answer, a rejected promise is not one at all.
+ * - tier 2 is anchored on the actual claude EXECUTABLE (argv[0]'s basename),
+ *   never a substring match anywhere in the command line, and excludes any
+ *   process that still carries a LIVE or attached pane marker — a live
+ *   interactive agent whose own argv happens to quote this file's docblock (it
+ *   contains the exact `daemon run --spawned-by {"pid":...}` shape) must never
+ *   become a kill seed.
+ *
+ * ## Known platform gap — tier 1 is Linux-only today
+ *
+ * Tier 1's env-marker attribution requires reading another process's
+ * environment. `/proc/<pid>/environ` makes that a plain file read on Linux.
+ * macOS has no `/proc`; `ps -E` was the fallback, but on modern macOS (verified
+ * live on mac-mini 15.6, macOS Sequoia) `ps -E` no longer prints another
+ * process's environment at all — only the CALLING process's own env shows up.
+ * `readAgentProcesses()` therefore returns every macOS process with
+ * `tmuxSession: undefined`, and tier 1's `if (!p.tmuxSession) continue` skips
+ * all of them. This is SAFE (tier 1 silently no-ops rather than misattributing
+ * anything) but not effective: on macOS, only tier 2 — the detached-helper
+ * registry — can reap anything today. A macOS fix needs a different channel
+ * entirely (env is inherently unreadable cross-process there without a native
+ * helper); it is not a parsing bug {@link parseTmuxSessionMarker} can fix.
  */
 
 import { execFile } from 'child_process';
@@ -67,6 +95,15 @@ const execFileAsync = promisify(execFile);
 
 /** Ceiling on the `ps` snapshot so a wedged `ps` can never stall the daemon tick. */
 const PS_TIMEOUT_MS = 10_000;
+
+/**
+ * Ceiling on a single tmux pane-owner query. Without this a wedged tmux server
+ * hangs `readPaneOwners` forever, which — before this bound existed — could
+ * only be told apart from "genuinely no sessions" by the caller giving up and
+ * treating it as empty (RUSH-2521 review: exactly the failure mode that let a
+ * flaky tick select every marked process on the box as orphaned).
+ */
+const TMUX_QUERY_TIMEOUT_MS = 10_000;
 
 /** Grace between SIGTERM and SIGKILL for a reaped orphan. */
 export const REAP_GRACE_MS = 2_000;
@@ -110,6 +147,12 @@ export interface OrphanReapResult {
   details: string[];
   /** Selected candidates, whether or not they were killed (`dryRun`). */
   candidates: OrphanCandidate[];
+  /**
+   * Non-fatal observations worth logging — e.g. "tier 1 skipped this sweep:
+   * a tmux query failed" (see {@link selectOrphanProcesses}'s `ownersReliable`).
+   * Never gates the reap; it only explains why fewer candidates were found.
+   */
+  warnings: string[];
 }
 
 /**
@@ -127,15 +170,39 @@ export interface DetachedHelperRule {
 }
 
 /**
+ * Basename of argv[0] — the actual executable a process runs, not whatever
+ * text later argv tokens happen to contain. `ps -o args=` gives one opaque
+ * command-line string (no reliable per-token quoting to split on), so this
+ * takes the first whitespace-delimited run and strips its directory prefix.
+ */
+function argv0Basename(args: string): string {
+  const m = /^\s*(\S+)/.exec(args);
+  const token = m ? m[1] : '';
+  const base = token.split(/[\\/]/).pop() ?? '';
+  return base.toLowerCase();
+}
+
+/**
  * Claude Code's background daemon pool. Its argv carries a JSON `--spawned-by`
  * blob naming the claude process that started it, e.g.
  * `claude.exe daemon run --origin transient --spawned-by {"label":"claude","cwd":"/…","pid":3834601}`.
  * The `bg-pty-host` / `bg-spare` workers are its children and are reaped as
  * descendants rather than matched individually — they carry no owner of their own.
+ *
+ * Anchored on argv[0]'s basename, not a substring match anywhere in the full
+ * command line: `daemon\s+run` and `--spawned-by\s+.*"pid"\s*:\s*(\d+)` both
+ * appear verbatim in THIS FILE's own docblock above, so a `grep`, `cat`, or
+ * pager viewing `orphan-reap.ts` — or a coding agent whose tool-call argv
+ * quotes this review's own bug report — matched the old substring-only rule
+ * and became a kill seed for its whole process subtree (RUSH-2521 review,
+ * reproduced against the exact diff text). Only a process whose real
+ * executable is `claude`/`claude.exe` can seed this rule now.
  */
 const CLAUDE_BG_DAEMON: DetachedHelperRule = {
   agent: 'claude',
   spawnerPid(args: string): number | undefined {
+    const exe = argv0Basename(args);
+    if (exe !== 'claude' && exe !== 'claude.exe') return undefined;
     if (!/\bdaemon\s+run\b/.test(args)) return undefined;
     const m = /--spawned-by\s+.*?"pid"\s*:\s*(\d+)/.exec(args);
     if (!m) return undefined;
@@ -178,16 +245,31 @@ function livePid(pid: number): boolean {
  * Pure. Select the processes whose owning agent is provably gone.
  *
  * `owners` maps a tmux session name to its liveness; a name ABSENT from the map
- * is a session tmux no longer has, which is the strongest orphan signal there is.
+ * is a session tmux no longer has, which is the strongest orphan signal there is
+ * — but ONLY when `owners` is itself known-complete. `opts.ownersReliable`
+ * (default `true`, so existing direct callers/tests keep their prior meaning)
+ * says whether the caller actually got a real answer from tmux for every
+ * socket it queried. When it is `false` — a query threw, timed out, or tmux
+ * itself never answered — tier 1 is skipped entirely for this call: an absent
+ * map entry proves nothing when the map itself might be missing entries for
+ * sessions tmux never got asked about (RUSH-2521 review — a flaky tick must
+ * never fall back to "treat every marked process as orphaned").
  */
 export function selectOrphanProcesses(
   procs: AgentProcess[],
   owners: Map<string, PaneOwner>,
-  opts: { protectedPids: Set<number>; isAlive?: (pid: number) => boolean },
+  opts: { protectedPids: Set<number>; isAlive?: (pid: number) => boolean; ownersReliable?: boolean },
 ): OrphanCandidate[] {
   const isAlive = opts.isAlive ?? livePid;
+  const ownersReliable = opts.ownersReliable ?? true;
   const eligible = (p: AgentProcess): boolean =>
     p.pid > 1 && !opts.protectedPids.has(p.pid) && !isProtectedAgentsService(p.args);
+  /** A process still owned by a live/attached pane can never seed a kill, whatever its own argv says. */
+  const ownedByLivePane = (p: AgentProcess): boolean => {
+    if (!p.tmuxSession) return false;
+    const owner = owners.get(p.tmuxSession);
+    return !!owner && (owner.agentAlive || owner.attached);
+  };
 
   const out: OrphanCandidate[] = [];
   const seen = new Set<number>();
@@ -197,25 +279,30 @@ export function selectOrphanProcesses(
     out.push({ pid: p.pid, args: p.args, reason, tmuxSession: p.tmuxSession });
   };
 
-  // Tier 1 — inherited pane marker with a dead owner.
-  for (const p of procs) {
-    if (!p.tmuxSession || !eligible(p)) continue;
-    const owner = owners.get(p.tmuxSession);
-    if (!owner) {
-      push(p, 'tmux-session-gone');
-      continue;
+  // Tier 1 — inherited pane marker with a dead owner. Skipped whole when the
+  // owners read is unreliable (see the docstring above).
+  if (ownersReliable) {
+    for (const p of procs) {
+      if (!p.tmuxSession || !eligible(p)) continue;
+      const owner = owners.get(p.tmuxSession);
+      if (!owner) {
+        push(p, 'tmux-session-gone');
+        continue;
+      }
+      // An attached client or a live agent pane process is a hard exclusion.
+      if (owner.attached || owner.agentAlive) continue;
+      push(p, 'tmux-agent-exited');
     }
-    // An attached client or a live agent pane process is a hard exclusion.
-    if (owner.attached || owner.agentAlive) continue;
-    push(p, 'tmux-agent-exited');
   }
 
   // Tier 2 — a detached helper daemon whose declared spawner is dead, plus the
   // workers it owns. Its own descendants are pulled in because they carry no
-  // owner declaration of their own.
+  // owner declaration of their own. A candidate seed that still carries a
+  // LIVE/attached pane marker is excluded even if its argv matches a rule: it
+  // is provably not a detached daemon, whatever text its command line quotes.
   const seeds: AgentProcess[] = [];
   for (const p of procs) {
-    if (!eligible(p)) continue;
+    if (!eligible(p) || ownedByLivePane(p)) continue;
     for (const rule of DETACHED_HELPER_RULES) {
       const spawner = rule.spawnerPid(p.args);
       if (spawner === undefined || isAlive(spawner)) continue;
@@ -310,14 +397,24 @@ export function parsePaneOwners(stdout: string, isAlive: (pid: number) => boolea
  *
  * Two readers because no single command works on both platforms: Linux exposes
  * `/proc/<pid>/environ` (one cheap read per pid), while macOS has no `/proc` and
- * instead lets `ps -E` print a process's own-uid environment after its command.
- * Windows has no tmux integration at all, so it returns an empty table rather
- * than pretending to reap.
+ * instead lets `ps -E` print a process's own-uid environment after its command
+ * — though on modern macOS `ps -E` no longer includes it at all (see the
+ * "Known platform gap" section in this file's docblock); tier 1 safely no-ops
+ * there rather than misattributing anything. Windows has no tmux integration
+ * at all, so it returns an empty table rather than pretending to reap.
+ *
+ * `opts.pids` restricts the `ps` snapshot to an explicit pid allowlist instead
+ * of the whole machine (`-A`) — a test-only escape hatch so a reap exercised
+ * against real spawned processes can never select or signal a real, unrelated
+ * process on a shared box (RUSH-2521 review: the integration tests previously
+ * called the machine-wide reap directly, which is safe only by construction of
+ * the fixture, not by anything the reaper itself guarantees).
  */
-export async function readAgentProcesses(): Promise<AgentProcess[]> {
+export async function readAgentProcesses(opts: { pids?: number[] } = {}): Promise<AgentProcess[]> {
   if (process.platform === 'win32') return [];
+  const scope = opts.pids && opts.pids.length > 0 ? ['-p', opts.pids.join(',')] : ['-A'];
   const hasProc = fs.existsSync('/proc/self/environ');
-  const args = hasProc ? ['-A', '-o', 'pid=,ppid=,args='] : ['-A', '-E', '-o', 'pid=,ppid=,args='];
+  const args = hasProc ? [...scope, '-o', 'pid=,ppid=,args='] : [...scope, '-E', '-o', 'pid=,ppid=,args='];
   let stdout: string;
   try {
     ({ stdout } = await execFileAsync('ps', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024, timeout: PS_TIMEOUT_MS }));
@@ -342,33 +439,74 @@ export async function readAgentProcesses(): Promise<AgentProcess[]> {
   return rows;
 }
 
-/** Read every tmux session's ownership state from one socket. */
-export async function readPaneOwners(socket: string): Promise<Map<string, PaneOwner>> {
-  if (!fs.existsSync(socket)) return new Map();
+/** One socket's pane-ownership read. `ok: false` means tmux never actually answered. */
+export interface PaneOwnersRead {
+  /**
+   * `true` when tmux completed the query (whatever its exit code — a nonzero
+   * exit from `list-panes -a` IS tmux affirmatively answering "no server /
+   * no sessions here", a real and trustworthy empty result). `false` means the
+   * query never got that far: a thrown error, a timeout, or a missing/wrong
+   * tmux — in which case `owners` carries no information and must not be
+   * trusted as "no sessions".
+   */
+  ok: boolean;
+  owners: Map<string, PaneOwner>;
+}
+
+/**
+ * Read one tmux socket's session-ownership state.
+ *
+ * Distinguishes "tmux answered: nothing here" from "tmux did not answer" —
+ * the two were previously conflated (`.catch(() => null)` then `!res` folded
+ * into the same empty-map return as a clean nonzero exit), which meant a
+ * missing/wrong-version tmux, a spawn failure, or a wedged server were
+ * indistinguishable from a genuinely empty box. A completed process — even a
+ * nonzero exit — is a real answer; a rejected promise is not an answer at all
+ * (RUSH-2521 review).
+ */
+export async function readPaneOwners(socket: string): Promise<PaneOwnersRead> {
+  // No socket file at all means no server was ever started here — for the
+  // shared agents socket this is reliable (tmux unlinks its own socket on
+  // exit), so this is a confident, reliable EMPTY read, not an unknown one.
+  if (!fs.existsSync(socket)) return { ok: true, owners: new Map() };
   const { runTmux } = await import('./binary.js');
-  const res = await runTmux({
-    socket,
-    args: ['list-panes', '-a', '-F', '#{session_name}\t#{pane_pid}\t#{session_attached}'],
-    throwOnError: false,
-  }).catch(() => null);
-  if (!res || res.code !== 0) return new Map();
-  return parsePaneOwners(res.stdout);
+  try {
+    const res = await runTmux({
+      socket,
+      args: ['list-panes', '-a', '-F', '#{session_name}\t#{pane_pid}\t#{session_attached}'],
+      throwOnError: false,
+      timeoutMs: TMUX_QUERY_TIMEOUT_MS,
+    });
+    // A completed run answered, whatever its exit code — tmux itself is
+    // telling us there's no server/no sessions on a nonzero exit here.
+    return { ok: true, owners: res.code === 0 ? parsePaneOwners(res.stdout) : new Map() };
+  } catch {
+    // Threw: tmux missing/unsupported version (assertTmuxAvailable), a spawn
+    // failure, or the query timed out. We genuinely do not know.
+    return { ok: false, owners: new Map() };
+  }
 }
 
 /**
  * Ownership across every socket that could own a marked process, merged so a
- * session that is live on ANY of them protects its processes.
+ * session that is live on ANY of them protects its processes. `reliable` is
+ * `false` the moment ANY queried socket's read failed — the merged map could
+ * then be missing entries for sessions that live there, so a caller MUST NOT
+ * treat an absent key in it as proof of anything.
  *
  * The union is load bearing, not defensive: the process table is machine-wide,
  * so a reap driven from a non-default socket (`agents sessions reap --socket`,
  * or a test's temp socket) would otherwise see every real agent's marker with no
  * matching session and classify a whole box's live helpers as orphans.
  */
-async function readAllPaneOwners(socket: string): Promise<Map<string, PaneOwner>> {
+async function readAllPaneOwners(socket: string): Promise<{ owners: Map<string, PaneOwner>; reliable: boolean }> {
   const { getDefaultSocketPath } = await import('./paths.js');
   const merged = new Map<string, PaneOwner>();
+  let reliable = true;
   for (const sock of new Set([socket, getDefaultSocketPath()].filter(Boolean))) {
-    for (const [name, owner] of await readPaneOwners(sock)) {
+    const read = await readPaneOwners(sock);
+    reliable = reliable && read.ok;
+    for (const [name, owner] of read.owners) {
       const prev = merged.get(name);
       merged.set(name, {
         agentAlive: (prev?.agentAlive ?? false) || owner.agentAlive,
@@ -376,7 +514,7 @@ async function readAllPaneOwners(socket: string): Promise<Map<string, PaneOwner>
       });
     }
   }
-  return merged;
+  return { owners: merged, reliable };
 }
 
 /** Pids the reaper must never signal: itself and its whole ancestor chain. */
@@ -421,18 +559,27 @@ function describe(c: OrphanCandidate): string {
  * Called from the daemon's periodic tick and from `agents sessions reap`. Panes
  * are read BEFORE processes so a session that disappears mid-scan is treated as
  * gone (reapable) rather than as a live owner.
+ *
+ * `opts.pids` is the test-only process-table scope described on
+ * {@link readAgentProcesses} — never set by production callers.
  */
 export async function reapOrphanAgentProcesses(
-  opts: { socket: string; dryRun?: boolean; graceMs?: number } = { socket: '' },
+  opts: { socket: string; dryRun?: boolean; graceMs?: number; pids?: number[] } = { socket: '' },
 ): Promise<OrphanReapResult> {
-  const result: OrphanReapResult = { killed: 0, details: [], candidates: [] };
+  const result: OrphanReapResult = { killed: 0, details: [], candidates: [], warnings: [] };
   if (process.platform === 'win32') return result;
 
-  const owners = await readAllPaneOwners(opts.socket);
-  const procs = await readAgentProcesses();
+  const { owners, reliable } = await readAllPaneOwners(opts.socket);
+  if (!reliable) {
+    result.warnings.push('tier 1 (pane-marker) sweep skipped this tick: a tmux session query failed to answer');
+  }
+  const procs = await readAgentProcesses({ pids: opts.pids });
   if (procs.length === 0) return result;
 
-  const candidates = selectOrphanProcesses(procs, owners, { protectedPids: selfProtectedPids(procs) });
+  const candidates = selectOrphanProcesses(procs, owners, {
+    protectedPids: selfProtectedPids(procs),
+    ownersReliable: reliable,
+  });
   result.candidates = candidates;
   if (candidates.length === 0) return result;
 
@@ -448,16 +595,40 @@ export async function reapOrphanAgentProcesses(
  * `killSession` calls this so an agent's helpers die with the session that owned
  * them instead of waiting for the next daemon tick. The tmux session is being
  * destroyed by the caller, so ownership needs no liveness check — anything still
- * carrying this session's marker is leftover by definition.
+ * carrying this session's marker is leftover by definition, PROVIDED the name
+ * is unique to the socket in play.
+ *
+ * `socket` narrows that: a session name is only unique WITHIN one tmux server,
+ * so the exact same marker value could legitimately belong to a live, unrelated
+ * session on a DIFFERENT socket (e.g. the shared agents socket vs. a test's own
+ * temp socket). When `socket` names a non-default socket, this checks the
+ * default agents socket for a live/attached session of the same name and backs
+ * off entirely if one exists — the caller is tearing down one session, not a
+ * same-named one it does not own.
+ *
+ * `opts.pids` is the test-only process-table scope described on
+ * {@link readAgentProcesses} — never set by production callers.
  */
 export async function reapProcessesForTmuxSession(
   name: string,
-  opts: { dryRun?: boolean; graceMs?: number } = {},
+  socket?: string,
+  opts: { dryRun?: boolean; graceMs?: number; pids?: number[] } = {},
 ): Promise<OrphanReapResult> {
-  const result: OrphanReapResult = { killed: 0, details: [], candidates: [] };
+  const result: OrphanReapResult = { killed: 0, details: [], candidates: [], warnings: [] };
   if (process.platform === 'win32') return result;
 
-  const procs = await readAgentProcesses();
+  const { getDefaultSocketPath } = await import('./paths.js');
+  const defaultSocket = getDefaultSocketPath();
+  if (socket && socket !== defaultSocket) {
+    const elsewhere = await readPaneOwners(defaultSocket);
+    const owner = elsewhere.owners.get(name);
+    if (owner && (owner.agentAlive || owner.attached)) {
+      result.warnings.push(`skipped: "${name}" is a live session on the agents socket, not the one being torn down`);
+      return result;
+    }
+  }
+
+  const procs = await readAgentProcesses({ pids: opts.pids });
   if (procs.length === 0) return result;
 
   const protectedPids = selfProtectedPids(procs);

--- a/apps/cli/src/lib/tmux/session.ts
+++ b/apps/cli/src/lib/tmux/session.ts
@@ -220,7 +220,7 @@ export async function killSession(
   }
   if (opts.reapOrphans !== false) {
     const { reapProcessesForTmuxSession } = await import('./orphan-reap.js');
-    await reapProcessesForTmuxSession(name).catch(() => ({ killed: 0, details: [], candidates: [] }));
+    await reapProcessesForTmuxSession(name, sock).catch(() => ({ killed: 0, details: [], candidates: [], warnings: [] }));
   }
   removeSessionMeta(name);
   return true;
@@ -264,6 +264,8 @@ export interface ReapDeadPanesResult {
   processes: number;
   /** One human-readable line per terminated helper process. */
   processDetails: string[];
+  /** Non-fatal observations worth logging — e.g. a tier-1 sweep skipped this tick because a tmux query failed. */
+  warnings: string[];
 }
 
 /**
@@ -290,16 +292,19 @@ export interface ReapDeadPanesResult {
  */
 export async function reapDeadTmuxPanes(
   socket?: string,
-  opts: { dryRun?: boolean } = {},
+  opts: { dryRun?: boolean; pids?: number[] } = {},
 ): Promise<ReapDeadPanesResult> {
   const sock = socket ?? getDefaultSocketPath();
-  const result: ReapDeadPanesResult = { reaped: 0, sessions: [], details: [], processes: 0, processDetails: [] };
+  const result: ReapDeadPanesResult = { reaped: 0, sessions: [], details: [], processes: 0, processDetails: [], warnings: [] };
 
   // The process sweep runs even with no server on this socket: a torn-down
   // server (`killAll` unlinks the socket) is the strongest orphan signal there
   // is, and skipping it here would strand exactly those leftovers forever.
+  // `opts.pids` is a test-only process-table scope (see `readAgentProcesses`)
+  // — production callers never set it.
   const { reapOrphanAgentProcesses } = await import('./orphan-reap.js');
-  const orphans = await reapOrphanAgentProcesses({ socket: sock, dryRun: opts.dryRun });
+  const orphans = await reapOrphanAgentProcesses({ socket: sock, dryRun: opts.dryRun, pids: opts.pids });
+  result.warnings = orphans.warnings;
   result.processes = opts.dryRun ? orphans.candidates.length : orphans.killed;
   result.processDetails = orphans.details;
 


### PR DESCRIPTION
**fix — closes a blocking review left unresolved when #2584 merged.**

#2584 landed the orphan reaper (RUSH-2521) but was squash-merged directly to
`main` at `bc0f70830` while a blocking non-author review's 4 findings were
still open — the PR branch was deleted on merge, so this is a new PR against
the current `main` porting the same fixes forward. Two of the four findings
are **reproduced paths where the reaper kills a live or just-migrated agent**,
so this lands as a follow-up fix rather than a report.

## What was wrong

1. **Migrated agent killed on the next tick.** `sessions-migrate.ts` created
   the target's tmux session on the bare default OS socket instead of the
   agents socket the reaper actually queries (`readAllPaneOwners`). The
   migrated agent's `AGENT_TMUX_SESSION_NAME` marker never matched anything
   the reaper could see, so `selectOrphanProcesses` marked it
   `tmux-session-gone` and killed it within 5 minutes of a successful
   migration.
2. **A flaky tmux query could orphan every marked process on the box.**
   `readPaneOwners` collapsed "tmux threw" (missing/wrong version, a spawn
   failure, a timeout) into the exact same empty result as "tmux answered:
   no sessions here." One bad tick and every live, marked agent read as gone.
3. **Tier 1 attribution is silently dead on macOS.** Modern `ps -E` no longer
   exposes another process's environment at all (verified live on
   mac-mini 15.6) — tier 1 already no-ops safely there, but the docs claimed
   full parity.
4. **Tier 2 matched a substring anywhere in argv, no liveness gate.** The
   `daemon run --spawned-by {"pid":...}` pattern this file's own docblock
   documents is *itself* a match for the old regex — a `grep`/`cat`/pager
   viewing the source, or an agent's own prompt quoting this bug, could seed
   a kill for a whole process subtree.

## The fix

- Migrate now targets the same agents socket the reaper queries (resolved
  against the **remote** `$HOME`, never the local one, and `mkdir -p`'d
  first for a fresh box).
- `readPaneOwners` distinguishes "tmux completed the query" (a real answer,
  any exit code) from "tmux never answered" (unknown) — tier 1 is skipped
  entirely for a sweep whose owners read wasn't fully reliable, rather than
  treating "unknown" as "empty."
- Tier 2 is anchored on the real executable (`argv[0]`'s basename), not a
  substring match, and excludes any process still owned by a live/attached
  pane.
- Docs/changelog now say plainly that tier 1 is Linux-only today.
- The integration tests scope `readAgentProcesses` to the fixture's own pids
  instead of snapshotting the whole machine (they could previously signal a
  real, unrelated process on a shared box). The teardown reap path now takes
  the socket in play and backs off if the same session name is live on a
  different one. Removed a dead import.

## Tests — real run attached

New/updated tests for the 4 fixes plus safety hardening, targeted run
(2 files, 39/39 passing), raw terminal output:
https://gist.githubusercontent.com/muqsitnawaz/f2bd49931e9d58eab826c29bee0c5b28/raw/fcca79095a26e47d01959d735fed50297898f343/rush-2521-v2-test-run.log

Full local suite (11821 tests), raw terminal output:
https://gist.githubusercontent.com/muqsitnawaz/582ac6c762e3b514f047856d902627a3/raw/1ddc57352e4717bccb41212e55c98b5b2fcbc34c/rush-2521-full-suite-run.log
— 21 pre-existing failures, all in unrelated modules (webhook-server timeouts
under load, feed-broadcast, project-key, models, monitors/dispatch) and
identical on the OLD unfixed worktree before this change, so not caused by
this diff. `tsc --noEmit` is clean. CI will confirm on a clean runner.

## Context

- Ticket: RUSH-2521
- Supersedes the unresolved review on #2584 (merged without those fixes)