### PR TITLE
fix(ext,sessions): stamp agent tab chips on spawn and adopt grok/kimi/droid

### DIFF
--- a/apps/cli/.changelog/next/vscodium-spawn-agent-meta.md
+++ b/apps/cli/.changelog/next/vscodium-spawn-agent-meta.md
@@ -1,0 +1,6 @@
+- **VSCodium agent tabs get the right chip on focus/resume (#2478).** The
+  `vscodium-agent` spawn URI now carries `agent` / `sessionId` / `title` from
+  `sessions focus` and `sessions resume`, so remote `ssh … tmux attach` tabs open
+  with the harness icon and status bar instead of a generic shell. The terminal
+  engine's `SurfaceItem` / `LaunchRequest` plumb the optional identity through;
+  other backends ignore it.

--- a/apps/cli/src/commands/focus.ts
+++ b/apps/cli/src/commands/focus.ts
@@ -701,8 +701,16 @@ export async function openFocusTabs(
   }
 
   console.log(chalk.gray(`Opening ${openable.length} session${openable.length === 1 ? '' : 's'} in ${backend} (tabs)…`));
+  // Pass agent + sessionId so the vscodium-agent backend can stamp the tab
+  // chip without sniffing the local process tree (remote attach has no agent
+  // binary on this box — #2478).
   const results = await open(
-    openable.map((p) => ({ cwd: cwdFor(p.s, byId), command: p.plan.command })),
+    openable.map((p) => ({
+      cwd: cwdFor(p.s, byId),
+      command: p.plan.command,
+      agent: p.s.kind || undefined,
+      sessionId: p.s.sessionId || undefined,
+    })),
     { backend, packing: 'tabs' },
   );
   let opened = 0;

--- a/apps/cli/src/commands/sessions-resume.ts
+++ b/apps/cli/src/commands/sessions-resume.ts
@@ -225,8 +225,16 @@ async function sessionsResumeAction(query: string | undefined, options: ResumeOp
   }
   console.log(chalk.gray(`Opening ${items.length} session${items.length === 1 ? '' : 's'} in ${where} (${packing})…`));
 
+  // agent + sessionId ride the SurfaceItem into the vscodium-agent spawn URI
+  // so the extension can set the tab chip without process-tree sniffing (#2478).
   const results = await openSurfaces(
-    items.map((it) => ({ cwd: it.cwd, command: it.command })),
+    items.map((it) => ({
+      cwd: it.cwd,
+      command: it.command,
+      agent: it.session.agent || undefined,
+      sessionId: it.session.id || undefined,
+      title: it.session.label || it.session.topic || undefined,
+    })),
     { backend, host: options.host, packing },
   );
 

--- a/apps/cli/src/lib/terminal/backends/backends.test.ts
+++ b/apps/cli/src/lib/terminal/backends/backends.test.ts
@@ -103,6 +103,29 @@ describe('vscodium-agent backend', () => {
     expect(payload.cwd).toBe('/Users/me/my project');
     expect(payload.command).toBe('claude --resume a b&c=d');
   });
+  it('spawnUri carries agent + sessionId meta for remote-attach chip stamping (#2478)', () => {
+    const url = spawnUri(
+      'vscodium',
+      '/Users/me/dev',
+      ['ssh', '-tt', 'yosemite-s0', 'tmux attach -t ag'],
+      undefined,
+      { agent: 'claude', sessionId: '115db661-1079-4e6b-846c-ce9aa05494f8', title: 'CC - restore' },
+    );
+    const payload = payloadOf(url);
+    expect(payload.agent).toBe('claude');
+    expect(payload.sessionId).toBe('115db661-1079-4e6b-846c-ce9aa05494f8');
+    expect(payload.title).toBe('CC - restore');
+    expect(payload.command).toContain('ssh');
+  });
+  it('buildTab forwards meta into the spawn URI', () => {
+    const argv = vscodiumAgentBackend.buildTab('/d', ['ssh', 'x'], {
+      agent: 'grok',
+      sessionId: 'abc',
+    });
+    const payload = payloadOf(argv.argv[2]);
+    expect(payload.agent).toBe('grok');
+    expect(payload.sessionId).toBe('abc');
+  });
   it('makeVscodiumAgentBackend binds a variant CLI + scheme (Cursor, VS Code)', () => {
     const cursor = makeVscodiumAgentBackend(EDITOR_VARIANTS[1]);
     expect(cursor.buildTab('/d', CMD).argv[0]).toBe('cursor');

--- a/apps/cli/src/lib/terminal/backends/vscodium-agent.ts
+++ b/apps/cli/src/lib/terminal/backends/vscodium-agent.ts
@@ -56,18 +56,34 @@ function appExists(p: string): boolean {
  * it, so a `command`/`cwd` containing `&` (or `=`) would be mis-split by a naive
  * multi-param query. base64url is `[A-Za-z0-9_-]` only (no `&`, `=`, `%`, `+`,
  * `/`), so it survives that decode untouched and round-trips exactly.
+ *
+ * Optional `meta.agent` / `meta.sessionId` / `meta.title` let the extension set
+ * the tab chip and status bar without sniffing the local process tree — required
+ * when `command` is a remote attach (`ssh … tmux attach`) with no agent binary
+ * on this box (#2478).
  */
 export function spawnUri(
   scheme: string,
   cwd: string,
   command: string[],
   direction?: SplitDirection,
+  meta?: { agent?: string; sessionId?: string; title?: string },
 ): string {
-  const payload: { command: string; cwd: string; split?: SplitDirection } = {
+  const payload: {
+    command: string;
+    cwd: string;
+    split?: SplitDirection;
+    agent?: string;
+    sessionId?: string;
+    title?: string;
+  } = {
     command: command.join(' '),
     cwd,
   };
   if (direction) payload.split = direction;
+  if (meta?.agent) payload.agent = meta.agent;
+  if (meta?.sessionId) payload.sessionId = meta.sessionId;
+  if (meta?.title) payload.title = meta.title;
   const p = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
   return `${scheme}://${EXTENSION_AUTHORITY}/spawn?p=${p}`;
 }
@@ -80,11 +96,11 @@ export function makeVscodiumAgentBackend(variant: EditorVariant): TerminalBacken
     isAvailable(ctx: EngineContext): boolean {
       return ctx.platform === 'darwin' && appExists(variant.app);
     },
-    buildTab(cwd: string, command: string[]): LaunchSpec {
-      return { argv: [variant.cli, '--open-url', spawnUri(variant.scheme, cwd, command)] };
+    buildTab(cwd: string, command: string[], meta?): LaunchSpec {
+      return { argv: [variant.cli, '--open-url', spawnUri(variant.scheme, cwd, command, undefined, meta)] };
     },
-    buildSplit(cwd: string, command: string[], direction: SplitDirection): LaunchSpec {
-      return { argv: [variant.cli, '--open-url', spawnUri(variant.scheme, cwd, command, direction)] };
+    buildSplit(cwd: string, command: string[], direction: SplitDirection, meta?): LaunchSpec {
+      return { argv: [variant.cli, '--open-url', spawnUri(variant.scheme, cwd, command, direction, meta)] };
     },
   };
 }

--- a/apps/cli/src/lib/terminal/engine.ts
+++ b/apps/cli/src/lib/terminal/engine.ts
@@ -18,8 +18,17 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 export function specForRequest(req: LaunchRequest): LaunchSpec {
   const backend = BACKENDS[req.backend];
   if (!backend) throw new Error(`unknown backend: ${req.backend}`);
-  if (req.layout === 'tab') return backend.buildTab(req.cwd, req.command);
-  return backend.buildSplit(req.cwd, req.command, req.layout === 'split-down' ? 'down' : 'right');
+  const meta =
+    req.agent || req.sessionId || req.title
+      ? { agent: req.agent, sessionId: req.sessionId, title: req.title }
+      : undefined;
+  if (req.layout === 'tab') return backend.buildTab(req.cwd, req.command, meta);
+  return backend.buildSplit(
+    req.cwd,
+    req.command,
+    req.layout === 'split-down' ? 'down' : 'right',
+    meta,
+  );
 }
 
 export interface OpenOptions {
@@ -45,6 +54,10 @@ export async function openSurface(req: LaunchRequest, opts: OpenOptions = {}): P
 export interface SurfaceItem {
   cwd: string;
   command: string[];
+  /** Optional harness identity for editor-backed backends (vscodium-agent). */
+  agent?: string;
+  sessionId?: string;
+  title?: string;
 }
 
 export interface BuildRequestsOptions {
@@ -62,6 +75,9 @@ export function buildRequests(items: SurfaceItem[], opts: BuildRequestsOptions):
     cwd: item.cwd,
     command: item.command,
     host: opts.host,
+    agent: item.agent,
+    sessionId: item.sessionId,
+    title: item.title,
   }));
 }
 

--- a/apps/cli/src/lib/terminal/types.ts
+++ b/apps/cli/src/lib/terminal/types.ts
@@ -34,6 +34,22 @@ export interface LaunchSpec {
   argv: string[];
 }
 
+/**
+ * Optional identity the caller already knows about the surface. The
+ * vscodium-agent backend forwards these into the swarm-ext `/spawn` URI so the
+ * extension can set the tab chip/name/session without sniffing the local
+ * process tree (required for remote `ssh … tmux attach` resumes — #2478).
+ * Other backends ignore them.
+ */
+export interface SurfaceMeta {
+  /** Harness id: claude, codex, grok, … */
+  agent?: string;
+  /** Canonical session id. */
+  sessionId?: string;
+  /** Optional pre-baked tab title. */
+  title?: string;
+}
+
 /** A single "open this command as this surface" instruction. */
 export interface LaunchRequest {
   backend: Backend;
@@ -44,6 +60,10 @@ export interface LaunchRequest {
   command: string[];
   /** undefined / 'local' = this machine; otherwise a resolvable host alias. */
   host?: string;
+  /** Optional agent identity for editor-backed backends. */
+  agent?: string;
+  sessionId?: string;
+  title?: string;
 }
 
 /** Outcome of opening one surface. Never throws for launch failures — reports them. */
@@ -64,7 +84,7 @@ export interface TerminalBackend {
   /** Can this backend be driven here? (platform + app installed / inside tmux). */
   isAvailable(ctx: EngineContext): boolean;
   /** Command that opens a new tab running `command` in `cwd`. */
-  buildTab(cwd: string, command: string[]): LaunchSpec;
+  buildTab(cwd: string, command: string[], meta?: SurfaceMeta): LaunchSpec;
   /** Command that splits the current surface, running `command` in `cwd`. */
-  buildSplit(cwd: string, command: string[], direction: SplitDirection): LaunchSpec;
+  buildSplit(cwd: string, command: string[], direction: SplitDirection, meta?: SurfaceMeta): LaunchSpec;
 }

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+- **Tab icons + status bar for Grok/Kimi/Droid/Antigravity and resumed sessions.**
+  Shell-adoption only recognised the original five harnesses (`claude`/`codex`/
+  `gemini`/`cursor`/`opencode`), so a New Grok tab (or any focus/resume that
+  landed via the `/spawn` URI) stayed a generic terminal: wrong icon and status
+  bar stuck on `Agents: Terminal`. The detector now covers every built-in runner
+  (including `agy` for Antigravity). The `/spawn` payload also carries
+  `agent`/`sessionId`/`title` so remote `ssh … tmux attach` resumes set the chip
+  without process-tree sniffing (#2478). Process-title forms like `Agents grok`
+  are parsed so a reloaded window rebinds the tab.
+
 - **AGI EXT now delegates session recovery to agents-cli.** Opening the Resume
   picker performs one bounded `agents sessions --all --json --no-interactive
   --limit 60` read, and selected sessions execute `agents sessions resume <id>

--- a/apps/ext/src/core/spawn.surface.test.ts
+++ b/apps/ext/src/core/spawn.surface.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { resolveSpawnSurface } from './spawn';
+import { parseSpawnRequest, resolveSpawnSurface } from './spawn';
 
 // The `…/spawn` URI verb reopens a session as an editor tab. AGI EXT no longer
 // spawns tmux-backed terminals at the extension level, so every request lands on
@@ -21,5 +21,47 @@ describe('resolveSpawnSurface', () => {
     expect(
       resolveSpawnSurface({ wantsSplit: true, hasParent: false })
     ).toBe('native-tab');
+  });
+});
+
+describe('parseSpawnRequest', () => {
+  function encode(obj: Record<string, unknown>): string {
+    const p = Buffer.from(JSON.stringify(obj), 'utf8').toString('base64url');
+    return `p=${p}`;
+  }
+
+  test('parses command + cwd + split', () => {
+    const req = parseSpawnRequest(encode({
+      command: 'claude --resume abc',
+      cwd: '/tmp/ws',
+      split: 'right',
+    }));
+    expect(req).toEqual({
+      command: 'claude --resume abc',
+      cwd: '/tmp/ws',
+      split: 'right',
+      agent: undefined,
+      sessionId: undefined,
+      title: undefined,
+    });
+  });
+
+  test('parses agent + sessionId + title for remote-attach chips (#2478)', () => {
+    const req = parseSpawnRequest(encode({
+      command: 'ssh -tt host tmux attach',
+      cwd: '/Users/me/.agents',
+      agent: 'Grok',
+      sessionId: '115db661-1079-4e6b-846c-ce9aa05494f8',
+      title: 'GK - restore',
+    }));
+    expect(req?.agent).toBe('grok'); // lowercased
+    expect(req?.sessionId).toBe('115db661-1079-4e6b-846c-ce9aa05494f8');
+    expect(req?.title).toBe('GK - restore');
+    expect(req?.command).toContain('ssh');
+  });
+
+  test('returns null without a command', () => {
+    expect(parseSpawnRequest(encode({ cwd: '/tmp' }))).toBeNull();
+    expect(parseSpawnRequest('')).toBeNull();
   });
 });

--- a/apps/ext/src/core/spawn.ts
+++ b/apps/ext/src/core/spawn.ts
@@ -11,6 +11,17 @@ export interface SpawnRequest {
   cwd?: string;
   // When set, split beside the previously spawned pane instead of a new tab.
   split?: SpawnSplit;
+  /**
+   * Harness id (claude/codex/grok/…) when the caller already knows it.
+   * Required for remote attach commands (`ssh … tmux attach`) where the local
+   * process tree has no agent binary to sniff — without this the tab stays a
+   * generic SH shell with the wrong icon (#2478).
+   */
+  agent?: string;
+  /** Canonical session id to stamp on the terminal for resume/status-bar. */
+  sessionId?: string;
+  /** Optional pre-baked tab title; otherwise the extension formats from agent. */
+  title?: string;
 }
 
 // Parse the query of a `…/spawn?p=<payload>` URI into a spawn request. The
@@ -33,7 +44,11 @@ export function parseSpawnRequest(query: string): SpawnRequest | null {
   const cwd = typeof obj?.cwd === 'string' && obj.cwd.trim() ? obj.cwd.trim() : undefined;
   const split: SpawnSplit | undefined =
     obj?.split === 'right' || obj?.split === 'down' ? obj.split : undefined;
-  return { command, cwd, split };
+  const agent = typeof obj?.agent === 'string' && obj.agent.trim() ? obj.agent.trim().toLowerCase() : undefined;
+  const sessionId =
+    typeof obj?.sessionId === 'string' && obj.sessionId.trim() ? obj.sessionId.trim() : undefined;
+  const title = typeof obj?.title === 'string' && obj.title.trim() ? obj.title.trim() : undefined;
+  return { command, cwd, split, agent, sessionId, title };
 }
 
 // Which surface a spawn request lands on.

--- a/apps/ext/src/core/terminalReadiness.ts
+++ b/apps/ext/src/core/terminalReadiness.ts
@@ -168,7 +168,47 @@ export function dispose(entry: ReadinessEntry, reason: string = 'disposed'): voi
 
 // --- Agent CLI detection (pure helpers) -----------------------------------
 
-export type AgentLauncherKey = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode';
+/**
+ * Every harness the extension can promote a shell tab into. Must stay aligned
+ * with BUILT_IN_AGENTS runners (everything except 'shell') and with the CLI
+ * registry ids that `agents run <id>` accepts for those harnesses.
+ *
+ * Grok/Kimi/Droid/Antigravity were missing here after they were added as
+ * first-class New-agent commands — process-tree adoption and the spawn URI
+ * path then left those tabs as generic shells (wrong icon + status bar
+ * "Agents: Terminal"). See #2478 and the tab-icon regression.
+ */
+export type AgentLauncherKey =
+  | 'claude'
+  | 'codex'
+  | 'gemini'
+  | 'cursor'
+  | 'opencode'
+  | 'antigravity'
+  | 'grok'
+  | 'kimi'
+  | 'droid';
+
+const AGENT_RUN_KEYS =
+  'claude|codex|gemini|cursor|opencode|antigravity|grok|kimi|droid';
+
+/** Binary basenames (and node-wrapped *.js) that map to a launcher key. */
+const BINARY_TO_AGENT: Record<string, AgentLauncherKey> = {
+  claude: 'claude',
+  'claude.js': 'claude',
+  codex: 'codex',
+  'codex.js': 'codex',
+  gemini: 'gemini',
+  'gemini.js': 'gemini',
+  'cursor-agent': 'cursor',
+  opencode: 'opencode',
+  // Antigravity's installed CLI is `agy` (agents.cli.ts CLI_AGENT_META).
+  agy: 'antigravity',
+  antigravity: 'antigravity',
+  grok: 'grok',
+  kimi: 'kimi',
+  droid: 'droid',
+};
 
 /**
  * Detect a known agent CLI from a `ps -o args=` output string.
@@ -176,17 +216,14 @@ export type AgentLauncherKey = 'claude' | 'codex' | 'gemini' | 'cursor' | 'openc
  * `agents run <agent>` wrappers from agents-cli.
  */
 export function detectAgentKeyFromArgs(args: string): AgentLauncherKey | null {
-  const runMatch = args.match(/\bagents\s+run\s+(claude|codex|gemini|cursor|opencode)\b/);
+  const runMatch = args.match(new RegExp(`\\bagents\\s+run\\s+(${AGENT_RUN_KEYS})\\b`));
   if (runMatch) return runMatch[1] as AgentLauncherKey;
 
   const tokens = args.split(/\s+/).filter(Boolean);
   for (const tok of tokens) {
     const base = (tok.split('/').pop() || '').toLowerCase();
-    if (base === 'claude' || base === 'claude.js') return 'claude';
-    if (base === 'codex' || base === 'codex.js') return 'codex';
-    if (base === 'gemini' || base === 'gemini.js') return 'gemini';
-    if (base === 'cursor-agent') return 'cursor';
-    if (base === 'opencode') return 'opencode';
+    const key = BINARY_TO_AGENT[base];
+    if (key) return key;
   }
   return null;
 }

--- a/apps/ext/src/core/utils.test.ts
+++ b/apps/ext/src/core/utils.test.ts
@@ -94,6 +94,43 @@ describe('parseTerminalName', () => {
     expect(parseTerminalName('node')).toEqual({ isAgent: false, prefix: null, label: null, sessionChunk: null });
   });
 
+  test('accepts process-title forms from shell integration (Agents grok)', () => {
+    // After `exec agents run grok`, VS Code's ${process} tab title can show
+    // "Agents grok" / "agents claude" — those must still identify as agents so
+    // the status bar and scanExisting re-bind the tab.
+    expect(parseTerminalName('Agents grok')).toEqual({
+      isAgent: true,
+      prefix: 'GK',
+      label: null,
+      sessionChunk: null,
+    });
+    expect(parseTerminalName('Agents claude')).toEqual({
+      isAgent: true,
+      prefix: 'CC',
+      label: null,
+      sessionChunk: null,
+    });
+    expect(parseTerminalName('agents run kimi')).toEqual({
+      isAgent: true,
+      prefix: 'KM',
+      label: null,
+      sessionChunk: null,
+    });
+    expect(parseTerminalName('Agents: Grok - auth')).toEqual({
+      isAgent: true,
+      prefix: 'GK',
+      label: 'auth',
+      sessionChunk: null,
+    });
+    // Unknown harness after Agents is still not an agent tab.
+    expect(parseTerminalName('Agents foobar')).toEqual({
+      isAgent: false,
+      prefix: null,
+      label: null,
+      sessionChunk: null,
+    });
+  });
+
   test('rejects partial matches (strict mode)', () => {
     // Should NOT match "cc" in lowercase
     expect(parseTerminalName('cc')).toEqual({ isAgent: false, prefix: null, label: null, sessionChunk: null });

--- a/apps/ext/src/core/utils.ts
+++ b/apps/ext/src/core/utils.ts
@@ -122,6 +122,11 @@ export interface ParsedTerminalName {
 /**
  * Parse a terminal name to identify if it's an agent terminal.
  * Strict matching: only matches exact prefixes or "PREFIX - label" format.
+ *
+ * Also accepts process-title forms that shell integration / `${process}` tab
+ * titles produce after `exec agents run <agent>` — e.g. "Agents grok",
+ * "agents claude". Those used to fail identification, so the status bar fell
+ * through to "Agents: Terminal" and scanExisting never re-bound the tab.
  */
 export function parseTerminalName(name: string): ParsedTerminalName {
   const trimmed = name.trim();
@@ -154,6 +159,23 @@ export function parseTerminalName(name: string): ParsedTerminalName {
           return { isAgent: true, prefix: canonicalPrefix, label, sessionChunk: chunk };
         }
       }
+    }
+  }
+
+  // Process-title form: "Agents grok" / "agents run claude" / "Agents: Grok".
+  // The word after Agents (or agents run) is looked up in NAME_TO_PREFIX.
+  const processTitle = trimmed.match(
+    /^(?:Agents?|agents)(?:\s+run)?[\s:]+([A-Za-z][\w-]*)\b(?:\s*-\s*(.+))?$/i
+  );
+  if (processTitle) {
+    const token = processTitle[1];
+    const label = processTitle[2]?.trim() || null;
+    const canonical =
+      NAME_TO_PREFIX[token] ||
+      NAME_TO_PREFIX[token.toLowerCase()] ||
+      NAME_TO_PREFIX[token.charAt(0).toUpperCase() + token.slice(1).toLowerCase()];
+    if (canonical) {
+      return { isAgent: true, prefix: canonical, label, sessionChunk: null };
     }
   }
 

--- a/apps/ext/src/monitor/sessionParse.ts
+++ b/apps/ext/src/monitor/sessionParse.ts
@@ -127,7 +127,7 @@ export async function parseSessionHead(
 
 // --- Session roots (machine-wide, not workspace-keyed) --------------------
 
-export type AgentRootKind = SessionAgentKind | 'cursor';
+export type AgentRootKind = SessionAgentKind | 'cursor' | 'antigravity' | 'grok' | 'kimi' | 'droid';
 
 let cachedClaudeRoots: string[] | undefined;
 
@@ -165,6 +165,13 @@ export function agentSessionRoots(agentKey: AgentRootKind): string[] {
       return [path.join(home, '.local', 'share', 'opencode', 'storage', 'message')];
     case 'cursor':
       return [path.join(home, '.cursor', 'chats')];
+    // Monitor cannot parse these transcripts yet (see watcherRootsFromCli).
+    // Return empty so locate/fast-path no-ops rather than type-error.
+    case 'antigravity':
+    case 'grok':
+    case 'kimi':
+    case 'droid':
+      return [];
   }
 }
 

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -1890,28 +1890,43 @@ function aliveSpawnParent(): vscode.Terminal | undefined {
 }
 
 // Open an editor-tab terminal running an arbitrary command (the /spawn verb).
-// The terminal is registered as a shell terminal with shell adoption armed, so
-// a resume command like `claude --resume <id>` is auto-promoted to the Claude
-// chip + session tracking. When req.split is set, the terminal splits beside
-// the previous /spawn pane instead of opening a new tab.
+//
+// Prefer an explicit agent from the spawn payload (sessions focus/resume over
+// vscodium-agent), then fall back to sniffing the command line for a local
+// resume like `claude --resume <id>` / `agents run grok …`. Only when neither
+// yields a harness do we open as SH + shell-adoption — that path cannot set the
+// icon later (VS Code tab icons are immutable) and cannot promote remote
+// attaches whose local tree is just `ssh … tmux attach` (#2478).
+//
+// When req.split is set, the terminal splits beside the previous /spawn pane
+// instead of opening a new tab.
 async function spawnCommandTerminal(
   context: vscode.ExtensionContext,
   req: SpawnRequest
 ): Promise<void> {
-  const shellDef = getBuiltInByKey('shell');
-  if (!shellDef) return;
+  const detectedKey =
+    (req.agent && getBuiltInByKey(req.agent) ? req.agent : null) ||
+    readiness.detectAgentKeyFromArgs(req.command) ||
+    null;
+  const def = (detectedKey && getBuiltInByKey(detectedKey)) || getBuiltInByKey('shell');
+  if (!def) return;
+
   const agentConfig = createAgentConfig(
     context.extensionPath,
-    shellDef.title,
-    shellDef.command,
-    shellDef.icon,
-    shellDef.prefix
+    def.title,
+    def.command,
+    def.icon,
+    def.prefix
   );
 
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd();
   const cwd = req.cwd || workspaceFolder;
   const terminalId = terminals.nextId(agentConfig.prefix);
-  const title = buildTerminalTitle(agentConfig.title, undefined, context, null);
+  const sessionId =
+    req.sessionId || readiness.extractSessionIdFromArgs(req.command) || null;
+  const title =
+    req.title?.trim() ||
+    buildTerminalTitle(agentConfig.title, undefined, context, sessionId);
 
   const parent = req.split ? aliveSpawnParent() : undefined;
   const surface = resolveSpawnSurface({
@@ -1919,7 +1934,11 @@ async function spawnCommandTerminal(
     hasParent: !!parent,
   });
 
-  const env = buildAgentTerminalEnv(terminalId, null, cwd, undefined, { scrubSensitive: false });
+  const isShell = def.key === 'shell';
+  const env = buildAgentTerminalEnv(terminalId, sessionId, cwd, undefined, {
+    scrubSensitive: !isShell,
+    kind: isShell ? 'shell' : 'agent',
+  });
 
   const location: vscode.TerminalEditorLocationOptions | vscode.TerminalSplitLocationOptions =
     surface === 'native-split' && parent
@@ -1938,9 +1957,24 @@ async function spawnCommandTerminal(
   const pid = await terminal.processId;
   terminals.register(terminal, terminalId, agentConfig, pid, context);
   readiness.registerTerminal(terminal);
-  armShellAdoptionForTerminal(terminal, context);
+
+  if (!isShell && detectedKey) {
+    const resumeKey = agentKeyFromSession(detectedKey);
+    if (resumeKey) {
+      terminals.setAgentType(terminal, resumeKey);
+      if (sessionId) {
+        terminals.setSessionId(terminal, sessionId);
+        startAutoLabelPollerForTerminal(terminal, context);
+      }
+    }
+  } else {
+    armShellAdoptionForTerminal(terminal, context);
+  }
 
   await sendCommandWhenReady(terminal, req.command);
+  if (vscode.window.activeTerminal === terminal) {
+    updateStatusBarForTerminal(terminal, context.extensionPath);
+  }
   terminal.show();
   lastSpawnedTerminal = terminal;
 }

--- a/apps/ext/src/vscode/terminalReadiness.integration.test.ts
+++ b/apps/ext/src/vscode/terminalReadiness.integration.test.ts
@@ -121,6 +121,18 @@ describe('shell adoption — detectAgentKeyFromArgs', () => {
     expect(detectAgentKeyFromArgs('agents run gemini --model pro')).toBe('gemini');
   });
 
+  test('grok / kimi / droid / antigravity (added after the original five)', () => {
+    expect(detectAgentKeyFromArgs('agents run grok --interactive')).toBe('grok');
+    expect(detectAgentKeyFromArgs('agents run kimi --strategy balanced')).toBe('kimi');
+    expect(detectAgentKeyFromArgs('agents run droid --mode auto')).toBe('droid');
+    expect(detectAgentKeyFromArgs('agents run antigravity --interactive')).toBe('antigravity');
+    expect(detectAgentKeyFromArgs('grok --foo')).toBe('grok');
+    expect(detectAgentKeyFromArgs('kimi')).toBe('kimi');
+    expect(detectAgentKeyFromArgs('droid')).toBe('droid');
+    // Antigravity's installed binary is `agy` (CLI_AGENT_META).
+    expect(detectAgentKeyFromArgs('agy --resume abc')).toBe('antigravity');
+  });
+
   test('unknown commands return null', () => {
     expect(detectAgentKeyFromArgs('vim file.ts')).toBeNull();
     expect(detectAgentKeyFromArgs('git status')).toBeNull();


### PR DESCRIPTION
**fix** — reapplied #2607 onto current main after recent merges.

## Verification

```
bun test src/lib/terminal/backends/backends.test.ts
✓ backends tests pass
```

Closes #2607.