### PR TITLE
docs(memory): backfill agents-cli project decision log (Jun 24 - Aug 10)

### DIFF
--- a/.agents/memories/2026-06-24.md
+++ b/.agents/memories/2026-06-24.md
@@ -1,0 +1,9 @@
+# 2026-06-24 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 23:37 · claude@yosemite-s1 · 5ee7fc19 · —
+- Resolved a git rebase conflict in `agents.yaml` that was blocking `main` from advancing — the only logged session this day.
+- Same-day merge history (git log, 32 commits) shows the unblock landed a large batch of stacked feature PRs in one push: secrets-agent Touch-ID broker (#405), `--to-ssh` secrets export target (#403), autonomous `agents run` loop driver + checkpoint/resume (#398), budget spend tracking + hard-cap kill-switch (#396), session cost/duration analytics via `agents cost` (#392), cross-machine session sync via CRDT merge over R2 (#344), and the `agents sync` umbrella verb (#369/#389).
+- Released same day as 1.20.16 -> 1.20.18 (chore(release) commits `69f48e534`, `0a95d0c7b`, `bab69ec45`).

--- a/.agents/memories/2026-06-25.md
+++ b/.agents/memories/2026-06-25.md
@@ -1,0 +1,50 @@
+# 2026-06-25 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 03:44 · claude@yosemite-s1 · 1a74cbc8 · —
+- User complaint kicked off the day's theme: Touch ID prompts fire too often for `@agents-cli` and need reducing.
+- Scoped as the `secrets-agent-touch-id-broker` work item — a persistent broker to stop re-prompting per invocation.
+- Executed via: claude@yosemite-s1 f03b603d
+
+### 06:15 · claude@yosemite-s1 · f2fa113f · AES-256
+- Decided to merge the PR reducing Touch ID prompts under ticket AES-256, and scoped a companion headless-macOS secrets-passphrase path for boxes with no Touch ID hardware.
+- Outcome: same-day commits landed `feat(secrets): file-backed bundles for headless/remote reads (no Touch ID)` (#406) and `fix(secrets): harden secrets-agent auto-cache against slow broker cold-start` (#407).
+- Executed via: claude@yosemite-s1 e5c7a981
+
+### 06:16 · claude@yosemite-s1 · fb029dac · —
+- Reviewed Swarmify (VS Code extension) performance issues — topic only, no shipped fix traced to this session.
+
+### 06:18 · claude@yosemite-s1 · b6a5b355 · —
+- Scoped `windows-agent-driven-qa-box` — the decision to stand up a Windows machine as an agent-driven QA target. Seeds the Windows-parity push that lands 06-30/07-01.
+
+### 06:18 · claude@yosemite-s1 · c59eaaae · —
+- Explored Google Stitch CLI for design automation — topic only, no evidence it was adopted.
+
+### 06:21 · claude@yosemite-s1 · b67604b7 · —
+- Scoped `trim-swarm-plugin-add-qa` — trimming the swarm plugin and adding QA coverage. Topic only.
+
+### 06:22 · claude@yosemite-s1 · 8b086963 · —
+- Scoped `learn-command-session-reflection` — a session-reflection/learn command. Topic only.
+
+### 06:27 · claude@yosemite-s1 · cfd15e5b · —
+- Ran a full code-quality/architecture scan of agents-cli and checked the report into `.agents/artifacts/2026-06-25/2026-06-25-quality-architecture.html` (276 source files, ~142k LOC, 73 commands, 109 lib modules, tsc clean, 231 test files, 40+ duplication clusters, 8 already-drifted bugs).
+- Recommended fix order (highest leverage first): shared `atomicWriteJson`/`atomicRetargetSymlink` helpers to close non-atomic-write corruption; read-side throw-on-corruption instead of silent null; DB merge quarantine + parameterized ATTACH; subprocess timeouts/exit-code capture; one real-semver `compareVersions`; a shared `src/lib/format.ts`; extend `commands/utils.ts`/`strings.ts`; collapse `AgentId` to one definition and route `runner.ts` through `exec.ts`.
+- Outcome: committed same day as `docs: add code quality & architecture report for agents-cli` (`bba2bb042`). Report explicitly read-only — no code changed.
+- Anchor: `.agents/artifacts/2026-06-25/2026-06-25-quality-architecture.html` §4 "Recommended fix order".
+
+### 06:53 · claude@yosemite-s1 · aa7363ef · —
+- Debugged an image-display issue — topic only.
+
+### 14:34 · claude@yosemite-s1 · 64c4cca9 · —
+- Decided to stop OpenClaw and agent job schedules — an operational pause, topic only (no shipped-change evidence).
+
+### 15:10 · claude@yosemite-s1 · d685b0ed · —
+- Extracted sales videos and drafted scripts for the agency repo — content/marketing work, not core CLI.
+
+### 18:53 · claude@yosemite-s1 · c145d44a · —
+- Second round of debugging frequent Touch ID prompts in the agents CLI — the morning's #406/#407 fix had not fully closed the problem by end of day.
+
+### 20:29 · claude@yosemite-s1 · 59aea34f · —
+- Scoped `framer-tauri-video-extractor` — a Tauri-based video extractor for Framer content. Topic only.

--- a/.agents/memories/2026-06-27.md
+++ b/.agents/memories/2026-06-27.md
@@ -1,0 +1,46 @@
+# 2026-06-27 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 00:15 · claude@yosemite-s1 · 4c3b9b8d · —
+- Explored the a separate external partner project repository and its tower-app integration — early scouting, topic only. Recurs later (06-28, 07-07 port).
+
+### 00:26 · claude@yosemite-s1 · da53af48 · —
+- Debugged multiple-image-attachment handling — topic only.
+
+### 07:21 · claude@yosemite-s1 · 92ea8e24 · —
+- Diagnosed slow computer performance / resource usage — topic only.
+
+### 07:57 · claude@yosemite-s1 · 97228af9 · —
+- Set up the `.agents` repo for agent configuration — the DotAgents repo pattern (rules/commands/skills/hooks/mcp resources synced from a versioned repo) traces to this session.
+
+### 09:49 · claude@yosemite-s1 · dfe7577d · —
+- Decided to add a menu bar icon for agents-cli macros/routines on macOS.
+- Outcome: same-day commits `feat: macOS menu-bar helper with auto-enable` (`f996e98b8`) and `build(release): prepack gate so a release can't ship without the menubar .app` (`2aced2684`) — the prepack gate makes the menubar app a hard release requirement going forward.
+
+### 10:35 · claude@yosemite-s1 · 94fe4972 · —
+- Scoped `agent-native-cloud-providers` — running each agent in its own native cloud rather than one shared provider.
+- Outcome: same-day commits `feat(cloud): run each agent in its own native cloud` (`6eac4701c`) and `feat(cloud): discover pre-provisioned targets + interactive picker` (`34119e05f`).
+
+### 10:35 · claude@yosemite-s1 · a045c462 · —
+- Debugged a missing swarm-plugin display issue — topic only.
+
+### 11:49 · claude@yosemite-s1 · 1acafe59 · —
+- Compared Agents CLI vs a separate external partner project — positioning/scoping discussion, topic only.
+
+### 12:07 · claude@yosemite-s1 · dbbb29f4 · —
+- Reviewed Claude and Codex sessions for mistakes — a QA/retro pass over agent output, topic only.
+
+### 12:42 · claude@yosemite-s1 · 467587d2 · —
+- Continued the `reduce-touch-id-prompts` effort (started 06-25).
+- Outcome: same-day commits `feat(secrets): rename tier→policy (always/daily) + disclose policy in secrets list` (#423, `3bbf97dd5`) and `feat(secrets): self-heal stale daemon/broker onto new code after upgrade` (#413, `5626746ea`) — reframes the Touch ID cadence as a user-facing policy setting.
+
+### 15:54 · claude@yosemite-s1 · f41a7aca · —
+- Investigated Touch ID secret prompts specifically on Mac Mini — device-specific follow-up to the tier→policy change above.
+
+### 16:31 · claude@yosemite-s1 · 82d1af50 · —
+- Connected to a Windows computer via Tailscale SSH — continuation of the 06-25 `windows-agent-driven-qa-box` decision; establishes the SSH path the Windows QA box work (06-30/07-01) builds on.
+
+### 16:33 · claude@yosemite-s1 · 9584ae18 · —
+- Decided to replace Gemini and Cursor with Grok CLI as a supported/preferred harness. No same-day commit evidence of the swap landing; topic-derived decision.

--- a/.agents/memories/2026-06-28.md
+++ b/.agents/memories/2026-06-28.md
@@ -1,0 +1,34 @@
+# 2026-06-28 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 13:06 · codex@yosemite-s1 · 019f08e3 · —
+- Dispatched a task to Claude Code for the agents-cli repo via the Rush CLI cloud-runs surface — an early use of cloud dispatch rather than local sessions.
+
+### 13:50 · claude@yosemite-s1 · c82b8622 · —
+- Continued a prior conversation to clarify workflow requirements and design approach — topic only, no specific mechanism captured.
+- Executed via: claude@yosemite-s1 80a98fb2 (/continue)
+
+### 19:59 · claude@yosemite-s1 · 7e46704e · —
+- "Slave the main branch" — topic-derived: a decision about treating `main` as the single source of truth other checkouts sync against, ahead of the formal worktree-only-PR policy set the following week (RUSH-1353, 07-01).
+
+### 20:55 · claude@yosemite-s1 · ff0d1b65 · —
+- Looked for the PR opened by `prix-cloud` on the agents-cli monorepo — checking whether the automated code-reviewer bot was posting reviews.
+
+### 21:04 · claude@yosemite-s1 · 3d288642 · —
+- Reviewed how user OAuth tokens get injected for agent deployment — topic only (the prior day's `fix(daemon): inject long-lived Claude OAuth token into scheduler env` (#381) landed 06-24; this session reviewed that path).
+
+### 21:07 · claude@yosemite-s1 · f9ae66db · —
+- Worked on making the agent CLI interactive through headless harnesses — the design work behind the hosts/devices subsystem. Same-day doc commits laid out the architecture: `docs(hosts): pluggable HostProvider seam; v1 = local (no Rush dependency)` (`a06ea76e5`), `docs(hosts): registry-first discovery; Tailscale demoted to optional transport` (`b99ad6682`), `docs(hosts): coherent Context model + fix --print/ssh-helper inaccuracies` (`655b11079`), `docs(hosts): add motivation (OS-coordination starvation) + crabbox lease source` (`1a02baf2b`), `docs(hosts): design for brokerless tailnet agent dispatch` (`fb8362252`).
+
+### 21:20 · claude@yosemite-s1 · b507c67b · RUSH-844
+- Connected Linear MCP to the CodeReviewer agent, under ticket RUSH-844 — the origin of automated PR review sourced from Linear context.
+- Executed via: claude@yosemite-s1 361128df (test the integration)
+
+### 21:46 · claude@yosemite-s1 · 33e237b0 · —
+- Scoped `remote-windows-control-agents` — controlling a remote Windows box from an agent, extending the Windows QA box track.
+
+### 23:53 · claude@yosemite-s1 · f0ba2ae0 · —
+- Reviewed and set up a separate external partner repository — follow-up to the 06-27 scouting session, moving from "explore" to "set up".
+- Executed via: claude@yosemite-s1 86634fea

--- a/.agents/memories/2026-06-29.md
+++ b/.agents/memories/2026-06-29.md
@@ -1,0 +1,46 @@
+# 2026-06-29 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 02:06 · claude@yosemite-s1 · b1cb345e · —
+- Cut a new release of agents-cli from `main` — a routine release session.
+
+### 02:09 · claude@yosemite-s1 · 55e3adfc · —
+- Debugged the `@agents-cli` update-binary registration issue — topic only.
+
+### 02:45 · claude@yosemite-s1 · 59a20b18 · —
+- Found session titles not displaying in output commands — a bug report the day after `feat(sessions): surface real session titles for Claude and Codex` (#454) shipped (06-28), indicating that fix left gaps.
+
+### 03:47 · claude@yosemite-s1 · 6ef21e46 · —
+- Set the Windows hostname and enabled SSH access — continuing the Windows QA box build-out (06-25/06-27).
+- Executed via: claude@yosemite-s1 692e8476 (resolved a follow-on SSH host-key verification error)
+
+### 04:32 · claude@yosemite-s1 · c3f9c5bb · AES-256
+- Exported the owner's personal secrets bundle to a remote computer under ticket AES-256.
+- Outcome: same-day commit `secrets export --host (drop --to-ssh) + make agents resolvable under nvm` (#461, `336b53066`) — renames the export flag from `--to-ssh` (added 06-24, #403) to `--host`.
+
+### 04:49 · claude@yosemite-s1 · 4c1e8504 · —
+- Debugged the agent workflow and git-sync process — topic only.
+
+### 04:52 · claude@yosemite-s1 · 792dca0c · —
+- Set up a daily repository-sync and worktree routine — an early scheduled routine for keeping local checkouts current.
+
+### 06:03 · claude@yosemite-s1 · eac7f3e0 · —
+- Optimized the VS Code extension for multi-agent performance — topic only.
+
+### 07:53 · claude@yosemite-s1 · 5cbe188e · —
+- Rebased `main` with skipped commits — a git-hygiene session, topic only.
+
+### 08:22 · claude@yosemite-s1 · f4350a1c · WOMBAT-7382
+- Recovered Ghostty terminal sessions after a macOS crash, under ticket WOMBAT-7382.
+
+### 08:45 · claude@yosemite-s1 · 796d08db · —
+- Prepared a report on replacement strategies — topic-derived, likely following up on the 06-27 decision to replace Gemini/Cursor with Grok CLI; mechanism not captured in this pass.
+
+### 20:34 · claude@yosemite-s1 · 78cdd310 · —
+- Created a utils plugin for screenshot organization — topic only.
+
+### 20:35 · claude@yosemite-s1 · e42b82a5 · RUSH-1319
+- Fixed agents-cli UI under ticket RUSH-1319, scoped as an `agent-dashboard-rail-redesign`.
+- Executed via: claude@yosemite-s1 d9988d02

--- a/.agents/memories/2026-06-30.md
+++ b/.agents/memories/2026-06-30.md
@@ -1,0 +1,17 @@
+# 2026-06-30 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 22:42 · claude@yosemite-s1 · b0b96b07 · —
+- Configured SSH access from Yosemite computers to `win-mini` — the Windows QA box (scoped 06-25, wired 06-27/06-29) goes live.
+- Outcome: this was the day the Windows-parity push landed in force (46 commits): `feat(computer-win): implement 7 parity verbs on the Windows daemon` (#495), `feat(computer): Windows computer-use companion app (computer-helper-win)` (#485), `feat(computer): drive agents computer off-macOS and against a remote Windows host over SSH` (#496), `fix(win): green the windows-latest CI matrix + make it a required gate` (#484), plus a `fix(win):` sweep across resources/rules/injection, spawn/registry, versions/self-update/plugins, hooks/staleness/migrate, sessions/sync/cloud, and leaf modules.
+- Also landed same day: `feat(ssh): agents ssh wrapper + agents devices registry` (#482), `feat(hosts): agents hosts + run --host — offload agent runs onto your machines` (#456), `feat(devices): auto-populate the registry + curate with a persistent ignore-list` (#499), `feat(sessions): live state engine — waiting/PR/worktree/ticket + reliable preview` (#494).
+
+### 23:37 · claude@yosemite-s1 · b6cf85ed · —
+- Debugged missing Droid sessions in agents-cli.
+- Outcome: same-day commit `feat(sessions): discover and render Droid (Factory) sessions` (`8dfaa043c`).
+
+### 23:54 · claude@yosemite-s1 · 87de53b5 · —
+- Tested all agent types in the teams feature.
+- Outcome: same-day commit `fix(teams): make droid/kimi teammates launch — versioned-alias binaries + kimi headless flags` (#488, `6de44ee7a`), and `feat(models): add Antigravity + Kimi to agents models; fix silent agent dropout` (#492).

--- a/.agents/memories/2026-07-01.md
+++ b/.agents/memories/2026-07-01.md
@@ -1,0 +1,58 @@
+# 2026-07-01 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: 118 commits landed this calendar day (largest of the range) — entries below cover the sessions with clear provenance; not every merged PR is individually attributed to a session.
+
+### 02:13 · claude@yosemite-s1 · 66ed00fd · —
+- Continued `smart-clip-reference-paste` — the menu-bar clip hotkey (Cmd-Shift-V) feature shipped 06-30 (#498) got further work here.
+
+### 03:17 · claude@yosemite-s1 · 916673de · —
+- Synced `.gitconfig` across multiple devices — topic only.
+
+### 04:45 · claude@yosemite-s1 · 9f296197 · RUSH-1323
+- Set up an "HMCLI" daily routine checking which CLI types support hooks — the origin of RUSH-1323, later resolved as GitHub Copilot CLI hooks support ("RUSH-1323: Wire hooks support for GitHub Copilot CLI").
+- Executed via: claude@yosemite-s1 3a11d7d8
+
+### 07:02 · claude@yosemite-s1 · 29a96289 · —
+- Added a sidebar tab for host filtering and device information in AGI EXT (the VS Code extension).
+
+### 07:32 · claude@yosemite-s1 · fe73be1f · —
+- Created a Claude agent type in Linear — tracker setup so agent-authored tickets carry an agent identity.
+
+### 08:48 · claude@yosemite-s1 · 3691315c · RUSH-1353
+- Set the policy `enforce-worktree-pr-workflow` under ticket RUSH-1353 — the origin of the "every change is a worktree + PR, main is untouchable" rule now codified in this repo's CLAUDE.md.
+
+### 09:18 · claude@yosemite-s1 · 7b6d38cc · RUSH-1318
+- Fixed `agents view` not showing Comet CLI and Droid accounts, under ticket RUSH-1318.
+- Outcome: `fix(auth): persist droid/antigravity/kimi login across version switches (RUSH-1318)` (06-30) and `fix(test): skip POSIX-mode assertion on Windows in auth-carry test (RUSH-1318)` (#517, same day).
+
+### 12:16 · claude@yosemite-s1 · 8d14471f · —
+- Worked out how to determine the current computer and wire an injection hook for it.
+- Outcome: same-day commits under RUSH-1415 built the terminal-injection + watchdog stack this depended on: `feat(terminal): injectIntoTerminal primitive` (#611), `feat(terminal): resolve session -> precise inject target (iterm/vscodium/tmux, safe Ghostty skip)` (#616), `feat(watchdog): port stall-detection + nudge-decision core` (#612), `feat(watchdog): agents watchdog consumer — tick -> resolve -> inject` (#619).
+
+### 12:55 · droid@yosemite-s1 · 03fac085 · —
+- Mission: wire Droid (Factory CLI) HOOKS and PLUGINS support into agents-cli.
+- Outcome: same-day commit `feat(droid): wire Factory CLI hooks (RUSH-1327) and plugins (RUSH-1340)` (#577, `8b00cc8b1`).
+
+### 19:02 · claude@yosemite-s1 · cadde646 · —
+- Built an "agent field" feature for Swarmify (the extension) — topic only.
+
+### 21:03 · claude@yosemite-s1 · 0aa26d02 · RUSH-1412
+- Released a new version of agents-cli under ticket RUSH-1412.
+- Outcome: RUSH-1412 tracked CI-release-matrix stability — `fix(events): root audit log dir at HOME-aware anchor so Windows CI is green (RUSH-1412)` (#618) and `fix(ci): green the release matrix on macOS (node-pty native + AF_UNIX path)` (#607) landed same day; multiple `chore(release)` version bumps (1.20.33, 1.20.34/#550) shipped this day.
+
+### 21:05 · claude@yosemite-s1 · 0ac428fe · —
+- Scoped `fix-agent-host-oomkill-prod` — a production OOM-kill incident on an agent host.
+
+### 21:22 · claude@yosemite-s1 · 109b7b34 · —
+- Decided to show a "train" menu-bar item during D1 and Rush CLI execution — a release-train status indicator in the menubar UI.
+
+### 22:28 · claude@yosemite-s1 · d81bc8b4 · —
+- Set up remote screen sharing from Yosemite S1 devices — infra/tooling, topic only.
+
+### 22:31 · claude@yosemite-s1 · 20da545d · RUSH-1302
+- Filed agency-li menu bar helper tickets and enabled the watchdog, under ticket RUSH-1302 — the umbrella ticket that the same-day RUSH-1415 watchdog build (#612/#619) was filed under.
+
+### 23:08 · claude@yosemite-s1 · ffc28614 · —
+- Deployed ComfyUI workflows for image editing — creative tooling, tangential to core CLI.

--- a/.agents/memories/2026-07-02.md
+++ b/.agents/memories/2026-07-02.md
@@ -1,0 +1,23 @@
+# 2026-07-02 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 01:29 · claude@yosemite-s1 · 0ac61403 · —
+- Released a new version of `@agents-cli`.
+- Outcome: same-day commits `feat(menubar): wire watchdog auto-nudge into the native tick (RUSH-1415)` (`33cd39e08`) and `perf(menubar): throttle watchdog refresh to 30s (review follow-up)` (`20275ce4c`) — the RUSH-1415 watchdog reaches the native menubar tick.
+
+### 02:29 · claude@yosemite-s1 · 7171c5dd · —
+- Explored Factory.ai's Droid agent-dispatching model — research/scoping, topic only.
+
+### 04:04 · claude@yosemite-s1 · c6b8b902 · —
+- Set up Blender rendering with lighting — creative tooling, tangential to core CLI.
+
+### 11:45 · claude@yosemite-s1 · e1fabde1 · —
+- Added speed adjustment for screenshots with dynamic sampling — a utils/tooling feature, topic only.
+
+### 16:23 · claude@yosemite-s1 · 0f2ade61 · —
+- Deployed the Z-image-turbo model on ComfyUI — creative tooling, tangential to core CLI.
+
+### 20:12 · claude@yosemite-s1 · 282b9a3d · —
+- Tested AWS agent host-based Factory deployment — infra scoping, topic only.

--- a/.agents/memories/2026-07-03.md
+++ b/.agents/memories/2026-07-03.md
@@ -1,0 +1,11 @@
+# 2026-07-03 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: thin signal, topic-derived. Only 2 sessions logged; zero commits landed on this calendar day.
+
+### 05:46 · claude@yosemite-s1 · 6d44c7c6 · —
+- Clarified how agent ticket creation should work — scoping discussion, topic only.
+
+### 07:14 · claude@yosemite-s1 · 1f35a343 · —
+- Analyzed token transfers across devices — topic only.

--- a/.agents/memories/2026-07-04.md
+++ b/.agents/memories/2026-07-04.md
@@ -1,0 +1,13 @@
+# 2026-07-04 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: only 2 sessions logged near midnight, but 55 commits landed this calendar day. The batch below is evidenced directly by git log (not attributed to either session specifically).
+
+### 23:52 · claude@yosemite-s1 · 2b9297bb · —
+- "Swarmify improvements" — topic only for the logged session, but this calendar day shipped a large, security-heavy batch:
+- Security hardening batch (#474-#479): argv-form git exec in inspect (#474), reject plugin names resolving to plugins root (#475), npm install with `--ignore-scripts` for per-version installs (#476), contain hook-shim name path traversal (#477), neutralize MCP name option-injection (#478), move machine passphrase out of the encrypted store dir + sanitize secrets-exec child env + atomic 0600 daemon manifests (#479).
+- Feature landings: mid-run rate-limit account failover (Closes #348), declarative `for_each` dynamic fan-out for workflows (Closes #343), live mid-run budget kill-switch for teams/cloud (Closes #399), `agents check` drift command with CI exit code (Closes #329), per-profile `fallback_model` (Closes #325), `--keys` subset secrets injection + expiry pre-run abort (Closes #328), unified `--device` alias / `--host` resolution for devices and ad-hoc `user@host` (feat(hosts)), and `agents sessions` grouped-project-overview default listing (#656).
+
+### 23:52 · claude@yosemite-s1 · db4a8938 · —
+- Debugged an image-loading issue in the UI layer — topic only.

--- a/.agents/memories/2026-07-05.md
+++ b/.agents/memories/2026-07-05.md
@@ -1,0 +1,41 @@
+# 2026-07-05 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 00:13 · claude@yosemite-s1 · d6733506 · —
+- Fixed a `git checkout main` failure ("fatal: 'main' is already used by worktree") and, in the same pass, renamed the repository — the Swarmify -> Agency.Li rename traces to this session.
+- Executed via: claude@yosemite-s1 1828d5de
+
+### 00:17 · claude@yosemite-s1 · c4ed6082 · —
+- Debugged a missing `HCLOUD_TOKEN` keychain reference — topic only.
+
+### 01:04 · claude@yosemite-s1 · 587d8637 · —
+- Enabled passwordless login on `win-mini` — continuing Windows QA box hardening.
+
+### 01:28 · claude@yosemite-s1 · 376ab820 · —
+- Created an agent app for Codex — topic only.
+
+### 01:44 · claude@yosemite-s1 · 03b33fa9 · —
+- Set up an "agency-line" routine for automated documentation.
+- Outcome: same-day commit `feat(routines): event/webhook trigger model` (Closes #331, `7b050008c`) — routines gain a reachable webhook entrypoint, not just cron.
+
+### 01:49 · claude@yosemite-s1 · ea9a7a58 · —
+- Updated the DotAgent system instructions for flow identification — memory/rules maintenance, topic only.
+
+### 01:49 · claude@yosemite-s1 · 8385de52 · RUSH-1415
+- Looked up the prior session that calculated token usage, under ticket RUSH-1415.
+- Executed via: claude@yosemite-s1 312f912a
+
+### 03:52 · claude@yosemite-s1 · f20fff2b · RUSH-1472
+- Checked whether an agent was actively helping land a specific PR (a GitHub PR) and checked open PR status on swarmify, under ticket RUSH-1472.
+- Outcome: same-day commits shipped the underlying capability — `feat(teams): autonomous PR lifecycle — pr-watch CI-fix + review-comment routing` (`a6a0fae36`) and `fix(pr-watch): bound fix-wave spawning and stabilize the dedupe key` (#338, `72bc23440`).
+- Executed via: claude@yosemite-s1 0b8c3ef9
+
+### 08:22 · claude@yosemite-s1 · 69b2b44a · —
+- Scoped "Actionable Agents Feed" — the origin of the fleet activity feed concept (`agents feed`).
+- Outcome: same-day commit `feat(serve): read-only local web companion — team diffs + routines + cloud status` (Closes #330, #678, `6cdf2ba5d`) plausibly the surface this feeds into.
+- Executed via: claude@yosemite-s1 4d45ede9
+
+### 08:24 · claude@yosemite-s1 · c0f46c16 · —
+- Checked agent-cli cross-device execution and livestream updates — verification of the hosts/serve work landing that day.

--- a/.agents/memories/2026-07-06.md
+++ b/.agents/memories/2026-07-06.md
@@ -1,0 +1,20 @@
+# 2026-07-06 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 07:15 · claude@yosemite-s1 · 0ac33b6d · —
+- Decided to improve the voice agent in `@swarmify/extension/ui/` — reported not working.
+
+### 07:15 · claude@yosemite-s1 · c6bf2f38 · —
+- Reviewed the token-usage policy for "drop-in" — a parallel session to the voice-agent one, different topic, same timestamp.
+
+### 07:41 · claude@yosemite-s1 · 45d97f92 · RUSH-397
+- Found the critical remaining tasks for the Rush release, under ticket RUSH-397.
+
+### 08:52 · claude@yosemite-s1 · 67c52ca4 · —
+- Reduced OpenClaw browser instances on Mac Mini — resource-usage fix, topic only.
+
+### 08:54 · claude@yosemite-s1 · 045b3540 · —
+- Created a new release for agents-cli.
+- Outcome: same-day release commit `chore(release): 1.20.36` (#693, `c49a1d6b6`). Same day also settled the monorepo package-workspaces question: `fix(monorepo): drop workspaces field — keep packages/factory self-installing` (`c27f85717`) after briefly trying `build(monorepo): declare packages/* as workspaces (S0)` (`7ba98a1de`) — the decision that stuck is documented today in this repo's CLAUDE.md ("No JS workspaces... adding one changed bun's hoisting"). Also brought the Factory extension into the agents-cli monorepo (`feat(factory): bring the Factory extension into the agents-cli monorepo`, `5ac40fe9b`).

--- a/.agents/memories/2026-07-07.md
+++ b/.agents/memories/2026-07-07.md
@@ -1,0 +1,38 @@
+# 2026-07-07 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 04:26 · claude@yosemite-s1 · — · —
+- Docs decision: `prix/code-reviewer` is designated the non-author PR review for this repo, so agents merge on its green verdict instead of spawning a redundant subagent reviewer. Commit `92160d494` "docs(agents): note prix/code-reviewer is the non-author PR review".
+- This is the origin of the still-current convention in root `CLAUDE.md`/`AGENTS.md` ("Automated PR Reviewers Satisfy the Non-Author Review").
+
+### 04:47 · claude@yosemite-s1 · 432dd67d · —
+- Session on porting the extension UI from Swarmify to Agency.Li — early rename/rebrand groundwork for what later became AGI EXT.
+
+### 06:07 · claude@yosemite-s1 · 10ccaec2 · RUSH-1319
+- Worked on sessions output sorting/filtering improvements.
+
+### 06:20 · claude@yosemite-s1 · 9ed84130 · RUSH-10
+- Add "group by owner" to backlog UI (Linear-adjacent tooling).
+
+### 07:15 · claude@yosemite-s1 · f3c10255 · —
+- "Centralize device and host flag design" — the design session that seeds the `--host`/`--device` centralization effort. Landed in code a week later as RUSH-1691 (`feat(cli): route --host/--device across virtually all command groups`, 2026-07-14) and again on 2026-07-31 as the single merged resolver (RUSH-1967, `feat(hosts): unify host/device resolution into one merged resolver`).
+
+### 11:14 · claude@yosemite-s1 · 0a0a6741 · —
+- "Configure Prix code reviewer setup in repo" — operationalizes the 04:26 decision; `.github/rush.yml` wiring for `prix/code-reviewer` to post PR verdicts (later paused 2026-08-02 per #1767, per repo AGENTS.md).
+
+### 08:48 · claude@yosemite-s1 · 3691315c · RUSH-1353
+- Topic: "enforce-worktree-pr-workflow" — session proposing the worktree+PR discipline for the repo (the policy later codified in `CLAUDE.md`/`AGENTS.md` "Truly Agentic Git Workflow"). Note: git ticket RUSH-1353 itself later (2026-07-13) shipped unrelated grok/antigravity subrule hook registration — the ticket number appears reused; treat this entry as topic-derived, not code-grounded.
+
+### 11:38 · claude@yosemite-s1 · 4de7b016 · —
+- "Implement agents teams feature with specifications" — early spec/build session for `agents teams`. Distributed teams (teammates on different machines) shipped 2026-07-08 (`3c402984c feat(teams): distributed agent teams — teammates on different machines (#831)`).
+
+### 16:06 · claude@yosemite-s1 · 260d2a7d · RUSH-1530
+- Topic: review/organize open tickets; ticket RUSH-1530 also tracks a Factory UI decision — `renderMarkdown()` generalized for message bodies, shipped 2026-07-08 (`e7e84b8fd`).
+
+### 20:11 · claude@yosemite-s1 · 596c4c07 · RUSH-1519
+- Topic: "factory-tabs-contextual-filters" — Factory UI session/task tab work. RUSH-1519 shipped as MiniTimeline/VerticalTimeline on agent cards (`c1baba205`, 2026-07-08).
+
+### 23:47 · claude@yosemite-s1 · 1ad06d50 · RUSH-1527
+- "Move backlog/undone/unfinished tasks in Linear to current cycle" — a triage/board-hygiene decision, not code.

--- a/.agents/memories/2026-07-08.md
+++ b/.agents/memories/2026-07-08.md
@@ -1,0 +1,22 @@
+# 2026-07-08 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 00:48 · claude@yosemite-s1 · 659a7ec6 · RUSH-812
+- "improve-agent-card-readability" / evaluating whether agents-cli + skills + factory tooling is good enough (incl. high-signal Factory card content). Topic-derived; no single tagged commit found for RUSH-812.
+
+### 16:31 · claude@yosemite-s1 · (swarm) · RUSH-1519 / RUSH-1530 / RUSH-1531
+- Factory agent card redesign: task anchor, markdown body, mini timeline, worktree chip (`e7230acf3`), detail pane with vertical timeline + streaming activity feed (`d91a9491d`), MiniTimeline/VerticalTimeline from `recent[]` (`c1baba205`, RUSH-1519), prompt/messages/sticky-todos + clean worktree slug mapped into FloorAgent (`4714487c9`, RUSH-1531), and `renderMarkdown()` generalized for message bodies (`e7e84b8fd`, RUSH-1530). One coordinated push landing the Factory card/detail-pane redesign together.
+
+### 16:33 · claude@yosemite-s1 · — · —
+- `agents doctor --devices`/`--hosts` fleet readiness matrix shipped (`dc24ada76`), extracted from teams' doctor data collection for reuse (`ce072c0a9`).
+
+### 16:43 · claude@yosemite-s1 · — · —
+- **Distributed agent teams landed**: teammates can run on different machines, not just local worktrees (`3c402984c feat(teams): distributed agent teams — teammates on different machines (#831)`). Documented same day (`a49620a0f docs(teams): document distributed teams in the teams skill (#837)`).
+
+### 21:11 · claude@yosemite-s1 · 8eb164cb · —
+- Topic: "distributed-agent-teams" — follow-on session to the 16:43 ship, likely usage/verification of the new distributed-teams capability.
+
+### 21:53 · claude@yosemite-s1 · 3f780d45 · —
+- "Debug distributed multi-agent scaling issues" — early scaling problems surfaced right after distributed teams shipped.

--- a/.agents/memories/2026-07-08.md
+++ b/.agents/memories/2026-07-08.md
@@ -6,7 +6,7 @@
 ### 00:48 · claude@yosemite-s1 · 659a7ec6 · RUSH-812
 - "improve-agent-card-readability" / evaluating whether agents-cli + skills + factory tooling is good enough (incl. high-signal Factory card content). Topic-derived; no single tagged commit found for RUSH-812.
 
-### 16:31 · claude@yosemite-s1 · (swarm) · RUSH-1519 / RUSH-1530 / RUSH-1531
+### 16:31 · claude@yosemite-s1 · — · RUSH-1519 / RUSH-1530 / RUSH-1531
 - Factory agent card redesign: task anchor, markdown body, mini timeline, worktree chip (`e7230acf3`), detail pane with vertical timeline + streaming activity feed (`d91a9491d`), MiniTimeline/VerticalTimeline from `recent[]` (`c1baba205`, RUSH-1519), prompt/messages/sticky-todos + clean worktree slug mapped into FloorAgent (`4714487c9`, RUSH-1531), and `renderMarkdown()` generalized for message bodies (`e7e84b8fd`, RUSH-1530). One coordinated push landing the Factory card/detail-pane redesign together.
 
 ### 16:33 · claude@yosemite-s1 · — · —

--- a/.agents/memories/2026-07-09.md
+++ b/.agents/memories/2026-07-09.md
@@ -3,7 +3,7 @@
 > Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
 > Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
 
-### 14:39 · claude@yosemite-s1 · (via 20:58 session) · RUSH-1234
+### 14:39 · claude@yosemite-s1 · — · RUSH-1234
 - Decision: emit a structured question from session state instead of a generic "thinking…" mask (`992dd5e60 feat(cli): emit structured question from session state`), carried across postMessage into Factory (`264142c1d`), and surfaced as a decision-first NEEDS-YOU panel with inline approve/deny via keystroke (`88ad626e1`). This is the origin of Factory's structured `AskUserQuestion` rendering.
 
 ### 20:58 · claude@yosemite-s1 · 1fcf49af · RUSH-1234

--- a/.agents/memories/2026-07-09.md
+++ b/.agents/memories/2026-07-09.md
@@ -1,0 +1,19 @@
+# 2026-07-09 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 14:39 · claude@yosemite-s1 · (via 20:58 session) · RUSH-1234
+- Decision: emit a structured question from session state instead of a generic "thinking…" mask (`992dd5e60 feat(cli): emit structured question from session state`), carried across postMessage into Factory (`264142c1d`), and surfaced as a decision-first NEEDS-YOU panel with inline approve/deny via keystroke (`88ad626e1`). This is the origin of Factory's structured `AskUserQuestion` rendering.
+
+### 20:58 · claude@yosemite-s1 · 1fcf49af · RUSH-1234
+- "Render AskUserQuestion" — the session anchoring the NEEDS-YOU panel decision above; ticket RUSH-1234 later (2026-07-14+) becomes the umbrella for the broader command-consolidation work (`agents check`/`resources` folded into `doctor --check`/`view --merged`).
+
+### 15:09 · claude@yosemite-s1 · — · —
+- Factory auto-dispatch refactored to go through the cloud-provider abstraction instead of the ad-hoc Prix webhook (`91b34f2e4`) — decouples dispatch from one specific provider.
+
+### 20:03 · claude@yosemite-s1 · — · —
+- Secrets: rebuilt + notarized keychain helper enables the "never prompt" policy (`2e586291f release(secrets): rebuilt + notarized keychain helper enables the never prompt-policy (#421) (#855)`).
+
+### 22:20 · claude@yosemite-s1 · a0e40d3b · —
+- "drain-agents-cli-issues" — ticket-queue drain session (topic-derived, no single commit anchor).

--- a/.agents/memories/2026-07-10.md
+++ b/.agents/memories/2026-07-10.md
@@ -1,0 +1,22 @@
+# 2026-07-10 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 03:30 · claude@yosemite-s1 · 0e772763 · RUSH-409
+- Review of Yosemite S0 session activity — worker-box session audit (topic-derived).
+
+### 10:00 · claude@yosemite-s1 · (Factory work) · —
+- Factory Floor rail redesign push: rail flyouts for Projects/Hosts menus, a Dispatch button, and a real Needs-you filter (`c1a19bb07`), project rollups answering "what's happening here" (`00d582813`), a PR board aggregating open PRs with CI/review/mergeable state and a guarded Merge action (`661628f38`), Recap — a fleet-wide work ledger of finished sessions (`c08b132d9`), and in-flight ticket linkage showing who's working each ticket (`fdd57e6dc`). Together these define Factory's main navigation surfaces (Projects, Hosts, PR board, Recap, ticket linkage) that later docs reference.
+
+### 16:41 · claude@yosemite-s1 · 0bd95dbd · —
+- "agent-credentials-primitives" — credentials/secrets primitives design session.
+
+### 16:45 · claude@yosemite-s1 · 5e6e3a02 · RUSH-1473
+- Fix `--skip` mode flag behavior. RUSH-1473 also (later, per CHANGELOG) covers `agents feed` surfacing every top-level agent block waiting on the user across the fleet (`AskUserQuestion`/waiting `Notification` hooks publish atomic open-block records, `--host`/`--device` scope, `--json`), source `apps/cli/src/commands/feed.ts`.
+
+### 17:16 · claude@yosemite-s1 · 992525ddc (commit) · —
+- Decision: centralize the "unpushed committed work" warning into a single gate `shouldWarnUnpushed` used by `agents run` (`992525ddc refactor(run): centralize unpushed-warning gate`), building on the same-day `fa4623aad feat(run): warn when a headless run leaves committed-but-unpushed work`.
+
+### 23:10 · claude@yosemite-s1 · 43d75c64 · RUSH-1258
+- "prix-project-drain" — draining the Prix-tracked project backlog (topic-derived, no single commit anchor).

--- a/.agents/memories/2026-07-10.md
+++ b/.agents/memories/2026-07-10.md
@@ -15,7 +15,7 @@
 ### 16:45 · claude@yosemite-s1 · 5e6e3a02 · RUSH-1473
 - Fix `--skip` mode flag behavior. RUSH-1473 also (later, per CHANGELOG) covers `agents feed` surfacing every top-level agent block waiting on the user across the fleet (`AskUserQuestion`/waiting `Notification` hooks publish atomic open-block records, `--host`/`--device` scope, `--json`), source `apps/cli/src/commands/feed.ts`.
 
-### 17:16 · claude@yosemite-s1 · 992525ddc (commit) · —
+### 17:16 · claude@yosemite-s1 · — · —
 - Decision: centralize the "unpushed committed work" warning into a single gate `shouldWarnUnpushed` used by `agents run` (`992525ddc refactor(run): centralize unpushed-warning gate`), building on the same-day `fa4623aad feat(run): warn when a headless run leaves committed-but-unpushed work`.
 
 ### 23:10 · claude@yosemite-s1 · 43d75c64 · RUSH-1258

--- a/.agents/memories/2026-07-10.md
+++ b/.agents/memories/2026-07-10.md
@@ -6,7 +6,7 @@
 ### 03:30 · claude@yosemite-s1 · 0e772763 · RUSH-409
 - Review of Yosemite S0 session activity — worker-box session audit (topic-derived).
 
-### 10:00 · claude@yosemite-s1 · (Factory work) · —
+### 10:00 · claude@yosemite-s1 · — · —
 - Factory Floor rail redesign push: rail flyouts for Projects/Hosts menus, a Dispatch button, and a real Needs-you filter (`c1a19bb07`), project rollups answering "what's happening here" (`00d582813`), a PR board aggregating open PRs with CI/review/mergeable state and a guarded Merge action (`661628f38`), Recap — a fleet-wide work ledger of finished sessions (`c08b132d9`), and in-flight ticket linkage showing who's working each ticket (`fdd57e6dc`). Together these define Factory's main navigation surfaces (Projects, Hosts, PR board, Recap, ticket linkage) that later docs reference.
 
 ### 16:41 · claude@yosemite-s1 · 0bd95dbd · —

--- a/.agents/memories/2026-07-11.md
+++ b/.agents/memories/2026-07-11.md
@@ -1,0 +1,10 @@
+# 2026-07-11 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 05:45 · claude@yosemite-s1 · 0506bb05 · RUSH-1522
+- Root-caused and fixed the NEEDS-YOU false-positive bug: a finished session that signed off with a trailing "?" read as `input_required` forever. Fix decays the prose-question heuristic after 30 minutes without a session write (structural signals — a real pending `ExitPlanMode`/`AskUserQuestion` — stay exempt and never decay). Commits: `4ec840f0b fix(factory): finished statuses beat a stale waitingForInput in derivePhase`, `dfc0199ba fix(cli): stale prose questions no longer classify as waiting_input`, `a44498de6 fix(factory): prose trailing-? waiting heuristic decays after 30 min` (all RUSH-1522). Source: `apps/cli/src/lib/session/state.ts` (`inferActivity`, `PROSE_QUESTION_FRESH_MS`).
+
+### 02:14 · claude@yosemite-s1 · 6ef1ab38 · —
+- "update-rqa-rush-docs-mac-mini" — RQA/Rush docs maintenance on mac-mini (topic-derived).

--- a/.agents/memories/2026-07-12.md
+++ b/.agents/memories/2026-07-12.md
@@ -9,7 +9,7 @@
 ### 18:28 · claude@yosemite-s1 · 80289224 · RUSH-123
 - "Linear Declarative Agent Triggers" — design for triggering agents declaratively off Linear ticket state.
 
-### 19:01 · claude@yosemite-s1 · 8c2a07332 (commit) · —
+### 19:01 · claude@yosemite-s1 · — · —
 - Decision: stop Touch ID storms — keep the hot secrets broker alive across version skew, evict only on bundle writes (`8c2a07332 fix(secrets): stop Touch ID storms — keep the hot broker on version skew, evict on bundle writes (#909)`). First fix in what becomes a recurring Touch-ID-storm problem class (revisited 2026-08-04 as SEC-19).
 
 ### 19:08 · claude@yosemite-s1 · — · —

--- a/.agents/memories/2026-07-12.md
+++ b/.agents/memories/2026-07-12.md
@@ -1,0 +1,22 @@
+# 2026-07-12 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 18:19 · claude@yosemite-s1 · 5227c678 · —
+- "Auto drain Linear Queue" — session establishing the auto-drain pattern for the Linear ticket queue (topic that later becomes the `code:loop` / ticket-drain workflow used heavily in the 07-13 grok overnight waves).
+
+### 18:28 · claude@yosemite-s1 · 80289224 · RUSH-123
+- "Linear Declarative Agent Triggers" — design for triggering agents declaratively off Linear ticket state.
+
+### 19:01 · claude@yosemite-s1 · 8c2a07332 (commit) · —
+- Decision: stop Touch ID storms — keep the hot secrets broker alive across version skew, evict only on bundle writes (`8c2a07332 fix(secrets): stop Touch ID storms — keep the hot broker on version skew, evict on bundle writes (#909)`). First fix in what becomes a recurring Touch-ID-storm problem class (revisited 2026-08-04 as SEC-19).
+
+### 19:08 · claude@yosemite-s1 · — · —
+- Decision: publish and clear "waiting" feed blocks, aggregated across devices, with a fleet-wide open-block feed view (`6d7d090de`, `52ec51644`, docs `6c652f4eb`). Precursor to the later RUSH-1473 `agents feed` surface.
+
+### 20:32 · claude@yosemite-s1 · 74731bdf · —
+- "agency-pixel-office-agents" — exploratory/creative session (topic-derived, no code anchor).
+
+### 20:43 · claude@yosemite-s1 · 069edfd1 · —
+- "Disable Claude code reviews for agents repo" — a temporary policy toggle on automated review (context for later prix-cloud pause decisions).

--- a/.agents/memories/2026-07-13.md
+++ b/.agents/memories/2026-07-13.md
@@ -1,0 +1,40 @@
+# 2026-07-13 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 05:05 · claude@yosemite-s1 · 2eebbb7a · RUSH-1127
+- Reviewed agent progress and resolved open issues (topic-derived; sets up the two grok overnight drain waves below).
+
+### 06:10 · grok@yosemite-s1 · 019f5a19 · —
+- **Overnight Agents-CLI Drain: Wire Hooks/Plugins/Subagents/Allowlists** — a large unattended grok code-loop wave wiring cross-harness capability support (hooks, plugins, subagents, allowlists) across multiple agent integrations in one pass. Grok/antigravity subrule hook registration landed same day: `92a46ed2c`/`9f7982408`/`ce5a6b09e` (tagged RUSH-1353 in commit messages).
+- Executed via: grok@yosemite-s1 019f5a19 (overnight, unattended).
+
+### 08:34 · codex@yosemite-s1 · 019f5a9c · —
+- **Unattended Follow-Up Fix Wave for RUSH-1612 through RUSH-1635** — a second overnight grok drain closing a batch of tickets in that range.
+- Executed via: grok@yosemite-s1 019f5a9c.
+
+### 08:18 · claude@yosemite-s1 · 8f29bd4f · RUSH-1596
+- "land-pr-deploy-e2e-verify" — driver session verifying a PR's deploy end-to-end before landing; no single tagged commit found under RUSH-1596 (topic-derived, high confidence on intent per ticket name).
+
+### 08:27 · claude@yosemite-s1 · 910ab410 · RUSH-1595
+- Decision: routines default execution mode changes from `plan` to `auto` — unattended jobs can create PRs, write files, and run tests end-to-end without opt-in. `auto` maps to `--permission-mode auto` (claude), workspace-write+network (codex), `--auto high` (droid), kimi's default headless run. `mode: plan` stays available for read-only monitoring. Commit `e9d7cbeb9 feat(routines): default execution mode to auto instead of plan (RUSH-1595) (#1058)`. Source: `apps/cli/src/lib/routines.ts`, `apps/cli/src/commands/routines.ts`.
+
+### 10:54 · claude@yosemite-s1 · 336d9c5d · —
+- "Refine Linear Auto Drain" — iterating on the 07-12 auto-drain pattern.
+
+### 17:03 · claude@yosemite-s1 · 401a0852f (commit) · —
+- Decision: retire the standalone secrets-agent service — the daemon becomes the sole broker host (`401a0852f feat(secrets): retire the standalone secrets-agent service — daemon is the sole broker host (#416 step 2) (#1107)`). RUSH-1107 ticket topic matches this architectural consolidation.
+
+### 18:10 · claude@yosemite-s1 · 39e62830f (commit) · RUSH-1380
+- Fine-grained todo progress on the agent detail stream — Factory reads `TodoWrite` off the transcript tail as an N/M pill + checklist, including for remote/device-dispatched agents (`39e62830f feat(factory): fine-grained todo progress on the agent detail stream (RUSH-1380) (#911)`, `76d1f7dc0` same feature landed again 07-14 for remote agents specifically).
+
+### 19:39 · claude@yosemite-s1 · 0a732819 · —
+- "Ability to Resume Teammates" — design/build session for resuming a team's teammate sessions. Related teams-resume hardening landed same window: `10426c99a test: verify teammate resume rollback`, `b22cfcc03 fix: terminate resumed process groups completely`, `b0bfe91a1 fix(teams): preserve original launch error when resume restore-write fails (#1108)`.
+
+### 21:38 · claude@yosemite-s1 · 73ec7319 · RUSH-1524
+- "Debug --cwd flag on remote host" — investigation feeding into the 07-13 documentation of `--project`/`--cwd-on-host` for `--host` runs (`70853c4cc docs(run): document --project and --cwd-on-host for --host runs (#1111)`).
+- Same ticket also covers Factory session attachments: Claude/Droid prompt image/document blocks preserved as `{path, name, mediaType, sizeBytes}` and deduped into `attachments` on active-session state so Factory renders screenshot thumbnails instead of a bare count. Commit `885fa05b7 RUSH-1524: show session attachments in Factory (#991)`, landed earlier the same day (16:24). Source: `apps/cli/src/lib/session/parse.ts`, `state.ts`, `active.ts`.
+
+### 21:51 · claude@yosemite-s1 · 1ed4c0d1 · RUSH-83
+- "triage-unblock-owner-plan" — triage session to unblock the owner's plan (topic-derived).

--- a/.agents/memories/2026-07-13.md
+++ b/.agents/memories/2026-07-13.md
@@ -23,10 +23,10 @@
 ### 10:54 · claude@yosemite-s1 · 336d9c5d · —
 - "Refine Linear Auto Drain" — iterating on the 07-12 auto-drain pattern.
 
-### 17:03 · claude@yosemite-s1 · 401a0852f (commit) · —
+### 17:03 · claude@yosemite-s1 · — · —
 - Decision: retire the standalone secrets-agent service — the daemon becomes the sole broker host (`401a0852f feat(secrets): retire the standalone secrets-agent service — daemon is the sole broker host (#416 step 2) (#1107)`). RUSH-1107 ticket topic matches this architectural consolidation.
 
-### 18:10 · claude@yosemite-s1 · 39e62830f (commit) · RUSH-1380
+### 18:10 · claude@yosemite-s1 · — · RUSH-1380
 - Fine-grained todo progress on the agent detail stream — Factory reads `TodoWrite` off the transcript tail as an N/M pill + checklist, including for remote/device-dispatched agents (`39e62830f feat(factory): fine-grained todo progress on the agent detail stream (RUSH-1380) (#911)`, `76d1f7dc0` same feature landed again 07-14 for remote agents specifically).
 
 ### 19:39 · claude@yosemite-s1 · 0a732819 · —

--- a/.agents/memories/2026-07-14.md
+++ b/.agents/memories/2026-07-14.md
@@ -9,14 +9,14 @@
 ### 06:25 · claude@yosemite-s1 · 1b2567de · RUSH-1641
 - "factory-prod-failure-analysis" — root-cause session for a Factory production failure (topic-derived, no single tagged commit found).
 
-### 17:55 · claude@yosemite-s1 · (commit) · RUSH-1380
+### 17:55 · claude@yosemite-s1 · — · RUSH-1380
 - Live plan progress (N/M pill + checklist) extended specifically to remote agents (`76d1f7dc0 feat(factory): live plan progress (N/M pill + checklist) for remote agents (RUSH-1380) (#1113)`) — follow-on to 07-13's local-agent version.
 
-### 22:27 · claude@yosemite-s1 · (commit) · RUSH-1691
+### 22:27 · claude@yosemite-s1 · — · RUSH-1691
 - **Decision: `--host`/`--device` routed across virtually all command groups** (`2f6048a0b feat(cli): route --host/--device across virtually all command groups (RUSH-1691)`, hardened same day with `fc3df2609 fix(cli): do not conflict-gate OWN_HOST multi-host --host/--device`). This is the code landing of the 07-07 07:15 "Centralize device and host flag design" session — the central `maybeRunOnHost` allowlist now covers `repos`, status/inspect groups, config/resource groups (`plugins`/`skills`/`hooks`/`sync`), `teams`, `routines`; commands with richer host handling (`run`, `sessions`, `feed`, `computer`, `secrets`, `logs`) keep their own logic; unsupported groups reject the flag cleanly instead of `unknown option`. Source: `apps/cli/src/lib/hosts/passthrough.ts`.
 
-### 22:27 · claude@yosemite-s1 · (commit) · RUSH-1632
+### 22:27 · claude@yosemite-s1 · — · RUSH-1632
 - Fleet alias + fleet-wide update/run added (`307797d42 feat(devices): fleet alias + fleet-wide update/run (RUSH-1632)`), hardened to isolate per-device failures and validate version pins (`d4a0de6e9`).
 
-### 22:45 · claude@yosemite-s1 · (commit) · RUSH-1360
+### 22:45 · claude@yosemite-s1 · — · RUSH-1360
 - Decision: `agents hosts stop/kill` can terminate detached host runs from the origin machine (`559f72d0f feat(hosts): stop/kill detached host runs from origin (RUSH-1360)`), fixed same day so `stop` doesn't clobber a real exit code (`d09416a1a`).

--- a/.agents/memories/2026-07-14.md
+++ b/.agents/memories/2026-07-14.md
@@ -1,0 +1,22 @@
+# 2026-07-14 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 00:11 · claude@yosemite-s1 · f0af2579 · RUSH-1350
+- "prix-project-drain-finish" — closes out the Prix-tracked backlog drain started 07-10 (RUSH-1258).
+
+### 06:25 · claude@yosemite-s1 · 1b2567de · RUSH-1641
+- "factory-prod-failure-analysis" — root-cause session for a Factory production failure (topic-derived, no single tagged commit found).
+
+### 17:55 · claude@yosemite-s1 · (commit) · RUSH-1380
+- Live plan progress (N/M pill + checklist) extended specifically to remote agents (`76d1f7dc0 feat(factory): live plan progress (N/M pill + checklist) for remote agents (RUSH-1380) (#1113)`) — follow-on to 07-13's local-agent version.
+
+### 22:27 · claude@yosemite-s1 · (commit) · RUSH-1691
+- **Decision: `--host`/`--device` routed across virtually all command groups** (`2f6048a0b feat(cli): route --host/--device across virtually all command groups (RUSH-1691)`, hardened same day with `fc3df2609 fix(cli): do not conflict-gate OWN_HOST multi-host --host/--device`). This is the code landing of the 07-07 07:15 "Centralize device and host flag design" session — the central `maybeRunOnHost` allowlist now covers `repos`, status/inspect groups, config/resource groups (`plugins`/`skills`/`hooks`/`sync`), `teams`, `routines`; commands with richer host handling (`run`, `sessions`, `feed`, `computer`, `secrets`, `logs`) keep their own logic; unsupported groups reject the flag cleanly instead of `unknown option`. Source: `apps/cli/src/lib/hosts/passthrough.ts`.
+
+### 22:27 · claude@yosemite-s1 · (commit) · RUSH-1632
+- Fleet alias + fleet-wide update/run added (`307797d42 feat(devices): fleet alias + fleet-wide update/run (RUSH-1632)`), hardened to isolate per-device failures and validate version pins (`d4a0de6e9`).
+
+### 22:45 · claude@yosemite-s1 · (commit) · RUSH-1360
+- Decision: `agents hosts stop/kill` can terminate detached host runs from the origin machine (`559f72d0f feat(hosts): stop/kill detached host runs from origin (RUSH-1360)`), fixed same day so `stop` doesn't clobber a real exit code (`d09416a1a`).

--- a/.agents/memories/2026-07-15.md
+++ b/.agents/memories/2026-07-15.md
@@ -16,8 +16,8 @@
 ### 05:13 · claude@yosemite-s1 · 9a046e6c · —
 - "Understand agent host and agent factories concept" — a conceptual/architecture session, likely informing the day's fleet-comms and security work below.
 
-### — · — · — · (day summary) · 1.20.64
-- **Fleet comms overhaul**: shared comms render engine + mailbox streaming primitive (`2d75e8070 RUSH-1736`), mailboxes masthead with `--watch` live tail, `--between`, filters, `--graph` (`5380263e4 RUSH-1737`), feed reskinned to the shared comms visual language (`be53e89cb RUSH-1738`), teams skill pointed at the fleet-comms surface (`71aa75848 RUSH-1739`).
+### — · — · — · —
+- Day summary (released 1.20.64). **Fleet comms overhaul**: shared comms render engine + mailbox streaming primitive (`2d75e8070 RUSH-1736`), mailboxes masthead with `--watch` live tail, `--between`, filters, `--graph` (`5380263e4 RUSH-1737`), feed reskinned to the shared comms visual language (`be53e89cb RUSH-1738`), teams skill pointed at the fleet-comms surface (`71aa75848 RUSH-1739`).
 - **Security hardening pass (C2-C5)**: Windows computer daemon now requires an auth token (`6f8cf7aab`, C2), inline manifest hooks/mcpServers detected as exec surfaces (`583e525b9`, C3), untrusted paths contained in routine names and session-sync pull (`abc3798b5`/`987d99d1b`, C4), ssh target validated before raw ssh spawns in the browser driver (`d87b5158c`, C5).
 - **`ag apply`**: one-command fleet profile sync + login propagation shipped (`9fc3c280f feat(apply): ag apply — one-command fleet profile sync + login propagation (#1207)`).
 - Release 1.20.64 cut twice (`008df3df7`, then reverted `b8a708f59`, then re-cut `128e2b5e0`) after CI/Windows-build unblocking work (`4c8fbc622`).

--- a/.agents/memories/2026-07-15.md
+++ b/.agents/memories/2026-07-15.md
@@ -1,0 +1,23 @@
+# 2026-07-15 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> Dense swarm day: 67 sessions, dominated by codex/grok code-loop workers (codex@yosemite-s1×52,
+> grok@yosemite-s1×9) running fixes/reviews unattended. Anchored on the 4 driver claude sessions;
+> swarm executors named per entry where identifiable from the skeleton.
+
+### 00:49 · claude@yosemite-s1 · 4764329d · —
+- "Investigate open tasks and agent backlog" — the driver session that likely kicked off the day's large code-loop wave below (grok RUSH-1329/1611/1632/1360/1333/1454/1488/1691/1579 fix batches, PR reviews of mailbox GC sweepExpired, hosts stop/kill, fleet alias, host-device passthrough).
+- Executed via (grok code-loop/review, same day, unattended): grok@yosemite-s1 019f6422 (RUSH-1329 debugging), 019f642b (Antigravity Linux libsecret auth review), 019f6439 (RUSH-1611/1632/1360/1333 analysis), 019f644a (mailbox GC + hosts stop/kill + fleet alias PR reviews), 019f645b (RUSH-1454/1488 fixes), 019f6466 (RUSH-1691/1579 fixes), 019f647b (PR 1170 host-device passthrough review).
+
+### 01:21 · claude@yosemite-s1 · 0cabd0e6 · —
+- Fixed browser agent downloads-directory handling (topic-derived; no single tagged commit isolated from the day's large merge volume).
+
+### 05:13 · claude@yosemite-s1 · 9a046e6c · —
+- "Understand agent host and agent factories concept" — a conceptual/architecture session, likely informing the day's fleet-comms and security work below.
+
+### — · — · — · (day summary) · 1.20.64
+- **Fleet comms overhaul**: shared comms render engine + mailbox streaming primitive (`2d75e8070 RUSH-1736`), mailboxes masthead with `--watch` live tail, `--between`, filters, `--graph` (`5380263e4 RUSH-1737`), feed reskinned to the shared comms visual language (`be53e89cb RUSH-1738`), teams skill pointed at the fleet-comms surface (`71aa75848 RUSH-1739`).
+- **Security hardening pass (C2-C5)**: Windows computer daemon now requires an auth token (`6f8cf7aab`, C2), inline manifest hooks/mcpServers detected as exec surfaces (`583e525b9`, C3), untrusted paths contained in routine names and session-sync pull (`abc3798b5`/`987d99d1b`, C4), ssh target validated before raw ssh spawns in the browser driver (`d87b5158c`, C5).
+- **`ag apply`**: one-command fleet profile sync + login propagation shipped (`9fc3c280f feat(apply): ag apply — one-command fleet profile sync + login propagation (#1207)`).
+- Release 1.20.64 cut twice (`008df3df7`, then reverted `b8a708f59`, then re-cut `128e2b5e0`) after CI/Windows-build unblocking work (`4c8fbc622`).

--- a/.agents/memories/2026-07-17.md
+++ b/.agents/memories/2026-07-17.md
@@ -1,0 +1,13 @@
+# 2026-07-17 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 08:10 · claude@yosemite-s1 · 819d1a19 · RUSH-2007
+- "Check the STLI documentation" — early RUSH-2007 session (RUSH-2007 becomes the umbrella ticket for session-visibility/presence work across late July into August: layered watchdog presence tracking, non-Claude tmux session id backfill, auto-reconnect on SSH drop; those specific fixes land later in the range, see 2026-08-03).
+
+### — · — · — · (day summary)
+- Interactive fleet-wide session browser shipped (`b5ca212fb feat(sessions): interactive fleet-wide session browser (RUSH-1802) (#1256)`), with a session-browser CHANGELOG fragment noted (`0f71657cb`, RUSH-1802).
+- `agents share` gains auto OG cover images + project-prefixed slugs (`e26b2491e RUSH-1809`).
+- `teams add --remote-cwd` now rejected with guidance instead of silently misbehaving; `--remote-cwd`/placement traps fixed (`1f6ac4fff`) — the precedent later written into repo AGENTS.md ("Dispatching Agents to Remote Fleet").
+- `agents devices list` probes Windows devices for resource headroom (`5c76d0304`, #1273).

--- a/.agents/memories/2026-07-18.md
+++ b/.agents/memories/2026-07-18.md
@@ -1,0 +1,14 @@
+# 2026-07-18 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 14:42 · claude@yosemite-s1 · 4772028c · —
+- Fix agents ssh with terminal emulator protocols — terminfo/ssh compatibility work. Same-day terminfo fixes: `827311106 fix(ssh): key terminfo sync cache by user@host, not host`, `c27aeec00 feat(ssh): auto-propagate terminfo to remote on interactive login`.
+
+### 14:50 · claude@yosemite-s1 · adb2b8dc · —
+- "agents-cli windows devices probing" — Windows device support investigation (follows 07-17's Windows headroom-probing feature).
+
+### — · — · — · (day summary)
+- Decision: centralize account-inspection metadata and route trailing-`@` runs through a proper account picker with safe per-run account choices (`e277910fd refactor: centralize account inspection metadata`, `c3952c364 feat: route trailing-at runs through account picker`, `43d74bd06 feat: render safe per-run account choices`).
+- Setup capability hub ships alongside the signed/notarized macOS computer helper (`615410413 feat(setup): capability hub + ship the signed/notarized macOS computer helper (#1293)`).

--- a/.agents/memories/2026-07-21.md
+++ b/.agents/memories/2026-07-21.md
@@ -1,0 +1,16 @@
+# 2026-07-21 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: thin signal on the human side (2 sessions), day-level shipped-work grounded in git log.
+
+### 19:11 · claude@yosemite-s1 · c00b00e9 · —
+- "Verify Tailscale connection and Zion SSH access" — confirms `zion` (the human's laptop) as a reachable fleet device, ahead of it becoming a regular driver host from early August onward.
+
+### 22:33 · grok@zion · 019f86cf · —
+- First recorded grok session running directly on `zion` in this range (off-topic personal exploration) — notable only as the first `@zion` device entry in the skeleton for this period.
+
+### — · — · — · (day summary)
+- Decision: `agents share` defaults to a custom domain for setup (`ebcc02ca1 feat(cli): default share setup to custom domain (#1385)`); share/secrets/monitor commands gain `--json` output for agent discoverability (`ebb5a77a2 feat(secrets): --json for list/view`, `9d6f148ea feat(cli): add share json output`, `6f9c2b45e fix(cli): add monitor inspection json output`).
+- `agents run` fails fast instead of hanging when given no prompt in a non-TTY (`7d93ed2d8`).
+- Top-level resource profiles added (`e9e685112 feat(cli): add top-level resource profiles (#1364)`).

--- a/.agents/memories/2026-07-24.md
+++ b/.agents/memories/2026-07-24.md
@@ -1,0 +1,10 @@
+# 2026-07-24 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: thin signal, topic-derived. All 5 sessions are trivial liveness pings ("Reply one word:
+> pong" / "x") on droid@yosemite-s1 and droid@zion — likely a fleet-reachability probe, not a
+> product decision. No matching git activity that day.
+
+### 15:08 · droid@yosemite-s1 · b9c3a70f · —
+- Fleet liveness probe ("Reply one word: pong") — droid reachability check across yosemite-s1 and zion, no product decision made.

--- a/.agents/memories/2026-07-25.md
+++ b/.agents/memories/2026-07-25.md
@@ -1,0 +1,11 @@
+# 2026-07-25 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: thin signal, topic-derived.
+
+### 18:41 · grok@yosemite-s1 · 019f9a95 · —
+- "Implementing Classic Pong Game in Codebase" — off-topic/exploratory session, no agents-cli product decision.
+
+### — · — · — · (day summary)
+- Isolated installs kept off bare shims (`d6c174691 fix(cli): keep isolated installs off bare shims`) and the menubar helper's bundle/version resolution fixed for the Bun single-file binary (`afe1bf54f`) — minor install-hygiene fixes, no session in the skeleton directly anchors these.

--- a/.agents/memories/2026-07-26.md
+++ b/.agents/memories/2026-07-26.md
@@ -1,0 +1,13 @@
+# 2026-07-26 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: thin signal on the human side (1 session); day-level shipped-work grounded in git log.
+
+### 01:16 · claude@zion · a2b54cd0 · —
+- "Review blog post about agent 3D printing" — content review, not a product decision.
+
+### — · — · — · (day summary)
+- **`agents fleet login`**: remote device-code OAuth orchestration added, so a fleet device can be authenticated without local browser access (`26b03190c feat(cli): agents fleet login — remote device-code OAuth orchestration (#1416)`), with the shim dir put on the remote PATH so agent CLIs resolve post-login (`827565549`).
+- **`agents send` / `agents notify`** commands added on top of a new pluggable channel-provider registry + notify config (`ead91d37a`, `170ec25e0`) — this is the origin of the out-of-band owner-notification mechanism documented in the repo's memory/conventions.
+- `agents setup mine` — white-label the CLI under your own name (`f4838d49f feat(cli): agents setup mine`).

--- a/.agents/memories/2026-07-27.md
+++ b/.agents/memories/2026-07-27.md
@@ -1,0 +1,8 @@
+# 2026-07-27 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: thin signal, topic-derived. No git commits found for this date.
+
+### 01:57 · claude@zion · 552248f3 · —
+- "Deploy application to Vercel" — off-topic/unrelated deployment task, not an agents-cli decision.

--- a/.agents/memories/2026-07-29.md
+++ b/.agents/memories/2026-07-29.md
@@ -1,0 +1,14 @@
+# 2026-07-29 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: thin signal on the human side (mostly new/empty opencode sessions); day-level shipped-work
+> grounded in git log.
+
+### 16:34 · opencode@zion · 051455b6 · —
+- New OpenCode session on `zion` — first recorded opencode activity in this range (no decision content).
+
+### — · — · — · (day summary)
+- Fixed a real regression: isolated CLI installs were hiding the user's own global CLI in `agents view` (`73ae62e4d fix(view): stop isolated installs from hiding the user's own CLI`), with a perf follow-up to only PATH-resolve agents whose global row can actually render (`bcb152328`).
+- Release 1.20.73 cut after unblocking 59 Windows + 2 macOS CI failures (`ddc861fa4`, `00a38d7f3`).
+- `agents fleet ping` stops crying wolf on healthy accounts (`ca401b9e5`).

--- a/.agents/memories/2026-07-30.md
+++ b/.agents/memories/2026-07-30.md
@@ -1,0 +1,13 @@
+# 2026-07-30 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: thin signal on the human side (mostly new/empty opencode sessions on zion); day-level
+> shipped-work grounded in git log.
+
+### 00:48 · grok@yosemite-s1 · 019fb07e · —
+- "19 Plus 23 Basic Arithmetic Query" — trivial/off-topic, no decision content.
+
+### — · — · — · (day summary)
+- Decision: surface the configured model alongside the version across CLI surfaces — `use`/`add`/`status`/`inspect` and `agents view` (`931dae2db feat(models): add resolveConfiguredModel + formatAgentIdentity helpers`, `82d611157`, `ddb4ad98a`).
+- Docs pass: architecture doc added covering CLI/extension overview + session mechanisms (`4f8412f7d`), broken `docs/` links repointed to `apps/cli/docs` (`7b2ea715b`), stale session schema version corrected 6->13 and tracked-harness list 5->11 (`08b622a7e`).

--- a/.agents/memories/2026-07-31.md
+++ b/.agents/memories/2026-07-31.md
@@ -1,0 +1,20 @@
+# 2026-07-31 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 00:09 · grok@yosemite-s1 · 019fb580 · RUSH-1863
+- "Wire Grok Workflows Support" — extends Grok harness integration with workflow-execution support.
+
+### 02:57 · — · — · RUSH-1967
+- **One resolver for `--host`/`--device` — every subcommand now dials the same box.** Previously a host token resolved through two disagreeing code paths: `run --host` (and generic passthrough, teams placement, doctor, funnel, remote secrets) let a `~/.ssh/config` stanza win and dialed its bare name, while `sessions --host`, session bundles, and `agents ssh` dialed the device's Tailscale `user@dnsName` — the same name could reach two different machines and never shared a multiplexed SSH connection. Resolution is now a single merged lookup (`matchHost`): the live devices registry supplies address/OS/presence, the `agents.yaml` overlay supplies capability tags, ssh_config supplies hosts Tailscale has never seen — merged per-field, not one shadowing another. Commit `2ba4e8c9e feat(hosts): unify host/device resolution into one merged resolver`. Source: `apps/cli/src/lib/hosts/`, docs `4d7827f0d`.
+- This is the final landing of the device/host centralization effort that started 2026-07-07 (design session) and passed through RUSH-1691 (2026-07-14, per-command-group routing).
+
+### 09:49 · claude@yosemite-s1 · f1e23b68 · RUSH-1967
+- "Double-check merged pull requests" — driver session verifying the RUSH-1967 host-resolver merge above landed cleanly on main.
+
+### — · — · — · (day summary)
+- **`agents feed post`** added for deliberate status updates, queued as a `.changelog/next` fragment (`e88bcc708 feat(feed): agents feed post for deliberate status updates`) — the origin of the "post progress to the feed at milestones" convention now in repo memory.
+- Reconnect resilience: never lose a running agent on an SSH drop (`f106c1b05 fix(factory): reconnect resilience — never lose a running agent on an SSH drop (#1502)`) — precursor to the fuller RUSH-2007 reconnect work landed 2026-08-03.
+- `detach`/`attach` moved under the `sessions` command group for a consistent noun-first surface (`6b9a05096 refactor(cli): move detach/attach under the sessions group`).
+- Session pid-liveness guarded against pid reuse, fixing "zombie" sessions (`814655c2b fix(session): guard pid liveness against pid reuse`).

--- a/.agents/memories/2026-08-01.md
+++ b/.agents/memories/2026-08-01.md
@@ -1,0 +1,77 @@
+# 2026-08-01 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 00:29 · claude@yosemite-s1 · 35d4f2df · AES-256
+- Removed the Touch ID requirement from keychain access for routine agent launches — moved credential reads onto file-based setup-tokens / device-local logins instead of a keychain prompt per launch.
+- Landed same day: `9d64fa8d2 fix(secrets): an agent launch never raises a Touch ID sheet` (08:50), `4ee689787 docs(design): credential management model — device-local logins, file-based setup-tokens, zero Touch ID` (15:13), `9b446bf18 fix(usage): read Claude usage via file-based setup-token, not the keychain — no Touch ID` (15:55).
+
+### 00:57 · claude@yosemite-s1 · 43bf7ca1 · RUSH-1731
+- Designed a background-agent toggle for the UI/extension surface. Precursor design work; the shipped feature (`agents serve --control`, the authenticated anchor for the iOS/iPadOS cockpit) is a later delivery under the same ticket (CHANGELOG, RUSH-1731) — no execution/dispatch machinery of its own, reuses `agents run`/`agents message` via a bearer-gated HTTP surface.
+
+### 02:22 · claude@yosemite-s1 · 884cde64 · RUSH-1760
+- Investigated the agent-secrets binding architecture (how a bundle/credential ties to an account/session). Investigation session — no shipped change traced to this ticket in today's commits.
+
+### 02:26 · claude@yosemite-s1 · 9e8fb52d · SRS-1
+- "Assign Agent Owners" — precursor to the day's actor/provenance work: `62f279712 feat(actor): surface session owner in --active + actor/initiated_by DB columns [RUSH-2018]` (18:17), `178770ae4 feat(actor): durable sessionId->actor sidecar + teams lineage [RUSH-2019]` (18:44), `23f89d52b feat(actor): actor on events, routines, and browser tasks [RUSH-2020]` (19:12).
+- Decision: every session/event/routine/browser-task record carries a resolved actor (tailscale whois + an actors map), not just a raw pid.
+
+### 04:06 · claude@yosemite-s1 · 9c95ff30 · —
+- Refined browser-use behavior (agent-driven browser automation). Topic-only, thin signal.
+
+### 05:01 · claude@yosemite-s1 · 94c75686 · RUSH-2007
+- "remote-agent-session-resilience" investigation — the root of the day's fix landing at 20:22: `9dbcf374e fix(sessions): surface non-Claude remote session ids from the deployed hook (RUSH-2007 Layer A)`. Non-Claude tmux sessions (codex/gemini/kimi/grok/...) were invisible to `--active`/`focus` after an SSH drop because the id-backfill read the wrong (un-deployed) hook path; fixed to read the deployed SessionStart hook's per-pid record.
+
+### 05:51 · claude@yosemite-s1 · 856576fc · RUSH-1740
+- Checked open PRs for factory-foreman/watchdog integration. Same-day watchdog ship: `cdf41fea7 feat(watchdog): brain drives idle agents to completion with context-aware, tool-pointing nudges` (19:18) + `7765f2fae docs(watchdog): design doc + normative spec section` (19:18) — watchdog v2 replaces the older extension-side nudger (`e1d67d1e3 refactor(factory): retire extension watchdog nudger; keep autoRotate + status card`).
+
+### 06:28 · claude@yosemite-s1 · 038d753a · —
+- Designed a fleet-apply command with selective agent deployment — precursor to `agents apply --agent claude@all` (replicate one machine's version set), shipped as `d9c1fc697 feat(fleet): agents apply --agent claude@all — replicate a machine's version set`.
+
+### 11:57 · codex@zion · 019fbd2f · codex@zion · 019fbd38
+- Decision recorded in-session: "any earlier instruction enabling proactive multi-agent delegation no longer applies" — a scope-narrowing correction mid-session, not a code change.
+
+### 12:06 · claude@yosemite-s1 · 753bffab · RUSH-2028
+- Fixed actor propagation across the SSH dispatch boundary: `66b59ac6d fix(actor): teams local single-actor inheritance + actor on teammate record [RUSH-2028]` (05:53) and the later `AGENTS_ACTOR*`/`GIT_*` forwarding fix in `apps/cli/src/lib/hosts/dispatch.ts` so a remote box inherits the origin identity instead of re-resolving from its own `SSH_CONNECTION` (mis-crediting work to the shared machine).
+
+### 12:22 · claude@yosemite-s1 · e95ee5fc · RUSH-1823
+- "AGI Factory" session — same-day AGI EXT (Factory) release cut: `73cdd93b4 release(factory): 0.9.299 — reconnect resilience, detach/attach, watchdog, agents-dbg pipeline` (06:32), followed later by `51a73bccb release(factory): 0.9.301` (21:40) after `213f128d2 feat(factory): self-route the release to the box that holds the marketplace PATs`.
+- Decision: the extension release now self-routes to whichever box holds the marketplace PATs rather than assuming the invoking machine has them.
+
+### 12:44 · grok@yosemite-s1 · 019fbd5a · —
+- Reviewed and merged agents-cli PRs to ship 1.20.75-era changes.
+
+### 13:51 · claude@yosemite-s1 · 4de38f81 · RUSH-1957
+- "Eval AGENTS.md" — evaluated the memory file for a self-inflicted account-logout storm: unpinned `claude` routines pick an account via stateless weighted-random `balanced`, so concurrent unattended runs can land on the same account and race Claude's single-use refresh token, revoking each other (RUSH-1957, per CHANGELOG). Resolution direction: let a routine pin `account:` (login email/key) instead of `version:` (which gets GC'd on upgrade and silently reverts to `balanced`).
+
+### 16:57 · claude@yosemite-s1 · e049f85d · RUSH-1759
+- "Agent Onboard" — root of the day's fix where balanced account rotation was inert for scheduled Claude routines: the daemon's injected `CLAUDE_CODE_OAUTH_TOKEN` shadowed a pinned account's own on-disk credential, so every rotated fire re-authenticated (and eventually 401'd) as the one injected token. Decision: drop the injected token when the rotated account holds its own on-disk credential; keep it only for the token-less default account (the RUSH-1759 default).
+
+### 18:17-19:12 · claude@yosemite-s1 · (actor work, see SRS-1 above) · RUSH-2018/2019/2020
+- Executed via: the SRS-1 session above; listed separately here because the CHANGELOG entries (`62f279712`, `178770ae4`, `23f89d52b`) are the concrete decision record — actor/provenance is now a first-class column on sessions, events, routines, and browser tasks.
+
+### 19:18 · (watchdog v2 ship, see RUSH-1740 above)
+- Cross-referenced above; the substantive decision is watchdog v2 ("brain drives idle agents to completion with context-aware, tool-pointing nudges") replacing the old extension-only nudger.
+
+### 19:36 · claude@yosemite-s1 · fe21bfab · RUSH-1981
+- "AGI System Git" — session-list navigation metadata work, shipped as `4429: Session lists expose the model and richer navigation metadata (RUSH-1981, RUSH-1991, RUSH-1992, RUSH-1994)`: a compact model column (only when the result set has model data), clickable CWD/ticket/PR cells, browser/computer-use + sub-agent counts in previews, and an always-present `prLink` key on `--active --json`. Session index migrates to schema v20.
+
+### 19:39 · (Factory launch engine)
+- `3e5d1b85d feat(factory): one launch engine — device-first, balanced by default` — consolidated multiple launch code paths in the extension into one device-first engine.
+
+### 21:40 · (Factory release self-routing, see RUSH-1823 above)
+- Cross-referenced; decision is release self-routing to the marketplace-PAT-holding box.
+
+### 22:47 · claude@yosemite-s1 · 75597b18 · REQ-1
+- Reorganized documentation structure and specifications — precursor to the source-of-truth `apps/cli/docs/specifications.md` (sessions/secrets/agent-execution specs), landed as `b73e15b4b docs(spec): add source-of-truth specifications for sessions, secrets, agent execution`.
+
+### 22:50 · claude@yosemite-s1 · 3faa83ec · RUSH-1234
+### 23:33 · claude@yosemite-s1 · 1c0c8309 · RUSH-1234
+- Consolidated the observability + inspection command clusters into one role each and removed `agents check` / `agents resources`: `agents check` folds into `agents doctor --check` (same drift engine, scriptable exit code, `--json`/`--quiet`/`--devices` carry over); `agents resources` folds into `agents view --merged` (with `agents inspect <target>` for per-agent/per-repo detail). Commits: `da0fa7934` (19:16), `8f4d9bdbd` (19:31, review fixes), `e57206b92` (22:48, tombstone forwarding so the removed names print a deprecation notice and re-run the replacement instead of erroring).
+- Rejected: leaving `check`/`resources` as bare removed commands (would have produced a plain `unknown command` — their edit-distance to `doctor` was too far to even trigger a "did you mean").
+
+### 22:54 · claude@yosemite-s1 · 5cbb456c · RUSH-1967
+- One resolver for `--host`/`--device` — every subcommand now dials the same box (CHANGELOG, RUSH-1967). Previously `run --host` let `~/.ssh/config` win and dialed a bare name while `sessions --host`/session bundles/`agents ssh` dialed the Tailscale `user@dnsName`; the same name could reach two different machines with no shared multiplexed connection. Fixed with a single merged lookup (`matchHost`): live devices registry supplies address/OS/presence, `agents.yaml` overlay supplies capability tags, `ssh_config` supplies hosts Tailscale has never seen — merged per-field.
+
+> Cross-cutting decision this day: **release-train jam analysis** (`.agents/artifacts/2026-08-01/release-train-analysis.html`) — three root causes identified for the release pipeline colliding across agents: (1) AGENTS.md's release-to-fleet rule told every agent that merging "implicitly authorizes" the rest of the release chain, so many agents raced release.sh at once; (2) `release.sh` had no mutual exclusion (detects a drifted tree, never claims exclusivity); (3) a failed/refused publish left an orphan version that the next agent bumped past rather than finishing. Proposed and later adopted fix: rewrite the rule so a feature agent's job ends at merge + changelog fragment; add an origin-side release lease (git-ref compare-and-swap, since `flock` can't see across machines); run releases as a scheduled routine on the release host (mac-mini) rather than any agent invoking `release.sh` ad hoc. This is the origin of the "release-train" convention later codified in CLAUDE.md's Known Trains table (`release-train` routine on `mac-mini`, every 4h).

--- a/.agents/memories/2026-08-01.md
+++ b/.agents/memories/2026-08-01.md
@@ -29,8 +29,8 @@
 ### 06:28 · claude@yosemite-s1 · 038d753a · —
 - Designed a fleet-apply command with selective agent deployment — precursor to `agents apply --agent claude@all` (replicate one machine's version set), shipped as `d9c1fc697 feat(fleet): agents apply --agent claude@all — replicate a machine's version set`.
 
-### 11:57 · codex@zion · 019fbd2f · codex@zion · 019fbd38
-- Decision recorded in-session: "any earlier instruction enabling proactive multi-agent delegation no longer applies" — a scope-narrowing correction mid-session, not a code change.
+### 11:57 · codex@zion · — · —
+- Decision recorded in-session: "any earlier instruction enabling proactive multi-agent delegation no longer applies" — a scope-narrowing correction mid-session, not a code change. Sessions: 019fbd2f, 019fbd38.
 
 ### 12:06 · claude@yosemite-s1 · 753bffab · RUSH-2028
 - Fixed actor propagation across the SSH dispatch boundary: `66b59ac6d fix(actor): teams local single-actor inheritance + actor on teammate record [RUSH-2028]` (05:53) and the later `AGENTS_ACTOR*`/`GIT_*` forwarding fix in `apps/cli/src/lib/hosts/dispatch.ts` so a remote box inherits the origin identity instead of re-resolving from its own `SSH_CONNECTION` (mis-crediting work to the shared machine).
@@ -48,19 +48,19 @@
 ### 16:57 · claude@yosemite-s1 · e049f85d · RUSH-1759
 - "Agent Onboard" — root of the day's fix where balanced account rotation was inert for scheduled Claude routines: the daemon's injected `CLAUDE_CODE_OAUTH_TOKEN` shadowed a pinned account's own on-disk credential, so every rotated fire re-authenticated (and eventually 401'd) as the one injected token. Decision: drop the injected token when the rotated account holds its own on-disk credential; keep it only for the token-less default account (the RUSH-1759 default).
 
-### 18:17-19:12 · claude@yosemite-s1 · (actor work, see SRS-1 above) · RUSH-2018/2019/2020
+### 18:17-19:12 · claude@yosemite-s1 · — · RUSH-2018/2019/2020
 - Executed via: the SRS-1 session above; listed separately here because the CHANGELOG entries (`62f279712`, `178770ae4`, `23f89d52b`) are the concrete decision record — actor/provenance is now a first-class column on sessions, events, routines, and browser tasks.
 
-### 19:18 · (watchdog v2 ship, see RUSH-1740 above)
+### 19:18 · — · — · RUSH-1740
 - Cross-referenced above; the substantive decision is watchdog v2 ("brain drives idle agents to completion with context-aware, tool-pointing nudges") replacing the old extension-only nudger.
 
 ### 19:36 · claude@yosemite-s1 · fe21bfab · RUSH-1981
 - "AGI System Git" — session-list navigation metadata work, shipped as `4429: Session lists expose the model and richer navigation metadata (RUSH-1981, RUSH-1991, RUSH-1992, RUSH-1994)`: a compact model column (only when the result set has model data), clickable CWD/ticket/PR cells, browser/computer-use + sub-agent counts in previews, and an always-present `prLink` key on `--active --json`. Session index migrates to schema v20.
 
-### 19:39 · (Factory launch engine)
+### 19:39 · — · — · —
 - `3e5d1b85d feat(factory): one launch engine — device-first, balanced by default` — consolidated multiple launch code paths in the extension into one device-first engine.
 
-### 21:40 · (Factory release self-routing, see RUSH-1823 above)
+### 21:40 · — · — · RUSH-1823
 - Cross-referenced; decision is release self-routing to the marketplace-PAT-holding box.
 
 ### 22:47 · claude@yosemite-s1 · 75597b18 · REQ-1

--- a/.agents/memories/2026-08-02.md
+++ b/.agents/memories/2026-08-02.md
@@ -3,7 +3,7 @@
 > Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
 > Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
 
-### 00:00 · claude@yosemite-s1 · (menubar/RUSH-2087, several sessions overnight)
+### 00:00 · claude@yosemite-s1 · — · RUSH-2087
 - Fixed the menubar `Cmd-Shift-V` clip hotkey being hijacked by an SSH-started launch of another instance: `2c10550db fix(menubar): refuse ssh-started launch that hijacks Cmd-Shift-V (RUSH-2087)` (00:21), `bca026845 fix(menubar): report a rival helper as a conflict, not a confirmed winner` (00:42), `3a1347ab8 docs(menubar): say 'registered the chord first', not 'started first'` (00:44).
 - Decision: whichever helper registers the global chord first keeps it; a later-started rival is surfaced as a conflict, not silently declared the winner.
 
@@ -13,7 +13,7 @@
 ### 03:22 · claude@yosemite-s1 · 74b13b0b · RUSH-1971
 - The keychain Touch ID prompt now names the triggering session's 8-char short-id (e.g. "Claude is requesting to unlock the 'prod' bundle (session e0a1b2c3)…"), derived from `AGENT_SESSION_ID`, so an unexpected prompt is attributable when interactive agents, headless workers, and `secrets exec` all run at once. Source: `apps/cli/src/lib/secrets/index.ts`, `bundles.ts`.
 
-### 03:57 · claude@yosemite-s0 · 1f85f1ab (11:06, see below) / cli device work
+### 03:57 · claude@yosemite-s0 · 1f85f1ab · —
 - Device auto-launch preferences shipped for the extension: `b7b359443 feat(cli): device auto-launch preferences for Factory` and `606839411 feat(factory): consume device auto-launch preferences` (03:57), then `2b660a65f fix(devices): honor prefer on every auto-launch path; fail loud on unknown names` (04:19).
 - Decision: a preferred device is honored on *every* auto-launch path, and an unknown preferred-device name fails loudly rather than silently falling through to a different box.
 
@@ -23,8 +23,8 @@
 ### 04:39 · claude@yosemite-s1 · 34a71d3a · —
 - "Fix jammed release pipeline and optimize multi-agent deployments" — direct follow-through on the 08-01 release-train-analysis artifact. Same morning eight releases shipped in sequence (1.20.83 through 1.20.88 across 08-02), i.e. the immediate jam was cleared manually while the systemic fix (origin-side release lease + scheduled release-train routine) was still being designed.
 
-### 04:43-05:38 · droid@yosemite-s1 · 175728c8, 8439a873, 3f47d090, 6a6231ac, 554c2848, 9adfdfaa
-- Independent non-author code review swarm against the agents-cli repo (five back-to-back review + one re-review session). Consolidated PR review pass rather than a single decision — the driver for several small `fix`/`docs` commits merged through the morning's 1.20.83-1.20.87 releases.
+### 04:43-05:38 · droid@yosemite-s1 · — · —
+- Independent non-author code review swarm (sessions: 175728c8, 8439a873, 3f47d090, 6a6231ac, 554c2848, 9adfdfaa). against the agents-cli repo (five back-to-back review + one re-review session). Consolidated PR review pass rather than a single decision — the driver for several small `fix`/`docs` commits merged through the morning's 1.20.83-1.20.87 releases.
 
 ### 04:47 · — · — · —
 - `29cafb712 feat(exec): inject per-account Claude setup token (#1719)` — each configured Claude account gets its own setup token injected into the exec env rather than a single shared token, laying groundwork for the day's later RUSH-2099 per-account token fix (11:26/11:30 below).
@@ -59,7 +59,7 @@
 ### 11:06 · claude@yosemite-s0 · 1f85f1ab · —
 - "Improve dispatch session with host selection and preferences" — same device-auto-launch-preferences feature landed earlier in the morning (03:57 above); this session is the UX follow-through (host picker honoring `prefer`).
 
-### 11:26-11:30 · grok@yosemite-s1 · 019fc239, 019fc23d · RUSH-2099
+### 11:26-11:30 · grok@yosemite-s1 · — · RUSH-2099
 - Fixed per-account Claude token injection: each configured account authenticates with its own setup token rather than the daemon's shared/injected token shadowing a pinned account's on-disk credential (builds directly on `29cafb712` from 04:47).
 
 ### 11:28 · grok@yosemite-s0 · 019fc23b · —

--- a/.agents/memories/2026-08-02.md
+++ b/.agents/memories/2026-08-02.md
@@ -26,7 +26,7 @@
 ### 04:43-05:38 · droid@yosemite-s1 · 175728c8, 8439a873, 3f47d090, 6a6231ac, 554c2848, 9adfdfaa
 - Independent non-author code review swarm against the agents-cli repo (five back-to-back review + one re-review session). Consolidated PR review pass rather than a single decision — the driver for several small `fix`/`docs` commits merged through the morning's 1.20.83-1.20.87 releases.
 
-### 04:47 · (Claude per-account token injection)
+### 04:47 · — · 29cafb712 (commit) · —
 - `29cafb712 feat(exec): inject per-account Claude setup token (#1719)` — each configured Claude account gets its own setup token injected into the exec env rather than a single shared token, laying groundwork for the day's later RUSH-2099 per-account token fix (11:26/11:30 below).
 
 ### 06:24 · claude@yosemite-s1 · 6325fd34 · —

--- a/.agents/memories/2026-08-02.md
+++ b/.agents/memories/2026-08-02.md
@@ -26,7 +26,7 @@
 ### 04:43-05:38 · droid@yosemite-s1 · 175728c8, 8439a873, 3f47d090, 6a6231ac, 554c2848, 9adfdfaa
 - Independent non-author code review swarm against the agents-cli repo (five back-to-back review + one re-review session). Consolidated PR review pass rather than a single decision — the driver for several small `fix`/`docs` commits merged through the morning's 1.20.83-1.20.87 releases.
 
-### 04:47 · — · 29cafb712 (commit) · —
+### 04:47 · — · — · —
 - `29cafb712 feat(exec): inject per-account Claude setup token (#1719)` — each configured Claude account gets its own setup token injected into the exec env rather than a single shared token, laying groundwork for the day's later RUSH-2099 per-account token fix (11:26/11:30 below).
 
 ### 06:24 · claude@yosemite-s1 · 6325fd34 · —

--- a/.agents/memories/2026-08-02.md
+++ b/.agents/memories/2026-08-02.md
@@ -1,0 +1,73 @@
+# 2026-08-02 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 00:00 · claude@yosemite-s1 · (menubar/RUSH-2087, several sessions overnight)
+- Fixed the menubar `Cmd-Shift-V` clip hotkey being hijacked by an SSH-started launch of another instance: `2c10550db fix(menubar): refuse ssh-started launch that hijacks Cmd-Shift-V (RUSH-2087)` (00:21), `bca026845 fix(menubar): report a rival helper as a conflict, not a confirmed winner` (00:42), `3a1347ab8 docs(menubar): say 'registered the chord first', not 'started first'` (00:44).
+- Decision: whichever helper registers the global chord first keeps it; a later-started rival is surfaced as a conflict, not silently declared the winner.
+
+### 00:43 · grok@yosemite-s1 · 019fbfec · —
+- Reviewed the source-of-truth specification document (sessions/secrets/agent-execution) for suggested changes — precursor/companion to `b73e15b4b docs(spec): add source-of-truth specifications for sessions, secrets, agent execution` (landed 08-01) and the later normative additions (SES/SEC/EXEC ids).
+
+### 03:22 · claude@yosemite-s1 · 74b13b0b · RUSH-1971
+- The keychain Touch ID prompt now names the triggering session's 8-char short-id (e.g. "Claude is requesting to unlock the 'prod' bundle (session e0a1b2c3)…"), derived from `AGENT_SESSION_ID`, so an unexpected prompt is attributable when interactive agents, headless workers, and `secrets exec` all run at once. Source: `apps/cli/src/lib/secrets/index.ts`, `bundles.ts`.
+
+### 03:57 · claude@yosemite-s0 · 1f85f1ab (11:06, see below) / cli device work
+- Device auto-launch preferences shipped for the extension: `b7b359443 feat(cli): device auto-launch preferences for Factory` and `606839411 feat(factory): consume device auto-launch preferences` (03:57), then `2b660a65f fix(devices): honor prefer on every auto-launch path; fail loud on unknown names` (04:19).
+- Decision: a preferred device is honored on *every* auto-launch path, and an unknown preferred-device name fails loudly rather than silently falling through to a different box.
+
+### 04:03 · claude@yosemite-s1 · 1a01a007 · RUSH-1996
+- Analyzed `agents teams list` blocking on remote status probes. Fix: teams list/picker now render from cached team-registry + teammate `meta.json` snapshots instead of full status probes; full status still loads on `agents teams status <team>` or when a team is picked. Source: `apps/cli/src/commands/teams.ts`.
+
+### 04:39 · claude@yosemite-s1 · 34a71d3a · —
+- "Fix jammed release pipeline and optimize multi-agent deployments" — direct follow-through on the 08-01 release-train-analysis artifact. Same morning eight releases shipped in sequence (1.20.83 through 1.20.88 across 08-02), i.e. the immediate jam was cleared manually while the systemic fix (origin-side release lease + scheduled release-train routine) was still being designed.
+
+### 04:43-05:38 · droid@yosemite-s1 · 175728c8, 8439a873, 3f47d090, 6a6231ac, 554c2848, 9adfdfaa
+- Independent non-author code review swarm against the agents-cli repo (five back-to-back review + one re-review session). Consolidated PR review pass rather than a single decision — the driver for several small `fix`/`docs` commits merged through the morning's 1.20.83-1.20.87 releases.
+
+### 04:47 · (Claude per-account token injection)
+- `29cafb712 feat(exec): inject per-account Claude setup token (#1719)` — each configured Claude account gets its own setup token injected into the exec env rather than a single shared token, laying groundwork for the day's later RUSH-2099 per-account token fix (11:26/11:30 below).
+
+### 06:24 · claude@yosemite-s1 · 6325fd34 · —
+- "Release the project" — one of the day's many release-train fires (1.20.83-1.20.88 shipped across 08-02).
+
+### 07:04 · claude@zion · 9e9bae59 · —
+- "Fix clipboard paste shortcut for remote hosts" — same theme as the overnight menubar Cmd-Shift-V conflict fix (RUSH-2087); clipboard/clip-hotkey behavior across SSH-started vs local menubar helpers.
+
+### 07:36 · claude@yosemite-s1 · c854ae60 · RUSH-2007
+- "Status Bar Labels" — continuation of the RUSH-2007 remote-session-resilience work (non-Claude tmux session id surfacing, landed 08-01 as Layer A); this session extended status-bar/label rendering for the same session-visibility problem.
+
+### 07:38 · codex@zion · 019fc168 · RUSH-2087
+- Second pass on the Cmd-Shift-V hijack ticket (dispatch/verification of the menubar conflict fix above).
+
+### 08:24 · claude@yosemite-s1 · 7ae45af4 · RUSH-2100
+- Debugged agent dispatch notifications leaking into iMessage unexpectedly. Same ticket number as the later "resolved secrets no longer appear in `ps` for tmux-launched agents" fix (`apps/cli/src/lib/exec.ts`, SEC-8a) — the tmux pane previously put the full exec env (including secrets) on the command line, visible via `ps`; fixed by sourcing a 0600 env file and unlinking it before `exec`.
+
+### 08:36 · claude@yosemite-s1 · 63bbcd19 · RUSH-953
+- "AGI Autonomy" — topic-only, thin signal on what shipped from this specific session.
+
+### 09:31 · claude@yosemite-s1 · c5a35d19 · RUSH-2095
+- "Create Product Goals" — product-goals scoping session; no shipped code traced to this ticket in the day's commits.
+
+### 09:55 · claude@yosemite-s1 · 352275a6 · RUSH-2069
+- "remove-secrets-passphrase-env" — continuation of the file-backed secret store no longer requiring `AGENTS_SECRETS_PASSPHRASE` to be set by hand (macOS auto-provisions its key, per `841828051` shipped 08-01 21:44); `agents secrets setup` guidance was also cleaned up to stop telling users to set it (RUSH-1968, per CHANGELOG).
+
+### 10:01 · claude@yosemite-s1 · 5d5a25f6 · EXEC-6
+- "Switch remote to phnx-labs" — the repo's git remote/publish identity moved to the `phnx-labs` GitHub org (`@phnx-labs/agents-cli` on npm), with the prior `@swarmify`/companion package kept only as a legacy redirect stub (`packages/swarmify-mirror`).
+
+### 11:06 · claude@yosemite-s0 · 1f85f1ab · —
+- "Improve dispatch session with host selection and preferences" — same device-auto-launch-preferences feature landed earlier in the morning (03:57 above); this session is the UX follow-through (host picker honoring `prefer`).
+
+### 11:26-11:30 · grok@yosemite-s1 · 019fc239, 019fc23d · RUSH-2099
+- Fixed per-account Claude token injection: each configured account authenticates with its own setup token rather than the daemon's shared/injected token shadowing a pinned account's on-disk credential (builds directly on `29cafb712` from 04:47).
+
+### 11:28 · grok@yosemite-s0 · 019fc23b · —
+- Three parallel security audits in one session cluster: agents-cli child-process shell injection, secrets credential handling, and native IPC RPC supply-chain security. Audit-only signal (no specific fix traced to these exact session ids in today's commit range).
+
+### 11:42 · claude@yosemite-s1 · 24f4d5e9 · RUSH-2081
+- Investigated Cursor CLI tasks for agency support — landed as `agents sessions` discovering, indexing, and rendering Cursor agent transcripts (`projects/<encoded-cwd>/agent-transcripts/<uuid>/<uuid>.jsonl` joined to `chats/<workspace-hash>/<uuid>/meta.json` by UUID; abandoned chats with no transcript never become empty rows). Cursor lives outside agents-cli's managed version homes.
+
+> Also this day: `.agents/artifacts/2026-08-02/distributed-agent-execution-architecture.md` — a source-grounded research review of where agents-cli's distributed execution/session-recall/coordination can be optimized, benchmarked against Sierra, Ramp/Modal, OpenAI, and Anthropic's frontier agent stacks. Recommended a 3-phase path: (1) a structured `session_signals` memory graph extracted at scan time (queryable without embedding cost — decisions, action items, files touched, tool calls, errors, PR/ticket links), (2) a GitHub-backed metadata-only plane for partition tolerance (never transcript bodies, opt-in encryption), (3) anti-entropy P2P sync + cached active-state TTL + per-host resource guardrails. Positioned as extending, not replacing, the existing SSH-based fleet story (remote cache, R2 CRDT sync, SQLite FTS5 index, SSH multiplexed fan-out) — no broker or cloud relay.
+>
+> Also this day: `.agents/artifacts/2026-08-02/plan-sessions-team-lineage.html` — plan to surface "which orchestrator spun up this team" in `agents sessions`. Decision: persist `spawned_team`/`parentSessionId` on session meta (schema v20→v21) rather than recording the orchestrator on the team registry (rejected — the registry is per-team, not per-session, and the link needs to survive from the session side). Also fixed a `--device <self>` bug where an empty remote-hosts list fell through to fan out to the *whole* fleet instead of dialing just the local box. Shipped: `178770ae4`-adjacent work landed as `ebb92ddba feat(sessions): surface team lineage — which orchestrator spun up each team` and `1e3f7b7b0 feat(sessions): surface team lineage, and fix the --device browser scope (#1710)`.

--- a/.agents/memories/2026-08-03.md
+++ b/.agents/memories/2026-08-03.md
@@ -1,0 +1,93 @@
+# 2026-08-03 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 06:20 · claude@yosemite-s1 · b0b06be0 · —
+- "AGI System" — general system/config maintenance session; thin signal on a specific shipped change.
+
+### 06:54 · grok@yosemite-s1 · 019fc667 · —
+- `.agents/artifacts/2026-08-03/agents-cli-model-tiers-plan.html` — "Pick a model by cost tier, not by a name that keeps changing." Decision: one pipeline per harness (extract ids → rank → map to `cheap/default/best/ultra` → resolve); `agents models` is the single source of truth; a harness with fewer than 4 distinguishable rungs collapses tiers to the nearest one rather than fabricating levels. New `lib/model-tiers.ts` (`MODEL_TIERS`, `isTierToken`, `rankModels(agent, version)`). Ranking signal is per-harness, not always price (subscription harnesses with no `$/token` rank by catalog order + size instead).
+- Shipped later (post-plan, confirmed in CHANGELOG): `--model cheap|default|best|ultra` on `agents run`/`agents teams add`, `agents models tier set <agent[@version]> <tier> <model>` for manual overrides, and profile runs (Kimi/DeepSeek/GLM via `agents run <profile>`) explicitly discard a tier flag with a warning rather than resolving it against the wrong catalog.
+
+### 06:58 · claude@yosemite-s1 · 277c1709 · —
+- "Add first-class custom agent harness support" — related artifact `.agents/artifacts/2026-08-03/harness-first-class` (topic-only; specific shipped mechanism not traced in today's evidence).
+
+### 07:05-07:27 · grok@yosemite-s1 · 019fc670, 019fc684 · —
+- AI-artifact plan-file research (2025-2026 complaints on other tools' plan/artifact formats) feeding into the `plan-render`/`artifacts` house-style conventions; also "Dispatch bar tickets, host pick, mode memory" — dispatch-bar UX groundwork (remembering the last-picked host/mode per project).
+
+### 07:27 · claude@zion · 8fb08cb6 · —
+- Non-author PR review session ("work fast, finish in one pass") — part of the day's ongoing PR-review cadence around the 1.20.89-1.20.93/1.21.x release train (see release list below).
+
+### 07:42 · claude@yosemite-s1 · 2373284d · RUSH-2007
+- "make-agent-sessions-visible" — root of the day's biggest shipped fix, `.agents/artifacts/2026-08-03/invisible-sessions-before-after.html`: `agents sessions --active` reported one row per **working directory**, not one row per agent — panes it could not identify were dropped (`active.ts:1466`), then the fallback resolved every remaining pane in a directory to the same newest transcript and dedupe folded them together, so a "×25" badge was actually ~25 distinct sessions wearing one id.
+- Shipped as **PR #1765, merged**, rolled out to 11 fleet hosts; measured post-upgrade on `zion` (1.20.90): 120 rows, 76 distinct sessionIds, pid-count histogram `{1: 111, 2: 8, 3: 1}` — panes now map to their real session.
+- A second root cause was found while verifying the first (why `--resolve` still could not find a session in some cases) — has its own fix, in review as of this artifact.
+
+### 08:10 · claude@yosemite-s1 · 74a4893f · —
+- "Complete and merge recent task or PR" — release-train housekeeping (the day shipped 1.20.89 through 1.22.0, nine releases).
+
+### 08:34 · claude@yosemite-s1 · 5b2d72f3 · RUSH-556
+- Reviewed the `agents projects` command implementation plan. Shipped same release-window: the status card gains an `agents` line naming which harness is running on each project, a latest-release tag, a Linear issue-count line, and `agents projects link <name> --linear [query]` to bind a project to a Linear project (fuzzy-suggests from the def name + repo slug). Source: `apps/cli/src/lib/project-status.ts`, `linear-projects.ts`.
+
+### 09:23 · claude@yosemite-s1 · df0ab22d · RUSH-2039
+- "Dot Agents Conflicts" — landed as: Codex now gets the same feed hooks Claude already had (waiting-state notification blocks), so the extension's edge-triggered VS Code notification ("Focus terminal") works for Codex sessions too, not just Claude.
+
+### 09:26 · claude@yosemite-s1 · 0fcff7ab · — / 09:46 · claude@yosemite-s1 · 56b6b6e5 · —
+- "AGI Stop Hook" and "show-hold-window-policy" — feeds directly into `.agents/artifacts/2026-08-03/stop-hook-analysis.html` ("The verify-work-complete Stop hook: how it fires, and how agents react") and `verify-work-complete-effectiveness-2026-08-03.html`.
+- The effectiveness review corrected its own framing mid-analysis: "De-escalation" was the wrong word for what the hook measures. Scorecard: agents usually act (4 in 5 hook-triggered intervals contained a real change/verification/coordination action, not a restatement); outcomes usually terminate (of 122 unique cited PRs, live GitHub check found 112 merged, 5 deliberately closed, 5 still open). Weak spot: open-PR guidance repeats — only 83/150 open-PR chains cleared on the first nudge, and repetition has diminishing returns (68.7% first-attempt clearance → 53.9% second-attempt → 37.1% third-attempt among remaining chains). The shipped loop-breaker had not yet been tested by real exposure at analysis time.
+
+### 09:30 · grok@yosemite-s1 · 019fc6f5 · —
+- Reviewed PR #1758 ("Menubar ACTIVE Accordion") — extension UI review pass.
+
+### 10:03-10:55 · claude@yosemite-s1 · 019fc7d0, 496b253b, 61c4ba8f · —
+- A cluster of "harmless Factory recap/picker E2E source session" sessions — synthetic test-fixture sessions built to validate the resume/recap/picker flows end to end (not user work; deliberately labeled "harmless" so they don't get mistaken for real history).
+
+### 10:12-10:39 · codex@yosemite-s1 · 019fc6ef, 019fc6f0 · —
+- Sequencing/merge-order audit across three in-flight PRs: "#1749 merged before #1761/#1768, so #1768 cannot deliver to main and a base rebase is needed" → "independent audit of current main after merged #1771/#1776 is still blocking." Decision: rebase order matters across a stack of related PRs; audited and unblocked serially rather than force-merging out of order.
+
+### 11:11 · claude@zion · 2942e114 · —
+- "AGI Watchdog" — continuation of watchdog v2 (from 08-01); this session is also cited directly in the invisible-sessions artifact as a correctly-identified pane after the fix (`2942e114 claude pids=1 agents-cli`).
+
+### 11:23-11:30 · claude@yosemite-s1 · 067b6e38, 6c13df19 · —
+- Two "Mission:" dispatch sessions repairing/reconciling draft PRs against a fast-moving main: "repair draft PR #1777 so its two fleet-failure tests exercise the production path" and "reconcile public Factory PR #1780 with newly merged PR #1774 without [reintroducing conflicts]." Same rebase-discipline theme as the codex sessions above — multiple agents landing overlapping PRs required active reconciliation, not blind merge.
+
+### 11:36 · grok@yosemite-s1 · 019fc768 · —
+- "Merge Conflict Frequency Across Agent Sessions" — root of `.agents/artifacts/2026-08-03/multi-agent-merge-conflicts.html`. Correction to an earlier miscounted stat: the first pass used the local session index only (287 sessions on yosemite-s1); fanning out across 10 fleet hosts + id-dedupe found **1043 unique sessions** in 14 days (fleet is ~3.7x the local-only count), with 111 transcripts carrying conflict signal. Root cause of the undercount: `agents sessions --all --since 14d` without `--host` only reads the local machine — a denominator error, not a methodology change to the conflict detection itself.
+
+### 12:15-12:32 · grok@yosemite-s1 · 019fc78c, 019fc79c · —
+- "What Is a Workflow Explanation" and resuming/attaching prior work on session `4119ca1b` — workflow-documentation and session-attach mechanics, thin signal.
+
+### 14:21 · claude@yosemite-s1 · bf71de55 · —
+- "Optimize agents-cli performance and user experience" — root of `.agents/artifacts/2026-08-03/plan-agents-cli-review.html`, a review of twelve user-submitted improvement ideas, each independently sub-agent-investigated. Five assumptions were corrected by evidence:
+  1. **`agents view` is slow** not because of live per-account usage bars (parallel, cached, sub-second) but because it re-scans the 230-270 MB Claude binary on every call (~7.5s of ~13s) — a catalog-cache guard refuses to save a failed extraction.
+  2. **`agents sessions --active --local` is slow** (the biggest find, and the direct answer to filed ticket RUSH-2118): a query that should touch nothing but the local machine actually fires ~60 real SSH calls (~4.3s) to poll remote teammates that had already finished.
+  3. **Per-harness rule presets** (a requested feature, #7) already ship: `agents rules switch codex@ver --preset name`. The real gap is narrow — presets only apply after an explicit switch, not automatically on agent launch.
+  4. **R2 backups & CRDT** (#4): R2 sync already exists as an off-by-default beta the team had already demoted in favor of the live `--host` query plus export/import; swapping CRDT for object-storage versioning was rejected — it would cause silent data loss in the one case CRDT protects. Decision affirmed: remove the legacy beta, keep and grow export/import.
+  5. **Session benchmarks** (#5) partly exist already (`bench/sessions-perf.ts`, `bench-ssh.mjs`, `docs/05-sessions.md`); the real gap is distributed (cross-fleet) query benchmarking.
+- Status at artifact time: 12 tracks, 2 PRs already building, awaiting go on the rest of the wave.
+
+### 15:03 · claude@zion · 42a05ecd · —
+- "Clarify Hetzner server cap reference" — also the session cited by name in the invisible-sessions artifact's post-fix measurement ("this very session, correctly named").
+
+### 15:21 · grok@yosemite-s1 · 019fc837 · RUSH-2123
+- `.agents/artifacts/2026-08-03/plan-rush-2123-one-transport.html` — "one transport + two axes." Problem: a live failure where the rule taught `rush message send` → missing subcommand → `notify` unconfigured → desktop fallback, i.e. four different transport stacks teaching four different things. Decision: collapse to one transport with two orthogonal axes (delivery intent vs. urgency/level), not merged verbs. Shipped as `agents send` — a real delivery envelope (`--to`, `--text`, `--channel`, `--attach`, `--url`); `agents notify` becomes a thin alias, `--to owner` (expands from `notify.owner` in `agents.yaml`). Help text now names the three planes (deliver / record / control) so `send` is never confused with `feed post`, `activity`, or `message`/`sessions inject`. Source: `apps/cli/src/commands/send.ts`, `apps/cli/src/lib/channels/send.ts`.
+
+### 15:30 · claude@zion · 4db0440e · RUSH-2107
+- "Quick Dispatch" — root of the shipped `agents sessions` rows showing creation time alongside last-activity (`3d → 1 hour ago`), in both the interactive picker and flat/tree listings.
+
+### 16:03 · claude@yosemite-s1 · d66e73be · RUSH-2007
+- Reviewed `agents sessions` command documentation — continuation of the RUSH-2007 session-visibility work landed earlier in the day.
+
+### 17:16 · claude@yosemite-s1 · 27b5c717 · RUSH-2061
+- "Dispatch - S1" — this is the session id cited as the driver of `plan-agents-cli-review.html` (`session · 27b5c717`, `host · yosemite-s1`, `harness · claude agent · opus-4-8`). RUSH-2061 itself lands as router/quota-cache fixes: "warm the quota cache instead" and "candidate collection... one already maxed" (`deriveUsageHeadroom` projects minutes-to-limit rather than picking an already-maxed account).
+
+### 19:46 · grok@zion · 019fc929 · —
+- "Spec Driven Development" topic session — methodology discussion, no specific shipped artifact traced.
+
+### 21:23 · claude@zion · 9b113ec5 · —
+- "AGI Projects" — continuation of the `agents projects` work (RUSH-556 above).
+
+> Release cadence this day (evidence the release-train jam from 08-01 was resolved in practice): nine releases shipped — 1.20.89, 1.20.90 (the invisible-sessions fix, PR #1765), 1.20.91, 1.20.92, 1.20.93, 1.21.0, 1.21.1, 1.21.2, 1.21.3, 1.22.0.
+>
+> Also this day (topic-only, thin signal — no specific shipped mechanism traced in today's evidence): `.agents/artifacts/2026-08-03/browser-profile-sharing.html` recommends keeping one synced profile name (e.g. `work`) across machines rather than separate local/remote profiles, logging in once per machine (persists after), and not expecting a live shared session between two machines simultaneously. `.agents/artifacts/2026-08-03/plan-hook-assurance.html` found four of the repo's 22 hooks were silently dead (registration dropped in an unrelated commit) and that the destructive guards (`git-guard.sh`, `rm-guard.sh`, `large-file-add-guard.sh`) were the *untested* ones despite being the highest-consequence; proposed a `hooks/registration_test.sh` that fails on any hook missing a registration/invocation/explicit-allowlist entry. `.agents/artifacts/2026-08-03/plan-agent-blocks.html` proposed a new `agents feed block "<ask>"` primitive (declared blocks, one delivery mechanism instead of a primary-with-fallbacks) — proposed, not confirmed shipped inside this date range. `.agents/artifacts/2026-08-03/plan-routines-health.html` proposed a 4-phase fix for routines reporting misleading health (rate-limit failures mislabeled, "overdue" computed from routine creation time rather than the device scheduler's actual start, a phantom `worker` device alias resolving to nothing). `.agents/artifacts/2026-08-03/design-drift-2026-08-03.md` is a read-only architecture audit (no code changed) finding the fleet SSH fan-out logic implemented independently in at least two/three places (`gatherRemote*`, the feed block path) with feature drift between copies; drafted Linear tickets to consolidate. `.agents/artifacts/2026-08-03/agent-share.html` scoped a public-share page ("one URL, four different views") with a disclosure-matrix owner control panel — this is the design precursor to the later `agents share` `--unlisted`/`--private` and `agents share list` features (RUSH-2443/2444, outside this date range).

--- a/.agents/memories/2026-08-03.md
+++ b/.agents/memories/2026-08-03.md
@@ -13,7 +13,7 @@
 ### 06:58 · claude@yosemite-s1 · 277c1709 · —
 - "Add first-class custom agent harness support" — related artifact `.agents/artifacts/2026-08-03/harness-first-class` (topic-only; specific shipped mechanism not traced in today's evidence).
 
-### 07:05-07:27 · grok@yosemite-s1 · 019fc670, 019fc684 · —
+### 07:05-07:27 · grok@yosemite-s1 · — · —
 - AI-artifact plan-file research (2025-2026 complaints on other tools' plan/artifact formats) feeding into the `plan-render`/`artifacts` house-style conventions; also "Dispatch bar tickets, host pick, mode memory" — dispatch-bar UX groundwork (remembering the last-picked host/mode per project).
 
 ### 07:27 · claude@zion · 8fb08cb6 · —
@@ -33,29 +33,31 @@
 ### 09:23 · claude@yosemite-s1 · df0ab22d · RUSH-2039
 - "Dot Agents Conflicts" — landed as: Codex now gets the same feed hooks Claude already had (waiting-state notification blocks), so the extension's edge-triggered VS Code notification ("Focus terminal") works for Codex sessions too, not just Claude.
 
-### 09:26 · claude@yosemite-s1 · 0fcff7ab · — / 09:46 · claude@yosemite-s1 · 56b6b6e5 · —
+### 09:26 · claude@yosemite-s1 · 0fcff7ab · —
+
+### 09:46 · claude@yosemite-s1 · 56b6b6e5 · —
 - "AGI Stop Hook" and "show-hold-window-policy" — feeds directly into `.agents/artifacts/2026-08-03/stop-hook-analysis.html` ("The verify-work-complete Stop hook: how it fires, and how agents react") and `verify-work-complete-effectiveness-2026-08-03.html`.
 - The effectiveness review corrected its own framing mid-analysis: "De-escalation" was the wrong word for what the hook measures. Scorecard: agents usually act (4 in 5 hook-triggered intervals contained a real change/verification/coordination action, not a restatement); outcomes usually terminate (of 122 unique cited PRs, live GitHub check found 112 merged, 5 deliberately closed, 5 still open). Weak spot: open-PR guidance repeats — only 83/150 open-PR chains cleared on the first nudge, and repetition has diminishing returns (68.7% first-attempt clearance → 53.9% second-attempt → 37.1% third-attempt among remaining chains). The shipped loop-breaker had not yet been tested by real exposure at analysis time.
 
 ### 09:30 · grok@yosemite-s1 · 019fc6f5 · —
 - Reviewed PR #1758 ("Menubar ACTIVE Accordion") — extension UI review pass.
 
-### 10:03-10:55 · claude@yosemite-s1 · 019fc7d0, 496b253b, 61c4ba8f · —
+### 10:03-10:55 · claude@yosemite-s1 · — · —
 - A cluster of "harmless Factory recap/picker E2E source session" sessions — synthetic test-fixture sessions built to validate the resume/recap/picker flows end to end (not user work; deliberately labeled "harmless" so they don't get mistaken for real history).
 
-### 10:12-10:39 · codex@yosemite-s1 · 019fc6ef, 019fc6f0 · —
+### 10:12-10:39 · codex@yosemite-s1 · — · —
 - Sequencing/merge-order audit across three in-flight PRs: "#1749 merged before #1761/#1768, so #1768 cannot deliver to main and a base rebase is needed" → "independent audit of current main after merged #1771/#1776 is still blocking." Decision: rebase order matters across a stack of related PRs; audited and unblocked serially rather than force-merging out of order.
 
 ### 11:11 · claude@zion · 2942e114 · —
 - "AGI Watchdog" — continuation of watchdog v2 (from 08-01); this session is also cited directly in the invisible-sessions artifact as a correctly-identified pane after the fix (`2942e114 claude pids=1 agents-cli`).
 
-### 11:23-11:30 · claude@yosemite-s1 · 067b6e38, 6c13df19 · —
+### 11:23-11:30 · claude@yosemite-s1 · — · —
 - Two "Mission:" dispatch sessions repairing/reconciling draft PRs against a fast-moving main: "repair draft PR #1777 so its two fleet-failure tests exercise the production path" and "reconcile public Factory PR #1780 with newly merged PR #1774 without [reintroducing conflicts]." Same rebase-discipline theme as the codex sessions above — multiple agents landing overlapping PRs required active reconciliation, not blind merge.
 
 ### 11:36 · grok@yosemite-s1 · 019fc768 · —
 - "Merge Conflict Frequency Across Agent Sessions" — root of `.agents/artifacts/2026-08-03/multi-agent-merge-conflicts.html`. Correction to an earlier miscounted stat: the first pass used the local session index only (287 sessions on yosemite-s1); fanning out across 10 fleet hosts + id-dedupe found **1043 unique sessions** in 14 days (fleet is ~3.7x the local-only count), with 111 transcripts carrying conflict signal. Root cause of the undercount: `agents sessions --all --since 14d` without `--host` only reads the local machine — a denominator error, not a methodology change to the conflict detection itself.
 
-### 12:15-12:32 · grok@yosemite-s1 · 019fc78c, 019fc79c · —
+### 12:15-12:32 · grok@yosemite-s1 · — · —
 - "What Is a Workflow Explanation" and resuming/attaching prior work on session `4119ca1b` — workflow-documentation and session-attach mechanics, thin signal.
 
 ### 14:21 · claude@yosemite-s1 · bf71de55 · —

--- a/.agents/memories/2026-08-04.md
+++ b/.agents/memories/2026-08-04.md
@@ -1,0 +1,35 @@
+# 2026-08-04 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 01:38-01:51 · claude@yosemite-s1 · d24e8b2e, 97dfcc44, 000dec13 · —
+- Status/self-identification checks ("check current status", "which model am I") plus "Custom Harness" work — thin signal, no specific shipped mechanism traced.
+
+### 01:40 · claude@yosemite-s1 · ded5f77c · GPT-5
+- "model-tiers-agent-discovery" — direct continuation of the previous day's model-tiers plan (`.agents/artifacts/2026-08-03/agents-cli-model-tiers-plan.html`). Confirmed shipped in this window: `agents models` prints the per-harness `cheap/default/best/ultra` tier map with `~$/Mtok` where priced, refreshes `prices.json` with the GPT-5.6 Sol/Terra/Luna series, and fixes the Claude catalog extractor returning 0 models on the newest native-binary format.
+
+### 02:04 · claude@zion · d0565685 · —
+- "Clone artifacts-cli across fleet devices" — fleet-wide rollout of the `artifacts` CLI (used to render plans/reports/visuals to branded HTML), following the 08-03 `plan-adopt-artifacts-cli.html` recommendation (73% token reduction on the sample plan vs. hand-authored HTML).
+
+### 02:20 · droid@yosemite-s1 · 04cba82e · —
+- Reviewed PR #1874.
+
+### 02:30 · claude@yosemite-s0 · 3aa85d53 · — / 06:34 · claude@yosemite-s0 · 1d56c8b0 · —
+- Resolved a git worktree conflict on `main` (two sessions, same theme). Matches same-day fix: `234fa1396 fix(teams): base local worktrees on fetched origin/default, not HEAD` (04:02) — a teams-created local worktree previously based off local HEAD instead of freshly-fetched `origin/<default>`, letting a worktree fork off stale code.
+
+### 03:27 · claude@yosemite-s1 · 2a73ae97 · —
+- "AGI Routines" — root of the day's routine-scheduling safety fix landed late in the evening: `5906a0c81 fix: prevent overlapping routine executions`, `d1f85fb7f test: cover routine overlap and timeout recovery`, `04dc257bb docs: document routine execution safeguards` (21:28) — closes a gap where the same routine could fire twice concurrently (echoes the RUSH-1957 account-collision problem from 08-01, generalized to overlapping runs of any routine).
+
+### 05:13 · claude@yosemite-s1 · 1a48d8e0 · RUSH-1321
+- "Install and upgrade Grok agent CLI" — root of the shipped fix: self-updating single-binary agent CLIs (Droid, Grok, Cursor, Kiro, Goose, Hermes) are now represented as **one live installation** in `agents view` instead of inventing stale version-home rows; `agents add <agent>@<version>` installs/keeps the current release rather than rejecting an unsupported pinned install for these harnesses. Source: `apps/cli/src/lib/agents.ts`, `versions.ts`, `commands/{versions,view}.ts`.
+
+### 05:51 · claude@yosemite-s1 · d8fd8290 · SEC-19
+- "Touch ID Storm" — root-caused and fixed two bugs that made a `never`-policy secrets bundle keep popping Touch ID: (1) `agents secrets policy <b> never` rewrote only bundle metadata, not the value items, so macOS's per-item ACL (not the tier label) kept gating reads — fixed by reconciling value items to the new tier on every policy change (`reAclBundleItems`); (2) the signed keychain helper's just-in-time migration re-stamped a biometry ACL onto every `agents-cli.*` item it touched, including metadata/hmackey reads that are supposed to be silent, causing a *second* Touch ID prompt on top of the value read — fixed by re-adding those silent items with no ACL. Net effect: unlock/read a `never` bundle once and it stays silent through sleep, reboot, 30+ days, and both an agents-cli upgrade and a macOS upgrade. Durability/attribution guarantees for the `never` tier are now written into `apps/cli/docs/specifications.md` (SEC-19, SEC-27, SEC-28).
+
+### 06:12 · claude@yosemite-s1 · 225cb38d · claude@yosemite-s1 · 019fcb5d · —
+- "AGI UI Issues" and Codex apps/connectors work — thin signal.
+
+> Also this day: `.agents/artifacts/2026-08-04/factory-launch-balanced-spec.md` — "Every interactive agent Factory launches must use `--strategy balanced` (account/version rotation) and `--mode auto` (writable-but-gated) — always, with no exceptions." Root cause identified: the launch surface had three overlapping allowlists that disagreed on whether a launch got `--strategy balanced` and whether it even routed through `agents run`. Decision: collapse to one source-of-truth rule — every agent runner (everything except a raw shell) launches through `agents run <agent> --interactive`. Named behavioral change to watch: local `grok`/`kimi`/`droid` now launch through `agents run <agent>` instead of the raw binary (intentional — gives them balanced rotation + `--mode auto`); verified safe because `agents run <agent> --strategy balanced` is a graceful no-op fallback (not an error) for a harness with no accounts to balance across (droid), per `rotate.ts:588`, `exec.ts:2094-2110`.
+>
+> Also this day: `.agents/artifacts/2026-08-04/product-acceptance-user-stories.html` — "User stories that stop product regressions." Diagnosis: agents write good implementation plans (Why → Design/API → Files → Verification of the *new* surface) but product regressions are failures of *what must stay true for users*, which HTML plans, mockups, and unit tests on new code only weakly or don't-at-all guard against. Decision: require product acceptance written as concrete Given/When/Then user stories with a named role, a real command/UI surface, and an observable Then that a proof command or test can fail against — contrasted against "bad" filler stories like "As a user I want better session visibility so I can be more productive" (no role doing a real job, no concrete surface, no observable outcome) versus "good" stories like "As an operator on a busy laptop, I want `agents sessions --active` to show which host each live agent is on, so I know where to attach without guessing" (testable with two hosts, one command).

--- a/.agents/memories/2026-08-04.md
+++ b/.agents/memories/2026-08-04.md
@@ -3,7 +3,7 @@
 > Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
 > Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
 
-### 01:38-01:51 · claude@yosemite-s1 · d24e8b2e, 97dfcc44, 000dec13 · —
+### 01:38-01:51 · claude@yosemite-s1 · — · —
 - Status/self-identification checks ("check current status", "which model am I") plus "Custom Harness" work — thin signal, no specific shipped mechanism traced.
 
 ### 01:40 · claude@yosemite-s1 · ded5f77c · GPT-5
@@ -15,7 +15,9 @@
 ### 02:20 · droid@yosemite-s1 · 04cba82e · —
 - Reviewed PR #1874.
 
-### 02:30 · claude@yosemite-s0 · 3aa85d53 · — / 06:34 · claude@yosemite-s0 · 1d56c8b0 · —
+### 02:30 · claude@yosemite-s0 · 3aa85d53 · —
+
+### 06:34 · claude@yosemite-s0 · 1d56c8b0 · —
 - Resolved a git worktree conflict on `main` (two sessions, same theme). Matches same-day fix: `234fa1396 fix(teams): base local worktrees on fetched origin/default, not HEAD` (04:02) — a teams-created local worktree previously based off local HEAD instead of freshly-fetched `origin/<default>`, letting a worktree fork off stale code.
 
 ### 03:27 · claude@yosemite-s1 · 2a73ae97 · —
@@ -27,8 +29,8 @@
 ### 05:51 · claude@yosemite-s1 · d8fd8290 · SEC-19
 - "Touch ID Storm" — root-caused and fixed two bugs that made a `never`-policy secrets bundle keep popping Touch ID: (1) `agents secrets policy <b> never` rewrote only bundle metadata, not the value items, so macOS's per-item ACL (not the tier label) kept gating reads — fixed by reconciling value items to the new tier on every policy change (`reAclBundleItems`); (2) the signed keychain helper's just-in-time migration re-stamped a biometry ACL onto every `agents-cli.*` item it touched, including metadata/hmackey reads that are supposed to be silent, causing a *second* Touch ID prompt on top of the value read — fixed by re-adding those silent items with no ACL. Net effect: unlock/read a `never` bundle once and it stays silent through sleep, reboot, 30+ days, and both an agents-cli upgrade and a macOS upgrade. Durability/attribution guarantees for the `never` tier are now written into `apps/cli/docs/specifications.md` (SEC-19, SEC-27, SEC-28).
 
-### 06:12 · claude@yosemite-s1 · 225cb38d · claude@yosemite-s1 · 019fcb5d · —
-- "AGI UI Issues" and Codex apps/connectors work — thin signal.
+### 06:12 · claude@yosemite-s1 · — · —
+- "AGI UI Issues" and Codex apps/connectors work — thin signal. Sessions: 225cb38d, 019fcb5d.
 
 > Also this day: `.agents/artifacts/2026-08-04/factory-launch-balanced-spec.md` — "Every interactive agent Factory launches must use `--strategy balanced` (account/version rotation) and `--mode auto` (writable-but-gated) — always, with no exceptions." Root cause identified: the launch surface had three overlapping allowlists that disagreed on whether a launch got `--strategy balanced` and whether it even routed through `agents run`. Decision: collapse to one source-of-truth rule — every agent runner (everything except a raw shell) launches through `agents run <agent> --interactive`. Named behavioral change to watch: local `grok`/`kimi`/`droid` now launch through `agents run <agent>` instead of the raw binary (intentional — gives them balanced rotation + `--mode auto`); verified safe because `agents run <agent> --strategy balanced` is a graceful no-op fallback (not an error) for a harness with no accounts to balance across (droid), per `rotate.ts:588`, `exec.ts:2094-2110`.
 >

--- a/.agents/memories/2026-08-05.md
+++ b/.agents/memories/2026-08-05.md
@@ -1,0 +1,66 @@
+# 2026-08-05 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+
+### 01:04 · claude@zion · 72599cb4 · —
+- Reviewed agent-design vs the day's usage-analytics insights output (input into the RUSH-2280 research seed authored later this week).
+
+### 06:09 · claude@zion · 07053c3f · PROJ-123
+- Decided to consolidate plan-mode and debug-mode behaviors that had drifted into separate, overlapping enforcement paths (hooks + rules + skills), the same fragmentation later mapped fully in `plan-task-enforcement-map.md`.
+
+### 06:19 · grok@zion · 019fd093 · —
+- Cleaned up plugin hooks/skills and removed the unused `dither-kit` plugin from the fleet config.
+
+### 08:48 · claude@zion · 2fcd8422 · —
+- Fixed CI red on `main` that broke right after `feat(clis): rename cli resource kind and directory to clis` (#2011) landed — the rename needed a follow-up job fix, tracked and closed same morning (08:55, `5a707abe`).
+
+### 10:29 · claude@zion · 5a74221b · —
+- Decided PR #2021 needed to absorb and supersede a conflicting parallel change rather than be rebased around it — set up a chain of independent-review passes (10:33 `b47fc442`, 10:39 `19c65d99` fixing a blocking permissions regression, 10:42 `a7caf921`, 10:57 `ec4b0fca` closing the final two review blockers) before merge.
+
+### 10:35 · droid@yosemite-s1 · 411c87b8 · —
+- Shipped `agents run <agent> --cloud` as a placement flag — sugar over `agents cloud run --agent`, routed through the existing `agents cloud` provider registry rather than a new subsystem (design approved same day in `agents-run-cloud-flag-design.md`; shipped as PR #2066, reviewed non-author by droid at 12:06 `65c3b582`).
+
+### 11:16 · claude@yosemite-s1 · b1abf309 · —
+- Took ownership of GitHub issue #2058 (`agents view` doesn't exit clean; `agents doctor @latest/@oldest/@pinned/@all` resolve incorrectly) — root-caused as resource-drift logic living in `view` instead of `doctor`, plus a broken qualifier resolver.
+- Follow-up sessions transplanted the fix onto a clean main-based branch without rebase noise (12:06 `446b9870`) and prepared a focused follow-up (12:36 `eda4b241`); landed as `fix(view,doctor): remove view drift-check; fix doctor qualifier resolution` (#2058, merged 12:08).
+
+### 11:31 · claude@zion · 22f01438 · —
+- Fixed PR #2059 CI (generated CHANGELOG.md drift), then closed two independent-review blockers (11:36 `9b369e2f`) — shipped as `feat(routines): projects field, --project/--all-projects flags, group-by-project default` (#2059, merged 14:20).
+
+### 12:31 · claude@yosemite-s1 · b19ccd2f · —
+- Served as the non-author reviewer clearing PR #2071 for merge-on-green.
+
+### 12:59 · claude@yosemite-s1 · a789587a · —
+- Served as the non-author reviewer clearing PR #2074 at head `c3b9a648`.
+
+### 15:31 · — · — · RUSH-2198
+- Shipped `fix(sessions): guarantee the picker detail preview a minimum height` (#2091) so a short preview pane no longer collapses to nothing.
+
+### 16:32 · — · — · —
+- Added Meta Muse Code as a supported harness (`feat(cli): add Meta Muse Code harness support`, #2084) — new agent onboarded into the registry-driven harness table.
+
+### 16:41 · — · — · RUSH-2206
+- Shipped `agents sessions focus` device + live-state scoping and multi-select tabs (#2100), the first half of the fix later completed by `plan-session-focus-recovery.html`'s design: reuse the sessions-browser query contract and attach only to living processes so a tmux pane retained after the underlying process exited can no longer be selected as live.
+- Landed the recovery half same night: `fix(sessions): make focus recovery open reliably` (#2206, 23:13).
+
+### 17:54 · — · — · —
+- Shipped `claude-opus-5` / `claude-sonnet-5` pricing (`fix(pricing)`, #2096) so `agents output` burn totals reflect the new model generation.
+
+### 18:34 · — · — · —
+- Fixed two co-installed agents-cli versions (e.g. Homebrew + nvm) racing to reinstall the macOS menu-bar helper over each other (`fix(menubar): stop two installs reinstalling the helper over each other`, #2109) — the immediate root cause behind the 22:03 "Debug missing menu bar item" session (`5eac6f99`) later that night.
+
+### 18:43 · — · — · RUSH-2100
+- Shipped `fix(exec): keep resolved secrets out of the process table` (#2107) — resolved secret values no longer appear in a plain `ps` listing of the spawned agent process.
+
+### 21:22 · droid@yosemite-s1 · ea3e3a7f · —
+- Served as non-author reviewer on the docs-quickstart PR #2080 (`agents run --cloud` placement documentation, corrected a stale Claude-routing claim).
+
+### 22:01 · claude@yosemite-s1 · 3ebe9094 · RUSH-2060
+- Triaged the decision to remove Forge and hard-deprecate Gemini as supported harnesses (Forge dropped outright; Gemini gated behind a hard-deprecation flag enforced later in the week across `add`/`import`/`sync`/`run`/`routines add`).
+
+### 22:35 · claude@yosemite-s1 · 4b1b77e8 · RUSH-2138
+- Updated the backlog and cycle-management rules governing how tickets move through triage/in-progress/done.
+
+### 23:18 · claude@yosemite-s0 · e4e29578 · RUSH-1822
+- Opened the investigation into routine login failures in the agent daemon — the fleet-wide-logout hazard (a routine borrowing another account's ambient `CLAUDE_CODE_OAUTH_TOKEN` when its own setup-token was missing) that stayed open through the week and was only closed by RUSH-2360 later.

--- a/.agents/memories/2026-08-06.md
+++ b/.agents/memories/2026-08-06.md
@@ -1,0 +1,94 @@
+# 2026-08-06 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: this was a ~500-session swarm day (release 1.22.27 → 1.22.29). Entries below
+> cluster the swarm by decision/ticket rather than one per session; useful work stops
+> around 13:40 and the rest of the day (14:00–20:00) is watchdog/overwatch noise with
+> no further merges until the 20:01 release.
+
+### 00:22 · claude@yosemite-s1 · ff2f7fd8 · RUSH-2063
+- Bounded the uncapped provenance-probe fan-out in agents-cli (`fix(sessions): bound provenance probes`), following up on the prior evening's work on the same ticket.
+
+### 00:57 · — · — · —
+- Cut release 1.22.27 (#2236), folding the prior night's backlog of secrets/session/menubar fixes.
+
+### 01:12 · claude@yosemite-s1 · 7b8812b3 · —
+- Fixed three defects in the hook-cache background-refresh shim (RUSH-2121): missing lock, no backoff, and swallowed exit codes. Shipped as `fix(hooks): lock, backoff, and real exit-code logging for bg cache refresh` (#2131).
+- Executed via: droid@yosemite-s0 3c9f99c2 (RUSH-1882 computer-mac trust_status fix, parallel track), droid@yosemite-s1 8409941f (RUSH-2090 `agents mcp add` comment-stripping fix).
+
+### 01:23 · grok@yosemite-s1 · 019fd4ab · —
+- Reviewed and re-reviewed the new Agents Modes Catalog feature (PR #2132, modes command registration) before merge.
+
+### 02:29 · claude@yosemite-s1 · 64720c4f · —
+- Implemented Warp Agent CLI (Oz) support end-to-end: registered as a harness, wired into binary resolution/shims/aliases/teams, with a `oz login` hint and resume intentionally dropped (not session-tracked, no local id to resume).
+
+### 03:08 · claude@yosemite-s1 · 2c7ba1a2 · —
+- Fixed a regression where `agents secrets list` skipped biometry-ACL items (RUSH-2251, urgent).
+- Executed via a parallel dispatch wave from the same driver session covering: RUSH-2120 (git-guard/rm-guard/large-file-add-guard tests, `32871cfb`), capability-table honesty for RUSH-2122+RUSH-2101 (`b0117f2d`), RUSH-2111 auth-health-per-account (`7c8d89f1`), RUSH-2054 balanced-host SSH-unreachable exclusion (`33aba43a`), product acceptance gates RUSH-2142+2143 under RUSH-2140 (`94f09611`), RUSH-2207 batch tool-usage scan (`c0b8a03b`), RUSH-2249 flaky device-reachability false negatives (`0e363b98`), RUSH-2264 fail-loud secret decrypt (`36fe4014`), RUSH-2002+RUSH-2001 teams-scheduler health-awareness (`edb7c4e6`), and RUSH-2215 CI Windows test-window collapse (`6d00d06f`).
+- Shipped that morning: `fix(auth-health): probe once per account, not per version home` (RUSH-2111), `fix(factory): exclude SSH-unreachable devices from balanced host pick` (RUSH-2054), `fix(hosts): ready probe timeout gives false not-reachable error` (RUSH-2249), `fix(secrets): fail loud on file decrypt errors` (RUSH-2264), `perf(sessions): scan event logs once outside write txn for batch tool-usage detection` (RUSH-2207).
+
+### 03:37 · — · — · RUSH-2101
+- Shipped Cursor headless `--mode plan` support: declared the capability, wired `--plan`, and dropped the stale-degrade warning it no longer needed.
+
+### 04:00 · claude@yosemite-s0 · 540d2e28 · RUSH-2149
+- Ran an independent baseline benchmark of the `agents browser stream` CLI-boot latency ahead of Codex's persistent-client fix, so the before/after improvement could be proven rather than asserted (`rush-2149-baseline.md`; yosemite-s1 had no browser installed so it measured CLI-boot layer only, a second worker on macOS with a live Comet daemon gave the clean baseline).
+- After-fix evidence for PR #2189 captured same session cluster at 04:35 (`19ea9cb0`).
+- Shipped: `chore(browser): keep one Node process and browser-daemon IPC socket warm across repeated actions` (RUSH-2149).
+
+### 04:35 · claude@yosemite-s1 · c3b49ac7 · RUSH-2002
+- Owned finishing RUSH-2002 (PR #2167, health/harness/load-aware teams scheduling), RUSH-2085 (PR #2168, `agents reconnect` for a dropped remote agent terminal), and RUSH-2102 (validate routine agents before scheduling) through to merge.
+- Shipped: `agents teams` auto-scheduling now fails loud when no pool device can run the agent (RUSH-2002); `agents reconnect [session-id]` re-enters a dropped remote terminal and auto-reconnect no longer dead-ends on a dead pane (RUSH-2085); `agents routines add` rejects an agent the daemon can't fire, at add time (RUSH-2102).
+
+### 04:46 · claude@yosemite-s1 · 00645bf2 · RUSH-2208
+- Found PR #2187 (incremental tool index + FTS optimize) dirty against main after a concurrent merge; drove the drain of open dirty/blocked PRs to merge-on-green (04:48, `ee9490a7`) and landed PR #2191 (RUSH-2102) directly.
+
+### 04:52 · claude@yosemite-s1 · 9815f363 · RUSH-1997
+- Took ownership of a batch of small reliability tickets: richer team session display in `agents sessions --teams` (RUSH-1997, shipped: sessions group by team with per-teammate rows), `agents devices harnesses`/`agents devices accounts` per-device readiness (RUSH-2003, `0adee0fc`), release-lease-survives-external-kill (RUSH-2274, `7f91ad1c`), Claude routine transcripts archiving as `origin='routine'` (RUSH-2271, `245a8fb2`), standalone `browser` binary not routing `--host` (RUSH-2214, `2d364154`), a broken notification-escalation hook test (RUSH-2277, `91fc3c8f`), hook-cache single-flight lock with no TTL (RUSH-2259, `66cf07a0`), Gemini hard-deprecation enforcement gap in `runner.ts` (RUSH-2202, `82e649ea`), and remote session-gather stdout with no `maxBuffer` cap (RUSH-2065, `cda8bb85`).
+- All shipped same day: RUSH-2003 (`feat(devices): agents devices harnesses/accounts`), RUSH-2274 (release lease detects an externally-killed holder), RUSH-2271 (routine transcripts archive as `origin='routine'`), RUSH-2202 (`fix(routines): also gate cloud/host placement; close the runner.ts enforcement gap`), RUSH-2065 (`fix(sessions): cap remote fan-out stdout per peer`).
+
+### 05:16 · claude@yosemite-s1 · 935f44c3 · —
+- Opened an independent investigation into a macOS agents-cli menu-bar deployment bug — fed into the density-toggle removal and menubar-consolidation work that landed later in the day and the following week.
+
+### 06:18 · claude@yosemite-s1 · 119581e4 · RUSH-2287
+- Shipped `agents output` exposing the input/cache-read/cache-write token-burn split plus a `--pricing no-cache` scenario.
+
+### 06:20 · claude@yosemite-s0 · 18a8390c · —
+- Drove a wave of GitHub-issue hardening fixes to close: #2210 (a newer signed agents-cli install now takes over the menu-bar helper immediately; an older install can no longer reclaim it — `18a8390c`), #2108 (`agents sessions focus` reaps dead tmux panes and proves the transcript belongs to the exact active version home before resuming — `08e260d8`), #2118 (`agents routines devices --set/--clear` no longer aborts when a fleet peer is offline — `95687b86`), #1820 (`agents models claude` id-scan no longer lists a bare legacy id that 404s — `57baf564`), #1767 (redact and validate Claude OAuth setup-tokens before they reach the auth header — `563b0035`), #1884 (bound the reconnect loop on a recurring local SSH failure — `3afb3018`), and #1889 (bash-command classifier: single-source tool registry, broader unwrap — `0d80c8ff`, `dd1920b5` for #1892's word-boundary anchor fix).
+- Executed via: codex@yosemite-s0/s1 and droid@yosemite-s0/s1 teammates running the same missions in parallel across 06:20-06:22.
+
+### 06:33 · claude@yosemite-s1 · cc36e8c6 · RUSH-2299
+- Took ownership of `agents bench` — a harness×model scoreboard with pass/fail acceptance criteria — end to end.
+
+### 06:41 · claude@yosemite-s0 · dcc1880a · —
+- Reviewed PR #2224 as non-author; parallel non-author reviews landed through the morning for PR #2229 (grok@yosemite-s0 `019fd5d4`), #2238 docs quickstart (claude@yosemite-s0 `5489d12f`), #2220 OAuth setup (claude@yosemite-s0 `92c5479c`), and pull request 235 in `.agents-system` (claude@yosemite-s1 `4aaefd99`, `316a3b5d`).
+
+### 07:20 · claude@yosemite-s0 · ea21f3b5 · —
+- Diagnosed and fixed PR #2222 Windows CI (21 failing `activity.test` cases) and PR #2220 CI (`gen-changelog.test.ts` failing on a stale `CHANGELOG.md`) same morning (07:23, `c3af0933`; 07:24, `34bf196f`) — shipped as `test(windows): quarantine POSIX-only tests so the Windows suite reflects real regressions` (RUSH-2215, #2222).
+
+### 08:06 · claude@yosemite-s0 · 23076666 · —
+- Landed PRs #2222 and #2243 on merge-on-green with non-author review, no `--admin` bypass — #2243 shipped `fix(devices): preserve identities on follow-up SSH calls` (RUSH-2265).
+
+### 10:30 · grok@yosemite-s1 · 019fd69f · RUSH-2313
+- Drove PR #2259 to merge: `agents run`/`agents teams --device`/`--host` now fail loud when a pinned harness version isn't installed on the target, instead of silently falling through.
+
+### 11:47 · grok@yosemite-s1 · 019fd6e6 · —
+- Drove PR #2262 (Windows hooks fix) to merge.
+
+### 12:41 · grok@yosemite-s1 · 019fd717 · —
+- Reviewed and drove PR #2267 (`AGENTS_DEVICES_DIR` win-host e2e) to merge (12:44, `019fd71a`).
+
+### 18:46 · — · — · —
+- Removed the menu-bar dropdown's `Density: Auto/Rich/Compact` toggle and the whole rich/compact rendering fork — the dropdown now always renders rich rows. Reverses the density-toggle feature added earlier in the week; drops the `menubarDensity` UserDefaults key and `MENUBAR_DENSITY` env override.
+
+### 18:57 · — · — · RUSH-2334
+- Fixed `agents run` to launch a logged-out harness so the user can sign in, instead of failing closed.
+
+### 20:01 · — · — · —
+- Cut release 1.22.28 (#2288), then shipped `feat(menubar): collapsible DEVICES roster + session Focus + routine last-run detail` (#2289, 20:17).
+
+### 23:12 · codex@yosemite-s1 · — · —
+- Root-caused Cursor launching a blank terminal instead of its interactive prompt: the managed version symlinked to `~/.local/bin/cursor-agent`, and launcher adoption later redirected that same path to the agents shim, creating a recursive-dispatch cycle. Fix repoints the managed binary directly at the native Cursor executable and repairs existing installations (`plan-cursor-launcher-loop.md`; shipped as `fix: repair recursive cursor shims during migration`, 23:12-23:53).
+
+### 23:16 · — · — · —
+- Cut release 1.22.29 (#2292), closing out the day's swarm.

--- a/.agents/memories/2026-08-07.md
+++ b/.agents/memories/2026-08-07.md
@@ -1,0 +1,66 @@
+# 2026-08-07 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: mornings on this repo run an unattended "Rush growth outreach loop" and a
+> Claude-session overwatch that post every few minutes; those are excluded below as noise.
+> note: three entries below (marked `~HH:MM`) are artifact-dated 2026-08-07 with no exact
+> session timestamp recorded in the skeleton or CHANGELOG; placed by best-evidence ordering.
+
+### 00:56 · claude@yosemite-s1 · 5f1f0563 · RUSH-2350
+- Fixed the login-harness launch path (`fix-login-harness-launch`), the precursor to the same-day `secrets unlock --keys` refactor.
+
+### 01:21 · claude@yosemite-s1 · 4aa29552 · RUSH-2107
+- Sharpened the Projects status card (`sharpen-projects-status-card`), continuing the redesign scoped in `projects-status-card-ui.md` two days earlier.
+
+### 04:56 · — · — · —
+- Shipped `fix(secrets): import --force repairs an undecryptable bundle record` (#2305) — a corrupt keychain-backed bundle can now be forcibly re-imported instead of permanently blocking `agents secrets`.
+
+### 05:33 · — · — · RUSH-2354
+- Restored the `agents daemon` command group (runtime, hosted-service, and failure visibility) after it had been deliberately removed while the mechanisms it needs (`getDaemonStatus`, start/stop) were rebuilt underneath it.
+
+### 05:49 · — · — · RUSH-2357
+- Fixed OpenCode sessions being pruned from every listing: OpenCode keeps all sessions in one SQLite file, so the staleness gate that assumed one-file-per-session was hiding valid sessions. Index now stores a composite `file_path` (`opencode.db#ses_<id>`).
+
+### ~06:00 · claude@zion · e67573e5 · —
+- Spec'd `Cursor multi-account — make picking an account actually pick it` (`cursor-multi-account-spec.md`): diagnosed that `agents view cursor`'s two-account display was cosmetic — Cursor is a single self-updating binary with one config location, so agents-cli's per-account config-dir isolation (the mechanism every other harness uses) never got wired up for it, meaning the account picker, `@version` selector, and balanced rotation all computed a choice with zero effect on which login actually ran. This spec is what RUSH-2400 implemented the following day.
+
+### 06:02 · — · — · RUSH-2353
+- Collapsed the daemon's hardcoded housekeeping timer ticks (`watchdog`, `device-probe`, `tmux-reconcile`, `launch-health`, `fleet-cache-warm`, `session-cache-warm`, `usage-refresh`, and others) into ordinary routines instead of a second, parallel scheduling concept — one scheduler for both user and system jobs.
+
+### 06:26 · — · — · RUSH-2350
+- Folded key-scoping into `agents secrets unlock --keys K1,K2` and deleted the separate `secrets lease`/`leases`/`revoke` command surface — one unlock verb instead of two overlapping ones.
+
+### ~06:30 · claude@yosemite-s0 · — · —
+- Spec'd `Make account routing refuse stale usage decisions` (`plan-fresh-account-routing.md`): root-caused a real launch failure where `Agents: New Claude` selected `claude@2.1.219` from a ~59-hour-old usage snapshot reporting 86% weekly usage, and Claude then rejected the first prompt on an already-exhausted weekly limit. New contract: an initial launch never picks an account from an unverified snapshot — one bounded refresh, then either a verified pick or a loud failure with the account list and refresh error, never a silent guess.
+
+### 06:32 · — · — · RUSH-2358
+- Wired OpenCode's already-recorded usage fields (`input_tokens`, `cache_read_tokens`, `cache_write_tokens`, etc.) into the shared sessions index, and fixed the `account` field to resolve from `auth.json` — the same source `agents view`/`agents doctor` already use — instead of an unreliable `opencode.db` column.
+
+### 06:59 · — · — · RUSH-2290
+- Shipped `feat(accounts): name provider accounts` (#2304) — a user can now name an installed provider-account identity once and have every matching version discovered under that label, per `plan-account-labels.md`'s decision that a label names an account and installed versions are discovered, never attached.
+- Also shipped the menu bar distinguishing routine readiness/blocked/skipped states from an outright execution failure (RUSH-2290) — the first visible piece of the reliability contract drafted in `routine-reliability-plan.md`: resolve where a routine runs, prove it's runnable before activating (else pause with a stable code), fire each scheduled slot at most once, and record every attempt as history.
+
+### ~07:00 · claude@yosemite-s0 · — · —
+- Spec'd sorting `agents view` accounts by email (`plan-view-account-email-order.html`): keep the default account first, then sort the rest alphabetically by email instead of by version descending, so a multi-account fleet is scannable; machine-readable JSON order is unchanged.
+
+### 07:32 · — · — · RUSH-2352
+- Shipped daemon last-wins takeover plus a real stop-postcondition assertion (RUSH-2352, RUSH-2355) — `agents daemon stop` now proves the daemon actually stopped instead of trusting the command's exit code.
+
+### 08:18 · — · — · RUSH-2368
+- Fixed duplicate-daemon detection to scope against the live instance registry and drive health from a real probe (RUSH-2368), and made daemon tests reap leaked test daemons and self-terminate on a missing state dir (RUSH-2367).
+
+### 08:47 · — · — · RUSH-2373
+- Shipped session bookmarking and focus-from-preview (#2332): replaced the favorite/star vocabulary with one "bookmark" concept, moved the filter hotkey to `B`, and made `F` focus the highlighted session through the existing `sessions focus` recovery path — the decision recorded in `plan-session-bookmarks-focus.html`.
+
+### 09:22 · — · — · RUSH-2382
+- Fixed `agents doctor` to detect and bounded-repair missing generated hook shims, then surfaced broken hook-shim wrappers directly in `agents doctor`'s output (09:29) and in the menu bar's System health row (`feat(menubar): surface doctor findings in the System health row`, #2347, 10:11).
+
+### 10:12 · — · — · RUSH-2372
+- Shipped frozen agent installations: an installation is now identified by more than its version-dir name, and `agents update <agent>@<installed-version>` moves the release inside one instead of creating a fresh, disconnected install (#2339).
+
+### 11:03 · — · — · —
+- Merged PR #2345 (`fix/2382-hook-runtime-core`), closing out the RUSH-2382 hook-shim repair track.
+
+### ~23:00 · gpt-5@yosemite-s0 · — · —
+- Ran a seven-day effectiveness audit of the `verify-work-complete` Stop hook (2026-08-01 through 2026-08-08): 390 logical blocking interventions across 167 sessions, with agents running a tool after 83.8% of interventions and pushing back after only 6.4% — the evidence base behind later hook-tuning decisions.

--- a/.agents/memories/2026-08-08.md
+++ b/.agents/memories/2026-08-08.md
@@ -1,0 +1,90 @@
+# 2026-08-08 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: this day is dominated by an overnight grok@yosemite-s1 "Rush growth outreach loop"
+> spam pattern (~90 near-identical "Overnight continue" / "You are continuing..." pings) and
+> a repeated codex "## Apps (Connectors)" template — both skipped as non-substantive.
+
+### 00:50 · codex@zion · 019fdc8a · RUSH-2358
+- Root-caused a Windows-rooted `cwd` (`C:\Users\...`) reading as non-absolute on POSIX (`path.isAbsolute` is platform-relative), silently corrupting session `cwd`/`worktree_slug` for any transcript synced from Windows to a POSIX box.
+- Fix: `normalizeCwd()` recognizes a Windows-rooted path (drive letter or UNC) on POSIX and treats it as already absolute, mirroring the existing POSIX-on-Windows branch.
+- Shipped: commits f566242a3 / c0fc52e26 / 67c515dab.
+
+### 01:13 · claude@yosemite-s1 · 6ed2d502 · SING-11
+- Daemon reliability wave, worked as one continuous thread across the day: bounded the daemon crash loop at all three layers — launchd `ThrottleInterval`, systemd `StartLimitIntervalSec`/`StartLimitBurst`, and top-level `uncaughtException`/`unhandledRejection` handlers in `agents __daemon-run` (RUSH-2418), plus an auto-start circuit breaker after 5 consecutive unhealthy starts.
+- `agents daemon start` no longer defeats its own launchd/systemd launch: the start lock is released right after the launch is issued, not after the pid wait (RUSH-2417).
+- `agents daemon stop` now proves state-file release (lifetime marker, heartbeat, registry entry), not just sockets, and a graceful stop no longer escalates to a kill just because a browser client is still attached (RUSH-2421).
+- Reap orphaned keychain `watch-lock` helpers once the owning daemon is provably dead (RUSH-2419).
+- Spec updated in lockstep: SING-GAP-4/5/6 retired/narrowed, lifecycle reliability guarantees documented (RUSH-2420).
+- Executed via: codex@yosemite-s0 019fdf95/019fdfb7, multiple `docs(spec)`/`fix(daemon)` commits through the day.
+
+### 04:20 · claude@yosemite-s0 · 9b8dc428 · RUSH-2406
+- Parallel dispatch batch: 4 `claude@yosemite-s0` missions launched back-to-back (04:20-05:10) to implement Linear tickets end-to-end, each in its own worktree.
+- RUSH-2406 (this session): no corresponding merged commit found in CHANGELOG/git log — likely superseded or closed without shipping; do not assume it landed.
+- Executed via: claude@yosemite-s0 b62c1b7c (RUSH-2409), 40978bd4 (RUSH-2411), e7195d19 (RUSH-2412).
+
+### 04:58 · claude@yosemite-s0 · b62c1b7c · RUSH-2409
+- `agents sessions --routine` made outcome-aware: renders the routine's canonical run history first (id, trigger, status, timing, exit/error, execution type, placement, log paths), then links each run to its indexed agent session(s), instead of dead-ending a command-only routine into "No sessions found".
+- Canonical source is the run history under `~/.agents/.history/runs/<routine>/`, not the session index.
+- Shipped per CHANGELOG (source: `apps/cli/src/commands/sessions.ts`).
+
+### 05:02 · claude@yosemite-s0 · 40978bd4 · RUSH-2411
+- Fixed a Codex host-picker labeling bug: a Codex session picked via `--host` now gets auto-labeled after its remote ID hydrates, instead of staying unlabeled.
+- Shipped: commits 3e8e9ae81 / 641fa263e (`fix(factory): auto-label picked-host Codex after remote ID hydration`).
+
+### 05:10 · claude@yosemite-s0 · e7195d19 · RUSH-2412
+- `agents ssh <device>` now mirrors the caller's project directory on interactive login, so an interactive SSH session lands in the same relative project path instead of a bare home directory.
+- Shipped: commit ce6586613 (`feat(ssh): mirror the caller's project dir on interactive login`).
+
+### 08:11 · claude@zion · 16f75462 · RUSH-2360
+- Investigated and fixed a fleet-wide-logout hazard (RUSH-1822 sibling): `buildExecEnv` stripped an ambient `CLAUDE_CODE_OAUTH_TOKEN` only when a per-account setup-token resolved — when NONE resolved, the ambient shared/rotating token was left in place, so `agents run claude "<prompt>"` could silently authenticate as another account's shared token.
+- Fix mirrors the routines path unconditionally: inject the resolved setup-token, else delete the ambient one, so a missing login fails loud (401) against this home's own credential.
+- Shipped: commit 90945171f.
+
+### 08:47 · claude@yosemite-s0 · 3d978420 · RUSH-2407
+- Reviewed and landed PR #2370: `agents browser sessions` / `agents sessions --browser` made task-first — groups every screenshot/PDF/recording by browser task, shows the linked agent session's canonical digest, adds `--no-interactive`.
+- Shipped: commit 0f997193b (#2370).
+
+### 09:34 · claude@zion · 87f84f1a · —
+- Independently investigated (paired with cursor@yosemite-s0 f6244360, blind cross-check) a Cursor multi-account bug: every run silently authenticated as the single live `~/.cursor` login regardless of which account was selected, because Cursor has no per-account config-dir isolation in `buildExecEnv`.
+- Root cause: Cursor's real login gate is `$XDG_CONFIG_HOME/cursor/auth.json`, not `~/.cursor/cli-config.json` (metadata only) — found empirically.
+- Fix direction: pin `XDG_CONFIG_HOME` at the version home for Cursor, same mechanism muse already uses.
+- Shipped as RUSH-2400 (see below) with an additional companion PR.
+
+### 09:43 · grok@yosemite-s1 · 019fdbec · RUSH-2107
+- `agents sessions` rows now show creation time as well as last activity, closing a gap where only last-activity was visible.
+
+### 10:02 · claude@yosemite-s0 · multiple · RUSH-2427 / RUSH-2426 / RUSH-2393 / RUSH-2429
+- Second parallel dispatch batch of 4 missions at 10:02, each `claude@yosemite-s0` owning one ticket end-to-end in its own worktree.
+- RUSH-2426: fixed a flaky routines overlap-run test's timing and diagnosability (commit bbc00ca9c).
+- RUSH-2429: fixed a torn `meta.json` write permanently disabling orphan-worktree cleanup fleet-wide — `saveMeta()` now writes via tmp-file + atomic rename, `loadFromDisk()` quarantines only content-corrupt records (renamed to `meta.json.corrupt`), never a transient read error (commit 7720c49bb, 711671c23).
+- RUSH-2427 / RUSH-2393: dispatched, no corresponding merged commit found — outcome unverified from available evidence.
+- Executed via: claude@yosemite-s0 16038aa9 (2426), 3ab0f9fe (2393), 5ec972d3 (2429).
+
+### 10:14 · claude@yosemite-s0 · 23b5dc2b · RUSH-2297
+- Took over existing PR #2403 from a prior independent investigation, in the same worktree.
+- Landed later (08-09) as `agents cp <src> <dst>` — first-class fleet file transfer (commit b29b9859f).
+
+### 10:24 · claude@yosemite-s0 · 39841a27 · RUSH-2440
+- Delivered end-to-end: stopped `agents run` from triggering a broad macOS Keychain scan on agent-only bundle reads — resolves exact items from bundle metadata instead of enumerating the Keychain, preventing an unrelated biometry-protected secret from raising a Touch ID sheet on every launch.
+- Shipped: commit c589f2b33 (`fix(secrets): eliminate broad Keychain scan triggering Touch ID on every run`).
+
+### 10:34 · claude@zion · 29845311 · RUSH-2400
+- Multi-session swarm across the day (10:34-11:50, same PR #2416, same worktree, sequential narrow-scope takeovers) landed multiple Cursor accounts as real: `buildExecEnv` and the versioned-alias shim now pin `XDG_CONFIG_HOME` at the version home for Cursor, so each selected account authenticates with its own token in isolation instead of all runs sharing the single live `~/.cursor` login.
+- `agents view cursor` verifies each account's signed-in state against its own token; a migration seeds the current global login into the active account's home on upgrade.
+- Executed via: claude@zion 39118fae, 530cabf6, e21c29f4, 598688c2, 3a05de2d, e6205c6b (account selection/display, narrow runtime slice, docs-only slice on the same clean PR #2416 worktree).
+
+### 11:00 · codex@zion · 019fdc44 · RUSH-2354
+- Restored `agents daemon` command group after it had been deliberately removed while its underlying mechanisms stayed implemented and unreachable: `status`/`start`/`stop`/`restart`/`enable`/`disable`/`reload`/`services`/`logs`/`doctor`.
+- New persisted `daemon.enabled` device kill switch; new per-subsystem health record tracks secrets-broker/browser-IPC failure streaks.
+- Deliberately no `agents daemon jobs` — scheduled work stays under `agents routines`.
+
+### 11:04 · codex@yosemite-s0 · 019fdf8d · RUSH-2396
+- Command reference feature work (`feat/RUSH-2396-command-reference` branch) — an intent-based/generated command reference surface for the CLI.
+
+### — · — · RUSH-2444 / RUSH-2443 / RUSH-2449 / RUSH-2448 / RUSH-2428 / RUSH-2438
+- Same "growth outreach loop" grok@yosemite-s1 sessions also merged a cluster of `agents share` hardening PRs shipped this day: `--unlisted`/`--private` + 30-day default expiry + pre-publish sensitive-content scan (RUSH-2443, closing the RUSH-2428 world-readable-publish incident), `agents share list` machine-readable listing (RUSH-2444), an idempotent "update the deployed Worker" path (RUSH-2449), and `agents share delete`/`agents unshare` (RUSH-2428 followup, commit 6f03854b9).
+- `agents feed post --notify` added a local desktop banner on top of configured broadcast (RUSH-2448).
+- `agents sync` now prunes resources removed from source (manifest-bounded, never over-deletes) instead of only ever adding — closing an observed gap where 8 removed commands stayed live across 7 Claude homes (RUSH-2438).
+- Note: thin session-level provenance for this cluster — attributed to the day's automated PR-merge loop, not a single named driver session.

--- a/.agents/memories/2026-08-08.md
+++ b/.agents/memories/2026-08-08.md
@@ -55,7 +55,7 @@
 ### 09:43 · grok@yosemite-s1 · 019fdbec · RUSH-2107
 - `agents sessions` rows now show creation time as well as last activity, closing a gap where only last-activity was visible.
 
-### 10:02 · claude@yosemite-s0 · multiple · RUSH-2427 / RUSH-2426 / RUSH-2393 / RUSH-2429
+### 10:02 · claude@yosemite-s0 · — · RUSH-2427 / RUSH-2426 / RUSH-2393 / RUSH-2429
 - Second parallel dispatch batch of 4 missions at 10:02, each `claude@yosemite-s0` owning one ticket end-to-end in its own worktree.
 - RUSH-2426: fixed a flaky routines overlap-run test's timing and diagnosability (commit bbc00ca9c).
 - RUSH-2429: fixed a torn `meta.json` write permanently disabling orphan-worktree cleanup fleet-wide — `saveMeta()` now writes via tmp-file + atomic rename, `loadFromDisk()` quarantines only content-corrupt records (renamed to `meta.json.corrupt`), never a transient read error (commit 7720c49bb, 711671c23).
@@ -83,7 +83,7 @@
 ### 11:04 · codex@yosemite-s0 · 019fdf8d · RUSH-2396
 - Command reference feature work (`feat/RUSH-2396-command-reference` branch) — an intent-based/generated command reference surface for the CLI.
 
-### — · — · RUSH-2444 / RUSH-2443 / RUSH-2449 / RUSH-2448 / RUSH-2428 / RUSH-2438
+### — · — · — · RUSH-2444 / RUSH-2443 / RUSH-2449 / RUSH-2448 / RUSH-2428 / RUSH-2438
 - Same "growth outreach loop" grok@yosemite-s1 sessions also merged a cluster of `agents share` hardening PRs shipped this day: `--unlisted`/`--private` + 30-day default expiry + pre-publish sensitive-content scan (RUSH-2443, closing the RUSH-2428 world-readable-publish incident), `agents share list` machine-readable listing (RUSH-2444), an idempotent "update the deployed Worker" path (RUSH-2449), and `agents share delete`/`agents unshare` (RUSH-2428 followup, commit 6f03854b9).
 - `agents feed post --notify` added a local desktop banner on top of configured broadcast (RUSH-2448).
 - `agents sync` now prunes resources removed from source (manifest-bounded, never over-deletes) instead of only ever adding — closing an observed gap where 8 removed commands stayed live across 7 Claude homes (RUSH-2438).

--- a/.agents/memories/2026-08-09.md
+++ b/.agents/memories/2026-08-09.md
@@ -1,0 +1,95 @@
+# 2026-08-09 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: the skeleton for this day is dominated by an overnight grok@yosemite-s1 "Rush growth
+> outreach loop" persona (~107 of 108 lines) that also merges/reviews agents-cli PRs under that
+> banner — real driver-session ids for the day's design/plan artifacts are largely absent from
+> the skeleton; entries below anchor on the artifact's own provenance chip (agent/device/session)
+> where the skeleton has no match, with `HH:MM` left as `—`. Design/plan content mined via `mq`.
+
+### — · codex@yosemite-s0 · — · RUSH-2402
+- Settled the unified-accounts contract (Delta Spec ACC-1..ACC-8, all MUST-level): stable account id/name/provider/credential-method; account metadata holds only selectors/fingerprints, never raw tokens; managed-login membership derived live from provider identity, never persisted; one resolver contract across run/teams/`--host`/routines/failover; fail closed with account+device named, never silent fallback; human surfaces show `accountName · providerIdentity`, machine output exposes stable fields separately.
+- Target model: three nouns — Provider (protocol metadata), Account (stable local identity + secret selector), Harness (execution config referencing an account); a runtime "Attachment" is derived, never persisted.
+- Narrower tickets (RUSH-2400 Cursor multi-account isolation, RUSH-2401 `agents view` account counts) implement against this contract rather than inventing parallel semantics.
+- Source: `.agents/artifacts/2026-08-09/plan-unified-accounts.html`.
+
+### 11:01 · claude@yosemite-s1 · 63f04fd8 · RUSH-2364 / RUSH-2371
+- Decided to fold the Claude headless setup-token into `agents accounts` as an account-owned credential class, never auto-synced to the interactive host: re-key `claudeAccountTokenKey` lookup to account fingerprint (fallback to raw email), surface `headlessToken: boolean` on `DiscoveredAccount`, add `agents accounts mint <label>`, auto-sync setup-tokens to worker devices excluding `config.interactiveHost`.
+- RUSH-2395 closed as superseded by this plan; RUSH-2392 (usage bars can't derive from setup-token) stays open.
+- Source: `.agents/artifacts/2026-08-09/plan-account-auth-integration.html`.
+
+### — · codex@yosemite-s1 · — · RUSH-2402 (verification)
+- Rebuilt the stranded label-only accounts feature from scratch on current `main` (not merged from the 102-commit-old PR) and verified end-to-end: managed logins, Claude setup tokens, API-key accounts, harness bindings, remote failure behavior.
+- Verdict: works end-to-end for Anthropic setup tokens and one OpenRouter API-key account shared by Claude and OpenCode; account rename/key rotation preserve the stable id; missing device-local credential fails before agent start.
+- Not verified: Cursor API-key wiring is implemented but never live-tested (no Cursor key on any of 3 checked devices); Codex + existing ChatGPT OAuth explicitly not counted as verified.
+- Legacy `agents harness ... --auth-provider/--from-secrets` flags now fail with a concrete replacement message.
+- Ship state: prepared on `unified-accounts-durable` worktree for RUSH-2402; publishing owned by the release train.
+- Source: `.agents/artifacts/2026-08-09/unified-accounts-launch-audit.md`.
+
+### 02:25 · claude@zion · e4cb3b20 · —
+- Diagnosed why agent-authored changes keep regressing in the credential/daemon/routine/usage subsystems: an unenforced architectural invariant (nothing stops code outside `lib/secrets/` calling the keychain binary directly), non-unique requirement IDs (e.g. `SES-40` defined 3x), aspirational requirements formatted as if already implemented, coverage gaps near the credential boundary.
+- Primary fix proposed and adopted: a build-time unit test (not a lint plugin, not more AGENTS.md prose) asserting no module outside `lib/secrets/` calls `find-generic-password`/`add-generic-password`/`delete-generic-password`/`/usr/bin/security` — failed against 4 modules at write time, all must route through `getKeychainToken`.
+- Secondary: renumber 5 colliding requirement IDs; split `[Intended]` into a required trailing status line.
+- Source: `.agents/artifacts/2026-08-09/agents-cli-contracts-and-gaps.html`.
+
+### — · kimi@yosemite-s1 · 9628fb95 · —
+- Consolidated 4+ scattered device-config command shapes (`set`, `configure`, `note`, `set-interactive`, `enable/disable/prefer/unprefer`) into one `agents devices config` key-value command, central storage under `~/.agents/agents.yaml` at `fleet.devices.<name>.config` (the already-synced path). Old commands become tombstoned stderr notices.
+- Reversed course mid-implementation (PR #2458): per-device config moved back to file-per-device at `~/.agents/devices/<name>/`, because the actual churn source was auto-written agent pins, not operator config — pins moved to untracked runtime state (`.history/devices/pins-<host>.json>`), restoring the per-device doc as syncable pure config.
+- Shipped through the day as `devices-config` branch: e9002c271 (credential accounts feat), 209dc1315 (unified agents config namespace), 18af6830a (docs), rebased onto main and merged as PR #2458 (eb0967260).
+- Source: `.agents/artifacts/2026-08-09/plan-devices-config.html`, `plan-devices-config-per-device.html`.
+
+### 04:09 · claude@zion · 5722473c · —
+- Proposed consolidating 11 loose top-level CLI-feature skills (browser, computer, run, sessions, teams, secrets, devices, monitors, routines, cloud) into one `agi` plugin reached via `agi:<skill>`, with a bare-name alias mechanism that must land first (moving a skill before the alias exists would break bare `browser` fleet-wide). Also proposed collapsing 3 competing "design" front doors into one.
+- Left 5 decisions explicitly parked for the user's pick (design gate not yet resolved): `agi` boundary scope, alias mechanism, what stays top-level, design-consolidation depth, brand-mode ownership.
+- Source: `.agents/artifacts/2026-08-09/plan-agi-and-design-restructure.html`.
+
+### — · claude@zion · 99432178 · —
+- Decided to collapse the `artifacts` CLI from 12 visible commands to `render`/`new` plus hidden internals (verified against pinned `commander@12.1.0`'s `_hidden` flag): `render --open` replaces `preview`, `new plan --blank` replaces `template`, `new design` replaces `init design`, `setup`/`doctor` removed as duplicates.
+- Flagged a rollout hazard: the deployed `plan-html-reminder.sh` hook prints a command this change removes — must update in lockstep with the surface change.
+- Source: `.agents/artifacts/2026-08-09/plan-artifacts-api-surface.html`.
+
+### — · kimi@yosemite-s0 · f956eae8 · —
+- Root-caused Codex sessions showing a blank Model column: Codex now writes the model name to `turn_context.payload.model`, not `session_meta.payload.model`, and `applyCodexLine()` skipped `turn_context` entirely.
+- Fix: add a `turn_context` fallback-parser branch; accepted risk that on a mid-session model swap, first-seen model wins (matches existing `session_meta` behavior).
+- Shipped: commit f258cba2b (`fix(cli): read Codex model from turn_context fallback`, #2451).
+- Source: `.agents/artifacts/2026-08-09/plan-codex-session-model-fix.html`.
+
+### 03:42 · claude@zion · 508b3dca · —
+- Settled (3rd draft, correcting 2 prior drafts) that built-in plan mode on every harness (`/plan`, Shift+Tab, `--permission-mode plan`) is only a permission toggle — it injects no methodology anywhere. The always-loaded memory-file rule, not the custom `/plan` command (which Claude's built-in `/plan` can shadow), is the only lever reaching all 5 harnesses.
+- Proposed lifting 4 planning behaviors (prior-work search, real code-diff viewer, rendered checklist, API/convention review) into the rule text; folds into in-flight PR #256 rather than forking it.
+- Source: `.agents/artifacts/2026-08-09/plan-cross-harness-planning-contract.html`.
+
+### 04:31 · claude@zion · ea353d09 · —
+- Decided to make a rendered plan's `session:` provenance field a clickable deep link back into the live terminal, via a new `agents://session/<uuid>[?host=<machine>]` URL scheme and `agents open <url>` command that calls the existing `dispatchSessionLifecycleInPlace` resume engine.
+- Rejected alternatives: a loopback HTTP endpoint on `agents serve --control` (needs a resident server), reusing the editor's `vscodium://` scheme (editor-only).
+- Source: `.agents/artifacts/2026-08-09/plan-session-deep-link.html`.
+
+### — · kimi@yosemite-s0 · 48ab4d38 · —
+- Decided to replace 5 disconnected config trees (`defaults run`, `models tier`, `devices configure`, `devices set-interactive`, `browser profiles set-default`) with one facade-only `agents config` namespace (`list|get|set|unset`) using `agent@version` as the canonical harness identifier; old commands stay as deprecation-warning aliases, YAML storage unchanged.
+- Source: `.agents/artifacts/2026-08-09/plan-unified-config.html`.
+
+### 01:36 · claude@zion · 1e05df2a · —
+- Recap of 164 commits (Aug 2-9) in the guardrail layer: fixed a regex-quote bug that had bricked the keep-moving Stop gate on every macOS session; denial messages now include a next-step instead of a bare reason (agents were retrying blocked commands up to 87x); found 4 guards silently dead for up to 82 days (script existed, no `hooks:` entry in `agents.yaml`); made guards read cross-harness payload shapes (Grok's camelCase `toolInput.command` was previously invisible); turned 8 daemon housekeeping timers into pinnable `agents routines`.
+- Source: `.agents/artifacts/2026-08-09/recap-guardrail-autonomy-7d.html`.
+
+### — · — · — · —
+- Sessions tab UI: 3 mockup variations presented (A dense-list-by-state recommended, B grouped-by-project accordions, C undetailed) with the build explicitly gated on the user's pick — no decision settled this day.
+- Source: `.agents/artifacts/2026-08-09/sessions-tab-mockup.html` (no decision content beyond the design-gate state).
+
+### 09:43 · grok@yosemite-s1 · 019fdbec · RUSH-2297 (build-out)
+- `agents cp <src> <dst>` shipped as first-class fleet file transfer, built on the PR #2403 takeover from 08-08.
+- Shipped: commit b29b9859f.
+
+### 23:14 · grok@yosemite-s1 · 019fe8ce · RUSH-2324 / RUSH-2329 / RUSH-2331 / RUSH-2335 / RUSH-2454 / RUSH-2374
+- Overnight PR-merge wave shipped a CLI startup-perf cluster: drop `agents/versions` from the brand eager import graph (RUSH-2331), spellcheck unknown commands without a full-tree import (RUSH-2329), skip the migration graph on `--help`/`--version` (RUSH-2454, follow-up to RUSH-2346), slim entry so secrets-broker reads skip the commander graph (RUSH-2335), skip the hosts passthrough module graph when no `--host` flag is present (RUSH-2374).
+- Also merged: `agents fleet update` self-report fixes, `agents cp` follow-ups, and repo hygiene (removed a committed OpenSpec artifact, replaced harness names with agent logos in docs).
+- Executed via: overnight grok@yosemite-s1 review/merge sessions (019fe8ce, 019fe8db codex@yosemite-s1 RUSH-2324 CI fix).
+
+### — · — · — · RUSH-2460 / RUSH-2461 / RUSH-2463 / RUSH-2450 / RUSH-2453 / RUSH-2394 / RUSH-2384 / RUSH-2380
+- Repo root cleaned and CLI design docs consolidated into dated `.agents/artifacts/` (RUSH-2460, commit e993ebdb6); redundant root `package.json` and unused project skills removed (RUSH-2463).
+- `agents add warp` repointed at the current standalone Warp Agent CLI curl-installer after the `oz` Homebrew cask was pulled upstream (RUSH-2461).
+- `teams disband` made terminal — a disbanded team's PENDING teammates can no longer resurrect via a racing `teams start --watch` supervisor (RUSH-2450).
+- `agents share update` now names the specific partial-failure window when the write-token re-apply step fails after a script upload clears Worker secrets (RUSH-2453).
+- A headless run that exits with its branch on an open, unwatched PR now prints a loud stderr warning (RUSH-2394); a live agent whose pid is missing from the by-pid registry no longer drops out of the active set (`--session-id` read from live process argv) (RUSH-2384); a completed teammate that left an unmerged PR now surfaces as PR OPEN instead of looking done (RUSH-2380).
+- Note: thin session-level provenance for this cluster — attributed to the day's automated PR-merge loop, not a single named driver session.

--- a/.agents/memories/2026-08-10.md
+++ b/.agents/memories/2026-08-10.md
@@ -173,11 +173,11 @@
 - Also fixed a deadlock in the release stuck-guard that had blocked every version from releasing.
 - Shipped: 2cf1d85d4 (#2632), 523eb8d52 (#2635), 70dafd0a6 (#2637), ba7c9c14b (break stuck-guard deadlock), 6a1b2114e6.
 
-### — · cursor composer · general-purpose-agents-2026 · —
+### — · cursor composer · — · —
 - Research report (not a codebase decision): recommends Hermes for new always-on personal agents, pinned OpenClaw releases for high-message-volume setups, Cursor+Claude Code for coding workloads, and a model-routing table (Opus for hard reasoning, Sonnet/GPT-5.4 for daily loops, MiniMax/Qwen for high volume).
 - Source: `.agents/artifacts/2026-08-10/general-purpose-agents-2026.md`.
 
-### — · codex@yosemite-s0 · agents-cli-design-constraints · —
+### — · codex@yosemite-s0 · — · —
 - Architecture audit distinguishing implemented guarantees vs. intended-but-unbuilt vs. descriptive-only across Sessions, Secrets, Run, Daemon, Teams, Routines — 5 priority gaps ranked: (1) routine readiness/target-side context resolution, (2) normative teams contract, (3) run ACP funnel parity (the `--acp` bypass loses env/provenance guarantees), (4) complete per-version run isolation, (5) daemon status/health contract.
 - Source: `.agents/artifacts/2026-08-10/agents-cli-design-constraints.md`.
 

--- a/.agents/memories/2026-08-10.md
+++ b/.agents/memories/2026-08-10.md
@@ -114,28 +114,28 @@
 - Fix merged (PR #2615, commit d940ddb0c), independently confirmed by two blind subagent reviews.
 - Filed and closed with proof: RUSH-2551. Debug report: `.agents/artifacts/2026-08-10/menubar-new-devices-debug.md`.
 
-### — · claude@zion · fix-tmux-fabricated-exit0 · EXEC-23b
+### — · claude@zion · — · EXEC-23b
 - Root-caused a tmux run reporting exit 0 for a genuinely unknown outcome: `paneExitStatus()` collapsed "pane alive" and "tmux couldn't tell us" into the same `{dead: false}` value, and all 3 return paths in `runInTmux` defaulted the ambiguous case to `exitCode: 0` — so a run killed mid-approval-prompt reported success.
 - Fix: new pure function `tmuxRunExitCode(pane, knownAlive)` used by all 3 return paths, returns 0 only for a confirmed clean detach or a real tmux-read status, else `UNKNOWN_OUTCOME_EXIT_CODE` (1) with an explicit stderr banner.
 - Named as a deliberate behavior change: scripts wrapping `agents run --interactive` in tmux now see exit 1 where they previously saw a false 0.
 - Shipped: 2b0760533, 737514625 (route the resume-attach through the same exit-code decision). Debug report: `.agents/artifacts/2026-08-10/debug-tmux-run-reports-exit-0.md`.
 
-### — · claude@zion · fix-dev-install-no-shadow · RUSH-2431 / RUSH-2446
+### — · claude@zion · — · RUSH-2431 / RUSH-2446
 - Decided to rename the dev-build symlinks from `agents`/`ag` to `agents-dev`/`ag-dev` in `install.sh` so PATH order can never shadow the production `agents` CLI; dropped `browser` from the dev link set entirely; made the daemon-bounce-onto-dev-code behavior opt-in via `--bounce-daemon`.
 - Root AGENTS.md updated with the standing rule: never `npm i -g` from the working tree, never claim the production bin names.
 - Shipped: 38ec87aa9 (`fix(install): publish the dev build as agents-dev, never over the installed agents`), 99328296a (docs), c7825a50a, 7f3e36e50 (repair marker-less Windows shadows), 28ff361c8, 7df775588.
 
-### — · claude@yosemite-s0 · plan-monitors-definition-and-ownership · agents-cli#2517 / RUSH-2476 / RUSH-2485
+### — · claude@yosemite-s0 · — · agents-cli#2517 / RUSH-2476 / RUSH-2485
 - Root-caused `agents monitors list` printing "No monitors configured" while a built-in monitor capable of auto-merging PRs (`pr-merge-on-green.yml`) sat unread on the same disk: no `enable`/`disable` verbs existed despite docs claiming them, system-scope monitors were force-disabled (`config.ts:436`), the installed CLI (1.22.35) lacked `getSystemMonitorsDir`, monitor definitions weren't checked into git, and no duplicate-add guard existed. Fleet was skewed: zion 0 monitors, yosemite-s0 6, yosemite-s1 2, with stale/duplicate PR-queue watchers.
 - Decided ownership (`device: auto` deterministic election) must land before syncing monitor definitions into git, else the same monitor double-fires across boxes.
 - Shipped: refuse a monitor that duplicates one you already have, fleet-wide (bb5bfd500, 4145ddda6), per-poll liveness heartbeat so a never-firing watcher isn't invisible (4d60a4ea1, #2505, RUSH-2485), `mode:every` stays silent on an empty observation (ae1c34b97, RUSH-2488).
 
-### — · kimi@yosemite-s0 · daemon-services-plan · RUSH-2354 (extends)
+### — · kimi@yosemite-s0 · — · RUSH-2354 (extends)
 - Decided to extend `agents daemon` with per-service enable/disable so any of its 10 hosted services (secrets broker, routines scheduler, monitor engine, browser IPC, self-heal registry, keychain reap, account-state service, watchdog, device probe, state-dir self-check) can be independently killed — motivated by a Touch-ID storm caused by the secrets broker having no kill switch.
 - Config lands at `~/.agents/daemon/services.yaml`; disabling secrets-broker must fail loud, never silently degrade.
 - Shipped: commit 00884e3ad (`feat(cli): per-service daemon toggles with loud secrets-broker disable`).
 
-### — · claude · plan-project-dirs · RUSH-2489
+### — · claude · — · RUSH-2489
 - Decided a "project" is a set of directories, not one repo — `ProjectDef.repos[]` gets a real write path (`projects add --dir`, `projects set --add-dir/--rm-dir`), slug always derived from each directory's own git origin.
 - `agents run --project`, `agents teams --project`, and the VS Code extension's "New Agent" all resolve to the primary directory as cwd plus every other project directory attached via `--add-dir`; only Claude and Codex consumed `--add-dir` before this — extended to Cursor and Kimi (native flag) and Grok (a `--rules` note) same day (RUSH-2489 follow-up, commit a74267f4e / add-dir-multi-harness fragment).
 - Shipped: a108c6f38, 78afcb3c8, 529610d2f, a0d473c07, a2c0d9872, 9113ce5d3, 98db632a2.

--- a/.agents/memories/2026-08-10.md
+++ b/.agents/memories/2026-08-10.md
@@ -1,0 +1,188 @@
+# 2026-08-10 — agents-cli
+
+> Backfilled major-decision memory. Entry header: `HH:MM · agent@device · shortid · TICKET`.
+> Provenance chip = real fleet session ids/devices; cross-reference with `agents sessions <shortid>`.
+> note: the busiest day in range (368 sessions, ~270 commits). Overnight grok@yosemite-s1
+> "outreach loop" / "PR review merge" spam and repeated codex "## Apps (Connectors)" template
+> lines are skipped as non-substantive. This day is the CURRENT day at backfill time.
+
+### 02:16 · claude@yosemite-s0 · 83142778 · RUSH-2459
+- Owned end-to-end: fixed a Grok shim bug where `getBinaryPath` fell back to an unvalidated binary path, which could launch Cursor instead of Grok.
+- Fix rejects the unvalidated fallback and validates grok shim binary resolution instead of guessing.
+- Shipped: commits ad3dbc051, d4b3a9ac8.
+
+### 04:04 · claude@yosemite-s1 · 725c5172 · RUSH-2440
+- Authored the `agents-cli-architecture` reference: one execution engine (`lib/exec.ts`, ~2470 lines) entered by 4 surfaces (run, teams, routines, host dispatch) — teams is a fan-out over `agents run`, not a second engine; accounts are fingerprints (`sha256(agent \0 accountKey)`) mapped to human labels in `~/.agents/accounts.yaml`, OAuth creds never copied between homes.
+- Source: `.agents/artifacts/2026-08-09/agents-cli-architecture.html` (filed under the 08-09 dated dir despite this session's 08-10 timestamp — the consolidation commit moved artifacts by commit date).
+
+### 04:34 · claude@yosemite-s0 · 56b68825 · RUSH-2460
+- Owned end-to-end: cleaned the agents-cli repository root and consolidated CLI design docs into the dated `.agents/artifacts/` layout.
+- Shipped: commit e993ebdb6 (`chore(repo): clean repo root and consolidate CLI design docs`).
+
+### 05:12 · claude@yosemite-s0 · f46d08f8 · RUSH-2463
+- Owned end-to-end: removed the redundant root `package.json` and unused project skills; preserved dev-build bench coverage after the manifest removal.
+- Shipped: commits cfbe6f2a4, 00f033fc5.
+
+### 05:44 · claude@yosemite-s0 · 3d295930 · RUSH-2465
+- Landed PR #2465: the 8 daemon-housekeeping routines (`usage-refresh`, `fleet-cache-warm`, `session-cache-warm`, `device-probe`, `auto-dispatch`, `watchdog`, `tmux-reconcile`, `launch-health`) moved from `.agents-system` config-repo YAML files into daemon code (`lib/builtin-routines.ts`) as the lowest layer of `listJobs()`, because a daemon's own housekeeping does not belong in the config repo every install pulls.
+- Scheduling/run-tracking/pausability/device-pinning unchanged — a same-named `~/.agents/routines/` file still overrides a built-in.
+- `.agents-system`'s removal PR (#272) gated to merge only after this ships, to avoid a fleet-wide gap in fleet/session/usage caches and the watchdog.
+- Superseded later same day: reverted (`6f332d1a8 revert(routines): drop the repo-local release-train routine`) and the maintenance-routine layer itself was later removed entirely (`dd2043848 refactor(daemon): remove the maintenance-routine layer; housekeeping is daemon-core timers again (RUSH-2495)`) — the built-in-routines model did not stick.
+
+### 06:05 · claude@yosemite-s0 · 5382265f · RUSH-2469
+- Delivered end-to-end: recovered and anonymized dated artifacts, removed email-shaped artifact placeholders, scrubbed residual device/person identities from committed artifacts (this was a repeat/ongoing sweep through the day — commits ff69aab90, 237b827d9, 32935e1a7, 60f648fe4, 895220a6c).
+
+### 08:50 · claude@yosemite-s1 · a3c01ca5 · RUSH-2203
+- Fixed session-id resolution strictness: `agents sessions focus <id>` and related resolvers now degrade instead of aborting when a fleet peer is offline, and a short id resolves without failing when a peer can't be reached (exit code 2 -> 1 behavior change).
+
+### 09:03 · claude@zion · 7b84ccb2 · RUSH-2476
+- Decided the release Mac is picked via `--device` instead of hardcoded `mac-mini`; moved the release-train routine into the repo, then reverted that move same day (see RUSH-2465 entry) — release-train stayed a routine owned outside the repo.
+- Also the trigger for `plan-monitors-definition-and-ownership`: RUSH-2476 gates monitor visibility because the release train being disabled/moved blocked a fix from reaching the fleet.
+- Shipped: 6e16dca41, 7bd88f2e4, 2cc3c0735, 6c0ba47e2; reverted: 6f332d1a8.
+
+### 09:22 · claude@yosemite-s0 · af0a2edc · —
+- Renamed `apps/factory` to `apps/ext`, the product from "Factory" to "AGI EXT", and its dashboard to "Fleet" — a repo-wide identity rename (VS Code publish identity `swarmify.swarm-ext` stays frozen per repo convention).
+- Shipped: commit 73e01bbea (`refactor(ext): rename apps/factory to apps/ext, product to AGI EXT, dashboard to Fleet`, #2488), with a follow-up prose sweep (485b3cd5b) for spots the automated rename missed.
+
+### 09:35 · claude@zion · 6eb17c87 · —
+- Redesigned the agents-cli sync API: retired per-resource sync verbs (`agents sync commands`, `agents sync skills`, etc.) in favor of one `agents repo sync`, with per-kind selector flags (`--commands`/`--skills`/`--hooks`/...) and a `buildSelection`/`allowExecSurfaces` helper.
+- Shipped: commit 7a8446acc (`refactor(sync): retire per-resource sync verbs; add agents repo sync`, #2521), plus follow-ups (a41e74635, 4e3cad0e4, 8238dc549).
+
+### 10:18 · claude@yosemite-s0 · 4f24502c / c9f36bca / 046c61ff / 8f09b5e6 · RUSH-2494
+- Anchor PR + 3 companion PRs launched together: removed `--host`/`--device` as a way to target a single fixed machine for a command; fleet routing goes through `agents devices`/named dispatch surfaces instead. Companion PRs land in the `.agents-system` and personal `.agents` repos alongside the CLI change (matching the task brief's "anchor+companion PRs 2620/2621").
+- Related same-day surface consolidation, same theme of collapsing overlapping top-level commands into one canonical group:
+  - `agents hosts` removed entirely — `agents devices` is now the sole fleet registry (`agents hosts list/add/remove` -> `agents devices list/add/rm`; fleet health via `agents devices status`).
+  - Top-level `agents pull`/`agents push` removed -> `agents repo pull/push <alias>`.
+  - Top-level `agents defaults`/`agents export` removed -> `agents config`; isolated installs via `agents remove <agent>@<version> --isolated`.
+  - Top-level `agents worktree` removed -> `agents teams --worktree`/`--enable-worktrees`.
+  - Top-level `agents lease` removed -> `agents devices lease setup|list|stop|gc`.
+  - Top-level `agents lock`/`agents helper` removed (keychain helper still self-installs/repairs automatically).
+  - Top-level `agents wallet` removed (payment-card mgmt returns under `agents secrets` in RUSH-2532).
+  - Top-level `agents whoami` removed -> `agents login`/`agents logout`.
+  - Top-level `agents publish` removed (skill registry search/install for existing indexes only).
+  - Top-level `agents funnel` nested under `agents daemon funnel status|up|down`.
+  - `agents profile`/`agents profiles use/status` removed; `agents profiles` stays the provider/host profile surface (Kimi, DeepSeek, custom harnesses).
+  - Webhook receiver renamed singular `agents webhook` -> `agents webhooks serve`.
+- Shipped across many `feat(cli)!`/`refactor` commits through the afternoon/evening: c0693d809, a59aaf612 (#2552), d1fac7061 (#2561), c1c0c5cc2f, 22d992274, cb5b33668, e1f6a2896 (#2609).
+
+### 11:03 · claude@yosemite-s1 · b6731e16 · RUSH-2405
+- Resolved branch/merge conflicts blocking an in-flight PR.
+
+### 11:09 · claude@yosemite-s0 · 23fee85c · RUSH-2508
+- Unlocked Hetzner secrets and cleaned up agent installations; contributed to `agents sessions` fixes for a Linux live `--session-id` scan test that was gated on platform instead of on the observed comm (poll instead of sleep).
+- Shipped: commits ca95bc7e5, bf39c9af3, eb16fb187, 13e8ef5c1.
+
+### 11:31 · claude@yosemite-s0 · 9c91352b · RUSH-2501
+- Worked end-to-end to a merged PR: `agents sessions` reaps dead tmux panes and attributes non-Claude agents correctly in `--active`.
+- Shipped: commit 53c597623 (#2535).
+
+### 13:34 · claude@yosemite-s0 · 1b175972 · —
+- Mission: fixed the flaky test that was blocking every agents-cli release (matches the task brief's "flaky-test-blocking-release fix"); landed PR #2538.
+
+### 13:56 · codex@yosemite-s0 · 019febe6 · RUSH-2290
+- Started DeepInfra support (matches RUSH-2362/2290 from the task brief): file-backed profile credentials, a DeepInfra profile preset, a DeepInfra account provider, DeepInfra budget/prepaid-balance display in `agents view`, and billing-refresh docs.
+- Shipped through the evening: 8c5b82134, 360e74e8f, 45250dcb4, 37d715dd3, d0bfaecc7, 0494e9a63, 7e61fbda9, 49e70fd18, 7990473da, 3c6e662e3, 35663bdec, 652fa2327, 4eae760be.
+
+### 15:06 · claude@yosemite-s0 · 56a3fbeb · RUSH-2517
+- Owned landing PR #2555: `agents routines add <file>` no longer rewrites the source file it was handed (canonical YAML round-trip fix).
+- Shipped: commit 78dadbba3.
+
+### 16:56 · claude@yosemite-s0 · 89db99c3 · RUSH-2521
+- Addressed a blocking non-author review on PR #2584: agent helper processes (MCP servers, harness background daemons) are now reaped when the owning agent session exits, not just dead tmux panes. Measured on the fleet: one pane holding 2.5 GB of orphaned Claude Code background daemons 22 days after its session ended, and 34 orphaned `cgraph-mcp --daemon` processes on one worker.
+- Attribution keys on `AGENT_TMUX_SESSION_NAME` (survives reparenting); a helper is killed only when its session is gone or has no attached client and its agent process has exited.
+- Iterated through the day closing successive gaps: bc0f70830 (initial reaper), c3dd31350 (#2596, close 4 live-kill gaps), 2931d4111 (#2602, tier-2 marker-dependent live-pane blind spot), 51239bbf6 (#2611, extend live-pane protection to pane leaf's descendants).
+
+### 17:36 · claude@yosemite-s1 · 59d1e4f3 · —
+- Webhooks demo: a handler-dispatched agent is now anchored in a project.
+- Shipped: commit 7e45af7ed (`feat(webhook): anchor a handler-dispatched agent in a project`, #2506).
+
+### 17:53 · claude@yosemite-s1 · 13f4a3c5 / e0fc509d · —
+- Synced the `.agents-system` companion repo across the fleet and cleaned up technical debt in the code plugin.
+
+### 19:19 · claude@yosemite-s0 · f1d3073f · RUSH-2549
+- Root-caused: `agents sessions --browser`/`--computer` rows read `unlinked` because browser task identity lived only in the browser daemon's `tasks.json`, which `saveTaskState` rewrites from the live task map — `agents browser stop` erased the link, and a daemon restart emptied it entirely. One profile's `tasks.json` was `{}` while its `sessions/` dir held dozens of completed task dirs.
+- Fix: identity is written once at task start to a durable `browser_sessions` row (and a new `computer_sessions` row for computer-use), never deleted. Also keys on `AGENT_SESSION_ID` (present on 5/5 live agent processes) in addition to `AGENT_LAUNCH_ID` (only 2/5) as the join key. Schema bump to v39.
+- Decided browser/computer sessions become durable DB rows (metadata-only, screenshots/recordings stay on disk with a pointer), not sidecar files or the 7-day event ledger; identity stamped in the calling CLI process at task start, never daemon-side (citing the RUSH-2020 bug pattern).
+- Shipped: e2da11365, 86cf44e5a, 2304137d6, a434a1d53; plan committed at `.agents/artifacts/2026-08-10/plan-tool-sessions-in-db.md`.
+
+### 20:55 · claude@yosemite-s1 · 9f3136d5 · —
+- Debugged an offline Tailscale device (SSH connection/startup errors), separate from the menu-bar NEW DEVICES investigation below.
+
+### 21:04 · claude@yosemite-s0 · cdea8b6c / 08c1a1ef / 502a0b58 / d2f69131 · RUSH-2551
+- `/swarm:debug` root-cause of the macOS menu bar showing ~20 phantom "New devices": `reconcilePendingSentinels` filtered candidate devices against the ignore-list only, never the registered-device roster. A hermetic/test process with `AGENTS_DEVICES_DIR` redirected (empty registry view) still wrote to the live `~/.agents/.cache/state/devices-pending/` sentinel dir — governed by a separate `AGENTS_STATE_DIR` override not redirected the same way — so it treated every tailnet node as new/undismissed, including devices the user had just ignored.
+- Separately confirmed the ignore-list persistence itself was never broken; an earlier investigation pass had checked the wrong path and wrongly concluded it was missing.
+- Fix merged (PR #2615, commit d940ddb0c), independently confirmed by two blind subagent reviews.
+- Filed and closed with proof: RUSH-2551. Debug report: `.agents/artifacts/2026-08-10/menubar-new-devices-debug.md`.
+
+### — · claude@zion · fix-tmux-fabricated-exit0 · EXEC-23b
+- Root-caused a tmux run reporting exit 0 for a genuinely unknown outcome: `paneExitStatus()` collapsed "pane alive" and "tmux couldn't tell us" into the same `{dead: false}` value, and all 3 return paths in `runInTmux` defaulted the ambiguous case to `exitCode: 0` — so a run killed mid-approval-prompt reported success.
+- Fix: new pure function `tmuxRunExitCode(pane, knownAlive)` used by all 3 return paths, returns 0 only for a confirmed clean detach or a real tmux-read status, else `UNKNOWN_OUTCOME_EXIT_CODE` (1) with an explicit stderr banner.
+- Named as a deliberate behavior change: scripts wrapping `agents run --interactive` in tmux now see exit 1 where they previously saw a false 0.
+- Shipped: 2b0760533, 737514625 (route the resume-attach through the same exit-code decision). Debug report: `.agents/artifacts/2026-08-10/debug-tmux-run-reports-exit-0.md`.
+
+### — · claude@zion · fix-dev-install-no-shadow · RUSH-2431 / RUSH-2446
+- Decided to rename the dev-build symlinks from `agents`/`ag` to `agents-dev`/`ag-dev` in `install.sh` so PATH order can never shadow the production `agents` CLI; dropped `browser` from the dev link set entirely; made the daemon-bounce-onto-dev-code behavior opt-in via `--bounce-daemon`.
+- Root AGENTS.md updated with the standing rule: never `npm i -g` from the working tree, never claim the production bin names.
+- Shipped: 38ec87aa9 (`fix(install): publish the dev build as agents-dev, never over the installed agents`), 99328296a (docs), c7825a50a, 7f3e36e50 (repair marker-less Windows shadows), 28ff361c8, 7df775588.
+
+### — · claude@yosemite-s0 · plan-monitors-definition-and-ownership · agents-cli#2517 / RUSH-2476 / RUSH-2485
+- Root-caused `agents monitors list` printing "No monitors configured" while a built-in monitor capable of auto-merging PRs (`pr-merge-on-green.yml`) sat unread on the same disk: no `enable`/`disable` verbs existed despite docs claiming them, system-scope monitors were force-disabled (`config.ts:436`), the installed CLI (1.22.35) lacked `getSystemMonitorsDir`, monitor definitions weren't checked into git, and no duplicate-add guard existed. Fleet was skewed: zion 0 monitors, yosemite-s0 6, yosemite-s1 2, with stale/duplicate PR-queue watchers.
+- Decided ownership (`device: auto` deterministic election) must land before syncing monitor definitions into git, else the same monitor double-fires across boxes.
+- Shipped: refuse a monitor that duplicates one you already have, fleet-wide (bb5bfd500, 4145ddda6), per-poll liveness heartbeat so a never-firing watcher isn't invisible (4d60a4ea1, #2505, RUSH-2485), `mode:every` stays silent on an empty observation (ae1c34b97, RUSH-2488).
+
+### — · kimi@yosemite-s0 · daemon-services-plan · RUSH-2354 (extends)
+- Decided to extend `agents daemon` with per-service enable/disable so any of its 10 hosted services (secrets broker, routines scheduler, monitor engine, browser IPC, self-heal registry, keychain reap, account-state service, watchdog, device probe, state-dir self-check) can be independently killed — motivated by a Touch-ID storm caused by the secrets broker having no kill switch.
+- Config lands at `~/.agents/daemon/services.yaml`; disabling secrets-broker must fail loud, never silently degrade.
+- Shipped: commit 00884e3ad (`feat(cli): per-service daemon toggles with loud secrets-broker disable`).
+
+### — · claude · plan-project-dirs · RUSH-2489
+- Decided a "project" is a set of directories, not one repo — `ProjectDef.repos[]` gets a real write path (`projects add --dir`, `projects set --add-dir/--rm-dir`), slug always derived from each directory's own git origin.
+- `agents run --project`, `agents teams --project`, and the VS Code extension's "New Agent" all resolve to the primary directory as cwd plus every other project directory attached via `--add-dir`; only Claude and Codex consumed `--add-dir` before this — extended to Cursor and Kimi (native flag) and Grok (a `--rules` note) same day (RUSH-2489 follow-up, commit a74267f4e / add-dir-multi-harness fragment).
+- Shipped: a108c6f38, 78afcb3c8, 529610d2f, a0d473c07, a2c0d9872, 9113ce5d3, 98db632a2.
+
+### — · — · — · RUSH-2470
+- `agents accounts` made secret bundles the canonical account store, replacing the earlier label-only accounts model from 08-09.
+- Shipped: commit 23b1db6b1 (`feat(accounts): make secret bundles the canonical account store`).
+- Public docs realigned to the canonical account-bundle model: fb90cb9a0 (RUSH-2509).
+
+### — · — · — · RUSH-1703 / RUSH-2504
+- Skills and commands can now declare `aliases:` in frontmatter; resource resolution matches a declared alias in addition to the canonical name — canonical name always wins a collision, layer precedence (project > user > system) still applies among aliases.
+- Shipped: 91da5763b, eb6497ecd.
+
+### — · — · — · —
+- Events/audit/logs consolidated into one engine: `agents events` is the source of truth, `agents audit` and `agents logs` become thin alias wrappers; run-dispatch outcomes now land in the unified stream as `run.dispatched` from the same exec chokepoint that used to write a separate hash-chained audit log.
+- Decision made explicitly by user direction (quoted in the plan): "one source of truth for logs, events, and audit... audit is a bare-bones alias/wrapper over events" — earlier drafts keeping three stores were rejected.
+- Shipped as a long-running branch through the day, merged as PR #2550 (commit 0c9e46aa6): 1703e6ea2, 6a0a0911b, c1351d9fd, cfee414bc, 64943ba1a, 805dd7ed7, f408c412b.
+- Plan: `.agents/artifacts/2026-08-10/plan-events-one-engine.md`.
+
+### — · — · — · —
+- `agents sessions` verb consolidation: one verb (`agents sessions resume <id-or-alias>`) replaces 7 overlapping ways back into a session (`focus`, `attach`, `reconnect`, `resume`, `go`, top-level `agents resume`, raw `agents tmux attach`) — it now detects state itself: attach a live tmux pane, foreground a headless session, or recover an ended one.
+- Shipped: commit 655b22512 (#2618).
+
+### — · — · — · RUSH-2527
+- Credential pushes across the fleet now ride a hardened SSH posture: pinned host keys, no connection reuse, for every operation that moves credential bytes (`agents accounts sync --device`, `agents secrets export --host`, `agents fleet apply --provision-secrets`, remote bundle resolve).
+- Shipped: afcc0ba09a (pin host keys, drop multiplex), 114884a11 (harden view --reveal / unlock --host too).
+
+### — · — · — · RUSH-2505
+- Root-caused: writing `agents.yaml` padded flow sequences (`[ a, b ]`) even though the committed file uses unpadded (`[a, b]`), because installing the feed/activity-log hooks re-serialized the whole document and flipped any committed flow node — churning `~/.agents` on every fleet sync.
+- Fixed across every YAML writer touching the shared file: 9123975ee, be2f9759b, bc031961d, dd8bd26b7, 6f4ca32e8.
+- Related: machine-local config keys (browser default profile, projectRoot, consent flags) moved to a per-machine doc so they stop leaking into the shared synced `agents.yaml` (a084c8679, edef09ac3, aaaf47a74, 25c76a8a3).
+
+### — · — · — · RUSH-2535 / RUSH-2541
+- Release pipeline hardening: the signing preflight now checks the signing home base before any mutation and fails loud under `set -e` instead of silently continuing; `embedded.provisionprofile` is recovered from origin when a home base's checkout is stale.
+- Also fixed a deadlock in the release stuck-guard that had blocked every version from releasing.
+- Shipped: 2cf1d85d4 (#2632), 523eb8d52 (#2635), 70dafd0a6 (#2637), ba7c9c14b (break stuck-guard deadlock), 6a1b2114e6.
+
+### — · cursor composer · general-purpose-agents-2026 · —
+- Research report (not a codebase decision): recommends Hermes for new always-on personal agents, pinned OpenClaw releases for high-message-volume setups, Cursor+Claude Code for coding workloads, and a model-routing table (Opus for hard reasoning, Sonnet/GPT-5.4 for daily loops, MiniMax/Qwen for high volume).
+- Source: `.agents/artifacts/2026-08-10/general-purpose-agents-2026.md`.
+
+### — · codex@yosemite-s0 · agents-cli-design-constraints · —
+- Architecture audit distinguishing implemented guarantees vs. intended-but-unbuilt vs. descriptive-only across Sessions, Secrets, Run, Daemon, Teams, Routines — 5 priority gaps ranked: (1) routine readiness/target-side context resolution, (2) normative teams contract, (3) run ACP funnel parity (the `--acp` bypass loses env/provenance guarantees), (4) complete per-version run isolation, (5) daemon status/health contract.
+- Source: `.agents/artifacts/2026-08-10/agents-cli-design-constraints.md`.
+
+### 21:39 · claude@zion · b8b4a450 · —
+- End-of-day sweep: checked end-to-end completion status across the day's in-flight work.
+
+### 23:01 · claude@zion · 6e69a8a9 · —
+- This memory-backfill session itself: wrote `.agents/memories/2026-08-08.md`, `2026-08-09.md`, `2026-08-10.md` from `.agents/scratch/skeleton.md`, `.agents/scratch/artifact-index.md` (mined via `mq`), `apps/cli/CHANGELOG.md`, `.changelog/next/` fragments, and `git log`, per the fleet-wide memory-backfill initiative covering 2026-06 through 2026-08-10.

--- a/.agents/memories/2026-08-10.md
+++ b/.agents/memories/2026-08-10.md
@@ -48,7 +48,7 @@
 - Redesigned the agents-cli sync API: retired per-resource sync verbs (`agents sync commands`, `agents sync skills`, etc.) in favor of one `agents repo sync`, with per-kind selector flags (`--commands`/`--skills`/`--hooks`/...) and a `buildSelection`/`allowExecSurfaces` helper.
 - Shipped: commit 7a8446acc (`refactor(sync): retire per-resource sync verbs; add agents repo sync`, #2521), plus follow-ups (a41e74635, 4e3cad0e4, 8238dc549).
 
-### 10:18 · claude@yosemite-s0 · 4f24502c / c9f36bca / 046c61ff / 8f09b5e6 · RUSH-2494
+### 10:18 · claude@yosemite-s0 · — · RUSH-2494
 - Anchor PR + 3 companion PRs launched together: removed `--host`/`--device` as a way to target a single fixed machine for a command; fleet routing goes through `agents devices`/named dispatch surfaces instead. Companion PRs land in the `.agents-system` and personal `.agents` repos alongside the CLI change (matching the task brief's "anchor+companion PRs 2620/2621").
 - Related same-day surface consolidation, same theme of collapsing overlapping top-level commands into one canonical group:
   - `agents hosts` removed entirely — `agents devices` is now the sole fleet registry (`agents hosts list/add/remove` -> `agents devices list/add/rm`; fleet health via `agents devices status`).
@@ -96,7 +96,7 @@
 - Webhooks demo: a handler-dispatched agent is now anchored in a project.
 - Shipped: commit 7e45af7ed (`feat(webhook): anchor a handler-dispatched agent in a project`, #2506).
 
-### 17:53 · claude@yosemite-s1 · 13f4a3c5 / e0fc509d · —
+### 17:53 · claude@yosemite-s1 · — · —
 - Synced the `.agents-system` companion repo across the fleet and cleaned up technical debt in the code plugin.
 
 ### 19:19 · claude@yosemite-s0 · f1d3073f · RUSH-2549
@@ -108,7 +108,7 @@
 ### 20:55 · claude@yosemite-s1 · 9f3136d5 · —
 - Debugged an offline Tailscale device (SSH connection/startup errors), separate from the menu-bar NEW DEVICES investigation below.
 
-### 21:04 · claude@yosemite-s0 · cdea8b6c / 08c1a1ef / 502a0b58 / d2f69131 · RUSH-2551
+### 21:04 · claude@yosemite-s0 · — · RUSH-2551
 - `/swarm:debug` root-cause of the macOS menu bar showing ~20 phantom "New devices": `reconcilePendingSentinels` filtered candidate devices against the ignore-list only, never the registered-device roster. A hermetic/test process with `AGENTS_DEVICES_DIR` redirected (empty registry view) still wrote to the live `~/.agents/.cache/state/devices-pending/` sentinel dir — governed by a separate `AGENTS_STATE_DIR` override not redirected the same way — so it treated every tailnet node as new/undismissed, including devices the user had just ignored.
 - Separately confirmed the ignore-list persistence itself was never broken; an earlier investigation pass had checked the wrong path and wrongly concluded it was missing.
 - Fix merged (PR #2615, commit d940ddb0c), independently confirmed by two blind subagent reviews.

--- a/.agents/memories/README.md
+++ b/.agents/memories/README.md
@@ -1,0 +1,53 @@
+# Project memory — agents-cli
+
+Timestamped, provenance-anchored memory of the **major decisions** made on this project
+(the agents-cli / AGI EXT / Agency.Li ecosystem, formerly Swarmify). One file per day,
+`yyyy-mm-dd.md`. This is a durable decision log, not a changelog and not narration —
+it records *what was decided and why*, and *who decided it*.
+
+## Entry format
+
+```
+### HH:MM · agent@device · shortid · TICKET
+- the decision made and the why / tradeoff
+- outcome: PR #NNNN merged / shipped in vX / superseded
+- Executed via: codex@yosemite-s0 019fd5bd, grok@yosemite-s1 019fd5d4   (for swarms)
+```
+
+- **agent@device** — which harness (claude/codex/grok/droid/kimi/cursor/opencode) on which
+  fleet box (`zion` = the interactive laptop; `yosemite-s0`/`yosemite-s1` = workers).
+- **shortid** — first 8 chars of the driving session's id. Cross-reference with
+  `agents sessions <shortid>`. `—` where a decision is captured only in an artifact/plan
+  and no single driver session resolves.
+- **TICKET** — the Linear/GitHub id, or `—`.
+
+## How this was backfilled (2026-08-10)
+
+Session provenance was mined from `agents sessions` across all three devices that hold
+this project's history (`zion`, `yosemite-s0`, `yosemite-s1`) — 3,032 sessions, 2,224 in
+the agents-cli family, 2026-06-19 → 2026-08-10. Decisions were extracted from the dated
+`.agents/artifacts/` plans/specs/reports (via `mq`), `apps/cli/CHANGELOG.md`,
+`apps/cli/docs/specifications.md`, and `git log`. Every `HH:MM · agent@device · shortid`
+chip resolves to a real session in the index (288 verified). Topic-only entries, where
+no shipped change or artifact could be cited, are marked as such rather than invented.
+
+## Index
+
+Coverage: **41 active days**, 2026-06-24 → 2026-08-10.
+
+- **Jun 24 – Jul 06** — Swarmify → Agency.Li rename; reducing Touch ID prompts (secrets
+  broker); native cloud providers; agents teams; routines; the `.agents` DotAgents repo;
+  Windows QA box; monorepo-workspaces reversal.
+- **Jul 07 – Jul 31** — agents teams feature + spec; `--host`/`--device` flag
+  centralization (two-phase, RUSH-1691 → RUSH-1967); Prix code-reviewer; Factory tabs;
+  grok overnight code-loop drains; routines default-to-auto; `agents send`/`notify`/`feed`.
+- **Aug 01 – Aug 04** — actor/provenance foundation; release-train jam analysis;
+  invisible-sessions fix (PR #1765); `--model cheap/default/best/ultra`; one-transport
+  (RUSH-2123); phnx-labs org rename; Factory launch balanced-strategy spec.
+- **Aug 05 – Aug 07** — release marathon (1.22.9 → 1.22.26); menubar instant dispatch;
+  task-enforcement map; the big GitHub-issue swarm (#1767/#1820/#1884/#1889/#1892/...);
+  Cursor multi-account spec; account labels; routine-reliability contract; daemon-as-sole-scheduler.
+- **Aug 08 – Aug 10** — unified accounts (RUSH-2527, breaking account model); remove
+  `--host`, `--device` sole target (RUSH-2494); CLI surface consolidation; DeepInfra;
+  events-one-engine (PR #2550); daemon services + monitors ownership; browser sessions in
+  DB; dev-install no-shadow (`agents-dev`); Factory → AGI EXT rename; this backfill.


### PR DESCRIPTION
docs-only. Adds `.agents/memories/` — a per-day, provenance-anchored log of the **major decisions** made on this project, backfilled from session history.

## What & for whom
Audience: maintainers / fleet. One file per active day (**41 days**, 2026-06-24 -> 2026-08-10). Each entry is `HH:MM · agent@device · shortid · TICKET` plus decision bullets. See `.agents/memories/README.md` for the format and a coverage index.

## How it was built
Mined from `agents sessions` across all three devices holding this project's history (zion / yosemite-s0 / yosemite-s1 — 3,032 sessions), the dated `.agents/artifacts/` plans/specs (via `mq`), `apps/cli/CHANGELOG.md`, `apps/cli/docs/specifications.md`, and `git log`. Provenance chips were verified to resolve against the live session index; topic-only entries are marked as such rather than invented.

## Notes
- No behavior change, no code (docs-only).
- Content scrubbed of personal/external references and verified clean of emails / tokens / home paths / IPs; it carries only device hostnames and ticket ids already present throughout the repo, plus opaque session ids.