### PR TITLE
feat(sessions): centralized wrapToWidth helper (RUSH-2757 part 1)

### DIFF
--- a/apps/cli/src/lib/wrap.test.ts
+++ b/apps/cli/src/lib/wrap.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { wrapToWidth, termCols } from './wrap';
+
+describe('wrapToWidth', () => {
+  it('wraps on word boundaries at the given width', () => {
+    const out = wrapToWidth('the quick brown fox jumps over', 12);
+    expect(out).toEqual(['the quick', 'brown fox', 'jumps over']);
+    for (const l of out) expect(l.length).toBeLessThanOrEqual(12);
+  });
+
+  it('hanging-indents continuation lines under the value, never the first', () => {
+    const out = wrapToWidth('alpha beta gamma delta', 12, 4);
+    // width shrinks to 12-4=8 for wrapping; first line has no pad, rest padded 4.
+    expect(out[0].startsWith(' ')).toBe(false);
+    for (const l of out.slice(1)) expect(l.startsWith('    ')).toBe(true);
+  });
+
+  it('never splits a single word longer than the width mid-word', () => {
+    const out = wrapToWidth('short verylongunbreakabletoken end', 10);
+    expect(out).toContain('verylongunbreakabletoken');
+  });
+
+  it('preserves existing newlines as paragraph breaks', () => {
+    const out = wrapToWidth('one two\nthree four', 20);
+    expect(out).toEqual(['one two', 'three four']);
+  });
+
+  it('returns [""] for empty input, not []', () => {
+    expect(wrapToWidth('', 40)).toEqual(['']);
+  });
+
+  it('an indent larger than cols still makes progress (floors at 8, does not crash)', () => {
+    const out = wrapToWidth('aaaa bbbb cccc dddd eeee', 10, 40);
+    // cols-indent is negative; the floor keeps a small positive width (8), so it
+    // wraps into multiple short lines rather than hanging or producing one long line.
+    expect(out.length).toBeGreaterThan(1);
+    expect(out[0]).toBe('aaaa'); // first line unpadded, wrapped at the 8-col floor
+    for (const l of out.slice(1)) expect(l.startsWith(' '.repeat(40))).toBe(true);
+  });
+
+  it('respects a legitimately small cols (does not force a 20-wide line)', () => {
+    const out = wrapToWidth('the quick brown fox jumps over', 12);
+    for (const l of out) expect(l.length).toBeLessThanOrEqual(12);
+  });
+});
+
+describe('termCols', () => {
+  it('falls back to 80 when stdout has no column count (piped / CI)', () => {
+    const orig = process.stdout.columns;
+    // @ts-expect-error deliberately clear for the test
+    process.stdout.columns = 0;
+    try {
+      expect(termCols()).toBe(80);
+      expect(termCols(100)).toBe(100);
+    } finally {
+      // @ts-expect-error restore
+      process.stdout.columns = orig;
+    }
+  });
+});

--- a/apps/cli/src/lib/wrap.test.ts
+++ b/apps/cli/src/lib/wrap.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { wrapToWidth, termCols } from './wrap';
+import { wrapToWidth } from './wrap';
+import { stringWidth } from './session/width';
 
 describe('wrapToWidth', () => {
   it('wraps on word boundaries at the given width', () => {
@@ -29,32 +30,37 @@ describe('wrapToWidth', () => {
     expect(wrapToWidth('', 40)).toEqual(['']);
   });
 
+  it('measures VISIBLE width, not raw .length — ANSI-coloured text is not over-counted', () => {
+    // Two green words: visible "hello world" is 11 cells, but the raw string is
+    // 31 chars (each `\x1b[32m…\x1b[39m` adds 10 invisible bytes). At cols=11 the
+    // coloured text must stay on ONE line — a raw-.length wrap would split it.
+    const green = (s: string) => `\x1b[32m${s}\x1b[39m`;
+    const coloured = `${green('hello')} ${green('world')}`;
+    expect(coloured.length).toBeGreaterThan(11); // sanity: raw length exceeds cols
+    const out = wrapToWidth(coloured, 11);
+    expect(out).toEqual([coloured]); // single line, untouched
+    for (const l of out) expect(stringWidth(l)).toBeLessThanOrEqual(11);
+  });
+
+  it('respects a legitimately small cols with no indent (floor is 1, not 8)', () => {
+    const out = wrapToWidth('ab cd ef gh', 3);
+    expect(out).toEqual(['ab', 'cd', 'ef', 'gh']);
+    for (const l of out) expect(l.length).toBeLessThanOrEqual(3);
+  });
+
   it('an indent larger than cols still makes progress (floors at 8, does not crash)', () => {
     const out = wrapToWidth('aaaa bbbb cccc dddd eeee', 10, 40);
-    // cols-indent is negative; the floor keeps a small positive width (8), so it
-    // wraps into multiple short lines rather than hanging or producing one long line.
+    // cols-indent is negative; the indent floor keeps a small positive width (8),
+    // so it wraps into multiple short lines rather than hanging.
     expect(out.length).toBeGreaterThan(1);
-    expect(out[0]).toBe('aaaa'); // first line unpadded, wrapped at the 8-col floor
+    expect(out[0]).toBe('aaaa'); // first line unpadded
     for (const l of out.slice(1)) expect(l.startsWith(' '.repeat(40))).toBe(true);
   });
 
-  it('respects a legitimately small cols (does not force a 20-wide line)', () => {
-    const out = wrapToWidth('the quick brown fox jumps over', 12);
-    for (const l of out) expect(l.length).toBeLessThanOrEqual(12);
-  });
-});
-
-describe('termCols', () => {
-  it('falls back to 80 when stdout has no column count (piped / CI)', () => {
-    const orig = process.stdout.columns;
-    // @ts-expect-error deliberately clear for the test
-    process.stdout.columns = 0;
-    try {
-      expect(termCols()).toBe(80);
-      expect(termCols(100)).toBe(100);
-    } finally {
-      // @ts-expect-error restore
-      process.stdout.columns = orig;
-    }
+  it('degrades a non-finite cols to the floor instead of joining everything on one line', () => {
+    const out = wrapToWidth('a b c', Number.NaN);
+    // With NaN cols the old raw `> NaN` comparison was always false and dumped the
+    // whole paragraph onto one line. The finite-guard floors width at 1 instead.
+    expect(out).toEqual(['a', 'b', 'c']);
   });
 });

--- a/apps/cli/src/lib/wrap.ts
+++ b/apps/cli/src/lib/wrap.ts
@@ -1,0 +1,57 @@
+/**
+ * Terminal text wrapping — one shared helper for the whole CLI.
+ *
+ * The session preview (and anywhere else that renders variable-length text into
+ * a fixed-width terminal) must wrap through THIS, never a per-field truncate or
+ * ad-hoc slice. It wraps on word boundaries, respects existing newlines, and
+ * hanging-indents continuation lines so they align under the value, not the label.
+ */
+
+/** Columns of the attached terminal, or 80 when not a TTY (piped / CI). */
+export function termCols(fallback = 80): number {
+  const c = process.stdout?.columns;
+  return typeof c === 'number' && c > 0 ? c : fallback;
+}
+
+/**
+ * Hard-wrap `text` to `cols` columns.
+ *
+ * - Splits on existing newlines first (each paragraph wraps independently).
+ * - Wraps on whitespace; a single word longer than the available width is
+ *   emitted on its own line rather than split mid-word.
+ * - `hangingIndent` pads every line AFTER the first with that many spaces, so a
+ *   labelled value ("Latest  <text>") keeps its continuation lines aligned under
+ *   the value. The available width is `cols - indent`, floored at a small
+ *   minimum (8) so a pathologically large indent still makes forward progress —
+ *   the floor guards the indent, it does NOT override a legitimately small cols.
+ *
+ * Returns the wrapped lines (never mutates input). An empty string yields [''].
+ */
+export function wrapToWidth(text: string, cols: number, hangingIndent = 0): string[] {
+  const indent = Math.max(0, Math.trunc(hangingIndent));
+  const width = Math.max(8, cols - indent);
+  const pad = ' '.repeat(indent);
+  const out: string[] = [];
+
+  for (const para of String(text).split('\n')) {
+    const words = para.split(/\s+/).filter(w => w.length > 0);
+    if (words.length === 0) {
+      out.push('');
+      continue;
+    }
+    let line = '';
+    for (const word of words) {
+      if (line.length === 0) {
+        line = word;
+      } else if (line.length + 1 + word.length > width) {
+        out.push(line);
+        line = word;
+      } else {
+        line = `${line} ${word}`;
+      }
+    }
+    if (line.length > 0) out.push(line);
+  }
+  if (out.length === 0) out.push('');
+  return out.map((l, i) => (i === 0 ? l : pad + l));
+}

--- a/apps/cli/src/lib/wrap.ts
+++ b/apps/cli/src/lib/wrap.ts
@@ -1,35 +1,42 @@
 /**
- * Terminal text wrapping — one shared helper for the whole CLI.
+ * Terminal word-wrap — one shared helper for the whole CLI.
  *
- * The session preview (and anywhere else that renders variable-length text into
- * a fixed-width terminal) must wrap through THIS, never a per-field truncate or
- * ad-hoc slice. It wraps on word boundaries, respects existing newlines, and
- * hanging-indents continuation lines so they align under the value, not the label.
+ * Multi-line word wrapping is the gap the single-line helpers in
+ * `session/width.ts` (`truncateToWidth`, `padToWidth`) do not fill. Anywhere that
+ * renders variable-length text into a fixed-width terminal wraps through THIS,
+ * never a per-field slice.
+ *
+ * Width is measured with `stringWidth` (from the canonical `session/width.ts`),
+ * NOT `String.length`: the text this wraps is routinely ANSI-coloured (chalk /
+ * marked-terminal output) and may carry OSC-8 hyperlinks, where `.length`
+ * over-counts the invisible escape bytes. Words are split on whitespace, so a
+ * wrap boundary always falls between escape sequences, never inside one.
  */
 
-/** Columns of the attached terminal, or 80 when not a TTY (piped / CI). */
-export function termCols(fallback = 80): number {
-  const c = process.stdout?.columns;
-  return typeof c === 'number' && c > 0 ? c : fallback;
-}
+import { stringWidth } from './session/width.js';
 
 /**
- * Hard-wrap `text` to `cols` columns.
+ * Hard-wrap `text` to `cols` visible columns.
  *
  * - Splits on existing newlines first (each paragraph wraps independently).
- * - Wraps on whitespace; a single word longer than the available width is
- *   emitted on its own line rather than split mid-word.
+ * - Wraps on whitespace; a single word wider than the available width is emitted
+ *   on its own line rather than split mid-word (and never mid-escape).
+ * - Width is the visible display width via `stringWidth`, so ANSI colour and
+ *   OSC-8 hyperlink escapes do not inflate the count.
  * - `hangingIndent` pads every line AFTER the first with that many spaces, so a
  *   labelled value ("Latest  <text>") keeps its continuation lines aligned under
- *   the value. The available width is `cols - indent`, floored at a small
- *   minimum (8) so a pathologically large indent still makes forward progress —
- *   the floor guards the indent, it does NOT override a legitimately small cols.
+ *   the value. The wrapping width is `cols - indent`.
+ * - Floor: when `hangingIndent` is set, the width is floored at 8 so a
+ *   pathologically large indent still makes forward progress. With no indent the
+ *   floor is 1, so a legitimately small `cols` is respected, never overridden. A
+ *   non-finite `cols` degrades to the floor rather than silently disabling wrap.
  *
  * Returns the wrapped lines (never mutates input). An empty string yields [''].
  */
 export function wrapToWidth(text: string, cols: number, hangingIndent = 0): string[] {
   const indent = Math.max(0, Math.trunc(hangingIndent));
-  const width = Math.max(8, cols - indent);
+  const floor = indent > 0 ? 8 : 1;
+  const width = Number.isFinite(cols) ? Math.max(floor, cols - indent) : floor;
   const pad = ' '.repeat(indent);
   const out: string[] = [];
 
@@ -40,17 +47,22 @@ export function wrapToWidth(text: string, cols: number, hangingIndent = 0): stri
       continue;
     }
     let line = '';
+    let lineWidth = 0;
     for (const word of words) {
-      if (line.length === 0) {
+      const wordWidth = stringWidth(word);
+      if (line === '') {
         line = word;
-      } else if (line.length + 1 + word.length > width) {
+        lineWidth = wordWidth;
+      } else if (lineWidth + 1 + wordWidth > width) {
         out.push(line);
         line = word;
+        lineWidth = wordWidth;
       } else {
         line = `${line} ${word}`;
+        lineWidth += 1 + wordWidth;
       }
     }
-    if (line.length > 0) out.push(line);
+    if (line !== '') out.push(line);
   }
   if (out.length === 0) out.push('');
   return out.map((l, i) => (i === 0 ? l : pad + l));


### PR DESCRIPTION
**What + type:** small new utility — a centralized terminal word-wrap helper (`apps/cli/src/lib/wrap.ts`) for the session-preview redesign (RUSH-2757). Part 1 of 2: this is the helper; the renderer integration is the follow-up.

## What changed
- **`apps/cli/src/lib/wrap.ts`** — `wrapToWidth(text, cols, hangingIndent)`: word-boundary wrap, preserves newlines, hanging-indents continuation lines. Width is measured with the canonical **`stringWidth`** from `session/width.ts` (ANSI + wide-char aware), not raw `.length`, because the real consumer (the last-response block) is `marked-terminal`-coloured. A word wider than the budget is emitted on its own line, never split mid-word or mid-escape.
- **`apps/cli/src/lib/wrap.test.ts`** — 9 tests, including one that pins visible-width measurement on ANSI-coloured input, one for a small `cols` with no indent, and one for a non-finite `cols`.

## Review fixes folded in (from the non-author review of the first push)
- **Dropped `termCols`** — it duplicated `session/width.ts` `terminalWidth` and read only `process.stdout.columns`, so it silently reverted to an 80-col guess under tmux / `--device` SSH. The width source is the canonical `terminalWidth` at the call site; the pure wrapper takes `cols` as an argument.
- **Floor scoped to the indent** — floored at 8 only when `hangingIndent > 0`; with no indent the floor is 1, so a legitimately small `cols` is respected, never overridden (the previous unconditional `Math.max(8, …)` contradicted its own docstring).
- **Non-finite `cols` degrades to the floor** instead of the old `> NaN`-always-false path that dumped the whole paragraph onto one line.

## Follow-up (RUSH-2757 part 2 — renderer integration)
Recon (file:line) confirmed the two integration anchors, correcting an earlier note in this PR:
- **Title already exists** — it is `session.label` (fallback `session.topic`), already on `SessionMeta` and read from DB column `label` (`db.ts:2528`), just rendered last on header line 3 (`sessions-picker.ts:489`). Leading with it is moving that existing push up in `formatHeader`. No new field to plumb.
- **Last-response is ANSI-coloured before the line cap** (`renderMarkdown`, `sessions-picker.ts:1114`), which is exactly why this helper measures via `stringWidth`.

## Verification
`cd apps/cli && bunx vitest run src/lib/wrap.test.ts`

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```
