### PR TITLE
docs(cli): repoint versions.ts / migrate.ts links after the RUSH-2708 installations move

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -55,7 +55,7 @@ elsewhere; route through `supports()`.
 
 ### 4. No fallback logic for legacy layouts
 
-[`src/lib/migrate.ts`](src/lib/migrate.ts) folds legacy paths ONCE at install time.
+[`src/lib/installations/migrate.ts`](src/lib/installations/migrate.ts) folds legacy paths ONCE at install time.
 The bootstrap gate that invokes `runMigration()` then writes the `.migrated` sentinel
 (`MIGRATED_SENTINEL_FILE`, [`src/lib/state.ts`](src/lib/state.ts)), keyed to the
 migration SCHEMA version, so the scan short-circuits next run — `runMigration()` itself
@@ -76,7 +76,7 @@ agents register a hook.
 
 DAG-style, boundary contracts, `--watch` supervisor, `--worktree` isolation, optional
 `--cloud` dispatch. The old `mcp__Swarm__*` surface was folded into teams
-(`migrateLegacySwarmToTeams()` in `src/lib/migrate.ts`). Don't reach for Swarm — gone.
+(`migrateLegacySwarmToTeams()` in `src/lib/installations/migrate.ts`). Don't reach for Swarm — gone.
 
 ### 7. Every agent conversation is a session; execution ledgers link to it
 
@@ -159,7 +159,7 @@ the installer only ever fetches the *current* release and the binary self-update
 place. `isSelfUpdatingAgent()` ([`src/lib/agents.ts`](src/lib/agents.ts)) is the single
 predicate for "no pinnable semver"; route every such decision through it, never a
 scattered `=== 'droid'`. Its narrower cousin `isGlobalBinaryAgent()`
-([`src/lib/versions.ts`](src/lib/versions.ts)) — computed by probing whether
+([`src/lib/installations/versions.ts`](src/lib/installations/versions.ts)) — computed by probing whether
 `getBinaryPath` ignores the version arg — is true only when the agent resolves to ONE
 global binary (droid). For those, `listInstalledVersions` collapses the phantom
 per-version dirs to a single canonical entry, `reconcileStaleLatestForAgent` folds the

--- a/apps/cli/docs/AGENT-CHEATSHEET.md
+++ b/apps/cli/docs/AGENT-CHEATSHEET.md
@@ -32,7 +32,7 @@ Snapshot in [`apps/cli/AGENTS.md`](../AGENTS.md) §Supported harnesses — keep 
 
 Each installed agent version lives under `~/.agents/.history/versions/<agent>/<version>/home/`. agi-cli swaps `HOME` to that directory before exec-ing the agent. No config bleed between versions.
 
-Source: [`src/lib/versions.ts`](../src/lib/versions.ts), [`src/lib/exec.ts`](../src/lib/exec.ts).
+Source: [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts), [`src/lib/exec.ts`](../src/lib/exec.ts).
 
 ## 6. Two unrelated things are called "session"
 
@@ -51,7 +51,7 @@ Every agent invocation goes through `buildExecEnv` → `execAgent` / `runWithFal
 
 ## 8. Self-updating vs pinnable agents
 
-Some harnesses (droid, grok, antigravity, cursor, hermes, kiro, goose) install via `curl | sh` / `brew` and the binary self-updates in place — no pinnable semver. Use `isSelfUpdatingAgent()` ([`src/lib/agents.ts`](../src/lib/agents.ts)) as the single predicate. `isGlobalBinaryAgent()` ([`src/lib/versions.ts`](../src/lib/versions.ts)) is narrower: true only for droid.
+Some harnesses (droid, grok, antigravity, cursor, hermes, kiro, goose) install via `curl | sh` / `brew` and the binary self-updates in place — no pinnable semver. Use `isSelfUpdatingAgent()` ([`src/lib/agents.ts`](../src/lib/agents.ts)) as the single predicate. `isGlobalBinaryAgent()` ([`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts)) is narrower: true only for droid.
 
 ## 9. Work on a worktree, never `main`
 
@@ -69,7 +69,7 @@ Tests hit the actual critical path. Integration tests live in `tests/`; unit tes
 | Resource resolution | `src/lib/resources.ts` |
 | Capability gating | `src/lib/capabilities.ts`, `src/lib/agents.ts` |
 | Agent execution | `src/lib/exec.ts` |
-| Version install/sync | `src/lib/versions.ts` |
+| Version install/sync | `src/lib/installations/versions.ts` |
 | Session transcript index | `src/lib/session/` |
 | Live active sessions | `src/lib/session/active.ts` |
 | Hosts / SSH dispatch | `src/lib/hosts/` |

--- a/apps/cli/docs/optimizations.md
+++ b/apps/cli/docs/optimizations.md
@@ -237,7 +237,7 @@ trades correctness guarantees for speed.
 
 | File | Change |
 |------|--------|
-| `src/lib/versions.ts` | Guard + manifest write in `syncResourcesToVersion`; `force?` option; skip dotfiles in `copyDir` |
+| `src/lib/installations/versions.ts` | Guard + manifest write in `syncResourcesToVersion`; `force?` option; skip dotfiles in `copyDir` |
 | `src/lib/rules-compile.ts` | Add `mtime?`/`size?` to `CompileManifest`; two-tier fast path in `isRulesStale` |
 
 ---

--- a/apps/cli/docs/self-healing.md
+++ b/apps/cli/docs/self-healing.md
@@ -79,7 +79,7 @@ swallowed.
 ### Layer 1 — install-integrity gate
 
 After a successful `npm install`, `installVersion()`
-([`src/lib/versions.ts`](../src/lib/versions.ts)) probes the resolved binary via
+([`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts)) probes the resolved binary via
 `verifyInstalledBinaryLaunches()`. If it can't launch, the install returns
 `success: false` and its `node_modules` is removed — so a gutted install is
 **never** recorded as healthy and its caller never sets it as the default pin.
@@ -201,11 +201,11 @@ difference:
 
 | Piece | Location |
 |---|---|
-| `ensureAgentRunnable()` — the self-heal engine | [`src/lib/versions.ts`](../src/lib/versions.ts) |
+| `ensureAgentRunnable()` — the self-heal engine | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
 | `resolveLaunchBinary()` — the not-installed probe | [`src/lib/exec.ts`](../src/lib/exec.ts) |
-| `verifyInstalledBinaryLaunches()` — the launch probe | [`src/lib/versions.ts`](../src/lib/versions.ts) |
-| `isMissingBinarySignature()` — the "broken" classifier | [`src/lib/versions.ts`](../src/lib/versions.ts) |
-| `installVersion(..., { clean })` — Layer 1 gate + wipe-then-reinstall | [`src/lib/versions.ts`](../src/lib/versions.ts) |
+| `verifyInstalledBinaryLaunches()` — the launch probe | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
+| `isMissingBinarySignature()` — the "broken" classifier | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
+| `installVersion(..., { clean })` — Layer 1 gate + wipe-then-reinstall | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
 | Self-heal wiring on the run path | [`src/commands/exec.ts`](../src/commands/exec.ts) |
 | `runInTmux()` dead-pane recap (Layer 3) | [`src/lib/exec.ts`](../src/lib/exec.ts) |
 | Tests | `src/lib/versions-integrity.test.ts`, `src/lib/tmux/session.test.ts`, `src/lib/exec.test.ts` |

--- a/apps/cli/docs/toolchain-thesis.md
+++ b/apps/cli/docs/toolchain-thesis.md
@@ -86,7 +86,7 @@ Every layer of the toolchain maps to a concrete implementation in the codebase.
 
 | Layer | agi-cli feature | Evidence |
 |---|---|---|
-| 1. Versions | `agents add/use/prune claude@2.0.65` -> `~/.agents/versions/{agent}/{version}/home/`, symlink swap + auto-backup to `~/.agents/backups/{agent}/{timestamp}/` on switch | `src/lib/versions.ts`, `src/lib/shims.ts` |
+| 1. Versions | `agents add/use/prune claude@2.0.65` -> `~/.agents/versions/{agent}/{version}/home/`, symlink swap + auto-backup to `~/.agents/backups/{agent}/{timestamp}/` on switch | `src/lib/installations/versions.ts`, `src/lib/shims.ts` |
 | 2. Config source-of-truth | Central `AGENTS.md` symlinked to CLAUDE.md / GEMINI.md / .cursorrules; `memory-compile.ts` inlines `@path` imports for agents without native support | `src/lib/memory.ts:37-58`, `src/lib/memory-compile.ts:20-24` |
 | 3. Resource registry | 8 resource types: commands, skills, hooks, memory, mcp, permissions, subagents, plugins. `agents install mcp:com.notion/mcp` fans out to all agents; git-tracked via `agents repo push` / `agents repo pull` (per-repo) and `agents secrets push` / `agents secrets pull` (bundle sync) | `src/lib/types.ts:288`, `src/commands/mcp.ts` |
 | 4. Profiles | Presets for Kimi, DeepSeek, Qwen, GLM, MiniMax; `agents run kimi "..."` resolves to Claude Code host + `ANTHROPIC_BASE_URL` + keychain auth at spawn time | `src/lib/profiles.ts:6-32`, `src/lib/profiles-presets.ts`, `src/commands/exec.ts:154-167` |

--- a/apps/cli/docs/version-management.md
+++ b/apps/cli/docs/version-management.md
@@ -115,7 +115,7 @@ agents add claude@2.0.65
            ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │  installVersion(agent, version)                                     │
-│  src/lib/versions.ts:installVersion()                               │
+│  src/lib/installations/versions.ts:installVersion()                               │
 │                                                                     │
 │  1. Create ~/.agents-system/versions/claude/2.0.65/                        │
 │  2. npm install @anthropic-ai/claude-code@2.0.65                    │


### PR DESCRIPTION
**docs-only** — no behavior change. Audience: maintainers. This is the current blocker on the 1.22.40 release.

## Why this is release-blocking

`dd6b0a0a1` (#2732, RUSH-2708 Move 3) moved `src/lib/versions.ts` and `src/lib/migrate.ts` into `src/lib/installations/` and left the docs pointing at the old paths. Reproduced against `origin/release/v1.22.40` (`7209007b0`):

```
✗ broken link in docs/AGENT-CHEATSHEET.md -> ../src/lib/versions.ts   (x2)
✗ broken link in docs/self-healing.md     -> ../src/lib/versions.ts   (x5)
✗ Docs verification failed with 7 error(s)
```

That reds `cli-docs`. It does not stop there — `tests.yml:171` declares

```yaml
test:
  needs: [scope, cli-preflight, cli-test-shard, cli-docs, ext, session-tracker, windows]
```

and gates on `DOCS_RESULT`, so `test` fails too. `test` is in `release.sh`'s `EXPECTED_CHECKS`, so `wait_for_ci_green` fails closed and **1.22.40 cannot publish** until this lands.

## What changed

| File | Links fixed |
|---|---|
| `docs/AGENT-CHEATSHEET.md` | 2 broken links + 1 stale table reference |
| `docs/self-healing.md` | 5 broken links |
| `docs/optimizations.md`, `docs/version-management.md`, `docs/toolchain-thesis.md` | stale prose references (not links, so not caught by the verifier, but wrong) |
| `apps/cli/AGENTS.md` | `migrate.ts` link + `versions.ts` link |

`docs/examples/sessions/**` is deliberately untouched — those are verbatim historical transcripts of past sessions, not current architecture, and rewriting them would falsify a record.

## Run result

```
$ bash scripts/verify-docs.sh
✓ AGENTS.md links to AGENT-CHEATSHEET.md
✓ docs/README.md links to AGENT-CHEATSHEET.md
✓ Docs verification passed
```

Ran against this branch; the same script fails with the 7 errors above on `main`.
