### PR TITLE
refactor(cli): complete Move 5 — route exec.ts through the lib/terminal barrel (RUSH-2708)

### DIFF
--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -637,8 +637,7 @@ async function handleTerminalHandoff(
   options: ExecCommandActionOptions,
   prompt: string | undefined,
 ): Promise<void> {
-  const { parseTerminalFlag, openRunInTerminal, toHostSamples } = await import('../lib/terminal/run-surface.js');
-  const { currentContext } = await import('../lib/terminal/index.js');
+  const { parseTerminalFlag, openRunInTerminal, toHostSamples, currentContext } = await import('../lib/terminal/index.js');
 
   const parsed = parseTerminalFlag(options.terminal);
   if (parsed.error) {

--- a/apps/cli/src/lib/terminal/index.ts
+++ b/apps/cli/src/lib/terminal/index.ts
@@ -64,3 +64,5 @@ export {
 } from './resolve.js';
 export { iLoginShell } from './shell.js';
 export { shellQuote } from './quote.js';
+export { parseTerminalFlag, stripTerminalFlag, buildRunCommand, openRunInTerminal, toHostSamples, TERMINAL_FLAG_BACKENDS } from './run-surface.js';
+export type { OpenRunSurfaceParams, OpenRunSurfaceResult } from './run-surface.js';


### PR DESCRIPTION
**refactor** — behavior-preserving, 2 files (+3/-2).

## What + why
#2712 gave `lib/terminal` a single public entry point (`index.js`) but left one deep import: `commands/exec.ts:640` still did `await import('../lib/terminal/run-surface.js')` — a lazy import the consumer sweep missed, so the 'single entry point' criterion was 1 short (a non-author reviewer caught it post-merge).

## Change
- Add `run-surface.js`'s public exports (`parseTerminalFlag`, `stripTerminalFlag`, `buildRunCommand`, `openRunInTerminal`, `toHostSamples`, `TERMINAL_FLAG_BACKENDS` + 2 types) to `lib/terminal/index.ts`.
- Fold `exec.ts`'s two dynamic imports into one through `index.js`.

## Proof
- `git grep` for deep `lib/terminal/*` imports outside `lib/terminal/` → **0** (criterion now genuinely met).
- `bun run build` (tsc) clean.

Follows Move 1 (#2703) + Move 2b (#2702) + Move 5 (#2712), all merged.