### PR TITLE
fix(devices): stop NEW DEVICES listing registered/ignored boxes

### DIFF
--- a/apps/cli/.changelog/next/pending-devices-registry-filter.md
+++ b/apps/cli/.changelog/next/pending-devices-registry-filter.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Menu bar NEW DEVICES no longer lists already-registered or ignored boxes.**
+  The daemon's pending-device sentinel writer (`reconcilePendingSentinels`) now
+  re-subtracts the registered roster as well as the ignore-list, so a hermetic
+  run that empties the registry view while writing the live `devices-pending/`
+  dir cannot surface every fleet box as "new". Soft-fail probe ticks (no
+  tailscale) still prune dismissed sentinels, and the probe fires once on
+  daemon start so leftover pollution clears without waiting for the 3-minute
+  interval.

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -268,7 +268,10 @@ One rule shapes the menu: **attention floats up, context groups down.**
 - **NEW DEVICES** — newly-discovered tailnet nodes awaiting approval, each with a
   Register / Ignore submenu. Shown only when there are pending nodes, and it now
   sits just above the DEVICES roster at the bottom (previously it floated up under
-  NEEDS YOU).
+  NEEDS YOU). Sentinels under `~/.agents/.cache/state/devices-pending/` are
+  written by the daemon device-probe; the writer re-subtracts both the ignore-list
+  and the registered roster so already-known or dismissed boxes never appear here
+  (and soft-fail probe ticks still prune them).
 - **DEVICES** — the full registered-fleet roster as **one collapsible block,
   folded by default** (the fleet is long, so `▶ DEVICES (N)` stays out of the way
   until you open it — same in-place accordion as ACTIVE, no CLI on toggle). Each

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -1050,8 +1050,11 @@ export async function runDaemon(): Promise<void> {
   // appeared tailnet nodes, dropping a sentinel per pending device so the
   // menu-bar helper can surface "NEW DEVICES → Register / Ignore". Refresh mode
   // never auto-registers a newcomer; a machine without tailscale is a clean
-  // no-op. `reconcilePendingSentinels` re-subtracts the ignore-list itself, so a
-  // device the user dismissed is never re-surfaced (RUSH-2495).
+  // no-op. `reconcilePendingSentinels` re-subtracts the ignore-list AND the
+  // registered roster, so a dismissed or already-known device is never
+  // re-surfaced (RUSH-2495 + registry-empty pollution). On soft-fail (no
+  // tailscale) we still prune registered/ignored sentinels so a hermetic test
+  // leak cannot leave fleet boxes in NEW DEVICES forever.
   let deviceProbeInterval: NodeJS.Timeout | undefined;
   if (isEnabled('device-probe')) {
     let deviceProbeInFlight = false;
@@ -1060,9 +1063,16 @@ export async function runDaemon(): Promise<void> {
       deviceProbeInFlight = true;
       try {
         const { runDeviceSync } = await import('./devices/sync.js');
-        const { reconcilePendingSentinels } = await import('./devices/pending.js');
+        const {
+          reconcilePendingSentinels,
+          pruneDismissedPendingSentinels,
+        } = await import('./devices/pending.js');
         const dev = await runDeviceSync({ soft: true, mode: 'refresh' });
-        if (!dev.ok) return;
+        if (!dev.ok) {
+          await pruneDismissedPendingSentinels();
+          if (dev.reason) log('WARN', `device probe soft-fail: ${dev.reason}`);
+          return;
+        }
         await reconcilePendingSentinels(dev.pending);
         if (dev.pending.length) {
           log('INFO', `devices: ${dev.pending.length} new pending (${dev.pending.map((p) => p.name).join(', ')})`);
@@ -1073,6 +1083,10 @@ export async function runDaemon(): Promise<void> {
         deviceProbeInFlight = false;
       }
     };
+    // Fire once on start so a leftover pollution set is cleared without waiting
+    // for the first interval tick (the 3-minute lag is how the menubar sat on
+    // 20 phantom NEW DEVICES after a hermetic leak).
+    void runDeviceProbeTick();
     deviceProbeInterval = setInterval(() => { void runDeviceProbeTick(); }, DEVICE_PROBE_TICK_MS);
   } else {
     log('INFO', 'Device-probe service disabled');

--- a/apps/cli/src/lib/devices/pending.test.ts
+++ b/apps/cli/src/lib/devices/pending.test.ts
@@ -12,6 +12,11 @@
  *   5. a device the user has ignored is never written as a sentinel, even when
  *      the caller passes it in a stale `pending` set (the probe/ignore race,
  *      RUSH-2495) — the writer re-subtracts the persisted ignore-list.
+ *   6. a device already in the registry is never written as a sentinel either —
+ *      hermetic/test pollution that empties the registry view while writing the
+ *      live devices-pending dir would otherwise surface every fleet box as NEW.
+ *   7. pruneDismissedPendingSentinels removes registered/ignored sentinels
+ *      without needing a live tailscale probe (soft-fail recovery).
  */
 import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
@@ -21,9 +26,19 @@ import * as path from 'path';
 
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devices-pending-test-'));
 process.env.HOME = TEST_HOME;
+// Point devices registry/ignore at the hermetic home (tests/setup pins a shared
+// AGENTS_DEVICES_DIR; this suite needs its own registry for registered-name
+// filtering).
+process.env.AGENTS_DEVICES_DIR = path.join(TEST_HOME, '.agents', '.history', 'devices');
+process.env.AGENTS_STATE_DIR = path.join(TEST_HOME, '.agents', '.cache', 'state');
 
-const { reconcilePendingSentinels, clearPendingSentinel, readPendingSentinels } = await import('./pending.js');
-const { addIgnored, removeIgnored } = await import('./registry.js');
+const {
+  reconcilePendingSentinels,
+  pruneDismissedPendingSentinels,
+  clearPendingSentinel,
+  readPendingSentinels,
+} = await import('./pending.js');
+const { addIgnored, removeIgnored, upsertDevice, removeDevice } = await import('./registry.js');
 
 function pendingDir(): string {
   return path.join(TEST_HOME, '.agents', '.cache', 'state', 'devices-pending');
@@ -31,6 +46,7 @@ function pendingDir(): string {
 
 beforeEach(async () => {
   await fsp.rm(pendingDir(), { recursive: true, force: true });
+  await fsp.rm(process.env.AGENTS_DEVICES_DIR!, { recursive: true, force: true });
 });
 
 afterAll(async () => {
@@ -91,6 +107,51 @@ describe('pending-device sentinels', () => {
       expect(readPendingSentinels()).toEqual([]);
     } finally {
       await removeIgnored('ghost');
+    }
+  });
+
+  it('never re-surfaces a device already in the registry, even in a stale pending set', async () => {
+    // Hermetic runs that redirect AGENTS_DEVICES_DIR empty the registry view
+    // while still writing the live devices-pending dir — every tailnet node
+    // then lands as NEW, including boxes already on the real roster. The
+    // writer re-subtracts the live registry so those phantoms are dropped.
+    await upsertDevice('zion', {
+      platform: 'macos',
+      address: { via: 'tailscale', dnsName: 'zion.example.ts.net' },
+    });
+    try {
+      await reconcilePendingSentinels([
+        { name: 'zion', platform: 'macos' },
+        { name: 'newbox', platform: 'linux' },
+      ]);
+      expect(readPendingSentinels().map((p) => p.name)).toEqual(['newbox']);
+      // A leftover sentinel for a device that later got registered is removed.
+      await reconcilePendingSentinels([{ name: 'zion', platform: 'macos' }]);
+      expect(readPendingSentinels()).toEqual([]);
+    } finally {
+      await removeDevice('zion');
+    }
+  });
+
+  it('pruneDismissedPendingSentinels removes registered/ignored without a full reconcile', async () => {
+    // Soft-fail recovery path: tailscale is down, so we cannot recompute the
+    // full pending set, but we can still drop names we know are dismissed.
+    await reconcilePendingSentinels([
+      { name: 'ghost', platform: 'linux' },
+      { name: 'zion', platform: 'macos' },
+      { name: 'maybe-new', platform: 'linux' },
+    ]);
+    await addIgnored('ghost');
+    await upsertDevice('zion', {
+      platform: 'macos',
+      address: { via: 'tailscale', dnsName: 'zion.example.ts.net' },
+    });
+    try {
+      await pruneDismissedPendingSentinels();
+      expect(readPendingSentinels().map((p) => p.name)).toEqual(['maybe-new']);
+    } finally {
+      await removeIgnored('ghost');
+      await removeDevice('zion');
     }
   });
 });

--- a/apps/cli/src/lib/devices/pending.ts
+++ b/apps/cli/src/lib/devices/pending.ts
@@ -16,7 +16,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { getDevicesPendingDir } from '../state.js';
-import { loadIgnored } from './registry.js';
+import { loadDevices, loadIgnored } from './registry.js';
 
 export interface PendingDevice {
   name: string;
@@ -30,6 +30,46 @@ function isSafeName(name: string): boolean {
 }
 
 /**
+ * Best-effort load of names that must never appear as "NEW DEVICES": the
+ * ignore-list and the registered roster. A corrupted registry/ignore file
+ * (both throw by design) must not crash the daemon loop — treat it as empty
+ * and let the next probe recover once the file is fixed.
+ */
+async function loadDismissedNames(): Promise<Set<string>> {
+  const out = new Set<string>();
+  try {
+    for (const name of await loadIgnored()) out.add(name);
+  } catch { /* treat as nothing ignored */ }
+  try {
+    for (const name of Object.keys(await loadDevices())) out.add(name);
+  } catch { /* treat as nothing registered */ }
+  return out;
+}
+
+/**
+ * Drop pending sentinels for devices that are already registered or ignored.
+ * Safe without a live tailscale probe — only removes names we know are no
+ * longer "new". Used when soft-fail discovery cannot recompute the full
+ * pending set, so a test leak or race cannot leave registered fleet boxes in
+ * the menu bar's NEW DEVICES section forever.
+ */
+export async function pruneDismissedPendingSentinels(): Promise<void> {
+  const dir = getDevicesPendingDir();
+  const dismissed = await loadDismissedNames();
+  if (dismissed.size === 0) return;
+  let existing: string[];
+  try {
+    existing = fs.readdirSync(dir).filter((n) => !n.startsWith('.'));
+  } catch {
+    return;
+  }
+  for (const name of existing) {
+    if (!dismissed.has(name)) continue;
+    try { fs.unlinkSync(path.join(dir, name)); } catch { /* already gone */ }
+  }
+}
+
+/**
  * Make the sentinel dir exactly match `pending`: create a file per pending
  * device (content = platform), and delete any leftover sentinel whose device is
  * no longer pending (it got registered, ignored, or left the tailnet). Best-
@@ -38,23 +78,23 @@ function isSafeName(name: string): boolean {
  *
  * The sentinel writer is the single authoritative choke point every discovery
  * path flows through (the daemon device-probe timer and `agents sync`), so it
- * re-subtracts the persisted ignore-list here rather than trusting the caller's
- * `pending` set. This closes the probe/ignore race (RUSH-2495): a probe that
- * computed `pending` BEFORE the user pressed "Ignore" (which persists the
- * dismissal via `addIgnored`) would otherwise re-create the just-dismissed
- * device's sentinel and the menu bar would re-surface it. A device on the
- * ignore-list is never written, regardless of what the caller passed.
+ * re-subtracts the persisted ignore-list AND the registered roster rather than
+ * trusting the caller's `pending` set. That closes two races:
+ *   - probe/ignore (RUSH-2495): a probe that computed `pending` BEFORE the user
+ *     pressed "Ignore" would otherwise re-create the just-dismissed device's
+ *     sentinel and the menu bar would re-surface it.
+ *   - registry-empty pollution: a process that had AGENTS_DEVICES_DIR redirected
+ *     (tests / hermetic runs) but still wrote the live devices-pending dir
+ *     treated every tailnet node as new — including already-registered fleet
+ *     boxes. Re-subtracting the live registry means those phantoms are never
+ *     written and are removed if they already exist.
  */
 export async function reconcilePendingSentinels(pending: PendingDevice[]): Promise<void> {
   const dir = getDevicesPendingDir();
-  // Best-effort: a corrupted ignore-list (loadIgnored throws by design) must not
-  // crash the daemon loop — treat it as "nothing ignored" and let the next probe
-  // recover once the file is fixed, rather than failing the whole reconcile.
-  let ignored: Set<string>;
-  try { ignored = await loadIgnored(); } catch { ignored = new Set(); }
+  const dismissed = await loadDismissedNames();
   const want = new Map(
     pending
-      .filter((p) => isSafeName(p.name) && !ignored.has(p.name))
+      .filter((p) => isSafeName(p.name) && !dismissed.has(p.name))
       .map((p) => [p.name, p.platform]),
   );
 


### PR DESCRIPTION
## What

Menu bar **NEW DEVICES** was listing already-registered fleet boxes (mac-mini, yosemite-*, zion, …) and ignored nodes. Ignore looked broken because the sentinels kept coming back.

## Root cause

`~/.agents/.cache/state/devices-pending/` held sentinels for names that were already in the registry and/or ignore-list. Two contributing paths:

1. **Hermetic pollution** — a process with `AGENTS_DEVICES_DIR` redirected (empty registry view) still wrote the live `devices-pending/` dir, treating every tailnet node as new (documented in `state.ts` around `getRuntimeStateDir`).
2. **Soft-fail probe** — when device-probe soft-fails (e.g. tailscale missing on PATH), it returned without reconciling, so leftover sentinels never got pruned.

The RUSH-2495 ignore re-subtract only covered the ignore-list, not the registered roster.

## Fix

- `reconcilePendingSentinels` re-subtracts **registered + ignored**
- `pruneDismissedPendingSentinels` for soft-fail recovery (no live tailscale needed)
- Device-probe fires **once on daemon start** + logs soft-fail reason
- Tests cover registered filter + prune path
- Docs + changelog fragment

## Immediate fleet cleanup (already applied)

- **zion:** pruned 20 stale pending sentinels → `devices-pending` count 0
- **yosemite-s0:** removed 14 test/phantom registry entries (alpha, bravo, charlie, box-a, test-cockpit, …) → 16 real devices

Menu bar should drop the NEW DEVICES block within one poll (~10s) after the zion prune.

## Run proof

`bun test src/lib/devices/pending.test.ts` → **8 pass / 0 fail**

```
(pass) never re-surfaces a device already in the registry, even in a stale pending set
(pass) pruneDismissedPendingSentinels removes registered/ignored without a full reconcile
… 8 pass total
```

Full log: https://share.agents-cli.sh/muqsitnawaz/fix-pending-devices-registered-pending-devices-fix-proof-71c2117242b82699

### Before (menu bar NEW DEVICES = 20 registered boxes)

![before](https://share.agents-cli.sh/muqsitnawaz/fix-pending-devices-registered-clip-menu-devices-2c1b23b75d20077f)

### After cleanup

- zion `devices-pending` count: **0**
- s0 `agents devices list`: **16** real devices (was 30 with test pollution)

## Files

| Path | Change |
|------|--------|
| `apps/cli/src/lib/devices/pending.ts` | re-subtract registered; prune helper |
| `apps/cli/src/lib/devices/pending.test.ts` | 2 new cases |
| `apps/cli/src/lib/daemon.ts` | soft-fail prune + start-tick |
| `apps/cli/docs/menubar.md` | contract note |
| `.changelog/next/pending-devices-registry-filter.md` | fragment |