### PR TITLE
fix(ext): Attach lists backgrounded sessions — machine from sourceDevice, not terminal-app host (RUSH-2670)

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+## [0.9.321] - 2026-08-14
+
+- **`Agents: Attach` finds your backgrounded agents again (RUSH-2670).** A
+  detached session's stream row names its terminal app in `host` — for a
+  backgrounded agent that is the bare tmux server, so the presentation store
+  (which fell back to `host` when the row had no `machine`) presented it as
+  living on a machine called "tmux". The Attach command's this-machine filter
+  then never matched, and `Agents: Attach` always reported "No backgrounded
+  agents to bring forward" even seconds after a successful Detach. The store
+  now takes device identity from `machine` (offloaded rows) or `sourceDevice`
+  (everything else) and never from the terminal-app `host`. Source:
+  `apps/ext/src/core/sessionPresentationStore.ts`.
+
 ## [0.9.320] - 2026-08-14
 
 - **Crash-restart no longer reopens every tab in a thundering herd (RUSH-2477).**

--- a/apps/ext/src/core/sessionPresentationStore.test.ts
+++ b/apps/ext/src/core/sessionPresentationStore.test.ts
@@ -10,6 +10,38 @@ describe('SessionPresentationStore', () => {
     expect(store.sessions()).toEqual([{ rowKey: 'b', sourceDevice: 'zion', status: 'orphaned' }]);
   });
 
+  // RUSH-2670: a detached session's row has host 'tmux' (the terminal APP — the
+  // bare tmux server is its only terminal) and carries its device identity in
+  // sourceDevice. Mapping host into the machine slot presented the session as
+  // living on a machine called "tmux", so Attach's host === local filter never
+  // matched and "Agents: Attach" always reported no backgrounded agents.
+  test('presents a detached local row (host: tmux) under the local label, not "tmux"', () => {
+    const store = new SessionPresentationStore();
+    store.apply({
+      version: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'zion',
+      rows: [{
+        rowKey: 'bg', sessionId: '2d29e6ac-7d5b-4bcc-91d1-8efc0818dbb3', kind: 'claude',
+        host: 'tmux', sourceDevice: 'zion', status: 'closed', presence: 'background', context: 'terminal',
+      }],
+    });
+    const presented = store.presentedSessions('zion', 'this-mac');
+    expect(presented).toHaveLength(1);
+    expect(presented[0]?.host).toBe('this-mac');
+    expect(presented[0]?.presence).toBe('background');
+  });
+
+  test('presents an offloaded row under its machine, not its terminal app', () => {
+    const store = new SessionPresentationStore();
+    store.apply({
+      version: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'zion',
+      rows: [{
+        rowKey: 'r', sessionId: 'abcd1234-0000-0000-0000-000000000000', kind: 'claude',
+        host: 'tmux', machine: 'yosemite-s1', sourceDevice: 'zion', status: 'running', context: 'terminal',
+      }],
+    });
+    expect(store.presentedSessions('zion', 'this-mac')[0]?.host).toBe('yosemite-s1');
+  });
+
   test('orders each stream independently and resets only its scope', () => {
     const store = new SessionPresentationStore();
     store.apply({ version: 1, type: 'reset', streamId: 'a', sequence: 5, capturedAt: 1, scope: 'zion', rows: [{ rowKey: 'z', sourceDevice: 'zion' }] });

--- a/apps/ext/src/core/sessionPresentationStore.ts
+++ b/apps/ext/src/core/sessionPresentationStore.ts
@@ -46,12 +46,20 @@ export class SessionPresentationStore {
   ): RemoteSession[] {
     return this.sessions().flatMap((value) => {
       if (!value || typeof value !== 'object') return [];
-      const row = value as RawActiveSession & { agentType?: string; host?: string };
+      const row = value as RawActiveSession & { agentType?: string; host?: string; sourceDevice?: string };
       const raw = {
         ...row,
         kind: row.kind || row.agentType || '',
       } as RawActiveSession;
-      const machine = typeof raw.machine === 'string' ? raw.machine : row.host;
+      // The CLI row's `host` is the terminal APP hosting the session (codium,
+      // iterm, tmux, ...), never a machine. `machine` is set only for offloaded
+      // sessions; a local row's device identity rides in `sourceDevice`. Using
+      // `host` here made a detached session (whose only terminal is the bare
+      // tmux server) present as living on a machine called "tmux", which broke
+      // every host === local filter (RUSH-2670).
+      const machine = typeof raw.machine === 'string' ? raw.machine
+        : typeof row.sourceDevice === 'string' ? row.sourceDevice
+        : undefined;
       const host = resolveSessionHost(machine, localLabel, normalizeHost(localMachineId), localLabel);
       return [normalizeActiveSession(raw, host, fetchedAt, projectRules)];
     });
@@ -63,10 +71,10 @@ export class SessionPresentationStore {
     const result = new Map<string, string>();
     for (const value of this.sessions()) {
       if (!value || typeof value !== 'object') continue;
-      const row = value as { terminalId?: unknown; sessionId?: unknown; id?: unknown; machine?: unknown; host?: unknown };
+      const row = value as { terminalId?: unknown; sessionId?: unknown; id?: unknown; machine?: unknown; sourceDevice?: unknown };
       const terminalId = typeof row.terminalId === 'string' ? row.terminalId : '';
       const sessionId = typeof row.sessionId === 'string' ? row.sessionId : typeof row.id === 'string' ? row.id : '';
-      const machine = normalizeHost(typeof row.machine === 'string' ? row.machine : typeof row.host === 'string' ? row.host : '');
+      const machine = normalizeHost(typeof row.machine === 'string' ? row.machine : typeof row.sourceDevice === 'string' ? row.sourceDevice : '');
       if (wanted && machine && wanted !== machine) continue;
       if (terminalId && sessionId) result.set(terminalId, sessionId);
     }


### PR DESCRIPTION
## What

Bug fix + regression test + CHANGELOG cut for 0.9.321. Fixes `Agents: Attach` always reporting "No backgrounded agents to bring forward" even right after a successful `Agents: Detach` (RUSH-2670).

## Root cause

The CLI stream row's `host` is the terminal app hosting the session (`codium`, `iterm`, `tmux` — `apps/cli/src/lib/session/active.ts:1380-1394`); `machine` is set only for offloaded rows (`active.ts:1269`), and a local row's device identity rides in `sourceDevice`. The presentation store fell back `machine ?? host` (`sessionPresentationStore.ts:54`), so a detached session — whose only terminal is the bare tmux server — presented as living on a machine called "tmux" and failed the Attach command's `host === 'this-mac'` filter (`extension.ts:299-301`).

## Run result

Uploaded run log: https://gist.githubusercontent.com/muqsitnawaz/1c2c3736f55a1a78d08d7015072a232e/raw/e2008b57a40f874a245dbb8fe2a0b2b3eb37a8f3/rush-2670-run.log — the real `bun test` run showing the new regression test fail against origin/main's store (3 pass / 1 fail) and pass with this PR's store (4 pass / 0 fail), plus the live zion watch-stream row (`2d29e6ac: host "tmux", sourceDevice "zion", presence "background"`) the test pins. Full ext suite after the fix: 1557 pass / 0 fail, `tsc` clean.

## Ticket

RUSH-2670 (https://linear.app/getrush/issue/RUSH-2670)