### PR TITLE
fix(release): prepack version gate tolerates bundler-merged declarations

### DIFF
--- a/apps/cli/scripts/verify-cli-binary.sh
+++ b/apps/cli/scripts/verify-cli-binary.sh
@@ -38,12 +38,15 @@ fi
 
 # scripts/build-bin.sh bakes the version in as `const VERSION = "<v>";` and
 # bun's bundler carries it into the binary as `var VERSION = "<v>";` (no
-# minification here). Grep the keyword-independent tail so a const/var change
-# in the bundler can't break the gate; -a because grep otherwise refuses to
-# match inside a binary. Runs even where the Mach-O cannot execute (Linux
-# release box).
+# minification here) — or, when it merges adjacent declarations, as
+# `var VERSION = "<v>", NEXT_CONST = …;` (observed with bun 1.3.14 once the
+# RUSH-2335 bootstrap split put another const right after VERSION). Grep only
+# up to the closing quote so declaration merging can't false-fail the gate;
+# the quoted version is already an exact match. -a because grep otherwise
+# refuses to match inside a binary. Runs even where the Mach-O cannot execute
+# (Linux release box).
 version="$(node -p "require('./package.json').version")"
-if ! LC_ALL=C grep -aqF "VERSION = \"$version\";" "$BIN"; then
+if ! LC_ALL=C grep -aqF "VERSION = \"$version\"" "$BIN"; then
   echo "dist/bin/agents does not embed version $version - stale binary; re-run scripts/sign-cli-binary.sh" >&2
   exit 1
 fi

--- a/apps/cli/scripts/verify-cli-binary.test.ts
+++ b/apps/cli/scripts/verify-cli-binary.test.ts
@@ -82,6 +82,21 @@ describe('verify-cli-binary.sh prepack gate', () => {
   });
 
   it.runIf(process.platform !== 'darwin')(
+    'passes when the bundler merged VERSION into a declaration list (comma, not semicolon)',
+    () => {
+      // bun 1.3.14 merges adjacent consts: the stamped line lands in the
+      // binary as `var VERSION = "<v>", IS_DEV_BUILD = …;` — the gate must
+      // not demand a semicolon after the version literal (1.22.36 publish
+      // blocker).
+      const root = stageTree({
+        binary: 'MACHO-STAND-IN\nvar VERSION = "1.0.0", IS_DEV_BUILD = false;\n',
+      });
+      const result = runGate(root);
+      expect(result.status, result.stderr).toBe(0);
+    },
+  );
+
+  it.runIf(process.platform !== 'darwin')(
     'passes on sha + version match where codesign does not exist',
     () => {
       const root = stageTree({});


### PR DESCRIPTION
## Why

The v1.22.36 publish died at npm's `prepack` gate with:

```
dist/bin/agents does not embed version 1.22.36 - stale binary; re-run scripts/sign-cli-binary.sh
```

The binary was correctly stamped, signed, and notarized — `--version` prints `1.22.36`, the sha pin matches. The gate (`scripts/verify-cli-binary.sh`) greps the compiled binary for the literal `VERSION = "<v>";` **with a trailing semicolon**. Since the RUSH-2335 entry split (`fd712c976`/`dbca54b0d`) moved `VERSION` into `bootstrap.ts` immediately before another `const`, bun's bundler merges the declarations and the binary carries:

```
var VERSION = "1.22.36", IS_DEV_BUILD = …;
```

— a comma, not a semicolon. The gate false-fails, making v1.22.36's tagged tree unpublishable on any machine. The next release rides the script's documented patch-from-main path.

## Fix

Match `VERSION = "<v>"` up to the closing quote instead of demanding the semicolon. The quoted version is already an exact match (a `1.22.360` can't false-pass — the quote follows the last digit).

## Tests

- New regression test stages the bundler-merged comma form and asserts the gate passes.
- Verified against the **real signed binary** from the failed v1.22.36 publish attempt (bun 1.3.14): old gate exits 1 with the publish-blocking error; fixed gate exits 0.
- `vitest run scripts/verify-cli-binary.test.ts`: 5 passed, 1 skipped (darwin-only codesign leg, runs in the macOS CI matrix).

No CHANGELOG entry: internal release tooling, no user-visible surface.