### PR TITLE
fix(sessions): extend live-pane protection to the pane leaf's own descendants (RUSH-2521)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2521.md
+++ b/apps/cli/.changelog/next/RUSH-2521.md
@@ -20,10 +20,13 @@
   matched instead (tier 2) on the spawner pid it declares in its own argv, anchored on the
   process's real executable rather than a substring match anywhere in its command line,
   and excludes anything still owned by a live/attached pane — checked two independent
-  ways, tmux's own live pane-pid data (works even with no env marker readable, so it
-  covers macOS and any `claude` started outside an agents-cli pane) and the env marker
-  when one is present — so a `grep`/`cat`/pager (or an agent's own prompt) quoting this
-  exact pattern can never become a kill seed. Reaped
+  ways, tmux's own live pane-pid data (expanded to that pane leaf's current process-tree
+  descendants, so it protects a live agent's own subprocesses too, and works even with no
+  env marker readable anywhere in that tree, covering macOS and any `claude` started
+  outside an agents-cli pane) and the env marker when one is present — so a
+  `grep`/`cat`/pager, or an agent's own prompt (or a subprocess it spawns) quoting this
+  exact pattern, can never become a kill seed. A process that has genuinely reparented
+  away from every live pane leaf remains reapable. Reaped
   only once the declared spawner pid is dead. `agents sessions reap --dry-run` lists what
   would be collected without killing anything. Source:
   `apps/cli/src/lib/tmux/orphan-reap.ts`, `apps/cli/src/lib/tmux/session.ts`,

--- a/apps/cli/docs/sessions.md
+++ b/apps/cli/docs/sessions.md
@@ -1311,14 +1311,20 @@ on the owner it declares in its own argv instead (tier 2) — Claude Code's
 one entry per harness, and are anchored on the process's REAL executable (argv[0]'s
 basename) rather than a substring match anywhere in its command line — a `grep`,
 `cat`, or pager viewing this rule's own source, or an agent whose prompt happens to
-quote it, must never become a kill seed. A process is excluded from seeding
-tier 2, whatever its own argv says, when EITHER of two independent signals
-says it is still owned: tmux's own `#{pane_pid}` says the pid itself is a
-live pane leaf right now — no environment marker needed, so this holds even
-where tier 1's attribution is dead (macOS, or a `claude` invocation started
-outside an agents-cli pane) — or the process carries a marker whose session
-is live/attached. Leaning on the marker alone left exactly that macOS/bare-
-invocation case open even after the executable anchor above.
+quote it — including a subprocess it spawns, e.g. its own Bash tool invoking
+`claude --print "…"` as a sub-task — must never become a kill seed. A process
+is excluded from seeding tier 2, whatever its own argv says, when EITHER of
+two independent signals says it is still owned: tmux's own `#{pane_pid}`,
+expanded to that pane leaf's current process-tree descendants, says the pid
+is still structurally part of a live agent's tree right now — no environment
+marker needed anywhere in that tree, so this holds even where tier 1's
+attribution is dead (macOS, or a `claude` invocation started outside an
+agents-cli pane) — or the process carries a marker whose session is
+live/attached. A process that has genuinely reparented away (a real detached
+daemon, no longer chained to any live pane leaf) is deliberately excluded
+from that tree and remains reapable. Leaning on the marker alone, and later
+on the pane leaf's own pid alone, each left a narrower slice of this open —
+see the file's docblock for both review rounds that found the gaps.
 
 Note that this collects **everything** a session's agent spawned, not only MCP
 servers — a server the agent deliberately backgrounded inside its pane is torn down

--- a/apps/cli/src/lib/tmux/orphan-reap.test.ts
+++ b/apps/cli/src/lib/tmux/orphan-reap.test.ts
@@ -263,6 +263,39 @@ describe('selectOrphanProcesses', () => {
     expect(picked.map(c => c.pid)).toEqual([3868250]);
   });
 
+  // Round-3 finding (non-author review of the round-2 fix): livePanePids only
+  // ever contains a pane LEAF's own pid — a live agent's own CHILD process
+  // (e.g. its Bash tool spawning `claude --print "…daemon run…"` as a
+  // sub-invocation, which the threat model in this file's docblock names
+  // explicitly) has no marker on macOS AND is not itself a pane_pid, so it
+  // was still an unprotected kill seed even after the round-2 fix.
+  it('NEVER seeds tier 2 from a LIVE CHILD of a pane leaf, even with no env marker and no pane_pid of its own', () => {
+    const daemonShapedPrompt = 'claude --print "please fix daemon run --spawned-by {\"label\":\"claude\",\"pid\":99999999} handling"';
+    const paneLeaf = proc(100, 1, 'claude'); // the interactive agent tmux itself tracks
+    const child = proc(55555, 100, daemonShapedPrompt); // its own Bash-tool sub-invocation, ppid=100, no marker
+    const picked = selectOrphanProcesses([paneLeaf, child], owners([]), {
+      ...noneProtected,
+      isAlive: pid => pid !== 99999999,
+      livePanePids: new Set([100]), // tmux only ever reports the LEAF's pid
+    });
+    expect(picked).toEqual([]);
+  });
+
+  it('a process that has genuinely reparented away from a live pane leaf remains reapable', () => {
+    // ppid 1 (init) — NOT a descendant of the live leaf's current tree, even
+    // though some other unrelated live agent happens to be running. This is
+    // the actual detached-daemon shape tier 2 exists to catch.
+    const daemonArgs = 'claude.exe daemon run --origin transient --spawned-by {"label":"claude","pid":3834601}';
+    const reparentedDaemon = proc(3868250, 1, daemonArgs);
+    const paneLeaf = proc(100, 1, 'claude');
+    const picked = selectOrphanProcesses([paneLeaf, reparentedDaemon], owners([]), {
+      ...noneProtected,
+      isAlive: pid => pid !== 3834601,
+      livePanePids: new Set([100]),
+    });
+    expect(picked.map(c => c.pid)).toEqual([3868250]);
+  });
+
   it('argv0Basename anchor: a real claude daemon nested deep in a quoting process is still reaped', () => {
     // Sanity check the anchor doesn't over-correct: the ACTUAL daemon (argv[0]
     // really is claude/claude.exe) is unaffected.

--- a/apps/cli/src/lib/tmux/orphan-reap.ts
+++ b/apps/cli/src/lib/tmux/orphan-reap.ts
@@ -66,16 +66,24 @@
  *   answer, a rejected promise is not one at all.
  * - tier 2 is anchored on the actual claude EXECUTABLE (argv[0]'s basename),
  *   never a substring match anywhere in the command line, and excludes any
- *   process that is a LIVE pane leaf (tmux's own `#{pane_pid}`, independent of
- *   whether that process's environment marker was ever readable) or that
- *   still carries a marker whose session is live/attached — a live
- *   interactive agent whose own argv happens to quote this file's docblock (it
- *   contains the exact `daemon run --spawned-by {"pid":...}` shape) must never
- *   become a kill seed, and that has to hold even where tier 1's marker is
- *   dead (macOS, or any `claude` invocation started outside an agents-cli
- *   pane) — a review round found the marker-only exclusion left exactly that
- *   gap open, which is why the pane-pid check exists as an independent signal
- *   rather than tier 2 leaning on tier 1's own attribution mechanism.
+ *   process still structurally part of a LIVE pane leaf's process tree right
+ *   now (tmux's own `#{pane_pid}`, expanded to its current descendants —
+ *   independent of whether any of those processes' environment markers were
+ *   ever readable) or that carries a marker whose own session is
+ *   live/attached — a live interactive agent, OR a subprocess it spawns
+ *   (e.g. its own Bash tool invoking `claude --print "…"` as a sub-task),
+ *   whose argv happens to quote this file's docblock (it contains the exact
+ *   `daemon run --spawned-by {"pid":...}` shape) must never become a kill
+ *   seed, and that has to hold even where tier 1's marker is dead (macOS, or
+ *   any `claude` invocation started outside an agents-cli pane). Two review
+ *   rounds found this: first that marker-only exclusion left the whole
+ *   macOS/bare-invocation case open (round 2, closed by the pane-pid check),
+ *   then that the pane-pid check alone only covered the pane LEAF itself, not
+ *   its own live children (round 3, closed by expanding the check to the
+ *   leaf's current descendant set via {@link descendantsOf}). A process that
+ *   has genuinely reparented away — a real detached daemon, no longer chained
+ *   to any live leaf by ppid — is deliberately NOT in that set and remains
+ *   reapable, whatever unrelated live agent happens to also be running.
  *
  * ## Known platform gap — tier 1 is Linux-only today
  *
@@ -288,13 +296,32 @@ export function selectOrphanProcesses(
   const eligible = (p: AgentProcess): boolean =>
     p.pid > 1 && !opts.protectedPids.has(p.pid) && !isProtectedAgentsService(p.args);
   /**
+   * Every pid STILL reachable, right now, from a live pane leaf through ppid
+   * links — not just the leaf itself. A live agent's own child (e.g. a Bash
+   * tool spawning `claude --print "…daemon run --spawned-by…"` as a
+   * sub-invocation) inherits nothing from `livePanePids` (that set only ever
+   * contains the leaf's own pid) unless we walk the tree, and on macOS that
+   * child ALSO carries no readable env marker (tier 1 is dead there) — so
+   * without this expansion, the "must never become a kill seed, whatever its
+   * own argv says" guarantee only held for the leaf itself, not the live
+   * agent's actual subprocess tree the same docblock's threat model names
+   * (RUSH-2521 review, round 3). A process that has genuinely reparented away
+   * (a real detached daemon, ppid now 1 or otherwise no longer chained to the
+   * leaf) is NOT in this set and remains reapable — this only protects what
+   * is still structurally part of the live agent's own tree right now.
+   */
+  const livePaneSubtree = opts.livePanePids && opts.livePanePids.size > 0
+    ? new Set(descendantsOf(procs, [...opts.livePanePids]))
+    : undefined;
+  /**
    * A process still owned by a live/attached pane can never seed a kill,
    * whatever its own argv says. Two independent signals, either sufficient:
-   * the process IS a pane's own leaf pid right now (tmux's own data, no
-   * marker needed), or it carries a marker whose session is live/attached.
+   * the process is still IN a live pane leaf's process tree right now (tmux's
+   * own data, no marker needed), or it carries a marker whose session is
+   * live/attached.
    */
   const ownedByLivePane = (p: AgentProcess): boolean => {
-    if (opts.livePanePids?.has(p.pid)) return true;
+    if (livePaneSubtree?.has(p.pid)) return true;
     if (!p.tmuxSession) return false;
     const owner = owners.get(p.tmuxSession);
     return !!owner && (owner.agentAlive || owner.attached);


### PR DESCRIPTION
**fix — follow-up to #2602, which merged at c3dd31350..2931d4111 before this commit landed.**

Non-author review of #2602's round-2 fix found that `livePanePids` only ever
contains a pane **leaf's** own pid — a live agent's own **child process**
(e.g. its Bash tool spawning `claude --print "...daemon run
--spawned-by..."` as a sub-invocation, exactly the threat model this file's
docblock already names) inherited nothing from that set, and on macOS that
child also carries no readable env marker (tier 1 is dead there per the
earlier fix). So the round-2 fix closed the gap for the pane leaf itself but
left the live agent's actual subprocess tree open.

## The fix

`selectOrphanProcesses` now expands `livePanePids` to that pane leaf's
current descendant set via the existing `descendantsOf` helper before
checking `ownedByLivePane`, so a process anywhere in a live agent's
still-connected process tree is protected — while a process that has
genuinely reparented away (ppid no longer chained to any live leaf, a real
detached daemon) remains reapable regardless of some unrelated live agent
still running.

## Tests

New tests in `orphan-reap.test.ts`:
- `'NEVER seeds tier 2 from a LIVE CHILD of a pane leaf, even with no env
  marker and no pane_pid of its own'` — reproduces + closes the gap
- `'a process that has genuinely reparented away from a live pane leaf
  remains reapable'` — confirms the fix doesn't over-protect

Real run, raw terminal output:
https://gist.githubusercontent.com/muqsitnawaz/6d4b57ccb32f75cca668d1582ecd3d04/raw/5dd83340ecf9aad4b38b2b1724d5c7a2df8301b0/rush-2521-round3-test-run.log
(2 files, 46/46 passing)

`tsc --noEmit` is clean.

## Context

- Ticket: RUSH-2521
- Third follow-up in this chain: #2584 (merged unfixed) → #2596 (4 blockers,
  merged) → #2602 (marker-independent pane-pid check, merged) → this PR
  (extends that check to the pane leaf's descendants)