### PR TITLE
docs(sync): correct two comments RUSH-2700 made stale

### DIFF
--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -438,11 +438,12 @@ describe('runFleetPassthrough — direct unit tests', () => {
   });
 
   it('uses the sync summarizer for sync command', async () => {
-    // RUSH-2700: this is the WIRING test. The unit tests below exercise
-    // summarizeSyncResult's arithmetic, but deleting the `command === 'sync'`
-    // line in summarizeResult left them all green — restoring the exact bug
-    // (every box rendering a flat `ok`) with no test failing. This drives the
-    // real fan-out so the roster must actually call the summarizer.
+    // RUSH-2700: this is the WIRING test. An earlier revision called
+    // summarizeSyncResult directly, so deleting the `command === 'sync'` line in
+    // summarizeResult restored the exact bug (every box rendering a flat `ok`)
+    // with no test failing. This drives the real fan-out instead, so the roster
+    // must actually dispatch to the summarizer; the describe block below was
+    // rewritten the same way for the same reason.
     console.log = (...args: unknown[]) => logs.push(args.join(' '));
     const registry = fakeRegistry([fakeDevice('mac-mini', 'macos')]);
     const runner = (_device: DeviceProfile, cmd: string[]) => {

--- a/apps/cli/src/lib/sync-umbrella.bench.ts
+++ b/apps/cli/src/lib/sync-umbrella.bench.ts
@@ -2,12 +2,12 @@
  * Benchmark for the `agents sync` config-translation hot path: the reconcile
  * stage that turns the DotAgents repos into each agent's native on-disk format.
  *
- * The entry point is sync-umbrella.ts:96 `runUmbrellaSync`, but that function is
+ * The entry point is sync-umbrella.ts:101 `runUmbrellaSync`, but that function is
  * a sequencer, not the cost. Its planner is pure (sync-umbrella.ts:51
  * `planUmbrellaStages`, "Pure -- no I/O"), its repos stage is a `git pull`
- * (sync-umbrella.ts:109 `pullRepo`) and its secrets stage is network + scrypt.
+ * (sync-umbrella.ts:114 `pullRepo`) and its secrets stage is network + scrypt.
  * Every local CPU/IO cost of a bare `agents sync` lives behind one line --
- * sync-umbrella.ts:152 `await refresh({ skipPrompts: yes, quiet })` -- so that is
+ * sync-umbrella.ts:161 `await refresh({ skipPrompts: yes, quiet })` -- so that is
  * what this file measures, decomposed into the four stages refresh.ts actually
  * runs per agent version:
  *


### PR DESCRIPTION
**docs-only** — two code comments, no behavior change. No test, doc, or CHANGELOG entry: nothing user-visible changed.

## What

Two comments went stale when `8dff0f5b4` (PR #2708, RUSH-2700) landed. Both were flagged by non-author reviewers on that PR as non-gating follow-ups.

### 1. The wiring-test comment asserts the bug is still present

`apps/cli/src/lib/hosts/passthrough.test.ts:441-445` said, in the present tense, that deleting the `command === 'sync'` dispatch in `summarizeResult` "left them all green — restoring the exact bug with no test failing."

That described the revision where the tests called `summarizeSyncResult` directly. `8dff0f5b4` rewrote both blocks to drive the real `runFleetPassthrough` fan-out precisely so that stops being true. The comment claimed the defect was live in the commit that removed it, and it contradicted its own file at `:600-603`.

### 2. Three drifted line citations

`apps/cli/src/lib/sync-umbrella.bench.ts` cites `sync-umbrella.ts` by line. Three had shifted:

| Symbol | Cited | Actual |
|---|---|---|
| `runUmbrellaSync` | `:96` | `:101` |
| `pullRepo` | `:109` | `:114` |
| `refresh({ skipPrompts, quiet })` | `:152` | `:161` |

The other two citations (`planUmbrellaStages` at `:51`, twice) were already correct and are unchanged.

## Run result

The touched test file, in a clean worktree off fresh `origin/main`:

```
 RUN  v4.1.9 .agents/worktrees/fix-stale-wiring-comment/apps/cli

 Test Files  1 passed (1)
      Tests  46 passed (46)
   Duration  2.56s
```

Each corrected citation was verified against the current source before editing:

```
$ grep -n "runUmbrellaSync\|planUmbrellaStages\|pullRepo" apps/cli/src/lib/sync-umbrella.ts
51:export function planUmbrellaStages(f: UmbrellaFlags): UmbrellaPlan {
101:export async function runUmbrellaSync(args: RunUmbrellaArgs): Promise<UmbrellaResult> {
114:      const r = await pullRepo(dir);

$ grep -n "await refresh({" apps/cli/src/lib/sync-umbrella.ts
161:    const refreshed = await refresh({ skipPrompts: yes, quiet });
```

## Context

- Follows #2708 (`8dff0f5b4`), RUSH-2700 — closed Done.
- Worth landing rather than dropping: a comment that tells the next reader "deleting this line breaks nothing" is an active invitation to delete it. That test exists because four rounds of tests on this line of work passed against the bug they were written for.
