### PR TITLE
test(ci): exact phase percentiles and provider sample-count gates (RUSH-2666)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: bun scripts/ci-scope.ts "$BASE_SHA" "$HEAD_SHA" "$GITHUB_OUTPUT"
       - name: Pin release-matrix trigger policy and .agents/ layout
-        run: bun test ./.github/workflows/
+        run: bun test ./.github/workflows/ ./scripts/ci-bench/
 
   # Install once for type-checking, the compiled-binary smoke, and the gating
   # distributed-session benchmark. The old separate jobs repeated dependency

--- a/scripts/ci-bench/cli.test.ts
+++ b/scripts/ci-bench/cli.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { main } from './cli';
+import type { BenchInput, BenchJob, BenchRun } from './types';
+
+function job(name: string, start: string, end: string, labels = ['ubuntu-latest']): BenchJob {
+  return {
+    name,
+    labels,
+    runner_group_name: labels.includes('crabbox') ? 'phnx-untrusted' : 'GitHub Actions',
+    started_at: start,
+    completed_at: end,
+    conclusion: 'success',
+    steps: [
+      { name: 'Set up job', started_at: start, completed_at: start },
+      { name: 'Run selected tests', started_at: start, completed_at: end },
+    ],
+  };
+}
+
+function runAt(id: number, created: string, done: string, labels: string[], kind: BenchRun['kind'] = 'required-ci'): BenchRun {
+  const start = new Date(Date.parse(created) + 1_000).toISOString().replace('.000Z', 'Z');
+  return {
+    id,
+    name: kind === 'release' ? 'Release' : 'Tests',
+    kind,
+    created_at: created,
+    conclusion: 'success',
+    jobs: [
+      job('impact', start, done, labels),
+      {
+        name: 'test',
+        labels,
+        runner_group_name: 'GitHub Actions',
+        started_at: done,
+        completed_at: done,
+        conclusion: 'success',
+        steps: [{ name: 'Gate every affected component', started_at: done, completed_at: done }],
+      },
+    ],
+  };
+}
+
+describe('cli', () => {
+  test('exits 2 when tails lack samples or windows is still required', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ci-bench-'));
+    const input = join(dir, 'runs.json');
+    writeFileSync(input, JSON.stringify({
+      runs: [runAt(1, '2026-08-15T00:00:00Z', '2026-08-15T00:00:20Z', ['ubuntu-latest'])],
+    } satisfies BenchInput));
+    const workflow = join(import.meta.dir, 'fixtures/workflow-windows-required.yml');
+    expect(main(['--input', input, '--workflow', workflow])).toBe(2);
+  });
+
+  test('exits 0 when CI and release tails clear their budgets and windows is optional', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ci-bench-'));
+    const runs: BenchRun[] = [];
+    for (let i = 0; i < 10_000; i++) {
+      const created = new Date(Date.UTC(2026, 7, 1, 0, 0, 0) + i * 1000).toISOString().replace('.000Z', 'Z');
+      const done = new Date(Date.parse(created) + 12_000).toISOString().replace('.000Z', 'Z');
+      const labels = i < 5_000 ? ['ubuntu-latest'] : ['self-hosted', 'crabbox'];
+      runs.push(runAt(i, created, done, labels, 'required-ci'));
+    }
+    for (let i = 0; i < 10_000; i++) {
+      const created = new Date(Date.UTC(2026, 7, 2, 0, 0, 0) + i * 1000).toISOString().replace('.000Z', 'Z');
+      const done = new Date(Date.parse(created) + 40_000).toISOString().replace('.000Z', 'Z');
+      runs.push(runAt(100_000 + i, created, done, ['ubuntu-latest'], 'release'));
+    }
+    const input = join(dir, 'runs.json');
+    writeFileSync(input, JSON.stringify({ runs } satisfies BenchInput));
+    const workflow = join(import.meta.dir, 'fixtures/workflow-windows-optional.yml');
+    expect(main(['--input', input, '--workflow', workflow, '--json'])).toBe(0);
+  });
+
+  test('prints usage and exits 0 on --help', () => {
+    expect(main(['--help'])).toBe(0);
+  });
+});

--- a/scripts/ci-bench/cli.ts
+++ b/scripts/ci-bench/cli.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env bun
+/**
+ * Measure required-CI and release latency against the RUSH-2666 hard
+ * targets (CI P99/P99.9/P99.99 <= 90s, release tails <= 180s).
+ *
+ * Reads recorded GitHub Actions run JSON (see fixtures/). Does not claim
+ * a tail percentile without the matching sample-count gate.
+ *
+ *   bun scripts/ci-bench/cli.ts --input fixtures/required-ci-run.json
+ *   bun scripts/ci-bench/cli.ts --input runs.json --workflow .github/workflows/tests.yml --json
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { buildReport, formatReport } from './report';
+import type { BenchInput, BenchRun } from './types';
+
+function printHelp(): void {
+  process.stdout.write(`ci-bench — exact phase percentiles + provider comparison
+
+Usage:
+  bun scripts/ci-bench/cli.ts --input <runs.json> [--workflow <tests.yml>] [--json]
+
+Sample-count gates: P99 needs 100, P99.9 needs 1000, P99.99 needs 10000.
+Windows must not appear in the required aggregator's needs list.
+`);
+}
+
+function loadInput(path: string): BenchInput {
+  const raw = JSON.parse(readFileSync(path, 'utf8')) as BenchInput | BenchRun[] | BenchRun;
+  if (Array.isArray(raw)) return { runs: raw };
+  if (raw && typeof raw === 'object' && Array.isArray((raw as BenchInput).runs)) {
+    return raw as BenchInput;
+  }
+  if (raw && typeof raw === 'object' && 'jobs' in (raw as BenchRun)) {
+    return { runs: [raw as BenchRun] };
+  }
+  throw new Error(`unrecognized bench input: ${path}`);
+}
+
+function parseArgs(argv: string[]): { input: string; workflow?: string; json: boolean; help: boolean } {
+  let input = '';
+  let workflow: string | undefined;
+  let json = false;
+  let help = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') help = true;
+    else if (arg === '--json') json = true;
+    else if (arg === '--input' || arg === '-i') input = argv[++i] ?? '';
+    else if (arg === '--workflow' || arg === '-w') workflow = argv[++i];
+    else if (arg.startsWith('--input=')) input = arg.slice('--input='.length);
+    else if (arg.startsWith('--workflow=')) workflow = arg.slice('--workflow='.length);
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return { input, workflow, json, help };
+}
+
+export function main(argv = process.argv.slice(2)): number {
+  const args = parseArgs(argv);
+  if (args.help || !args.input) {
+    printHelp();
+    return args.help ? 0 : 2;
+  }
+  const input = loadInput(resolve(args.input));
+  const workflow = args.workflow ? readFileSync(resolve(args.workflow), 'utf8') : undefined;
+  const report = buildReport(input, workflow);
+  if (args.json) process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+  else process.stdout.write(formatReport(report));
+  return report.pass ? 0 : 2;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/scripts/ci-bench/compare.test.ts
+++ b/scripts/ci-bench/compare.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { extractAllPhaseTimes } from './phases';
+import { compareProviders, classifyProvider, groupByProvider } from './providers';
+import {
+  evaluateCiTargets,
+  evaluateReleaseTargets,
+  windowsRequiredFromWorkflow,
+} from './gates';
+import { buildReport } from './report';
+import type { BenchInput, BenchJob, PhaseTimes } from './types';
+
+const fixtures = join(import.meta.dir, 'fixtures');
+
+function load(name: string): BenchInput {
+  return JSON.parse(readFileSync(join(fixtures, name), 'utf8')) as BenchInput;
+}
+
+function sampleTimes(n: number, e2eMs: number, provider: PhaseTimes['provider'] = 'github-hosted'): PhaseTimes[] {
+  return Array.from({ length: n }, (_, i) => ({
+    runId: i,
+    kind: 'required-ci',
+    provider,
+    queueMs: 1_000,
+    setupMs: 3_000,
+    executionMs: 8_000,
+    reportMs: 2_000,
+    e2eMs,
+    includedJobNames: ['impact', 'test'],
+    excludedJobNames: [],
+  }));
+}
+
+describe('classifyProvider', () => {
+  test('maps ubuntu-latest / GitHub Actions to github-hosted', () => {
+    const job: BenchJob = {
+      name: 'impact',
+      labels: ['ubuntu-latest'],
+      runner_group_name: 'GitHub Actions',
+      started_at: null,
+      completed_at: null,
+    };
+    expect(classifyProvider(job)).toBe('github-hosted');
+  });
+
+  test('maps crabbox / self-hosted / phnx labels to crabbox', () => {
+    expect(classifyProvider({
+      name: 'impact',
+      labels: ['self-hosted', 'crabbox', 'linux'],
+      runner_name: 'crabbox-0',
+      started_at: null,
+      completed_at: null,
+    })).toBe('crabbox');
+  });
+
+  test('maps windows-latest to windows', () => {
+    expect(classifyProvider({
+      name: 'windows',
+      labels: ['windows-latest'],
+      started_at: null,
+      completed_at: null,
+    })).toBe('windows');
+  });
+});
+
+describe('provider comparison sample-count gates', () => {
+  test('refuses a winner when either side is under the P99 gate', () => {
+    const times = extractAllPhaseTimes(load('provider-compare.json').runs);
+    const groups = groupByProvider(times);
+    const cmp = compareProviders(
+      groups.get('github-hosted') ?? [],
+      groups.get('crabbox') ?? [],
+      'github-hosted',
+      'crabbox',
+      'e2e',
+      99,
+    );
+    expect(cmp.status).toBe('insufficient-sample');
+    expect(cmp.deltaMs).toBeNull();
+    expect(cmp.faster).toBeNull();
+    expect(cmp.left.sample.n).toBe(1);
+    expect(cmp.right.sample.n).toBe(1);
+    expect(cmp.left.sample.required).toBe(100);
+  });
+
+  test('emits an exact P99 delta once both providers have 100 samples', () => {
+    const github = sampleTimes(100, 80_000, 'github-hosted');
+    const crabbox = sampleTimes(100, 20_000, 'crabbox');
+    const cmp = compareProviders(github, crabbox, 'github-hosted', 'crabbox', 'e2e', 99);
+    expect(cmp.status).toBe('ok');
+    expect(cmp.left.sample.valueMs).toBe(80_000);
+    expect(cmp.right.sample.valueMs).toBe(20_000);
+    expect(cmp.deltaMs).toBe(60_000);
+    expect(cmp.faster).toBe('crabbox');
+  });
+});
+
+describe('CI / release target gates', () => {
+  test('cannot claim P99.99 <= 90s on 200 required-CI samples', () => {
+    const evals = evaluateCiTargets(Array.from({ length: 200 }, () => 12_000));
+    const p9999 = evals.find((e) => e.p === 99.99)!;
+    expect(p9999.pass).toBe(false);
+    expect(p9999.sample.status).toBe('insufficient-sample');
+    expect(p9999.reason).toContain('need 10000');
+  });
+
+  test('passes every CI tail when 10000 samples sit under 90s', () => {
+    const evals = evaluateCiTargets(Array.from({ length: 10_000 }, (_, i) => 10_000 + (i % 50)));
+    expect(evals.map((e) => ({ p: e.p, pass: e.pass, value: e.sample.valueMs }))).toEqual([
+      { p: 99, pass: true, value: 10_049 },
+      { p: 99.9, pass: true, value: 10_049 },
+      { p: 99.99, pass: true, value: 10_049 },
+    ]);
+  });
+
+  test('fails P99 when the observed required-CI tail exceeds 90s', () => {
+    const values = Array.from({ length: 100 }, (_, i) => (i >= 98 ? 120_000 : 20_000));
+    const p99 = evaluateCiTargets(values).find((e) => e.p === 99)!;
+    expect(p99.sample.valueMs).toBe(120_000);
+    expect(p99.pass).toBe(false);
+    expect(p99.reason).toContain('exceeds 90000ms');
+  });
+
+  test('release tails gate at 180s, not 90s', () => {
+    const values = Array.from({ length: 10_000 }, () => 150_000);
+    const evals = evaluateReleaseTargets(values);
+    expect(evals.every((e) => e.pass)).toBe(true);
+    expect(evals[0].budgetMs).toBe(180_000);
+  });
+});
+
+describe('windows-required workflow gate', () => {
+  test('fails when the aggregator needs windows', () => {
+    const src = readFileSync(join(fixtures, 'workflow-windows-required.yml'), 'utf8');
+    const finding = windowsRequiredFromWorkflow(src);
+    expect(finding.required).toBe(true);
+    expect(finding.pass).toBe(false);
+    expect(finding.evidence).toContain('windows');
+  });
+
+  test('passes when windows is only a post-merge smoke and not in needs', () => {
+    const src = readFileSync(join(fixtures, 'workflow-windows-optional.yml'), 'utf8');
+    const finding = windowsRequiredFromWorkflow(src);
+    expect(finding.required).toBe(false);
+    expect(finding.pass).toBe(true);
+    expect(finding.evidence).not.toMatch(/needs: \[.*windows/);
+  });
+});
+
+describe('buildReport', () => {
+  test('does not pass a one-run fixture — tails are sample-gated', () => {
+    const report = buildReport(load('required-ci-run.json'), readFileSync(join(fixtures, 'workflow-windows-required.yml'), 'utf8'));
+    expect(report.requiredCi.n).toBe(1);
+    expect(report.windows?.pass).toBe(false);
+    expect(report.pass).toBe(false);
+    const e2e = report.requiredCi.phases.find((p) => p.phase === 'e2e')!;
+    expect(e2e.percentiles.find((s) => s.p === 50)?.status).toBe('insufficient-sample');
+    expect(e2e.percentiles.find((s) => s.p === 99.99)?.status).toBe('insufficient-sample');
+  });
+});

--- a/scripts/ci-bench/fixtures/provider-compare.json
+++ b/scripts/ci-bench/fixtures/provider-compare.json
@@ -1,0 +1,71 @@
+{
+  "runs": [
+    {
+      "id": 1,
+      "name": "Tests",
+      "kind": "required-ci",
+      "created_at": "2026-08-15T11:00:00Z",
+      "conclusion": "success",
+      "jobs": [
+        {
+          "name": "impact",
+          "labels": ["ubuntu-latest"],
+          "runner_group_name": "GitHub Actions",
+          "started_at": "2026-08-15T11:00:20Z",
+          "completed_at": "2026-08-15T11:02:20Z",
+          "conclusion": "success",
+          "steps": [
+            { "name": "Set up job", "started_at": "2026-08-15T11:00:20Z", "completed_at": "2026-08-15T11:00:22Z" },
+            { "name": "Run selected tests", "started_at": "2026-08-15T11:00:22Z", "completed_at": "2026-08-15T11:02:18Z" },
+            { "name": "Complete job", "started_at": "2026-08-15T11:02:18Z", "completed_at": "2026-08-15T11:02:20Z" }
+          ]
+        },
+        {
+          "name": "test",
+          "labels": ["ubuntu-latest"],
+          "runner_group_name": "GitHub Actions",
+          "started_at": "2026-08-15T11:02:22Z",
+          "completed_at": "2026-08-15T11:02:30Z",
+          "conclusion": "success",
+          "steps": [
+            { "name": "Gate every affected component", "started_at": "2026-08-15T11:02:22Z", "completed_at": "2026-08-15T11:02:29Z" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Tests",
+      "kind": "required-ci",
+      "created_at": "2026-08-15T11:10:00Z",
+      "conclusion": "success",
+      "jobs": [
+        {
+          "name": "impact",
+          "labels": ["self-hosted", "crabbox", "linux"],
+          "runner_name": "crabbox-0",
+          "runner_group_name": "phnx-untrusted",
+          "started_at": "2026-08-15T11:10:02Z",
+          "completed_at": "2026-08-15T11:10:28Z",
+          "conclusion": "success",
+          "steps": [
+            { "name": "Set up job", "started_at": "2026-08-15T11:10:02Z", "completed_at": "2026-08-15T11:10:03Z" },
+            { "name": "Run selected tests", "started_at": "2026-08-15T11:10:03Z", "completed_at": "2026-08-15T11:10:26Z" },
+            { "name": "Complete job", "started_at": "2026-08-15T11:10:26Z", "completed_at": "2026-08-15T11:10:28Z" }
+          ]
+        },
+        {
+          "name": "test",
+          "labels": ["self-hosted", "crabbox"],
+          "runner_name": "crabbox-0",
+          "started_at": "2026-08-15T11:10:28Z",
+          "completed_at": "2026-08-15T11:10:32Z",
+          "conclusion": "success",
+          "steps": [
+            { "name": "Gate every affected component", "started_at": "2026-08-15T11:10:28Z", "completed_at": "2026-08-15T11:10:31Z" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/ci-bench/fixtures/release-run.json
+++ b/scripts/ci-bench/fixtures/release-run.json
@@ -1,0 +1,30 @@
+{
+  "runs": [
+    {
+      "id": 9001,
+      "name": "Release",
+      "kind": "release",
+      "event": "workflow_dispatch",
+      "created_at": "2026-08-15T10:00:00Z",
+      "run_started_at": "2026-08-15T10:00:04Z",
+      "conclusion": "success",
+      "jobs": [
+        {
+          "name": "publish",
+          "labels": ["ubuntu-latest"],
+          "runner_group_name": "GitHub Actions",
+          "started_at": "2026-08-15T10:00:04Z",
+          "completed_at": "2026-08-15T10:03:10Z",
+          "conclusion": "success",
+          "steps": [
+            { "name": "Set up job", "started_at": "2026-08-15T10:00:04Z", "completed_at": "2026-08-15T10:00:05Z" },
+            { "name": "Run actions/checkout@sha", "started_at": "2026-08-15T10:00:05Z", "completed_at": "2026-08-15T10:00:12Z" },
+            { "name": "Promote attested tarball", "started_at": "2026-08-15T10:00:12Z", "completed_at": "2026-08-15T10:02:40Z" },
+            { "name": "Install smoke", "started_at": "2026-08-15T10:02:40Z", "completed_at": "2026-08-15T10:03:08Z" },
+            { "name": "Complete job", "started_at": "2026-08-15T10:03:08Z", "completed_at": "2026-08-15T10:03:10Z" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/ci-bench/fixtures/required-ci-run.json
+++ b/scripts/ci-bench/fixtures/required-ci-run.json
@@ -1,0 +1,72 @@
+{
+  "runs": [
+    {
+      "id": 31883800224,
+      "name": "Tests",
+      "kind": "required-ci",
+      "event": "pull_request",
+      "created_at": "2026-08-15T12:07:30Z",
+      "run_started_at": "2026-08-15T12:07:33Z",
+      "conclusion": "success",
+      "head_sha": "224b2af8b0000000000000000000000000000000",
+      "jobs": [
+        {
+          "name": "scope",
+          "labels": ["ubuntu-latest"],
+          "runner_group_name": "GitHub Actions",
+          "started_at": "2026-08-15T12:07:33Z",
+          "completed_at": "2026-08-15T12:07:50Z",
+          "conclusion": "success",
+          "steps": [
+            { "name": "Set up job", "started_at": "2026-08-15T12:07:33Z", "completed_at": "2026-08-15T12:07:34Z" },
+            { "name": "Run actions/checkout@sha", "started_at": "2026-08-15T12:07:34Z", "completed_at": "2026-08-15T12:07:40Z" },
+            { "name": "Run oven-sh/setup-bun@sha", "started_at": "2026-08-15T12:07:40Z", "completed_at": "2026-08-15T12:07:42Z" },
+            { "name": "Classify changed paths", "started_at": "2026-08-15T12:07:42Z", "completed_at": "2026-08-15T12:07:48Z" },
+            { "name": "Complete job", "started_at": "2026-08-15T12:07:48Z", "completed_at": "2026-08-15T12:07:50Z" }
+          ]
+        },
+        {
+          "name": "cli-test-shard (1)",
+          "labels": ["ubuntu-latest"],
+          "runner_group_name": "GitHub Actions",
+          "started_at": "2026-08-15T12:07:52Z",
+          "completed_at": "2026-08-15T12:16:40Z",
+          "conclusion": "success",
+          "steps": [
+            { "name": "Set up job", "started_at": "2026-08-15T12:07:52Z", "completed_at": "2026-08-15T12:07:53Z" },
+            { "name": "Run actions/checkout@sha", "started_at": "2026-08-15T12:07:53Z", "completed_at": "2026-08-15T12:07:58Z" },
+            { "name": "Run oven-sh/setup-bun@sha", "started_at": "2026-08-15T12:07:58Z", "completed_at": "2026-08-15T12:08:00Z" },
+            { "name": "Run bun install --frozen-lockfile", "started_at": "2026-08-15T12:08:00Z", "completed_at": "2026-08-15T12:08:17Z" },
+            { "name": "Run node ./node_modules/vitest/vitest.mjs run --shard=1/3", "started_at": "2026-08-15T12:08:17Z", "completed_at": "2026-08-15T12:16:38Z" },
+            { "name": "Complete job", "started_at": "2026-08-15T12:16:38Z", "completed_at": "2026-08-15T12:16:40Z" }
+          ]
+        },
+        {
+          "name": "windows",
+          "labels": ["windows-latest"],
+          "runner_group_name": "GitHub Actions",
+          "started_at": "2026-08-15T12:07:52Z",
+          "completed_at": "2026-08-15T12:10:20Z",
+          "conclusion": "success",
+          "steps": [
+            { "name": "Set up job", "started_at": "2026-08-15T12:07:52Z", "completed_at": "2026-08-15T12:07:54Z" },
+            { "name": "Run bun run test -- src/lib/platform", "started_at": "2026-08-15T12:08:10Z", "completed_at": "2026-08-15T12:10:18Z" }
+          ]
+        },
+        {
+          "name": "test",
+          "labels": ["ubuntu-latest"],
+          "runner_group_name": "GitHub Actions",
+          "started_at": "2026-08-15T12:16:45Z",
+          "completed_at": "2026-08-15T12:17:12Z",
+          "conclusion": "success",
+          "steps": [
+            { "name": "Set up job", "started_at": "2026-08-15T12:16:45Z", "completed_at": "2026-08-15T12:16:46Z" },
+            { "name": "Gate every affected component", "started_at": "2026-08-15T12:16:46Z", "completed_at": "2026-08-15T12:17:10Z" },
+            { "name": "Complete job", "started_at": "2026-08-15T12:17:10Z", "completed_at": "2026-08-15T12:17:12Z" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/ci-bench/fixtures/workflow-windows-optional.yml
+++ b/scripts/ci-bench/fixtures/workflow-windows-optional.yml
@@ -1,0 +1,21 @@
+name: Tests
+on:
+  pull_request:
+    branches: ['main']
+jobs:
+  scope:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo scope
+  windows:
+    runs-on: windows-latest
+    if: github.event_name == 'schedule'
+    steps:
+      - run: echo post-merge smoke
+  test:
+    needs: [scope, cli-preflight, cli-test-shard, cli-docs, ext, session-tracker]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate every affected component
+        run: echo gate

--- a/scripts/ci-bench/fixtures/workflow-windows-required.yml
+++ b/scripts/ci-bench/fixtures/workflow-windows-required.yml
@@ -1,0 +1,20 @@
+name: Tests
+on:
+  pull_request:
+    branches: ['main']
+jobs:
+  scope:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo scope
+  windows:
+    runs-on: windows-latest
+    steps:
+      - run: echo smoke
+  test:
+    needs: [scope, cli-preflight, cli-test-shard, cli-docs, ext, session-tracker, windows]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate every affected component
+        run: echo gate

--- a/scripts/ci-bench/gates.ts
+++ b/scripts/ci-bench/gates.ts
@@ -1,0 +1,114 @@
+import { gatedPercentile } from './percentile';
+import type {
+  GatedPercentile,
+  RunKind,
+  TargetEvaluation,
+  WindowsRequiredFinding,
+} from './types';
+import {
+  CI_P99_BUDGET_MS,
+  CI_TAIL_PERCENTILES,
+  RELEASE_P99_BUDGET_MS,
+} from './types';
+
+export function evaluateTarget(
+  name: string,
+  kind: RunKind,
+  p: number,
+  budgetMs: number,
+  values: readonly number[],
+): TargetEvaluation {
+  const sample = gatedPercentile(values, p);
+  if (sample.status === 'insufficient-sample') {
+    return {
+      name,
+      kind,
+      p,
+      budgetMs,
+      sample,
+      pass: false,
+      reason: `need ${sample.required} samples for P${p}; have ${sample.n}`,
+    };
+  }
+  const valueMs = sample.valueMs!;
+  const pass = valueMs <= budgetMs;
+  return {
+    name,
+    kind,
+    p,
+    budgetMs,
+    sample,
+    pass,
+    reason: pass
+      ? `P${p}=${valueMs}ms <= ${budgetMs}ms`
+      : `P${p}=${valueMs}ms exceeds ${budgetMs}ms`,
+  };
+}
+
+/** CI required-path e2e: P99, P99.9, P99.99 each <= 90s. */
+export function evaluateCiTargets(e2eMs: readonly number[]): TargetEvaluation[] {
+  return CI_TAIL_PERCENTILES.map((p) =>
+    evaluateTarget(`required-ci e2e P${p}`, 'required-ci', p, CI_P99_BUDGET_MS, e2eMs),
+  );
+}
+
+/** Ordinary release e2e: P99 / P99.9 / P99.99 each <= 180s. */
+export function evaluateReleaseTargets(e2eMs: readonly number[]): TargetEvaluation[] {
+  return CI_TAIL_PERCENTILES.map((p) =>
+    evaluateTarget(`release e2e P${p}`, 'release', p, RELEASE_P99_BUDGET_MS, e2eMs),
+  );
+}
+
+/**
+ * The required aggregator must not `need` the windows job. Skipped-when-unneeded
+ * is not enough: the aggregator still waits on that identity.
+ */
+export function windowsRequiredFromWorkflow(source: string): WindowsRequiredFinding {
+  const aggregator = extractJobBlock(source, 'test') ?? extractJobBlock(source, 'required');
+  if (!aggregator) {
+    return {
+      required: false,
+      evidence: 'no required aggregator job named test/required',
+      pass: true,
+    };
+  }
+  const needsMatch = aggregator.match(/^\s*needs:\s*\[([^\]]*)\]/m);
+  if (!needsMatch) {
+    return {
+      required: false,
+      evidence: 'aggregator has no needs list',
+      pass: true,
+    };
+  }
+  const needs = needsMatch[1].split(',').map((s) => s.trim().replace(/['"]/g, ''));
+  const required = needs.includes('windows');
+  return {
+    required,
+    evidence: `aggregator needs: [${needs.join(', ')}]`,
+    pass: !required,
+  };
+}
+
+function extractJobBlock(source: string, jobId: string): string | null {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => line === `  ${jobId}:`);
+  if (start < 0) return null;
+  const out = [lines[start]];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^  [A-Za-z0-9_-]+:\s*$/.test(line)) break;
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
+export function allTargetsPass(evals: readonly TargetEvaluation[]): boolean {
+  return evals.every((e) => e.pass);
+}
+
+export function formatSample(sample: GatedPercentile): string {
+  if (sample.status === 'insufficient-sample') {
+    return `P${sample.p}=insufficient-sample n=${sample.n} need=${sample.required}`;
+  }
+  return `P${sample.p}=${sample.valueMs}ms n=${sample.n}`;
+}

--- a/scripts/ci-bench/percentile.test.ts
+++ b/scripts/ci-bench/percentile.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { exactPercentile, gatedPercentile, minSamplesForPercentile } from './percentile';
+
+describe('minSamplesForPercentile', () => {
+  test('P99 / P99.9 / P99.99 require 100 / 1000 / 10000 observations', () => {
+    expect(minSamplesForPercentile(99)).toBe(100);
+    expect(minSamplesForPercentile(99.9)).toBe(1000);
+    expect(minSamplesForPercentile(99.99)).toBe(10_000);
+  });
+
+  test('P50 needs 2 and P90 needs 10', () => {
+    expect(minSamplesForPercentile(50)).toBe(2);
+    expect(minSamplesForPercentile(90)).toBe(10);
+  });
+
+  test('rejects a percentile outside [0, 100]', () => {
+    expect(() => minSamplesForPercentile(-1)).toThrow(RangeError);
+    expect(() => minSamplesForPercentile(101)).toThrow(RangeError);
+  });
+});
+
+describe('exactPercentile', () => {
+  test('returns an observed sample — never interpolates the midpoint', () => {
+    // Linear interpolation of [10, 20] at p50 is 15. Nearest-rank is 10.
+    expect(exactPercentile([10, 20], 50)).toBe(10);
+    expect(exactPercentile([10, 20, 30, 40, 50], 50)).toBe(30);
+  });
+
+  test('P99 of 1..100 is the 99th observed value', () => {
+    const sorted = Array.from({ length: 100 }, (_, i) => i + 1);
+    expect(exactPercentile(sorted, 99)).toBe(99);
+    expect(exactPercentile(sorted, 100)).toBe(100);
+    expect(exactPercentile(sorted, 0)).toBe(1);
+  });
+
+  test('P99.99 of 10000 samples is the last observed value', () => {
+    const sorted = Array.from({ length: 10_000 }, (_, i) => i + 1);
+    expect(exactPercentile(sorted, 99.99)).toBe(9999);
+    expect(exactPercentile(sorted, 99.9)).toBe(9990);
+    expect(exactPercentile(sorted, 100)).toBe(10_000);
+  });
+});
+
+describe('gatedPercentile', () => {
+  test('refuses P99.99 when n is 200', () => {
+    const values = Array.from({ length: 200 }, (_, i) => i);
+    const gated = gatedPercentile(values, 99.99);
+    expect(gated).toEqual({
+      p: 99.99,
+      n: 200,
+      required: 10_000,
+      status: 'insufficient-sample',
+      valueMs: null,
+      rank: null,
+    });
+  });
+
+  test('refuses P99 when n is 99 and emits the observed rank at n=100', () => {
+    expect(gatedPercentile(Array.from({ length: 99 }, (_, i) => i), 99).status)
+      .toBe('insufficient-sample');
+    const ok = gatedPercentile(Array.from({ length: 100 }, (_, i) => (i + 1) * 10), 99);
+    expect(ok.status).toBe('ok');
+    expect(ok.valueMs).toBe(990);
+    expect(ok.rank).toBe(99);
+  });
+});

--- a/scripts/ci-bench/percentile.ts
+++ b/scripts/ci-bench/percentile.ts
@@ -1,0 +1,64 @@
+import type { GatedPercentile } from './types';
+
+/** p=99.99 → 9999. Integer tenths-of-a-basis-point, so 99.9 is not 0.998999… */
+export function percentileUnits(p: number): number {
+  if (!Number.isFinite(p) || p < 0 || p > 100) {
+    throw new RangeError(`percentile must be in [0, 100], got ${p}`);
+  }
+  return Math.round(p * 100);
+}
+
+/**
+ * Minimum observations so percentile `p` is an actual sample, not a
+ * fabricated interpolation. P99 needs 100, P99.9 needs 1_000, P99.99
+ * needs 10_000. That is `ceil(1 / (1 - p/100))` in integer 1e-4 units.
+ */
+export function minSamplesForPercentile(p: number): number {
+  const units = percentileUnits(p);
+  if (units === 0 || units === 10_000) return 1;
+  return Math.ceil(10_000 / (10_000 - units));
+}
+
+export function nearestRank(n: number, p: number): number {
+  const units = percentileUnits(p);
+  if (n <= 0) throw new RangeError('nearestRank requires n > 0');
+  if (units === 0) return 1;
+  return Math.ceil((units * n) / 10_000);
+}
+
+/**
+ * Nearest-rank percentile of a sorted-ascending array.
+ * rank = ceil(p/100 * n); value = sorted[rank - 1].
+ * This returns an observed sample. It never interpolates.
+ */
+export function exactPercentile(sortedAscending: readonly number[], p: number): number {
+  if (sortedAscending.length === 0) {
+    throw new RangeError('exactPercentile requires at least one sample');
+  }
+  return sortedAscending[nearestRank(sortedAscending.length, p) - 1];
+}
+
+export function gatedPercentile(values: readonly number[], p: number): GatedPercentile {
+  const n = values.length;
+  const required = minSamplesForPercentile(p);
+  if (n < required) {
+    return { p, n, required, status: 'insufficient-sample', valueMs: null, rank: null };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = nearestRank(n, p);
+  return {
+    p,
+    n,
+    required,
+    status: 'ok',
+    valueMs: sorted[rank - 1],
+    rank,
+  };
+}
+
+export function gatedPercentiles(
+  values: readonly number[],
+  percentiles: readonly number[],
+): GatedPercentile[] {
+  return percentiles.map((p) => gatedPercentile(values, p));
+}

--- a/scripts/ci-bench/phases.test.ts
+++ b/scripts/ci-bench/phases.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { extractAllPhaseTimes, extractPhaseTimes, isSetupStep } from './phases';
+import type { BenchInput } from './types';
+
+const fixtures = join(import.meta.dir, 'fixtures');
+
+function load(name: string): BenchInput {
+  return JSON.parse(readFileSync(join(fixtures, name), 'utf8')) as BenchInput;
+}
+
+describe('extractPhaseTimes', () => {
+  test('splits queue / setup / execution / report / e2e on the recorded Tests run', () => {
+    const times = extractPhaseTimes(load('required-ci-run.json').runs[0]);
+    expect(times).not.toBeNull();
+    expect(times!.kind).toBe('required-ci');
+    expect(times!.provider).toBe('github-hosted');
+    expect(times!.excludedJobNames).toEqual(['windows']);
+    expect(times!.includedJobNames).toEqual(['scope', 'cli-test-shard (1)', 'test']);
+
+    // event 12:07:30 → first job 12:07:33
+    expect(times!.queueMs).toBe(3_000);
+    // shard setup: 1s + 5s + 2s + 17s + 2s complete = 27s (max leaf)
+    expect(times!.setupMs).toBe(27_000);
+    // vitest 12:08:17 → 12:16:38 = 501s
+    expect(times!.executionMs).toBe(501_000);
+    // aggregator 12:16:45 → 12:17:12 = 27s
+    expect(times!.reportMs).toBe(27_000);
+    // event → aggregator done 12:17:12 = 582s
+    expect(times!.e2eMs).toBe(582_000);
+  });
+
+  test('does not fold the Windows job into required-path e2e', () => {
+    const times = extractPhaseTimes(load('required-ci-run.json').runs[0])!;
+    expect(times.e2eMs).toBe(582_000);
+    expect(times.excludedJobNames).toContain('windows');
+  });
+
+  test('drops cancelled runs', () => {
+    const run = structuredClone(load('required-ci-run.json').runs[0]);
+    run.conclusion = 'cancelled';
+    expect(extractPhaseTimes(run)).toBeNull();
+  });
+
+  test('release fixture is tagged release and measured event-to-terminal', () => {
+    const times = extractPhaseTimes(load('release-run.json').runs[0])!;
+    expect(times.kind).toBe('release');
+    expect(times.e2eMs).toBe(190_000);
+    expect(times.queueMs).toBe(4_000);
+  });
+
+  test('classifies checkout / bun install as setup, not execution', () => {
+    expect(isSetupStep('Run actions/checkout@sha')).toBe(true);
+    expect(isSetupStep('Run bun install --frozen-lockfile')).toBe(true);
+    expect(isSetupStep('Run node ./node_modules/vitest/vitest.mjs run --shard=1/3')).toBe(false);
+  });
+});
+
+describe('extractAllPhaseTimes', () => {
+  test('keeps github-hosted and crabbox runs as separate samples', () => {
+    const times = extractAllPhaseTimes(load('provider-compare.json').runs);
+    expect(times.map((t) => t.provider).sort()).toEqual(['crabbox', 'github-hosted']);
+    const gh = times.find((t) => t.provider === 'github-hosted')!;
+    const crab = times.find((t) => t.provider === 'crabbox')!;
+    expect(gh.e2eMs).toBe(150_000);
+    expect(crab.e2eMs).toBe(32_000);
+  });
+});

--- a/scripts/ci-bench/phases.ts
+++ b/scripts/ci-bench/phases.ts
@@ -1,0 +1,175 @@
+import type { BenchJob, BenchRun, BenchStep, PhaseTimes, Provider, RunKind } from './types';
+import { classifyProvider } from './providers';
+
+const AGGREGATOR_NAMES = new Set(['test', 'required', 'gate']);
+
+export function isAggregatorJob(name: string): boolean {
+  const n = name.trim().toLowerCase();
+  return AGGREGATOR_NAMES.has(n);
+}
+
+export function isWindowsJob(job: BenchJob): boolean {
+  if (classifyProvider(job) === 'windows') return true;
+  return job.name.trim().toLowerCase() === 'windows';
+}
+
+export function isSetupStep(name: string): boolean {
+  const n = name.toLowerCase();
+  return (
+    n.includes('set up job')
+    || n.includes('checkout')
+    || n.includes('setup-bun')
+    || n.includes('setup-node')
+    || n.includes('use node.js')
+    || n.includes('bun install')
+    || n.includes('install dependencies')
+    || n.startsWith('post ')
+    || n.includes('complete job')
+  );
+}
+
+export function isReportStep(name: string): boolean {
+  const n = name.toLowerCase();
+  return (
+    n.includes('gate every affected')
+    || n.includes('attestation')
+    || n.includes('required check')
+    || (n.includes('upload') && n.includes('artifact'))
+  );
+}
+
+export function stepDurationMs(step: BenchStep): number | null {
+  if (!step.started_at || !step.completed_at) return null;
+  const ms = Date.parse(step.completed_at) - Date.parse(step.started_at);
+  return Number.isFinite(ms) && ms >= 0 ? ms : null;
+}
+
+export function jobDurationMs(job: BenchJob): number | null {
+  if (!job.started_at || !job.completed_at) return null;
+  const ms = Date.parse(job.completed_at) - Date.parse(job.started_at);
+  return Number.isFinite(ms) && ms >= 0 ? ms : null;
+}
+
+function sumClassified(steps: readonly BenchStep[] | undefined, pred: (name: string) => boolean): number {
+  let total = 0;
+  for (const step of steps ?? []) {
+    if (!pred(step.name)) continue;
+    const ms = stepDurationMs(step);
+    if (ms !== null) total += ms;
+  }
+  return total;
+}
+
+export function inferRunKind(run: BenchRun): RunKind {
+  if (run.kind) return run.kind;
+  const name = (run.name ?? '').toLowerCase();
+  if (name.includes('release') || name.includes('publish')) return 'release';
+  return 'required-ci';
+}
+
+export function isUsableRun(run: BenchRun): boolean {
+  const conclusion = (run.conclusion ?? '').toLowerCase();
+  if (conclusion === 'cancelled' || conclusion === 'skipped') return false;
+  return true;
+}
+
+/** Jobs that sit on the required / release critical path. Windows never does. */
+export function requiredPathJobs(run: BenchRun): { included: BenchJob[]; excluded: BenchJob[] } {
+  const included: BenchJob[] = [];
+  const excluded: BenchJob[] = [];
+  for (const job of run.jobs) {
+    const skipped = (job.conclusion ?? '').toLowerCase() === 'skipped';
+    if (skipped || !job.started_at || !job.completed_at) {
+      excluded.push(job);
+      continue;
+    }
+    if (isWindowsJob(job)) {
+      excluded.push(job);
+      continue;
+    }
+    included.push(job);
+  }
+  return { included, excluded };
+}
+
+function majorityProvider(jobs: readonly BenchJob[]): Provider {
+  const counts = new Map<Provider, number>();
+  for (const job of jobs) {
+    if (isAggregatorJob(job.name)) continue;
+    const provider = classifyProvider(job);
+    counts.set(provider, (counts.get(provider) ?? 0) + 1);
+  }
+  let best: Provider = 'unknown';
+  let bestN = -1;
+  for (const [provider, n] of counts) {
+    if (n > bestN) {
+      best = provider;
+      bestN = n;
+    }
+  }
+  return best;
+}
+
+/**
+ * Exact wall-clock phases for one completed run.
+ *
+ * - queue: event `created_at` → first required-path job start
+ * - setup / execution: max across parallel required-path leaves (not the aggregator)
+ * - report: aggregator job duration (or report-classified steps if no aggregator)
+ * - e2e: required-check terminal (`aggregator.completed_at` else last job) − event
+ */
+export function extractPhaseTimes(run: BenchRun): PhaseTimes | null {
+  if (!isUsableRun(run)) return null;
+  const { included, excluded } = requiredPathJobs(run);
+  if (included.length === 0) return null;
+
+  const eventMs = Date.parse(run.created_at);
+  if (!Number.isFinite(eventMs)) return null;
+
+  const firstStart = Math.min(...included.map((j) => Date.parse(j.started_at!)));
+  const queueMs = Math.max(0, firstStart - eventMs);
+
+  const leaves = included.filter((j) => !isAggregatorJob(j.name));
+  const setupMs = leaves.length === 0
+    ? Math.max(...included.map((j) => sumClassified(j.steps, isSetupStep)))
+    : Math.max(...leaves.map((j) => sumClassified(j.steps, isSetupStep)));
+  const executionMs = leaves.length === 0
+    ? Math.max(...included.map((j) => sumClassified(j.steps, (n) => !isSetupStep(n) && !isReportStep(n))))
+    : Math.max(...leaves.map((j) => sumClassified(j.steps, (n) => !isSetupStep(n) && !isReportStep(n))));
+
+  const aggregator = included.find((j) => isAggregatorJob(j.name));
+  const reportMs = aggregator
+    ? (jobDurationMs(aggregator) ?? sumClassified(aggregator.steps, isReportStep))
+    : Math.max(...included.map((j) => sumClassified(j.steps, isReportStep)));
+
+  const terminal = aggregator ?? included.reduce((latest, job) => {
+    return Date.parse(job.completed_at!) > Date.parse(latest.completed_at!) ? job : latest;
+  });
+  const e2eMs = Math.max(0, Date.parse(terminal.completed_at!) - eventMs);
+
+  return {
+    runId: run.id,
+    kind: inferRunKind(run),
+    provider: majorityProvider(leaves.length > 0 ? leaves : included),
+    queueMs,
+    setupMs,
+    executionMs,
+    reportMs,
+    e2eMs,
+    includedJobNames: included.map((j) => j.name),
+    excludedJobNames: excluded.map((j) => j.name),
+  };
+}
+
+export function extractAllPhaseTimes(runs: readonly BenchRun[]): PhaseTimes[] {
+  const out: PhaseTimes[] = [];
+  for (const run of runs) {
+    const times = extractPhaseTimes(run);
+    if (times) out.push(times);
+  }
+  return out;
+}
+
+export function valuesForPhase(times: readonly PhaseTimes[], phase: keyof Pick<PhaseTimes, 'queueMs' | 'setupMs' | 'executionMs' | 'reportMs' | 'e2eMs'>): number[] {
+  return times.map((t) => t[phase]);
+}

--- a/scripts/ci-bench/providers.ts
+++ b/scripts/ci-bench/providers.ts
@@ -1,0 +1,106 @@
+import { gatedPercentile } from './percentile';
+import type { BenchJob, Phase, PhaseTimes, Provider, ProviderComparison } from './types';
+import { PHASES } from './types';
+
+const PHASE_KEY = {
+  queue: 'queueMs',
+  setup: 'setupMs',
+  execution: 'executionMs',
+  report: 'reportMs',
+  e2e: 'e2eMs',
+} as const;
+
+export function classifyProvider(job: BenchJob): Provider {
+  const labels = (job.labels ?? []).map((l) => l.toLowerCase());
+  const name = (job.name ?? '').toLowerCase();
+  const runner = `${job.runner_name ?? ''} ${job.runner_group_name ?? ''}`.toLowerCase();
+  const blob = [...labels, name, runner].join(' ');
+
+  if (blob.includes('windows')) return 'windows';
+  if (blob.includes('macos') || blob.includes('osx')) return 'macos';
+  if (
+    blob.includes('crabbox')
+    || blob.includes('self-hosted')
+    || blob.includes('phnx-')
+    || blob.includes('firecracker')
+  ) {
+    return 'crabbox';
+  }
+  if (
+    labels.some((l) => l === 'ubuntu-latest' || l === 'ubuntu-24.04' || l === 'ubuntu-22.04')
+    || runner.includes('github actions')
+  ) {
+    return 'github-hosted';
+  }
+  return 'unknown';
+}
+
+export function groupByProvider(times: readonly PhaseTimes[]): Map<Provider, PhaseTimes[]> {
+  const groups = new Map<Provider, PhaseTimes[]>();
+  for (const row of times) {
+    const list = groups.get(row.provider) ?? [];
+    list.push(row);
+    groups.set(row.provider, list);
+  }
+  return groups;
+}
+
+/**
+ * Compare two providers on one phase/percentile. Both sides must clear the
+ * sample-count gate or the comparison is `insufficient-sample` and carries
+ * no delta — a thin sample must not claim a winner.
+ */
+export function compareProviders(
+  leftTimes: readonly PhaseTimes[],
+  rightTimes: readonly PhaseTimes[],
+  left: Provider,
+  right: Provider,
+  phase: Phase,
+  p: number,
+): ProviderComparison {
+  const key = PHASE_KEY[phase];
+  const leftSample = gatedPercentile(leftTimes.map((t) => t[key]), p);
+  const rightSample = gatedPercentile(rightTimes.map((t) => t[key]), p);
+  if (leftSample.status !== 'ok' || rightSample.status !== 'ok') {
+    return {
+      phase,
+      p,
+      left: { provider: left, sample: leftSample },
+      right: { provider: right, sample: rightSample },
+      status: 'insufficient-sample',
+      deltaMs: null,
+      faster: null,
+    };
+  }
+  const deltaMs = leftSample.valueMs! - rightSample.valueMs!;
+  let faster: Provider | 'tie' = 'tie';
+  if (deltaMs > 0) faster = right;
+  else if (deltaMs < 0) faster = left;
+  return {
+    phase,
+    p,
+    left: { provider: left, sample: leftSample },
+    right: { provider: right, sample: rightSample },
+    status: 'ok',
+    deltaMs,
+    faster,
+  };
+}
+
+export function compareAllProviders(
+  times: readonly PhaseTimes[],
+  pair: readonly [Provider, Provider] = ['github-hosted', 'crabbox'],
+  percentiles: readonly number[] = [99, 99.9, 99.99],
+): ProviderComparison[] {
+  const groups = groupByProvider(times);
+  const [left, right] = pair;
+  const leftTimes = groups.get(left) ?? [];
+  const rightTimes = groups.get(right) ?? [];
+  const out: ProviderComparison[] = [];
+  for (const phase of PHASES) {
+    for (const p of percentiles) {
+      out.push(compareProviders(leftTimes, rightTimes, left, right, phase, p));
+    }
+  }
+  return out;
+}

--- a/scripts/ci-bench/report.ts
+++ b/scripts/ci-bench/report.ts
@@ -1,0 +1,113 @@
+import { extractAllPhaseTimes, valuesForPhase } from './phases';
+import { gatedPercentiles } from './percentile';
+import { compareAllProviders } from './providers';
+import {
+  allTargetsPass,
+  evaluateCiTargets,
+  evaluateReleaseTargets,
+  windowsRequiredFromWorkflow,
+} from './gates';
+import type {
+  BenchInput,
+  PhasePercentiles,
+  PhaseTimes,
+  ProviderComparison,
+  TargetEvaluation,
+  WindowsRequiredFinding,
+} from './types';
+import { PHASES, REPORTED_PERCENTILES } from './types';
+
+export interface BenchReport {
+  requiredCi: {
+    n: number;
+    phases: PhasePercentiles[];
+    targets: TargetEvaluation[];
+  };
+  release: {
+    n: number;
+    phases: PhasePercentiles[];
+    targets: TargetEvaluation[];
+  };
+  providers: ProviderComparison[];
+  windows: WindowsRequiredFinding | null;
+  pass: boolean;
+}
+
+function phaseTable(times: readonly PhaseTimes[]): PhasePercentiles[] {
+  return PHASES.map((phase) => {
+    const key = `${phase}Ms` as 'queueMs' | 'setupMs' | 'executionMs' | 'reportMs' | 'e2eMs';
+    const values = valuesForPhase(times, key);
+    return {
+      phase,
+      n: values.length,
+      percentiles: gatedPercentiles(values, REPORTED_PERCENTILES),
+    };
+  });
+}
+
+export function buildReport(
+  input: BenchInput,
+  workflowSource?: string,
+): BenchReport {
+  const times = extractAllPhaseTimes(input.runs);
+  const ci = times.filter((t) => t.kind === 'required-ci');
+  const release = times.filter((t) => t.kind === 'release');
+  const ciTargets = evaluateCiTargets(valuesForPhase(ci, 'e2eMs'));
+  const releaseTargets = evaluateReleaseTargets(valuesForPhase(release, 'e2eMs'));
+  const windows = workflowSource ? windowsRequiredFromWorkflow(workflowSource) : null;
+  const pass =
+    allTargetsPass(ciTargets)
+    && allTargetsPass(releaseTargets)
+    && (windows ? windows.pass : true);
+
+  return {
+    requiredCi: { n: ci.length, phases: phaseTable(ci), targets: ciTargets },
+    release: { n: release.length, phases: phaseTable(release), targets: releaseTargets },
+    providers: compareAllProviders(ci),
+    windows,
+    pass,
+  };
+}
+
+export function formatReport(report: BenchReport): string {
+  const lines: string[] = [];
+  lines.push(`ci-bench  required-ci n=${report.requiredCi.n}  release n=${report.release.n}  ${report.pass ? 'PASS' : 'FAIL'}`);
+  for (const [label, block] of [['required-ci', report.requiredCi], ['release', report.release]] as const) {
+    lines.push(`${label}:`);
+    for (const phase of block.phases) {
+      const cells = phase.percentiles.map((s) => {
+        if (s.status === 'insufficient-sample') {
+          return `P${s.p}=insufficient(n=${s.n}<${s.required})`;
+        }
+        return `P${s.p}=${s.valueMs}ms`;
+      });
+      lines.push(`  ${phase.phase.padEnd(10)} ${cells.join('  ')}`);
+    }
+    for (const t of block.targets) {
+      lines.push(`  ${t.pass ? 'ok  ' : 'fail'} ${t.reason}`);
+    }
+  }
+  lines.push('providers github-hosted vs crabbox:');
+  for (const cmp of report.providers) {
+    if (cmp.status === 'insufficient-sample') {
+      lines.push(
+        `  ${cmp.phase} P${cmp.p}: insufficient-sample `
+        + `github n=${cmp.left.sample.n}/${cmp.left.sample.required} `
+        + `crabbox n=${cmp.right.sample.n}/${cmp.right.sample.required}`,
+      );
+      continue;
+    }
+    lines.push(
+      `  ${cmp.phase} P${cmp.p}: github=${cmp.left.sample.valueMs}ms `
+      + `crabbox=${cmp.right.sample.valueMs}ms `
+      + `faster=${cmp.faster} delta=${cmp.deltaMs}ms`,
+    );
+  }
+  if (report.windows) {
+    lines.push(
+      `windows-required: ${report.windows.pass ? 'ok (not required)' : 'fail (still required)'} `
+      + `(${report.windows.evidence})`,
+    );
+  }
+  return lines.join('\n') + '\n';
+}

--- a/scripts/ci-bench/types.ts
+++ b/scripts/ci-bench/types.ts
@@ -1,0 +1,112 @@
+/** Required-CI tails the plan hard-gates at 90s. Release hard-gates P99 at 180s. */
+export const CI_TAIL_PERCENTILES = [99, 99.9, 99.99] as const;
+export const REPORTED_PERCENTILES = [50, 90, 99, 99.9, 99.99] as const;
+
+export const CI_P99_BUDGET_MS = 90_000;
+export const CI_CACHE_HIT_BUDGET_MS = 10_000;
+export const RELEASE_P99_BUDGET_MS = 180_000;
+
+export const PHASES = ['queue', 'setup', 'execution', 'report', 'e2e'] as const;
+export type Phase = (typeof PHASES)[number];
+
+export type RunKind = 'required-ci' | 'release';
+
+export type Provider =
+  | 'github-hosted'
+  | 'crabbox'
+  | 'windows'
+  | 'macos'
+  | 'unknown';
+
+export type SampleGateStatus = 'ok' | 'insufficient-sample';
+
+export interface GatedPercentile {
+  p: number;
+  n: number;
+  required: number;
+  status: SampleGateStatus;
+  /** Nearest-rank observed sample. Null when the sample-count gate fails. */
+  valueMs: number | null;
+  rank: number | null;
+}
+
+export interface BenchStep {
+  name: string;
+  started_at: string | null;
+  completed_at: string | null;
+  conclusion?: string | null;
+}
+
+export interface BenchJob {
+  name: string;
+  labels?: string[];
+  runner_name?: string | null;
+  runner_group_name?: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  conclusion?: string | null;
+  steps?: BenchStep[];
+}
+
+export interface BenchRun {
+  id: number | string;
+  name?: string;
+  event?: string;
+  kind?: RunKind;
+  created_at: string;
+  run_started_at?: string | null;
+  conclusion?: string | null;
+  head_sha?: string;
+  jobs: BenchJob[];
+}
+
+export interface BenchInput {
+  runs: BenchRun[];
+}
+
+export interface PhaseTimes {
+  runId: number | string;
+  kind: RunKind;
+  /** Primary provider on the required path (windows never counts). */
+  provider: Provider;
+  queueMs: number;
+  setupMs: number;
+  executionMs: number;
+  reportMs: number;
+  e2eMs: number;
+  includedJobNames: string[];
+  excludedJobNames: string[];
+}
+
+export interface PhasePercentiles {
+  phase: Phase;
+  n: number;
+  percentiles: GatedPercentile[];
+}
+
+export interface ProviderComparison {
+  phase: Phase;
+  p: number;
+  left: { provider: Provider; sample: GatedPercentile };
+  right: { provider: Provider; sample: GatedPercentile };
+  status: 'ok' | 'insufficient-sample';
+  deltaMs: number | null;
+  faster: Provider | 'tie' | null;
+}
+
+export interface TargetEvaluation {
+  name: string;
+  kind: RunKind;
+  p: number;
+  budgetMs: number;
+  sample: GatedPercentile;
+  /** Pass only when the sample-count gate cleared AND value <= budget. */
+  pass: boolean;
+  reason: string;
+}
+
+export interface WindowsRequiredFinding {
+  required: boolean;
+  evidence: string;
+  pass: boolean;
+}


### PR DESCRIPTION
test-only — RUSH-2666 baseline instrument.

Adds `scripts/ci-bench` so required-CI **P99 / P99.9 / P99.99** and release tails are measured from recorded GitHub Actions runs, with sample-count gates. Windows in the required aggregator `needs` list fails the gate. This does not yet make those tails pass on live traffic.

## What

| Surface | Rule |
| --- | --- |
| Required CI e2e | P99 / P99.9 / P99.99 each ≤ 90s |
| Ordinary release e2e | same tails ≤ 180s |
| Sample-count gate | P99 needs 100, P99.9 needs 1000, P99.99 needs 10000. Under that the tail is `insufficient-sample`, never a claimed pass |
| Percentile | nearest-rank observed sample — no interpolation |
| Phases | queue, setup, execution, report, e2e. Windows jobs are excluded from the required path |
| Providers | github-hosted vs crabbox; no winner unless both sides clear the gate |
| Windows | aggregator `needs` must not include `windows` |

Ticket: [RUSH-2666](https://linear.app/getrush/issue/RUSH-2666/release-ci-and-test-reliability)
Plan: `.agents/artifacts/2026-08-15/plan-ci-release-near-instant.md`

## Run

```
$ bun test ./scripts/ci-bench/ ./.github/workflows/
  36 pass
  0 fail
  91 expect() calls
Ran 36 tests across 6 files. [313.00ms]
```

Recorded Tests run fixture (event 12:07:30Z → aggregator 12:17:12Z):

```
queue=3000ms  setup=27000ms  execution=501000ms  report=27000ms  e2e=582000ms
excluded: windows
```

One-run fixture correctly refuses the 90s claim (`need 100 samples for P99; have 1`) and reports `windows-required: fail (still required)`.

## Out of scope

Impact planner, Crabbox executor, release attestation promotion, and making Windows non-required on live `tests.yml` belong to the other RUSH-2666 tracks.