### PR TITLE
refactor(cli): group feed/activity/events into lib/feed (Move 3, RUSH-2708)

### DIFF
--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -192,7 +192,7 @@ long it must live and how it's read back:
 | Transcripts | `~/.claude/projects/…`, `~/.codex/sessions/…`, … | agent-native files (read-only) | the raw truth; parsed on demand |
 | CLI pid-registry | `~/.agents/.cache/terminals/by-pid/<pid>.json` | ephemeral file | `ag run`/shim write; CLI reads (§3) |
 | Live-session state | `~/.agents/.cache/terminals/sessions/<pid>.json` | ephemeral file | hook writes; extension reads (§3) |
-| Audit log | `~/.agents/.history/events/YYYY-MM-DD/events.jsonl` | dated, locked shared log | `emit()` in [`src/lib/events.ts`](../src/lib/events.ts); `agents events` reads; `agents audit` / `agents logs` are aliases |
+| Audit log | `~/.agents/.history/events/YYYY-MM-DD/events.jsonl` | dated, locked shared log | `emit()` in [`src/lib/feed/events.ts`](../src/lib/feed/events.ts); `agents events` reads; `agents audit` / `agents logs` are aliases |
 | Teams sentinels | `…/agents/<uuid>/exit_code`, `hosts/<id>.log` + `.exit` | ephemeral files | teammate writes exit code; supervisor reads (§6) |
 | Mailbox spool | `~/.agents/.history/mailbox/<id>/…` | append-only dirs | `agents message` / feed; `agents mailboxes` reads |
 

--- a/apps/cli/docs/observability.md
+++ b/apps/cli/docs/observability.md
@@ -222,7 +222,7 @@ what the sessions index's `usedBrowser`/`usedComputer` columns are built on
 (see [sessions.md](sessions.md)).
 
 Every record carries **attribution** computed once per process
-([`src/lib/events.ts`](../src/lib/events.ts)):
+([`src/lib/feed/events.ts`](../src/lib/feed/events.ts)):
 
 - `osUser` — the OS account that ran it.
 - `transport` — `local`, or `ssh` when `$SSH_CONNECTION` is present.

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -2802,7 +2802,7 @@ is not two daemons existing — it is two daemons consuming the **same** input.
   is a misconfiguration that fires only on the owner with a fix hint,
   `lib/scheduler.ts`); or (b) **atomic claim** — each item is claimed with an
   atomic primitive before work begins (precedent: the feed's `O_EXCL` block claim,
-  `lib/feed.ts` — two concurrent claimers cannot both succeed); or
+  `lib/feed/feed.ts` — two concurrent claimers cannot both succeed); or
   (c) **idempotency** — a concurrent second execution of the same item is a
   verified no-op. `dispatch: fleet` (one online device picked per run,
   `lib/routines.ts`) satisfies (a) for dispatch targets.

--- a/apps/cli/src/bootstrap.ts
+++ b/apps/cli/src/bootstrap.ts
@@ -89,7 +89,7 @@ import { applyGlobalHelpConventions } from './lib/help.js';
 import { renderWhatsNew } from './lib/whats-new.js';
 import { IS_WINDOWS } from './lib/platform/index.js';
 import { getCliLaunch } from './lib/cli-entry.js';
-import { emit, emitFriction, redactArgs } from './lib/events.js';
+import { emit, emitFriction, redactArgs } from './lib/feed/events.js';
 import { stampProvenance } from './lib/event-provenance.js';
 import { die } from './lib/format.js';
 // Leaf (zero imports). Gates the dynamic passthrough import so the ~187ms

--- a/apps/cli/src/commands/cloud.ts
+++ b/apps/cli/src/commands/cloud.ts
@@ -16,7 +16,7 @@ import { MAX_IMAGES_PER_DISPATCH } from '../lib/cloud/types.js';
 import { resolveCloudPrompt, executeCloudDispatch } from '../lib/cloud/dispatch.js';
 import type { JobConfig, JobTrigger } from '../lib/routines.js';
 import { normalizeTriggerEvent, validateTrigger, writeJob, setJobEnabled, jobExists, GITHUB_TRIGGER_EVENTS } from '../lib/routines.js';
-import { emit } from '../lib/events.js';
+import { emit } from '../lib/feed/events.js';
 
 /** Return a chalk color function appropriate for the given task status. */
 export function statusColor(status: string): (s: string) => string {

--- a/apps/cli/src/commands/computer-actions.test.ts
+++ b/apps/cli/src/commands/computer-actions.test.ts
@@ -21,7 +21,7 @@ import {
   type AppInfo,
 } from './computer-actions.js';
 import { resolveRpcTimeoutMs, RPC_TIMEOUT_MS, type ComputerClient, type RPCResponse } from '../lib/computer-rpc.js';
-import { query, _resetForTest } from '../lib/events.js';
+import { query, _resetForTest } from '../lib/feed/events.js';
 
 const tempDirs: string[] = [];
 

--- a/apps/cli/src/commands/computer.test.ts
+++ b/apps/cli/src/commands/computer.test.ts
@@ -9,7 +9,7 @@ import {
   shouldBlockOffPlatform,
   emitComputerRunTaskMarker,
 } from './computer.js';
-import { query, _resetForTest } from '../lib/events.js';
+import { query, _resetForTest } from '../lib/feed/events.js';
 import { TASK_PREVIEW_MAX_CHARS } from '../lib/computer/sessions-list.js';
 
 // Real leading magic bytes, matching what each helper actually encodes.

--- a/apps/cli/src/commands/computer.ts
+++ b/apps/cli/src/commands/computer.ts
@@ -37,7 +37,7 @@ import { makeVerbDispatcher } from '../lib/computer/dispatch.js';
 import { makeClaudeResponder, resolveApiKey, DEFAULT_CLAUDE_MODEL, DEFAULT_CLAUDE_BASE_URL } from '../lib/computer/model.js';
 import { TASK_PREVIEW_MAX_CHARS } from '../lib/computer/sessions-list.js';
 import { runComputerSessionsCommand } from './computer-sessions-picker.js';
-import { truncate } from '../lib/events.js';
+import { truncate } from '../lib/feed/events.js';
 
 // Help groups — mirror `agents browser` so the mental model carries over.
 const COMPUTER_HELP_GROUPS = [

--- a/apps/cli/src/commands/events.ts
+++ b/apps/cli/src/commands/events.ts
@@ -16,7 +16,7 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
-import { getLogsPath, stats, rotate, type EventRecord, type EventType, type EventLevel } from '../lib/events.js';
+import { getLogsPath, stats, rotate, type EventRecord, type EventType, type EventLevel } from '../lib/feed/events.js';
 import { readUnifiedEvents } from '../lib/event-stream.js';
 import { parseFamilyList, EVENT_FAMILIES, type EventFamily } from '../lib/event-families.js';
 import { ingestBatch } from '../lib/events-ingest.js';

--- a/apps/cli/src/commands/factory.ts
+++ b/apps/cli/src/commands/factory.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import { homedir } from 'os';
 import { betaEnableHint, isBetaEnabled } from '../lib/beta.js';
 import { insertTask } from '../lib/cloud/store.js';
-import { emit } from '../lib/events.js';
+import { emit } from '../lib/feed/events.js';
 import { buildFactorySnapshot, type FactorySnapshot } from '../lib/factory/snapshot.js';
 
 

--- a/apps/cli/src/commands/feed.test.ts
+++ b/apps/cli/src/commands/feed.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { spawn, type ChildProcess } from 'child_process';
 import { Command } from 'commander';
-import type { OpenBlock } from '../lib/feed.js';
+import type { OpenBlock } from '../lib/feed/feed.js';
 import {
   controlFeedSession,
   formatFeedMastheadRight,
@@ -22,7 +22,7 @@ import {
 } from './feed.js';
 import { groupBlocksByOutcome } from '../lib/feed-outcome.js';
 import { GLYPH } from '../lib/comms-render.js';
-import { formatActivityLine } from '../lib/activity.js';
+import { formatActivityLine } from '../lib/feed/activity.js';
 
 describe('resolveFeedFilter', () => {
   it('defaults to needs and normalizes aliases', () => {

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -25,7 +25,7 @@ import {
   buildDeclaredBlock,
   publishBlock,
   type OpenBlock,
-} from '../lib/feed.js';
+} from '../lib/feed/feed.js';
 
 import {
   ensureActivityLogHook,
@@ -36,7 +36,7 @@ import {
   parseActivityPayload,
   type ActivityEvent,
   type EnrichedActivityEvent,
-} from '../lib/activity.js';
+} from '../lib/feed/activity.js';
 import { projectKeyFromCwd } from '../lib/project-key.js';
 import { postFeedStatus } from '../lib/feed-post.js';
 import {

--- a/apps/cli/src/commands/logs.test.ts
+++ b/apps/cli/src/commands/logs.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   emit, query, rotate, stats,
   _resetForTest,
-} from '../lib/events.js';
+} from '../lib/feed/events.js';
 
 const tempDirs: string[] = [];
 

--- a/apps/cli/src/commands/logs.ts
+++ b/apps/cli/src/commands/logs.ts
@@ -32,7 +32,7 @@ import { listTasks, type HostTask } from '../lib/hosts/tasks.js';
 import { itemPicker } from '../lib/picker.js';
 import {
   stats, getLogsPath, rotate,
-} from '../lib/events.js';
+} from '../lib/feed/events.js';
 import { addEventsReadOptions, runEventsCommand, type EventsOptions } from './events.js';
 
 interface LogsOptions {

--- a/apps/cli/src/commands/mcp.ts
+++ b/apps/cli/src/commands/mcp.ts
@@ -13,7 +13,7 @@ import ora from 'ora';
 import { checkbox } from '@inquirer/prompts';
 
 import { capableAgents, isCapable } from '../lib/capabilities.js';
-import { emit } from '../lib/events.js';
+import { emit } from '../lib/feed/events.js';
 import {
   AGENTS,
   ALL_AGENT_IDS,

--- a/apps/cli/src/commands/message.ts
+++ b/apps/cli/src/commands/message.ts
@@ -46,7 +46,7 @@ import {
   recordAnswer,
   recordMessageReceipt,
   type OpenBlock,
-} from '../lib/feed.js';
+} from '../lib/feed/feed.js';
 import { verifyOperatorIdentity } from '../lib/operator.js';
 import {
   resolveAnswerRoute,

--- a/apps/cli/src/commands/perf.ts
+++ b/apps/cli/src/commands/perf.ts
@@ -27,7 +27,7 @@ import {
   aggregateHookProfile,
   type HookProfileRow,
 } from '../lib/hooks/profile.js';
-import { query } from '../lib/events.js';
+import { query } from '../lib/feed/events.js';
 import { detectRepeatedGuardBlocks } from '../lib/friction-heuristics.js';
 
 interface PerfGlobalOpts {

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -116,7 +116,7 @@ import { saveSession, deleteBundleSessions, deleteAllSessions } from '../lib/sec
 import { getCliVersionFresh } from '../lib/version.js';
 import { readMeta } from '../lib/state.js';
 import { parseDuration } from '../lib/hooks/cache.js';
-import { emit, query } from '../lib/events.js';
+import { emit, query } from '../lib/feed/events.js';
 import { emitSecretAudit } from '../lib/secrets/audit.js';
 import { SYNC_PASSPHRASE_ENV, resolveSyncPassphraseFromEnv } from '../lib/secrets/sync-passphrase.js';
 import {

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -25,7 +25,7 @@ import {
 import { mailboxDir, enqueue } from '../lib/mailbox.js';
 import { resolveProvider } from '../lib/cloud/registry.js';
 import type { CloudProviderId, DispatchOptions } from '../lib/cloud/types.js';
-import { emit } from '../lib/events.js';
+import { emit } from '../lib/feed/events.js';
 import { maybeShowStarNudge } from '../lib/star-nudge.js';
 import { shareRuntimeEnv } from '../lib/share/config.js';
 import { runSupervisor } from '../lib/teams/supervisor.js';

--- a/apps/cli/src/lib/accounting/rotate.ts
+++ b/apps/cli/src/lib/accounting/rotate.ts
@@ -20,7 +20,7 @@ import {
 import { readMeta, writeMeta, getHelpersDir } from '../state.js';
 import { listInstalledVersions, getVersionHomePath, resolveVersion } from '../versions.js';
 import { getProjectRunConfigs } from '../run-config.js';
-import { emit } from '../events.js';
+import { emit } from '../feed/events.js';
 import {
   getUsageInfoByIdentity,
   getUsageLookupKey,

--- a/apps/cli/src/lib/answer-router.test.ts
+++ b/apps/cli/src/lib/answer-router.test.ts
@@ -7,7 +7,7 @@ import {
   resolveAnswerRoute,
   resumeArgv,
 } from './answer-router.js';
-import type { OpenBlock } from './feed.js';
+import type { OpenBlock } from './feed/feed.js';
 import type { ActiveSession } from './session/active.js';
 
 function block(over: Partial<OpenBlock> = {}): OpenBlock {

--- a/apps/cli/src/lib/answer-router.ts
+++ b/apps/cli/src/lib/answer-router.ts
@@ -10,7 +10,7 @@
  * This module picks the delivery mechanism from (open feed block × session
  * liveness × runtime rail). Pure — unit-testable without a live PTY.
  */
-import type { OpenBlock, BlockOption } from './feed.js';
+import type { OpenBlock, BlockOption } from './feed/feed.js';
 import type { ActiveSession } from './session/active.js';
 import type { InjectTarget } from './terminal/index.js';
 import { injectTargetFromReplyRail } from './session/inject.js';

--- a/apps/cli/src/lib/ask-classifier.test.ts
+++ b/apps/cli/src/lib/ask-classifier.test.ts
@@ -9,7 +9,7 @@ import {
   suppressStallBlock,
   suppressionDigest,
 } from './ask-classifier.js';
-import { blockIdForSession, listBlocks, publishBlock, type OpenBlock } from './feed.js';
+import { blockIdForSession, listBlocks, publishBlock, type OpenBlock } from './feed/feed.js';
 import { drain, mailboxDir } from './mailbox.js';
 
 function makeBlock(sessionId: string, text: string, over?: Partial<OpenBlock>): OpenBlock {

--- a/apps/cli/src/lib/ask-classifier.ts
+++ b/apps/cli/src/lib/ask-classifier.ts
@@ -13,8 +13,8 @@
  * Rules-based on stable high-volume shapes. Pure classify/match; suppression has
  * side effects via the feed store when applied.
  */
-import type { OpenBlock } from './feed.js';
-import { recordAnswer, recordMessageReceipt, removeBlock } from './feed.js';
+import type { OpenBlock } from './feed/feed.js';
+import { recordAnswer, recordMessageReceipt, removeBlock } from './feed/feed.js';
 import { enqueue, mailboxDir } from './mailbox.js';
 
 /** Taxonomy for a published ask. Exactly one class per block. */

--- a/apps/cli/src/lib/audit/log.test.ts
+++ b/apps/cli/src/lib/audit/log.test.ts
@@ -13,7 +13,7 @@ import {
   GENESIS_HASH,
   type AuditEntry,
 } from './log.js';
-import { query, _resetForTest as resetEvents } from '../events.js';
+import { query, _resetForTest as resetEvents } from '../feed/events.js';
 
 /** Absolute path to the log module under test — imported by the spawned workers. */
 const LOG_MODULE = fileURLToPath(new URL('./log.ts', import.meta.url));

--- a/apps/cli/src/lib/audit/log.ts
+++ b/apps/cli/src/lib/audit/log.ts
@@ -15,7 +15,7 @@ import { spawnSync } from 'child_process';
 import { sha256 } from '../staleness/fingerprint.js';
 import { getHistoryDir } from '../state.js';
 import { ensureLockTarget, withFileLock } from '../fs-atomic.js';
-import { emit } from '../events.js';
+import { emit } from '../feed/events.js';
 
 /** First record's `prevHash` — a fixed anchor so the chain has a root. */
 export const GENESIS_HASH = 'GENESIS';

--- a/apps/cli/src/lib/browser/service.test.ts
+++ b/apps/cli/src/lib/browser/service.test.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'node:events';
 import * as yaml from 'yaml';
 import * as state from '../state.js';
 import * as profiles from './profiles.js';
-import { query, _resetForTest } from '../events.js';
+import { query, _resetForTest } from '../feed/events.js';
 
 const TEST_HOME = path.join(tmpdir(), 'agents-cli-browser-service-test');
 const TEST_AGENTS_DIR = path.join(TEST_HOME, '.agents');

--- a/apps/cli/src/lib/browser/service.ts
+++ b/apps/cli/src/lib/browser/service.ts
@@ -51,7 +51,7 @@ import {
   uploadToFileInput,
   uploadViaFileChooser,
 } from './upload.js';
-import { emit } from '../events.js';
+import { emit } from '../feed/events.js';
 import { resolveActor } from '../actor.js';
 import { recordBrowserSession } from '../session/db.js';
 import { sshExecAsync } from '../ssh-exec.js';

--- a/apps/cli/src/lib/browser/sessions-list.ts
+++ b/apps/cli/src/lib/browser/sessions-list.ts
@@ -26,7 +26,7 @@ import type { SessionMeta } from '../session/types.js';
 import { getSessionById, listBrowserSessionRecords, pruneToolSessions } from '../session/db.js';
 import { listPidSessionEntries } from '../session/pid-registry.js';
 import { loadHookSessionIndex } from '../session/hook-sessions.js';
-import { readRecentActivity } from '../activity.js';
+import { readRecentActivity } from '../feed/activity.js';
 
 export type ArtifactKind = 'screenshot' | 'pdf' | 'recording' | 'download';
 

--- a/apps/cli/src/lib/cloud/dispatch.ts
+++ b/apps/cli/src/lib/cloud/dispatch.ts
@@ -16,7 +16,7 @@ import { insertTask, updateTaskStatus } from './store.js';
 import { renderStream } from './stream.js';
 import type { CloudProvider, CloudProviderId, CloudTarget, CloudTaskStatus, DispatchOptions, ImageAttachment, SkillRef } from './types.js';
 import { MissingTargetError, MAX_IMAGES_PER_DISPATCH } from './types.js';
-import { emit } from '../events.js';
+import { emit } from '../feed/events.js';
 import { shareRuntimeEnv } from '../share/config.js';
 
 /** Map a supported image file extension to its wire mimeType. Rejects anything else. */

--- a/apps/cli/src/lib/computer/actions.ts
+++ b/apps/cli/src/lib/computer/actions.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'node:crypto';
 import type { ComputerClient, RPCResponse } from '../computer-rpc.js';
 import { resolvePolicyPath } from '../computer-rpc.js';
 import { COMPUTER_INPUT_GATED_VERBS, formatComputerPermissionGrantHint } from '../permissions.js';
-import { emit as emitEvent } from '../events.js';
+import { emit as emitEvent } from '../feed/events.js';
 import { recordComputerSession } from '../session/db.js';
 import { resolveActor } from '../actor.js';
 

--- a/apps/cli/src/lib/computer/dispatch.test.ts
+++ b/apps/cli/src/lib/computer/dispatch.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { rpcMethodFor, toRpcParams, makeVerbDispatcher } from './dispatch.js';
 import type { ComputerClient, RPCResponse } from '../computer-rpc.js';
-import { query, _resetForTest } from '../events.js';
+import { query, _resetForTest } from '../feed/events.js';
 
 // The verb -> RPC translation in dispatch.ts is the load-bearing seam behind
 // `computer run`: a single wrong param key silently breaks every gated macOS

--- a/apps/cli/src/lib/computer/sessions-list.test.ts
+++ b/apps/cli/src/lib/computer/sessions-list.test.ts
@@ -16,7 +16,7 @@ import {
   type ComputerAction,
   type ComputerRunRow,
 } from './sessions-list.js';
-import { emit, query, truncate, _resetForTest } from '../events.js';
+import { emit, query, truncate, _resetForTest } from '../feed/events.js';
 import type { SessionMeta } from '../session/types.js';
 
 function makeSession(overrides: Partial<SessionMeta> = {}): SessionMeta {

--- a/apps/cli/src/lib/computer/sessions-list.ts
+++ b/apps/cli/src/lib/computer/sessions-list.ts
@@ -58,7 +58,7 @@
  * `sessionId` doesn't resolve (a rotated/unindexed session) but `launchId`
  * still does via the more authoritative pid registry.
  */
-import { query, truncate, type EventRecord } from '../events.js';
+import { query, truncate, type EventRecord } from '../feed/events.js';
 import { formatRelativeTime } from '../session/relative-time.js';
 import type { SessionMeta } from '../session/types.js';
 import { getSessionById, listComputerSessionRecords, pruneToolSessions } from '../session/db.js';

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -34,7 +34,7 @@ import { reapTerminalRoutineProcesses } from './routine-process-cleanup.js';
 import { recordSubsystemOk, recordSubsystemError, recordSubsystemErrorReason, readSubsystemHealth, SUBSYSTEM_SECRETS_BROKER, SUBSYSTEM_BROWSER_IPC, SUBSYSTEM_DAEMON_START } from './daemon-health.js';
 import { startAccountStateService } from './account-state-service.js';
 import { runActiveSessionsWarmTick, runFleetCacheWarmTick, runSessionIndexWarmTick, runUsageRefreshTick } from './daemon-ticks.js';
-import { emit, emitRoutineEnd } from './events.js';
+import { emit, emitRoutineEnd } from './feed/events.js';
 import { readDaemonServicesConfig, isDaemonServiceEnabled, type DaemonServiceId } from './daemon-services.js';
 
 const PID_FILE = 'daemon.pid';

--- a/apps/cli/src/lib/event-families.test.ts
+++ b/apps/cli/src/lib/event-families.test.ts
@@ -2,8 +2,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { emit, _resetForTest } from './events.js';
-import { appendActivityEvent } from './activity.js';
+import { emit, _resetForTest } from './feed/events.js';
+import { appendActivityEvent } from './feed/activity.js';
 import { readUnifiedEvents } from './event-stream.js';
 import { parseFamilyList, applyFamilies } from './event-families.js';
 

--- a/apps/cli/src/lib/event-families.ts
+++ b/apps/cli/src/lib/event-families.ts
@@ -4,7 +4,7 @@
  * eventTypes, level) so the engine stays single-path.
  */
 
-import type { EventType, EventLevel } from './events.js';
+import type { EventType, EventLevel } from './feed/events.js';
 import type { UnifiedQuery } from './event-stream.js';
 
 export const EVENT_FAMILIES = [

--- a/apps/cli/src/lib/event-stream.test.ts
+++ b/apps/cli/src/lib/event-stream.test.ts
@@ -2,8 +2,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { emit, _resetForTest } from './events.js';
-import { appendActivityEvent } from './activity.js';
+import { emit, _resetForTest } from './feed/events.js';
+import { appendActivityEvent } from './feed/activity.js';
 import { readUnifiedEvents } from './event-stream.js';
 
 const tempDirs: string[] = [];

--- a/apps/cli/src/lib/event-stream.ts
+++ b/apps/cli/src/lib/event-stream.ts
@@ -11,8 +11,8 @@
  * per-session shards (high frequency, one writer each). This module is the
  * single READ surface that merges them; nothing here writes.
  */
-import { query, type EventRecord, type EventType, type EventLevel, levelFor } from './events.js';
-import { readActivityAsEventRecords } from './activity.js';
+import { query, type EventRecord, type EventType, type EventLevel, levelFor } from './feed/events.js';
+import { readActivityAsEventRecords } from './feed/activity.js';
 import { applyFamilies, type EventFamily } from './event-families.js';
 
 export interface UnifiedQuery {

--- a/apps/cli/src/lib/events-ingest.test.ts
+++ b/apps/cli/src/lib/events-ingest.test.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { ingestBatch, routeFor } from './events-ingest.js';
-import { query, _resetForTest } from './events.js';
+import { query, _resetForTest } from './feed/events.js';
 
 const tempDirs: string[] = [];
 

--- a/apps/cli/src/lib/events-ingest.ts
+++ b/apps/cli/src/lib/events-ingest.ts
@@ -22,12 +22,12 @@ import {
   isEventType,
   type EventPayload,
   type EventType,
-} from './events.js';
+} from './feed/events.js';
 import {
   appendActivityEvent,
   tierForEvent,
   type ActivityEvent,
-} from './activity.js';
+} from './feed/activity.js';
 
 /** Envelope keys an incoming line may set directly; everything else is payload. */
 const ENVELOPE_KEYS = [

--- a/apps/cli/src/lib/events.bench.ts
+++ b/apps/cli/src/lib/events.bench.ts
@@ -2,7 +2,7 @@
  * Benchmark: the event-emission + provenance bootstrap that index.ts pays.
  *
  * `index.ts:213-214` imports `{ emit, emitFriction, redactArgs }` from
- * `./lib/events.js` and `{ stampProvenance }` from `./lib/event-provenance.js`
+ * `./lib/feed/events.js` and `{ stampProvenance }` from `./lib/event-provenance.js`
  * EAGERLY — top-level, before commander parses argv (`program.parseAsync()` at
  * index.ts:1440 is reached only after all module evaluation; index.ts:71 is the
  * separate `__secrets-ping`/`__secrets-get` fast-path intercept). Every `agents`
@@ -39,7 +39,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawnSync } from 'node:child_process';
-import { emit, emitFriction, redactArgs, _resetForTest } from './events.js';
+import { emit, emitFriction, redactArgs, _resetForTest } from './feed/events.js';
 import { stampProvenance, resetEventProvenanceForTest } from './event-provenance.js';
 import { resetActorCache } from './actor.js';
 
@@ -69,7 +69,7 @@ function coldEval(specs: string[]): void {
   }
 }
 
-const EVENTS_SPEC = distUrl('lib/events.js');
+const EVENTS_SPEC = distUrl('lib/feed/events.js');
 const PROVENANCE_SPEC = distUrl('lib/event-provenance.js');
 /**
  * state.js is ALREADY eager via index.ts:513, and it is the source of the two
@@ -105,7 +105,7 @@ describe('cold module-graph evaluation — index.ts:213-214 eager imports, paid 
     coldEval([PROVENANCE_SPEC]);
   }, COLD_OPTS);
 
-  bench('lib/events.js alone (index.ts:213). Heavier graph: fs-atomic.js (proper-lockfile), state.js (yaml), event-provenance.js, actor.js (events.ts:15-23)', () => {
+  bench('lib/feed/events.js alone (index.ts:213). Heavier graph: fs-atomic.js (proper-lockfile), state.js (yaml), event-provenance.js, actor.js (events.ts:15-23)', () => {
     coldEval([EVENTS_SPEC]);
   }, COLD_OPTS);
 

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -15,7 +15,7 @@ import { parseTimeout } from './routines.js';
 import { compareVersions, getBinaryPath, getVersionHomePath, isVersionInstalled, listInstalledVersions, resolveVersion } from './versions.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
 import { isTierToken, resolveTier } from './model-tiers.js';
-import { emitStart, createTimer, redactPrompt, redactArgs } from './events.js';
+import { emitStart, createTimer, redactPrompt, redactArgs } from './feed/events.js';
 import { sanitizeProcessEnv } from './secrets/bundles.js';
 import { resolveActor, actorEnv } from './actor.js';
 import { expandLocalHome } from './project-root.js';

--- a/apps/cli/src/lib/feed-blocked.test.ts
+++ b/apps/cli/src/lib/feed-blocked.test.ts
@@ -9,9 +9,9 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { buildDeclaredBlock, publishBlock, listBlocks, type DeclaringAgent } from './feed.js';
+import { buildDeclaredBlock, publishBlock, listBlocks, type DeclaringAgent } from './feed/feed.js';
 import { blockBroadcastContext, planFeedBroadcast, renderSinkArgv, blockDeliveryFailure } from './feed-broadcast.js';
-import { MILESTONE_EVENTS, tierForEvent } from './activity.js';
+import { MILESTONE_EVENTS, tierForEvent } from './feed/activity.js';
 
 const AGENT: DeclaringAgent = {
   sessionId: '74a4893f-63b3-49ef-bbcb-2437914f792e',

--- a/apps/cli/src/lib/feed-outcome.test.ts
+++ b/apps/cli/src/lib/feed-outcome.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { blockIdForSession, type OpenBlock } from './feed.js';
+import { blockIdForSession, type OpenBlock } from './feed/feed.js';
 import {
   deriveOutcome,
   enrichBlockFromSession,

--- a/apps/cli/src/lib/feed-outcome.ts
+++ b/apps/cli/src/lib/feed-outcome.ts
@@ -17,7 +17,7 @@
  * and any UI that collapses blocks under deliverables.
  */
 import { detectTicket, extractPrUrl } from './session/state.js';
-import type { OpenBlock } from './feed.js';
+import type { OpenBlock } from './feed/feed.js';
 
 export type OutcomeKind = 'ticket' | 'pr' | 'worktree' | 'unassigned';
 

--- a/apps/cli/src/lib/feed-policy.test.ts
+++ b/apps/cli/src/lib/feed-policy.test.ts
@@ -10,7 +10,7 @@ import {
   isTimedOut,
   applyPolicyToBlock,
 } from './feed-policy.js';
-import { publishBlock, readBlock, listBlocks, blockIdForSession, type OpenBlock } from './feed.js';
+import { publishBlock, readBlock, listBlocks, blockIdForSession, type OpenBlock } from './feed/feed.js';
 import { drain, mailboxDir } from './mailbox.js';
 
 function tmpDir(): string {

--- a/apps/cli/src/lib/feed-policy.ts
+++ b/apps/cli/src/lib/feed-policy.ts
@@ -23,7 +23,7 @@ import {
   recordParked,
   type OpenBlock,
   type AnswerRecord,
-} from './feed.js';
+} from './feed/feed.js';
 import { enqueue, mailboxDir } from './mailbox.js';
 
 export type BlockClass = 'approval' | 'decision';

--- a/apps/cli/src/lib/feed-post.test.ts
+++ b/apps/cli/src/lib/feed-post.test.ts
@@ -14,7 +14,7 @@ import {
   STATUS_POST_MAX_CHARS,
   STATUS_TITLE_MAX_CHARS,
 } from './feed-post.js';
-import { appendActivityEvent, readSessionActivity, tierForEvent } from './activity.js';
+import { appendActivityEvent, readSessionActivity, tierForEvent } from './feed/activity.js';
 import type { PidSessionEntry } from './session/pid-registry.js';
 
 function tmpActivityDir(): string {

--- a/apps/cli/src/lib/feed-post.ts
+++ b/apps/cli/src/lib/feed-post.ts
@@ -21,7 +21,7 @@ import {
   readRecentActivity,
   type ActivityEvent,
   type Attachment,
-} from './activity.js';
+} from './feed/activity.js';
 import { resolveProjectNameForCwd, listProjectDefs } from './projects.js';
 import { getHistoryDir } from './state.js';
 import { machineId } from './machine-id.js';

--- a/apps/cli/src/lib/feed-ranking.test.ts
+++ b/apps/cli/src/lib/feed-ranking.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { OpenBlock, FeedAskStats } from './feed.js';
+import type { OpenBlock, FeedAskStats } from './feed/feed.js';
 import {
   buildSessionSignals,
   needyControlCards,

--- a/apps/cli/src/lib/feed-ranking.ts
+++ b/apps/cli/src/lib/feed-ranking.ts
@@ -1,4 +1,4 @@
-import type { OpenBlock, FeedAskStats } from './feed.js';
+import type { OpenBlock, FeedAskStats } from './feed/feed.js';
 import type { Classification } from './ask-classifier.js';
 import { classifyBlock } from './ask-classifier.js';
 import { outcomeForBlock } from './feed-outcome.js';

--- a/apps/cli/src/lib/feed/activity.test.ts
+++ b/apps/cli/src/lib/feed/activity.test.ts
@@ -32,8 +32,8 @@ import {
   type EnrichedActivityEvent,
 } from './activity.js';
 import { emit, query, _resetForTest as resetEventsForTest } from './events.js';
-import { resetActorCache } from './actor.js';
-import { resetEventProvenanceForTest } from './event-provenance.js';
+import { resetActorCache } from '../actor.js';
+import { resetEventProvenanceForTest } from '../event-provenance.js';
 
 /** Minimal well-formed enriched event; override any field per test. */
 function ev(partial: Partial<EnrichedActivityEvent>): EnrichedActivityEvent {

--- a/apps/cli/src/lib/feed/activity.ts
+++ b/apps/cli/src/lib/feed/activity.ts
@@ -20,21 +20,21 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'yaml';
-import { stringifyDoc } from './yaml-io.js';
+import { stringifyDoc } from '../yaml-io.js';
 import chalk from 'chalk';
-import { relTime, truncate } from './format.js';
-import { getActivityDir, getUserAgentsDir } from './state.js';
-import { normalizeHost } from './machine-id.js';
-import { projectKeyFromCwd } from './project-key.js';
-import { stampProvenance } from './event-provenance.js';
-import type { ActorKind } from './actor.js';
+import { relTime, truncate } from '../format.js';
+import { getActivityDir, getUserAgentsDir } from '../state.js';
+import { normalizeHost } from '../machine-id.js';
+import { projectKeyFromCwd } from '../project-key.js';
+import { stampProvenance } from '../event-provenance.js';
+import type { ActorKind } from '../actor.js';
 // Type-only import: no runtime dependency on events.ts, so no import cycle
 // (events.ts / event-stream.ts import THIS module at runtime).
 import type { EventRecord } from './events.js';
 import {
   pythonToolRegistryLiteral,
   pythonValueFlagsLiteral,
-} from './session/bash-command.js';
+} from '../session/bash-command.js';
 
 /** Recognizable milestone events, ordered first in any activity lane. */
 export type MilestoneEvent =

--- a/apps/cli/src/lib/feed/events.test.ts
+++ b/apps/cli/src/lib/feed/events.test.ts
@@ -12,7 +12,7 @@ import {
   levelFor, isEventType, EVENT_TYPES,
   getLogsPath, _resetForTest,
 } from './events.js';
-import { resetActorCache } from './actor.js';
+import { resetActorCache } from '../actor.js';
 
 // RUSH-2215: quarantine only I/O-heavy event-bus suites on win32; pure
 // event-kind / level tables still run (review: do not skip platform-neutral guards).

--- a/apps/cli/src/lib/feed/events.ts
+++ b/apps/cli/src/lib/feed/events.ts
@@ -17,10 +17,10 @@ import * as path from 'path';
 import * as os from 'os';
 import { createHash } from 'node:crypto';
 import { gzipSync, gunzipSync } from 'node:zlib';
-import { ensureLockTarget, withFileLock } from './fs-atomic.js';
-import { getUserAgentsDir } from './state.js';
-import { stampProvenance, resetEventProvenanceForTest } from './event-provenance.js';
-import type { ActorKind } from './actor.js';
+import { ensureLockTarget, withFileLock } from '../fs-atomic.js';
+import { getUserAgentsDir } from '../state.js';
+import { stampProvenance, resetEventProvenanceForTest } from '../event-provenance.js';
+import type { ActorKind } from '../actor.js';
 
 /** Lazy perf warehouse write — avoids a hard cycle at module load. */
 function recordPerfTiming(payload: {
@@ -34,7 +34,7 @@ function recordPerfTiming(payload: {
 }): void {
   try {
     // Dynamic import keeps events.ts free of a load-time dependency on perf/db.
-    void import('./perf/spool.js').then(({ recordSample }) => {
+    void import('../perf/spool.js').then(({ recordSample }) => {
       recordSample({
         kind: 'perf.timing',
         label: payload.label,

--- a/apps/cli/src/lib/feed/feed.test.ts
+++ b/apps/cli/src/lib/feed/feed.test.ts
@@ -22,9 +22,9 @@ import {
   listAskStats,
   type OpenBlock,
 } from './feed.js';
-import { classifyBlock, filterBlocksForFeed } from './ask-classifier.js';
-import { isPhoneUrgent, DEFAULT_POLICY } from './feed-policy.js';
-import { loadOperators } from './operator.js';
+import { classifyBlock, filterBlocksForFeed } from '../ask-classifier.js';
+import { isPhoneUrgent, DEFAULT_POLICY } from '../feed-policy.js';
+import { loadOperators } from '../operator.js';
 
 const hasPython = spawnSync('python3', ['--version']).status === 0;
 

--- a/apps/cli/src/lib/feed/feed.ts
+++ b/apps/cli/src/lib/feed/feed.ts
@@ -24,10 +24,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'yaml';
-import { stringifyDoc } from './yaml-io.js';
-import { getFeedDir, getUserAgentsDir } from './state.js';
-import { isAdmin, isHighConsequenceAllowed, isKnownOperator } from './operator.js';
-import { projectKeyFromCwd } from './project-key.js';
+import { stringifyDoc } from '../yaml-io.js';
+import { getFeedDir, getUserAgentsDir } from '../state.js';
+import { isAdmin, isHighConsequenceAllowed, isKnownOperator } from '../operator.js';
+import { projectKeyFromCwd } from '../project-key.js';
 
 export interface BlockOption {
   label: string;

--- a/apps/cli/src/lib/format.test.ts
+++ b/apps/cli/src/lib/format.test.ts
@@ -18,7 +18,7 @@ import {
   formatDie,
   dieFriction,
 } from './format.js';
-import { _resetForTest } from './events.js';
+import { _resetForTest } from './feed/events.js';
 
 const tempDirs: string[] = [];
 

--- a/apps/cli/src/lib/format.ts
+++ b/apps/cli/src/lib/format.ts
@@ -9,7 +9,7 @@
  */
 import chalk from 'chalk';
 import { readSync } from 'node:fs';
-import { emitFriction } from './events.js';
+import { emitFriction } from './feed/events.js';
 
 /** Options for {@link die} — opt into machine-readable failure output. */
 export interface DieOptions {

--- a/apps/cli/src/lib/friction-heuristics.test.ts
+++ b/apps/cli/src/lib/friction-heuristics.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { detectRepeatedGuardBlocks } from './friction-heuristics.js';
-import type { EventRecord } from './events.js';
+import type { EventRecord } from './feed/events.js';
 
 function friction(overrides: Partial<EventRecord> & { surface: string; failureId: string }): EventRecord {
   return {

--- a/apps/cli/src/lib/friction-heuristics.ts
+++ b/apps/cli/src/lib/friction-heuristics.ts
@@ -6,7 +6,7 @@
  * yet. This is a starting point: one detector for the most actionable pattern,
  * an agent stuck retrying the SAME denied action instead of adapting.
  */
-import type { EventRecord } from './events.js';
+import type { EventRecord } from './feed/events.js';
 
 export interface RepeatedGuardBlockFinding {
   /** Session id the repeated blocks happened in, or 'unknown' when the

--- a/apps/cli/src/lib/index.bench.ts
+++ b/apps/cli/src/lib/index.bench.ts
@@ -98,7 +98,7 @@ import {
   readMeta,
 } from './state.js';
 import { isGitRepo } from './git.js';
-import { emit, redactArgs, _resetForTest } from './events.js';
+import { emit, redactArgs, _resetForTest } from './feed/events.js';
 import { stampProvenance } from './event-provenance.js';
 import { installMenubarLaunchAgentOnUpgrade } from './menubar/install-menubar.js';
 import {
@@ -479,7 +479,7 @@ const HELP_SPEC = distUrl('lib/help.js');
 const WHATS_NEW_SPEC = distUrl('lib/whats-new.js');
 const PLATFORM_SPEC = distUrl('lib/platform/index.js');
 const CLI_ENTRY_SPEC = distUrl('lib/cli-entry.js');
-const EVENTS_SPEC = distUrl('lib/events.js');
+const EVENTS_SPEC = distUrl('lib/feed/events.js');
 const EVENT_PROVENANCE_SPEC = distUrl('lib/event-provenance.js');
 const FORMAT_SPEC = distUrl('lib/format.js');
 const VIEW_COMMAND_SPEC = distUrl('commands/view.js');

--- a/apps/cli/src/lib/installations/update.ts
+++ b/apps/cli/src/lib/installations/update.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { AGENTS, isAgentHardDeprecated, hardDeprecationError } from '../agents.js';
-import { emit } from '../events.js';
+import { emit } from '../feed/events.js';
 import {
   getBinaryPath,
   invalidateInstalledVersionsCache,

--- a/apps/cli/src/lib/mailbox-gc.test.ts
+++ b/apps/cli/src/lib/mailbox-gc.test.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { mailboxDir, enqueue, drain } from './mailbox.js';
 import { gcMailbox } from './mailbox-gc.js';
-import { blockIdForSession, publishBlock, readBlock } from './feed.js';
+import { blockIdForSession, publishBlock, readBlock } from './feed/feed.js';
 
 function tmpRoot(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-mailbox-gc-'));

--- a/apps/cli/src/lib/mailbox-gc.ts
+++ b/apps/cli/src/lib/mailbox-gc.ts
@@ -15,7 +15,7 @@ import {
   readMessage,
   sweepExpired,
 } from './mailbox.js';
-import { listBlocks, removeBlock, recordMessageReceipt } from './feed.js';
+import { listBlocks, removeBlock, recordMessageReceipt } from './feed/feed.js';
 
 export interface GcResult {
   boxesScanned: number;

--- a/apps/cli/src/lib/mailbox.test.ts
+++ b/apps/cli/src/lib/mailbox.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { mailboxDir, enqueue, drain, peek, clear, assertValidMailboxId, isExpired, sweepExpired, listBoxes, readBox, watchMessages, DEFAULT_TTL_SECONDS, MAILBOX_TTL_ENV, type MailboxMessage } from './mailbox.js';
-import { blockIdForSession, getBlockReceipts, publishBlock } from './feed.js';
+import { blockIdForSession, getBlockReceipts, publishBlock } from './feed/feed.js';
 
 function tmpRoot(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-mailbox-test-'));

--- a/apps/cli/src/lib/mailbox.ts
+++ b/apps/cli/src/lib/mailbox.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { getMailboxRootDir } from './state.js';
-import { recordMessageReceipt } from './feed.js';
+import { recordMessageReceipt } from './feed/feed.js';
 import { parseDuration } from './hooks/cache.js';
 
 /** Default delivery TTL for messages enqueued without an explicit one (24 hours). */

--- a/apps/cli/src/lib/notify.test.ts
+++ b/apps/cli/src/lib/notify.test.ts
@@ -9,7 +9,7 @@ import {
   sendToOwner,
 } from './notify.js';
 import type { Meta } from './types.js';
-import type { OpenBlock } from './feed.js';
+import type { OpenBlock } from './feed/feed.js';
 
 describe('buildOpenClawNotifyArgs', () => {
   it('builds message-send argv with the caller-supplied target (no hardcoded number)', () => {

--- a/apps/cli/src/lib/notify.ts
+++ b/apps/cli/src/lib/notify.ts
@@ -13,7 +13,7 @@
  * monitor daemon and the feed-dispatch loop call in here, and `process.exit()`
  * would take them down on a typo'd channel name, bypassing their try/catch.
  */
-import type { OpenBlock } from './feed.js';
+import type { OpenBlock } from './feed/feed.js';
 import type { Meta } from './types.js';
 import { readMeta } from './state.js';
 import { getOwnerNotifyFromHumans } from './humans.js';

--- a/apps/cli/src/lib/project-key.test.ts
+++ b/apps/cli/src/lib/project-key.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { projectKeyFromCwd, repoAgentsDirForCwd, repoRootForCwd, resolveProjectKey } from './project-key.js';
-import { projectFromCwd } from './activity.js';
+import { projectFromCwd } from './feed/activity.js';
 import { overviewProjectKey } from '../commands/sessions.js';
 
 describe('projectKeyFromCwd', () => {

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -17,7 +17,7 @@ import { promisify } from 'util';
 import chalk from 'chalk';
 import type { ActiveSession, ActiveStatus } from './session/active.js';
 import { projectNameForCwd, type ProjectDef } from './projects.js';
-import { readRecentActivity } from './activity.js';
+import { readRecentActivity } from './feed/activity.js';
 
 const execFileAsync = promisify(execFile);
 

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -12,7 +12,7 @@ import type { RotateCandidate, RotateResult } from './accounting/rotate.js';
 import { saveTask, hostsCacheDir } from './hosts/tasks.js';
 import { _resetPerfDbForTest, aggregateSamples } from './perf/db.js';
 import * as activation from './routine-activation.js';
-import { query, _resetForTest } from './events.js';
+import { query, _resetForTest } from './feed/events.js';
 
 // RUSH-2215: only process-group / real-spawn holder suites are POSIX-oriented.
 // Pure command construction and path helpers must still run on Windows.

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -42,7 +42,7 @@ import type { AgentId } from './types.js';
 import { shortCodexHome } from './codex-home.js';
 import { prepareJobHome, buildSpawnEnv, getJobHomePath } from './sandbox.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
-import { createTimer, redactPrompt, emitRoutineEnd } from './events.js';
+import { createTimer, redactPrompt, emitRoutineEnd } from './feed/events.js';
 import { codexEditWritableRoots, codexPolicyArgs } from './codex-policy.js';
 import { applyAddDirs } from './add-dir.js';
 import {

--- a/apps/cli/src/lib/secrets/audit.test.ts
+++ b/apps/cli/src/lib/secrets/audit.test.ts
@@ -15,9 +15,9 @@ import * as os from 'os';
 import * as path from 'path';
 import { emitSecretAudit, resolveAuditAgent } from './audit.js';
 import { getBundleUsage, getUsageHistory, closeSecretsUsageDb } from './usage-db.js';
-import { query, levelFor, _resetForTest } from '../events.js';
+import { query, levelFor, _resetForTest } from '../feed/events.js';
 import { readUnifiedEvents } from '../event-stream.js';
-import { MILESTONE_EVENTS } from '../activity.js';
+import { MILESTONE_EVENTS } from '../feed/activity.js';
 import {
   bundleItemStore,
   keychainRef,

--- a/apps/cli/src/lib/secrets/audit.ts
+++ b/apps/cli/src/lib/secrets/audit.ts
@@ -33,7 +33,7 @@
  *                         underlying resolve emits its own `secrets.get`.
  *  - `secrets.view`     — a bundle's (masked) metadata was inspected via `view`.
  */
-import { emit } from '../events.js';
+import { emit } from '../feed/events.js';
 import { recordSecretUsage, type SecretUsageEvent } from './usage-db.js';
 
 export type SecretAuditEvent =

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -54,7 +54,7 @@ import {
   vaultSetItems,
   vaultSetItem,
 } from './vault.js';
-import { emit } from '../events.js';
+import { emit } from '../feed/events.js';
 import { emitSecretAudit } from './audit.js';
 import { readMeta, getHelpersDir } from '../state.js';
 import { assertNameActiveInResourceProfile, filterNamesForActiveResourceProfile } from '../resource-profiles.js';

--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -25,7 +25,7 @@ const {
   SCHEMA_VERSION,
 } = await import('../db.js');
 const { costOfUsage } = await import('../../pricing/index.js');
-const { emit } = await import('../../events.js');
+const { emit } = await import('../../feed/events.js');
 type SessionMeta = import('../types.js').SessionMeta;
 
 // JSONL files live under TEST_HOME so they're isolated and torn down with it.

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -14,7 +14,7 @@ import type { SessionAgentId, SessionEvent, SessionMeta, SessionRunMode } from '
 import { parseSession, sessionFilePathContainer } from './parse.js';
 import { extractRecentDirectoriesTouched, extractTodoProgressFromEvents } from './state.js';
 import { getSessionsDir, getSessionsDbPath } from '../state.js';
-import { query as queryEvents, queryToolUsageForSessions } from '../events.js';
+import { query as queryEvents, queryToolUsageForSessions } from '../feed/events.js';
 import { machineForSessionFile } from './origin-machine.js';
 import { loadSessionActorIndex, readSessionActorRecord } from './actor-sidecar.js';
 import { toolCallsFromEvents, type IndexedToolCall } from './tool-calls.js';

--- a/apps/cli/src/lib/skills.ts
+++ b/apps/cli/src/lib/skills.ts
@@ -18,7 +18,7 @@ import { capableAgents, isCapable } from './capabilities.js';
 import { getAgentsDir, getUserSkillsDir, getSkillsDir as getSystemSkillsDir, getProjectAgentsDir, getEnabledExtraRepos, getTrashSkillsDir } from './state.js';
 import { getEffectiveHome, getVersionHomePath, listInstalledVersions } from './versions.js';
 import { listCommandSkillsInVersion } from './command-skills.js';
-import { emit } from './events.js';
+import { emit } from './feed/events.js';
 
 const HOME = os.homedir();
 

--- a/apps/cli/src/lib/snapshot.test.ts
+++ b/apps/cli/src/lib/snapshot.test.ts
@@ -5,7 +5,7 @@ import {
   summarizeFeedBlocks,
   type SnapshotSessionRow,
 } from './snapshot.js';
-import type { OpenBlock } from './feed.js';
+import type { OpenBlock } from './feed/feed.js';
 import type { ViewJsonAgent } from './view-types.js';
 
 function block(partial: Partial<OpenBlock> & Pick<OpenBlock, 'blockId' | 'sessionId' | 'ts'>): OpenBlock {

--- a/apps/cli/src/lib/snapshot.ts
+++ b/apps/cli/src/lib/snapshot.ts
@@ -15,7 +15,7 @@
  */
 
 import { machineId } from './machine-id.js';
-import { listBlocks, type OpenBlock } from './feed.js';
+import { listBlocks, type OpenBlock } from './feed/feed.js';
 import { computeAgentCounts, type FleetAgentCounts } from './fleet-status.js';
 import type { AgentId } from './types.js';
 import type { UnifiedSyncStatus } from './sync-status.js';

--- a/apps/cli/src/lib/state.bench.ts
+++ b/apps/cli/src/lib/state.bench.ts
@@ -54,7 +54,7 @@ const DIST_ROOT = path.resolve(__dirname, '../../dist');
 const distUrl = (rel: string): string => pathToFileURL(path.join(DIST_ROOT, rel)).href;
 
 const STATE_SPEC = distUrl('lib/state.js');
-const EVENTS_SPEC = distUrl('lib/events.js');
+const EVENTS_SPEC = distUrl('lib/feed/events.js');
 const PROVENANCE_SPEC = distUrl('lib/event-provenance.js');
 
 /**

--- a/apps/cli/src/lib/teams/registry.ts
+++ b/apps/cli/src/lib/teams/registry.ts
@@ -13,7 +13,7 @@ import * as path from 'path';
 import { randomBytes } from 'crypto';
 import lockfile from 'proper-lockfile';
 import { getTeamsRegistryPath } from '../state.js';
-import { emit } from '../events.js';
+import { emit } from '../feed/events.js';
 
 /** Metadata for a registered team. */
 export interface TeamMeta {

--- a/apps/cli/src/lib/triggers/handlers.test.ts
+++ b/apps/cli/src/lib/triggers/handlers.test.ts
@@ -29,7 +29,7 @@ describe('handler config layer', () => {
     process.env.AGENTS_SYSTEM_ROUTINES_DIR = path.join(tmpHome, '.agents', '.system', 'routines');
     eventsFile = path.join(tmpHome, 'events.jsonl');
     process.env.AGENTS_EVENTS_PATH = eventsFile;
-    const events = await import('../events.js');
+    const events = await import('../feed/events.js');
     events._resetForTest(eventsFile);
     handlerMod = await import('./handlers.js');
   });

--- a/apps/cli/src/lib/triggers/handlers.ts
+++ b/apps/cli/src/lib/triggers/handlers.ts
@@ -10,7 +10,7 @@ import { exec } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'yaml';
-import { emit } from '../events.js';
+import { emit } from '../feed/events.js';
 import { machineId, normalizeHost } from '../machine-id.js';
 import { safeJoin } from '../paths.js';
 import { pickFleetDevice } from '../routines-placement.js';

--- a/apps/cli/src/lib/triggers/webhook.ts
+++ b/apps/cli/src/lib/triggers/webhook.ts
@@ -26,7 +26,7 @@ import type {
 } from '../routines.js';
 import { jobRunsOnThisDevice, listJobs, substituteWebhookPrompt } from '../routines.js';
 import { executeJobDetached } from '../runner.js';
-import { emit } from '../events.js';
+import { emit } from '../feed/events.js';
 import {
   listHandlers,
   handlerMatchesWebhook,

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -56,7 +56,7 @@ import { discoverPlugins, syncPluginToVersion, isPluginSynced, pluginSupportsAge
 import { composeRulesFromState } from './rules/compose.js';
 import { loadManifest, saveManifest, buildManifest as buildSyncManifest, isStale } from './staleness/index.js';
 import { pruneRemovedResources, type PrunableKind } from './staleness/prune.js';
-import { emit } from './events.js';
+import { emit } from './feed/events.js';
 import { safeJoin } from './paths.js';
 import {
   installCommandSkillToVersion,

--- a/apps/cli/src/lib/watchdog/runner.test.ts
+++ b/apps/cli/src/lib/watchdog/runner.test.ts
@@ -17,7 +17,7 @@ import type { ActiveSession } from '../session/active.js';
 import type { SessionProvenance, MuxLocation } from '../session/provenance.js';
 import type { InjectTarget } from '../terminal/index.js';
 import type { WatchdogCandidate } from './watchdog.js';
-import type { OpenBlock } from '../feed.js';
+import type { OpenBlock } from '../feed/feed.js';
 import {
   runWatchdogTick,
   DEFAULT_THRESHOLDS,

--- a/apps/cli/src/lib/watchdog/runner.ts
+++ b/apps/cli/src/lib/watchdog/runner.ts
@@ -70,7 +70,7 @@ import { withFileLock, atomicWriteFileSync, ensureLockTarget } from '../fs-atomi
 import { resolveAnswerRoute, isOpenQuestionBlock } from '../answer-router.js';
 import { enqueue, mailboxDir } from '../mailbox.js';
 import { mailboxIdForActiveSession } from '../mailbox-target.js';
-import { readBlock, blockIdForSession, buildDeclaredBlock, publishBlock, type OpenBlock } from '../feed.js';
+import { readBlock, blockIdForSession, buildDeclaredBlock, publishBlock, type OpenBlock } from '../feed/feed.js';
 import { summarizeWatchdogTail } from './watchdogTail.js';
 import { appendWatchdogEvents, type WatchdogEvent } from './log.js';
 import {

--- a/apps/cli/tests/events-redact.test.ts
+++ b/apps/cli/tests/events-redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { redactPrompt, redactArgs } from '../src/lib/events.js';
+import { redactPrompt, redactArgs } from '../src/lib/feed/events.js';
 
 describe('redactPrompt', () => {
   it('replaces raw text with length and short sha', () => {


### PR DESCRIPTION
**refactor / no behavior change** — Move 3 of the RUSH-2708 `apps/cli/src/lib/` domain collapse. Groups the loose feed-activity-events modules into a `lib/feed/` subdir. Import-path updates only; no logic changes, no re-export shims.

## What moved
`git mv` (rename-preserving) of six files into `apps/cli/src/lib/feed/`:

| From | To |
|---|---|
| `lib/feed.ts` / `lib/feed.test.ts` | `lib/feed/feed.ts` / `lib/feed/feed.test.ts` |
| `lib/activity.ts` / `lib/activity.test.ts` | `lib/feed/activity.ts` / `lib/feed/activity.test.ts` |
| `lib/events.ts` / `lib/events.test.ts` | `lib/feed/events.ts` / `lib/feed/events.test.ts` |

Non-import diff vs `origin/main` for all six moved files: **only import lines changed** (intra-group `./feed`/`./activity`/`./events` kept; every other `./x` deepened to `../x`; the dynamic `import('./perf/spool.js')` → `../perf/spool.js`).

## Consumers repointed
All static and dynamic importers across the tree — command layer, `lib/` and its subdirs (`audit/`, `browser/`, `computer/`, `secrets/`, `session/`, `teams/`, `triggers/`, `watchdog/`, `installations/`, `accounting/`), the `.bench.ts` `distUrl(...)` runtime paths, and the `apps/cli/tests/` integration dir. Sibling command files `commands/{feed,events}.ts` (imported as `./feed.js`/`./events.js`) were correctly left untouched. Three doc source-links to the moved files were repointed.

**The mission grep returns 0:**
```
$ git grep -nE "from '.*lib/(feed|activity|events)\.js'|import\(.*lib/(feed|activity|events)\.js" apps/cli/src | grep -v 'src/lib/feed/' | wc -l
0
```

## Verification
- `bun run build` (tsc): **clean** — proves every repointed `.js` specifier resolves.
- `bun run vitest run`: the moved suites (`feed/feed`, `feed/activity`, `feed/events`) and every consumer suite pass. Remaining failures are pre-existing nested-worktree environment flakes unrelated to the move — `monitors.test.ts`, `exec.test.ts`, `project-key.test.ts` (the mission's declared-ignorable trio), plus `git-output.test.ts` (temp-git author filtering), `release-lease.test.ts`, `secrets/remote.test.ts`, and one 30s file-lock timeout in `feed/events.test.ts` whose body is byte-identical to `origin/main`.

Ref: RUSH-2708.
