### PR TITLE
refactor(cli): group plugins/plugin-marketplace/skills into lib/plugins (Move 3, RUSH-2708)

### DIFF
--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -2214,7 +2214,7 @@ export function registerRunCommand(program: Command): void {
         import('../lib/secrets/remote.js'),
         import('../lib/accounting/rotate.js'),
         import('../lib/versions.js'),
-        import('../lib/plugins.js'),
+        import('../lib/plugins/plugins.js'),
         import('../lib/workflows.js'),
         import('../lib/run-defaults.js'),
         import('../lib/mcp.js'),

--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -49,7 +49,7 @@ import {
 import { listHookEntriesFromDir } from '../lib/hooks.js';
 import { getResourceInventory, type ResourceInventory } from '../lib/resource-inventory.js';
 import { listMcpServerConfigs, discoverMcpConfigsFromRepo, type McpYamlConfig } from '../lib/mcp.js';
-import { discoverPlugins, discoverPluginsInDir, pluginResourceGroups, inspectPluginCapabilities, pluginCapabilityLabels, type PluginResourceGroup } from '../lib/plugins.js';
+import { discoverPlugins, discoverPluginsInDir, pluginResourceGroups, inspectPluginCapabilities, pluginCapabilityLabels, type PluginResourceGroup } from '../lib/plugins/plugins.js';
 import { showResourceList } from './resource-view.js';
 import { PLUGIN_GROUP_COLORS } from './plugins.js';
 import { isInteractiveTerminal } from './utils.js';

--- a/apps/cli/src/commands/packages.ts
+++ b/apps/cli/src/commands/packages.ts
@@ -40,7 +40,7 @@ import {
   discoverSkillsFromRepo,
   installSkill,
   installSkillCentrally,
-} from '../lib/skills.js';
+} from '../lib/plugins/skills.js';
 import {
   discoverHooksFromRepo,
   installHooks,
@@ -488,7 +488,7 @@ delegate to the same underlying installers.
             pluginSupportsAgent,
             syncPluginToVersion,
             pluginResourceGroups,
-          } = await import('../lib/plugins.js');
+          } = await import('../lib/plugins/plugins.js');
           const { listInstalledVersions, getGlobalDefault, getVersionHomePath, syncResourcesToVersion } =
             await import('../lib/versions.js');
           const { agentLabel } = await import('../lib/agents.js');

--- a/apps/cli/src/commands/plugins.test.ts
+++ b/apps/cli/src/commands/plugins.test.ts
@@ -4,9 +4,9 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { inspectPluginCapabilities } from '../lib/plugins.js';
+import { inspectPluginCapabilities } from '../lib/plugins/plugins.js';
 import { shouldRefusePluginInstall, collectMarketplaceRows } from './plugins.js';
-import { discoverMarketplaces } from '../lib/plugin-marketplace.js';
+import { discoverMarketplaces } from '../lib/plugins/plugin-marketplace.js';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');

--- a/apps/cli/src/commands/plugins.ts
+++ b/apps/cli/src/commands/plugins.ts
@@ -34,7 +34,7 @@ import {
   syncPluginToVersion,
   pluginResourceGroups,
   type PluginCapabilities,
-} from '../lib/plugins.js';
+} from '../lib/plugins/plugins.js';
 import {
   listInstalledVersions,
   syncResourcesToVersion,
@@ -58,7 +58,7 @@ import {
 } from './resource-view.js';
 import { getPluginsDir } from '../lib/state.js';
 import { safeJoin } from '../lib/paths.js';
-import { discoverMarketplaces } from '../lib/plugin-marketplace.js';
+import { discoverMarketplaces } from '../lib/plugins/plugin-marketplace.js';
 
 /** Replace the home directory prefix with ~ for display. */
 function formatPath(p: string): string {

--- a/apps/cli/src/commands/prune.ts
+++ b/apps/cli/src/commands/prune.ts
@@ -36,7 +36,7 @@ import {
   diffVersionSkills,
   iterSkillsCapableVersions,
   removeSkillFromVersion,
-} from '../lib/skills.js';
+} from '../lib/plugins/skills.js';
 import {
   listUnmanagedHooksInVersionHome,
   iterHooksCapableVersions,
@@ -46,7 +46,7 @@ import {
   diffVersionPlugins,
   iterPluginsCapableVersions,
   removePluginSkillFromVersion,
-} from '../lib/plugins.js';
+} from '../lib/plugins/plugins.js';
 import {
   diffVersionSubagents,
   iterSubagentsCapableVersions,

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -76,7 +76,7 @@ import { ALL_AGENT_IDS, isAgentName, resolveAgentName } from '../lib/agents.js';
 import { refresh } from '../lib/refresh.js';
 import { capableAgents } from '../lib/capabilities.js';
 import { getGlobalDefault, getVersionHomePath, listInstalledVersions } from '../lib/versions.js';
-import { syncAllMarketplaces } from '../lib/plugin-marketplace.js';
+import { syncAllMarketplaces } from '../lib/plugins/plugin-marketplace.js';
 import { gatherRemoteAgentsJson } from '../lib/remote-agents-json.js';
 import { machineId, normalizeHost } from '../lib/machine-id.js';
 

--- a/apps/cli/src/commands/sessions-stats.ts
+++ b/apps/cli/src/commands/sessions-stats.ts
@@ -26,7 +26,7 @@ import {
   type ResourceStatRow,
 } from '../lib/session/db.js';
 import { listResources } from '../lib/resources.js';
-import { discoverPlugins } from '../lib/plugins.js';
+import { discoverPlugins } from '../lib/plugins/plugins.js';
 import { setHelpSections } from '../lib/help.js';
 import { terminalWidth, truncateToWidth, padToWidth, stringWidth } from '../lib/session/width.js';
 

--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -40,7 +40,7 @@ import {
   removeSkillFromVersion,
   type SkillParseError,
   type VersionSkillDiff,
-} from '../lib/skills.js';
+} from '../lib/plugins/skills.js';
 import {
   listInstalledVersions,
   getGlobalDefault,
@@ -253,7 +253,7 @@ Examples:
             const skillMdPath = path.join(localPath, 'SKILL.md');
             if (fs.existsSync(skillMdPath)) {
               const skillName = path.basename(localPath);
-              const { validateSkillMetadata, countSkillRules } = await import('../lib/skills.js');
+              const { validateSkillMetadata, countSkillRules } = await import('../lib/plugins/skills.js');
               const parseResult = tryParseSkillMetadata(localPath);
               const validation = validateSkillMetadata(parseResult.metadata, skillName);
 

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -70,7 +70,7 @@ import { renderMergedResources } from '../lib/merged-resources.js';
 import { resolveVersionFilter, AgentSpecError } from '../lib/agent-spec/index.js';
 import { listCliStatus } from '../lib/cli-resources.js';
 import { isCapable } from '../lib/capabilities.js';
-import { discoverPlugins, pluginSupportsAgent } from '../lib/plugins.js';
+import { discoverPlugins, pluginSupportsAgent } from '../lib/plugins/plugins.js';
 import { getAgentsDir, getUserAgentsDir, getEffectivePromptcutsPath, readMergedPromptcuts, readMeta } from '../lib/state.js';
 import { listNativeAccounts } from '../lib/account-registry.js';
 import { isGitRepo, getGitSyncStatus } from '../lib/git.js';

--- a/apps/cli/src/lib/__tests__/bugfixes.test.ts
+++ b/apps/cli/src/lib/__tests__/bugfixes.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { symlinkAllowedDirs } from '../sandbox.js';
 import { validateJob, parseAtTime, writeJob, readJob, deleteJob, resolveJobPrompt } from '../routines.js';
-import { cleanOrphanedPluginSkills } from '../plugins.js';
+import { cleanOrphanedPluginSkills } from '../plugins/plugins.js';
 
 describe('Bug Fix: Path traversal in sandbox.ts', () => {
   let overlayHome: string;

--- a/apps/cli/src/lib/__tests__/plugin-marketplace.test.ts
+++ b/apps/cli/src/lib/__tests__/plugin-marketplace.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { copyPluginToMarketplace } from '../plugin-marketplace.js';
+import { copyPluginToMarketplace } from '../plugins/plugin-marketplace.js';
 import type { DiscoveredPlugin } from '../types.js';
 
 /**

--- a/apps/cli/src/lib/__tests__/plugins-prune.test.ts
+++ b/apps/cli/src/lib/__tests__/plugins-prune.test.ts
@@ -17,7 +17,7 @@ import * as crypto from 'crypto';
 import {
   cleanOrphanedPluginSkills,
   removePluginSkillFromVersion,
-} from '../plugins.js';
+} from '../plugins/plugins.js';
 import { getVersionsDir, getTrashPluginsDir } from '../state.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/apps/cli/src/lib/__tests__/plugins.test.ts
+++ b/apps/cli/src/lib/__tests__/plugins.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { loadPluginManifest } from '../plugins.js';
+import { loadPluginManifest } from '../plugins/plugins.js';
 
 const tempDirs: string[] = [];
 

--- a/apps/cli/src/lib/commands.ts
+++ b/apps/cli/src/lib/commands.ts
@@ -18,7 +18,7 @@ import { normalizeAliases } from './resource-aliases.js';
 import { markdownToToml } from './convert.js';
 import { getCommandsDir, getUserCommandsDir, getEnabledExtraRepos, getProjectAgentsDir, getSkillsDir, getTrashCommandsDir } from './state.js';
 import { getEffectiveHome, getVersionHomePath, listInstalledVersions, resolveVersion } from './versions.js';
-import { discoverPlugins } from './plugins.js';
+import { discoverPlugins } from './plugins/plugins.js';
 import type { AgentId, CommandInstallation } from './types.js';
 import {
   commandSkillMatches,

--- a/apps/cli/src/lib/doctor-diff.ts
+++ b/apps/cli/src/lib/doctor-diff.ts
@@ -42,15 +42,15 @@ import {
   getVersionHomePath,
   compareVersions,
 } from './versions.js';
-import { discoverPlugins, marketplaceSpecForName } from './plugins.js';
+import { discoverPlugins, marketplaceSpecForName } from './plugins/plugins.js';
 import type { DiscoveredPlugin } from './types.js';
-import { pluginInstallDir, repairableManifestFields } from './plugin-marketplace.js';
+import { pluginInstallDir, repairableManifestFields } from './plugins/plugin-marketplace.js';
 import { markdownToToml } from './convert.js';
 import { listCommandsInVersionHome, getVersionCommandsDir, listPluginCommandNames } from './commands.js';
 import { shouldInstallCommandAsSkill, commandSkillMatches, commandSkillName } from './command-skills.js';
 import { gooseCommandMatches, gooseCommandsDir } from './goose-commands.js';
 import { supports } from './capabilities.js';
-import { listSkillsInVersionHome, getVersionSkillsDir } from './skills.js';
+import { listSkillsInVersionHome, getVersionSkillsDir } from './plugins/skills.js';
 import { listHookEntriesFromDir, type HookWiringReport } from './hooks.js';
 import { getResourceInventory, type ResourceInventory } from './resource-inventory.js';
 

--- a/apps/cli/src/lib/drift.ts
+++ b/apps/cli/src/lib/drift.ts
@@ -13,7 +13,7 @@ import { getGlobalDefault, listInstalledVersions } from './versions.js';
 import { loadManifest, isStale } from './staleness/index.js';
 import { diffVersionResources, type VersionResourceReport, type SourceLayerBehind } from './doctor-diff.js';
 import { diffVersionCommands, iterCommandsCapableVersions } from './commands.js';
-import { diffVersionSkills, iterSkillsCapableVersions } from './skills.js';
+import { diffVersionSkills, iterSkillsCapableVersions } from './plugins/skills.js';
 import { iterHooksCapableVersions, listUnmanagedHooksInVersionHome, checkVersionHookWiring } from './hooks.js';
 import { commitsBehindUpstream } from './git.js';
 import { getUserAgentsDir, getSystemAgentsDir, getEnabledExtraRepos } from './state.js';

--- a/apps/cli/src/lib/heal.ts
+++ b/apps/cli/src/lib/heal.ts
@@ -45,8 +45,8 @@ import {
   updatePlugin,
   readPluginSourceInfo,
   getUpstreamManifestVersion,
-} from './plugins.js';
-import { repairPluginManifestFile } from './plugin-marketplace.js';
+} from './plugins/plugins.js';
+import { repairPluginManifestFile } from './plugins/plugin-marketplace.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';

--- a/apps/cli/src/lib/plugins/plugin-marketplace.test.ts
+++ b/apps/cli/src/lib/plugins/plugin-marketplace.test.ts
@@ -6,7 +6,7 @@
  * Real filesystem under os.tmpdir(). The only thing redirected is state.js's
  * path getters (getPluginsDir / getEnabledExtraRepos / getProjectPluginsDir) so
  * discovery points at tmp repos instead of the real ~/.agents — the same
- * vi.doMock('./state.js') pattern used in plugins.test.ts.
+ * vi.doMock('../state.js') pattern used in plugins.test.ts.
  */
 
 import * as fs from 'fs';
@@ -31,7 +31,7 @@ import {
   unregisterCopilotInstalledPlugin,
   validateClaudePluginManifest,
 } from './plugin-marketplace.js';
-import type { DiscoveredPlugin, MarketplaceSpec } from './types.js';
+import type { DiscoveredPlugin, MarketplaceSpec } from '../types.js';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -112,8 +112,8 @@ describe('discoverMarketplaces', () => {
   ): Promise<void> {
     const { vi } = await import('vitest');
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       return {
         ...actual,
         getPluginsDir: () => overrides.pluginsDir ?? userPlugins,
@@ -129,7 +129,7 @@ describe('discoverMarketplaces', () => {
       const mod = await import('./plugin-marketplace.js');
       await fn(mod);
     } finally {
-      vi.doUnmock('./state.js');
+      vi.doUnmock('../state.js');
       vi.resetModules();
     }
   }
@@ -487,8 +487,8 @@ describe('syncAllMarketplaces', () => {
   it('produces one entry per discovered marketplace that has copied plugins', async () => {
     const { vi } = await import('vitest');
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       return {
         ...actual,
         getPluginsDir: () => userPlugins,
@@ -515,7 +515,7 @@ describe('syncAllMarketplaces', () => {
       const known = JSON.parse(fs.readFileSync(mod.knownMarketplacesPath('claude', versionHome), 'utf-8'));
       expect(Object.keys(known).sort()).toEqual(['agents-cli', 'agents-project']);
     } finally {
-      vi.doUnmock('./state.js');
+      vi.doUnmock('../state.js');
       vi.resetModules();
     }
   });
@@ -523,8 +523,8 @@ describe('syncAllMarketplaces', () => {
   it('skips discovered marketplaces with no copied plugins (no empty registration)', async () => {
     const { vi } = await import('vitest');
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       return {
         ...actual,
         getPluginsDir: () => userPlugins,
@@ -539,7 +539,7 @@ describe('syncAllMarketplaces', () => {
       const results = mod.syncAllMarketplaces('claude', versionHome);
       expect(results.map(r => r.name)).toEqual(['agents-cli']);
     } finally {
-      vi.doUnmock('./state.js');
+      vi.doUnmock('../state.js');
       vi.resetModules();
     }
   });

--- a/apps/cli/src/lib/plugins/plugin-marketplace.ts
+++ b/apps/cli/src/lib/plugins/plugin-marketplace.ts
@@ -27,10 +27,10 @@
  */
 
 import * as fs from 'fs';
-import { agentConfigDirName } from './agents.js';
+import { agentConfigDirName } from '../agents.js';
 import * as path from 'path';
-import type { AgentId, DiscoveredPlugin, PluginManifest, MarketplaceSpec, DiscoveredMarketplace } from './types.js';
-import { getPluginsDir, getEnabledExtraRepos, getProjectPluginsDir, getSystemPluginsDir } from './state.js';
+import type { AgentId, DiscoveredPlugin, PluginManifest, MarketplaceSpec, DiscoveredMarketplace } from '../types.js';
+import { getPluginsDir, getEnabledExtraRepos, getProjectPluginsDir, getSystemPluginsDir } from '../state.js';
 
 /**
  * Canonical name for the user-repo marketplace (~/.agents/plugins/). Kept as an

--- a/apps/cli/src/lib/plugins/plugins.test.ts
+++ b/apps/cli/src/lib/plugins/plugins.test.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as yaml from 'yaml';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { toPosix } from './platform/index.js';
+import { toPosix } from '../platform/index.js';
 
 // RUSH-2215 review: do not skip the whole file on win32. Symlink-only cases
 // already use it.skipIf(win32); pure suites (expandPluginVars, parseInstallSpec, …)
@@ -38,7 +38,7 @@ import {
   isHermesPluginInstalled,
   isOpenCodePluginInstalled,
 } from './plugins.js';
-import type { DiscoveredPlugin, PluginManifest } from './types.js';
+import type { DiscoveredPlugin, PluginManifest } from '../types.js';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -275,8 +275,8 @@ describePlugins('discoverPlugins', () => {
     fs.symlinkSync(sourceRoot, path.join(pluginsDir, 'linked-plugin'), process.platform === 'win32' ? 'junction' : 'dir');
 
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       return { ...actual, getPluginsDir: () => pluginsDir, getEnabledExtraRepos: () => [], getProjectPluginsDir: () => null, getSystemPluginsDir: () => path.join(tmpDir, 'no-system') };
     });
 
@@ -292,7 +292,7 @@ describePlugins('discoverPlugins', () => {
       expect(plugins[0]?.repoRoot).toBe(tmpDir);
       expect(plugins[0]?.snapshotSha).toBeUndefined();
     } finally {
-      vi.doUnmock('./state.js');
+      vi.doUnmock('../state.js');
       vi.resetModules();
     }
   });
@@ -309,14 +309,14 @@ describePlugins('discoverPlugins', () => {
     fs.renameSync(path.join(tmpDir, 'test-plugin'), path.join(pluginsDir, 'git-tracked-plugin'));
 
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       return { ...actual, getPluginsDir: () => pluginsDir, getEnabledExtraRepos: () => [], getProjectPluginsDir: () => null, getSystemPluginsDir: () => path.join(tmpDir, 'no-system') };
     });
 
     try {
       const { discoverPlugins: discover } = await import('./plugins.js');
-      const { _resetSnapshotShaCacheForTest } = await import('./git.js');
+      const { _resetSnapshotShaCacheForTest } = await import('../git.js');
       _resetSnapshotShaCacheForTest();
       const plugins = discover();
       expect(plugins.map((plugin) => plugin.name)).toEqual(['git-tracked-plugin']);
@@ -324,7 +324,7 @@ describePlugins('discoverPlugins', () => {
       expect(plugins[0]?.snapshotSha).toBe(expectedSha);
       _resetSnapshotShaCacheForTest();
     } finally {
-      vi.doUnmock('./state.js');
+      vi.doUnmock('../state.js');
       vi.resetModules();
     }
   });
@@ -334,8 +334,8 @@ describePlugins('discoverPlugins', () => {
     fs.symlinkSync(path.join(tmpDir, 'missing'), path.join(pluginsDir, 'missing-plugin'), 'dir');
 
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       return { ...actual, getPluginsDir: () => pluginsDir, getEnabledExtraRepos: () => [], getProjectPluginsDir: () => null, getSystemPluginsDir: () => path.join(tmpDir, 'no-system') };
     });
 
@@ -343,7 +343,7 @@ describePlugins('discoverPlugins', () => {
       const { discoverPlugins: discover } = await import('./plugins.js');
       expect(discover()).toEqual([]);
     } finally {
-      vi.doUnmock('./state.js');
+      vi.doUnmock('../state.js');
       vi.resetModules();
     }
   });
@@ -359,8 +359,8 @@ describePlugins('discoverPlugins', () => {
     fs.renameSync(path.join(tmpDir, 'test-plugin'), path.join(pluginsDir, 'goodplug'));
 
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       return { ...actual, getPluginsDir: () => pluginsDir, getEnabledExtraRepos: () => [], getProjectPluginsDir: () => null, getSystemPluginsDir: () => path.join(tmpDir, 'no-system') };
     });
 
@@ -374,7 +374,7 @@ describePlugins('discoverPlugins', () => {
       expect(plugins.map((p) => p.name)).toEqual(['goodplug']);
     } finally {
       process.stderr.write = origWrite;
-      vi.doUnmock('./state.js');
+      vi.doUnmock('../state.js');
       vi.resetModules();
     }
 
@@ -415,18 +415,18 @@ describePlugins('discoverPlugins across marketplaces', () => {
   });
 
   afterEach(() => {
-    vi.doUnmock('./state.js');
+    vi.doUnmock('../state.js');
     vi.resetModules();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   async function withState(
-    overrides: Partial<typeof import('./state.js')>,
+    overrides: Partial<typeof import('../state.js')>,
     fn: (mod: typeof import('./plugins.js')) => Promise<void> | void
   ) {
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       // Isolate from a real ~/.agents/.system/plugins on the dev machine; a test
       // can still opt into a system repo by passing getSystemPluginsDir in overrides.
       return { ...actual, getSystemPluginsDir: () => path.join(tmpDir, 'no-system'), ...overrides };
@@ -435,7 +435,7 @@ describePlugins('discoverPlugins across marketplaces', () => {
       const mod = await import('./plugins.js');
       await fn(mod);
     } finally {
-      vi.doUnmock('./state.js');
+      vi.doUnmock('../state.js');
       vi.resetModules();
     }
   }
@@ -866,8 +866,8 @@ describePlugins('loadUserConfig / saveUserConfig', () => {
     const pluginsDir = path.join(tmpDir, 'plugins');
 
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       return { ...actual, getPluginsDir: () => pluginsDir };
     });
     try {
@@ -876,7 +876,7 @@ describePlugins('loadUserConfig / saveUserConfig', () => {
       const loaded = load(pluginName);
       expect(loaded).toEqual(testConfig);
     } finally {
-      vi.doUnmock('./state.js');
+      vi.doUnmock('../state.js');
       vi.resetModules();
     }
   });
@@ -950,8 +950,8 @@ describePlugins('installPlugin validation', () => {
     pluginsDir = path.join(tmpDir, 'plugins');
     execFileSyncMock = vi.fn();
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       return { ...actual, getPluginsDir: () => pluginsDir };
     });
     vi.doMock('child_process', async (importOriginal) => {
@@ -961,7 +961,7 @@ describePlugins('installPlugin validation', () => {
   });
 
   afterEach(() => {
-    vi.doUnmock('./state.js');
+    vi.doUnmock('../state.js');
     vi.doUnmock('child_process');
     vi.resetModules();
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -2029,8 +2029,8 @@ describePlugins('updatePlugin exec-surface consent gate', () => {
 
   async function loadUpdate() {
     vi.resetModules();
-    vi.doMock('./state.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('./state.js')>();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
       return {
         ...actual,
         getPluginsDir: () => pluginsDir,
@@ -2051,7 +2051,7 @@ describePlugins('updatePlugin exec-surface consent gate', () => {
   });
 
   afterEach(() => {
-    vi.doUnmock('./state.js');
+    vi.doUnmock('../state.js');
     vi.resetModules();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });

--- a/apps/cli/src/lib/plugins/plugins.ts
+++ b/apps/cli/src/lib/plugins/plugins.ts
@@ -14,14 +14,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'yaml';
 import { execFileSync } from 'child_process';
-import type { AgentId, DiscoveredPlugin, PluginManifest, MarketplaceSpec } from './types.js';
-import { getPluginsDir, getTrashPluginsDir, getExtraPluginsDir, getProjectPluginsDir, getSystemPluginsDir } from './state.js';
-import { IS_WINDOWS, isWindowsAbsolutePath, homeDir } from './platform/index.js';
-import { assertSafeGitTransport, resolveSnapshotSha } from './git.js';
-import { listInstalledVersions, getVersionHomePath } from './versions.js';
-import { AGENTS, agentConfigDirName } from './agents.js';
-import { capableAgents, isCapable } from './capabilities.js';
-import { shouldInstallCommandAsSkill, installCommandSkillToVersion } from './command-skills.js';
+import type { AgentId, DiscoveredPlugin, PluginManifest, MarketplaceSpec } from '../types.js';
+import { getPluginsDir, getTrashPluginsDir, getExtraPluginsDir, getProjectPluginsDir, getSystemPluginsDir } from '../state.js';
+import { IS_WINDOWS, isWindowsAbsolutePath, homeDir } from '../platform/index.js';
+import { assertSafeGitTransport, resolveSnapshotSha } from '../git.js';
+import { listInstalledVersions, getVersionHomePath } from '../versions.js';
+import { AGENTS, agentConfigDirName } from '../agents.js';
+import { capableAgents, isCapable } from '../capabilities.js';
+import { shouldInstallCommandAsSkill, installCommandSkillToVersion } from '../command-skills.js';
 import {
   copyPluginToMarketplace,
   syncMarketplaceManifest,

--- a/apps/cli/src/lib/plugins/skills.test.ts
+++ b/apps/cli/src/lib/plugins/skills.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 });
 
 const tsxBin = path.resolve('node_modules/.bin/tsx');
-const skillsModuleUrl = pathToFileURL(path.resolve('src/lib/skills.ts')).href;
+const skillsModuleUrl = pathToFileURL(path.resolve('src/lib/plugins/skills.ts')).href;
 
 /**
  * Spawn a subprocess with an isolated HOME so os.homedir() returns tempHome.

--- a/apps/cli/src/lib/plugins/skills.ts
+++ b/apps/cli/src/lib/plugins/skills.ts
@@ -11,14 +11,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as yaml from 'yaml';
-import type { AgentId, SkillMetadata, InstalledSkill } from './types.js';
-import { normalizeAliases } from './resource-aliases.js';
-import { AGENTS, ensureSkillsDir, agentConfigDirName } from './agents.js';
-import { capableAgents, isCapable } from './capabilities.js';
-import { getAgentsDir, getUserSkillsDir, getSkillsDir as getSystemSkillsDir, getProjectAgentsDir, getEnabledExtraRepos, getTrashSkillsDir } from './state.js';
-import { getEffectiveHome, getVersionHomePath, listInstalledVersions } from './versions.js';
-import { listCommandSkillsInVersion } from './command-skills.js';
-import { emit } from './events.js';
+import type { AgentId, SkillMetadata, InstalledSkill } from '../types.js';
+import { normalizeAliases } from '../resource-aliases.js';
+import { AGENTS, ensureSkillsDir, agentConfigDirName } from '../agents.js';
+import { capableAgents, isCapable } from '../capabilities.js';
+import { getAgentsDir, getUserSkillsDir, getSkillsDir as getSystemSkillsDir, getProjectAgentsDir, getEnabledExtraRepos, getTrashSkillsDir } from '../state.js';
+import { getEffectiveHome, getVersionHomePath, listInstalledVersions } from '../versions.js';
+import { listCommandSkillsInVersion } from '../command-skills.js';
+import { emit } from '../events.js';
 
 const HOME = os.homedir();
 

--- a/apps/cli/src/lib/project-launch.test.ts
+++ b/apps/cli/src/lib/project-launch.test.ts
@@ -45,7 +45,7 @@ import {
   SYSTEM_MARKETPLACE_NAME,
   marketplaceManifestPath,
   marketplaceRoot,
-} from './plugin-marketplace.js';
+} from './plugins/plugin-marketplace.js';
 
 function writeFile(abs: string, content: string): void {
   fs.mkdirSync(path.dirname(abs), { recursive: true });

--- a/apps/cli/src/lib/project-launch.ts
+++ b/apps/cli/src/lib/project-launch.ts
@@ -53,7 +53,7 @@ import { getVersionHomePath } from './versions.js';
 import { toPortableKey } from './platform/index.js';
 import { compileRulesForProject } from './rules/compile.js';
 import { syncProjectResourcesToAgent } from './project-resources.js';
-import { discoverPluginsInDir, hasPluginExecSurfaces, inspectPluginCapabilities } from './plugins.js';
+import { discoverPluginsInDir, hasPluginExecSurfaces, inspectPluginCapabilities } from './plugins/plugins.js';
 import type { DiscoveredPlugin } from './types.js';
 import {
   MARKETPLACE_NAME,
@@ -67,7 +67,7 @@ import {
   registerMarketplace,
   removePluginFromSettings,
   syncMarketplaceManifest,
-} from './plugin-marketplace.js';
+} from './plugins/plugin-marketplace.js';
 
 export interface LaunchSyncOptions {
   agent: AgentId;

--- a/apps/cli/src/lib/registry.ts
+++ b/apps/cli/src/lib/registry.ts
@@ -21,7 +21,7 @@ import type {
 } from './types.js';
 import { DEFAULT_REGISTRIES, SEEDED_REGISTRIES } from './types.js';
 import { readMeta, writeMeta } from './state.js';
-import { discoverSkillsFromRepo } from './skills.js';
+import { discoverSkillsFromRepo } from './plugins/skills.js';
 
 const UNSAFE_PACKAGE_SPEC_CHARS = /[;&|`$\s\x00-\x1f\x7f]/;
 const NPM_SPEC_PATTERN = /^(@[a-z0-9][a-z0-9-_.]*\/)?[a-z0-9][a-z0-9-_.]*(@[A-Za-z0-9._+-]+)?$/;

--- a/apps/cli/src/lib/resources.ts
+++ b/apps/cli/src/lib/resources.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import type { AgentId } from './types.js';
 import { AGENTS, listInstalledMcpsWithScope } from './agents.js';
 import { listInstalledCommandsWithScope, parseCommandMetadata } from './commands.js';
-import { listInstalledSkillsWithScope, parseSkillMetadata, type SkillParseError } from './skills.js';
+import { listInstalledSkillsWithScope, parseSkillMetadata, type SkillParseError } from './plugins/skills.js';
 import { listOnDiskHooks } from './resource-inventory.js';
 import { listInstalledInstructionsWithScope } from './rules/rules.js';
 import { getEffectiveHome } from './versions.js';

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -22,7 +22,7 @@ import { persistToolCalls, toolEvidenceSourcePath } from './tool-store.js';
 import { buildClaudeAccountIndex, resolveClaudeAccount } from './claude-accounts.js';
 import { extractSkills, extractSlashCommands } from './highlights.js';
 import { resolveResource } from '../resources.js';
-import { discoverPlugins } from '../plugins.js';
+import { discoverPlugins } from '../plugins/plugins.js';
 import { machineId } from '../machine-id.js';
 import type { DiscoveredPlugin } from '../types.js';
 

--- a/apps/cli/src/lib/staleness/detectors/plugins.ts
+++ b/apps/cli/src/lib/staleness/detectors/plugins.ts
@@ -5,7 +5,7 @@
  */
 import type { AgentId } from '../../types.js';
 import { capableAgents } from '../../capabilities.js';
-import { discoverPlugins, isPluginSynced } from '../../plugins.js';
+import { discoverPlugins, isPluginSynced } from '../../plugins/plugins.js';
 import type { ResourceDetector, DetectArgs } from './types.js';
 import { lazyAgentMap } from '../writers/lazy-map.js';
 

--- a/apps/cli/src/lib/staleness/writers/plugins.ts
+++ b/apps/cli/src/lib/staleness/writers/plugins.ts
@@ -4,7 +4,7 @@
  */
 import type { AgentId } from '../../types.js';
 import { capableAgents } from '../../capabilities.js';
-import { discoverPlugins, syncPluginToVersion, pluginSupportsAgent, cleanOrphanedPluginSkills } from '../../plugins.js';
+import { discoverPlugins, syncPluginToVersion, pluginSupportsAgent, cleanOrphanedPluginSkills } from '../../plugins/plugins.js';
 import type { ResourceWriter, WriteArgs, WriteResult } from './types.js';
 import { lazyAgentMap } from './lazy-map.js';
 

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -52,7 +52,7 @@ import { listInstalledSubagents, transformSubagentForClaude, syncSubagentToOpenc
 import { listInstalledWorkflows, syncWorkflowToVersion } from './workflows.js';
 import { parseHookManifest, registerHooksToSettings, selectHookManifest, pruneVersionHomeHookEntriesFromSettings } from './hooks.js';
 import { supports, explainSkip, capableAgents } from './capabilities.js';
-import { discoverPlugins, syncPluginToVersion, isPluginSynced, pluginSupportsAgent, cleanOrphanedPluginSkills, marketplaceSpecForName } from './plugins.js';
+import { discoverPlugins, syncPluginToVersion, isPluginSynced, pluginSupportsAgent, cleanOrphanedPluginSkills, marketplaceSpecForName } from './plugins/plugins.js';
 import { composeRulesFromState } from './rules/compose.js';
 import { loadManifest, saveManifest, buildManifest as buildSyncManifest, isStale } from './staleness/index.js';
 import { pruneRemovedResources, type PrunableKind } from './staleness/prune.js';

--- a/apps/cli/tests/extra-repos.test.ts
+++ b/apps/cli/tests/extra-repos.test.ts
@@ -46,7 +46,7 @@ vi.mock('../src/lib/versions.js', () => ({
 }));
 
 async function importSkillsLib() {
-  return await import('../src/lib/skills.js');
+  return await import('../src/lib/plugins/skills.js');
 }
 
 function writeSkill(baseSkillsDir: string, name: string, description: string): void {

--- a/apps/cli/tests/plugin-manifest-repair.test.ts
+++ b/apps/cli/tests/plugin-manifest-repair.test.ts
@@ -19,7 +19,7 @@ import * as os from 'os';
 import {
   repairableManifestFields,
   repairPluginManifestFile,
-} from '../src/lib/plugin-marketplace.js';
+} from '../src/lib/plugins/plugin-marketplace.js';
 
 let TMP: string;
 let manifestPath: string;

--- a/apps/cli/tests/versions.test.ts
+++ b/apps/cli/tests/versions.test.ts
@@ -104,7 +104,7 @@ vi.mock('../src/lib/state.js', () => {
 });
 
 // Mock external dependencies that syncResourcesToVersion calls
-vi.mock('../src/lib/plugins.js', () => ({
+vi.mock('../src/lib/plugins/plugins.js', () => ({
   discoverPlugins: () => [],
   syncPluginToVersion: () => ({ success: false }),
   isPluginSynced: () => false,


### PR DESCRIPTION
**refactor** — behavior-preserving, moves + import-path only.

Move 3 domain collapse: `lib/plugins.ts`, `lib/plugin-marketplace.ts`, `lib/skills.ts` (+ tests) → `lib/plugins/`, consumers repointed, moved files' imports depth-fixed.

## Proof
- `bun run build` (tsc) clean — 0 errors.
- Same-named different files correctly left alone (`commands/plugins.js`, `lib/resources/skills.js`).

Follows Move 1/2b/5/3-accounting/3-feed.