### PR TITLE
test(cli): strip CR so signing-home-base-probe tests pass on Windows

### DIFF
--- a/apps/cli/scripts/signing-home-base-probe.test.ts
+++ b/apps/cli/scripts/signing-home-base-probe.test.ts
@@ -168,7 +168,7 @@ describe('signing home-base probe: it cannot advance a release', () => {
 
 describe('release.sh: the preflight gates the mutating phases', () => {
   it('calls assert_signing_home_base before the crabbox, PR, merge, and tag push', () => {
-    const lines = fs.readFileSync(RELEASE, 'utf-8').split('\n');
+    const lines = fs.readFileSync(RELEASE, 'utf-8').replace(/\r/g, '').split('\n');
     const lineOf = (needle: RegExp) => {
       const i = lines.findIndex((l) => needle.test(l));
       expect(i, `expected to find ${needle} in release.sh`).toBeGreaterThanOrEqual(0);
@@ -200,7 +200,7 @@ describe('release.sh: the preflight gates the mutating phases', () => {
 function runAssert(probeExit: 'fail' | 'pass'): { status: number | null; out: string } {
   // Extract the function definition (from its header to the first line that is a
   // bare `}` at column 0) rather than sourcing release.sh, which executes.
-  const lines = fs.readFileSync(RELEASE, 'utf-8').split('\n');
+  const lines = fs.readFileSync(RELEASE, 'utf-8').replace(/\r/g, '').split('\n');
   const start = lines.findIndex((l) => l.startsWith('assert_signing_home_base() {'));
   expect(start, 'assert_signing_home_base() { not found').toBeGreaterThanOrEqual(0);
   const end = lines.findIndex((l, i) => i > start && l === '}');


### PR DESCRIPTION
**test-only** — the required `windows` job is red on every current apps/cli PR because `signing-home-base-probe.test.ts` reads `release.sh` with Windows CRLF and then matches `^…$` / a bare `}`.

## Change

Two `readFileSync(RELEASE)` sites now strip `\r` before splitting lines.

## Run

```
bun vitest run scripts/signing-home-base-probe.test.ts
Test Files  1 passed (1)
     Tests  9 passed (9)
```

Unblocks #2573 #2620 #2621 #2622 (and #2698).