### PR TITLE
fix(daemon): parse heartbeat wire timestamps

### DIFF
--- a/apps/cli/menubar/Sources/MenubarHelper/DaemonLiveness.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/DaemonLiveness.swift
@@ -24,7 +24,7 @@ enum DaemonLiveness: Equatable {
         guard let heartbeatData,
               let heartbeat = try? JSONDecoder().decode(Heartbeat.self, from: heartbeatData),
               heartbeat.pid == pid,
-              let lastTick = ISO8601DateFormatter().date(from: heartbeat.lastTick)
+              let lastTick = parseHeartbeatDate(heartbeat.lastTick)
         else {
             // A live PID with no trustworthy heartbeat is not enough evidence
             // to terminate it. The CLI status surface can still report the
@@ -32,5 +32,15 @@ enum DaemonLiveness: Equatable {
             return .running
         }
         return now.timeIntervalSince(lastTick) > wedgeThreshold ? .wedged : .running
+    }
+
+    /// JavaScript's Date.toISOString() always writes milliseconds. Accept the
+    /// older second-precision form too so an upgrade never turns a valid live
+    /// heartbeat into ambiguous state.
+    private static func parseHeartbeatDate(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: value) { return date }
+        return ISO8601DateFormatter().date(from: value)
     }
 }

--- a/apps/cli/menubar/Sources/MenubarHelper/DaemonLivenessSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/DaemonLivenessSelfTest.swift
@@ -3,21 +3,23 @@ import Foundation
 enum DaemonLivenessSelfTest {
     static func run() -> Never {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let fresh = heartbeat(pid: 42, date: now.addingTimeInterval(-60))
-        let stale = heartbeat(pid: 42, date: now.addingTimeInterval(-181))
+        // Exact Date.toISOString() wire format written by daemon.ts, including
+        // the fractional seconds Swift's default ISO8601 formatter rejects.
+        let fresh = heartbeat(pid: 42, stamp: "2027-01-15T07:59:00.000Z")
+        let stale = heartbeat(pid: 42, stamp: "2027-01-15T07:56:59.000Z")
 
         assert(DaemonLiveness.classify(pid: nil, heartbeatData: nil, now: now) == .stopped, "missing pid is stopped")
         assert(DaemonLiveness.classify(pid: 42, heartbeatData: fresh, now: now) == .running, "fresh heartbeat is running")
         assert(DaemonLiveness.classify(pid: 42, heartbeatData: stale, now: now) == .wedged, "stale heartbeat is wedged")
-        assert(DaemonLiveness.classify(pid: 42, heartbeatData: heartbeat(pid: 7, date: now.addingTimeInterval(-181)), now: now) == .running, "mismatched heartbeat fails closed")
+        assert(DaemonLiveness.classify(pid: 42, heartbeatData: heartbeat(pid: 7, stamp: "2027-01-15T07:56:59.000Z"), now: now) == .running, "mismatched heartbeat fails closed")
+        assert(DaemonLiveness.classify(pid: 42, heartbeatData: heartbeat(pid: 42, stamp: "2027-01-15T07:56:59Z"), now: now) == .wedged, "second-precision heartbeat remains compatible")
         assert(DaemonLiveness.classify(pid: 42, heartbeatData: Data("broken".utf8), now: now) == .running, "malformed heartbeat fails closed")
 
         print("PASS daemon-liveness")
         exit(0)
     }
 
-    private static func heartbeat(pid: Int, date: Date) -> Data {
-        let stamp = ISO8601DateFormatter().string(from: date)
+    private static func heartbeat(pid: Int, stamp: String) -> Data {
         return Data("{\"lastTick\":\"\(stamp)\",\"pid\":\(pid)}".utf8)
     }
 

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -97,6 +97,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     // this process's own `Notifier`, not a spawned `--notify` child, so the
     // alert cannot depend on anything the dead daemon would have provided.
     private var daemonUnhealthyTicks = 0
+    private var daemonUnhealthyState: DaemonLiveness?
     private var daemonDownNotified = false
     /// True once `daemonUnhealthyTicks` has crossed the threshold; drives the
     /// always-visible badge (see `refreshBadge`), independent of whether the
@@ -266,6 +267,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         let liveness = AgentsCLI.daemonLiveness()
         if liveness == .running {
             daemonUnhealthyTicks = 0
+            daemonUnhealthyState = nil
             daemonDownNotified = false
             if schedulerDown {
                 schedulerDown = false
@@ -273,7 +275,13 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             }
             return
         }
-        daemonUnhealthyTicks += 1
+        if daemonUnhealthyState == liveness {
+            daemonUnhealthyTicks += 1
+        } else {
+            daemonUnhealthyState = liveness
+            daemonUnhealthyTicks = 1
+            daemonDownNotified = false
+        }
         if daemonUnhealthyTicks >= Self.daemonDownTickThreshold && !schedulerDown {
             schedulerDown = true
             refreshBadge()


### PR DESCRIPTION
Fixes the already-merged RUSH-2636 watchdog so its recovery path can actually classify the daemon's real heartbeat timestamps.

## Blocking review findings fixed

- Parse JavaScript `Date.toISOString()` timestamps with fractional seconds, with a second-precision compatibility path.
- Exercise the exact `...00.000Z` daemon wire format in the self-test instead of Swift's non-fractional formatter output.
- Require three consecutive observations of the same unhealthy state, so two stopped ticks plus one wedged tick cannot trigger a restart.

## Run result

```text
$ swift build
Build complete! (32.36s)
$ MENUBAR_DAEMON_LIVENESS_TEST=1 .build/debug/MenubarHelper
PASS daemon-liveness
```

Fleet-local run capture: `zion:/tmp/rush-2636-daemon-liveness.png`.

## Tracking

- Follow-up to #2673 and its blocking independent review.
- [RUSH-2636](https://linear.app/getrush/issue/RUSH-2636/agents-daemon-can-hang-alive-but-frozen-after-laptop-sleepwake-and)
