### PR TITLE
fix(ext): the Foreman overlay no longer covers the Fleet session detail

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+- **The Foreman orb no longer covers the Fleet session detail.** The orb, its speaker
+  chip and its composer are a `position: fixed` bottom-right overlay, so the newest
+  Activity line in the session detail column rendered underneath them and could not be
+  scrolled clear (measured: 48-71px of the live `Bash:` line covered at a 430px column).
+  The detail column now reserves the overlay's footprint. The composer's placeholder is
+  also shortened to `Ask Foreman… (Enter to send)` — the old hint wrapped to a second
+  line that the one-row input clipped (measured 17px). Source:
+  `apps/ext/ui/settings/components/mission-control/floor.css`, `index.css`,
+  `components/foreman/ForemanOrb.tsx`.
+
 - **Fleet sessions list ranks by progress — idle work no longer hides below running.**
   The state-grouped Sessions list now surfaces a **Needs attention** band (live sessions
   that have stopped progressing — waiting on input, stalled, idle, or failed) *above* the

--- a/apps/ext/ui/settings/components/foreman/ForemanOrb.test.ts
+++ b/apps/ext/ui/settings/components/foreman/ForemanOrb.test.ts
@@ -15,10 +15,12 @@ import { join } from 'node:path'
 const orbPath = join(import.meta.dir, 'ForemanOrb.tsx')
 const indexCssPath = join(import.meta.dir, '../../index.css')
 const floorCssPath = join(import.meta.dir, '../mission-control/floor.css')
+const panelCssPath = join(import.meta.dir, '../panel/panel.css')
 
 const orb = readFileSync(orbPath, 'utf8')
 const indexCss = readFileSync(indexCssPath, 'utf8')
 const floorCss = readFileSync(floorCssPath, 'utf8')
+const panelCss = readFileSync(panelCssPath, 'utf8')
 
 /** The persistent overlay stack, from the real values in ForemanOrb.tsx. */
 const ORB_SIZE_ACTIVE = 56 // OrbBlob: `const size = big ? 56 : 40`
@@ -58,6 +60,14 @@ describe('Foreman overlay does not cover the surface behind it', () => {
 
   test('the Fleet detail column reserves that clearance', () => {
     const rule = floorCss.match(/\.swarmify-root \.detail-col \{[^}]*\}/)
+    expect(rule).not.toBeNull()
+    expect(rule![0]).toContain('padding-bottom: var(--foreman-overlay-clear)')
+  })
+
+  test('the Panel tab reserves that clearance', () => {
+    // Rendered as a sibling of the overlay (App.tsx), full height, own scrollbar —
+    // its bottom-right corner is under the orb exactly like the detail column's.
+    const rule = panelCss.match(/\.sw-panel-tab \{[^}]*\}/)
     expect(rule).not.toBeNull()
     expect(rule![0]).toContain('padding-bottom: var(--foreman-overlay-clear)')
   })

--- a/apps/ext/ui/settings/components/foreman/ForemanOrb.test.ts
+++ b/apps/ext/ui/settings/components/foreman/ForemanOrb.test.ts
@@ -1,0 +1,71 @@
+import { expect, test, describe } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Source-level regression guards for the two ways the floating Foreman overlay
+// broke the surface behind it (RUSH-1522 follow-up):
+//
+//  1. The orb root is `position: fixed; bottom: 16; right: 16`, so it floats over
+//     the Fleet detail column. With no reserved space the newest Activity line
+//     rendered underneath the composer and could not be scrolled clear — measured
+//     71px of the now-line covered at a 430px column.
+//  2. The composer is `rows={1}` at width 260. The old placeholder wrapped to a
+//     second line the one-row box then clipped — measured 17px of clipped text.
+
+const orbPath = join(import.meta.dir, 'ForemanOrb.tsx')
+const indexCssPath = join(import.meta.dir, '../../index.css')
+const floorCssPath = join(import.meta.dir, '../mission-control/floor.css')
+
+const orb = readFileSync(orbPath, 'utf8')
+const indexCss = readFileSync(indexCssPath, 'utf8')
+const floorCss = readFileSync(floorCssPath, 'utf8')
+
+/** The persistent overlay stack, from the real values in ForemanOrb.tsx. */
+const ORB_SIZE_ACTIVE = 56 // OrbBlob: `const size = big ? 56 : 40`
+const STACK_GAP = 10 // foreman-orb-root `gap: 10`
+const SPEAKER_HEIGHT = 19 // 10px/1.3 text + 2+2 padding + 2 border
+const COMPOSER_HEIGHT = 36 // 12.5px * 1.4 line + 8+8 padding + 2 border
+const BOTTOM_OFFSET = 16 // foreman-orb-root `bottom: 16`
+const OVERLAY_FOOTPRINT =
+  ORB_SIZE_ACTIVE + STACK_GAP + SPEAKER_HEIGHT + STACK_GAP + COMPOSER_HEIGHT + BOTTOM_OFFSET
+
+/** The composer's usable text width, from its inline style in ForemanOrb.tsx. */
+const COMPOSER_WIDTH = 260
+const COMPOSER_PADDING_X = 11
+const COMPOSER_BORDER = 1
+const COMPOSER_FONT_PX = 12.5
+// Inter averages ~0.5em per glyph for mixed-case Latin; the browser check that
+// motivated this test clipped a 44-character placeholder and fit a 28-character
+// one at this width, which brackets the cap below.
+const AVG_GLYPH_RATIO = 0.5
+const MAX_PLACEHOLDER_CHARS = Math.floor(
+  (COMPOSER_WIDTH - 2 * COMPOSER_PADDING_X - 2 * COMPOSER_BORDER) /
+    (COMPOSER_FONT_PX * AVG_GLYPH_RATIO),
+)
+
+describe('Foreman overlay does not cover the surface behind it', () => {
+  test('the orb root is a viewport-fixed bottom-right overlay', () => {
+    expect(orb).toContain("position: 'fixed'")
+    expect(orb).toMatch(/bottom:\s*16/)
+    expect(orb).toMatch(/right:\s*16/)
+  })
+
+  test('index.css declares a clearance at least the overlay footprint', () => {
+    const declared = indexCss.match(/--foreman-overlay-clear:\s*(\d+)px/)
+    expect(declared).not.toBeNull()
+    expect(Number(declared![1])).toBeGreaterThanOrEqual(OVERLAY_FOOTPRINT)
+  })
+
+  test('the Fleet detail column reserves that clearance', () => {
+    const rule = floorCss.match(/\.swarmify-root \.detail-col \{[^}]*\}/)
+    expect(rule).not.toBeNull()
+    expect(rule![0]).toContain('padding-bottom: var(--foreman-overlay-clear)')
+  })
+
+  test('the placeholder fits the one-row composer', () => {
+    expect(orb).toContain('rows={1}')
+    const placeholder = orb.match(/placeholder="([^"]+)"/)
+    expect(placeholder).not.toBeNull()
+    expect(placeholder![1].length).toBeLessThanOrEqual(MAX_PLACEHOLDER_CHARS)
+  })
+})

--- a/apps/ext/ui/settings/components/foreman/ForemanOrb.tsx
+++ b/apps/ext/ui/settings/components/foreman/ForemanOrb.tsx
@@ -298,6 +298,9 @@ export function ForemanOrb({ vscode }: ForemanOrbProps) {
         {speakerMuted ? 'silent' : 'voice'}
       </button>
 
+      {/* The placeholder must fit one row at width 260 — a longer hint wraps to a
+          second line that this rows={1} box then clips. Dictation is taught by the
+          orb's own press-and-hold title, not by the placeholder. */}
       <textarea
         className="foreman-orb-smart-input"
         value={smartInput}
@@ -308,7 +311,7 @@ export function ForemanOrb({ vscode }: ForemanOrbProps) {
             submitSmart()
           }
         }}
-        placeholder="Ask Foreman… (type or dictate, Enter to send)"
+        placeholder="Ask Foreman… (Enter to send)"
         rows={1}
         aria-label="Ask Foreman in smart mode"
         style={{

--- a/apps/ext/ui/settings/components/mission-control/floor.css
+++ b/apps/ext/ui/settings/components/mission-control/floor.css
@@ -214,7 +214,10 @@
 /* ============ LAYOUT: FEED (3-pane: scope . feed . detail) ============ */
 .swarmify-root .feed-col { flex: 1; min-width: 0; overflow: auto; display: flex; justify-content: center; }
 .swarmify-root .feed { width: 100%; max-width: 820px; padding: 14px 18px 60px; }
-.swarmify-root .detail-col { flex: 0 0 430px; border-left: 1px solid var(--ds-border); overflow: auto; background: var(--ds-bg-panel); }
+/* The Foreman orb + composer float over this column's bottom-right corner, so the
+   newest Activity line landed underneath them and could not be scrolled clear.
+   Pad the scroll region by the overlay's footprint (index.css). */
+.swarmify-root .detail-col { flex: 0 0 430px; border-left: 1px solid var(--ds-border); overflow: auto; padding-bottom: var(--foreman-overlay-clear); background: var(--ds-bg-panel); }
 .swarmify-root .detail-empty { height: 100%; display: flex; align-items: center; justify-content: center; color: var(--ds-text-faint); font-size: 12px; padding: 20px; text-align: center; }
 /* Detail-pane artifacts row: the selected agent's outputs (PR / CI / team / tickets),
    color-coded per the mockup — blue PR, green CI, violet team, amber created tickets. */

--- a/apps/ext/ui/settings/components/panel/panel.css
+++ b/apps/ext/ui/settings/components/panel/panel.css
@@ -1,7 +1,11 @@
+/* Full-height scroll container rendered as a sibling of the Foreman overlay
+   (App.tsx), so its bottom-right corner is always underneath it — same clearance
+   as the Fleet detail column (index.css). */
 .sw-panel-tab {
   height: 100%;
   overflow-y: auto;
   padding: 18px;
+  padding-bottom: var(--foreman-overlay-clear);
   background:
     radial-gradient(circle at top left, rgba(242, 109, 91, 0.08), transparent 22%),
     linear-gradient(180deg, var(--ds-bg) 0%, var(--ds-bg-sunken) 100%);

--- a/apps/ext/ui/settings/index.css
+++ b/apps/ext/ui/settings/index.css
@@ -297,9 +297,11 @@ input[type="number"]::-webkit-inner-spin-button {
 /* The orb root is `position: fixed; bottom: 16; right: 16` (ForemanOrb.tsx), so it
    floats over whatever bottom-right scroll region is behind it. Scroll regions it
    covers reserve this much bottom padding so their last line stays readable.
-   Measured: orb 40px (56px while listening/speaking) + 10px gap + speaker chip 19px
-   + 10px gap + one-row composer 36px = 133px at the orb's largest, + the 16px bottom
-   offset + 11px breathing room. Keep this in sync with OrbBlob's `size`. */
+   Measured at the orb's largest: orb 56px (40px at rest, 56px while listening or
+   speaking) + 10px gap + speaker chip 19px + 10px gap + one-row composer 36px =
+   131px, + the 16px bottom offset = 147px, + 13px breathing room. ForemanOrb.test.ts
+   recomputes that floor from these same parts and fails if the value drops below it,
+   so keep both in sync with OrbBlob's `size` and the composer's inline style. */
 :root {
   --foreman-overlay-clear: 160px;
 }

--- a/apps/ext/ui/settings/index.css
+++ b/apps/ext/ui/settings/index.css
@@ -294,6 +294,16 @@ input[type="number"]::-webkit-inner-spin-button {
 
 /* -------- Foreman orb (floating voice coordinator) -------- */
 
+/* The orb root is `position: fixed; bottom: 16; right: 16` (ForemanOrb.tsx), so it
+   floats over whatever bottom-right scroll region is behind it. Scroll regions it
+   covers reserve this much bottom padding so their last line stays readable.
+   Measured: orb 40px (56px while listening/speaking) + 10px gap + speaker chip 19px
+   + 10px gap + one-row composer 36px = 133px at the orb's largest, + the 16px bottom
+   offset + 11px breathing room. Keep this in sync with OrbBlob's `size`. */
+:root {
+  --foreman-overlay-clear: 160px;
+}
+
 .foreman-orb {
   border: none;
   background: transparent;


### PR DESCRIPTION
**Bug fix (AGI EXT UI).** The floating Foreman overlay covered the bottom of the Fleet session detail column, so the newest Activity line was unreadable — and its own composer placeholder was clipped.

Reported from the Fleet panel: *"the preview of the session on the right side is so messed up."*

## What was wrong

The orb, its speaker chip and its composer are one `position: fixed; bottom: 16; right: 16` overlay (`ForemanOrb.tsx:222-236`), mounted unconditionally (`App.tsx:922`). Nothing behind it reserved space, so:

| Defect | Measured |
| --- | --- |
| The live `Bash: …` now-line in the detail column renders under the composer and the `voice` chip | **48-71px** of the line covered at the column's 430px width |
| The composer is `rows={1}` at width 260; `Ask Foreman… (type or dictate, Enter to send)` wraps to a second line the one-row box clips | **17px** clipped |

## What changed

- `index.css` declares `--foreman-overlay-clear: 160px` next to the orb styles that own the geometry (orb at its largest 56px + gaps + speaker + one-row composer + the 16px bottom offset).
- `floor.css` — `.swarmify-root .detail-col` reserves it as `padding-bottom`.
- `ForemanOrb.tsx` — placeholder shortened to `Ask Foreman… (Enter to send)`. Press-and-hold dictation is taught by the orb's own `title`, not the placeholder.

## Run result

Both lanes render the exact DOM `UnifiedAgentsPane.tsx:2001-2043` and `ForemanOrb.tsx:222-330` emit, against the **shipped** stylesheet (`vite build --config vite.preview.config.ts`); the left lane reverts only the one declaration this PR adds. Columns scrolled to the bottom, as a reader does. The numbers under each lane are measured in the page (`getBoundingClientRect` overlap, `scrollHeight - clientHeight`).

![Foreman overlay before/after — 48px covered + 17px clipped, versus 0px and 0px](https://share.agents-cli.sh/muqsitnawaz/muqsit-foreman-overlay-ab-2547b8e56d8b3169)

## Note on scope

A prior session diagnosed this as a CSS width-containment problem in `.sw-activity-now` / `.sw-activity-msg` / `.todo-md pre`. That does not reproduce: `.todo-md` already sets `word-break: break-word; overflow-wrap: anywhere` (`index.css`), paths break at `/`, and the measured horizontal overflow of `.detail-col` is **0px** with and without those rules. That direction was backed out; this PR fixes what the screenshot actually shows.

`.feed-col` sits under the same overlay when the detail column is closed on a narrow window. Not changed here — it was not the reported surface and I have not reproduced it.

## Tests

`apps/ext/ui/settings/components/foreman/ForemanOrb.test.ts` (new, 1:1 with its source) pins all three invariants against the real files: the declared clearance covers the overlay footprint computed from the actual orb/composer sizes, `.detail-col` consumes it, and the placeholder fits one row. The old 44-character placeholder fails that last check.

```
bun run compile:ext   → tsc clean
bun test              → 1564 pass, 3 skip, 0 fail (136 files)
```
