### PR TITLE
fix(routines): use canonical agent model flags

### DIFF
--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -51,6 +51,25 @@ function baseConfig(partial: Partial<JobConfig> = {}): JobConfig {
   } as JobConfig;
 }
 
+describe('routine model flags', () => {
+  it.each([
+    ['claude', '--model'],
+    ['codex', '--model'],
+    ['cursor', '--model'],
+    ['kimi', '--model'],
+    ['droid', '-m'],
+    ['muse', '--model'],
+  ] as const)('uses the canonical %s model flag', (agent, modelFlag) => {
+    const cmd = buildJobCommand(baseConfig({
+      agent,
+      config: { model: 'test-model' },
+    }), 'inspect');
+
+    expect(cmd).toContain(modelFlag);
+    expect(cmd[cmd.indexOf(modelFlag) + 1]).toBe('test-model');
+  });
+});
+
 describe('Codex routine permission profiles', () => {
   it('keeps plan read-only with network and on-request approvals', () => {
     const cmd = buildJobCommand(baseConfig({ agent: 'codex', mode: 'plan' }), 'inspect');

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -56,6 +56,7 @@ import {
   type ExecOptions,
   type ExecEffort,
   type FallbackEntry,
+  AGENT_COMMANDS,
 } from './exec.js';
 import { resolveActor } from './actor.js';
 import type { LoopDeps } from './loop.js';
@@ -79,7 +80,7 @@ import {
 } from './accounting/rotate.js';
 import { readAuthHealth, isDeadVerdict } from './auth-health.js';
 import { machineId } from './machine-id.js';
-import { isSelfUpdatingAgent, ROUTINE_AGENT_COMMANDS as AGENT_COMMANDS, ROUTINE_AGENT_IDS, isAgentHardDeprecated, hardDeprecationError } from './agents.js';
+import { isSelfUpdatingAgent, ROUTINE_AGENT_COMMANDS, ROUTINE_AGENT_IDS, isAgentHardDeprecated, hardDeprecationError } from './agents.js';
 
 /** Result of a completed job execution, including metadata and optional report. */
 export interface RunResult {
@@ -582,7 +583,7 @@ export function buildJobCommand(config: JobConfig, resolvedPrompt: string, forwa
     return cmd;
   }
 
-  const template = AGENT_COMMANDS[agent];
+  const template = ROUTINE_AGENT_COMMANDS[agent];
   if (!template) {
     throw new Error(`Unsupported agent for daemon jobs: ${agent}`);
   }
@@ -695,7 +696,7 @@ export function buildJobCommand(config: JobConfig, resolvedPrompt: string, forwa
 }
 
 /**
- * Append --model and reasoning flags to a command being assembled.
+ * Append the agent's canonical model flag and reasoning flags to a command.
  *
  * Pass-through model resolution: validates against the installed (agent, version)
  * catalog when possible and writes a warning to stderr on miss, but never blocks.
@@ -706,14 +707,18 @@ function appendModelAndReasoning(cmd: string[], config: JobConfig): void {
   const agent = config.agent!;
   const model = config.config?.model as string | undefined;
   if (model) {
+    const modelFlag = AGENT_COMMANDS[agent].modelFlag;
+    if (!modelFlag) {
+      throw new Error(`Agent ${agent} does not support routine model selection`);
+    }
     if (config.version) {
       const resolved = resolveModel(agent, config.version, model);
       if (resolved.warning) {
         process.stderr.write(`[agents] ${resolved.warning}\n`);
       }
-      cmd.push('--model', resolved.forwarded);
+      cmd.push(modelFlag, resolved.forwarded);
     } else {
-      cmd.push('--model', model);
+      cmd.push(modelFlag, model);
     }
   }
 


### PR DESCRIPTION
Fix: routine model selection now emits each harness's canonical CLI flag.

## What changed

- Read `modelFlag` from the central execution template instead of hardcoding `--model` in the routine runner.
- Cover every routine-capable harness in one table-driven regression test; Droid now receives `-m`, while Claude, Codex, Cursor, Kimi, and Muse keep `--model`.
- Fail loudly if a future routine target accepts a configured model without declaring a model flag.

## Run evidence

```text
bun test src/lib/runner.test.ts -t "routine model flags"
6 pass · 48 filtered out · 0 fail · 12 assertions

./scripts/build.sh
Build @phnx-labs/agents-cli@1.22.40
Installing dependencies
Compiling TypeScript
Building session-tracker hook helper
exit 0
```

The complete `runner.test.ts` file was also attempted. Its six model-flag cases passed; 28 unrelated stateful cases failed because this sandbox cannot write under the real home directory (`EROFS`).

## Tracking

[RUSH-2772](https://linear.app/getrush/issue/RUSH-2772/refactor-workspace-architecture-across-sibling-repositories)

No docs or CHANGELOG change: this restores the already-declared Droid CLI contract and does not add a command, flag, or configuration surface.
