### PR TITLE
fix(devices): drop registered machines from NEW DEVICES sentinels

### DIFF
--- a/apps/cli/.changelog/next/pending-sentinels-drop-registered.md
+++ b/apps/cli/.changelog/next/pending-sentinels-drop-registered.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Menu bar "NEW DEVICES"** no longer lists machines that are already registered or ignored. `reconcilePendingSentinels` now re-subtracts the device registry (not only the ignore-list), and a soft-failed device probe still re-prunes known non-pending sentinels instead of leaving stale phantoms on disk.

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -1050,8 +1050,10 @@ export async function runDaemon(): Promise<void> {
   // appeared tailnet nodes, dropping a sentinel per pending device so the
   // menu-bar helper can surface "NEW DEVICES → Register / Ignore". Refresh mode
   // never auto-registers a newcomer; a machine without tailscale is a clean
-  // no-op. `reconcilePendingSentinels` re-subtracts the ignore-list itself, so a
-  // device the user dismissed is never re-surfaced (RUSH-2495).
+  // no-op. `reconcilePendingSentinels` re-subtracts ignore-list + registry, so a
+  // dismissed or already-registered device is never re-surfaced (RUSH-2495 +
+  // stale-sentinel defense). Soft-fail still re-prunes via the on-disk set so a
+  // tailscale blip cannot leave registered/ignored phantoms in the menu bar.
   let deviceProbeInterval: NodeJS.Timeout | undefined;
   if (isEnabled('device-probe')) {
     let deviceProbeInFlight = false;
@@ -1060,12 +1062,15 @@ export async function runDaemon(): Promise<void> {
       deviceProbeInFlight = true;
       try {
         const { runDeviceSync } = await import('./devices/sync.js');
-        const { reconcilePendingSentinels } = await import('./devices/pending.js');
+        const { reconcilePendingSentinels, readPendingSentinels } = await import('./devices/pending.js');
         const dev = await runDeviceSync({ soft: true, mode: 'refresh' });
-        if (!dev.ok) return;
-        await reconcilePendingSentinels(dev.pending);
-        if (dev.pending.length) {
+        // Soft-fail: re-run the on-disk set through the writer so registered /
+        // ignored sentinels still get pruned; do not invent a full clear.
+        await reconcilePendingSentinels(dev.ok ? dev.pending : readPendingSentinels());
+        if (dev.ok && dev.pending.length) {
           log('INFO', `devices: ${dev.pending.length} new pending (${dev.pending.map((p) => p.name).join(', ')})`);
+        } else if (!dev.ok) {
+          log('WARN', `device probe soft-fail (pruned known non-pending): ${dev.reason ?? 'unknown'}`);
         }
       } catch (err) {
         log('WARN', `device probe tick failed: ${(err as Error).message}`);

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -1066,11 +1066,18 @@ export async function runDaemon(): Promise<void> {
         const dev = await runDeviceSync({ soft: true, mode: 'refresh' });
         // Soft-fail: re-run the on-disk set through the writer so registered /
         // ignored sentinels still get pruned; do not invent a full clear.
+        const before = new Set(readPendingSentinels().map((p) => p.name));
         await reconcilePendingSentinels(dev.ok ? dev.pending : readPendingSentinels());
         if (dev.ok && dev.pending.length) {
           log('INFO', `devices: ${dev.pending.length} new pending (${dev.pending.map((p) => p.name).join(', ')})`);
         } else if (!dev.ok) {
-          log('WARN', `device probe soft-fail (pruned known non-pending): ${dev.reason ?? 'unknown'}`);
+          const after = new Set(readPendingSentinels().map((p) => p.name));
+          const pruned = [...before].filter((n) => !after.has(n));
+          // Silent when nothing changed (no-tailscale hosts soft-fail every tick).
+          // INFO only when we actually removed a phantom so operators can see cleanup.
+          if (pruned.length) {
+            log('INFO', `device probe soft-fail pruned ${pruned.length} non-pending (${pruned.join(', ')}): ${dev.reason ?? 'unknown'}`);
+          }
         }
       } catch (err) {
         log('WARN', `device probe tick failed: ${(err as Error).message}`);

--- a/apps/cli/src/lib/devices/pending.test.ts
+++ b/apps/cli/src/lib/devices/pending.test.ts
@@ -12,6 +12,9 @@
  *   5. a device the user has ignored is never written as a sentinel, even when
  *      the caller passes it in a stale `pending` set (the probe/ignore race,
  *      RUSH-2495) — the writer re-subtracts the persisted ignore-list.
+ *   6. a device already in the registry is never written as a sentinel either
+ *      (stale/polluted sentinels for registered machines must not keep the
+ *      menu bar "NEW DEVICES" section lit).
  */
 import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
@@ -23,7 +26,7 @@ const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devices-pending-
 process.env.HOME = TEST_HOME;
 
 const { reconcilePendingSentinels, clearPendingSentinel, readPendingSentinels } = await import('./pending.js');
-const { addIgnored, removeIgnored } = await import('./registry.js');
+const { addIgnored, removeIgnored, removeDevice, upsertDevice } = await import('./registry.js');
 
 function pendingDir(): string {
   return path.join(TEST_HOME, '.agents', '.cache', 'state', 'devices-pending');
@@ -91,6 +94,29 @@ describe('pending-device sentinels', () => {
       expect(readPendingSentinels()).toEqual([]);
     } finally {
       await removeIgnored('ghost');
+    }
+  });
+
+  it('never re-surfaces an already-registered device, even in a stale pending set', async () => {
+    // Registry already has mac-mini. A polluted/stale pending list still names
+    // it — the writer must drop it and remove any leftover sentinel.
+    await upsertDevice('mac-mini', { platform: 'macos' });
+    try {
+      // Seed a phantom sentinel as if a prior probe/test wrote it.
+      fs.mkdirSync(pendingDir(), { recursive: true });
+      fs.writeFileSync(path.join(pendingDir(), 'mac-mini'), 'macos\n');
+      await reconcilePendingSentinels([
+        { name: 'mac-mini', platform: 'macos' },
+        { name: 'new-box', platform: 'linux' },
+      ]);
+      expect(readPendingSentinels().map((p) => p.name)).toEqual(['new-box']);
+      // Soft-fail prune path: re-running the on-disk set through the writer
+      // must still drop the registered phantom without inventing newcomers.
+      fs.writeFileSync(path.join(pendingDir(), 'mac-mini'), 'macos\n');
+      await reconcilePendingSentinels(readPendingSentinels());
+      expect(readPendingSentinels().map((p) => p.name).sort()).toEqual(['new-box']);
+    } finally {
+      await removeDevice('mac-mini');
     }
   });
 });

--- a/apps/cli/src/lib/devices/pending.test.ts
+++ b/apps/cli/src/lib/devices/pending.test.ts
@@ -24,12 +24,17 @@ import * as path from 'path';
 
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devices-pending-test-'));
 process.env.HOME = TEST_HOME;
+// Match apps/cli/tests/setup.ts: pending sentinels resolve via AGENTS_STATE_DIR,
+// not HOME. Pin both so this file stays hermetic when run alone or under vitest.
+process.env.AGENTS_STATE_DIR = path.join(TEST_HOME, 'state');
+process.env.AGENTS_DEVICES_DIR = path.join(TEST_HOME, 'devices');
 
 const { reconcilePendingSentinels, clearPendingSentinel, readPendingSentinels } = await import('./pending.js');
 const { addIgnored, removeIgnored, removeDevice, upsertDevice } = await import('./registry.js');
+const { getDevicesPendingDir } = await import('../state.js');
 
 function pendingDir(): string {
-  return path.join(TEST_HOME, '.agents', '.cache', 'state', 'devices-pending');
+  return getDevicesPendingDir();
 }
 
 beforeEach(async () => {

--- a/apps/cli/src/lib/devices/pending.ts
+++ b/apps/cli/src/lib/devices/pending.ts
@@ -16,7 +16,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { getDevicesPendingDir } from '../state.js';
-import { loadIgnored } from './registry.js';
+import { loadDevices, loadIgnored } from './registry.js';
 
 export interface PendingDevice {
   name: string;
@@ -38,23 +38,37 @@ function isSafeName(name: string): boolean {
  *
  * The sentinel writer is the single authoritative choke point every discovery
  * path flows through (the daemon device-probe timer and `agents sync`), so it
- * re-subtracts the persisted ignore-list here rather than trusting the caller's
- * `pending` set. This closes the probe/ignore race (RUSH-2495): a probe that
- * computed `pending` BEFORE the user pressed "Ignore" (which persists the
- * dismissal via `addIgnored`) would otherwise re-create the just-dismissed
- * device's sentinel and the menu bar would re-surface it. A device on the
- * ignore-list is never written, regardless of what the caller passed.
+ * re-subtracts both the persisted ignore-list AND the device registry here
+ * rather than trusting the caller's `pending` set:
+ *
+ *   - Ignore (RUSH-2495): a probe that computed `pending` BEFORE the user
+ *     pressed "Ignore" would otherwise re-create the just-dismissed device's
+ *     sentinel and the menu bar would re-surface it.
+ *   - Registered: stale or polluted sentinels for already-registered machines
+ *     (test leaks, a soft-failed probe that never cleaned, a registry write
+ *     that raced the probe) would otherwise keep showing as "NEW DEVICES"
+ *     forever. The menu bar's Register/Ignore gate is only for newcomers.
+ *
+ * A device that is ignored or already registered is never written, regardless
+ * of what the caller passed.
  */
 export async function reconcilePendingSentinels(pending: PendingDevice[]): Promise<void> {
   const dir = getDevicesPendingDir();
-  // Best-effort: a corrupted ignore-list (loadIgnored throws by design) must not
-  // crash the daemon loop — treat it as "nothing ignored" and let the next probe
-  // recover once the file is fixed, rather than failing the whole reconcile.
+  // Best-effort: a corrupted ignore-list / registry (both throw by design) must
+  // not crash the daemon loop — treat the broken side as empty and let the next
+  // probe recover once the file is fixed, rather than failing the whole reconcile.
   let ignored: Set<string>;
   try { ignored = await loadIgnored(); } catch { ignored = new Set(); }
+  let registered: Set<string>;
+  try {
+    const reg = await loadDevices();
+    registered = new Set(Object.keys(reg));
+  } catch {
+    registered = new Set();
+  }
   const want = new Map(
     pending
-      .filter((p) => isSafeName(p.name) && !ignored.has(p.name))
+      .filter((p) => isSafeName(p.name) && !ignored.has(p.name) && !registered.has(p.name))
       .map((p) => [p.name, p.platform]),
   );
 

--- a/apps/cli/src/lib/sync-umbrella.ts
+++ b/apps/cli/src/lib/sync-umbrella.ts
@@ -158,10 +158,13 @@ export async function runUmbrellaSync(args: RunUmbrellaArgs): Promise<UmbrellaRe
     // tailscale is a clean no-op, never a sync failure. First-run population is
     // `agents setup` / manual `agents devices sync` (bootstrap).
     const { runDeviceSync } = await import('./devices/sync.js');
-    const { reconcilePendingSentinels } = await import('./devices/pending.js');
+    const { reconcilePendingSentinels, readPendingSentinels } = await import('./devices/pending.js');
     const dev = await runDeviceSync({ soft: true, mode: 'refresh' });
-    if (dev.ok) await reconcilePendingSentinels(dev.pending);
-    result.devices = { synced: dev.synced, pending: dev.pending.length, skipped: !dev.ok };
+    // Soft-fail still re-prunes registered/ignored phantoms from the on-disk set.
+    const pendingIn = dev.ok ? dev.pending : readPendingSentinels();
+    await reconcilePendingSentinels(pendingIn);
+    const pendingAfter = readPendingSentinels().length;
+    result.devices = { synced: dev.synced, pending: pendingAfter, skipped: !dev.ok };
     if (dev.ok) {
       log(`devices: ${dev.synced} refreshed${dev.pending.length ? `, ${dev.pending.length} new pending` : ''}`);
     }


### PR DESCRIPTION
fix for menu-bar **NEW DEVICES** listing already-registered (and ignored) machines.

## What changed

- **`reconcilePendingSentinels`** re-subtracts the **device registry** as well as the ignore-list, so a stale/polluted caller `pending` set cannot re-create sentinels for machines that are already registered.
- **Daemon device probe** and **`agents sync`** no longer skip reconcile on soft-fail: they re-run the on-disk sentinel set through the writer so registered/ignored phantoms still get pruned (does not invent a full clear of true newcomers).
- Test covers the registered-stale path + soft-fail prune path.
- Changelog fragment under `apps/cli/.changelog/next/`.

## Why

Observed on zion: registry had 15 registered devices (mac-mini, yosemite-*, zion) while `~/.agents/.cache/state/devices-pending/` still held sentinels for those same names, so the menu bar showed **NEW DEVICES (20)** for already-known machines. Ignore re-subtraction (RUSH-2495) already existed; registered machines had no equivalent defense, and a soft-failed probe left stale files forever.

## Verification

Ran in worktree:

```
$ bunx vitest run src/lib/devices/pending.test.ts src/lib/devices/sync.test.ts

 ✓ src/lib/devices/sync.test.ts (26 tests) 4ms
 ✓ src/lib/devices/pending.test.ts (7 tests) 41ms

 Test Files  2 passed (2)
      Tests  33 passed (33)
```

No UI screenshot (daemon/CLI path; menu-bar consumes the sentinel dir). Live zion pending dir was already empty at prune time.
