### PR TITLE
docs(observability): repoint usage/rotate links after the accounting move — main is red on cli-docs

### DIFF
--- a/apps/cli/docs/observability.md
+++ b/apps/cli/docs/observability.md
@@ -1378,7 +1378,7 @@ a stable per-account key:
   is **local-only, no network**. It reads each agent's on-disk credential and
   surfaces an email when one is readable, else a stable account id, else a bare
   `signed in`.
-- **Usage bars** — a separate network pass ([`src/lib/usage.ts`](../src/lib/usage.ts))
+- **Usage bars** — a separate network pass ([`src/lib/accounting/usage.ts`](../src/lib/accounting/usage.ts))
   fetches live quota and renders `S:`/`W:`/`M:` bars + plan, according to each
   provider's reported window duration. It's **stale-while-revalidate**
   (on-disk cache under `~/.agents/.cache/`, keyed per account: 2-min fresh, 24-h
@@ -1387,7 +1387,7 @@ a stable per-account key:
   (RUSH-2061).** Displaying a slightly old bar costs nothing; *choosing an account*
   from one must not cost a network round trip on `agents run` cold-start.
   `collectRunCandidates` reads the cache with `readOnly`
-  ([`src/lib/rotate.ts`](../src/lib/rotate.ts), [`src/lib/usage.ts`](../src/lib/usage.ts))
+  ([`src/lib/accounting/rotate.ts`](../src/lib/accounting/rotate.ts), [`src/lib/accounting/usage.ts`](../src/lib/accounting/usage.ts))
   and never blocks on a live fetch. A snapshot older than **5 minutes**
   (`USAGE_DECISION_MAX_AGE_MS`) is still not trusted for the pick — but the guard
   is `isUsageVerified`, which routes around an unconfirmable number and reports
@@ -1420,7 +1420,7 @@ a stable per-account key:
   credential, a locally-expired one, a rejected request, and a request that threw
   are distinct errors (`usageNoCredentialError` / `usageExpiredCredentialError` /
   `usageRejectedError` / `usageUnreachableError`,
-  [`src/lib/usage.ts`](../src/lib/usage.ts)), not a silent
+  [`src/lib/accounting/usage.ts`](../src/lib/accounting/usage.ts)), not a silent
   null. All four networked providers — Claude, Kimi, Droid, Cursor — share them,
   because they share one cache fallback: a silent null in any of them presents a
   stale reading as confirmed. Because a usage read never refreshes a token,


### PR DESCRIPTION
**docs-only** — `main` is red on `cli-docs`. Four broken links, none of them mine.

```
✗ broken link in docs/observability.md -> ../src/lib/usage.ts
✗ broken link in docs/observability.md -> ../src/lib/rotate.ts
✗ broken link in docs/observability.md -> ../src/lib/usage.ts
✗ broken link in docs/observability.md -> ../src/lib/usage.ts
✗ Docs verification failed with 4 error(s)
```

`f9e9edca9` ("drop leftover lib/usage and lib/rotate after the move") deleted both files — they now live at `src/lib/accounting/usage.ts` and `src/lib/accounting/rotate.ts` — but `docs/observability.md:1381,1390,1423` still pointed at the old paths. Repointed to the real locations.

`bash scripts/verify-docs.sh` → `✓ Docs verification passed`.

Found while triaging why #2715 was red: it is not, on its own diff. This blocks every PR to `main` until it lands, which is why it is a separate one-file change rather than folded in.

Declared **docs-only**, so no run screenshot — the passing `cli-docs` check is the evidence.