### PR TITLE
refactor(cli): give lib/terminal a single public entry (Move 5, RUSH-2708)

### DIFF
--- a/apps/cli/src/commands/message.ts
+++ b/apps/cli/src/commands/message.ts
@@ -53,7 +53,7 @@ import {
   resumeArgv,
   type AnswerRoute,
 } from '../lib/answer-router.js';
-import { injectIntoTerminal } from '../lib/terminal/inject.js';
+import { injectIntoTerminal } from '../lib/terminal/index.js';
 import { setHelpSections } from '../lib/help.js';
 
 /** Find the still-open block addressed to `mailboxId`, if any. */

--- a/apps/cli/src/commands/sessions-inject.ts
+++ b/apps/cli/src/commands/sessions-inject.ts
@@ -16,8 +16,7 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { getActiveSessions } from '../lib/session/active.js';
-import { resolveInjectTargetForSession } from '../lib/terminal/resolve.js';
-import { injectIntoTerminal, type InjectTarget } from '../lib/terminal/index.js';
+import { injectIntoTerminal, resolveInjectTargetForSession, type InjectTarget } from '../lib/terminal/index.js';
 import { setHelpSections } from '../lib/help.js';
 
 interface InjectOptions {

--- a/apps/cli/src/commands/sessions-migrate.ts
+++ b/apps/cli/src/commands/sessions-migrate.ts
@@ -38,9 +38,7 @@ import { getActiveSessions } from '../lib/session/active.js';
 import { discoverSessions, resolveSessionById } from '../lib/session/discover.js';
 import { buildResumeCommand } from './sessions.js';
 import { injectTargetFromReplyRail } from '../lib/session/inject.js';
-import { injectIntoTerminal } from '../lib/terminal/index.js';
-import { iLoginShell } from '../lib/terminal/shell.js';
-import { shellQuote as quoteArg } from '../lib/terminal/quote.js';
+import { injectIntoTerminal, iLoginShell, shellQuote as quoteArg } from '../lib/terminal/index.js';
 import { killSession } from '../lib/tmux/session.js';
 import { getDefaultSocketPath } from '../lib/tmux/paths.js';
 

--- a/apps/cli/src/lib/answer-router.ts
+++ b/apps/cli/src/lib/answer-router.ts
@@ -12,7 +12,7 @@
  */
 import type { OpenBlock, BlockOption } from './feed.js';
 import type { ActiveSession } from './session/active.js';
-import type { InjectTarget } from './terminal/inject.js';
+import type { InjectTarget } from './terminal/index.js';
 import { injectTargetFromReplyRail } from './session/inject.js';
 
 export type AnswerRouteKind = 'mailbox' | 'pty' | 'tmux' | 'iterm' | 'resume' | 'refuse';

--- a/apps/cli/src/lib/session/inject.ts
+++ b/apps/cli/src/lib/session/inject.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ReplyRail } from './provenance.js';
-import type { InjectTarget } from '../terminal/inject.js';
+import type { InjectTarget } from '../terminal/index.js';
 
 /**
  * Map a session's `ReplyRail` to an engine `InjectTarget`. Today only tmux rails

--- a/apps/cli/src/lib/terminal/index.ts
+++ b/apps/cli/src/lib/terminal/index.ts
@@ -62,3 +62,5 @@ export {
   type InjectRail,
   type ResolveOptions,
 } from './resolve.js';
+export { iLoginShell } from './shell.js';
+export { shellQuote } from './quote.js';

--- a/apps/cli/src/lib/watchdog/rotate.test.ts
+++ b/apps/cli/src/lib/watchdog/rotate.test.ts
@@ -15,7 +15,7 @@ import * as os from 'os';
 import * as path from 'path';
 import type { ActiveSession } from '../session/active.js';
 import type { SessionProvenance } from '../session/provenance.js';
-import type { InjectTarget } from '../terminal/inject.js';
+import type { InjectTarget } from '../terminal/index.js';
 import {
   runWatchdogTick,
   type SmartDecider,

--- a/apps/cli/src/lib/watchdog/rotate.ts
+++ b/apps/cli/src/lib/watchdog/rotate.ts
@@ -30,7 +30,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { InjectTarget } from '../terminal/inject.js';
+import type { InjectTarget } from '../terminal/index.js';
 import type { ActiveSession } from '../session/active.js';
 import { readMeta, writeMeta } from '../state.js';
 import {

--- a/apps/cli/src/lib/watchdog/runner.test.ts
+++ b/apps/cli/src/lib/watchdog/runner.test.ts
@@ -15,7 +15,7 @@ import * as os from 'os';
 import * as path from 'path';
 import type { ActiveSession } from '../session/active.js';
 import type { SessionProvenance, MuxLocation } from '../session/provenance.js';
-import type { InjectTarget } from '../terminal/inject.js';
+import type { InjectTarget } from '../terminal/index.js';
 import type { WatchdogCandidate } from './watchdog.js';
 import type { OpenBlock } from '../feed.js';
 import {

--- a/apps/cli/src/lib/watchdog/runner.ts
+++ b/apps/cli/src/lib/watchdog/runner.ts
@@ -46,8 +46,10 @@ import {
 import {
   resolveInjectTargetForSession,
   type InjectRail,
-} from '../terminal/resolve.js';
-import { injectIntoTerminal, type InjectResult, type InjectTarget } from '../terminal/inject.js';
+  injectIntoTerminal,
+  type InjectResult,
+  type InjectTarget,
+} from '../terminal/index.js';
 import {
   classifyTerminal,
   isLikelyTrulyBlocked,


### PR DESCRIPTION
Refactor: makes `apps/cli/src/lib/terminal/index.ts` the single public entry for terminal consumers, with no behavior change.

## Changes

- Exports the externally used backend registry, injection API, launch API, `iLoginShell`, and `shellQuote` from the terminal barrel.
- Routes every consumer outside `lib/terminal` through `terminal/index.js`.
- Leaves `lib/secrets` backends untouched.

## Verification

```text
deep terminal imports outside lib/terminal: 0
```

```text
$ bun run build
exit 0
```

Full suite executed:

```text
Test Files  5 failed | 857 passed | 6 skipped (868)
Tests  10 failed | 12197 passed | 93 skipped (12300)
```

The three declared nested-worktree environment failures occurred in `src/commands/monitors.test.ts`, `src/lib/exec.test.ts`, and `src/lib/project-key.test.ts`. Two additional unchanged Git-fixture files failed in this host environment: `scripts/release-lease.test.ts` (2 tests) and `src/lib/output/__tests__/git-output.test.ts` (4 tests). Neither file is in this PR; both failures reproduce when those two files run alone.

## Tracking

RUSH-2708 · Move 5
