### PR TITLE
test(cli): fix Windows CRLF phantom-dirty in pullRepo strict + pullProjectTargets fixtures

### DIFF
--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -1075,6 +1075,14 @@ describe('pullRepo strict mode (default-branch-fast-forward)', () => {
     await simpleGit().raw(['init', '--bare', '-b', 'main', remote]);
     await simpleGit().clone(remote, author);
     await configIdentity(author);
+    // Commit `* -text` before anything clones this repo. On Windows CI the
+    // *checkout* during `git clone` runs with the machine-default autocrlf
+    // (true) before configIdentity() can set autocrlf=false on the fresh clone,
+    // so the local working tree comes out as CRLF while the index holds LF and
+    // status.isClean() sees a phantom modification — making pullRepo strict
+    // mode refuse with "dirty working tree". A committed .gitattributes wins
+    // over autocrlf at checkout time and prevents that.
+    fs.writeFileSync(path.join(author, '.gitattributes'), '* -text\n');
     await commitFile(author, 'README.md', 'v1\n', 'init');
     await simpleGit(author).push('origin', 'main');
 

--- a/apps/cli/src/lib/project-pull.test.ts
+++ b/apps/cli/src/lib/project-pull.test.ts
@@ -251,6 +251,14 @@ describe('pullProjectTargets', () => {
     await simpleGit().raw(['init', '--bare', '-b', 'main', remote]);
     await simpleGit().clone(remote, author);
     await configIdentity(author);
+    // Commit `* -text` before anything clones this repo. On Windows CI the
+    // *checkout* during `git clone` runs with the machine-default autocrlf
+    // (true) before configIdentity() can set autocrlf=false on the fresh clone,
+    // so the local working tree comes out as CRLF while the index holds LF and
+    // status.isClean() sees a phantom modification — making pullProjectTargets'
+    // strict pullRepo refuse a clean tree as dirty. A committed .gitattributes
+    // wins over autocrlf at checkout time and prevents that.
+    fs.writeFileSync(path.join(author, '.gitattributes'), '* -text\n');
     await commitFile(author, 'README.md', 'v1\n', 'init');
     await simpleGit(author).push('origin', 'main');
 


### PR DESCRIPTION
test-only — no runtime/behavior change.

## What

Two test fixtures create a git repo, set `core.autocrlf=false` only **after** cloning, and never commit a `.gitattributes`. On Windows CI the clone checkout already renormalized LF→CRLF, so `status.isClean()` sees a phantom modification and `pullRepo` strict mode refuses the clean tree as `"dirty working tree"`.

Failing Windows tests (latent on `main` — the cross-platform matrix rarely runs, so this only surfaced when PR #2622 tripped the `WINDOWS_EXPECTED` path filter):
- `git.test.ts` › pullRepo strict mode: *fast-forwards a clean checkout*, *reports success when up-to-date*, *blocks on a non-default branch*
- `project-pull.test.ts` › pullProjectTargets: *fast-forwards a clean checkout*

## Fix

Commit `* -text` `.gitattributes` before anything clones the fixture repo — the exact pattern the rest of `git.test.ts` already uses (lines 168/424/563/803). `.gitattributes` wins over autocrlf at checkout time, so the working tree comes out LF and reads clean on Windows.

## Verification

Linux unchanged: `git.test.ts` 73/73, `project-pull.test.ts` 36/36 pass locally. The real proof is the Windows leg of CI on this PR.

## Why it matters

This is the required `test` gate failure (via its `windows` leg) currently blocking **#2622**; landing this clears it for #2622 and any future Windows-touching PR.