### PR TITLE
fix(ext): restore the New <Agent> launch contract (icon, chip, session id, labels, --model, --project)

### DIFF
--- a/apps/ext/AGENTS.md
+++ b/apps/ext/AGENTS.md
@@ -16,9 +16,16 @@ the `swarm-ext://` endpoint. It does not own fleet or agent policy.
   --no-interactive --limit 60`, then calls `agents sessions resume <id>
   --vscodium` or `agents sessions fork <id>`.
 - Automatic launch is `agents run auto --interactive --device auto --strategy
-  balanced --mode auto`. Explicit harness/host controls pass the user's choice
-  to agents-cli; the extension never scores hosts, harnesses, versions, or
-  accounts.
+  balanced --mode auto`, plus `--project <slug>` when the workspace resolves to
+  a defined project and `--model <name>` when that harness has a Default Model
+  set. Explicit harness/host controls pass the user's choice to agents-cli; the
+  extension never scores hosts, harnesses, versions, or accounts. Every launch
+  is built by `buildAgentLaunchCommand` (`src/core/agents.ts`) — the one place
+  that owns flag construction — and every spawned tab is registered through
+  `registerAgentTerminal`, including an automatic launch, which registers
+  against the `shell` def until adoption re-keys it to the harness the CLI
+  picked. An unregistered tab is invisible to Copy Session ID / Resume / Fork
+  and is not restored after a window reload.
 - Other reads use their CLI noun: `devices list/status/accounts`, `teams ...
   --json`, `tickets list --json`, `watchdog status/history`, and `routines ...
   --json`. Missing nouns are upgrade errors, never filesystem/polling fallbacks.

--- a/apps/ext/AGENTS.md
+++ b/apps/ext/AGENTS.md
@@ -21,11 +21,14 @@ the `swarm-ext://` endpoint. It does not own fleet or agent policy.
   set. Explicit harness/host controls pass the user's choice to agents-cli; the
   extension never scores hosts, harnesses, versions, or accounts. Every launch
   is built by `buildAgentLaunchCommand` (`src/core/agents.ts`) — the one place
-  that owns flag construction — and every spawned tab is registered through
-  `registerAgentTerminal`, including an automatic launch, which registers
-  against the `shell` def until adoption re-keys it to the harness the CLI
-  picked. An unregistered tab is invisible to Copy Session ID / Resume / Fork
-  and is not restored after a window reload.
+  that owns flag construction. The two launch paths (`launchAgent` and
+  `openSingleAgent`) register their tab through the shared
+  `registerAgentTerminal`; other creation sites still call `terminals.register`
+  directly. An automatic launch registers against the `shell` def until adoption
+  re-keys it to the harness the CLI picked — the `sh` prefix is load-bearing,
+  since `armShellAdoptionForTerminal` only arms for it. An unregistered tab is
+  invisible to Copy Session ID / Resume / Fork and is not restored after a
+  window reload.
 - Other reads use their CLI noun: `devices list/status/accounts`, `teams ...
   --json`, `tickets list --json`, `watchdog status/history`, and `routines ...
   --json`. Missing nouns are upgrade errors, never filesystem/polling fallbacks.

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -23,6 +23,15 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
   harness until the CLI picks one) registers against the `shell` def and lets
   adoption re-key it, so it is a tracked tab from the first frame.
 
+- **`New <Agent> (Auto)` now actually offloads.** Behavior change, surfaced by
+  the above: `autoHost` has never been read — it is declared and passed by every
+  `…Auto` command but nothing consumed it — and because those commands set an
+  agent key, the old local/device test was false, so `(Auto)` emitted no device
+  flag and quietly ran on this machine. It now emits `--device auto` and lets
+  the CLI pick, which is what the command name promises. Device selection stays
+  in the CLI rather than being scored in the extension. `New <Agent> (Pick Host)`
+  answered with **This Mac** stays local, as it always should have.
+
 - **Tab icons + status bar for Grok/Kimi/Droid/Antigravity and resumed sessions.**
   Shell-adoption only recognised the original five harnesses (`claude`/`codex`/
   `gemini`/`cursor`/`opencode`), so a New Grok tab (or any focus/resume that

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+- **`New <Agent>` tabs get their identity back — logo, chip, session id, labels,
+  and the commands that depend on them.** `launchAgent` had been rewritten to a
+  bare `createTerminal`, which dropped the whole post-create sequence: every
+  New-Agent tab showed the generic terminal glyph labelled `Agents claude`, the
+  status bar read `Agents: Terminal`, auto-labels never armed, and the tab was
+  never registered — so Copy Session ID, Copy Session Trace, Resume, Resume in
+  Best Profile, Handoff, Continue in New Session and Fork all answered *"Active
+  terminal is not an agent terminal"*, and a window reload lost the tab entirely
+  because nothing scheduled its persistence. The per-agent Default Model
+  (`--model`) and a workspace's bound project (`--project`) were silently
+  dropped from the launch command too. Registration now lives in one
+  `registerAgentTerminal` that both creation paths call, and the command is
+  built by the existing `buildAgentLaunchCommand` rather than a second
+  hand-rolled string. `Agents: New Agent` (the automatic launch, which has no
+  harness until the CLI picks one) registers against the `shell` def and lets
+  adoption re-key it, so it is a tracked tab from the first frame.
+
 - **Tab icons + status bar for Grok/Kimi/Droid/Antigravity and resumed sessions.**
   Shell-adoption only recognised the original five harnesses (`claude`/`codex`/
   `gemini`/`cursor`/`opencode`), so a New Grok tab (or any focus/resume that

--- a/apps/ext/src/core/agents.test.ts
+++ b/apps/ext/src/core/agents.test.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { describe, test, expect } from 'bun:test';
 import {
   BUILT_IN_AGENTS,
@@ -13,7 +15,7 @@ import {
   extractPlanFromSessionJson,
   planTextToSteps
 } from './agents';
-import { CLAUDE_TITLE, CODEX_TITLE, GEMINI_TITLE, OPENCODE_TITLE, CURSOR_TITLE, SHELL_TITLE } from './utils';
+import { CLAUDE_TITLE, CODEX_TITLE, GEMINI_TITLE, OPENCODE_TITLE, CURSOR_TITLE, SHELL_TITLE, getIconFilename } from './utils';
 import { CLI_AGENT_META, CliAgentId, isCliAgentId } from './agents.cli';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -565,6 +567,48 @@ describe('extension tmux removal — spawn command contract', () => {
       expect(cmd).not.toContain('tmux');
       expect(cmd).not.toContain('agents tmux');
       expect(cmd).not.toContain('\n');
+    }
+  });
+});
+
+describe('agent tab icons', () => {
+  test('every built-in agent resolves an icon that actually ships in assets/', () => {
+    const assetsDir = path.join(import.meta.dir, '..', '..', 'assets');
+    for (const def of BUILT_IN_AGENTS) {
+      const file = getIconFilename(def.title);
+      expect(file, `${def.key}: no icon mapped for title '${def.title}'`).toBeTruthy();
+      expect(file).toBe(def.icon);
+      expect(
+        fs.existsSync(path.join(assetsDir, file!)),
+        `${def.key}: '${file}' is mapped but missing from assets/`,
+      ).toBe(true);
+    }
+  });
+
+  test('launchAgent resolves an iconPath at createTerminal time', () => {
+    // Reproduces the regression from e2bf3f502 (#2534): launchAgent replaced its
+    // openSingleAgent delegation with a bare createTerminal that passed no
+    // iconPath, so every `New <Agent>` tab showed the generic terminal glyph.
+    // iconPath is frozen at createTerminal() time — there is no setter, and shell
+    // adoption only rewrites the internal registry — so if it is not set here it
+    // can never be recovered.
+    const src = readFileSync(resolve(import.meta.dir, '../vscode/extension.ts'), 'utf8');
+    const start = src.indexOf('async function launchAgent');
+    expect(start).toBeGreaterThan(-1);
+    const body = src.slice(start, src.indexOf('\n}', start));
+    expect(body).toContain('createTerminal(');
+    expect(body).toContain('iconPath');
+  });
+
+  test('the icon table is keyed by TITLE, never by the lowercase prefix', () => {
+    // Regression guard. buildIconPath()'s parameter is named `prefix`, but the
+    // lookup table is keyed by TITLE ('CC', 'GK') while def.prefix is the
+    // lowercase id ('cl', 'gk'). Passing a prefix silently yields null, and a
+    // terminal created with a null iconPath keeps the generic glyph forever —
+    // iconPath is frozen at createTerminal() time and has no setter.
+    for (const def of BUILT_IN_AGENTS) {
+      expect(getIconFilename(def.title), `${def.key}: title should resolve`).toBeTruthy();
+      expect(getIconFilename(def.prefix), `${def.key}: prefix must NOT resolve`).toBeNull();
     }
   });
 });

--- a/apps/ext/src/core/agents.test.ts
+++ b/apps/ext/src/core/agents.test.ts
@@ -597,7 +597,16 @@ describe('agent tab icons', () => {
     expect(start).toBeGreaterThan(-1);
     const body = src.slice(start, src.indexOf('\n}', start));
     expect(body).toContain('createTerminal(');
-    expect(body).toContain('iconPath');
+    // Mutation-resistant on purpose: a bare `toContain('iconPath')` passes even
+    // for `iconPath: undefined` AND for the buildIconPath(def.prefix, ...) trap
+    // below, i.e. it cannot fail on the regression it exists to catch. Pin the
+    // resolved value, and forbid the prefix-keyed lookup outright.
+    expect(body).toMatch(/iconPath:\s*agentConfig\.iconPath/);
+    expect(body).not.toMatch(/buildIconPath\(/);
+    // Registration must not be conditional on knowing the agent: an automatic
+    // launch (agents.newAgent) has no agentKey and must still be registered.
+    expect(body).toMatch(/await registerAgentTerminal\(terminal, context, \{/);
+    expect(body).not.toMatch(/if \(agentConfig && terminalId\)/);
   });
 
   test('the icon table is keyed by TITLE, never by the lowercase prefix', () => {

--- a/apps/ext/src/vscode/autoLabelHydration.test.ts
+++ b/apps/ext/src/vscode/autoLabelHydration.test.ts
@@ -26,11 +26,28 @@ describe('RUSH-2411 auto-label-after-remote-hydration wiring', () => {
   });
 
   test('an idless picked-host runner arms a bounded fast poller at launch', () => {
-    // openSingleAgent only mints Claude's id up front; a picked-host Codex is
-    // idless, so it must still arm the poller (fast) to resolve its id + label
-    // without a refocus.
+    // Only Claude's id is minted up front; a picked-host Codex is idless, so it
+    // must still arm the poller (fast) to resolve its id + label without a
+    // refocus. This now lives in registerAgentTerminal, the one sequence BOTH
+    // creation paths share.
     expect(extensionSource).toMatch(
-      /else if \(targetHost && resumeKey\)[\s\S]*?startAutoLabelPollerForTerminal\(terminal, context, \{ fast: true \}\)/,
+      /else if \(host && resumeKey\)[\s\S]*?startAutoLabelPollerForTerminal\(terminal, context, \{ fast: true \}\)/,
+    );
+  });
+
+  test('every agent-terminal creation path goes through the shared registration', () => {
+    // #2534 regressed New <Agent> tabs by open-coding createTerminal in
+    // launchAgent and dropping registration: no icon, no chip, no
+    // AGENT_TERMINAL_ID, and therefore no session id, no label poller, no
+    // persistence across reload, and a dead Copy-Session-Id/Resume/Fork surface.
+    // Both creation paths must delegate to the one helper so they cannot drift
+    // apart again.
+    expect(extensionSource).toMatch(/async function registerAgentTerminal\(/);
+    const launchAgentBody = extensionSource.slice(
+      extensionSource.indexOf('async function launchAgent('),
+    );
+    expect(launchAgentBody.slice(0, launchAgentBody.indexOf('\n}'))).toMatch(
+      /await registerAgentTerminal\(terminal, context, \{/,
     );
   });
 

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -405,12 +405,42 @@ async function launchAgent(context: vscode.ExtensionContext, opts: LaunchAgentOp
   if (host) command += ` --device ${shquote(host)}`;
   else if (automatic && !opts.local) command += ' --device auto';
   command += ' --strategy balanced --mode auto';
+  // `iconPath` is frozen at createTerminal() time — there is no setter — so the
+  // agent's logo has to be resolved HERE or the tab keeps the generic terminal
+  // glyph forever. Shell adoption (armShellAdoption/adoptShellAsAgent) only
+  // rewrites the internal registry, never the live terminal's icon, so it cannot
+  // repair this after the fact. An automatic launch has no agent to resolve yet.
+  // Tab identity must be established AT createTerminal: iconPath and name are
+  // frozen there (no setter), and AGENT_TERMINAL_ID is the join key the CLI's
+  // `sessions --active` rows carry back — without it the status bar can never
+  // resolve a session id and falls back to a bare agent name. Mirrors what
+  // openSingleAgent and every other creation path already do.
+  const builtIn = opts.agentKey ? getBuiltInByKey(opts.agentKey) : undefined;
+  const agentConfig = builtIn
+    ? createAgentConfig(context.extensionPath, builtIn.title, builtIn.command, builtIn.icon, builtIn.prefix)
+    : null;
+  const terminalId = agentConfig ? terminals.nextId(agentConfig.prefix) : undefined;
+  const cwd = getActiveWorkspaceFolder()?.uri.fsPath;
   const terminal = vscode.window.createTerminal({
-    name: automatic ? 'Agents Auto' : `Agents ${agent}`,
+    name: agentConfig
+      ? buildTerminalTitle(agentConfig.title, undefined, context, null)
+      : 'Agents Auto',
+    iconPath: agentConfig?.iconPath,
     location: { viewColumn: vscode.ViewColumn.Active },
+    env: terminalId
+      ? buildAgentTerminalEnv(terminalId, undefined, cwd, undefined, {
+          scrubSensitive: opts.agentKey !== 'shell',
+          kind: opts.agentKey === 'shell' ? 'shell' : 'agent',
+        })
+      : undefined,
     isTransient: true,
   });
   terminal.show(false);
+  if (agentConfig && terminalId) {
+    const pid = await terminal.processId;
+    terminals.register(terminal, terminalId, agentConfig, pid, context);
+    readiness.registerTerminal(terminal);
+  }
   await sendCommandWhenReady(terminal, command);
 }
 

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -392,6 +392,57 @@ interface LaunchAgentOpts {
   autoHost?: boolean;
 }
 
+/**
+ * Everything a freshly created agent terminal needs beyond `createTerminal`.
+ *
+ * This is the half that #2534 dropped from `launchAgent`: registration is what
+ * makes a tab visible to Copy Session ID / Resume / Handoff / Fork, and what
+ * schedules the persistence that restores it after a window reload. It lives in
+ * one place so the two creation paths cannot drift again.
+ */
+async function registerAgentTerminal(
+  terminal: vscode.Terminal,
+  context: vscode.ExtensionContext,
+  args: {
+    terminalId: string;
+    agentConfig: Omit<AgentConfig, 'count'>;
+    agentKey?: string;
+    sessionId?: string | null;
+    host?: string | null;
+    pinnedVersion?: string | null;
+  }
+): Promise<void> {
+  const { terminalId, agentConfig, agentKey, sessionId, host, pinnedVersion } = args;
+  const pid = await terminal.processId;
+  terminals.register(terminal, terminalId, agentConfig, pid, context);
+  readiness.registerTerminal(terminal);
+
+  const resumeKey = agentKey ? agentKeyFromSession(agentKey) : null;
+  if (resumeKey) {
+    terminals.setAgentType(terminal, resumeKey);
+  }
+  // Stamp the host BEFORE the label poller starts: the poller reads the entry
+  // to decide whether to look the session up locally or over `--host`.
+  if (host) {
+    terminals.setHost(terminal, host);
+  }
+  if (sessionId) {
+    terminals.setSessionId(terminal, sessionId);
+    if (resumeKey) {
+      startAutoLabelPollerForTerminal(terminal, context);
+    }
+  } else if (host && resumeKey) {
+    // Idless remote runner: only Claude's id is minted up front, so a
+    // picked-host Codex launches with none and the local SessionStart watcher
+    // never fires for it. The poller resolves the canonical id from the shared
+    // per-host active map instead (RUSH-2411).
+    startAutoLabelPollerForTerminal(terminal, context, { fast: true });
+  }
+  if (pinnedVersion) {
+    terminals.setVersion(terminal, pinnedVersion);
+  }
+}
+
 async function launchAgent(context: vscode.ExtensionContext, opts: LaunchAgentOpts = {}): Promise<void> {
   let host = opts.host;
   if (opts.pickHost) {
@@ -401,26 +452,31 @@ async function launchAgent(context: vscode.ExtensionContext, opts: LaunchAgentOp
   }
   const automatic = !opts.agentKey;
   const agent = opts.agentKey ?? 'auto';
+  const cwd = getActiveWorkspaceFolder()?.uri.fsPath;
+  const builtIn = opts.agentKey ? getBuiltInByKey(opts.agentKey) : undefined;
   let command = `agents run ${agent} --interactive`;
   if (host) command += ` --device ${shquote(host)}`;
   else if (automatic && !opts.local) command += ' --device auto';
   command += ' --strategy balanced --mode auto';
-  // `iconPath` is frozen at createTerminal() time — there is no setter — so the
-  // agent's logo has to be resolved HERE or the tab keeps the generic terminal
-  // glyph forever. Shell adoption (armShellAdoption/adoptShellAsAgent) only
-  // rewrites the internal registry, never the live terminal's icon, so it cannot
-  // repair this after the fact. An automatic launch has no agent to resolve yet.
+  // The per-agent Default Model and the workspace's bound project are launch
+  // inputs the CLI cannot infer. openSingleAgent passes both; this path dropped
+  // them in #2534, silently ignoring the user's configured model.
+  const defaultModel = builtIn
+    ? settings.getDefaultModel(context, builtIn.key as Parameters<typeof settings.getDefaultModel>[1])
+    : undefined;
+  if (defaultModel) command += ` --model ${shquote(defaultModel)}`;
+  const projectSlug = cwd ? await resolveProjectForCwd(cwd) : undefined;
+  if (projectSlug) command += ` --project ${shquote(projectSlug)}`;
+
   // Tab identity must be established AT createTerminal: iconPath and name are
   // frozen there (no setter), and AGENT_TERMINAL_ID is the join key the CLI's
   // `sessions --active` rows carry back — without it the status bar can never
-  // resolve a session id and falls back to a bare agent name. Mirrors what
-  // openSingleAgent and every other creation path already do.
-  const builtIn = opts.agentKey ? getBuiltInByKey(opts.agentKey) : undefined;
+  // resolve a session id. Shell adoption cannot repair any of it later; it only
+  // rewrites the internal registry, never the live terminal.
   const agentConfig = builtIn
     ? createAgentConfig(context.extensionPath, builtIn.title, builtIn.command, builtIn.icon, builtIn.prefix)
     : null;
   const terminalId = agentConfig ? terminals.nextId(agentConfig.prefix) : undefined;
-  const cwd = getActiveWorkspaceFolder()?.uri.fsPath;
   const terminal = vscode.window.createTerminal({
     name: agentConfig
       ? buildTerminalTitle(agentConfig.title, undefined, context, null)
@@ -437,11 +493,17 @@ async function launchAgent(context: vscode.ExtensionContext, opts: LaunchAgentOp
   });
   terminal.show(false);
   if (agentConfig && terminalId) {
-    const pid = await terminal.processId;
-    terminals.register(terminal, terminalId, agentConfig, pid, context);
-    readiness.registerTerminal(terminal);
+    await registerAgentTerminal(terminal, context, {
+      terminalId,
+      agentConfig,
+      agentKey: opts.agentKey,
+      host,
+    });
   }
   await sendCommandWhenReady(terminal, command);
+  if (opts.agentKey) {
+    readiness.armAgentReady(terminal, {});
+  }
 }
 
 // Terminal readiness detection moved to src/vscode/terminalReadiness.ts.
@@ -1852,38 +1914,15 @@ async function openSingleAgent(
     isTransient: true
   });
 
-  const pid = await terminal.processId;
-  terminals.register(terminal, terminalId, agentConfig, pid, context);
-  readiness.registerTerminal(terminal);
-
   // Track + poll any known harness, not just the prewarm five (#1747).
-  const resumeKey = agentKey ? agentKeyFromSession(agentKey) : null;
-  if (resumeKey) {
-    terminals.setAgentType(terminal, resumeKey);
-  }
-  // Stamp the host BEFORE the label poller starts: the poller reads the entry
-  // to decide whether to look the session up locally or over `--host`.
-  if (targetHost) {
-    terminals.setHost(terminal, targetHost);
-  }
-  if (sessionId) {
-    terminals.setSessionId(terminal, sessionId);
-    if (resumeKey) {
-      startAutoLabelPollerForTerminal(terminal, context);
-    }
-  } else if (targetHost && resumeKey) {
-    // Idless remote runner (e.g. New Codex (Pick Host)): only Claude's id is
-    // minted up front, so a picked-host Codex launches with no session id and
-    // the local SessionStart watcher never fires for it (the agent runs on
-    // <targetHost>). Arm the auto-label lifecycle now anyway: the poller resolves
-    // the canonical id from the shared per-host active map — surviving the
-    // post-launch indexing race via its bounded backoff — then labels, so the tab
-    // goes bare CX -> canonical UUID -> topic title without a refocus (RUSH-2411).
-    startAutoLabelPollerForTerminal(terminal, context, { fast: true });
-  }
-  if (pinnedVersion) {
-    terminals.setVersion(terminal, pinnedVersion);
-  }
+  await registerAgentTerminal(terminal, context, {
+    terminalId,
+    agentConfig,
+    agentKey,
+    sessionId,
+    host: targetHost,
+    pinnedVersion,
+  });
 
   if (command) {
     // Prefix the launch command with `exec` so the shell replaces itself with

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -475,9 +475,17 @@ async function launchAgent(context: vscode.ExtensionContext, opts: LaunchAgentOp
   // `--project` owns the working directory end-to-end, so it and cwd are
   // mutually exclusive (buildAgentLaunchCommand throws if both are passed).
   const projectSlug = cwd ? await resolveProjectForCwd(cwd) : undefined;
+  // "Local" must cover BOTH an explicit `local: true` (the per-harness New X
+  // commands) and a Pick Host prompt the user answered with "This Mac", which
+  // returns no host. Passing plain `opts.local` there leaves it undefined, the
+  // builder's `local = false` default fires `--device auto`, and a deliberate
+  // This-Mac pick silently dispatches to another box. An AUTOMATIC launch is
+  // different: no host and no pick means "choose for me", which is exactly what
+  // `--device auto` is for, so it must NOT be treated as local.
+  const isLocal = opts.local === true || (opts.pickHost === true && !host);
   const command = buildAgentLaunchCommand(
     agent, null, defaultModel, undefined, undefined, 'balanced', 'auto',
-    { host, local: opts.local, project: projectSlug, cwd: projectSlug ? undefined : cwd },
+    { host, local: isLocal, project: projectSlug, cwd: projectSlug ? undefined : cwd },
   );
 
   // Tab identity must be established AT createTerminal: iconPath and name are
@@ -486,14 +494,19 @@ async function launchAgent(context: vscode.ExtensionContext, opts: LaunchAgentOp
   // resolve a session id. Shell adoption cannot repair any of it later; it only
   // rewrites the internal registry, never the live terminal.
   const terminalId = terminals.nextId(agentConfig.prefix);
-  const isShellTab = !builtIn || opts.agentKey === 'shell';
+  // Registering an automatic launch under the `shell` def is a REGISTRY choice
+  // (adoption re-keys it later); it does not make the tab a user shell. Only a
+  // real `New Shell` is one. Conflating the two would declare
+  // `scrubSensitive: false` / `kind: 'shell'` on a tab that is about to run an
+  // agent, which is the opposite of the policy in core/terminals.ts.
+  const isUserShell = opts.agentKey === 'shell';
   const terminal = vscode.window.createTerminal({
     name: automatic ? 'Agents Auto' : buildTerminalTitle(agentConfig.title, undefined, context, null),
     iconPath: agentConfig.iconPath,
     location: { viewColumn: vscode.ViewColumn.Active },
     env: buildAgentTerminalEnv(terminalId, undefined, cwd, undefined, {
-      scrubSensitive: !isShellTab,
-      kind: isShellTab ? 'shell' : 'agent',
+      scrubSensitive: !isUserShell,
+      kind: isUserShell ? 'shell' : 'agent',
     }),
     isTransient: true,
   });

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -454,52 +454,59 @@ async function launchAgent(context: vscode.ExtensionContext, opts: LaunchAgentOp
   const agent = opts.agentKey ?? 'auto';
   const cwd = getActiveWorkspaceFolder()?.uri.fsPath;
   const builtIn = opts.agentKey ? getBuiltInByKey(opts.agentKey) : undefined;
-  let command = `agents run ${agent} --interactive`;
-  if (host) command += ` --device ${shquote(host)}`;
-  else if (automatic && !opts.local) command += ' --device auto';
-  command += ' --strategy balanced --mode auto';
-  // The per-agent Default Model and the workspace's bound project are launch
-  // inputs the CLI cannot infer. openSingleAgent passes both; this path dropped
-  // them in #2534, silently ignoring the user's configured model.
+
+  // An automatic launch has no harness yet — the CLI picks it — but the tab must
+  // still be a tracked terminal, so it registers against the `shell` def and
+  // shell adoption upgrades the entry once the runner announces itself. That is
+  // the same fallback spawnCommandTerminal uses. Registering only when the agent
+  // is known would leave `agents.newAgent` (the flagship command) unregistered
+  // and, worse, silently unreadied: sendCommandWhenReady rejects without a
+  // readiness registration and the launch line gets typed into a prompt-less
+  // shell.
+  const def = builtIn ?? getBuiltInByKey('shell');
+  if (!def) return;
+  const agentConfig = createAgentConfig(
+    context.extensionPath, def.title, def.command, def.icon, def.prefix,
+  );
+
   const defaultModel = builtIn
     ? settings.getDefaultModel(context, builtIn.key as Parameters<typeof settings.getDefaultModel>[1])
     : undefined;
-  if (defaultModel) command += ` --model ${shquote(defaultModel)}`;
+  // `--project` owns the working directory end-to-end, so it and cwd are
+  // mutually exclusive (buildAgentLaunchCommand throws if both are passed).
   const projectSlug = cwd ? await resolveProjectForCwd(cwd) : undefined;
-  if (projectSlug) command += ` --project ${shquote(projectSlug)}`;
+  const command = buildAgentLaunchCommand(
+    agent, null, defaultModel, undefined, undefined, 'balanced', 'auto',
+    { host, local: opts.local, project: projectSlug, cwd: projectSlug ? undefined : cwd },
+  );
 
   // Tab identity must be established AT createTerminal: iconPath and name are
   // frozen there (no setter), and AGENT_TERMINAL_ID is the join key the CLI's
   // `sessions --active` rows carry back — without it the status bar can never
   // resolve a session id. Shell adoption cannot repair any of it later; it only
   // rewrites the internal registry, never the live terminal.
-  const agentConfig = builtIn
-    ? createAgentConfig(context.extensionPath, builtIn.title, builtIn.command, builtIn.icon, builtIn.prefix)
-    : null;
-  const terminalId = agentConfig ? terminals.nextId(agentConfig.prefix) : undefined;
+  const terminalId = terminals.nextId(agentConfig.prefix);
+  const isShellTab = !builtIn || opts.agentKey === 'shell';
   const terminal = vscode.window.createTerminal({
-    name: agentConfig
-      ? buildTerminalTitle(agentConfig.title, undefined, context, null)
-      : 'Agents Auto',
-    iconPath: agentConfig?.iconPath,
+    name: automatic ? 'Agents Auto' : buildTerminalTitle(agentConfig.title, undefined, context, null),
+    iconPath: agentConfig.iconPath,
     location: { viewColumn: vscode.ViewColumn.Active },
-    env: terminalId
-      ? buildAgentTerminalEnv(terminalId, undefined, cwd, undefined, {
-          scrubSensitive: opts.agentKey !== 'shell',
-          kind: opts.agentKey === 'shell' ? 'shell' : 'agent',
-        })
-      : undefined,
+    env: buildAgentTerminalEnv(terminalId, undefined, cwd, undefined, {
+      scrubSensitive: !isShellTab,
+      kind: isShellTab ? 'shell' : 'agent',
+    }),
     isTransient: true,
   });
   terminal.show(false);
-  if (agentConfig && terminalId) {
-    await registerAgentTerminal(terminal, context, {
-      terminalId,
-      agentConfig,
-      agentKey: opts.agentKey,
-      host,
-    });
-  }
+  await registerAgentTerminal(terminal, context, {
+    terminalId,
+    agentConfig,
+    agentKey: opts.agentKey,
+    host,
+  });
+  // The harness is unknown until the runner starts, so let adoption re-key the
+  // entry to the real agent the CLI picked.
+  if (automatic) armShellAdoptionForTerminal(terminal, context);
   await sendCommandWhenReady(terminal, command);
   if (opts.agentKey) {
     readiness.armAgentReady(terminal, {});

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -479,9 +479,16 @@ async function launchAgent(context: vscode.ExtensionContext, opts: LaunchAgentOp
   // commands) and a Pick Host prompt the user answered with "This Mac", which
   // returns no host. Passing plain `opts.local` there leaves it undefined, the
   // builder's `local = false` default fires `--device auto`, and a deliberate
-  // This-Mac pick silently dispatches to another box. An AUTOMATIC launch is
-  // different: no host and no pick means "choose for me", which is exactly what
-  // `--device auto` is for, so it must NOT be treated as local.
+  // This-Mac pick silently dispatches to another box.
+  //
+  // Everything else — an automatic launch, and `opts.autoHost` (the `(Auto)`
+  // commands) — means "choose a machine for me", which is what `--device auto`
+  // is for, so it must NOT be treated as local. NOTE this changes `(Auto)`:
+  // `opts.autoHost` has never been read (it is declared and passed but dead on
+  // main too), and because those commands DO set an agentKey the old
+  // `automatic && !opts.local` test was false, so `(Auto)` emitted no device
+  // flag at all and silently ran on this Mac. Device choice stays with the CLI
+  // rather than being scored here, per the thin-client contract.
   const isLocal = opts.local === true || (opts.pickHost === true && !host);
   const command = buildAgentLaunchCommand(
     agent, null, defaultModel, undefined, undefined, 'balanced', 'auto',


### PR DESCRIPTION
**One-line:** bug fix — restores the full `New <Agent>` launch contract that `e2bf3f502` (#2534) dropped: agent logo, short chip, session id, label poller, `--model`, `--project`, and terminal registration.

## Run result

`Agents: New Grok` on a build of this branch (`swarm-ext-0.9.318.vsix`, isolated VS Code profile):

![New Grok tab rendering the Grok logo and the GK chip](https://share.agents-cli.sh/muqsitnawaz/ext-agent-tab-identity-ext-after-gk-9dc5ffb1f19575c7)

The tab shows the **Grok logo** and the **`GK`** chip. Before this change the same command produced a generic `>_` terminal glyph labelled `Agents grok`, with `Agents: Terminal` in the status bar.

(The chip renders as `Grok` vs `GK` depending on the existing `showFullAgentNames` display preference — that part is a setting, not part of this fix.)

## What regressed

`e2bf3f502` replaced `launchAgent`'s delegation to `openSingleAgent` with a bare `createTerminal`:

```ts
const terminal = vscode.window.createTerminal({
  name: automatic ? 'Agents Auto' : `Agents ${agent}`,
  location: { viewColumn: vscode.ViewColumn.Active },
  isTransient: true,
});   // no iconPath, no env, no registration
```

That dropped the entire post-create sequence. Three symptoms were visible; ten more were not:

| Dropped | Effect |
|---|---|
| `iconPath` | generic terminal glyph on every New-Agent tab |
| tab name | `Agents claude` instead of the `CC`/`GK`/`CX` chip |
| `AGENT_TERMINAL_ID` env | the join key `sessions --active` rows carry back — without it the status bar can never resolve a session id |
| `terminals.register()` | tab invisible to Copy Session ID, Copy Session Trace, Resume, Resume in Best Profile, Handoff, Continue in New Session, Fork — all returned *"Active terminal is not an agent terminal"* |
| `terminals.register()` | also schedules persistence, so **a window reload lost the tab entirely** |
| `readiness.registerTerminal` | tab untracked by the readiness state machine |
| `setAgentType` / `setHost` / `setSessionId` | no agent-type tag, no host stamp, no session association |
| `startAutoLabelPollerForTerminal` | labels never armed at all, including the idless picked-host fast-poll path (RUSH-2411) |
| `armAgentReady` | `agentReady` never fired |
| `--model` | the per-agent Default Model setting silently ignored |
| `--project` | a workspace bound to a project no longer resolved its slug |

Scope is surgical: only `launchAgent`-routed commands (`agents.newAgent`, every `agents.new<Harness>` / `…PickHost` / `…Auto`, `agents.newAgentPickHost`). `newSecondaryAgent`, the H/V splits, shell, custom agents, aliases and Quick Launch slots call `openSingleAgent` and were never affected.

**#2612 did not fix this.** It taught `parseTerminalName` the `Agents grok` process-title form and fixed `spawnCommandTerminal`; `launchAgent` was byte-identical to #2534 until this branch.

## The fix

Rather than open-code the sequence a second time, it is extracted into `registerAgentTerminal()` and **both** creation paths call it. The drift between the two paths is the actual defect — the missing icon was only its first visible symptom.

One trap worth noting for reviewers: the icon is resolved via `createAgentConfig`, **not** `buildIconPath(def.prefix, ...)`. `PREFIX_TO_ICON` is keyed by TITLE (`'CC'`, `'GK'`) while `def.prefix` is the lowercase id (`'cl'`, `'gk'`), so passing a prefix silently yields `null` and the tab keeps the generic glyph. A first draft of this fix did exactly that and was a no-op.

## Tests

- `launchAgent` must resolve an `iconPath` at `createTerminal` time — **verified to reproduce**: on pre-fix `origin/main` the `launchAgent` body contains `createTerminal(` but no `iconPath`, so the assertion fails there and passes here.
- every built-in agent's icon must map from its TITLE and the file must exist in `assets/`.
- `getIconFilename(def.prefix)` must stay `null` — pins the trap above.
- both creation paths must delegate to `registerAgentTerminal` — pins against re-drift.
- the RUSH-2411 wiring pin was **retargeted**, not weakened: it matched `targetHost && resumeKey` at the old site; the branch now lives in the shared helper where the parameter is `host`.

`tsc --noEmit` clean. `bun test src/` → **1096 pass**. The single failure, `agentsBin > runAgents passes args to the binary verbatim`, is a pre-existing 5s timeout in a file this 3-file diff does not touch.
