### PR TITLE
fix(ext): auto-label offloaded --device auto tabs

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+- **Offloaded tabs get auto-labels again (`--device auto` / Pick Host).** Default
+  `New Claude` emits `--device auto` and never records which box the CLI picked,
+  so the label poller scanned this laptop's `~/.claude` for a transcript that
+  lives on the worker. The fallback `agents sessions <id> --host` call has also
+  been dead since RUSH-2494 removed `--host` (commander rejects the lookup). The
+  watch stream already has `machine` + `topic`: we now stamp the host from that
+  row, title the tab from its topic, and talk to the CLI with `--device`.
+  Focusing a tab whose label arrived while it was unfocused also applies the
+  title instead of leaving the bare `CC` chip.
+
 ## [0.9.326] - 2026-08-17
 
 - **Device auto-launch reads the two-layer device-config store (PR #2622).**

--- a/apps/ext/src/core/remoteSessions.test.ts
+++ b/apps/ext/src/core/remoteSessions.test.ts
@@ -859,6 +859,31 @@ describe('parseSessionLabelSource', () => {
     expect(parseSessionLabelSource(record({ cwd: '/x', label: '   ', topic: '' }))).toEqual({ label: null, topic: null });
   });
 
+  test('reads the first real user event when session.topic is missing', () => {
+    const raw = JSON.stringify({
+      session: { id: 'abc', cwd: '/x' },
+      events: [
+        { type: 'hook', hookName: 'SessionStart' },
+        { type: 'message', role: 'user', content: 'Base directory for this skill: /tmp/continue', _synthetic: true },
+        { type: 'message', role: 'user', content: 'Compact the PageHeader across every page' },
+      ],
+    });
+    expect(parseSessionLabelSource(raw, 'abc')).toEqual({
+      label: null,
+      topic: 'Compact the PageHeader across every page',
+    });
+  });
+
+  test('does not treat a synthetic user event as a topic', () => {
+    const raw = JSON.stringify({
+      session: { id: 'abc', cwd: '/x' },
+      events: [
+        { type: 'message', role: 'user', content: '<command-name>/continue</command-name>', _synthetic: true },
+      ],
+    });
+    expect(parseSessionLabelSource(raw, 'abc')).toEqual({ label: null, topic: null });
+  });
+
   test('returns null for output that is not a session record', () => {
     expect(parseSessionLabelSource('not json')).toBeNull();
     expect(parseSessionLabelSource('{}')).toBeNull();

--- a/apps/ext/src/core/remoteSessions.ts
+++ b/apps/ext/src/core/remoteSessions.ts
@@ -952,9 +952,35 @@ export function parseSessionLabelSource(rawJson: string, sessionId?: string): Se
   const record = pickSessionRecord(data, sessionId);
   if (!record) return null;
   const label = typeof record.label === 'string' && record.label.trim() ? record.label.trim() : null;
-  const topic = typeof record.topic === 'string' && record.topic.trim() ? record.topic.trim() : null;
+  let topic = typeof record.topic === 'string' && record.topic.trim() ? record.topic.trim() : null;
+  // `agents sessions <id> --json` is `{ session, events }` and the session
+  // object often has no topic/label (those live on the list/active shapes).
+  // The events array still has the first real user turn — use it so an
+  // offloaded tab can be labelled without a second query.
+  if (!topic) {
+    const events = !Array.isArray(data) && data && typeof data === 'object'
+      ? (data as { events?: unknown }).events
+      : record.events;
+    topic = topicFromUserEvents(events);
+  }
   const cwd = typeof record.cwd === 'string' ? record.cwd : '';
   return { label: label && isDerivedSessionName(label, cwd) ? null : label, topic };
+}
+
+/** First non-synthetic user message in a `sessions <id> --json` events array. */
+export function topicFromUserEvents(events: unknown): string | null {
+  if (!Array.isArray(events)) return null;
+  for (const item of events) {
+    if (!item || typeof item !== 'object') continue;
+    const event = item as { type?: unknown; role?: unknown; content?: unknown; _synthetic?: unknown };
+    if (event.type !== 'message' || event.role !== 'user') continue;
+    if (event._synthetic === true) continue;
+    const content = typeof event.content === 'string' ? event.content.trim() : '';
+    if (!content) continue;
+    if (/^Base directory for this skill:/i.test(content)) continue;
+    return content;
+  }
+  return null;
 }
 
 export interface SessionIdentity {

--- a/apps/ext/src/core/sessionPresentationStore.test.ts
+++ b/apps/ext/src/core/sessionPresentationStore.test.ts
@@ -62,6 +62,7 @@ describe('SessionPresentationStore', () => {
         machine: 'yosemite-s1',
         topic: 'Compact the PageHeader across every page',
         label: '',
+        cwd: '/home/muqsit/src/github.com/muqsitnawaz/svatlas',
         sourceDevice: 'yosemite-s1',
         status: 'running',
         context: 'terminal',
@@ -71,6 +72,7 @@ describe('SessionPresentationStore', () => {
       machine: 'yosemite-s1',
       topic: 'Compact the PageHeader across every page',
       label: '',
+      cwd: '/home/muqsit/src/github.com/muqsitnawaz/svatlas',
     });
     expect(store.liveSession('missing')).toBeUndefined();
   });

--- a/apps/ext/src/core/sessionPresentationStore.test.ts
+++ b/apps/ext/src/core/sessionPresentationStore.test.ts
@@ -49,4 +49,29 @@ describe('SessionPresentationStore', () => {
     expect(store.apply({ version: 1, type: 'remove', streamId: 'a', sequence: 4, capturedAt: 2, scope: 'zion', rowKey: 'z' })).toBe(false);
     expect(store.sessions()).toEqual([{ rowKey: 'z', sourceDevice: 'zion' }, { rowKey: 'y', sourceDevice: 'yosemite-s1' }]);
   });
+
+  test('liveSession returns machine + topic for a --device auto tab that never recorded its host', () => {
+    const store = new SessionPresentationStore();
+    store.apply({
+      version: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'yosemite-s1',
+      rows: [{
+        rowKey: 'r',
+        sessionId: '022fe0a8-7674-402a-a5e0-248195894663',
+        kind: 'claude',
+        host: 'tmux',
+        machine: 'yosemite-s1',
+        topic: 'Compact the PageHeader across every page',
+        label: '',
+        sourceDevice: 'yosemite-s1',
+        status: 'running',
+        context: 'terminal',
+      }],
+    });
+    expect(store.liveSession('022fe0a8-7674-402a-a5e0-248195894663')).toEqual({
+      machine: 'yosemite-s1',
+      topic: 'Compact the PageHeader across every page',
+      label: '',
+    });
+    expect(store.liveSession('missing')).toBeUndefined();
+  });
 });

--- a/apps/ext/src/core/sessionPresentationStore.ts
+++ b/apps/ext/src/core/sessionPresentationStore.ts
@@ -81,6 +81,43 @@ export class SessionPresentationStore {
     return result;
   }
 
+  /**
+   * Live stream row for one session id — machine + topic + label, no extra
+   * CLI subprocess. `--device auto` tabs never learn their host at launch;
+   * this is how they recover it (and a title) once the watch stream indexes
+   * the session.
+   */
+  liveSession(sessionId: string): { machine: string; topic: string; label: string } | undefined {
+    const wanted = sessionId.trim();
+    if (!wanted) return undefined;
+    for (const value of this.sessions()) {
+      if (!value || typeof value !== 'object') continue;
+      const row = value as {
+        sessionId?: unknown;
+        id?: unknown;
+        machine?: unknown;
+        sourceDevice?: unknown;
+        topic?: unknown;
+        prompt?: unknown;
+        firstUserMessage?: unknown;
+        label?: unknown;
+      };
+      const id = typeof row.sessionId === 'string' ? row.sessionId
+        : typeof row.id === 'string' ? row.id : '';
+      if (id !== wanted) continue;
+      const machine = typeof row.machine === 'string' ? row.machine
+        : typeof row.sourceDevice === 'string' ? row.sourceDevice
+        : '';
+      const topic = typeof row.topic === 'string' ? row.topic
+        : typeof row.prompt === 'string' ? row.prompt
+        : typeof row.firstUserMessage === 'string' ? row.firstUserMessage
+        : '';
+      const label = typeof row.label === 'string' ? row.label : '';
+      return { machine, topic, label };
+    }
+    return undefined;
+  }
+
   private rowKeyOf(value: unknown): string | undefined {
     if (!value || typeof value !== 'object') return undefined;
     const rowKey = (value as { rowKey?: unknown }).rowKey;

--- a/apps/ext/src/core/sessionPresentationStore.ts
+++ b/apps/ext/src/core/sessionPresentationStore.ts
@@ -87,7 +87,7 @@ export class SessionPresentationStore {
    * this is how they recover it (and a title) once the watch stream indexes
    * the session.
    */
-  liveSession(sessionId: string): { machine: string; topic: string; label: string } | undefined {
+  liveSession(sessionId: string): { machine: string; topic: string; label: string; cwd: string } | undefined {
     const wanted = sessionId.trim();
     if (!wanted) return undefined;
     for (const value of this.sessions()) {
@@ -101,6 +101,7 @@ export class SessionPresentationStore {
         prompt?: unknown;
         firstUserMessage?: unknown;
         label?: unknown;
+        cwd?: unknown;
       };
       const id = typeof row.sessionId === 'string' ? row.sessionId
         : typeof row.id === 'string' ? row.id : '';
@@ -113,7 +114,8 @@ export class SessionPresentationStore {
         : typeof row.firstUserMessage === 'string' ? row.firstUserMessage
         : '';
       const label = typeof row.label === 'string' ? row.label : '';
-      return { machine, topic, label };
+      const cwd = typeof row.cwd === 'string' ? row.cwd : '';
+      return { machine, topic, label, cwd };
     }
     return undefined;
   }

--- a/apps/ext/src/vscode/autoLabelHydration.test.ts
+++ b/apps/ext/src/vscode/autoLabelHydration.test.ts
@@ -82,6 +82,8 @@ describe('RUSH-2411 auto-label-after-remote-hydration wiring', () => {
     expect(vscodeSource).toMatch(/args\.push\('--device', host\)/);
     expect(vscodeSource).not.toMatch(/\['sessions', sessionId, '--host'/);
     expect(extensionSource).toContain('sessionPresentationStore.liveSession');
+    expect(extensionSource).toContain('isDerivedSessionName(rawLabel, live.cwd)');
+    expect(extensionSource).not.toContain("live.label.includes(' ')");
   });
 });
 

--- a/apps/ext/src/vscode/autoLabelHydration.test.ts
+++ b/apps/ext/src/vscode/autoLabelHydration.test.ts
@@ -71,9 +71,17 @@ describe('RUSH-2411 auto-label-after-remote-hydration wiring', () => {
 
   test('the shared per-host active-map fetch is the id source (no per-tab SSH poll)', () => {
     // remoteAutoLabelHooks.fetchMap funnels through the coalesced per-host cache,
-    // and the host-aware `agents sessions <id> --host` stays the LABEL source.
+    // and the host-aware `agents sessions <id> --device` stays the LABEL source.
     expect(extensionSource).toMatch(/fetchMap:\s*\(host\)\s*=>\s*fetchTerminalIdSessionMap\(host\)/);
     expect(extensionSource).toMatch(/fetchLabel:[\s\S]*?fetchAndSetAutoLabel\(t\.terminal, t\)/);
+  });
+
+  test('session lookups use --device, never the retired --host flag', () => {
+    const vscodeSource = fs.readFileSync(path.join(import.meta.dir, 'remoteSessions.vscode.ts'), 'utf8');
+    expect(vscodeSource).toMatch(/\['sessions', sessionId, '--device', host, '--json'\]/);
+    expect(vscodeSource).toMatch(/args\.push\('--device', host\)/);
+    expect(vscodeSource).not.toMatch(/\['sessions', sessionId, '--host'/);
+    expect(extensionSource).toContain('sessionPresentationStore.liveSession');
   });
 });
 

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -3521,36 +3521,53 @@ interface FetchAutoLabelOpts {
   useFullConversation?: boolean;
 }
 
-/**
- * Auto-label for a tab whose agent runs on another machine.
- *
- * Same two-step shape as the local path — reuse a real persisted name, else
- * summarize the first user message — but both inputs come from the host over
- * `agents sessions <id> --host`. A ticket id in the first message is prefixed
- * exactly as locally, so a remote tab reads the same as a local one.
- */
-async function fetchRemoteAutoLabel(
-  terminal: vscode.Terminal,
-  entry: terminals.EditorTerminal,
-  host: string
-): Promise<string | undefined> {
-  if (!entry.sessionId) return undefined;
-  const source = await fetchRemoteSessionLabelSource(entry.sessionId, host);
-  if (!source) return undefined;
+function isLocalDeviceName(name: string): boolean {
+  return isLocalActiveMapKey(activeMapCacheKey(name));
+}
 
-  const ticket = source.topic ? extractLinearTicketId(source.topic) : null;
+function isScaffoldingTopic(text: string): boolean {
+  return /^Base directory for this skill:/i.test(text)
+    || /^<command-(?:name|message)>/i.test(text);
+}
+
+/** Stamp a {label, topic} pair onto the tab — persisted name, else LLM/5-word. */
+async function applyLabelSource(
+  terminal: vscode.Terminal,
+  source: { label: string | null; topic: string | null },
+): Promise<string | undefined> {
+  const topic = source.topic && !isScaffoldingTopic(source.topic) ? source.topic : null;
+  const ticket = topic ? extractLinearTicketId(topic) : null;
   if (source.label) {
     const label = ticket ? `${ticket} ${source.label}` : source.label;
     terminals.setAutoLabel(terminal, label);
     return label;
   }
-  if (!source.topic) return undefined;
-
-  const llmTitle = await generateLabelWithLLM(source.topic);
-  const base = llmTitle ?? extractFirstNWords(source.topic, 5);
+  if (!topic) return undefined;
+  const llmTitle = await generateLabelWithLLM(topic);
+  const base = llmTitle ?? extractFirstNWords(topic, 5);
   const autoLabel = ticket && base ? `${ticket} ${base}` : (ticket ?? base);
   if (autoLabel) terminals.setAutoLabel(terminal, autoLabel);
   return autoLabel ?? undefined;
+}
+
+/**
+ * Auto-label for a tab whose agent runs on another machine.
+ *
+ * Same two-step shape as the local path — reuse a real persisted name, else
+ * summarize the first user message — but both inputs come from
+ * `agents sessions <id> [--device <host>] --json`. A ticket id in the first
+ * message is prefixed exactly as locally, so a remote tab reads the same as a
+ * local one.
+ */
+async function fetchRemoteAutoLabel(
+  terminal: vscode.Terminal,
+  entry: terminals.EditorTerminal,
+  host?: string
+): Promise<string | undefined> {
+  if (!entry.sessionId) return undefined;
+  const source = await fetchRemoteSessionLabelSource(entry.sessionId, host);
+  if (!source) return undefined;
+  return applyLabelSource(terminal, source);
 }
 
 async function fetchAndSetAutoLabel(
@@ -3561,9 +3578,36 @@ async function fetchAndSetAutoLabel(
   if (!entry.sessionId) return entry.autoLabel;
   if (!opts.force && entry.autoLabel) return entry.autoLabel;
 
+  // `--device auto` never records which box the CLI picked. The watch stream
+  // does: stamp the machine so every later lookup (label, resume, identity)
+  // routes to the transcript's owner instead of scanning this laptop.
+  if (!entry.host && entry.sessionId) {
+    const live = sessionPresentationStore.liveSession(entry.sessionId);
+    if (live?.machine && !isLocalDeviceName(live.machine)) {
+      terminals.setHost(terminal, live.machine);
+      entry = terminals.getByTerminal(terminal) ?? entry;
+    }
+  }
+
+  // Prefer the live stream (already has topic/label, no extra subprocess).
+  // Falls through when the row is not indexed yet or carries only scaffolding.
+  if (!opts.useFullConversation) {
+    const live = sessionPresentationStore.liveSession(entry.sessionId);
+    if (live) {
+      const topic = live.topic.trim() && !isScaffoldingTopic(live.topic) ? live.topic.trim() : null;
+      // A real /rename title has a space ("Fix Fleet Login"). Claude's derived
+      // `<dirname>-<n>` placeholder does not — skip those so we summarize.
+      const label = live.label.trim() && live.label.includes(' ') ? live.label.trim() : null;
+      if (label || topic) {
+        const applied = await applyLabelSource(terminal, { label, topic });
+        if (applied) return applied;
+      }
+    }
+  }
+
   // Offloaded tab: the transcript is on the host, so the local session-file scan
-  // and jsonl preview below have nothing to read. Ask the host for the same two
-  // inputs instead — its persisted name, else its first message to summarize.
+  // and jsonl preview below have nothing to read. Ask the CLI (device-aware, or
+  // fleet-wide when the host is still unknown) for the same two inputs.
   if (entry.host) {
     return await fetchRemoteAutoLabel(terminal, entry, entry.host);
   }
@@ -3591,8 +3635,11 @@ async function fetchAndSetAutoLabel(
     }
 
     // 2) Otherwise summarize the session's activity into a short title. This
-    //    needs a first user message to summarize.
-    if (!firstUserMessage) return undefined;
+    //    needs a first user message to summarize. A `--device auto` tab has no
+    //    local transcript — ask the CLI (fleet-wide) instead of giving up.
+    if (!firstUserMessage) {
+      return await fetchRemoteAutoLabel(terminal, entry);
+    }
 
     const sourceText = opts.useFullConversation && previewInfo?.lastUserMessage
       ? `Initial task:\n${firstUserMessage}\n\nLatest activity:\n${previewInfo.lastUserMessage}`
@@ -3841,11 +3888,11 @@ async function tryFetchLabelOnFocus(
   // Heal a stuck derived-placeholder label so focusing the tab re-resolves it.
   await maybeHealDerivedLabel(terminal, entry, context);
 
-  // Skip if it already has a (real) label
-  if (entry.label || entry.autoLabel) return;
-
-  // Fetch the label from session file
-  const autoLabel = await fetchAndSetAutoLabel(terminal, entry);
+  // A label fetched while this tab was unfocused is already on the entry, but
+  // the title update is gated on `activeTerminal === terminal` — so focusing
+  // later used to no-op and leave the bare agent chip forever.
+  const existing = entry.label || entry.autoLabel;
+  const autoLabel = existing ?? await fetchAndSetAutoLabel(terminal, entry);
   if (!autoLabel) return;
 
   // Update status bar
@@ -3990,6 +4037,11 @@ function applyHydratedSessionId(
   if (!liveId) return;
   if (entry.sessionId !== liveId) {
     terminals.setSessionId(terminal, liveId);
+    // `--device auto` never knew the machine at launch. The watch stream does.
+    const live = sessionPresentationStore.liveSession(liveId);
+    if (!entry.host && live?.machine && !isLocalDeviceName(live.machine)) {
+      terminals.setHost(terminal, live.machine);
+    }
     // The tab just gained (or corrected to) its canonical id. Arm the auto-label
     // lifecycle now — the same transition the local SessionStart watcher performs
     // via onSessionChanged. Without this, a remote-hydrated tab (e.g. picked-host

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -3575,14 +3575,15 @@ async function fetchAndSetAutoLabel(
   entry: terminals.EditorTerminal,
   opts: FetchAutoLabelOpts = {}
 ): Promise<string | undefined> {
-  if (!entry.sessionId) return entry.autoLabel;
+  const sessionId = entry.sessionId;
+  if (!sessionId) return entry.autoLabel;
   if (!opts.force && entry.autoLabel) return entry.autoLabel;
 
   // `--device auto` never records which box the CLI picked. The watch stream
   // does: stamp the machine so every later lookup (label, resume, identity)
   // routes to the transcript's owner instead of scanning this laptop.
-  if (!entry.host && entry.sessionId) {
-    const live = sessionPresentationStore.liveSession(entry.sessionId);
+  if (!entry.host) {
+    const live = sessionPresentationStore.liveSession(sessionId);
     if (live?.machine && !isLocalDeviceName(live.machine)) {
       terminals.setHost(terminal, live.machine);
       entry = terminals.getByTerminal(terminal) ?? entry;
@@ -3592,7 +3593,7 @@ async function fetchAndSetAutoLabel(
   // Prefer the live stream (already has topic/label, no extra subprocess).
   // Falls through when the row is not indexed yet or carries only scaffolding.
   if (!opts.useFullConversation) {
-    const live = sessionPresentationStore.liveSession(entry.sessionId);
+    const live = sessionPresentationStore.liveSession(sessionId);
     if (live) {
       const topic = live.topic.trim() && !isScaffoldingTopic(live.topic) ? live.topic.trim() : null;
       // A real /rename title has a space ("Fix Fleet Login"). Claude's derived
@@ -3626,7 +3627,7 @@ async function fetchAndSetAutoLabel(
     //    even before its first turn is recorded. Codex/Gemini/Opencode don't
     //    persist an equivalent, so they fall through to the summary path.
     if (entry.agentType === 'claude') {
-      const persistedName = await readClaudeSessionName(entry.sessionId);
+      const persistedName = await readClaudeSessionName(sessionId);
       if (persistedName) {
         const claudeLabel = ticket ? `${ticket} ${persistedName}` : persistedName;
         terminals.setAutoLabel(terminal, claudeLabel);

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -15,7 +15,7 @@ import { AgentsHtmlReaderProvider } from './htmlReader';
 import * as git from './git.vscode';
 import { AgentSettings, hasLoginEnabled, PromptEntry, QUICK_LAUNCH_SLOT_KEYS, getQuickLaunchSlot, QuickLaunchSlot, QuickLaunchSlotKey } from '../core/settings';
 import { listRegisteredDevices } from './deviceHealth.vscode';
-import { normalizeHost } from '../core/remoteSessions';
+import { isDerivedSessionName, normalizeHost } from '../core/remoteSessions';
 import * as settings from './settings.vscode';
 import * as swarm from './swarm.vscode';
 import {
@@ -3596,9 +3596,10 @@ async function fetchAndSetAutoLabel(
     const live = sessionPresentationStore.liveSession(sessionId);
     if (live) {
       const topic = live.topic.trim() && !isScaffoldingTopic(live.topic) ? live.topic.trim() : null;
-      // A real /rename title has a space ("Fix Fleet Login"). Claude's derived
-      // `<dirname>-<n>` placeholder does not — skip those so we summarize.
-      const label = live.label.trim() && live.label.includes(' ') ? live.label.trim() : null;
+      // Reuse isDerivedSessionName so a real one-word /rename ("RUSH-2058",
+      // "Auth") is kept and only Claude's `<dirname>-<n>` placeholder is dropped.
+      const rawLabel = live.label.trim();
+      const label = rawLabel && !isDerivedSessionName(rawLabel, live.cwd) ? rawLabel : null;
       if (label || topic) {
         const applied = await applyLabelSource(terminal, { label, topic });
         if (applied) return applied;

--- a/apps/ext/src/vscode/remoteSessions.vscode.ts
+++ b/apps/ext/src/vscode/remoteSessions.vscode.ts
@@ -153,7 +153,7 @@ export async function fetchRecentForHost(
   const fetchedAt = Date.now();
   const args = ['sessions', '--json', '--limit', String(limit)];
   if (isLocal) args.push('--local');
-  else args.push('--host', sshTarget);
+  else args.push('--device', sshTarget);
   try {
     const { stdout } = await execFileAsync(agentsBin, args, {
       timeout: isLocal ? HISTORY_TIMEOUT_LOCAL_MS : HISTORY_TIMEOUT_REMOTE_MS,
@@ -181,11 +181,16 @@ export async function fetchRecentForHost(
 /**
  * Label inputs for ONE session that lives on another machine.
  *
- * A tab spawned with `agents run --host` has its transcript on the host, so the
+ * A tab spawned with `agents run --device` has its transcript on the host, so the
  * local by-session-id lookups the label poller normally uses (the Claude
  * sessions/*.json scan, the jsonl preview read) find nothing and the tab keeps
- * the bare agent prefix forever. `agents sessions <id> --host <name> --json`
- * resolves both fields on the machine that owns the session.
+ * the bare agent prefix forever. `agents sessions <id> --device <name> --json`
+ * resolves both fields on the machine that owns the session. `--host` was
+ * removed in RUSH-2494; passing it makes commander reject the whole lookup.
+ *
+ * `host` is optional: omit it and the CLI fans the id out across the fleet
+ * (the default). A `--device auto` tab that never recorded which box the CLI
+ * picked still gets a title this way.
  *
  * Returns null when the host is unreachable or the session is not indexed there
  * yet — a fresh session has no first message for a second or two, and the poller
@@ -193,13 +198,15 @@ export async function fetchRecentForHost(
  */
 export async function fetchRemoteSessionLabelSource(
   sessionId: string,
-  host: string,
+  host?: string,
 ): Promise<SessionLabelSource | null> {
   const agentsBin = await findAgentsCli();
+  const args = ['sessions', sessionId, '--json'];
+  if (host) args.push('--device', host);
   try {
     const { stdout } = await execFileAsync(
       agentsBin,
-      ['sessions', sessionId, '--host', host, '--json'],
+      args,
       { timeout: DETAIL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024, env: pathAugmentedEnv() },
     );
     return parseSessionLabelSource(stdout, sessionId);
@@ -210,8 +217,8 @@ export async function fetchRemoteSessionLabelSource(
 
 /**
  * Resolve a running session's real `version` + `account` via
- * `agents sessions <id> [--host <device>] --json`. `host` is passed for an
- * offloaded (`--host`) tab whose session lives on another machine; omitted for a
+ * `agents sessions <id> [--device <device>] --json`. `host` is passed for an
+ * offloaded (`--device`) tab whose session lives on another machine; omitted for a
  * local session. This is the authoritative source for the status bar's
  * version/account — `agents view` reports only machine-default install metadata.
  *
@@ -224,7 +231,7 @@ export async function fetchSessionIdentity(
 ): Promise<SessionIdentity | null> {
   const agentsBin = await findAgentsCli();
   const args = host
-    ? ['sessions', sessionId, '--host', host, '--json']
+    ? ['sessions', sessionId, '--device', host, '--json']
     : ['sessions', sessionId, '--json'];
   try {
     const { stdout } = await execFileAsync(
@@ -271,7 +278,7 @@ export interface HostSessionDetail {
 
 /**
  * Tier-2: render one remote (or local) session as markdown on demand. Runs
- * `agents sessions <id> --markdown --include tools`, over SSH via --host for
+ * `agents sessions <id> --markdown --include tools`, over SSH via --device for
  * remote machines. Returns an error string rather than throwing.
  */
 export async function fetchHostSessionDetail(
@@ -281,7 +288,7 @@ export async function fetchHostSessionDetail(
   const agentsBin = await findAgentsCli();
   const isLocal = host === LOCAL_HOST || host === LOCAL_LABEL;
   const args = ['sessions', sessionId, '--markdown', '--include', 'tools'];
-  if (!isLocal) args.push('--host', host);
+  if (!isLocal) args.push('--device', host);
   try {
     const { stdout } = await execFileAsync(agentsBin, args, {
       timeout: DETAIL_TIMEOUT_MS,


### PR DESCRIPTION
Offloaded Claude tabs stay bare `CC` after 28+ minutes. The status bar has the UUID but no title.

## What broke

Default `New Claude` emits `--device auto` (0.9.319) and never records which box the CLI picked. The label poller then scans this laptop's `~/.claude` for a transcript that lives on the worker.

The fallback `agents sessions <id> --host <device> --json` has also been dead since RUSH-2494 removed `--host` — commander rejects the lookup, the catch returns null, and the tab never advances past the agent chip.

Same dead `--host` call is why the status bar on these tabs shows `Agents: Claude (uuid)` with no version or account.

## Fix

- Stamp `entry.host` from the watch-stream `machine` once the session id hydrates
- Title the tab from that row's topic (already in memory; no extra subprocess)
- Talk to the CLI with `--device`, never `--host`
- Parse the first real user event when `sessions <id> --json` has no `topic`
- Apply an already-fetched auto-label when the tab is focused (the rename was gated on `activeTerminal === terminal` and then skipped forever)

## Run

No Marketplace UI screenshot — this is the extension-host label path. Proof is the live CLI lookup that used to fail (`sessions <id> --host` → `unknown option '--host'`) and the unit run:

**110 pass, 0 fail** on `remoteSessions`, `sessionPresentationStore`, `autoLabelHydration`, `sessionIdHydrate`.

![test run](https://share.agents-cli.sh/muqsitnawaz/fix-ext-autolabel-device-auto-tests-01d90ae3a156fe26)

## Audience

Extension users launching via default `New Claude` / `--device auto` (sessions land on fleet workers).
