### PR TITLE
test(hermeticity): clear an ambient CLAUDE_CODE_OAUTH_TOKEN in the fork default

### DIFF
--- a/apps/cli/tests/setup.ts
+++ b/apps/cli/tests/setup.ts
@@ -67,6 +67,18 @@ process.env.AGENTS_SECRETS_NO_AGENT = '1';
 // Usage stamping writes bundle metadata back to the secret store on reads.
 process.env.AGENTS_NO_USAGE_TRACK = '1';
 
+// A developer box that exports CLAUDE_CODE_OAUTH_TOKEN (mac-mini does, from
+// ~/.zshenv) changed what the CLI PRINTS for a version with no per-version
+// login: view.ts renders "(no per-version login - using ambient
+// CLAUDE_CODE_OAUTH_TOKEN)" instead of "(logged out - log in with: ...)",
+// because ambientClaudeToken() (signin-badge.ts) reads this variable. Any
+// test asserting the logged-out row then failed on that box alone and passed
+// in CI -- and the suite is the release gate, so the release home base could
+// never produce a green attestation. Clear it as the fork default; tests that
+// exercise ambient-token behavior set it themselves and restore the value
+// they saved, which is simply this hermetic default.
+delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+
 // Events: redirect the sink to a fork-private file. Redirect, not disable —
 // events.test.ts / logs.test.ts assert on written content and re-point the
 // sink themselves via _resetForTest, which takes precedence over this env.


### PR DESCRIPTION
**test-only** — one line added to `apps/cli/tests/setup.ts`. No production code, no behavior change.

## Why this blocks the release

The release gate is the full suite (`release-attestation-produce.sh` fails closed on red), and it **could not go green on mac-mini** — the designated release home base. That box exports `CLAUDE_CODE_OAUTH_TOKEN` from `~/.zshenv` (len 108).

The chain:

| Step | Evidence |
| --- | --- |
| `ambientClaudeToken()` returns true when the var is set | `apps/cli/src/lib/signin-badge.ts:76` |
| `view` then prints `(no per-version login — using ambient CLAUDE_CODE_OAUTH_TOKEN)` instead of `(logged out — log in with: …)` | `apps/cli/src/commands/view.ts:757-762` |
| the test filters human rows on `'(logged out'`, so that row disappears | `apps/cli/tests/non-interactive.test.ts:860` |
| `runAgents()` spawns the CLI with `env: {...process.env}`, inheriting the token | `apps/cli/tests/non-interactive.test.ts:119-143` |

Result: 3 rows instead of 4, on that box only — green in CI, which has no ambient token. CI never caught it because the `test` check is `skipped` on recent `main` commits.

## Why the fix is in `tests/setup.ts`

That file is already the source for fork-level env hermeticity (`HOME`, `AGENTS_DEVICES_DIR`, `AGENTS_EVENTS_PATH`, `AGENTS_STATE_DIR`, …) and it explicitly covers `env: {...process.env}` subprocess spawns — which is exactly how `runAgents()` invokes the CLI. Clearing it there fixes every spawn path at once instead of one test at a time.

Tests that genuinely exercise ambient-token behavior set the variable themselves and restore the value they saved — which is now simply this hermetic default:
- `src/lib/__tests__/runner.test.ts:436`
- `src/lib/claude-account-token.test.ts:32-46`

## Run result — measured on mac-mini, the box that failed

Full before/after output: https://share.agents-cli.sh/muqsitnawaz/svatlas-hermeticity-before-after-6f2a18a5406b2b47

Before, on `origin/main` @ `5c033f077` (reproduced twice — once in the full suite, once in isolation):

```
FAIL  tests/non-interactive.test.ts > sorts human view accounts by email after the default while keeping JSON version order
AssertionError: expected [ '2.1.100', '2.1.200', '2.1.300' ] to deeply equal [ '2.1.100', '2.1.200', …(2) ]
-   "2.1.400",
```

After, this branch, same box:

```
Test Files  2 passed (2)
     Tests  32 passed (32)
  Duration  19.71s
```

## Not included

The same producer run also hit `src/lib/session/active.live-session-id.test.ts` ("sessionIdFromLivePid … empty by-pid"). That one **passed on re-run in isolation** — it spawns a real process and polls for it on the process table, and its whole history is load-flake hardening (RUSH-2508: `ca95bc7e5`, `bf39c9af3`, `eb16fb187`, `13e8ef5c1`). It is a load flake on a busy box, not a regression, and is out of scope here.