### PR TITLE
test(cli): seal macOS release home sandbox

### DIFF
--- a/apps/cli/src/lib/profiles.test.ts
+++ b/apps/cli/src/lib/profiles.test.ts
@@ -226,7 +226,14 @@ describe('resolveProfileEnv fails fast in a headless context', () => {
       };
       // Past the guard the read reaches the real platform path (helper absent
       // in a source checkout / item absent on CI) — never the headless error.
-      expect(() => resolveProfileEnv(p)).toThrow(/^(?!.*non-interactive).*$/);
+      let message = '';
+      try {
+        resolveProfileEnv(p);
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+      expect(message).toBeTruthy();
+      expect(message).not.toContain('non-interactive');
     } finally {
       setKeychainHeadlessDetectorForTest(null);
     }

--- a/apps/cli/tests/home-sandbox.test.ts
+++ b/apps/cli/tests/home-sandbox.test.ts
@@ -33,6 +33,11 @@ describe('vitest HOME sandbox (RUSH-2639)', () => {
     expect(getUserAgentsDir()).not.toBe(path.join(realOsHome, '.agents'));
   });
 
+  it('pins the explicit real-home seam to the same fork-private sandbox', () => {
+    expect(process.env.AGENTS_REAL_HOME).toBe(process.env.HOME);
+    expect(process.env.AGENTS_REAL_HOME).not.toBe(os.userInfo().homedir);
+  });
+
   it('a naive subprocess spawn (env: {...process.env}) inherits the sandboxed HOME for free', () => {
     // This is the exact shape of the historical bug class: a test spawns the
     // CLI (or any subprocess) with the parent env spread verbatim and never
@@ -41,9 +46,9 @@ describe('vitest HOME sandbox (RUSH-2639)', () => {
     // already-sandboxed HOME with zero per-test effort.
     const out = execFileSync(
       process.execPath,
-      ['-e', 'process.stdout.write(process.env.HOME || "")'],
+      ['-e', 'process.stdout.write(`${process.env.HOME || ""}\n${process.env.AGENTS_REAL_HOME || ""}`)'],
       { env: { ...process.env } },
     ).toString();
-    expect(out).toBe(process.env.HOME);
+    expect(out).toBe(`${process.env.HOME}\n${process.env.HOME}`);
   });
 });

--- a/apps/cli/tests/non-interactive.test.ts
+++ b/apps/cli/tests/non-interactive.test.ts
@@ -118,6 +118,8 @@ function runAgents(home: string, args: string[], extraEnv: Record<string, string
     env: {
       ...process.env,
       HOME: home,
+      USERPROFILE: home,
+      AGENTS_REAL_HOME: home,
       SHELL: '/bin/zsh',
       AGENTS_SYNC_MACHINE_ID: DEVICE_ID,
       ...extraEnv,
@@ -132,6 +134,8 @@ function runSessionDbScript(home: string, body: string): string {
     env: {
       ...process.env,
       HOME: home,
+      USERPROFILE: home,
+      AGENTS_REAL_HOME: home,
       SHELL: '/bin/zsh',
     },
     encoding: 'utf-8',

--- a/apps/cli/tests/setup.ts
+++ b/apps/cli/tests/setup.ts
@@ -50,6 +50,11 @@ const sandboxHome = path.join(tmp, 'home');
 fs.mkdirSync(sandboxHome, { recursive: true });
 process.env.HOME = sandboxHome;
 process.env.USERPROFILE = sandboxHome;
+// Several paths intentionally distinguish an agent's isolated HOME from the
+// active installation home via AGENTS_REAL_HOME. Pin that canonical seam too:
+// child processes launched through login shells/service managers may restore
+// HOME to the account home, but they still inherit AGENTS_REAL_HOME.
+process.env.AGENTS_REAL_HOME = sandboxHome;
 
 // Broker: pin the socket dir to a fork-private temp path so nothing in this
 // fork — nor any CLI subprocess it spawns with inherited env — can reach the


### PR DESCRIPTION
test-only: fixes the two deterministic macOS release-matrix failures blocking 1.22.40.

## What changed
- Pin `AGENTS_REAL_HOME` to the same fork-private home as `HOME`/`USERPROFILE`, including inherited child processes.
- Assert the explicit real-home seam in `home-sandbox.test.ts`.
- Replace a single-line negative regex with a direct multiline-safe error-message assertion.

## Run result
`bun run build` passed.

`bun run test -- tests/home-sandbox.test.ts src/lib/profiles.test.ts`

```text
Test Files  2 passed (2)
Tests  56 passed (56)
```

The wider macOS target run exercised 301 tests; the changed tests passed. Its remaining failures were local `CI=1` tripwires observing live zion fleet writes and three pre-existing timing/live-peer cases, not failures in these changes.

Tracking: RUSH-2639