### PR TITLE
feat(ci): map metadata-class diffs to a minimal suite (RUSH-2666)

### DIFF
--- a/apps/cli/ci/test-ownership.yaml
+++ b/apps/cli/ci/test-ownership.yaml
@@ -85,12 +85,24 @@ groups:
   - id: toolchain
     when:
       - apps/cli/bun.lock
-      - apps/cli/package.json
       - apps/cli/vitest.config.ts
       - apps/cli/tsconfig.json
       - apps/cli/tests/setup.ts
       - apps/cli/tests/global-setup.ts
     suite: cli-full
+    checks: [typecheck]
+
+  # A version-only edit (release bump) is metadata: RUSH-2666. A dependency,
+  # script, or field change in package.json still routes to cli-full because
+  # the diff itself decides — see classifyPackageJsonChange in ci-scope.ts.
+  # When base/head shas are unavailable to diff, this fails closed to
+  # cli-full too.
+  - id: toolchain-metadata
+    when:
+      - apps/cli/package.json
+    suite: metadata-gated
+    tests:
+      - apps/cli/src/lib/version.test.ts
     checks: [typecheck]
 
   - id: impact-policy

--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -15,6 +15,7 @@ import {
   changedFilesBetween,
   isVitestWorkerCrashWithZeroFailures,
   classifyCiScope,
+  classifyPackageJsonChange,
   commandForTestFile,
   commandsForPlan,
   companionCandidates,
@@ -263,6 +264,118 @@ describe('selectImpact policy', () => {
     const result = validateOwnershipManifest(MANIFEST, REPO);
     expect(result.missingTests).toEqual([]);
     expect(result.unmapped).toEqual([]);
+  });
+});
+
+describe('metadata-class diffs stop selecting the full suite (RUSH-2666)', () => {
+  function initPackageJsonHistory(before: object, after: object): { repo: string; base: string; head: string } {
+    const dir = mkdtempSync(join(tmpdir(), 'agents-ci-pkg-'));
+    const repo = join(dir, 'repo');
+    mkdirSync(repo);
+    git(repo, 'init', '-b', 'main');
+    writeFixture(repo, 'apps/cli/package.json', `${JSON.stringify(before, null, 2)}\n`);
+    git(repo, 'add', 'apps/cli/package.json');
+    git(repo, 'commit', '-m', 'base');
+    const base = git(repo, 'rev-parse', 'HEAD');
+    writeFixture(repo, 'apps/cli/package.json', `${JSON.stringify(after, null, 2)}\n`);
+    git(repo, 'add', 'apps/cli/package.json');
+    git(repo, 'commit', '-m', 'head');
+    const head = git(repo, 'rev-parse', 'HEAD');
+    return { repo, base, head };
+  }
+
+  test('classifyPackageJsonChange: a version-only bump is version-only', () => {
+    const { repo, base, head } = initPackageJsonHistory(
+      { name: '@phnx-labs/agents-cli', version: '1.22.35', dependencies: { chalk: '^5.0.0' } },
+      { name: '@phnx-labs/agents-cli', version: '1.22.36', dependencies: { chalk: '^5.0.0' } },
+    );
+    try {
+      expect(classifyPackageJsonChange('apps/cli/package.json', repo, base, head)).toBe('version-only');
+    } finally {
+      rmSync(dirname(repo), { recursive: true, force: true });
+    }
+  });
+
+  test('classifyPackageJsonChange: a dependency edit is not metadata', () => {
+    const { repo, base, head } = initPackageJsonHistory(
+      { name: '@phnx-labs/agents-cli', version: '1.22.35', dependencies: { chalk: '^5.0.0' } },
+      { name: '@phnx-labs/agents-cli', version: '1.22.36', dependencies: { chalk: '^5.1.0' } },
+    );
+    try {
+      expect(classifyPackageJsonChange('apps/cli/package.json', repo, base, head)).toBe('dependency');
+    } finally {
+      rmSync(dirname(repo), { recursive: true, force: true });
+    }
+  });
+
+  test('classifyPackageJsonChange: no base/head shas fails closed to unknown', () => {
+    expect(classifyPackageJsonChange('apps/cli/package.json', REPO)).toBe('unknown');
+  });
+
+  test('a version-only package.json bump selects the minimal set, never cli-full', () => {
+    const { repo, base, head } = initPackageJsonHistory(
+      { name: '@phnx-labs/agents-cli', version: '1.22.35' },
+      { name: '@phnx-labs/agents-cli', version: '1.22.36' },
+    );
+    try {
+      const plan = selectImpact({
+        files: ['apps/cli/package.json'],
+        repoRoot: repo,
+        manifest: MANIFEST,
+        related: false,
+        baseSha: base,
+        headSha: head,
+      });
+      expect(plan.suite).toBe('selected');
+      expect(plan.unmapped).toEqual([]);
+      expect(plan.tests.map((t) => t.file)).toEqual(['apps/cli/src/lib/version.test.ts']);
+      expect(plan.checks).toEqual(['typecheck']);
+    } finally {
+      rmSync(dirname(repo), { recursive: true, force: true });
+    }
+  });
+
+  test('a dependency-changing package.json diff still fails safe to cli-full', () => {
+    const { repo, base, head } = initPackageJsonHistory(
+      { name: '@phnx-labs/agents-cli', version: '1.22.35', dependencies: { chalk: '^5.0.0' } },
+      { name: '@phnx-labs/agents-cli', version: '1.22.35', dependencies: { chalk: '^5.1.0' } },
+    );
+    try {
+      const plan = selectImpact({
+        files: ['apps/cli/package.json'],
+        repoRoot: repo,
+        manifest: MANIFEST,
+        related: false,
+        baseSha: base,
+        headSha: head,
+      });
+      expect(plan.suite).toBe('cli-full');
+    } finally {
+      rmSync(dirname(repo), { recursive: true, force: true });
+    }
+  });
+
+  test('a package.json diff with no base/head shas fails closed to cli-full', () => {
+    const plan = selectImpact({
+      files: ['apps/cli/package.json'],
+      repoRoot: REPO,
+      manifest: MANIFEST,
+      related: false,
+    });
+    expect(plan.suite).toBe('cli-full');
+  });
+
+  test('a CHANGELOG-only diff selects nothing, never cli-full', () => {
+    const plan = selectImpact({
+      files: ['CHANGELOG.md', 'apps/cli/CHANGELOG.md'],
+      repoRoot: REPO,
+      manifest: MANIFEST,
+      related: false,
+    });
+    expect(plan.suite).toBe('selected');
+    expect(plan.unmapped).toEqual([]);
+    expect(plan.tests).toEqual([]);
+    expect(plan.checks).toEqual(['docs']);
   });
 });
 

--- a/scripts/ci-scope.ts
+++ b/scripts/ci-scope.ts
@@ -62,7 +62,7 @@ interface OwnershipGroup {
   when: string[];
   tests?: string[];
   checks?: string[];
-  suite?: 'selected' | 'cli-full';
+  suite?: 'selected' | 'cli-full' | 'metadata-gated';
 }
 
 interface OwnershipArea {
@@ -163,6 +163,44 @@ export function gitRevParse(ref: string, cwd: string): string {
     throw new Error(Buffer.from(proc.stderr).toString('utf8').trim() || `git rev-parse ${ref} failed`);
   }
   return Buffer.from(proc.stdout).toString('utf8').trim();
+}
+
+function gitShowFile(ref: string, file: string, cwd: string): string | null {
+  const proc = Bun.spawnSync({
+    cmd: ['git', 'show', `${ref}:${file}`],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (proc.exitCode !== 0) return null;
+  return Buffer.from(proc.stdout).toString('utf8');
+}
+
+export type PackageJsonChangeKind = 'version-only' | 'dependency' | 'unknown';
+
+/**
+ * A `package.json` diff is `version-only` only when every key besides
+ * `version` is byte-identical before vs after. Missing refs, unreadable
+ * blobs, and unparsable JSON all fall back to `unknown` — the caller treats
+ * that the same as a real dependency change (fail-closed, RUSH-2666).
+ */
+export function classifyPackageJsonChange(
+  file: string,
+  repoRoot: string,
+  baseSha?: string,
+  headSha?: string,
+): PackageJsonChangeKind {
+  if (!baseSha || !headSha) return 'unknown';
+  const before = gitShowFile(baseSha, file, repoRoot);
+  const after = gitShowFile(headSha, file, repoRoot);
+  if (before === null || after === null) return 'unknown';
+  try {
+    const { version: _beforeVersion, ...beforeRest } = JSON.parse(before) as Record<string, unknown>;
+    const { version: _afterVersion, ...afterRest } = JSON.parse(after) as Record<string, unknown>;
+    return JSON.stringify(beforeRest) === JSON.stringify(afterRest) ? 'version-only' : 'dependency';
+  } catch {
+    return 'unknown';
+  }
 }
 
 export function changedFilesBetween(base: string, head: string, cwd = process.cwd()): string[] {
@@ -420,7 +458,12 @@ export function selectImpact(input: SelectImpactInput): ImpactPlan {
     }
 
     for (const group of groups) {
-      if (group.suite === 'cli-full') suite = 'cli-full';
+      const groupSuite = group.suite === 'metadata-gated'
+        ? (classifyPackageJsonChange(file, repoRoot, input.baseSha, input.headSha) === 'version-only'
+          ? 'selected'
+          : 'cli-full')
+        : group.suite;
+      if (groupSuite === 'cli-full') suite = 'cli-full';
       for (const test of group.tests ?? []) {
         addTest(selected, mapping, file, test, `owner:${group.id}`);
         mark();


### PR DESCRIPTION
config-only — extends the RUSH-2666 impact planner (#2753), no product behavior change.

## What changed

**`scripts/ci-scope.ts`** — adds `classifyPackageJsonChange(file, repoRoot, baseSha, headSha)`: diffs the git blob content of `apps/cli/package.json` at base vs head, ignoring the `version` key. Returns `version-only`, `dependency`, or `unknown` (missing refs / unparsable JSON). Wires a new `metadata-gated` group-suite value into `selectImpact`'s group loop: a `metadata-gated` group resolves to `selected` only when the diff is `version-only`; every other case (`dependency`, `unknown`) resolves to `cli-full`.

**`apps/cli/ci/test-ownership.yaml`** — splits `apps/cli/package.json` out of the unconditional `toolchain` group (which forces `suite: cli-full` on every match) into a new `toolchain-metadata` group with `suite: metadata-gated`, `tests: [apps/cli/src/lib/version.test.ts]`, `checks: [typecheck]`. `bun.lock`, `vitest.config.ts`, `tsconfig.json`, and the two test-setup files stay in `toolchain` — a real dependency/toolchain change still always runs the full suite.

**`scripts/ci-scope.test.ts`** — 7 new tests: `classifyPackageJsonChange` for a version-only bump, a dependency edit, and a missing-shas case; `selectImpact` end-to-end for a version-only bump (minimal set), a dependency-changing diff (cli-full), no-shas (cli-full, fail-closed), and a CHANGELOG-only diff (zero selection).

## Why

Owner-measured reality: 7 of the last 8 real PRs ran the required check 11-15.5 minutes; only trivial diffs hit the ~27s fast lane. `apps/cli/package.json` was in the `toolchain` group unconditionally routing to `suite: cli-full` — and every release bump touches only its `version` field, so every release PR paid the full ~1200s budget for a one-line string change. This tightens that one gap: a real dependency/script/toolchain change still fails safe to the full suite; a version-only bump does not.

## Verification

```
$ bun test scripts/ci-scope.test.ts
bun test v1.3.14 (0d9b296a)

 48 pass
 0 fail
 95 expect() calls
Ran 48 tests across 1 file. [4.30s]
```

Real release-bump commit `3fe93b8ce` (`chore(release): 1.22.40`, `apps/cli/package.json` `1.22.39` → `1.22.40` only) run through the planner with real base/head shas:

```
BEFORE (old manifest — toolchain group, unconditional cli-full):
{"suite":"cli-full","tests":[],"checks":["typecheck"]}

AFTER (this branch, version-only bump classified via git-blob diff):
{"suite":"selected","tests":["apps/cli/src/lib/version.test.ts"],"checks":["typecheck"]}
```

No base/head shas available to diff (e.g. a bare local file-list invocation) — fails closed, unchanged from before:

```
{"suite":"cli-full","tests":["apps/cli/src/lib/version.test.ts"],"checks":["typecheck"]}
```

CHANGELOG-only diff (`CHANGELOG.md` + `apps/cli/CHANGELOG.md`) — already minimal pre-existing behavior, reconfirmed:

```
{"suite":"selected","tests":[],"checks":["docs"],"unmapped":[]}
```

Manifest still validates clean:

```
$ bun scripts/ci-scope.ts --validate-manifest
ownership manifest covers 2979 tracked files
```

Genuinely unmapped paths remain fail-closed (`unmapped` array populated, `planIsFailing` true) — untouched by this change, covered by the existing `an unmapped production path fails the plan` test.