### PR TITLE
docs(ext): changelog for 0.9.327 — Reader ESM fix + offloaded-tab auto-labels

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
-## [Unreleased]
+## [0.9.327] - 2026-08-17
 
 - **The markdown Reader renders again instead of a blank pane.** The reader
   webview (`agents.markdownEditor`) loaded the Vite editor bundle with a


### PR DESCRIPTION
docs-only. Stamps the Unreleased section as 0.9.327 (2026-08-17) ahead of the ext release: the Reader blank-pane fix (#2767) and the offloaded-tab auto-label fix. release.sh requires the `## [0.9.327]` section to publish. No code change, no run needed.