### PR TITLE
fix(tests): forward hermeticity isolation vars into the SSH-peer exec channel (RUSH-2639)

### DIFF
--- a/apps/cli/src/commands/testdata/session-resolver-ssh-peer.mjs
+++ b/apps/cli/src/commands/testdata/session-resolver-ssh-peer.mjs
@@ -71,9 +71,38 @@ if (mode === 'old-peer') {
 }
 fs.chmodSync(shimBin, 0o755);
 
+// RUSH-2639: this exec channel is exactly the "child process launched through
+// a login-shell-like boundary" class the fork-private AGENTS_* isolation vars
+// exist for (see tests/setup.ts). The env below used to start from scratch
+// with only HOME/USERPROFILE/PATH/NODE_NO_WARNINGS, silently dropping every
+// hermeticity escape hatch (AGENTS_DEVICES_DIR, AGENTS_STATE_DIR,
+// AGENTS_SECRETS_AGENT_DIR, AGENTS_EVENTS_PATH, AGENTS_HOOK_SHIMS_DIR,
+// AGENTS_HOOK_CACHE_DIR, AGENTS_LOGS_DIR, AGENTS_PERF_DIR, AGENTS_REAL_HOME)
+// the parent vitest fork set — the one spawn path in sessions.test.ts that
+// did not carry them through, unlike every other subprocess helper in this
+// file. Forward them so the exec'd CLI resolves everything under peerHome
+// instead of falling back to a real-HOME-derived default.
+const FORWARDED_ISOLATION_VARS = [
+  'AGENTS_DEVICES_DIR',
+  'AGENTS_STATE_DIR',
+  'AGENTS_SECRETS_AGENT_DIR',
+  'AGENTS_SECRETS_NO_AGENT',
+  'AGENTS_NO_USAGE_TRACK',
+  'AGENTS_EVENTS_PATH',
+  'AGENTS_HOOK_SHIMS_DIR',
+  'AGENTS_HOOK_CACHE_DIR',
+  'AGENTS_LOGS_DIR',
+  'AGENTS_PERF_DIR',
+  'AGENTS_REAL_HOME',
+];
+
 function runExecCommand(command) {
   return new Promise((resolve) => {
     const inherited = process.env;
+    const forwarded = {};
+    for (const key of FORWARDED_ISOLATION_VARS) {
+      if (inherited[key] !== undefined) forwarded[key] = inherited[key];
+    }
     const child = spawn('bash', ['-c', command], {
       cwd: peerHome,
       env: {
@@ -81,6 +110,8 @@ function runExecCommand(command) {
         USERPROFILE: peerHome,
         PATH: `${shimDir}${path.delimiter}${inherited.PATH || ''}`,
         NODE_NO_WARNINGS: '1',
+        AGENTS_SKIP_MIGRATION: '1',
+        ...forwarded,
         ...(inherited.HTTP_PROXY ? { HTTP_PROXY: inherited.HTTP_PROXY } : {}),
         ...(inherited.HTTPS_PROXY ? { HTTPS_PROXY: inherited.HTTPS_PROXY } : {}),
         ...(inherited.NO_PROXY ? { NO_PROXY: inherited.NO_PROXY } : {}),


### PR DESCRIPTION
bugfix — CI/test-only, no production behavior change

## What broke

`release/v1.22.40` CI (`ci.yml`) fails both macOS legs — `build (macos-latest, 22)` and `build (macos-latest, 24)` — with:

```
Error: hermeticity leak (RUSH-2639): the real user dir (/Users/runner/.agents) gained, lost,
or modified a top-level entry during this test file. Before: null.
After: .cache:128:...|.history:128:...|.system:256:...|routines:64:....
```

on both `src/commands/routines.test.ts` and `src/commands/sessions.test.ts`. All individual `it()`s in both files pass — only the file-level `afterAll` hermeticity tripwire (`tests/setup.ts:223`) fails, and only on macOS (Linux `test`/`cli-test-shard` is green on the same commit).

Run/job refs: `31884487479` / jobs `95011685075` (macos-latest 22), `95011685101` (macos-latest 24).

## Root cause

`src/commands/testdata/session-resolver-ssh-peer.mjs`'s `runExecCommand` — the real SSH2-protocol exec channel `sessions.test.ts`'s two fleet-failure tests use — built its exec env from scratch:

```js
env: {
  HOME: peerHome,
  USERPROFILE: peerHome,
  PATH: `${shimDir}${path.delimiter}${inherited.PATH || ''}`,
  NODE_NO_WARNINGS: '1',
  ...(proxy vars),
}
```

It never spreads `...process.env`, so it silently drops every hermeticity isolation var `tests/setup.ts` pins per-fork (`AGENTS_DEVICES_DIR`, `AGENTS_STATE_DIR`, `AGENTS_SECRETS_AGENT_DIR`, `AGENTS_EVENTS_PATH`, `AGENTS_HOOK_SHIMS_DIR`, `AGENTS_HOOK_CACHE_DIR`, `AGENTS_LOGS_DIR`, `AGENTS_PERF_DIR`, `AGENTS_REAL_HOME`) and `AGENTS_SKIP_MIGRATION`, which every other subprocess helper in both test files carries through via `...process.env`. This is the exact "child process launched through a login-shell-like boundary" class `AGENTS_REAL_HOME` exists for (`tests/setup.ts:52-56`).

## Fix

Forward the isolation vars (read from the fixture process's own `process.env`, which does inherit them correctly) into the exec'd child's env, and add `AGENTS_SKIP_MIGRATION: '1'` to match the sibling spawn helpers.

## Verification

Ran `sessions.test.ts` / `routines.test.ts` on a real macOS box (`mac-mini`) with a genuinely fresh outer `$HOME` (matching a fresh GH Actions runner) at the exact release commit (`7209007b0`):

- Before the fix: could not cleanly reproduce the exact tripwire locally (macOS-runner-only timing), but confirmed the gap exists by code inspection and diff against every sibling spawn site in these two files (all others correctly spread `...process.env`; this was the only exception).
- After the fix: `sessions.test.ts`'s SSH-peer-based tests (`transport-level corruption`/`malformed`) run clean with no hermeticity error across 3 separate fresh-`$HOME` sandboxes on the mac box.
- `node -c` confirms the `.mjs` fixture still parses.

This does not touch the release payload — `session-resolver-ssh-peer.mjs` is test-only fixture code (`src/commands/testdata/`), never shipped.