### PR TITLE
fix(triggers): log webhook match at dispatch time, not after settle

### DIFF
--- a/apps/cli/src/commands/webhook.ts
+++ b/apps/cli/src/commands/webhook.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 import chalk from 'chalk';
 import { readAndResolveBundleEnv } from '../lib/secrets/bundles.js';
 import { createFileDeliveryStore, startWebhookServer, waitForListening, type WebhookSecrets } from '../lib/triggers/webhook.js';
-import type { FiredHandler } from '../lib/triggers/handlers.js';
 import { getRuntimeStateDir } from '../lib/state.js';
 
 const DEFAULT_HOST = '127.0.0.1';
@@ -79,10 +78,13 @@ export function registerWebhooksCommand(program: Command): void {
           deliveryStore: createFileDeliveryStore(
             path.join(getRuntimeStateDir(), 'webhook', 'deliveries.json'),
           ),
-          onDelivery: (webhook, fired, handlers) => {
+          // Logged at MATCH time, before dispatch — a `run.command` handler can
+          // block on a shelled-out agent run for minutes, and that must never
+          // delay the log that says a delivery fired (RUSH-2722).
+          onMatch: (webhook, matchedJobNames, matchedHandlerNames) => {
             const parts: string[] = [];
-            if (fired.length) parts.push(`routines ${fired.map((f) => f.jobName).join(', ')}`);
-            if (handlers.length) parts.push(`handlers ${handlers.map((h) => h.handlerName).join(', ')}`);
+            if (matchedJobNames.length) parts.push(`routines ${matchedJobNames.join(', ')}`);
+            if (matchedHandlerNames.length) parts.push(`handlers ${matchedHandlerNames.join(', ')}`);
             console.log(
               `${new Date().toISOString()} ${webhook.source}:${webhook.event} ` +
               (parts.length ? `fired ${parts.join('; ')}` : 'no match'),

--- a/apps/cli/src/lib/daemon-webhooks.ts
+++ b/apps/cli/src/lib/daemon-webhooks.ts
@@ -221,10 +221,13 @@ export async function startHostedWebhookReceivers(opts: {
         deliveryStore: createFileDeliveryStore(
           path.join(getRuntimeStateDir(), 'webhook', `deliveries-${port}.json`),
         ),
-        onDelivery: (webhook, fired, handlers) => {
+        // Logged at MATCH time, before dispatch — a `run.command` handler can
+        // block on a shelled-out agent run for minutes, and that must never
+        // delay the log that says a delivery fired (RUSH-2722).
+        onMatch: (webhook, matchedJobNames, matchedHandlerNames) => {
           const parts: string[] = [];
-          if (fired.length) parts.push(`routines ${fired.map((f) => f.jobName).join(', ')}`);
-          if (handlers.length) parts.push(`handlers ${handlers.map((h) => h.handlerName).join(', ')}`);
+          if (matchedJobNames.length) parts.push(`routines ${matchedJobNames.join(', ')}`);
+          if (matchedHandlerNames.length) parts.push(`handlers ${matchedHandlerNames.join(', ')}`);
           log('INFO', `webhook ${webhook.source}:${webhook.event} ${parts.length ? `fired ${parts.join('; ')}` : 'no match'}`);
         },
         // The 202 ack means no HTTP status carries a settle failure — the daemon

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -909,6 +909,86 @@ describe('startWebhookServer', () => {
       fs.rmSync(webhookDir, { recursive: true, force: true });
     }
   });
+
+  // RUSH-2722: a `run.command` handler shells out via `exec()`, which only
+  // resolves once the child process exits. Before this fix, the "fired" log
+  // rode `onDelivery` — settled only after that exit — so verifying a delivery
+  // fired meant waiting out however long the shelled-out command (a real agent
+  // run in production) took to finish. `onMatch` must fire immediately after
+  // the ack, well before the slow command settles.
+  it.skipIf(process.platform === 'win32')('reports onMatch immediately, before a slow run.command handler settles', async () => {
+    const secret = 'linear-secret';
+    const webhookDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webhook-onmatch-'));
+    process.env.AGENTS_WEBHOOKS_DIR = webhookDir;
+    try {
+      fs.writeFileSync(
+        path.join(webhookDir, 'slow-handler.yml'),
+        yaml.stringify({
+          name: 'slow-handler',
+          source: 'linear',
+          event: 'Issue',
+          action: 'update',
+          run: { command: 'sleep 0.3' },
+        }),
+        'utf-8',
+      );
+
+      const waiter = settleWaiter();
+      let matchedAt: number | null = null;
+      let settledAt: number | null = null;
+      const server = startWebhookServer({
+        secrets: { linear: secret },
+        onMatch: (_webhook, _matchedJobNames, matchedHandlerNames) => {
+          if (matchedHandlerNames.includes('slow-handler')) matchedAt = Date.now();
+        },
+        onDelivery: () => {
+          settledAt = Date.now();
+          waiter.hit();
+        },
+        onDeliveryError: waiter.hit,
+        fire: { jobs: [], dispatch: async (): Promise<RunMeta> => { throw new Error('should not dispatch routine'); } },
+      });
+      await new Promise<void>((resolve) => server.once('listening', resolve));
+      const address = server.address();
+      if (!address || typeof address !== 'object') throw new Error('server did not bind');
+      try {
+        const payload = Buffer.from(JSON.stringify(linearIssueWebhook(['agent']).payload));
+        const sig = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+        const ackedAt = await new Promise<number>((resolve, reject) => {
+          const req = http.request({
+            host: '127.0.0.1',
+            port: address.port,
+            path: '/hooks/linear',
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              'content-length': String(payload.length),
+              'linear-signature': sig,
+              'linear-delivery': 'delivery-onmatch-1',
+            },
+          }, (res) => {
+            res.resume();
+            res.on('end', () => resolve(Date.now()));
+          });
+          req.on('error', reject);
+          req.end(payload);
+        });
+
+        await waiter.until(1);
+        expect(matchedAt).not.toBeNull();
+        expect(settledAt).not.toBeNull();
+        // onMatch trails the ack by a scheduling tick, not the 300ms sleep.
+        expect(matchedAt! - ackedAt).toBeLessThan(150);
+        // onDelivery only fires once the shelled-out `sleep 0.3` has exited.
+        expect(settledAt! - matchedAt!).toBeGreaterThanOrEqual(250);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    } finally {
+      delete process.env.AGENTS_WEBHOOKS_DIR;
+      fs.rmSync(webhookDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('createFileDeliveryStore', () => {

--- a/apps/cli/src/lib/triggers/webhook.ts
+++ b/apps/cli/src/lib/triggers/webhook.ts
@@ -546,10 +546,24 @@ export interface WebhookServerOptions {
   /** Override the fire options (mainly for tests). */
   fire?: FireWebhookOptions;
   /**
+   * Called the moment a delivery's matches are known — BEFORE any routine or
+   * handler is dispatched. Matching is a pure, synchronous lookup (no I/O), so
+   * this fires immediately after the ack, regardless of how long the matched
+   * work then takes to run. This is the right hook for a "webhook X fired Y"
+   * log line: a `run.command` handler that shells out a long agent session
+   * (`exec()`, which only resolves on process exit) used to hold that log back
+   * for as long as the session ran — `ps` would show the agent already running
+   * while the log still implied nothing had matched (RUSH-2722). Names only
+   * (no runId/exitCode yet — those aren't known until dispatch settles).
+   */
+  onMatch?: (webhook: IncomingWebhook, matchedJobNames: string[], matchedHandlerNames: string[]) => void;
+  /**
    * Called after a delivery has fully settled — every matched routine and
-   * handler dispatched. Because the receiver acks the HTTP response BEFORE
-   * dispatch (see `startWebhookServer`), this fires strictly after the response
-   * has been written, and is the only way a caller observes the outcome.
+   * handler dispatched (and, for `run.command` handlers, exited). Because the
+   * receiver acks the HTTP response BEFORE dispatch (see `startWebhookServer`),
+   * this fires strictly after the response has been written, and is the only
+   * way a caller observes the dispatch outcome (runId/exitCode/output). It is
+   * NOT the right hook for "did this webhook match" logging — use `onMatch`.
    */
   onDelivery?: (webhook: IncomingWebhook, fired: FiredJob[], handlers: FiredHandler[]) => void;
   /**
@@ -589,6 +603,11 @@ export interface WebhookServerOptions {
  * duplicate from an in-flight set, since `deliveryStore.seen` only reports
  * completed deliveries and would otherwise let a mid-flight retry double-fire.
  *
+ * `onMatch` fires as soon as matching is known, before any dispatch; `onDelivery`
+ * fires only once every matched routine/handler has settled — see their docs on
+ * `WebhookServerOptions`. A caller that wants a prompt "this fired" log uses
+ * `onMatch`, not `onDelivery` (RUSH-2722).
+ *
  * Returns the underlying server so callers can `close()` it.
  */
 export function startWebhookServer(options: WebhookServerOptions): http.Server {
@@ -611,8 +630,19 @@ export function startWebhookServer(options: WebhookServerOptions): http.Server {
     try {
       const context = buildWebhookContext(webhook);
       const fireOptions = options.fire ?? {};
+
+      // Match FIRST, before any dispatch — matching is a pure in-memory lookup,
+      // so this is the earliest point the receiver knows what fired, and the
+      // right time to log it (RUSH-2722). Dispatching a `run.command` handler
+      // can then block on the shelled-out process for minutes; that must never
+      // hold the "fired" log back with it.
+      const matchedJobs = matchJobsToWebhook(fireOptions.jobs ?? listJobs(), webhook);
+      const matchedHandlers = listHandlers().filter((handler) => handlerMatchesWebhook(handler, webhook));
+      options.onMatch?.(webhook, matchedJobs.map((job) => job.name), matchedHandlers.map((handler) => handler.name));
+
       const firedJobs = await fireWebhookJobs(webhook, {
         ...fireOptions,
+        jobs: matchedJobs,
         context,
         skipJobNames: deliveryStore.completedJobs(id),
         onJobFired: (job, firedJob) => {
@@ -622,7 +652,6 @@ export function startWebhookServer(options: WebhookServerOptions): http.Server {
         },
       });
 
-      const matchedHandlers = listHandlers().filter((handler) => handlerMatchesWebhook(handler, webhook));
       const firedHandlers: FiredHandler[] = [];
       const handlerErrors: { handlerName: string; error: string }[] = [];
       await Promise.allSettled(


### PR DESCRIPTION
**bug fix** — daemon log line only; no flag/command/behavior change, no CHANGELOG entry needed.

## What changed

`RUSH-2722`: the daemon's `webhook <source>:<event> fired ...` log line rode `onDelivery`, which only fires after **every** matched routine *and* handler has fully settled. A `run.command` handler shells out via `exec()`, which only resolves once the child process **exits** — so a handler that spawns a long agent session (the fleet-webhook demo's `agents run claude "..." --mode auto ...`) held the log back for as long as that session ran. Observed during the RUSH-2548 demo: `ps` showed `agents run claude ... --name fleet-hook-RUSH-2721` running within seconds, but the daemon log still implied "no match" minutes later.

## Fix

Add `onMatch` (`apps/cli/src/lib/triggers/webhook.ts`) — fired synchronously right after matching, which is a pure in-memory lookup with **no I/O**, before any dispatch begins. Move the "fired"/"no match" log construction in `daemon-webhooks.ts` and `agents webhooks serve` (`commands/webhook.ts`) onto it. `onDelivery` is unchanged and still carries the post-settle `runId`/`exitCode`/`output` for callers that need the dispatch outcome (its doc comment now says so).

## Run result

New regression test: `reports onMatch immediately, before a slow run.command handler settles`. It registers a handler whose command is `sleep 0.3` (reproduces the real blocking-`exec()` bug without spawning a real agent) and asserts `onMatch` fires within 150ms of the ack while `onDelivery` only fires once the sleep has actually exited (≥250ms later, 309ms observed).

![rush-2722 webhook test run — 30/30 passed](https://share.agents-cli.sh/muqsitnawaz/rush-2722-webhook-fired-log-timing-rush-2722-test-run-1e443161d9bd019a)

Full `apps/cli` suite (`bun run test`): **12233 passed**, 1 pre-existing unrelated failure (`src/lib/project-key.test.ts` — a stray `/tmp/.git` on the test box makes `repoRootForCwd` resolve `/tmp` as a repo root; reproduces with this diff fully reverted, and `project-key.ts`/`.test.ts` are untouched here).

## Ticket

RUSH-2722 — https://linear.app/getrush/issue/RUSH-2722