### PR TITLE
fix(doctor): don't label a non-purgeable duplicate 'healthy' (RUSH-2713)

### DIFF
--- a/apps/cli/src/bootstrap.ts
+++ b/apps/cli/src/bootstrap.ts
@@ -429,10 +429,11 @@ function maybeWarnMultiInstall(): void {
   for (const info of inventory) {
     console.error(chalk.gray(`  ${info.packageRoot}  ${info.version}  (${info.note})`));
   }
-  // RUSH-2705: only advertise `agents doctor --fix` for copies it will really
-  // delete. A healthy duplicate (>=1.22.30, not npx-cache, not legacy) is
-  // deliberately never auto-purged, so pointing at --fix for it is a remedy
-  // that no-ops forever — name the manual removal command instead.
+  // RUSH-2705/2713: only advertise `agents doctor --fix` for copies it will
+  // really delete. A duplicate --fix won't auto-purge (a healthy >=1.22.30 peer,
+  // OR a pre-1.22.30 copy left alone only because no fixed peer exists — the
+  // latter is genuinely vulnerable, not healthy) makes --fix a remedy that
+  // no-ops forever — name the manual removal command instead.
   const peers = inventory.filter((info) => !info.running);
   console.error(chalk.gray('Upgrades apply to the running copy.'));
   if (peers.some((info) => info.autoPurgeable)) {
@@ -883,8 +884,10 @@ async function runUpgrade(version: string | undefined, options: UpgradeOptions):
               `Could not purge ${purge.failed.length} stale install${purge.failed.length === 1 ? '' : 's'}; re-run agents doctor --fix.`,
             ));
           }
-          // RUSH-2705: healthy duplicates are never auto-purged — name the
-          // command that removes them instead of leaving a silent nag behind.
+          // RUSH-2705/2713: duplicates --fix won't auto-purge (a healthy
+          // >=1.22.30 peer, or a pre-1.22.30 copy with no fixed peer to fall back
+          // to — not healthy) — name the command that removes them instead of
+          // leaving a silent nag behind.
           for (const u of purge.unresolved) {
             console.log(chalk.gray(
               `Duplicate ${u.version} at ${u.packageRoot} left in place; remove it with: ${u.manualRemoveCommand}`,

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1407,12 +1407,14 @@ function renderStaleInstallPurgeText(purge: RemediateStaleInstallsResult): void 
       `  ${chalk.red('hold  ')} ${chalk.gray(`${f.packageRoot}  ${f.version}  — ${f.error}`)}`,
     );
   }
-  // RUSH-2705: a healthy duplicate (>=1.22.30, not npx-cache, not legacy) is
-  // deliberately never auto-purged, so --fix must hand back the command that
-  // does remove it instead of ending on a bare "everything in sync".
+  // RUSH-2705/2713: a duplicate --fix cannot auto-purge — either a healthy
+  // >=1.22.30 peer, OR a pre-1.22.30 copy left alone only because no fixed peer
+  // exists to fall back to (that one is NOT healthy). Either way, hand back the
+  // command that removes it instead of ending on a bare "everything in sync".
+  // Don't call it "healthy" — that would understate a genuinely vulnerable copy.
   for (const u of purge.unresolved) {
     console.log(
-      `  ${chalk.yellow('manual')} ${chalk.gray(`${u.packageRoot}  ${u.version}  — a healthy duplicate --fix will not delete; remove it with:`)}`,
+      `  ${chalk.yellow('manual')} ${chalk.gray(`${u.packageRoot}  ${u.version}  — --fix will not delete this copy; remove it with:`)}`,
     );
     console.log(`         ${chalk.bold(u.manualRemoveCommand)}`);
   }

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -529,8 +529,9 @@ export interface MultiInstallInventoryEntry {
   /**
    * True when a bare `agents doctor --fix` deletes this copy (RUSH-2415:
    * npx-cache / unsafe-legacy / pre-1.22.30 with a fixed peer). False for the
-   * running copy and for healthy duplicates --fix will not touch — those need
-   * the manual command from manualUninstallCommand() (RUSH-2705).
+   * running copy and for any duplicate --fix will not touch — a healthy
+   * >=1.22.30 peer, or a pre-1.22.30 copy with no fixed peer to fall back to;
+   * both need the manual command from manualUninstallCommand() (RUSH-2705/2713).
    */
   autoPurgeable: boolean;
 }
@@ -814,9 +815,13 @@ export interface RemediateStaleInstallsResult extends PurgeRemovableInstallsResu
   inventory: MultiInstallInventoryEntry[];
   candidates: RemovableAgentsCliInstall[];
   /**
-   * Duplicates detected but deliberately left alone (healthy >=1.22.30
-   * globals). The caller must surface manualRemoveCommand — otherwise the
-   * multi-install warning keeps firing with no working remedy (RUSH-2705).
+   * Duplicates detected but NOT auto-purged, for either reason:
+   *   1. a healthy >=1.22.30 global (safe, just redundant), or
+   *   2. a pre-1.22.30 copy left alone only because no fixed peer exists to fall
+   *      back to (the anti-stranding guard) — this one is genuinely vulnerable,
+   *      not healthy.
+   * Either way the caller must surface manualRemoveCommand — otherwise the
+   * multi-install warning keeps firing with no working remedy (RUSH-2705/2713).
    */
   unresolved: UnresolvedDuplicateInstall[];
 }


### PR DESCRIPTION
## fix / copy — don't call a non-purgeable duplicate "healthy" (RUSH-2713)

**refactor / copy-only — no logic or control-flow change.** Follow-up to the non-author review of #2701.

### What changed
- **`apps/cli/src/commands/doctor.ts`** — the `--fix` "manual" line for each `purge.unresolved` entry no longer says *"a healthy duplicate --fix will not delete"*; it now says *"— --fix will not delete this copy; remove it with:"*. `unresolved` also contains a **pre-1.22.30** copy left alone only because no fixed peer exists (the anti-stranding guard) — that copy is genuinely Touch-ID-storm-vulnerable, and calling it "healthy" understated the urgency to upgrade.
- **`apps/cli/src/lib/self-update.ts`** — corrected the `RemediateStaleInstallsResult.unresolved` and `autoPurgeable` JSDoc to describe **both** reasons a duplicate lands there (healthy >=1.22.30 peer, OR pre-1.22.30 with no fixed peer), not just the healthy case.

### Verification
Copy + comment change only — no logic, no control flow, no type surface touched (string-literal body + JSDoc). No test asserts the old wording (`rg 'healthy duplicate|will not delete'` over `src/**/*test*` → no hits), so nothing regresses. The classification logic (`classifyRemovableAgentsCliInstalls` / `remediateStaleAgentsCliInstalls`) is unchanged.
