### PR TITLE
fix(sessions): fail closed when tmux owner is absent (RUSH-2603)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2603.md
+++ b/apps/cli/.changelog/next/RUSH-2603.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The daemon orphan reaper no longer terminates live agents after a tmux server restart. A missing tmux session is now treated as unknown; helper processes are reaped only when their pane owner is present and confirmed dead, or a harness-specific rule proves their declared spawner exited.

--- a/apps/cli/docs/sessions.md
+++ b/apps/cli/docs/sessions.md
@@ -1284,22 +1284,23 @@ replaced by init, the controlling terminal is disassociated from the whole POSIX
 session when its leader exits, and the surviving helpers are precisely the ones
 that left the pane's process group. What does survive is the environment: the pane
 exports `AGENT_TMUX_SESSION_NAME` and every descendant inherits it, reparented or
-not. A process carrying that marker is reaped when its tmux session no longer
-exists, or when that session has **no attached client AND** its agent pane process
-has exited. A live agent or an attached client protects everything it owns, and the
-routines daemon, the secrets broker, and the reaping process's own ancestry are
-never candidates. Reading that marker needs another process's environment, which is
+not. A process carrying that marker is reaped only when tmux still reports its
+session and that session has **no attached client AND** its agent pane process has
+exited. An absent session is not proof: a tmux server can restart while its pane's
+process tree is still alive. A live agent, an attached client, or an absent owner
+protects everything it owns. The routines daemon, the secrets broker, and the
+reaping process's own ancestry are never candidates. Reading that marker needs
+another process's environment, which is
 a plain `/proc/<pid>/environ` file read on Linux but has no working equivalent on
 macOS: modern `ps -E` no longer prints another process's environment at all
 (verified on macOS Sequoia), so `readAgentProcesses()` returns every macOS process
 with no marker and tier 1 correctly finds nothing to do there — safe, not
 effective. Only tier 2 (below) reaps anything on macOS today.
 
-**When tmux itself can't be asked.** Tier 1 only trusts an ABSENT session as proof
-of "gone" when the tmux query that built that answer actually completed — a query
-that threw (tmux missing/unsupported version, a spawn failure, or a timed-out
-server) skips tier 1 entirely for that tick rather than treating "we don't know" as
-"there's nothing here". `agents sessions reap --json`'s `warnings` array (and a
+**When tmux itself can't be asked.** A query that threw (tmux
+missing/unsupported version, a spawn failure, or a timed-out server) skips tier 1
+entirely for that tick. A completed empty answer also reaps nothing: absence is not
+positive liveness evidence. `agents sessions reap --json`'s `warnings` array (and a
 `WARN`-level daemon log line) says so when it happens; tier 2 is unaffected, since
 it never consults tmux at all.
 

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -406,6 +406,14 @@ SSH access (§7); rendering sessions that no harness produced.
   semantics), leaving the original untouched, and MUST refuse harnesses it can't
   yet handle with a clear message (Claude-only in v1)
   (`lib/session/fork.ts:1-16,84-86`).
+- **SES-21a (MUST).** The tmux helper-process reaper MUST fail closed. A process
+  carrying `AGENT_TMUX_SESSION_NAME` MAY be selected only when the corresponding
+  tmux owner is present, its pane process is confirmed dead, and it has no
+  attached client. An absent owner, including a reliable empty answer after a
+  tmux server restart, MUST be treated as unknown and MUST NOT select the
+  process. A harness-specific detached-helper rule MAY select a process only
+  when its declared spawner pid is confirmed dead. (`lib/tmux/orphan-reap.ts`;
+  regression tests in `lib/tmux/orphan-reap.test.ts`, RUSH-2603.)
 - **SES-41 (MUST).** A direct lifecycle selector (full session id, unique id
   prefix, full `ag-<agent>-<8hex>` tmux alias, or unique alias prefix/suffix of at
   least six characters) MUST resolve to one canonical harness-native session id

--- a/apps/cli/src/lib/tmux/orphan-reap.test.ts
+++ b/apps/cli/src/lib/tmux/orphan-reap.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -26,6 +27,7 @@ import {
   parseProcessRows,
   parseTmuxSessionMarker,
   readPaneOwners,
+  reapOrphanAgentProcesses,
   selectOrphanProcesses,
   type AgentProcess,
   type PaneOwner,
@@ -33,6 +35,9 @@ import {
 
 const posix = process.platform !== 'win32';
 const skipReason = !posix ? 'POSIX-only' : (isTmuxInstalled() ? null : 'tmux not installed');
+const tier1SkipReason = !fs.existsSync('/proc/self/environ')
+  ? 'tier 1 requires Linux /proc environment reads'
+  : skipReason;
 
 const proc = (pid: number, ppid: number, args: string, tmuxSession?: string): AgentProcess =>
   ({ pid, ppid, args, tmuxSession });
@@ -101,10 +106,10 @@ describe('parsePanePids', () => {
 });
 
 describe('selectOrphanProcesses', () => {
-  it('reaps a helper whose tmux session no longer exists', () => {
+  it('NEVER treats an absent tmux session as proof that a live marked process is orphaned', () => {
     const table = [proc(500, 1, 'cgraph-mcp --daemon', 'ag-codex-ff55f79f')];
     const picked = selectOrphanProcesses(table, owners([]), noneProtected);
-    expect(picked).toEqual([{ pid: 500, args: 'cgraph-mcp --daemon', reason: 'tmux-session-gone', tmuxSession: 'ag-codex-ff55f79f' }]);
+    expect(picked).toEqual([]);
   });
 
   it('reaps a helper whose session exists but whose agent pane process has exited', () => {
@@ -171,16 +176,13 @@ describe('selectOrphanProcesses', () => {
     expect(rule.spawnerPid('claude.exe daemon run --spawned-by {"pid":42}')).toBe(42);
   });
 
-  // Blocker 2 (RUSH-2521 review): a tmux query that failed to answer must not
-  // be treated as "genuinely no sessions" — an absent map entry is only proof
-  // of anything when the map is known-complete.
+  // RUSH-2603: neither a failed query nor a reliable empty answer proves the
+  // marked process itself is dead. Only a present owner with a dead pane does.
   it('NEVER runs tier 1 when the owners read is unreliable — even a process with no matching session survives', () => {
     const table = [proc(500, 1, 'cgraph-mcp --daemon', 'ag-codex-ff55f79f')];
-    // Same inputs as the very first test in this block (which DOES reap this
-    // process when owners is reliable) — only `ownersReliable` differs.
     const reliable = selectOrphanProcesses(table, owners([]), { ...noneProtected, ownersReliable: true });
     const unreliable = selectOrphanProcesses(table, owners([]), { ...noneProtected, ownersReliable: false });
-    expect(reliable).toHaveLength(1);
+    expect(reliable).toEqual([]);
     expect(unreliable).toEqual([]);
   });
 
@@ -191,10 +193,10 @@ describe('selectOrphanProcesses', () => {
     expect(picked.map(c => c.pid)).toEqual([3868250]);
   });
 
-  it('ownersReliable defaults to true (unchanged behavior for every existing direct caller)', () => {
-    const table = [proc(500, 1, 'cgraph-mcp --daemon', 'ag-codex-ff55f79f')];
-    const picked = selectOrphanProcesses(table, owners([]), noneProtected);
-    expect(picked).toHaveLength(1);
+  it('ownersReliable defaults to true and still requires a present, dead owner', () => {
+    const table = [proc(500, 1, 'cgraph-mcp --daemon', 'ag-codex-dead')];
+    const picked = selectOrphanProcesses(table, owners([['ag-codex-dead', { agentAlive: false, attached: false }]]), noneProtected);
+    expect(picked.map(c => c.reason)).toEqual(['tmux-agent-exited']);
   });
 
   // Blocker 4 (RUSH-2521 review): tier 2 must not fire on a substring match
@@ -349,7 +351,30 @@ describe('readPaneOwners', () => {
   });
 });
 
-describe.skipIf(skipReason)('reaping a real leaked helper', () => {
+describe.skipIf(!fs.existsSync('/proc/self/environ'))('daemon-start regression (RUSH-2603)', () => {
+  it('keeps a real live marked agent alive when its tmux server is absent', async () => {
+    const missingSocket = path.join(os.tmpdir(), `agents-rush-2603-${process.pid}`, 'server.sock');
+    const child = spawn('sleep', ['120'], {
+      env: { ...process.env, [TMUX_SESSION_ENV]: `ag-claude-rush2603-${process.pid}` },
+      stdio: 'ignore',
+    });
+    expect(child.pid).toBeTypeOf('number');
+    try {
+      const result = await reapOrphanAgentProcesses({
+        socket: missingSocket,
+        pids: [child.pid!],
+        graceMs: 10,
+      });
+      expect(result.candidates).toEqual([]);
+      expect(alive(child.pid!)).toBe(true);
+    } finally {
+      child.kill('SIGKILL');
+      await new Promise<void>(resolve => child.once('exit', () => resolve()));
+    }
+  });
+});
+
+describe.skipIf(tier1SkipReason)('reaping a real leaked helper', () => {
   let socket: string;
   let tempDir: string;
   const spawned: number[] = [];

--- a/apps/cli/src/lib/tmux/orphan-reap.ts
+++ b/apps/cli/src/lib/tmux/orphan-reap.ts
@@ -58,12 +58,10 @@
  * - the reaping process itself, its ancestors, pid 1, and every long-lived
  *   agents-cli service ({@link isProtectedAgentsService}) are never candidates.
  * - an UNRELIABLE read of tmux's session state (the query threw, timed out, or
- *   tmux itself never answered) disables tier 1 for that sweep entirely — an
- *   absent map entry proves a session is gone only when the map is known-good.
- *   Distinguishing "tmux answered: no such session" (a completed, if nonzero,
- *   exit — genuinely nothing there) from "tmux did not answer" (a thrown
- *   error/timeout — unknown) is exactly this: a completed process is a real
- *   answer, a rejected promise is not one at all.
+ *   tmux itself never answered) disables tier 1 for that sweep entirely;
+ * - an absent session entry is unknown, even after a reliable read. A tmux
+ *   server restart can produce the same empty snapshot while marked agents
+ *   remain alive, so tier 1 requires a present owner with positive death proof.
  * - tier 2 is anchored on the actual claude EXECUTABLE (argv[0]'s basename),
  *   never a substring match anywhere in the command line, and excludes any
  *   process still structurally part of a LIVE pane leaf's process tree right
@@ -637,8 +635,8 @@ function describe(c: OrphanCandidate): string {
  * Reap every helper process whose owning agent has exited.
  *
  * Called from the daemon's periodic tick and from `agents sessions reap`. Panes
- * are read BEFORE processes so a session that disappears mid-scan is treated as
- * gone (reapable) rather than as a live owner.
+ * are read before processes to take one ownership snapshot. A session absent
+ * from that snapshot is unknown and is never sufficient proof for tier 1.
  *
  * `opts.pids` is the test-only process-table scope described on
  * {@link readAgentProcesses} — never set by production callers.

--- a/apps/cli/src/lib/tmux/orphan-reap.ts
+++ b/apps/cli/src/lib/tmux/orphan-reap.ts
@@ -144,7 +144,7 @@ export interface PaneOwner {
 }
 
 /** Why a process was selected, for human output and tests. */
-export type OrphanReason = 'tmux-session-gone' | 'tmux-agent-exited' | 'detached-helper';
+export type OrphanReason = 'tmux-agent-exited' | 'detached-helper';
 
 export interface OrphanCandidate {
   pid: number;
@@ -258,16 +258,14 @@ function livePid(pid: number): boolean {
 /**
  * Pure. Select the processes whose owning agent is provably gone.
  *
- * `owners` maps a tmux session name to its liveness; a name ABSENT from the map
- * is a session tmux no longer has, which is the strongest orphan signal there is
- * — but ONLY when `owners` is itself known-complete. `opts.ownersReliable`
- * (default `true`, so existing direct callers/tests keep their prior meaning)
- * says whether the caller actually got a real answer from tmux for every
- * socket it queried. When it is `false` — a query threw, timed out, or tmux
- * itself never answered — tier 1 is skipped entirely for this call: an absent
- * map entry proves nothing when the map itself might be missing entries for
- * sessions tmux never got asked about (RUSH-2521 review — a flaky tick must
- * never fall back to "treat every marked process as orphaned").
+ * `owners` maps a tmux session name to its liveness. An ABSENT name is never
+ * proof that the marked process is orphaned: the tmux server can restart or its
+ * socket can disappear while the pane's process tree is still alive. That exact
+ * state made the daemon classify every live agent as `tmux-session-gone` and
+ * SIGTERM it on startup (RUSH-2603). Tier 1 therefore requires a PRESENT owner
+ * whose pane process is confirmed dead and has no attached client. A reliable
+ * empty map means "nothing proven dead", not "every marked process is dead".
+ * `opts.ownersReliable` still disables tier 1 when any query failed to answer.
  */
 export function selectOrphanProcesses(
   procs: AgentProcess[],
@@ -341,10 +339,7 @@ export function selectOrphanProcesses(
     for (const p of procs) {
       if (!p.tmuxSession || !eligible(p)) continue;
       const owner = owners.get(p.tmuxSession);
-      if (!owner) {
-        push(p, 'tmux-session-gone');
-        continue;
-      }
+      if (!owner) continue;
       // An attached client or a live agent pane process is a hard exclusion.
       if (owner.attached || owner.agentAlive) continue;
       push(p, 'tmux-agent-exited');

--- a/apps/cli/src/lib/tmux/session.ts
+++ b/apps/cli/src/lib/tmux/session.ts
@@ -297,9 +297,10 @@ export async function reapDeadTmuxPanes(
   const sock = socket ?? getDefaultSocketPath();
   const result: ReapDeadPanesResult = { reaped: 0, sessions: [], details: [], processes: 0, processDetails: [], warnings: [] };
 
-  // The process sweep runs even with no server on this socket: a torn-down
-  // server (`killAll` unlinks the socket) is the strongest orphan signal there
-  // is, and skipping it here would strand exactly those leftovers forever.
+  // The process sweep may run with no server, but an absent session is not
+  // evidence that a still-live marked process is orphaned. Tier 1 only acts on
+  // a present pane owner confirmed dead; tier 2 independently verifies its
+  // declared spawner pid (RUSH-2603).
   // `opts.pids` is a test-only process-table scope (see `readAgentProcesses`)
   // — production callers never set it.
   const { reapOrphanAgentProcesses } = await import('./orphan-reap.js');


### PR DESCRIPTION
**Bug fix — the daemon no longer SIGTERMs live agents when the tmux server/session map disappears.**

## What changed

- Removed `tmux-session-gone` as a kill reason. An absent owner is unknown, never proof of death.
- Tier 1 now acts only on a present tmux owner whose pane process is confirmed dead and has no attached client.
- Kept harness-specific tier 2: it still requires a declared spawner pid confirmed dead.
- Added SES-21a, user docs, and a changelog fragment.

## Regression coverage

The new Linux real-process test starts a live `sleep` carrying `AGENT_TMUX_SESSION_NAME`, points the production reaper at an absent tmux socket, and asserts the process remains alive. Existing real-tmux leak collection remains covered on Linux.

No visible UI surface — safety bug fix. Actual passing-run screenshot (fleet-local path; `agents share` was unavailable because the share bundle is locked):

`/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/rush-2603-orphan-reaper/apps/cli/.agents/scratch/rush-2603-test-run.png`

Run result: 2 test files passed; 63 tests passed, 4 platform skips; `bunx tsc --noEmit` exited 0. The skips are Linux `/proc` integrations; CI is the Linux full-suite gate.

## Incident proof

The installed 1.22.37 daemon logged `Dead-pane reaper: terminated 20 orphaned helper process(es)` immediately after startup, including live Claude/Codex pane leaves classified `tmux-session-gone`; affected `agents run` exited 143.

Ticket: [RUSH-2603](https://linear.app/getrush/issue/RUSH-2603)