### PR TITLE
fix(ext): Reader webview loads its ESM bundle as a module — was a blank pane on every .md

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [Unreleased]
 
+- **The markdown Reader renders again instead of a blank pane.** The reader
+  webview (`agents.markdownEditor`) loaded the Vite editor bundle with a
+  classic `<script>` tag, but the bundle is an ES module carrying top-level
+  const bindings — prosemirror-view's `const chrome` browser sniff — which in
+  a classic script collide with the webview's global `chrome` binding and
+  throw `SyntaxError: Identifier 'chrome' has already been declared` before
+  React mounts. Every `.md` opened through Reader showed an empty page. The
+  script tag now carries `type="module"` (matching the Fleet dashboard
+  webview, which already did), the HTML shell moved to a pure
+  `buildEditorWebviewHtml` in `src/core/editorHtml.ts`, and a regression test
+  pins the module attribute. Source: `src/vscode/customEditor.ts`,
+  `src/core/editorHtml.ts`.
+
 - **Offloaded tabs get auto-labels again (`--device auto` / Pick Host).** Default
   `New Claude` emits `--device auto` and never records which box the CLI picked,
   so the label poller scanned this laptop's `~/.claude` for a transcript that

--- a/apps/ext/src/core/editorHtml.test.ts
+++ b/apps/ext/src/core/editorHtml.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { buildEditorWebviewHtml } from './editorHtml';
+
+describe('buildEditorWebviewHtml', () => {
+  const html = buildEditorWebviewHtml({
+    scriptUri: 'webview-uri:/ext/out/ui/editor/assets/index.js',
+    styleUri: 'webview-uri:/ext/out/ui/editor/assets/index.css',
+    agentsIconUri: 'webview-uri:/ext/assets/agents.png',
+    cspSource: 'vscode-resource:',
+    nonce: 'testnonce',
+  });
+
+  test('loads the editor bundle as an ES module', () => {
+    // The Vite editor bundle is ESM: it carries top-level const bindings
+    // (prosemirror-view declares `const chrome = ...` for browser sniffing).
+    // Loaded as a classic script, that redeclares the webview's global
+    // `chrome` binding and throws "Identifier 'chrome' has already been
+    // declared" before React mounts — the reader renders a blank pane.
+    const scriptTag = html.match(/<script[^>]*src="[^"]*index\.js"[^>]*>/)?.[0];
+    expect(scriptTag).toBeDefined();
+    expect(scriptTag).toContain('type="module"');
+    expect(scriptTag).toContain('nonce="testnonce"');
+  });
+
+  test('CSP still restricts scripts to the nonce', () => {
+    expect(html).toContain("script-src 'nonce-testnonce'");
+    expect(html).toContain("default-src 'none'");
+  });
+});

--- a/apps/ext/src/core/editorHtml.ts
+++ b/apps/ext/src/core/editorHtml.ts
@@ -1,0 +1,41 @@
+/**
+ * HTML shell for the markdown reader webview (agents.markdownEditor).
+ *
+ * The script tag MUST carry type="module": the Vite editor bundle is ESM and
+ * declares top-level const bindings (prosemirror-view's `chrome` browser
+ * sniff). Loaded as a classic script, those land in the webview's global
+ * scope, collide with the built-in `chrome` binding, and throw
+ * "Identifier 'chrome' has already been declared" before React mounts —
+ * the reader renders a blank pane.
+ */
+export interface EditorWebviewHtmlParts {
+  scriptUri: string;
+  styleUri: string;
+  agentsIconUri: string;
+  cspSource: string;
+  nonce: string;
+}
+
+export function buildEditorWebviewHtml(parts: EditorWebviewHtmlParts): string {
+  const { scriptUri, styleUri, agentsIconUri, cspSource, nonce } = parts;
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none';
+    style-src ${cspSource} 'unsafe-inline';
+    script-src 'nonce-${nonce}';
+    img-src ${cspSource} https: data:;
+    media-src data:;
+    font-src ${cspSource};
+    connect-src https:;">
+  <link href="${styleUri}" rel="stylesheet">
+  <title>Agents Markdown Editor</title>
+</head>
+<body>
+  <div id="root" data-agents-icon="${agentsIconUri}"></div>
+  <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+}

--- a/apps/ext/src/vscode/customEditor.ts
+++ b/apps/ext/src/vscode/customEditor.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import { execFile } from 'child_process';
 import { maybePromptForAgentSymlinks } from './agentlinks.vscode';
 import { resolvePdfEngine, buildPdfArgs } from '../core/pdfEngine';
+import { buildEditorWebviewHtml } from '../core/editorHtml';
 
 // Track spawned agent terminals per document URI
 const documentAgents = new Map<string, vscode.Terminal>();
@@ -572,28 +573,13 @@ ${bodyHtml}
       vscode.Uri.joinPath(this.context.extensionUri, 'assets', 'agents.png')
     );
 
-    const nonce = getNonce();
-
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none';
-    style-src ${webview.cspSource} 'unsafe-inline';
-    script-src 'nonce-${nonce}';
-    img-src ${webview.cspSource} https: data:;
-    media-src data:;
-    font-src ${webview.cspSource};
-    connect-src https:;">
-  <link href="${styleUri}" rel="stylesheet">
-  <title>Agents Markdown Editor</title>
-</head>
-<body>
-  <div id="root" data-agents-icon="${agentsIconUri}"></div>
-  <script nonce="${nonce}" src="${scriptUri}"></script>
-</body>
-</html>`;
+    return buildEditorWebviewHtml({
+      scriptUri: scriptUri.toString(),
+      styleUri: styleUri.toString(),
+      agentsIconUri: agentsIconUri.toString(),
+      cspSource: webview.cspSource,
+      nonce: getNonce(),
+    });
   }
 }
 


### PR DESCRIPTION
Bug fix: the markdown Reader (`agents.markdownEditor`) rendered a blank pane for every `.md` file.

## Root cause

`customEditor.ts` injected the Vite editor bundle with a **classic** `<script>` tag. The bundle is an ES module carrying top-level `const` bindings — prosemirror-view's `const chrome = ...` browser sniff — which in a classic script land in the webview's global scope, collide with Chromium's global `chrome` binding, and throw before React mounts:

```
Uncaught SyntaxError: Identifier 'chrome' has already been declared @ assets/index.js:1
```

Nothing runs, so the pane stays empty. The Fleet dashboard webview already loads its bundle with `type="module"` (`settings.vscode.ts:3620`) — which is why the dashboard works and only the Reader was dead.

## Fix

- Script tag now carries `type="module"`.
- The HTML shell is extracted to a pure `buildEditorWebviewHtml` (`src/core/editorHtml.ts`, per the ext layout's "src/core = presentation-only pure functions") with a regression test pinning the module attribute — testable without fighting the shared `mock.module('vscode')` state across the suite.
- CHANGELOG entry under Unreleased.

## Run evidence

Reproduced against the **exact installed bundle** from the 0.9.325 install (copied from the user's machine) in a browser harness stubbing `acquireVsCodeApi` + the ready/update handshake.

Before — classic script, bundle throws at line 1, blank pane (same as the report):

![before](https://share.agents-cli.sh/muqsitnawaz/reader-module-script-reader-before-blank-f48681a014d9162f)

After — same bundle with `type="module"`: outline, frontmatter, headings, code block all render, `ready`/`checkActiveAgent` posted:

![after](https://share.agents-cli.sh/muqsitnawaz/reader-module-script-reader-after-module-01b67028ecdca3f2)

Full ext suite: `1573 pass, 3 skip, 0 fail` (138 files).
