### PR TITLE
fix(ci): stop the required Linux check from running the full 864-file suite (RUSH-2666)

### DIFF
--- a/.github/workflows/tests-gate.test.ts
+++ b/.github/workflows/tests-gate.test.ts
@@ -28,10 +28,15 @@ describe('tests.yml required Linux gate', () => {
 
   test('the Linux job plans with ci-scope and enforces the selected budget', () => {
     expect(TESTS_YML).toContain('bun scripts/ci-scope.ts');
-    expect(TESTS_YML).toContain('--deadline-sec 1200');
     expect(TESTS_YML).toContain('--fail-unmapped');
     expect(TESTS_YML).toContain('--validate-manifest');
     expect(TESTS_YML).toContain('impact-proof-');
+    // RUSH-2666 (wave 6): the workflow must NOT pass --deadline-sec here.
+    // ci-scope.ts's own --run path already picks 1200s for a cli-full plan
+    // and IMPACT_BUDGET_SEC (85s) for a selected plan; a hardcoded
+    // `--deadline-sec 1200` in the workflow overrides that and silently
+    // disables the 85s selected-run budget check on every PR.
+    expect(TESTS_YML).not.toContain('--deadline-sec');
   });
 
   test('fork code stays on GitHub-hosted runners', () => {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           set -euo pipefail
           export IMPACT_STARTED_AT="$(date +%s)"
-          bun scripts/ci-scope.ts --run "$RUNNER_TEMP/impact-plan.json" --deadline-sec 1200
+          bun scripts/ci-scope.ts --run "$RUNNER_TEMP/impact-plan.json"
           bun scripts/ci-scope.ts --base "${{ github.event.pull_request.base.sha }}" \
             --head "${{ github.event.pull_request.head.sha }}" \
             --plan-file "$RUNNER_TEMP/impact-plan.json" \

--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -332,9 +332,31 @@ describe('commandsForPlan', () => {
       suite: 'selected',
     }, REPO);
     expect(cmds).toHaveLength(1);
-    expect(cmds[0].cmd.slice(0, 4)).toEqual(['node', './node_modules/vitest/vitest.mjs', 'run', '--']);
+    expect(cmds[0].cmd.slice(0, 3)).toEqual(['node', './node_modules/vitest/vitest.mjs', 'run']);
     expect(cmds[0].cmd).toContain('src/lib/state.test.ts');
     expect(cmds[0].cmd.join(' ')).not.toContain('--shard');
+  });
+
+  // RUSH-2666 (wave 6): vitest's CLI treats every arg after a literal `--`
+  // as opaque pass-through, not a file filter. `vitest run -- state.test.ts`
+  // silently falls back to the full `include` glob. Measured on PR #2770:
+  // the plan selected 3 files, the `--` invocation ran all 864 (883.72s)
+  // instead of the selected files (~13s single-file). Guard the exact
+  // token shape so this regression can't sneak back in.
+  test('vitest invocations never carry a bare `--` before the file list', () => {
+    const single = commandForTestFile('apps/cli/src/lib/state.test.ts', REPO);
+    expect(single.cmd).not.toContain('--');
+
+    const batched = commandsForPlan({
+      ...selectImpact({ files: ['apps/cli/src/lib/state.ts'], repoRoot: REPO, related: false }),
+      tests: [
+        { file: 'apps/cli/src/lib/state.test.ts', reason: 'companion' },
+        { file: 'apps/cli/src/commands/webhook.test.ts', reason: 'companion' },
+      ],
+      checks: [],
+      suite: 'selected',
+    }, REPO);
+    for (const c of batched) expect(c.cmd).not.toContain('--');
   });
 });
 

--- a/scripts/ci-scope.ts
+++ b/scripts/ci-scope.ts
@@ -551,7 +551,12 @@ export function commandForTestFile(file: string, repoRoot: string): RunCommand {
   if (f.startsWith('apps/cli/') && f.endsWith('.test.ts')) {
     return {
       cwd: join(repoRoot, 'apps/cli'),
-      cmd: ['node', './node_modules/vitest/vitest.mjs', 'run', '--', f.slice('apps/cli/'.length)],
+      // No `--` before the path: vitest's CLI treats args after `--` as an
+      // opaque pass-through, not a filter, so the file list is silently
+      // dropped and vitest falls back to its full `include` glob. Measured
+      // on PR #2770 (RUSH-2666): the plan selected 3 files, the `--`
+      // invocation ran all 864, "Selected proof" took 15m21s instead of ~13s.
+      cmd: ['node', './node_modules/vitest/vitest.mjs', 'run', f.slice('apps/cli/'.length)],
     };
   }
   if (f.startsWith('packages/session-tracker/') && f.endsWith('.test.ts')) {
@@ -577,9 +582,10 @@ export function commandsForPlan(plan: ImpactPlan, repoRoot: string): RunCommand[
       .filter((f) => f.startsWith('apps/cli/') && f.endsWith('.test.ts'))
       .map((f) => f.slice('apps/cli/'.length));
     if (cliTests.length) {
+      // No `--` — see commandForTestFile above for why.
       out.push({
         cwd: cli,
-        cmd: ['node', './node_modules/vitest/vitest.mjs', 'run', '--', ...cliTests],
+        cmd: ['node', './node_modules/vitest/vitest.mjs', 'run', ...cliTests],
       });
     }
   }


### PR DESCRIPTION
**fix, CI-only** — no CLI/package behavior change; no CHANGELOG entry.

**Run evidence (real commands + real output, before/after):**
![RUSH-2666 wave 6 run evidence](https://share.agents-cli.sh/muqsitnawaz/muqsit-rush-2666-wave6-evidence-bba67376fdcf3581)
(the link above is a plain-text log — click through: https://share.agents-cli.sh/muqsitnawaz/muqsit-rush-2666-wave6-evidence-bba67376fdcf3581)

## What was actually wrong

RUSH-2666 wave 6 brief asked for two levers to hit the new <=60s required-check bar: tighten impact mapping, and wire the required job onto the warm Firecracker executor from #2745. Investigating the first lever against real Actions runs found the actual root cause of the whole latency gap.

`commandsForPlan` in `scripts/ci-scope.ts` built the selected-tests vitest invocation as `vitest run -- <files>`. vitest's CLI treats every argument after a literal `--` as opaque pass-through, **not a filter** — so the file list was silently dropped and vitest fell back to its full `include` glob (864 files) on every PR, regardless of what the impact planner selected.

**Measured on PR #2770** (`gh run view 32026151957`): the impact plan correctly selected 3 files (`daemon-webhooks.test.ts`, `handlers.test.ts`, `webhook.test.ts`), but the "Selected proof" step still ran all 864 test files / 12215 tests and took **15m21s**. Local repro of the same diff (full transcript in the evidence link above):

| Command | Test Files | Duration |
| --- | --- | --- |
| `vitest run -- src/lib/daemon-webhooks.test.ts` (buggy) | 864 passed | 883.72s |
| `vitest run src/lib/daemon-webhooks.test.ts` (fixed) | 1 passed | 13.16s |

This was the entire gap between the plan's stated 11-15.5 minute real-diff measurement and the target bar — not missing infrastructure.

Also removed the workflow's `--deadline-sec 1200` override on the "Selected proof" step. It forced every selected-suite run onto the cli-full budget, silently disabling the intended 85s (`IMPACT_BUDGET_SEC`) budget check for selected runs — `ci-scope.ts`'s own `--run` path already picks 1200s for `cli-full` and 85s otherwise when the flag is absent.

Both bugs had a unit test asserting the buggy shape as correct (`tests-gate.test.ts` literally asserted `--deadline-sec 1200` was present; `ci-scope.test.ts` asserted the `--` token). Fixed both assertions and added a regression guard (`vitest invocations never carry a bare '--' before the file list`) so this exact class of bug can't silently return.

## Full end-to-end local repro (same diff as PR #2770)

```
$ time bun scripts/ci-scope.ts --run /tmp/plan1.json
 Test Files  3 passed (3)
      Tests  72 passed (72)
impact ran in 39s (budget 85s, suite selected)
bun scripts/ci-scope.ts --run /tmp/plan1.json  55.47s user 4.43s system 152% cpu 39.350 total
```

39s total (install + build + selected vitest + docs + command-index checks), down from 15m21s for the "Selected proof" step alone — well under the plan's committed 90s P99 bar.

## Lever 2 — warm Firecracker executor wiring

Investigated wiring the required job onto the executor from #2745 (`scripts/ci-runner`). No untrusted executor host is provisioned in this GitHub org today:

```
$ gh api repos/phnx-labs/agi-cli/actions/runners --jq '.total_count'
1   # only yosemite-s0 is registered; no crabbox-ci / untrusted-executor runner
```

No `ci-runner-fsn1` / Hetzner credentials are reachable from this box (`agents secrets list`). This is tracked on **RUSH-2773** ("crabbox fleet unhealthy + ci-runner-fsn1 locked out") and **RUSH-2665** ("ci-runner-fsn1 rejects SSH from zion"); I logged these findings there instead of duplicating a new ticket. `scripts/ci-runner` internals are untouched, per the wave-6 ownership contract.

## What changed

- **`scripts/ci-scope.ts`** — remove the stray `--` before the selected test file args in both `commandForTestFile` and `commandsForPlan`'s batched CLI-tests command.
- **`.github/workflows/tests.yml`** — drop the `--deadline-sec 1200` override on the "Selected proof" step.
- **`scripts/ci-scope.test.ts`** — fix the assertion that had enshrined the `--` shape; add a regression guard.
- **`.github/workflows/tests-gate.test.ts`** — fix the assertion that had enshrined `--deadline-sec 1200`; assert it's absent instead.

## Verification

```
$ bun test ./.github/workflows/ ./scripts/ci-bench/ scripts/ci-scope.test.ts
 82 pass
 0 fail

$ bun scripts/ci-scope.ts --validate-manifest
ownership manifest covers 2979 tracked files
```

Unmapped-file failure and Windows non-required behavior are untouched by this diff (verified locally — unmapped file → `planIsFailing: true`; `windows` job unedited). Watching this PR's own required check next, which exercises the fix on a real (non-trivial) diff.