### PR TITLE
chore(ext): cut CHANGELOG for 0.9.320

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+## [0.9.320] - 2026-08-14
+
 - **Crash-restart no longer reopens every tab in a thundering herd (RUSH-2477).**
   `restoreAgentTerminals` reopened each persisted tab and fired its resume with no
   cap or stagger, so N crashed tabs became N near-simultaneous resume processes


### PR DESCRIPTION
release — no run needed.

Re-heads the three accumulated `[Unreleased]` entries into `## [0.9.320] - 2026-08-14`, which `apps/ext/scripts/release.sh` requires before publishing. Ships:

- RUSH-2477 staggered crash-restart
- RUSH-2593 failed launch keeps the terminal open
- `Agents: New <Harness>` defaults to the fleet worker pool (`agents.launch.defaultTarget`)

Follow-up: `release.sh 0.9.320 --confirm` after merge.