### PR TITLE
fix(ext): forward the follower socket so the monitor replays session state (RUSH-2733)

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+- **The Fleet panel no longer reports 0 sessions in a second editor window (RUSH-2733).**
+  One window per machine wins the monitor lease and owns the single `agents sessions watch
+  --json` child; that stream emits a `reset` once at startup and only deltas afterwards, so
+  every other window depends on the host replaying a synthetic `reset` when it reports in.
+  The host registered its request handler as `(payload) => handleRequest(payload)`, dropping
+  the `socket` the broadcast server passes — and the replay is guarded by `if (socket)`, so
+  it silently never ran. Follower windows were ACKed, received only deltas for rows they
+  never had, and rendered "0 agents running" while agents were running. Source:
+  `apps/ext/src/monitor/host.ts`.
+
 ## [0.9.323] - 2026-08-15
 
 - **The Foreman orb no longer covers the Fleet session detail.** The orb, its speaker

--- a/apps/ext/src/monitor/host.test.ts
+++ b/apps/ext/src/monitor/host.test.ts
@@ -1,0 +1,115 @@
+// Follower replay round-trip (no mocks).
+//
+// A real MonitorHost, a real child process standing in for `agents sessions
+// watch --json`, a real MonitorFollower over a real Unix socket.
+//
+// Regression: the host registered its request handler as `(payload) =>
+// handleRequest(payload)`, dropping the `socket` the broadcast server passes
+// (broadcast.ts). `handleRequest`'s replay is guarded by `if (socket)`, so a
+// follower that reported in was ACKed but never received the retained
+// session-cli `reset`. The stream emits `reset` ONCE at startup and only deltas
+// after, so any window that connected later rendered zero sessions forever —
+// the Fleet panel reporting "0 agents running" while agents were running.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawn, ChildProcess, ChildProcessWithoutNullStreams } from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+import { MonitorHost } from './host';
+import { MonitorFollower } from './follower';
+import { MONITOR_FACT } from './protocol';
+import { MonitorEvent } from './broadcastTypes';
+
+const spawned: ChildProcess[] = [];
+const hosts: MonitorHost[] = [];
+const followers: MonitorFollower<unknown>[] = [];
+let counter = 0;
+
+function tempSocketPath(): string {
+  return path.join(os.tmpdir(), `monitor-host-${process.pid}-${counter++}.sock`);
+}
+
+/**
+ * A real child process that speaks the watch protocol: one `reset` carrying a
+ * row, then it idles (exactly like the CLI once it has emitted its snapshot).
+ */
+function spawnFakeWatch(): ChildProcessWithoutNullStreams {
+  const reset = JSON.stringify({
+    version: 1,
+    type: 'reset',
+    streamId: 'test-stream',
+    sequence: 1,
+    capturedAt: 1,
+    scope: 'testbox',
+    rows: [{ rowKey: 'row-1', sessionId: 'sess-1', status: 'running' }],
+  });
+  const child = spawn(
+    process.execPath,
+    ['-e', `process.stdout.write(${JSON.stringify(reset + '\n')}); setInterval(() => {}, 1e9)`],
+    { stdio: ['pipe', 'pipe', 'pipe'] },
+  ) as ChildProcessWithoutNullStreams;
+  spawned.push(child);
+  return child;
+}
+
+function waitFor(predicate: () => boolean, timeoutMs: number, label: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const tick = (): void => {
+      if (predicate()) return resolve();
+      if (Date.now() - start > timeoutMs) return reject(new Error(`Timed out waiting for ${label}`));
+      setTimeout(tick, 20);
+    };
+    tick();
+  });
+}
+
+afterEach(async () => {
+  for (const f of followers.splice(0)) f.stop();
+  for (const h of hosts.splice(0)) await h.stop();
+  for (const c of spawned.splice(0)) c.kill();
+});
+
+describe('MonitorHost replays session state to a late follower', () => {
+  test('a follower that reports tuples receives the retained reset', async () => {
+    const socketPath = tempSocketPath();
+    const host = new MonitorHost({
+      socketPath,
+      detectors: { readiness: false, sessionCli: true, spawnSessionWatch: spawnFakeWatch },
+    });
+    hosts.push(host);
+    await host.start();
+
+    // The stream emits its only `reset` now — before the follower exists. This
+    // is the real-world ordering: the leader has been up for hours.
+    await waitFor(() => host.clientCount === 0, 1000, 'host listening');
+    await new Promise((r) => setTimeout(r, 200));
+
+    const received: MonitorEvent[] = [];
+    const follower = new MonitorFollower<unknown>({
+      windowId: 'late-window',
+      resolver: () => undefined,
+      socketPath,
+    });
+    followers.push(follower as MonitorFollower<unknown>);
+    follower.onMonitorEvent((event) => received.push(event));
+    follower.start();
+
+    await waitFor(() => follower.connected, 2000, 'follower connected');
+    expect(await follower.reportTuples([])).toBe(true);
+
+    await waitFor(
+      () => received.some((e) => e.type === MONITOR_FACT.sessionCli
+        && (e.payload as { type?: string })?.type === 'reset'),
+      2000,
+      'replayed reset',
+    );
+
+    const reset = received
+      .filter((e) => e.type === MONITOR_FACT.sessionCli)
+      .map((e) => e.payload as { type?: string; scope?: string; rows?: unknown[] })
+      .find((p) => p.type === 'reset');
+    expect(reset?.scope).toBe('testbox');
+    expect(reset?.rows).toHaveLength(1);
+  });
+});

--- a/apps/ext/src/monitor/host.ts
+++ b/apps/ext/src/monitor/host.ts
@@ -32,6 +32,7 @@ import {
 import { ReadinessDetector } from './readinessDetector';
 import { SessionCliStream } from './sessionCliStream';
 import { SessionCliReplay } from './sessionCliStream';
+import type { SessionCliStreamOptions } from './sessionCliStream';
 import type { Socket } from 'net';
 
 /** Enable + configure the centralized presentation detectors. */
@@ -40,6 +41,13 @@ export interface MonitorDetectorOptions {
   readiness?: boolean;
   /** Consume the canonical agents-cli session stream. Default true. */
   sessionCli?: boolean;
+  /**
+   * Supply the watch child instead of spawning `agents sessions watch --json`.
+   * `SessionCliStream` already accepts this; the host forwards it so a test can
+   * drive the real stream/replay path from a real child process without
+   * depending on an installed CLI.
+   */
+  spawnSessionWatch?: SessionCliStreamOptions['spawnWatch'];
 }
 
 export interface MonitorHostOptions {
@@ -69,7 +77,10 @@ export class MonitorHost {
     this.detectorOpts = options.detectors;
     this.server = new MonitorBroadcastServer({
       socketPath: options.socketPath,
-      onRequest: (payload) => this.handleRequest(payload),
+      // Forward the socket: handleRequest replays the retained session-cli reset
+      // to THIS follower's socket, and without it that replay silently no-ops
+      // (`if (socket)` below), leaving every follower window at zero sessions.
+      onRequest: (payload, socket) => this.handleRequest(payload, socket),
     });
   }
 
@@ -116,6 +127,7 @@ export class MonitorHost {
           this.broadcast(MONITOR_FACT.sessionCli, event);
         },
         onError: (message) => console.error(`[MONITOR] ${message}`),
+        ...(opts.spawnSessionWatch ? { spawnWatch: opts.spawnSessionWatch } : {}),
       });
       this.sessionCliStream.start();
     }


### PR DESCRIPTION
**Bug fix.** The Fleet panel reported **0 sessions in every editor window except the monitor leader's**, while the CLI on the same machine reported 6 running. Fixes RUSH-2733.

This is the status-accuracy complaint the whole Fleet reliability effort exists for: a panel confidently reporting zero running agents while agents are running.

## Root cause — a dropped argument

One window per machine wins the lease and owns the single `agents sessions watch --json` child. That stream emits a `reset` **once** at startup, then only `upsert`/`remove`/`scope`/`heartbeat` deltas. So any window that connects later depends entirely on the host replaying a synthetic `reset` per scope when the follower reports in (`host.ts` `handleRequest`).

That replay is guarded by `if (socket)`. The host registered its handler as:

```ts
onRequest: (payload) => this.handleRequest(payload),   // socket dropped
```

while the server calls it with both (`this.onRequest(payload, socket)`, `broadcast.ts`). So `socket` was always `undefined`, the replay never ran, and a follower's store started empty and only ever received deltas for rows it never had.

## Run result — probed against a live leader

Connected to `~/.agents/.tmp/monitor-broadcast.sock` as a synthetic follower and sent the real `report-tuples` op:

```
RESPONSE: {"ok":true,"windowId":"probe-readonly","count":0}
sessionCli frame: type=scope     scope=ci-runner-fsn1
sessionCli frame: type=heartbeat scope=win-mini
sessionCli frame: type=upsert    scope=yosemite-m6
sessionCli frame: type=remove    scope=yosemite-m6
sessionCli frame: type=upsert    scope=zion
SUMMARY sessionCli-frames=10 rows=0
```

Ten frames in 8s, every one incremental, **zero resets** — with the leader's stream child healthy (`node /opt/homebrew/bin/agents sessions watch --json`), the lease renewing, and the CLI stream emitting a proper `reset` with rows when run directly.

## Test

`apps/ext/src/monitor/host.test.ts` (new, 1:1 with its source) drives the real path: a real `MonitorHost`, a real child process speaking the watch protocol, a real `MonitorFollower` over a real Unix socket — with the follower connecting **after** the only `reset` was emitted, which is the real-world ordering.

Verified it reproduces the bug, not just the fix:

```
pre-fix line:  (fail) ... error: Timed out waiting for replayed reset
with the fix:  1 pass, 0 fail
full suite:    1566 pass, 3 skip, 0 fail (137 files);  tsc clean
```

`MonitorDetectorOptions` gains `spawnSessionWatch`, forwarding the injection point `SessionCliStream` already declares, so the test drives a real child process and needs no installed CLI.

## Not in scope

The follower still has no self-heal: if a `reset` never arrives for any other reason, it renders an empty panel rather than a degraded/unknown state. Tracked in RUSH-2733's fix-direction #2 — a follower that cannot get state must never present "0 sessions" as fact. Deliberately separate from this root-cause fix.
