### PR TITLE
docs(cli): repoint versions.ts links after the RUSH-2708 installations/ move

### DIFF
--- a/apps/cli/docs/AGENT-CHEATSHEET.md
+++ b/apps/cli/docs/AGENT-CHEATSHEET.md
@@ -32,7 +32,7 @@ Snapshot in [`apps/cli/AGENTS.md`](../AGENTS.md) §Supported harnesses — keep 
 
 Each installed agent version lives under `~/.agents/.history/versions/<agent>/<version>/home/`. agi-cli swaps `HOME` to that directory before exec-ing the agent. No config bleed between versions.
 
-Source: [`src/lib/versions.ts`](../src/lib/versions.ts), [`src/lib/exec.ts`](../src/lib/exec.ts).
+Source: [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts), [`src/lib/exec.ts`](../src/lib/exec.ts).
 
 ## 6. Two unrelated things are called "session"
 
@@ -51,7 +51,7 @@ Every agent invocation goes through `buildExecEnv` → `execAgent` / `runWithFal
 
 ## 8. Self-updating vs pinnable agents
 
-Some harnesses (droid, grok, antigravity, cursor, hermes, kiro, goose) install via `curl | sh` / `brew` and the binary self-updates in place — no pinnable semver. Use `isSelfUpdatingAgent()` ([`src/lib/agents.ts`](../src/lib/agents.ts)) as the single predicate. `isGlobalBinaryAgent()` ([`src/lib/versions.ts`](../src/lib/versions.ts)) is narrower: true only for droid.
+Some harnesses (droid, grok, antigravity, cursor, hermes, kiro, goose) install via `curl | sh` / `brew` and the binary self-updates in place — no pinnable semver. Use `isSelfUpdatingAgent()` ([`src/lib/agents.ts`](../src/lib/agents.ts)) as the single predicate. `isGlobalBinaryAgent()` ([`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts)) is narrower: true only for droid.
 
 ## 9. Work on a worktree, never `main`
 
@@ -69,7 +69,7 @@ Tests hit the actual critical path. Integration tests live in `tests/`; unit tes
 | Resource resolution | `src/lib/resources.ts` |
 | Capability gating | `src/lib/capabilities.ts`, `src/lib/agents.ts` |
 | Agent execution | `src/lib/exec.ts` |
-| Version install/sync | `src/lib/versions.ts` |
+| Version install/sync | `src/lib/installations/versions.ts` |
 | Session transcript index | `src/lib/session/` |
 | Live active sessions | `src/lib/session/active.ts` |
 | Hosts / SSH dispatch | `src/lib/hosts/` |

--- a/apps/cli/docs/self-healing.md
+++ b/apps/cli/docs/self-healing.md
@@ -79,7 +79,7 @@ swallowed.
 ### Layer 1 — install-integrity gate
 
 After a successful `npm install`, `installVersion()`
-([`src/lib/versions.ts`](../src/lib/versions.ts)) probes the resolved binary via
+([`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts)) probes the resolved binary via
 `verifyInstalledBinaryLaunches()`. If it can't launch, the install returns
 `success: false` and its `node_modules` is removed — so a gutted install is
 **never** recorded as healthy and its caller never sets it as the default pin.
@@ -201,11 +201,11 @@ difference:
 
 | Piece | Location |
 |---|---|
-| `ensureAgentRunnable()` — the self-heal engine | [`src/lib/versions.ts`](../src/lib/versions.ts) |
+| `ensureAgentRunnable()` — the self-heal engine | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
 | `resolveLaunchBinary()` — the not-installed probe | [`src/lib/exec.ts`](../src/lib/exec.ts) |
-| `verifyInstalledBinaryLaunches()` — the launch probe | [`src/lib/versions.ts`](../src/lib/versions.ts) |
-| `isMissingBinarySignature()` — the "broken" classifier | [`src/lib/versions.ts`](../src/lib/versions.ts) |
-| `installVersion(..., { clean })` — Layer 1 gate + wipe-then-reinstall | [`src/lib/versions.ts`](../src/lib/versions.ts) |
+| `verifyInstalledBinaryLaunches()` — the launch probe | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
+| `isMissingBinarySignature()` — the "broken" classifier | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
+| `installVersion(..., { clean })` — Layer 1 gate + wipe-then-reinstall | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
 | Self-heal wiring on the run path | [`src/commands/exec.ts`](../src/commands/exec.ts) |
 | `runInTmux()` dead-pane recap (Layer 3) | [`src/lib/exec.ts`](../src/lib/exec.ts) |
 | Tests | `src/lib/versions-integrity.test.ts`, `src/lib/tmux/session.test.ts`, `src/lib/exec.test.ts` |


### PR DESCRIPTION
**docs-only** — fixes a release-blocking \`cli-docs\` failure, no behavior change.

## What

\`docs/AGENT-CHEATSHEET.md\` and \`docs/self-healing.md\` linked \`src/lib/versions.ts\`, which PR #2732 (RUSH-2708 Move 3) relocated to \`src/lib/installations/versions.ts\`. \`scripts/verify-docs.sh\` (the \`cli-docs\` required check) was failing every 1.22.40 release-branch build on this drift, independent of the release's own content — same pattern as the earlier \`events.ts\` -> \`feed/events.ts\` fix in PR #2739.

## Verification

Ran the actual broken-link check (verify-docs.sh's link-resolution logic) against this branch: 0 broken links, down from 7 before the fix. All 7 occurrences repointed to \`src/lib/installations/versions.ts\`.