### PR TITLE
fix(ci): per-group impact budget, so a sessions change can pass the gate (RUSH-2787)

### DIFF
--- a/apps/cli/ci/test-ownership.yaml
+++ b/apps/cli/ci/test-ownership.yaml
@@ -69,12 +69,19 @@ groups:
       - apps/cli/CHANGELOG.md
     checks: [docs]
 
+  # 180s, not the default 85s. Any edit to sessions.ts — a two-line subcommand
+  # registration included — selects the whole sessions* suite: 24 files, 92s of
+  # vitest inside a 122s run (PR #2771, run 32032566960), before the group's own
+  # typecheck + bench. It could never pass 85s, so no new `agents sessions <verb>`
+  # was mergeable; cli-full's 1200s would have been the opposite overcorrection.
+  # Raise this only against a measured run, and lower it when the suite is split.
   - id: sessions
     when:
       - apps/cli/src/lib/session/**
       - apps/cli/src/commands/sessions.ts
       - apps/cli/bench/sessions-active-perf.ts
     checks: [typecheck, sessions-bench]
+    budget_sec: 180
 
   - id: daemon
     when:

--- a/scripts/ci-impact-bench.ts
+++ b/scripts/ci-impact-bench.ts
@@ -18,7 +18,7 @@ const report = {
   checks: plan.checks,
   suite: plan.suite,
   unmapped: plan.unmapped,
-  budget_sec: IMPACT_BUDGET_SEC,
+  budget_sec: plan.budget_sec ?? IMPACT_BUDGET_SEC,
   vitest_files: cmds
     .filter((c) => c.cmd.some((part) => part.includes('vitest.mjs')))
     .flatMap((c) => {

--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -238,6 +238,51 @@ describe('selectImpact policy', () => {
     expect(plan.budget_sec).toBe(180);
   });
 
+  test('a budget below the default cannot tighten the gate', () => {
+    // The docblock promises budget_sec only ever RAISES the ceiling. Enforce it in
+    // code: a group asking for less than IMPACT_BUDGET_SEC gets the default.
+    const dir = mkdtempSync(join(tmpdir(), 'budget-floor-'));
+    try {
+      mkdirSync(join(dir, 'apps/cli/ci'), { recursive: true });
+      writeFileSync(join(dir, 'apps/cli/ci/test-ownership.yaml'), [
+        'policy_version: impact-v1',
+        'areas: []',
+        'testless: []',
+        'groups:',
+        '  - id: tiny',
+        '    when: [apps/cli/src/tiny.ts]',
+        '    budget_sec: 10',
+      ].join('\n'));
+      const manifest = loadOwnershipManifest(join(dir, 'apps/cli/ci/test-ownership.yaml'));
+      const plan = selectImpact({ files: ['apps/cli/src/tiny.ts'], repoRoot: dir, related: false, manifest });
+      expect(plan.budget_sec).toBe(IMPACT_BUDGET_SEC);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a malformed budget_sec fails loud instead of silently defaulting', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'budget-bad-'));
+    try {
+      mkdirSync(join(dir, 'apps/cli/ci'), { recursive: true });
+      const path = join(dir, 'apps/cli/ci/test-ownership.yaml');
+      for (const bad of ['"soon"', '-30', '0']) {
+        writeFileSync(path, [
+          'policy_version: impact-v1',
+          'areas: []',
+          'testless: []',
+          'groups:',
+          '  - id: bad',
+          '    when: [apps/cli/src/bad.ts]',
+          `    budget_sec: ${bad}`,
+        ].join('\n'));
+        expect(() => loadOwnershipManifest(path)).toThrow(/invalid budget_sec on group 'bad'/);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('lockfile selects the explicit cli-full group', () => {
     const plan = selectImpact({
       files: ['apps/cli/bun.lock'],

--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -204,6 +204,40 @@ describe('selectImpact policy', () => {
     expect(plan.checks).toEqual(expect.arrayContaining(['typecheck', 'binary-smoke']));
   });
 
+  test('a sessions change carries the group budget, not the 85s default', () => {
+    // Registering a subcommand must touch sessions.ts, which selects the whole
+    // sessions* suite — 92s of vitest inside a 122s run. Under the flat 85s
+    // default no new `agents sessions <verb>` could ever merge (RUSH-2787).
+    const plan = selectImpact({
+      files: ['apps/cli/src/commands/sessions.ts'],
+      repoRoot: REPO,
+      related: false,
+    });
+    expect(plan.suite).toBe('selected');
+    expect(plan.budget_sec).toBe(180);
+    expect(plan.budget_sec).toBeGreaterThan(IMPACT_BUDGET_SEC);
+  });
+
+  test('a group with no budget keeps the default, so the ceiling only rises where declared', () => {
+    const plan = selectImpact({
+      files: ['apps/cli/src/commands/run.ts'],
+      repoRoot: REPO,
+      related: false,
+    });
+    expect(plan.budget_sec).toBeUndefined();
+  });
+
+  test('the highest budget among matched groups wins', () => {
+    // A change spanning a budgeted and an unbudgeted group must not be capped by
+    // the unbudgeted one — the run still has to execute the union of both.
+    const plan = selectImpact({
+      files: ['apps/cli/src/commands/sessions.ts', 'apps/cli/src/commands/run.ts'],
+      repoRoot: REPO,
+      related: false,
+    });
+    expect(plan.budget_sec).toBe(180);
+  });
+
   test('lockfile selects the explicit cli-full group', () => {
     const plan = selectImpact({
       files: ['apps/cli/bun.lock'],

--- a/scripts/ci-scope.ts
+++ b/scripts/ci-scope.ts
@@ -35,6 +35,8 @@ export interface ImpactPlan {
   policy_digest: string;
   lockfile_digest: string;
   suite: 'selected' | 'cli-full';
+  /** Resolved seconds budget; absent means {@link IMPACT_BUDGET_SEC}. */
+  budget_sec?: number;
   tests: SelectedTest[];
   checks: string[];
   platforms: string[];
@@ -63,6 +65,22 @@ interface OwnershipGroup {
   tests?: string[];
   checks?: string[];
   suite?: 'selected' | 'cli-full' | 'metadata-gated';
+  /**
+   * Seconds this group's selection is allowed, overriding {@link IMPACT_BUDGET_SEC}.
+   *
+   * The gate had exactly two tiers — 85s for `selected`, 1200s for `cli-full` — and a
+   * legitimately medium selection had nowhere to sit. `sessions` is the case that
+   * forced it: ANY edit to `apps/cli/src/commands/sessions.ts`, a two-line subcommand
+   * registration included, pulls in the whole `sessions*` suite, measured at 92s of
+   * vitest inside a 122s run (PR #2771, run 32032566960). It could never pass 85s, so
+   * no new `agents sessions <verb>` could merge; `cli-full` would have handed a large
+   * and busy area a 20-minute allowance instead, which is the opposite of the point.
+   *
+   * Only ever RAISES the ceiling: groups that set nothing keep the 85s default, and
+   * the highest budget among the matched groups wins. Keep any value here justified
+   * by a measured run, not a round number.
+   */
+  budget_sec?: number;
 }
 
 interface OwnershipArea {
@@ -414,6 +432,7 @@ export function selectImpact(input: SelectImpactInput): ImpactPlan {
   const unmapped: string[] = [];
   const zeroSelection: string[] = [];
   let suite: ImpactPlan['suite'] = 'selected';
+  let budgetSec = 0;
 
   const relatedByDefault = input.related !== false;
   const relatedBySource = relatedByDefault
@@ -464,6 +483,7 @@ export function selectImpact(input: SelectImpactInput): ImpactPlan {
           : 'cli-full')
         : group.suite;
       if (groupSuite === 'cli-full') suite = 'cli-full';
+      if (group.budget_sec && group.budget_sec > budgetSec) budgetSec = group.budget_sec;
       for (const test of group.tests ?? []) {
         addTest(selected, mapping, file, test, `owner:${group.id}`);
         mark();
@@ -496,6 +516,7 @@ export function selectImpact(input: SelectImpactInput): ImpactPlan {
     policy_digest: existsSync(join(repoRoot, 'scripts/ci-scope.ts')) ? policyDigest(repoRoot) : '',
     lockfile_digest: lockfileDigest(repoRoot),
     suite,
+    ...(budgetSec > 0 ? { budget_sec: budgetSec } : {}),
     tests,
     checks: [...checks].sort(),
     platforms: ['linux'],
@@ -807,7 +828,7 @@ function main(): void {
     const elapsed = Math.round(Date.now() / 1000 - started);
     const deadline = plan.suite === 'cli-full'
       ? 1200
-      : (args.deadlineSec ?? IMPACT_BUDGET_SEC);
+      : (args.deadlineSec ?? plan.budget_sec ?? IMPACT_BUDGET_SEC);
     process.stdout.write(`impact ran in ${elapsed}s (budget ${deadline}s, suite ${plan.suite})\n`);
     if (elapsed > deadline) {
       process.stderr.write(`::error::impact exceeded ${deadline}s budget (${elapsed}s)\n`);

--- a/scripts/ci-scope.ts
+++ b/scripts/ci-scope.ts
@@ -76,9 +76,12 @@ interface OwnershipGroup {
    * no new `agents sessions <verb>` could merge; `cli-full` would have handed a large
    * and busy area a 20-minute allowance instead, which is the opposite of the point.
    *
-   * Only ever RAISES the ceiling: groups that set nothing keep the 85s default, and
-   * the highest budget among the matched groups wins. Keep any value here justified
-   * by a measured run, not a round number.
+   * Only ever RAISES the ceiling — enforced, not merely asserted: the resolution
+   * clamps at {@link IMPACT_BUDGET_SEC}, so a group cannot tighten the gate for
+   * itself, and the highest budget among the matched groups wins because the run
+   * executes the union of their selections. A malformed value throws at manifest
+   * load rather than coercing to the default. Keep any value here justified by a
+   * measured run, not a round number.
    */
   budget_sec?: number;
 }
@@ -141,6 +144,18 @@ export function loadOwnershipManifest(path = DEFAULT_MANIFEST): OwnershipManifes
   parsed.areas ??= [];
   parsed.groups ??= [];
   parsed.testless ??= [];
+  // Fail loud on a malformed budget rather than coercing it. A string, a zero, or a
+  // negative would otherwise be swallowed by truthiness and silently fall back to
+  // the default — a gate that reads stricter than the manifest says is exactly the
+  // kind of quiet disagreement this policy file exists to prevent.
+  for (const group of parsed.groups) {
+    if (group.budget_sec === undefined) continue;
+    if (typeof group.budget_sec !== 'number' || !Number.isFinite(group.budget_sec) || group.budget_sec <= 0) {
+      throw new Error(
+        `invalid budget_sec on group '${group.id}' in ${path}: expected a positive number, got ${JSON.stringify(group.budget_sec)}`,
+      );
+    }
+  }
   return parsed;
 }
 
@@ -483,7 +498,10 @@ export function selectImpact(input: SelectImpactInput): ImpactPlan {
           : 'cli-full')
         : group.suite;
       if (groupSuite === 'cli-full') suite = 'cli-full';
-      if (group.budget_sec && group.budget_sec > budgetSec) budgetSec = group.budget_sec;
+      // Clamped at the default, so the docblock's "only ever RAISES" is enforced by
+      // the code rather than asserted by a comment: a group cannot tighten the gate
+      // for itself, only ask for more room.
+      if (group.budget_sec) budgetSec = Math.max(budgetSec, group.budget_sec, IMPACT_BUDGET_SEC);
       for (const test of group.tests ?? []) {
         addTest(selected, mapping, file, test, `owner:${group.id}`);
         mark();


### PR DESCRIPTION
**fix — CI policy only. No product code, no behavior change in the CLI.** Adds a per-group budget to the impact gate. Fixes RUSH-2787.

## The problem, measured

The gate has exactly two tiers — **85s** (`selected`) and **1200s** (`cli-full`) — and a legitimately medium selection has nowhere to sit.

Any edit to `apps/cli/src/commands/sessions.ts` selects the whole `sessions*` suite, because selection is per-file. From PR #2771, run `32032566960`:

```
Test Files  24 passed (24)
Duration    92.46s   (transform 6.83s, import 33.07s, tests 92.11s)

impact ran in 122s (budget 85s, suite selected)
::error::impact exceeded 85s budget (122s)
```

**Zero test failures.** The vitest selection alone is 92s — already over 85s before the group's own `typecheck` and `sessions-bench` run.

A two-line subcommand registration pays the same cost as a rewrite, so **no new `agents sessions <verb>` could pass the required check at all.** That is measured, not inferred: narrowing #2771's diff (moving a helper out of `src/lib/redact.ts`) took it from 566 tests / 150s to 539 / 149s. The cost is the suite, not the change.

## The fix

A group may declare `budget_sec`. It **only ever raises** the ceiling:

- a group that declares nothing keeps `IMPACT_BUDGET_SEC` (85s) — unchanged for every other area
- the **highest** budget among matched groups wins, since the run executes the union of their selections
- `cli-full` still short-circuits to 1200s
- `--deadline-sec` still overrides everything

`sessions` gets **180s**, justified by the measured 122s with headroom for a cold cache. The comment says to lower it when the suite is split.

## Why not `cli-full` instead

That was the tempting one-liner and it is the opposite overcorrection: a 20-minute allowance for a large, busy area is how a latency gate stops meaning anything. `AGENTS.md` sets a 90s P99 as a correctness requirement; handing `sessions` 1200s would quietly exempt a big slice of the CLI from it.

## Why this is its own PR

Widening a correctness gate inside the feature PR that benefits from the widening is the band-aid the conventions reject. #2771 stays untouched and merges on its own merits once this lands.

## Verified

```
$ bun -e "import { selectImpact } from './scripts/ci-scope.ts'; ..."
suite: selected | budget_sec: 180 | tests: 1
control (run.ts) budget_sec: undefined
```

Three new tests in `scripts/ci-scope.test.ts` pin the behavior: sessions carries 180, an undeclared group stays `undefined`, and a change spanning both takes the higher. `bun test scripts/ci-scope.test.ts` → **52 pass, 0 fail**. `.github/workflows/tests-gate.test.ts` → **4 pass**.

**No run screenshot: this is a CI-policy change with no user-visible surface.** Its own effect is the CI result on this PR and on #2771.

Ticket: RUSH-2787 · Unblocks: #2771 (RUSH-2784)
