### PR TITLE
fix(daemon): assert the published 'health' key, not the internal 'record'

### DIFF
--- a/apps/cli/src/commands/daemon.test.ts
+++ b/apps/cli/src/commands/daemon.test.ts
@@ -291,9 +291,14 @@ describeDaemon('agents daemon', () => {
     await new Promise((r) => setTimeout(r, 1500));
     const services = run(home, ['services', '--json']);
     expect(services.status).toBe(0);
-    const payload = JSON.parse(services.stdout) as { secretsBroker: { reachable: boolean; record: unknown } };
+    // `record` is the internal field name (probeSecretsBroker, daemon.ts:318);
+    // `services --json` publishes it as `health` (daemon.ts:547, and :454 for
+    // `status --json`). Asserting `record` here read an absent key as undefined,
+    // so this test could never pass on macOS — and since the macOS legs only run
+    // on release/** branches, it stayed invisible until a release PR ran.
+    const payload = JSON.parse(services.stdout) as { secretsBroker: { reachable: boolean; health: unknown } };
     expect(payload.secretsBroker.reachable).toBe(false);
-    expect(payload.secretsBroker.record).toBeNull();
+    expect(payload.secretsBroker.health).toBeNull();
     run(home, ['stop']);
   }, 30_000);
 


### PR DESCRIPTION
**test-only** — one assertion. No behavior change, no CHANGELOG (test-only exemption).

## This blocks every release, not just ours

`build (macos-latest, 22)` and `(macos-latest, 24)` fail on any release PR. Hit on release PR #2631 (1.22.37):

```
FAIL src/commands/daemon.test.ts > agents daemon > a disabled secrets-broker is not hosted by the daemon on macOS
AssertionError: expected undefined to be null
  - Expected: null
  + Received: undefined
 -> src/commands/daemon.test.ts:296:42
```

1 failed / 11,727 passed. Ubuntu and Windows are green.

## Why it can never pass

| Where | What it says |
|---|---|
| `daemon.test.ts:296` | asserts `payload.secretsBroker.record` |
| `daemon.ts:547` | emits `health: secrets.record` — the JSON key is **`health`** |
| `daemon.ts:318,338` | `record` is only the *internal* field on `probeSecretsBroker`'s return |

There is no `record` key in `services --json`, so the lookup is always `undefined` and `toBeNull()` always fails. Deterministic, not flaky — I re-ran the failed macOS jobs to rule that out before diagnosing.

## Why nobody noticed

The test is gated to darwin (`daemon.test.ts:285`: `if (process.platform !== 'darwin') return;`), and per `apps/cli/AGENTS.md` the cross-platform matrix is cost-gated to `release/**` pushes and `workflow_dispatch` — not ordinary PRs to `main`. So it passed review in `00884e3ad` (the commit that added it) and only fired once a release PR ran the macOS legs.

## Run result

Ran the previously-failing test on macOS (zion, node v26) with the fix:

```
RUN  v4.1.9 .../fix-daemon-services-json-key/apps/cli
 Test Files  1 passed (1)
      Tests  1 passed | 28 skipped (29)
   Duration  9.49s
```

Failing direction is evidenced by the CI log quoted above; passing direction by this local macOS run.

## Note (not fixed here)

`daemon.test.ts:285` uses a bare `if (...) return;` rather than `it.skipIf`, so on Linux/Windows it reports as **passed** while asserting nothing. Worth converting, but it is not what breaks the build and I kept this diff to the one line.