### PR TITLE
ci: Windows required gate is a 2-3 minute smoke, not the full suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -147,7 +147,7 @@ jobs:
     needs: scope
     if: needs.scope.outputs.windows == 'true'
     runs-on: windows-latest
-    timeout-minutes: 25
+    timeout-minutes: 8
     defaults:
       run:
         working-directory: apps/cli
@@ -156,14 +156,12 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install --frozen-lockfile
       - run: bun run build
-      # Run the full Vitest suite on Windows so the gate reflects real Windows
-      # regressions, not a hand-picked slice (RUSH-2215). The POSIX-only
-      # integration tests that used to collapse the run — openclaw `which`+`sh`
-      # delivery, ssh ControlMaster multiplexing, `#!/bin/sh` PATH stubs, bash
-      # release-script checks, sqlite-locked teardown — now skip on win32 (expanded RUSH-2215 quarantine) with a
-      # stated reason (describe/it.skipIf), so the suite runs green and a genuine
-      # Windows break stops standing out from the noise instead of hiding in it.
-      - run: bun run test
+      # Smoke only — path/hooks/shims. Linux shards own the full suite.
+      # A full unsharded `bun run test` on windows-latest is ~21 minutes
+      # (855 files, no --shard) and was restarting on every push, so PRs
+      # sat on the required `test` aggregator for hours. RUSH-2215's full
+      # Windows suite lives in #2707, not this required PR gate.
+      - run: bun run test -- src/lib/platform src/lib/hooks src/lib/binary-shadow.test.ts src/lib/shims.test.ts src/lib/shims.device-pins.test.ts
 
   test:
     needs: [scope, cli-preflight, cli-test-shard, cli-docs, ext, session-tracker, windows]

--- a/apps/cli/docs/observability.md
+++ b/apps/cli/docs/observability.md
@@ -1184,7 +1184,7 @@ it by the account that did the work. Counter recipes share the same verb as
 do not invent a second top-level analytics command.
 
 That account split is the reason the behavioural path exists. `getConfiguredRunStrategy`
-defaults to `balanced` (`lib/rotate.ts`), so sessions are sprayed across every signed-in
+defaults to `balanced` (`lib/accounting/rotate.ts`), so sessions are sprayed across every signed-in
 Claude account. A report that reads one account's directory — which is what Claude Code's
 own `/insights` does — describes a fraction of the work and attributes all of it to one org.
 
@@ -1378,7 +1378,7 @@ a stable per-account key:
   is **local-only, no network**. It reads each agent's on-disk credential and
   surfaces an email when one is readable, else a stable account id, else a bare
   `signed in`.
-- **Usage bars** — a separate network pass ([`src/lib/usage.ts`](../src/lib/usage.ts))
+- **Usage bars** — a separate network pass ([`src/lib/usage.ts`](../src/lib/accounting/usage.ts))
   fetches live quota and renders `S:`/`W:`/`M:` bars + plan, according to each
   provider's reported window duration. It's **stale-while-revalidate**
   (on-disk cache under `~/.agents/.cache/`, keyed per account: 2-min fresh, 24-h
@@ -1387,7 +1387,7 @@ a stable per-account key:
   (RUSH-2061).** Displaying a slightly old bar costs nothing; *choosing an account*
   from one must not cost a network round trip on `agents run` cold-start.
   `collectRunCandidates` reads the cache with `readOnly`
-  ([`src/lib/rotate.ts`](../src/lib/rotate.ts), [`src/lib/usage.ts`](../src/lib/usage.ts))
+  ([`src/lib/rotate.ts`](../src/lib/accounting/rotate.ts), [`src/lib/usage.ts`](../src/lib/accounting/usage.ts))
   and never blocks on a live fetch. A snapshot older than **5 minutes**
   (`USAGE_DECISION_MAX_AGE_MS`) is still not trusted for the pick — but the guard
   is `isUsageVerified`, which routes around an unconfirmable number and reports
@@ -1420,7 +1420,7 @@ a stable per-account key:
   credential, a locally-expired one, a rejected request, and a request that threw
   are distinct errors (`usageNoCredentialError` / `usageExpiredCredentialError` /
   `usageRejectedError` / `usageUnreachableError`,
-  [`src/lib/usage.ts`](../src/lib/usage.ts)), not a silent
+  [`src/lib/usage.ts`](../src/lib/accounting/usage.ts)), not a silent
   null. All four networked providers — Claude, Kimi, Droid, Cursor — share them,
   because they share one cache fallback: a silent null in any of them presents a
   stale reading as confirmed. Because a usage read never refreshes a token,


### PR DESCRIPTION
refactor

CI-only: no product behavior. The Windows job this PR starts is the run.

## What

The required `windows` job ran unsharded `bun run test` on one `windows-latest` runner (~855 files, ~21 minutes). Linux already shards the same suite. Every push cancelled that job (`cancel-in-progress: true`), so folding main into a PR restarted the 21-minute clock. Four PRs doing that is hours on a required check.

Windows is now a path/hooks/shims smoke (`timeout-minutes: 8`). Full-suite Windows stays #2707.

## Evidence

`.github/workflows/tests.yml` windows job was:

```
- run: bun run test
```

Linux shards:

```
- run: node ./node_modules/vitest/vitest.mjs run --shard=${{ matrix.shard }}/3
```

Aggregator requires windows when `ci-scope` sets `windows=true`.

Independent confirmation: team `win-ci-debug` (claude + grok, plan-mode).
