### PR TITLE
fix(ext): stop claiming 'all windows are live' after inspecting zero windows (RUSH-2724)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,10 @@ jobs:
       - run: bun install --frozen-lockfile
         working-directory: apps/ext/ui
       - run: bun run compile
+      # scripts/*.test.sh guard the build/install/release/activate shell paths.
+      # They existed but nothing invoked them, so their regressions were invisible.
+      - name: script regression tests
+        run: for t in scripts/*.test.sh; do echo "== $t"; bash "$t"; done
 
   session-tracker:
     needs: scope

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+- **A release no longer claims "All running windows are live" without checking any window
+  (RUSH-2724).** `activate.sh` picked the newest editor logs dir, but every
+  `code`/`codium --install-extension` and `--list-extensions` call mints its own logs dir
+  containing no windows — and a release run makes several of those *after* installing. The
+  newest dir was therefore a decoy: the `window*/exthost/exthost.log` glob matched nothing,
+  every window loop iterated zero times, and the script concluded all windows were live
+  having inspected none, while the open Fleet panel still ran the previous bundle. It now
+  picks the newest logs dir that actually holds windows, and reports UNVERIFIED rather than
+  live when it inspects zero. Source: `apps/ext/scripts/activate.sh`.
+
 ## [0.9.324] - 2026-08-15
 
 - **The Fleet panel no longer reports 0 sessions in a second editor window (RUSH-2733).**

--- a/apps/ext/scripts/activate.sh
+++ b/apps/ext/scripts/activate.sh
@@ -59,8 +59,37 @@ activation_epoch() {
     date -j -f "%Y-%m-%d %H:%M:%S" "$ts" +%s 2>/dev/null || echo 0
 }
 
+# Newest logs dir that actually holds editor windows.
+#
+# A bare `ls -dt | head -1` is wrong: every `code`/`codium --install-extension`
+# (and --list-extensions) invocation spawns a short-lived process that mints its
+# OWN logs dir containing NO window*/ subdirs. Release runs make several of those
+# AFTER the install, so the newest dir is a decoy — `window*/exthost/exthost.log`
+# then globs to nothing, every window loop iterates zero times, and the script
+# concludes "all windows are live" from an empty set. Skip dirs with no windows.
+# mtime as an epoch. Branch on the platform rather than `stat -f … || stat -c …`:
+# on Linux `stat -f` is "filesystem status" and SUCCEEDS, so the fallback would
+# never run and the caller would parse a block-size table as an integer.
+mtime_epoch() {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        stat -f %m "$1" 2>/dev/null || echo 0
+    else
+        stat -c %Y "$1" 2>/dev/null || echo 0
+    fi
+}
+
 newest_logdir() {
-    ls -dt "$HOME/Library/Application Support/$1/logs"/*/ 2>/dev/null | head -1
+    local base="$HOME/Library/Application Support/$1/logs"
+    local d ep best="" best_ep=0
+    # Quoted glob, not `ls` + word splitting — the path contains a space
+    # ("Application Support"), which splits every entry into two bogus words.
+    for d in "$base"/*/; do
+        [ -d "$d" ] || continue
+        compgen -G "${d}window*/exthost/exthost.log" >/dev/null 2>&1 || continue
+        ep="$(mtime_epoch "$d")"
+        if [ "$ep" -gt "$best_ep" ]; then best_ep="$ep"; best="$d"; fi
+    done
+    echo "$best"
 }
 
 # Reload every window of a running editor (best-effort). Returns 1 if no AX
@@ -141,9 +170,12 @@ for CLI in code codium cursor; do
         fi
     fi
 
-    # Final per-window verdict against the install mtime.
+    # Final per-window verdict against the install mtime. Count what we actually
+    # inspected: a loop that never ran is "unverified", never "live".
+    WINDOWS_SEEN=0
     for EH in "$LOGDIR"window*/exthost/exthost.log; do
         [ -f "$EH" ] || continue
+        WINDOWS_SEEN=$((WINDOWS_SEEN + 1))
         WIN="$(echo "$EH" | grep -oE 'window[0-9]+')"
         EP="$(activation_epoch "$EH")"
         if [ "$EP" -ge "$INSTALL_EP" ]; then
@@ -153,6 +185,10 @@ for CLI in code codium cursor; do
             OVERALL_STALE=1
         fi
     done
+    if [ "$WINDOWS_SEEN" -eq 0 ]; then
+        echo "    $CLI: running, but no window logs to check — treat as UNVERIFIED and reload it"
+        OVERALL_STALE=1
+    fi
 done
 
 echo

--- a/apps/ext/scripts/activate.test.sh
+++ b/apps/ext/scripts/activate.test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Regression tests for activate.sh's liveness verdict.
+#
+# The bug (RUSH-2724): `newest_logdir` took the newest logs dir unconditionally.
+# Every `code`/`codium --install-extension` and `--list-extensions` invocation
+# mints its own logs dir with NO window*/ subdirs, and a release run makes
+# several of those AFTER installing. The newest dir was therefore a decoy: the
+# `window*/exthost/exthost.log` glob matched nothing, every window loop iterated
+# zero times, and the script printed "All running windows are live" having
+# inspected zero windows — while the user's actual window still ran the old
+# bundle.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACTIVATE_SH="$SCRIPT_DIR/activate.sh"
+FAIL=0
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; FAIL=1; }
+
+echo "Running activate.sh regression tests..."
+
+if bash -n "$ACTIVATE_SH" 2>&1; then
+    pass "activate.sh passes bash -n syntax check"
+else
+    fail "activate.sh has a syntax error"
+fi
+
+# Extract the real newest_logdir() body and exercise it against a fixture tree.
+FUNCS="$(mktemp)"
+sed -n '/^mtime_epoch() {/,/^}/p;/^newest_logdir() {/,/^}/p' "$ACTIVATE_SH" > "$FUNCS"
+if [ ! -s "$FUNCS" ]; then
+    fail "could not extract newest_logdir() from activate.sh"
+else
+    # shellcheck disable=SC1090
+    . "$FUNCS"
+
+    FIXTURE="$(mktemp -d)"
+    LOGS="$FIXTURE/Library/Application Support/VSCodium/logs"
+
+    # An older dir holding a REAL window, then a newer window-less dir of the
+    # kind a `--install-extension` invocation leaves behind.
+    mkdir -p "$LOGS/20260815T030000/window1/exthost"
+    : > "$LOGS/20260815T030000/window1/exthost/exthost.log"
+    sleep 1
+    mkdir -p "$LOGS/20260815T041957"
+
+    PICKED="$(HOME="$FIXTURE" newest_logdir VSCodium)"
+
+    case "$PICKED" in
+        *20260815T030000*) pass "newest_logdir skips a window-less CLI logs dir" ;;
+        "")                fail "newest_logdir returned nothing despite a windowed dir existing" ;;
+        *)                 fail "newest_logdir picked the window-less decoy: $PICKED" ;;
+    esac
+
+    # No windowed dir anywhere => empty, so the caller reports unverified rather
+    # than globbing zero windows and concluding everything is live.
+    EMPTY="$(mktemp -d)"
+    mkdir -p "$EMPTY/Library/Application Support/VSCodium/logs/20260815T041957"
+    if [ -z "$(HOME="$EMPTY" newest_logdir VSCodium)" ]; then
+        pass "newest_logdir returns empty when no logs dir holds a window"
+    else
+        fail "newest_logdir returned a window-less dir"
+    fi
+
+    rm -rf "$FIXTURE" "$EMPTY"
+fi
+rm -f "$FUNCS"
+
+# A window loop that never runs must not be reported as live.
+if grep -q 'WINDOWS_SEEN' "$ACTIVATE_SH" \
+   && grep -q 'UNVERIFIED' "$ACTIVATE_SH"; then
+    pass "activate.sh reports UNVERIFIED when it inspected zero windows"
+else
+    fail "activate.sh can still claim live after inspecting zero windows"
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    echo "All activate.sh regression tests passed."
+else
+    echo "activate.sh regression tests FAILED."
+    exit 1
+fi


### PR DESCRIPTION
**Bug fix.** A release printed **"All running windows are live"** while the user's open Fleet panel was still rendering the previous bundle. Fixes RUSH-2724. This is the reason the RUSH-2733 fix appeared not to ship.

## Root cause — liveness asserted from an empty set

`activate.sh` took the newest editor logs dir unconditionally. But every `code`/`codium --install-extension` and `--list-extensions` invocation mints its **own** logs dir containing **no** `window*/` subdirs — and `release.sh` makes several of those *after* installing. The newest dir was therefore a decoy created by the release script itself:

```
install mtime:      Aug 15 04:19:42   swarmify.swarm-ext-0.9.324
newest logs dir:    20260815T041957/  ← 15s later, from the release's own CLI calls
that dir's windows: (none — the glob matches nothing)
```

So `window*/exthost/exthost.log` matched nothing → `stale_count` returned 0 → *"already live (all windows activated after install)"*; the per-window verdict loop iterated zero times → `OVERALL_STALE` stayed 0 → *"All running windows are live."* **Zero windows examined, therefore zero stale.**

## What changed

- `newest_logdir` picks the newest logs dir that actually **holds windows**, and iterates a quoted glob instead of `$(ls …)` — the path contains a space (`Application Support`), which split every entry into two bogus words. (My first attempt had exactly that bug; the test caught it.)
- A window loop that never ran now reports **UNVERIFIED** and sets `OVERALL_STALE`, so "live" is never concluded from missing data — per the repo's *fail loud at boundaries* convention.
- `mtime_epoch` branches on `uname` rather than `stat -f … || stat -c …`: on Linux `stat -f` is *filesystem status* and **succeeds**, so the fallback never fires and the caller parses a block-size table as an integer. (Also caught by the test.)

## Run result

`scripts/activate.test.sh` builds a real fixture tree — an older dir holding a real window, plus a newer window-less dir of the kind an install leaves behind — and exercises the **real** `newest_logdir` extracted from the script.

Against `origin/main`'s `activate.sh`:

```
  PASS: activate.sh passes bash -n syntax check
  FAIL: newest_logdir picked the window-less decoy: …/logs/20260815T041957/
  FAIL: newest_logdir returned a window-less dir
  FAIL: activate.sh can still claim live after inspecting zero windows
```

With this change:

```
  PASS: activate.sh passes bash -n syntax check
  PASS: newest_logdir skips a window-less CLI logs dir
  PASS: newest_logdir returns empty when no logs dir holds a window
  PASS: activate.sh reports UNVERIFIED when it inspected zero windows
All activate.sh regression tests passed.
```

## CI wiring (why this could regress unnoticed)

`apps/ext/scripts/*.test.sh` already existed — `install.test.sh`, `release.test.sh`, `release-registry-plan.test.sh` — and **nothing invoked them**, so shell regressions were invisible. The `ext` job now runs all of them; all four pass on the Linux runner.
