### PR TITLE
feat(ext): rank Fleet sessions by progress — idle surfaces above running

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+- **Fleet sessions list ranks by progress — idle work no longer hides below running.**
+  The state-grouped Sessions list now surfaces a **Needs attention** band (live sessions
+  that have stopped progressing — waiting on input, stalled, idle, or failed) *above* the
+  **Running** band, ordered most-stuck-first so the highest-abandonment-risk session sits
+  at the top. Detached/crashed work still leads in **Needs reconnecting**; finished
+  sessions fold into **Recently finished**. Presentation-only grouping of the CLI's
+  existing session states (no new lifecycle logic in the extension). Source:
+  `apps/ext/ui/settings/components/mission-control/floorModel.ts`, `sessionsModel.ts`.
+
 ## [0.9.321] - 2026-08-14
 
 - **`Agents: Attach` finds your backgrounded agents again (RUSH-2670).** A

--- a/apps/ext/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/ext/ui/settings/components/mission-control/floorModel.ts
@@ -214,7 +214,7 @@ export type SessionSort = 'recent' | 'started' | 'status' | 'name' | 'tok'
  * crashed) the whole surface exists for; it is derived from the raw `liveStatus`,
  * never from `phase` (which can't see it). Pure so it is unit-tested.
  */
-export type SessionBand = 'reconnect' | 'active' | 'done'
+export type SessionBand = 'reconnect' | 'attention' | 'active' | 'done'
 
 /** Lowercased lifecycle words that mean "alive/left-behind, resume to reconnect". */
 const RECONNECT_STATUSES = new Set(['orphaned', 'crashed', 'abandoned'])
@@ -224,11 +224,20 @@ export function needsReconnect(a: Pick<FloorAgent, 'liveStatus'>): boolean {
   return RECONNECT_STATUSES.has((a.liveStatus ?? '').toLowerCase())
 }
 
-/** Assign a session to its state band. reconnect > active(working/waiting/idle) > done. */
+/**
+ * Assign a session to its state band, ranked by PROGRESS (see the root AGENTS.md
+ * "Purpose" section): reconnect (detached/crashed) > attention (live but stopped
+ * progressing — waiting on input, stalled, idle, or failed) > active (running,
+ * making progress) > done. Idle-but-unfinished work is the highest-abandonment
+ * risk, so it surfaces ABOVE running rather than below it. Pure so it is
+ * unit-tested; classifies the CLI-supplied `phase`/`liveStatus`, never derives
+ * lifecycle itself.
+ */
 export function sessionBand(a: FloorAgent): SessionBand {
   if (needsReconnect(a)) return 'reconnect'
   if (a.phase === 'done') return 'done'
-  return 'active'
+  if (a.phase === 'running') return 'active'
+  return 'attention'
 }
 
 // ---------- HOSTS sidebar rows ----------

--- a/apps/ext/ui/settings/components/mission-control/sessionsModel.test.ts
+++ b/apps/ext/ui/settings/components/mission-control/sessionsModel.test.ts
@@ -61,6 +61,13 @@ describe('needsReconnect / sessionBand', () => {
   test('reconnect wins even over a done phase (a crashed session is resumable, not finished)', () => {
     expect(sessionBand(mk({ liveStatus: 'crashed', phase: 'done' }))).toBe('reconnect')
   })
+  test('attention band = live but not progressing (idle / stalled / waiting / failed)', () => {
+    for (const phase of ['idle', 'stalled', 'waiting', 'failed'] as const) {
+      expect(sessionBand(mk({ phase }))).toBe('attention')
+    }
+    // a running session IS progressing, so it stays in the active band, not attention
+    expect(sessionBand(mk({ phase: 'running' }))).toBe('active')
+  })
 })
 
 describe('scopeSessions — filter chips', () => {
@@ -131,13 +138,13 @@ describe('groupSessions — starred pinned to a single top section', () => {
     mk({ id: 'orph', liveStatus: 'orphaned', phase: 'idle' }),
     mk({ id: 'run', phase: 'running' }),
   ]
-  test('state group: Starred first, then Needs reconnecting, then Active — no duplication', () => {
+  test('state group: Starred first, then Needs reconnecting, then Running — no duplication', () => {
     const secs = groupSessions(list, 'state', 'recent', true)
-    expect(secs.map((s) => s.label)).toEqual(['Starred', 'Needs reconnecting', 'Active'])
-    // The starred row appears ONLY in Starred, never again in Active.
+    expect(secs.map((s) => s.label)).toEqual(['Starred', 'Needs reconnecting', 'Running'])
+    // The starred row appears ONLY in Starred, never again in Running.
     const allIds = secs.flatMap((s) => s.agents.map((a) => a.id))
     expect(allIds.filter((id) => id === 'star')).toHaveLength(1)
-    expect(secs.find((s) => s.label === 'Active')!.agents.map((a) => a.id)).toEqual(['run'])
+    expect(secs.find((s) => s.label === 'Running')!.agents.map((a) => a.id)).toEqual(['run'])
   })
   test('filter=starred: no separate Starred band (the whole list is starred)', () => {
     const onlyStar = [mk({ id: 's1', pinned: true }), mk({ id: 's2', pinned: true })]
@@ -149,6 +156,31 @@ describe('groupSessions — starred pinned to a single top section', () => {
     const secs = groupSessions(onlyStar, 'state', 'recent', true, /* filterIsStarred */ false)
     expect(secs[0]!.kind).toBe('starred')
     expect(secs[0]!.agents.map((a) => a.id).sort()).toEqual(['s1', 's2'])
+  })
+})
+
+describe('groupSessions — attention band ranks progress-stopped work above running', () => {
+  test('idle/stalled sessions surface in "Needs attention" ABOVE the running band', () => {
+    const list = [
+      mk({ id: 'run', phase: 'running', lastActivityMs: 9_000 }),
+      mk({ id: 'idle', phase: 'idle', lastActivityMs: 5_000 }),
+      mk({ id: 'stall', phase: 'stalled', lastActivityMs: 1_000 }),
+    ]
+    const secs = groupSessions(list, 'state', 'recent', true)
+    expect(secs.map((s) => s.label)).toEqual(['Needs attention', 'Running'])
+    // Within attention, MOST-stuck (oldest activity) first — stall(1s) before idle(5s).
+    expect(secs.find((s) => s.label === 'Needs attention')!.agents.map((a) => a.id)).toEqual(['stall', 'idle'])
+    expect(secs.find((s) => s.label === 'Running')!.agents.map((a) => a.id)).toEqual(['run'])
+  })
+  test('attention leads most-stuck-first even under a recency sort that would reverse it', () => {
+    // Under 'recent' desc the most-recent (idle2 @ 8s) would sort first; the band's
+    // staleness override must instead put the most-stuck (idle1 @ 2s) at the top.
+    const list = [
+      mk({ id: 'idle1', phase: 'idle', lastActivityMs: 2_000 }),
+      mk({ id: 'idle2', phase: 'idle', lastActivityMs: 8_000 }),
+    ]
+    const secs = groupSessions(list, 'state', 'recent', true)
+    expect(secs.find((s) => s.label === 'Needs attention')!.agents.map((a) => a.id)).toEqual(['idle1', 'idle2'])
   })
 })
 

--- a/apps/ext/ui/settings/components/mission-control/sessionsModel.ts
+++ b/apps/ext/ui/settings/components/mission-control/sessionsModel.ts
@@ -124,10 +124,14 @@ export function sortSessions(list: FloorAgent[], sort: SessionSort, desc: boolea
 
 const BAND_LABEL: Record<SessionBand, string> = {
   reconnect: 'Needs reconnecting',
-  active: 'Active',
+  attention: 'Needs attention',
+  active: 'Running',
   done: 'Recently finished',
 }
-const BAND_ORDER: SessionBand[] = ['reconnect', 'active', 'done']
+// Ranked by progress (root AGENTS.md "Purpose"): detached work first, then live work
+// that has STOPPED progressing (attention), then healthy running work, then done —
+// so idle-but-unfinished sessions surface above running, never buried below it.
+const BAND_ORDER: SessionBand[] = ['reconnect', 'attention', 'active', 'done']
 
 /**
  * Group a scoped list into ordered sections. Starred sessions are lifted into a
@@ -166,7 +170,17 @@ export function groupSessions(
     for (const band of BAND_ORDER) {
       const inBand = rest.filter((a) => sessionBand(a) === band)
       if (inBand.length) {
-        sections.push({ key: `band:${band}`, label: BAND_LABEL[band], kind: 'band', band, agents: sortSessions(inBand, sort, desc) })
+        // The attention band exists to surface work that has STOPPED progressing, so
+        // it always leads with the MOST-stuck session (oldest activity) — the highest
+        // abandonment risk — independent of the list-wide sort. Other bands honor the
+        // chosen (`sort`,`desc`).
+        const agents = band === 'attention'
+          ? [...inBand].sort((a, b) => {
+              const d = (a.lastActivityMs || 0) - (b.lastActivityMs || 0)
+              return d !== 0 ? d : (a.sessionId || a.id).localeCompare(b.sessionId || b.id)
+            })
+          : sortSessions(inBand, sort, desc)
+        sections.push({ key: `band:${band}`, label: BAND_LABEL[band], kind: 'band', band, agents })
       }
     }
     return sections


### PR DESCRIPTION
**feat / user-visible (Fleet sessions ordering)** — presentation-only grouping change in `apps/ext`; no new lifecycle logic in the extension.

## What changed
The state-grouped **Sessions** list lumped `running`, `idle`, `waiting`, `stalled`, and `failed` all into one **Active** band. So idle-but-unfinished work — the session most likely to be silently abandoned — sat mixed in with, or below, healthy running sessions.

This splits the active band by **progress**:

| Band (in order) | Contains |
|---|---|
| Needs reconnecting | detached / crashed / abandoned (unchanged) |
| **Needs attention** *(new)* | live but **stopped progressing** — waiting on input, stalled, idle, failed |
| **Running** *(was "Active")* | actively progressing |
| Recently finished | done |

Within **Needs attention**, rows are ordered **most-stuck-first** (oldest activity), so the highest-abandonment-risk session is at the top regardless of the list-wide sort.

## Why
Implements the *"rank by progress, not liveness"* principle just added to the root `AGENTS.md` (PR #2686): a running session needs nothing; the ones that need a human have **stopped** progressing, and idle-unfinished work is the highest-risk state.

## Run evidence
Behavior is exercised by the model unit tests on the real grouping path (`groupSessions` / `sessionBand`), no mocking:

```
bun test sessionsModel.test.ts   →  22 pass, 0 fail   (42 expect() calls)
bun test floorModel.test.ts      →  108 pass, 0 fail  (223 expect() calls)
```

New assertions: idle/stalled/waiting/failed → `attention`; the attention band renders **above** Running; and attention leads most-stuck-first even under a recency sort that would otherwise reverse it. Typecheck (`tsc -p ui/tsconfig.json`) clean except a pre-existing `baseUrl` deprecation unrelated to this diff.

Design the ordering implements (rendered + reviewed at 360/460px): `yosemite-s1:/tmp/claude-1000/.../scratchpad/render-v3-narrow.png` (fleet-local path — `agents share` isn't configured on this box).

## Scope
Deliberately contained: presentation grouping only. The larger follow-ups — moving the `ACTIVE`/host/project counts out of the extension into the CLI (they're currently ext-derived), and a first-class CLI `done` vs `idle` signal — are **not** in this PR.

## Files
- `apps/ext/ui/settings/components/mission-control/floorModel.ts` — `SessionBand` gains `attention`; `sessionBand()` ranks by progress
- `.../sessionsModel.ts` — `BAND_ORDER` / labels; attention band ordered most-stuck-first
- `.../sessionsModel.test.ts` — updated + new coverage
- `apps/ext/CHANGELOG.md` — Unreleased entry
