### PR TITLE
fix(release): attestation producer tolerates vitest teardown worker-exit on a green suite (RUSH-2758)

### DIFF
--- a/apps/cli/scripts/release-attestation-produce.sh
+++ b/apps/cli/scripts/release-attestation-produce.sh
@@ -106,10 +106,31 @@ cd "$WT/apps/cli"
 bun install --frozen-lockfile || die "bun install failed for ${SHA:0:12}"
 
 bold "Running the full suite..."
-if ! bun run test; then
-  die "suite failed for ${SHA:0:12} -- refusing to attest a red tree"
+# Mirrors isVitestWorkerCrashWithZeroFailures (scripts/ci-scope.ts): vitest can
+# exit 1 on an unhandled teardown "Worker exited unexpectedly" after every test
+# passed (RUSH-2215; hit by this producer on a fully green tree, RUSH-2758).
+# Only that exact shape is tolerated -- any 'failed' in the summary, or a
+# missing summary, stays fail-closed.
+suite_green_despite_worker_crash() {
+  local log="$1" files_line tests_line
+  grep -q 'Worker exited unexpectedly' "$log" || return 1
+  files_line="$(grep -E '^[[:space:]]*Test Files[[:space:]]' "$log" | tail -1)"
+  tests_line="$(grep -E '^[[:space:]]*Tests[[:space:]]' "$log" | tail -1)"
+  [[ -n "$files_line" && -n "$tests_line" ]] || return 1
+  grep -qE '(^|[^[:alnum:]])failed([^[:alnum:]]|$)' <<<"$files_line" && return 1
+  grep -qE '(^|[^[:alnum:]])failed([^[:alnum:]]|$)' <<<"$tests_line" && return 1
+  grep -qE '(^|[^[:alnum:]])passed([^[:alnum:]]|$)' <<<"$tests_line"
+}
+SUITE_LOG="$(mktemp "${TMPDIR:-/tmp}/agents-cli-attest-suite.XXXXXX")"
+if bun run test 2>&1 | tee "$SUITE_LOG"; then
+  green "Suite passed."
+elif suite_green_despite_worker_crash "$SUITE_LOG"; then
+  gray "vitest worker exited after zero test failures; treating as pass (RUSH-2215)."
+  green "Suite passed (teardown worker-exit tolerated on a green summary)."
+else
+  die "suite failed for ${SHA:0:12} -- refusing to attest a red tree (log: $SUITE_LOG)"
 fi
-green "Suite passed."
+rm -f "$SUITE_LOG"
 
 # Sign + notarize headlessly, matching what release.sh's privileged phase did
 # before RUSH-2666 moved build/sign to attestation time. Skipped off a macOS

--- a/apps/cli/scripts/release-attestation-produce.test.ts
+++ b/apps/cli/scripts/release-attestation-produce.test.ts
@@ -40,7 +40,29 @@ function git(cwd: string, ...args: string[]): string {
 // package.json, bun.lock, vitest.config.ts, ci/test-ownership.yaml } plus a
 // root-level scripts/ci-scope.ts. A fake bun/npm on PATH stand in for the
 // real toolchain; `failSuite` makes the fake `bun run test` exit non-zero.
-function buildFixture(root: string, opts: { failSuite?: boolean } = {}): { caller: string; fakebin: string; store: string; headCommit: string } {
+function fakeSuiteBody(opts: { failSuite?: boolean; suite?: 'greenWorkerCrash' | 'redWorkerCrash' }): string {
+  // Summary lines mirror real vitest output so the producer's
+  // suite_green_despite_worker_crash parser is exercised against the shape it
+  // sees in production (RUSH-2758).
+  if (opts.suite === 'greenWorkerCrash')
+    return [
+      '  echo " Test Files  861 passed | 8 skipped (870)"',
+      '  echo "      Tests  12200 passed | 105 skipped (12325)"',
+      '  echo "Error: Worker exited unexpectedly"',
+      '  exit 1',
+    ].join('\n');
+  if (opts.suite === 'redWorkerCrash')
+    return [
+      '  echo " Test Files  2 failed | 859 passed (870)"',
+      '  echo "      Tests  3 failed | 12197 passed (12325)"',
+      '  echo "Error: Worker exited unexpectedly"',
+      '  exit 1',
+    ].join('\n');
+  if (opts.failSuite) return '  echo "1 test failed" >&2; exit 1';
+  return '  echo "tests passed"; exit 0';
+}
+
+function buildFixture(root: string, opts: { failSuite?: boolean; suite?: 'greenWorkerCrash' | 'redWorkerCrash' } = {}): { caller: string; fakebin: string; store: string; headCommit: string } {
   const remote = path.join(root, 'remote.git');
   const caller = path.join(root, 'caller');
   git(root, 'init', '-q', '--bare', '-b', 'main', remote);
@@ -74,7 +96,7 @@ function buildFixture(root: string, opts: { failSuite?: boolean } = {}): { calle
       'if [[ "$1" == "--version" ]]; then echo "1.2.3"; exit 0; fi',
       'if [[ "$1" == "install" ]]; then exit 0; fi',
       'if [[ "$1" == "run" && "$2" == "test" ]]; then',
-      opts.failSuite ? '  echo "1 test failed" >&2; exit 1' : '  echo "tests passed"; exit 0',
+      fakeSuiteBody(opts),
       'fi',
       'if [[ "$1" == "run" && "$2" == "build" ]]; then mkdir -p dist; exit 0; fi',
       'echo "fake bun: unhandled args: $*" >&2; exit 1',
@@ -206,6 +228,26 @@ describe('release-attestation-produce.sh', () => {
   it('never writes an attestation for a red suite (fail closed)', () => {
     const root = tmp('attest-produce-red-');
     const fx = buildFixture(root, { failSuite: true });
+    const result = runProduce(fx);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain('refusing to attest a red tree');
+    expect(fs.existsSync(fx.store) ? fs.readdirSync(fx.store).filter((f) => f.endsWith('.json')) : []).toEqual([]);
+  });
+
+  it('attests a green suite whose only failure is a teardown worker-exit (RUSH-2758)', () => {
+    const root = tmp('attest-produce-worker-crash-green-');
+    const fx = buildFixture(root, { suite: 'greenWorkerCrash' });
+    const result = runProduce(fx);
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(result.stdout + result.stderr).toContain('treating as pass');
+    const jsonFile = fs.readdirSync(fx.store).find((f) => f.endsWith('.json'));
+    expect(jsonFile).toBeTruthy();
+    expect(JSON.parse(fs.readFileSync(path.join(fx.store, jsonFile!), 'utf-8')).conclusion).toBe('pass');
+  });
+
+  it('stays fail-closed when a worker crash accompanies real test failures', () => {
+    const root = tmp('attest-produce-worker-crash-red-');
+    const fx = buildFixture(root, { suite: 'redWorkerCrash' });
     const result = runProduce(fx);
     expect(result.status).not.toBe(0);
     expect(result.stdout + result.stderr).toContain('refusing to attest a red tree');


### PR DESCRIPTION
Fixes [RUSH-2758](https://linear.app/getrush/issue/RUSH-2758); unblocks the wedged 1.22.40 release (RUSH-2749).

## What

`release-attestation-produce.sh` refused to attest a fully green tree: on main b6fe895a0 the suite finished **861 files / 12200 tests passed, 0 failed**, then vitest exited 1 on an unhandled teardown `Worker exited unexpectedly` (the RUSH-2215 flake), and the producer's bare `if ! bun run test` treated that as red.

CI already special-cases exactly this shape (`isVitestWorkerCrashWithZeroFailures`, 07ae35081). This PR ports the same heuristic to the producer: the suite output is teed to a log; on a nonzero exit the summary is parsed, and only a green summary (no `failed` token on the `Test Files`/`Tests` lines, `passed` present) accompanied by a worker-exit is treated as pass. Any real failure, or a missing summary, stays fail-closed.

## Run result

6/6 tests pass against the real script (fake-bun fixture), including the two new cases — 'attests a green suite whose only failure is a teardown worker-exit' and 'stays fail-closed when a worker crash accompanies real test failures':

![vitest run of release-attestation-produce.test.ts, 6 passed](https://share.agents-cli.sh/muqsitnawaz/rush-2758-attest-worker-crash-rush-2758-test-run-e7d218cc1a70018e)

The motivating real-world run (producer on zion, main b6fe895a0: suite green, exit 1, attestation refused) is at `zion:/tmp/attest-produce-main-2.log`.

## Why now

Every agents-cli release is wedged behind this (RUSH-2749): the interim producer is the only attestation path, and it cannot attest current main. `CI=true` as a workaround is worse — it perturbs the suite itself (431 test files fail under ambient `CI`).