### PR TITLE
fix(daemon): bake HOME into the launchd plist/systemd unit (RUSH-2639)

### DIFF
--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -159,6 +159,188 @@ describe('generateLaunchdPlist', () => {
   });
 });
 
+// RUSH-2639 (reopened from the 1.22.40 macOS release CI legs): launchd does
+// NOT inherit `launchctl load`'s caller's process environment, so a plist
+// whose EnvironmentVariables dict carries only PATH lets a launchd-started
+// daemon resolve HOME against the login session's real value regardless of
+// what HOME the process that generated (and loaded) the plist was running
+// under. Under the hermetic test harness (tests/setup.ts redirects HOME to a
+// fork-private sandbox) that meant a launchd-started daemon silently escaped
+// the sandbox and bootstrapped a real ~/.agents on the CI runner — see
+// tests/setup.ts:222's hermeticity tripwire, which caught exactly this:
+// "Before: null. After: .cache:...|.history:...|.system:...|routines:...".
+describe('generateLaunchdPlist / generateSystemdUnit — HOME seam (RUSH-2639)', () => {
+  let prevHome: string | undefined;
+  let prevRealHome: string | undefined;
+
+  beforeEach(() => {
+    prevHome = process.env.HOME;
+    prevRealHome = process.env.AGENTS_REAL_HOME;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+    if (prevRealHome === undefined) delete process.env.AGENTS_REAL_HOME; else process.env.AGENTS_REAL_HOME = prevRealHome;
+  });
+
+  it('bakes the CALLER\'s HOME into the plist EnvironmentVariables dict, not just PATH', () => {
+    const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agd-2639-home-'));
+    process.env.HOME = sandboxHome;
+    delete process.env.AGENTS_REAL_HOME;
+    try {
+      const plist = generateLaunchdPlist();
+      expect(plist).toMatch(new RegExp(`<key>HOME</key>\\s*<string>${sandboxHome.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</string>`));
+      // With AGENTS_REAL_HOME unset, it falls back to the same sandbox HOME —
+      // never to os.homedir()'s un-redirected real value.
+      expect(plist).toMatch(new RegExp(`<key>AGENTS_REAL_HOME</key>\\s*<string>${sandboxHome.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</string>`));
+    } finally {
+      fs.rmSync(sandboxHome, { recursive: true, force: true });
+    }
+  });
+
+  it('honors a distinct AGENTS_REAL_HOME rather than collapsing it into HOME', () => {
+    const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agd-2639-home-'));
+    const activeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agd-2639-real-'));
+    process.env.HOME = sandboxHome;
+    process.env.AGENTS_REAL_HOME = activeHome;
+    try {
+      const plist = generateLaunchdPlist();
+      expect(plist).toContain(`<key>HOME</key>\n    <string>${sandboxHome}</string>`);
+      expect(plist).toContain(`<key>AGENTS_REAL_HOME</key>\n    <string>${activeHome}</string>`);
+    } finally {
+      fs.rmSync(sandboxHome, { recursive: true, force: true });
+      fs.rmSync(activeHome, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'bakes the CALLER\'s HOME into the systemd unit, not just PATH',
+    () => {
+      const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agd-2639-home-'));
+      process.env.HOME = sandboxHome;
+      delete process.env.AGENTS_REAL_HOME;
+      try {
+        const unit = generateSystemdUnit();
+        expect(unit).toContain(`Environment=HOME=${sandboxHome}`);
+        expect(unit).toContain(`Environment=AGENTS_REAL_HOME=${sandboxHome}`);
+      } finally {
+        fs.rmSync(sandboxHome, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+// RUSH-2639: reproduce the actual macOS CI leak end to end. launchd applies a
+// plist's EnvironmentVariables dict on top of the login session's OWN
+// environment — never the environment of whatever process called `launchctl
+// load` — so a shim that (like every other shim in this file) simply execs the
+// program with `env: {...process.env}` inherited is unrealistic here and would
+// never have caught this bug: it silently hands the daemon child the CALLING
+// test's sandboxed HOME regardless of what the plist says. This shim instead
+// parses the real generated plist and applies ONLY its ProgramArguments /
+// EnvironmentVariables against a deliberately foreign base env (no HOME at
+// all) — the same shape launchd actually uses — so the assertion only passes
+// when `generateLaunchdPlist()` itself carries HOME/AGENTS_REAL_HOME.
+describe.skipIf(process.platform !== 'darwin')('startDaemon — launchd does not inherit the caller env (RUSH-2639)', () => {
+  let tmpHome = '';
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join('/tmp', 'agd-2639-launchd-'));
+    for (const k of ['HOME', 'PATH', 'AGENTS_DAEMON_DIR', 'AGENTS_REAL_HOME']) saved[k] = process.env[k];
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (tmpHome) fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('a launchd-started daemon resolves the SANDBOX HOME baked into the plist, never the login session default', () => {
+    const daemonDir = path.join(tmpHome, 'daemon');
+    const shimDir = path.join(tmpHome, 'bin');
+    fs.mkdirSync(daemonDir, { recursive: true });
+    fs.mkdirSync(shimDir, { recursive: true });
+
+    const lockPath = path.join(daemonDir, 'daemon.lock');
+    const pidPath = path.join(daemonDir, 'daemon.pid');
+    const resultPath = path.join(tmpHome, 'observed-home.json');
+    // The stand-in "daemon": records what HOME it was actually launched with,
+    // then behaves exactly like the other launchd-shim test's child.
+    const childPath = path.join(tmpHome, 'fake-daemon.mjs');
+    fs.writeFileSync(childPath, [
+      `import fs from 'fs';`,
+      `setTimeout(() => {`,
+      `  fs.writeFileSync(process.env.AGD_RESULT, JSON.stringify({ observedHome: process.env.HOME || null, observedRealHome: process.env.AGENTS_REAL_HOME || null }));`,
+      `  fs.writeFileSync(process.env.AGD_PID, String(process.pid));`,
+      `  setTimeout(() => {}, 3000);`,
+      `}, 400);`,
+    ].join('\n'), 'utf-8');
+
+    // A minimal parser+launcher standing in for launchd: reads the REAL plist
+    // `startDaemon()` wrote, pulls only its <key>EnvironmentVariables</key>
+    // dict, and spawns the stand-in child with that dict as the WHOLE
+    // environment plus a foreign base (no HOME) — never `process.env` of
+    // whatever called `launchctl load`. This is what makes the test able to
+    // fail: without the RUSH-2639 fix, EnvironmentVariables carries only PATH,
+    // so the child would see no HOME at all instead of the sandbox HOME.
+    const launcherPath = path.join(tmpHome, 'fake-launchd.mjs');
+    fs.writeFileSync(launcherPath, [
+      `import fs from 'fs';`,
+      `import { spawn } from 'child_process';`,
+      `const plistPath = process.argv[2];`,
+      `const xml = fs.readFileSync(plistPath, 'utf-8');`,
+      `const envSection = xml.match(/<key>EnvironmentVariables<\\/key>\\s*<dict>([\\s\\S]*?)<\\/dict>/)?.[1] || '';`,
+      `const pairs = [...envSection.matchAll(/<key>([^<]+)<\\/key>\\s*<string>([^<]*)<\\/string>/g)];`,
+      `const plistEnv = Object.fromEntries(pairs.map((m) => [m[1], m[2]]));`,
+      // A "foreign login session" base — deliberately WITHOUT HOME, so the
+      // only way the child ever sees the sandbox HOME is via the plist.
+      `const loginSessionEnv = { PATH: '/usr/bin:/bin', AGD_RESULT: process.env.AGD_RESULT, AGD_PID: process.env.AGD_PID };`,
+      `spawn(process.execPath, [process.env.AGD_CHILD], { env: { ...loginSessionEnv, ...plistEnv }, detached: true, stdio: 'ignore' }).unref();`,
+    ].join('\n'), 'utf-8');
+
+    const shim = [
+      '#!/bin/sh',
+      'for a in "$@"; do',
+      '  if [ "$a" = "load" ]; then',
+      `    "${process.execPath}" "${launcherPath}" "$2" >/dev/null 2>&1 &`,
+      '  fi',
+      'done',
+      'exit 0',
+    ].join('\n');
+    const shimPath = path.join(shimDir, 'launchctl');
+    fs.writeFileSync(shimPath, shim, 'utf-8');
+    fs.chmodSync(shimPath, 0o755);
+
+    const sandboxHome = path.join(tmpHome, 'sandbox-home');
+    fs.mkdirSync(sandboxHome, { recursive: true });
+    process.env.HOME = sandboxHome;
+    process.env.AGENTS_REAL_HOME = sandboxHome;
+    process.env.AGENTS_DAEMON_DIR = daemonDir;
+    process.env.PATH = `${shimDir}${path.delimiter}${saved.PATH ?? ''}`;
+    process.env.AGD_CHILD = childPath;
+    process.env.AGD_LOCK = lockPath;
+    process.env.AGD_PID = pidPath;
+    process.env.AGD_RESULT = resultPath;
+
+    try {
+      const res = startDaemon(DIST_ENTRY);
+      expect(res.method).toBe('launchd');
+      expect(res.pid).toBeTruthy();
+
+      const recorded = JSON.parse(fs.readFileSync(resultPath, 'utf-8'));
+      expect(recorded.observedHome).toBe(sandboxHome);
+      expect(recorded.observedRealHome).toBe(sandboxHome);
+    } finally {
+      for (const k of ['AGD_CHILD', 'AGD_LOCK', 'AGD_PID', 'AGD_RESULT']) delete process.env[k];
+      const pid = fs.existsSync(pidPath) ? parseInt(fs.readFileSync(pidPath, 'utf-8').trim(), 10) : NaN;
+      if (!isNaN(pid)) { try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ } }
+    }
+  }, 30_000);
+});
+
 // RUSH-2418: crash-loop prevention had no application-level guarantee at all —
 // only the OS supervisor's retry, uncapped. `KeepAlive` with no
 // `ThrottleInterval` lets launchd relaunch on its ~10s default, so a daemon that

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -1543,12 +1543,29 @@ export function writeOwnerOnlyServiceManifest(filePath: string, content: string)
  * credential at all. Routine runs authenticate through the per-account
  * CLAUDE_CONFIG_DIR login on this device, exactly like an interactive
  * `agents run`, so no credential ever touches the service manifest.
+ *
+ * RUSH-2639: launchd does NOT inherit `launchctl load`'s caller's process
+ * environment — a spawned daemon only ever sees the login session's default
+ * env plus whatever this dict adds/overrides. Before this fix the dict carried
+ * only PATH, so HOME resolved to the launchd session's own value regardless of
+ * what HOME the process that generated (and loaded) the plist was running
+ * under. In production that's a no-op (the login session's HOME already is the
+ * real HOME), but under a hermetic test harness that redirects HOME to a
+ * fork-private sandbox, a launchd-started daemon silently escaped the sandbox
+ * and bootstrapped `~/.agents` (.cache/.history/.system/routines) in the
+ * developer's/runner's REAL home. Baking HOME (and the AGENTS_REAL_HOME seam
+ * every version-home consumer honors, see tests/setup.ts) into the plist at
+ * generation time makes the launchd child inherit the SAME home the caller
+ * resolved, exactly like the plain detached-spawn path already does via
+ * `env: {...process.env}`.
  */
 export function generateLaunchdPlist(
   agentsBin: string = getAgentsBinPath(),
 ): string {
   const launch = getDaemonLaunch(agentsBin);
   const logPath = getDaemonLogPath();
+  const home = process.env.HOME || os.homedir();
+  const realHome = process.env.AGENTS_REAL_HOME || home;
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -1574,6 +1591,10 @@ ${[launch.command, ...launch.args].map((arg) => `    <string>${xmlEscape(arg)}</
   <dict>
     <key>PATH</key>
     <string>${daemonPathValue(agentsBin, ['/usr/local/bin', '/usr/bin', '/bin', '/opt/homebrew/bin', `${os.homedir()}/.bun/bin`])}</string>
+    <key>HOME</key>
+    <string>${xmlEscape(home)}</string>
+    <key>AGENTS_REAL_HOME</key>
+    <string>${xmlEscape(realHome)}</string>
   </dict>
 </dict>
 </plist>`;
@@ -1591,12 +1612,21 @@ function systemdExecArg(value: string): string {
  * credential at all. Routine runs authenticate through the per-account
  * CLAUDE_CONFIG_DIR login on this device, exactly like an interactive
  * `agents run`, so no credential ever touches the unit file.
+ *
+ * RUSH-2639: same seam as `generateLaunchdPlist` — a systemd --user unit is
+ * started by the user's systemd instance, not the process that generated the
+ * unit, so HOME is whatever that session provides unless this file pins it.
+ * Baking HOME (and AGENTS_REAL_HOME) in at generation time keeps a
+ * hermetic-test-started unit inside its sandbox instead of resolving against
+ * the real account home.
  */
 export function generateSystemdUnit(
   agentsBin: string = getAgentsBinPath(),
 ): string {
   const launch = getDaemonLaunch(agentsBin);
   const execStart = [launch.command, ...launch.args].map(systemdExecArg).join(' ');
+  const home = process.env.HOME || os.homedir();
+  const realHome = process.env.AGENTS_REAL_HOME || home;
 
   return `[Unit]
 Description=Agents Daemon - Scheduled Job Runner
@@ -1610,6 +1640,8 @@ ExecStart=${execStart}
 Restart=always
 RestartSec=${DAEMON_THROTTLE_SECONDS}
 Environment=PATH=${daemonPathValue(agentsBin, ['/usr/local/bin', '/usr/bin', '/bin'])}
+Environment=HOME=${home}
+Environment=AGENTS_REAL_HOME=${realHome}
 
 [Install]
 WantedBy=default.target`;


### PR DESCRIPTION
**fix** — reopened RUSH-2639, root cause + regression tests.

## What broke

PR #2663 fixed the `tests/setup.ts` HOME redirect, but release 1.22.40's macOS Node 22/24 CI legs still hit the RUSH-2639 hermeticity tripwire:

```
Error: hermeticity leak (RUSH-2639): the real user dir (/Users/runner/.agents) gained, lost,
or modified a top-level entry during this test file. ... Before: null. After:
.cache:128:...|.history:128:...|.system:256:...|routines:64:...
```
(https://github.com/phnx-labs/agi-cli/actions/runs/31872085976/job/94982211142, `src/commands/sessions.test.ts`)

## Root cause

`launchctl load` / `systemctl start` do **not** inherit the calling process's environment — a service-manager-started daemon only ever sees the login session's own env plus whatever the manifest's `EnvironmentVariables` dict adds. `generateLaunchdPlist`/`generateSystemdUnit` (`apps/cli/src/lib/daemon.ts`) only ever baked in `PATH`:

```
apps/cli/src/lib/daemon.ts:1590 (pre-fix)
  <key>EnvironmentVariables</key>
  <dict>
    <key>PATH</key>
    <string>...</string>
  </dict>
```

In production that's a no-op (the login session's `HOME` already is the real `HOME`). Under the hermetic test harness — which redirects `HOME` to a fork-private sandbox before any test file's imports run (`apps/cli/tests/setup.ts:57`) — a launchd-started daemon silently escaped the sandbox and bootstrapped a real `~/.agents` on the CI runner, because it resolved `os.homedir()` against the login session's real `HOME`, not the sandbox `HOME` the calling test set. Every existing launchd-shim test in `daemon.test.ts` masked this: they all spawn the stand-in child with `env: {...process.env}` inherited from the calling test process, which is realistic for the detached-spawn path but NOT for launchd/systemd — so none of them ever exercised the actual non-inheriting behavior.

## Fix

Bake the *caller's* `HOME` (and `AGENTS_REAL_HOME`) into both `generateLaunchdPlist` and `generateSystemdUnit` at generation time, so a service-manager-started daemon inherits the same home the generating process resolved.

## Verification

**Unit-level (Linux, this sandbox — `yosemite-m1`):**
```
CI=1 node ./node_modules/vitest/vitest.mjs run src/lib/daemon.test.ts -t "RUSH-2639"
 Test Files  1 passed (1)
      Tests  3 passed | 79 skipped (82)
```

**Full local suite (Linux, agent-identity env vars stripped, matching the last verified RUSH-2639 comment):**
```
 Test Files  859 passed | 6 skipped (865)
      Tests  12123 passed | 103 skipped (12226)
```

**Real macOS reproduction + regression proof (`mac-mini`, via a scratch clone at `~/scratch/rush-2639-verify`, never the interactive checkout — no GUI, no unshimmed `launchctl`, no real `LaunchAgent` touched):**

The new darwin-only test (`startDaemon — launchd does not inherit the caller env (RUSH-2639)`) drives the real `startDaemon()` → `platform === 'darwin'` → `launchctl load` branch, with `launchctl` shimmed to a script that parses the *real generated plist* and applies only its `EnvironmentVariables` against a deliberately foreign base env (no `HOME` at all) — mirroring what real launchd does, unlike the file's other shims.

With the fix (`HEAD`):
```
✓ src/lib/daemon.test.ts (82 tests | 78 skipped) 738ms
    ✓ a launchd-started daemon resolves the SANDBOX HOME baked into the plist, never the login session default 733ms
 Test Files  1 passed (1)
      Tests  4 passed | 78 skipped (82)
```

With the fix mechanically reverted in the same scratch clone (`generateLaunchdPlist`/`generateSystemdUnit` stripped back to PATH-only), all 4 new tests fail — proving they're real regression tests, not tautologies:
```
FAIL src/lib/daemon.test.ts > ... > bakes the CALLER's HOME into the plist EnvironmentVariables dict, not just PATH
FAIL src/lib/daemon.test.ts > ... > honors a distinct AGENTS_REAL_HOME rather than collapsing it into HOME
FAIL src/lib/daemon.test.ts > ... > bakes the CALLER's HOME into the systemd unit, not just PATH
FAIL src/lib/daemon.test.ts > startDaemon — launchd does not inherit the caller env (RUSH-2639) > a launchd-started daemon resolves the SANDBOX HOME baked into the plist, never the login session default
  AssertionError: expected null to be '/tmp/agd-2639-launchd-VPWaNl/sandbox-home'
 Test Files  1 failed (1)
      Tests  4 failed | 78 skipped (82)
```

**No real macOS state touched:** the real `com.phnx-labs.agents-daemon.plist` on mac-mini is untouched (`stat` shows `Aug 12 18:25:20`, predating this session) and the real daemon (pid 41261) stayed alive throughout — the shim never issued a real `launchctl load`/`unload`, and the scratch clone (`~/scratch/rush-2639-verify`) was removed after verification.

## Scope

`daemon.ts` and `daemon.test.ts` only. No changes to `sessions.test.ts`, `tests/setup.ts`, RUSH-2545, the release branch, versions, CHANGELOG, or release scripts.