### PR TITLE
fix(doctor): RUSH-2705 — name the exact removal command for duplicates --fix will not purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **`agents doctor --fix` names the exact removal command for a duplicate install it will not purge, and the multi-install banner only advertises `--fix` when it can really resolve the peer (RUSH-2705).** A healthy `>=1.22.30` duplicate
+  global (for example a second install under nvm) was detected and nagged about on
+  every command, but `--fix` deliberately never deletes it and ended on
+  "Everything in sync" — the advertised remedy was a no-op, so the nag returned
+  forever. `doctor --fix` and the post-upgrade purge now list such peers with the
+  `npm uninstall -g --prefix <peer prefix> @phnx-labs/agents-cli` command that
+  removes them, and the startup banner prints that same command instead of
+  pointing at `--fix`. Auto-purge itself is unchanged (npx-cache / unsafe-legacy /
+  pre-1.22.30 copies only; the running copy is never deleted). Source:
+  `apps/cli/src/lib/self-update.ts`, `apps/cli/src/commands/doctor.ts`,
+  `apps/cli/src/bootstrap.ts`.
+
 - **`agents open` resumes a session from an `agents://` deep link, and registers the OS URL-scheme handler.** A rendered artifact (plan/report) can now carry an
   `agents://session/<id>` link in its provenance line; clicking it hands off to the
   OS, which runs `agents open <url>`, parses it, and routes the id into the existing

--- a/apps/cli/src/bootstrap.ts
+++ b/apps/cli/src/bootstrap.ts
@@ -375,6 +375,7 @@ import {
   resolveMultiInstallInventory,
   remediateStaleAgentsCliInstalls,
   resolveRunningPackageRoot,
+  manualUninstallCommand,
   type UpdateCheckCache,
 } from './lib/self-update.js';
 const UPDATE_CHECK_FILE = getUpdateCheckPath();
@@ -428,9 +429,22 @@ function maybeWarnMultiInstall(): void {
   for (const info of inventory) {
     console.error(chalk.gray(`  ${info.packageRoot}  ${info.version}  (${info.note})`));
   }
-  console.error(chalk.gray(
-    'Upgrades apply to the running copy. Purge npx-cache / legacy / pre-1.22.30 copies with: agents doctor --fix',
-  ));
+  // RUSH-2705: only advertise `agents doctor --fix` for copies it will really
+  // delete. A healthy duplicate (>=1.22.30, not npx-cache, not legacy) is
+  // deliberately never auto-purged, so pointing at --fix for it is a remedy
+  // that no-ops forever — name the manual removal command instead.
+  const peers = inventory.filter((info) => !info.running);
+  console.error(chalk.gray('Upgrades apply to the running copy.'));
+  if (peers.some((info) => info.autoPurgeable)) {
+    console.error(chalk.gray(
+      'Purge npx-cache / legacy / pre-1.22.30 copies with: agents doctor --fix',
+    ));
+  }
+  for (const peer of peers.filter((info) => !info.autoPurgeable)) {
+    console.error(chalk.gray(
+      `Remove the ${peer.version} copy at ${peer.packageRoot} with: ${manualUninstallCommand(peer.packageRoot)}`,
+    ));
+  }
 
   try {
     fs.mkdirSync(path.dirname(sentinel), { recursive: true });
@@ -867,6 +881,13 @@ async function runUpgrade(version: string | undefined, options: UpgradeOptions):
           if (purge.failed.length > 0) {
             console.log(chalk.yellow(
               `Could not purge ${purge.failed.length} stale install${purge.failed.length === 1 ? '' : 's'}; re-run agents doctor --fix.`,
+            ));
+          }
+          // RUSH-2705: healthy duplicates are never auto-purged — name the
+          // command that removes them instead of leaving a silent nag behind.
+          for (const u of purge.unresolved) {
+            console.log(chalk.gray(
+              `Duplicate ${u.version} at ${u.packageRoot} left in place; remove it with: ${u.manualRemoveCommand}`,
             ));
           }
         } catch {

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -86,7 +86,7 @@ import { detectAgentsBinaryShadows } from '../lib/binary-shadow.js';
 import {
   remediateStaleAgentsCliInstalls,
   resolveRunningPackageRoot,
-  type PurgeRemovableInstallsResult,
+  type RemediateStaleInstallsResult,
 } from '../lib/self-update.js';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -1378,7 +1378,7 @@ function renderHookRuntimeRepairText(repair: HookRuntimeRepairReport): void {
  * `doctor <agent>@<version> --fix` only heals that version home and must not
  * touch other CLI installs on the box.
  */
-function purgeStaleAgentsCliCopies(_opts: DoctorOptions): PurgeRemovableInstallsResult | null {
+function purgeStaleAgentsCliCopies(_opts: DoctorOptions): RemediateStaleInstallsResult | null {
   let runningRoot: string;
   try {
     // dist/commands/doctor.js (or src/commands/doctor.ts under vitest) —
@@ -1393,8 +1393,8 @@ function purgeStaleAgentsCliCopies(_opts: DoctorOptions): PurgeRemovableInstalls
   });
 }
 
-function renderStaleInstallPurgeText(purge: PurgeRemovableInstallsResult): void {
-  if (purge.removed.length === 0 && purge.failed.length === 0) return;
+function renderStaleInstallPurgeText(purge: RemediateStaleInstallsResult): void {
+  if (purge.removed.length === 0 && purge.failed.length === 0 && purge.unresolved.length === 0) return;
   console.log(chalk.bold('\nStale agents-cli installs'));
   for (const r of purge.removed) {
     const why = r.reasons.join(', ');
@@ -1406,6 +1406,15 @@ function renderStaleInstallPurgeText(purge: PurgeRemovableInstallsResult): void 
     console.log(
       `  ${chalk.red('hold  ')} ${chalk.gray(`${f.packageRoot}  ${f.version}  — ${f.error}`)}`,
     );
+  }
+  // RUSH-2705: a healthy duplicate (>=1.22.30, not npx-cache, not legacy) is
+  // deliberately never auto-purged, so --fix must hand back the command that
+  // does remove it instead of ending on a bare "everything in sync".
+  for (const u of purge.unresolved) {
+    console.log(
+      `  ${chalk.yellow('manual')} ${chalk.gray(`${u.packageRoot}  ${u.version}  — a healthy duplicate --fix will not delete; remove it with:`)}`,
+    );
+    console.log(`         ${chalk.bold(u.manualRemoveCommand)}`);
   }
 }
 

--- a/apps/cli/src/lib/self-update.test.ts
+++ b/apps/cli/src/lib/self-update.test.ts
@@ -19,6 +19,7 @@ import {
   isMultiInstallScanFresh,
   isNpxCacheInstall,
   isTouchIdStormFixedVersion,
+  manualUninstallCommand,
   MULTI_INSTALL_SCAN_TTL_MS,
   purgeRemovableAgentsCliInstalls,
   readInstalledVersion,
@@ -566,7 +567,48 @@ describe('buildMultiInstallInventory', () => {
       packageRoot: runningRoot,
       version: '1.20.88',
       note: 'running; unsafe legacy helper installer — remove this copy',
+      running: true,
+      autoPurgeable: false,
     }]);
+  });
+
+  // RUSH-2705: the multi-install banner chooses its remedy from these flags —
+  // `agents doctor --fix` for auto-purgeable peers, a manual command otherwise.
+  it('flags an npx-cache peer auto-purgeable but not a healthy >=1.22.30 duplicate', () => {
+    const runningRoot = '/opt/homebrew/lib/node_modules/@phnx-labs/agents-cli';
+    const nvmRoot = '/home/u/.nvm/versions/node/v24.15.0/lib/node_modules/@phnx-labs/agents-cli';
+    const npxRoot = '/home/u/.npm/_npx/abc123/node_modules/@phnx-labs/agents-cli';
+    const inventory = buildMultiInstallInventory(runningRoot, '1.22.39', [
+      { packageRoot: runningRoot, version: '1.22.39', atomicHelperInstall: true },
+      { packageRoot: nvmRoot, version: '1.22.37', atomicHelperInstall: true },
+      { packageRoot: npxRoot, version: '1.20.65', atomicHelperInstall: true },
+    ]);
+
+    const byRoot = new Map(inventory.map((entry) => [entry.packageRoot, entry]));
+    expect(byRoot.get(runningRoot)).toMatchObject({ running: true, autoPurgeable: false });
+    // The stale-but-safe global: detected, never auto-purged.
+    expect(byRoot.get(nvmRoot)).toMatchObject({ running: false, autoPurgeable: false });
+    // npx-cache + pre-1.22.30 with a fixed peer: --fix removes it.
+    expect(byRoot.get(npxRoot)).toMatchObject({ running: false, autoPurgeable: true });
+  });
+});
+
+describe('manualUninstallCommand (RUSH-2705)', () => {
+  it('pins the peer npm prefix for a POSIX global layout (the nvm duplicate case)', () => {
+    const root = '/home/u/.nvm/versions/node/v24.15.0/lib/node_modules/@phnx-labs/agents-cli';
+    expect(manualUninstallCommand(root)).toBe(
+      'npm uninstall -g --prefix /home/u/.nvm/versions/node/v24.15.0 @phnx-labs/agents-cli',
+    );
+  });
+
+  it('uses bun for a bun global layout', () => {
+    const root = path.join(os.homedir(), '.bun', 'install', 'global', 'node_modules', '@phnx-labs', 'agents-cli');
+    expect(manualUninstallCommand(root)).toBe('bun remove -g @phnx-labs/agents-cli');
+  });
+
+  it('falls back to deleting the directory when no npm prefix owns the tree', () => {
+    const root = '/srv/checkouts/agents-cli';
+    expect(manualUninstallCommand(root)).toBe(`rm -rf '${root}'`);
   });
 });
 
@@ -581,6 +623,8 @@ describe('multi-install scan cache (RUSH-2324)', () => {
     packageRoot: runningRoot,
     version: '1.22.35',
     note: 'running',
+    running: true,
+    autoPurgeable: false,
   }];
 
   function makeCache(overrides: Partial<MultiInstallScanCache> = {}): MultiInstallScanCache {
@@ -623,6 +667,18 @@ describe('multi-install scan cache (RUSH-2324)', () => {
     expect(readMultiInstallScanCache(bad)).toBeNull();
   });
 
+  it('rejects a pre-RUSH-2705 cache whose entries lack the remedy flags', () => {
+    const dir = makeTempDir('multi-install-cache-old-shape');
+    const file = path.join(dir, '.multi-install-scan');
+    fs.writeFileSync(file, JSON.stringify(makeCache({
+      // The shape written before running/autoPurgeable existed.
+      inventory: [
+        { packageRoot: runningRoot, version: '1.22.35', note: 'running' },
+      ] as unknown as MultiInstallScanCache['inventory'],
+    })));
+    expect(readMultiInstallScanCache(file)).toBeNull();
+  });
+
   it('resolveMultiInstallInventory returns the cached inventory without re-scanning when fresh', () => {
     const dir = makeTempDir('multi-install-resolve');
     const file = path.join(dir, '.multi-install-scan');
@@ -632,8 +688,8 @@ describe('multi-install scan cache (RUSH-2324)', () => {
     const seeded = makeCache({
       pathEnv: '',
       inventory: [
-        { packageRoot: runningRoot, version: '1.22.35', note: 'running' },
-        { packageRoot: '/other/lib/node_modules/@phnx-labs/agents-cli', version: '1.20.0', note: 'discovered install' },
+        { packageRoot: runningRoot, version: '1.22.35', note: 'running', running: true, autoPurgeable: false },
+        { packageRoot: '/other/lib/node_modules/@phnx-labs/agents-cli', version: '1.20.0', note: 'discovered install', running: false, autoPurgeable: true },
       ],
     });
     writeMultiInstallScanCache(file, seeded);
@@ -664,8 +720,8 @@ describe('multi-install scan cache (RUSH-2324)', () => {
       pathEnv: '',
       scannedAt: NOW - MULTI_INSTALL_SCAN_TTL_MS - 1,
       inventory: [
-        { packageRoot: runningRoot, version: '1.22.35', note: 'running' },
-        { packageRoot: '/stale/other', version: '0.0.1', note: 'discovered install' },
+        { packageRoot: runningRoot, version: '1.22.35', note: 'running', running: true, autoPurgeable: false },
+        { packageRoot: '/stale/other', version: '0.0.1', note: 'discovered install', running: false, autoPurgeable: false },
       ],
     });
     writeMultiInstallScanCache(file, seeded);
@@ -686,7 +742,7 @@ describe('multi-install scan cache (RUSH-2324)', () => {
     );
     // Empty PATH + empty known roots → inventory is just the running copy.
     expect(resolved).toEqual([
-      { packageRoot: runningRoot, version: '1.22.35', note: 'running' },
+      { packageRoot: runningRoot, version: '1.22.35', note: 'running', running: true, autoPurgeable: false },
     ]);
     const rewritten = readMultiInstallScanCache(file);
     expect(rewritten?.scannedAt).toBe(NOW);
@@ -873,5 +929,51 @@ describe('classifyRemovableAgentsCliInstalls / purge (RUSH-2415)', () => {
     expect(result.removed.some((r) => r.packageRoot === npxCanonical)).toBe(true);
     expect(fs.existsSync(npxRoot)).toBe(false);
     expect(fs.existsSync(fixedRoot)).toBe(true);
+  });
+
+  // RUSH-2705: the bug this pins — a healthy >=1.22.30 duplicate was detected
+  // (and nagged about) but never purged, while --fix reported nothing at all.
+  it.skipIf(process.platform === 'win32')('remediateStaleAgentsCliInstalls reports a healthy duplicate as unresolved with its exact removal command', () => {
+    const homeDir = makeTempDir('remediate-unresolved');
+    const runningRoot = path.join(homeDir, 'brew', 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
+    fs.mkdirSync(path.join(runningRoot, 'dist', 'lib'), { recursive: true });
+    fs.writeFileSync(
+      path.join(runningRoot, 'package.json'),
+      JSON.stringify({ name: '@phnx-labs/agents-cli', version: '1.22.39' }),
+    );
+    fs.writeFileSync(path.join(runningRoot, 'dist', 'lib', 'app-bundle-install.js'), '// atomic\n');
+
+    // The nvm-shaped peer: >=1.22.30, atomic helper, not npx-cache. --fix must
+    // leave it on disk and hand back the npm uninstall pinned to its prefix.
+    const nvmPrefix = path.join(homeDir, '.nvm', 'versions', 'node', 'v24.15.0');
+    const dupRoot = path.join(nvmPrefix, 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
+    fs.mkdirSync(path.join(dupRoot, 'dist', 'lib'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dupRoot, 'package.json'),
+      JSON.stringify({ name: '@phnx-labs/agents-cli', version: '1.22.37' }),
+    );
+    fs.writeFileSync(path.join(dupRoot, 'dist', 'lib', 'app-bundle-install.js'), '// atomic\n');
+
+    const result = remediateStaleAgentsCliInstalls({
+      runningRoot,
+      runningVersion: '1.22.39',
+      pathEnv: '',
+      findOpts: {
+        homeDir,
+        npmCacheDir: path.join(homeDir, 'no-npm-cache'),
+        globalNodeModulesDirs: [path.join(nvmPrefix, 'lib', 'node_modules')],
+        fnmDir: path.join(homeDir, 'empty-fnm'),
+      },
+    });
+
+    expect(result.removed).toHaveLength(0);
+    expect(fs.existsSync(dupRoot)).toBe(true);
+    expect(result.unresolved).toHaveLength(1);
+    const unresolved = result.unresolved[0];
+    expect(unresolved.version).toBe('1.22.37');
+    expect(fs.realpathSync(unresolved.packageRoot)).toBe(fs.realpathSync(dupRoot));
+    expect(unresolved.manualRemoveCommand).toBe(
+      `npm uninstall -g --prefix ${fs.realpathSync(nvmPrefix)} @phnx-labs/agents-cli`,
+    );
   });
 });

--- a/apps/cli/src/lib/self-update.test.ts
+++ b/apps/cli/src/lib/self-update.test.ts
@@ -597,7 +597,7 @@ describe('manualUninstallCommand (RUSH-2705)', () => {
   it('pins the peer npm prefix for a POSIX global layout (the nvm duplicate case)', () => {
     const root = '/home/u/.nvm/versions/node/v24.15.0/lib/node_modules/@phnx-labs/agents-cli';
     expect(manualUninstallCommand(root)).toBe(
-      'npm uninstall -g --prefix /home/u/.nvm/versions/node/v24.15.0 @phnx-labs/agents-cli',
+      "npm uninstall -g --prefix '/home/u/.nvm/versions/node/v24.15.0' @phnx-labs/agents-cli",
     );
   });
 
@@ -973,7 +973,7 @@ describe('classifyRemovableAgentsCliInstalls / purge (RUSH-2415)', () => {
     expect(unresolved.version).toBe('1.22.37');
     expect(fs.realpathSync(unresolved.packageRoot)).toBe(fs.realpathSync(dupRoot));
     expect(unresolved.manualRemoveCommand).toBe(
-      `npm uninstall -g --prefix ${fs.realpathSync(nvmPrefix)} @phnx-labs/agents-cli`,
+      `npm uninstall -g --prefix '${fs.realpathSync(nvmPrefix)}' @phnx-labs/agents-cli`,
     );
   });
 });

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -177,6 +177,15 @@ export function readMultiInstallScanCache(file: string): MultiInstallScanCache |
     ) {
       return null;
     }
+    // A cache written before the entries carried running/autoPurgeable
+    // (RUSH-2705) cannot drive the banner's remedy choice — treat it as
+    // corrupt so the caller re-scans rather than mis-advertising --fix.
+    const entries = raw.inventory as Array<Partial<MultiInstallInventoryEntry>>;
+    if (entries.some(
+      (entry) => typeof entry?.running !== 'boolean' || typeof entry?.autoPurgeable !== 'boolean',
+    )) {
+      return null;
+    }
     return raw as MultiInstallScanCache;
   } catch {
     return null;
@@ -515,6 +524,68 @@ export interface MultiInstallInventoryEntry {
   packageRoot: string;
   version: string;
   note: string;
+  /** True for the copy that is currently executing. */
+  running: boolean;
+  /**
+   * True when a bare `agents doctor --fix` deletes this copy (RUSH-2415:
+   * npx-cache / unsafe-legacy / pre-1.22.30 with a fixed peer). False for the
+   * running copy and for healthy duplicates --fix will not touch — those need
+   * the manual command from manualUninstallCommand() (RUSH-2705).
+   */
+  autoPurgeable: boolean;
+}
+
+/** Best-effort canonical path; keeps the input when realpath fails. */
+function canonicalPath(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
+ * Ensure the running copy participates in classification (the "has a fixed
+ * peer" check) even when the PATH scan missed it — a source tree or unusual
+ * layout. The running root is never deleted regardless.
+ */
+function withRunningInstall(
+  installs: AgentsCliInstall[],
+  runningRoot: string,
+  runningVersion: string,
+): AgentsCliInstall[] {
+  const runningCanonical = canonicalPath(runningRoot);
+  const already = installs.some(
+    (install) => canonicalPath(install.packageRoot) === runningCanonical,
+  );
+  if (already) return installs;
+  return [...installs, {
+    packageRoot: runningRoot,
+    version: runningVersion,
+    // Unknown for a synthetic entry — classify only uses version for the
+    // fixed-peer check; the running root is never deleted regardless.
+    atomicHelperInstall: true,
+  }];
+}
+
+/**
+ * The exact shell command that removes the install at `packageRoot` by hand —
+ * the remedy for duplicates `doctor --fix` deliberately will not purge
+ * (RUSH-2705). `--prefix` pins the target tree no matter which npm binary
+ * PATH resolves, mirroring installPackageIntoPrefix.
+ */
+export function manualUninstallCommand(packageRoot: string): string {
+  const resolved = path.resolve(packageRoot);
+  if (detectPackageManager(resolved) === 'bun') {
+    return `bun remove -g ${NPM_PACKAGE_NAME}`;
+  }
+  try {
+    return `npm uninstall -g --prefix ${deriveGlobalPrefix(resolved)} ${NPM_PACKAGE_NAME}`;
+  } catch {
+    // Not inside a node_modules tree — no npm prefix owns it; deleting the
+    // directory is the only removal there is.
+    return `rm -rf '${resolved}'`;
+  }
 }
 
 export function buildMultiInstallInventory(
@@ -522,10 +593,24 @@ export function buildMultiInstallInventory(
   runningVersion: string,
   installs: AgentsCliInstall[],
 ): MultiInstallInventoryEntry[] {
+  const runningCanonical = canonicalPath(runningRoot);
+  const removableRoots = new Set(
+    classifyRemovableAgentsCliInstalls(
+      runningRoot,
+      withRunningInstall(installs, runningRoot, runningVersion),
+    ).map((candidate) => candidate.packageRoot),
+  );
   const byRoot = new Map<string, MultiInstallInventoryEntry>();
-  byRoot.set(runningRoot, { packageRoot: runningRoot, version: runningVersion, note: 'running' });
+  byRoot.set(runningRoot, {
+    packageRoot: runningRoot,
+    version: runningVersion,
+    note: 'running',
+    running: true,
+    autoPurgeable: false,
+  });
   for (const install of installs) {
-    const notes = [install.packageRoot === runningRoot
+    const running = canonicalPath(install.packageRoot) === runningCanonical;
+    const notes = [running
       ? 'running'
       : install.binPath
         ? `agents on PATH: ${install.binPath}`
@@ -535,6 +620,8 @@ export function buildMultiInstallInventory(
       packageRoot: install.packageRoot,
       version: install.version,
       note: notes.join('; '),
+      running,
+      autoPurgeable: !running && removableRoots.has(canonicalPath(install.packageRoot)),
     });
   }
   return [...byRoot.values()];
@@ -715,6 +802,25 @@ export function purgeRemovableAgentsCliInstalls(
   return result;
 }
 
+/** A detected duplicate that `doctor --fix` will not purge (RUSH-2705). */
+export interface UnresolvedDuplicateInstall {
+  packageRoot: string;
+  version: string;
+  /** Exact shell command that removes this copy by hand. */
+  manualRemoveCommand: string;
+}
+
+export interface RemediateStaleInstallsResult extends PurgeRemovableInstallsResult {
+  inventory: MultiInstallInventoryEntry[];
+  candidates: RemovableAgentsCliInstall[];
+  /**
+   * Duplicates detected but deliberately left alone (healthy >=1.22.30
+   * globals). The caller must surface manualRemoveCommand — otherwise the
+   * multi-install warning keeps firing with no working remedy (RUSH-2705).
+   */
+  unresolved: UnresolvedDuplicateInstall[];
+}
+
 /**
  * Scan + classify + purge in one call. Used by `agents doctor --fix` and
  * `agents upgrade` so both paths remediate the same set of latent copies.
@@ -725,46 +831,32 @@ export function remediateStaleAgentsCliInstalls(opts: {
   pathEnv?: string;
   findOpts?: FindAgentsCliInstallsOptions;
   dryRun?: boolean;
-}): PurgeRemovableInstallsResult & {
-  inventory: MultiInstallInventoryEntry[];
-  candidates: RemovableAgentsCliInstall[];
-} {
+}): RemediateStaleInstallsResult {
   const pathEnv = opts.pathEnv ?? (process.env.PATH || '');
-  const installs = findAgentsCliInstalls(pathEnv, opts.findOpts);
+  let installs = findAgentsCliInstalls(pathEnv, opts.findOpts);
   // Ensure the running root participates in "has a fixed peer" even when the
   // PATH scan missed it (source tree, unusual layout).
   if (opts.runningVersion) {
-    const already = installs.some((i) => {
-      try {
-        return fs.realpathSync(i.packageRoot) === fs.realpathSync(opts.runningRoot);
-      } catch {
-        return i.packageRoot === opts.runningRoot;
-      }
-    });
-    if (!already) {
-      installs.push({
-        packageRoot: opts.runningRoot,
-        version: opts.runningVersion,
-        // Unknown for a synthetic entry — classify only uses version for the
-        // fixed-peer check; the running root is never deleted regardless.
-        atomicHelperInstall: true,
-      });
-    }
+    installs = withRunningInstall(installs, opts.runningRoot, opts.runningVersion);
   }
   const candidates = classifyRemovableAgentsCliInstalls(opts.runningRoot, installs);
   const purge = purgeRemovableAgentsCliInstalls(candidates, {
     dryRun: opts.dryRun,
     runningRoot: opts.runningRoot,
   });
-  return {
-    ...purge,
-    candidates,
-    inventory: buildMultiInstallInventory(
-      opts.runningRoot,
-      opts.runningVersion ?? 'unknown',
-      installs,
-    ),
-  };
+  const inventory = buildMultiInstallInventory(
+    opts.runningRoot,
+    opts.runningVersion ?? 'unknown',
+    installs,
+  );
+  const unresolved = inventory
+    .filter((entry) => !entry.running && !entry.autoPurgeable)
+    .map((entry) => ({
+      packageRoot: entry.packageRoot,
+      version: entry.version,
+      manualRemoveCommand: manualUninstallCommand(entry.packageRoot),
+    }));
+  return { ...purge, candidates, inventory, unresolved };
 }
 
 function childDirectories(parent: string): string[] {

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -580,7 +580,7 @@ export function manualUninstallCommand(packageRoot: string): string {
     return `bun remove -g ${NPM_PACKAGE_NAME}`;
   }
   try {
-    return `npm uninstall -g --prefix ${deriveGlobalPrefix(resolved)} ${NPM_PACKAGE_NAME}`;
+    return `npm uninstall -g --prefix '${deriveGlobalPrefix(resolved)}' ${NPM_PACKAGE_NAME}`;
   } catch {
     // Not inside a node_modules tree — no npm prefix owns it; deleting the
     // directory is the only removal there is.


### PR DESCRIPTION
Bug fix — `agents doctor --fix` advertised itself as the remedy for a duplicate install it deliberately never purges (RUSH-2705).

## Root cause

- `apps/cli/src/bootstrap.ts:430` — the multi-install banner fired on any second install and unconditionally said `Purge npx-cache / legacy / pre-1.22.30 copies with: agents doctor --fix`.
- `apps/cli/src/lib/self-update.ts` `classifyRemovableAgentsCliInstalls()` — auto-purge is limited (by design, RUSH-2415) to `npx-cache` / `unsafe-legacy-helper` / `pre-fixed-version` roots. A healthy `>=1.22.30` global (e.g. a second nvm install at 1.22.37) gets `reasons.length === 0` and is never a candidate.
- `apps/cli/src/commands/doctor.ts` `renderStaleInstallPurgeText()` — returned early when nothing was removed or failed, so `--fix` ended on `✓ Everything in sync — nothing to heal` while the nag returned on every command, forever.

## What changed

- **`self-update.ts`**: inventory entries now carry `running` / `autoPurgeable`; new `manualUninstallCommand()` derives the exact `npm uninstall -g --prefix <peer prefix> @phnx-labs/agents-cli` (or `bun remove -g`, or `rm -rf` for an unmanaged tree); `remediateStaleAgentsCliInstalls()` returns the `unresolved` peers. The scan cache rejects pre-flag entry shapes so a stale cache cannot mis-advertise the remedy.
- **`doctor.ts`**: `--fix` renders each unresolved duplicate with its exact removal command (`manual` rows) instead of staying silent.
- **`bootstrap.ts`**: the banner advertises `agents doctor --fix` only when an auto-purgeable peer exists; for healthy duplicates it prints the manual command. The post-upgrade purge message does the same.

RUSH-2415 safety invariants unchanged: the running copy is never deleted, a lone stale install is never stranded, auto-purge scope is untouched (verified: mixed sandbox purges the npx-cache copy and leaves the healthy duplicate).

## Run proof

Real before/after CLI transcript against a sandbox HOME containing a healthy 1.22.37 nvm duplicate — before: banner points at `--fix`, `--fix` prints `✓ Everything in sync` and leaves the copy; after: banner and `--fix` both print `npm uninstall -g --prefix /private/tmp/rush2705-sandbox/home/.nvm/versions/node/v24.15.0 @phnx-labs/agents-cli`, copy still safely on disk:

[![before/after transcript](https://share.agents-cli.sh/muqsitnawaz/agents-rush2705-proof-69112b522e4b0bc7.png)](https://share.agents-cli.sh/muqsitnawaz/agents-rush2705-proof-69112b522e4b0bc7)

## Tests

`apps/cli/src/lib/self-update.test.ts` — new: `manualUninstallCommand` (nvm/bun/unmanaged layouts), inventory flags for an npx-cache vs healthy peer, pre-RUSH-2705 cache shape rejection, and a remediate end-to-end pinning the detected-but-not-purgeable branch (`unresolved` carries the exact command, nothing deleted). Suites: self-update 56/56, doctor 54/54 pass; `tsc --noEmit` clean.

Ticket: RUSH-2705
