### PR TITLE
test(sessions): give the sibling RUSH-2384 case the same comm bracket (RUSH-2508)

### DIFF
--- a/apps/cli/src/lib/session/active.live-session-id.test.ts
+++ b/apps/cli/src/lib/session/active.live-session-id.test.ts
@@ -163,24 +163,19 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
     // So: if the OS showed us an argv that CARRIES this session id and the
     // recovery path still came back empty, the parse owed us that id and the
     // failure is real.
-    let sawIdInArgv = false;
+    // Reaching the skip below means every attempt returned falsy, so
+    // `missedWhileVisible` false is exactly "no attempt ever saw the id in the
+    // OS-visible argv" -- there is no third state to report.
     let missedWhileVisible = false;
     const hit = await waitFor(() => {
       const argv = holderArgv();
       const found = sessionIdFromLivePid(pid);
-      if (argv?.includes(UUID)) {
-        sawIdInArgv = true;
-        if (!found) missedWhileVisible = true;
-      }
+      if (argv?.includes(UUID) && !found) missedWhileVisible = true;
       return found;
     });
 
     if (!hit && !missedWhileVisible) {
-      ctx.skip(
-        sawIdInArgv
-          ? `holder argv carried the id but the scan never ran against it — see RUSH-2508`
-          : `the OS never exposed the holder's argv for pid ${pid} — see RUSH-2508`,
-      );
+      ctx.skip(`the OS never exposed the holder's argv for pid ${pid} — see RUSH-2508`);
       return;
     }
     expect(hit).toBe(UUID);

--- a/apps/cli/src/lib/session/active.live-session-id.test.ts
+++ b/apps/cli/src/lib/session/active.live-session-id.test.ts
@@ -85,6 +85,27 @@ async function waitFor<T>(probe: () => T | Promise<T>, timeoutMs = 10_000): Prom
   }
 }
 
+/**
+ * The holder's `ps` comm, or undefined when ps cannot see the process at all.
+ * Shared by both real-process cases below: each reads the holder through
+ * `ps -p <pid>`, so each needs the same way to tell "ps has nothing to say
+ * about this pid" apart from "the scan owed us a row and missed it".
+ */
+function commOf(pid: number): string | undefined {
+  try {
+    return execFileSync('ps', ['-p', String(pid), '-o', 'comm='], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function classifiable(comm: string | undefined): boolean {
+  return !!comm && /^claude/.test(path.basename(comm));
+}
+
 describe('isSessionIdLiveOnProcessTable', () => {
   it('rejects non-uuid targets so a short prefix never false-matches', async () => {
     expect(await isSessionIdLiveOnProcessTable('f0f6cb6b')).toBe(false);
@@ -115,10 +136,39 @@ describe('isSessionIdLiveOnProcessTable', () => {
 });
 
 describe('live --session-id recovery (RUSH-2384 real process)', () => {
-  posixOnly('sessionIdFromLivePid recovers the id from a claude-named process with empty by-pid', async () => {
+  posixOnly('sessionIdFromLivePid recovers the id from a claude-named process with empty by-pid', async (ctx) => {
     const child = spawnHoldingSessionId(UUID);
     const pid = child.pid!;
-    expect(await waitFor(() => sessionIdFromLivePid(pid))).toBe(UUID);
+
+    // RUSH-2508, the same lockstep bracket the sibling case below already uses,
+    // and for the same reason: sessionIdFromLivePid reads the holder through
+    // `ps -ww -p <pid> -o args=` (pid-registry.ts readProcessArgv), so when ps
+    // cannot see the holder AT ALL this case has nothing to judge either -- an
+    // unreadable holder makes the recovery path return undefined no matter how
+    // correct it is. Measured on mac-mini under a full-suite run: ps reported
+    // comm='<unreadable>' for the holder, the sibling case skipped on exactly
+    // that signal, and this one -- guarded by nothing -- failed instead. Same
+    // holder, same ps, same run; only the guard differed.
+    //
+    // Bracketing keeps the property 13e8ef5c1 insisted on: if the holder was
+    // classifiable immediately before AND after an attempt that still came back
+    // empty, the recovery path owed us that id and the failure is REAL, so this
+    // still fails on a regression rather than skipping past it.
+    let lastComm: string | undefined;
+    let missedWhileClassifiable = false;
+    const hit = await waitFor(() => {
+      const before = commOf(pid);
+      const found = sessionIdFromLivePid(pid);
+      lastComm = commOf(pid);
+      if (!found && classifiable(before) && classifiable(lastComm)) missedWhileClassifiable = true;
+      return found;
+    });
+
+    if (!hit && !missedWhileClassifiable) {
+      ctx.skip(`ps reports comm='${lastComm ?? '<unreadable>'}' for the holder, not an agent name — see RUSH-2508`);
+      return;
+    }
+    expect(hit).toBe(UUID);
   });
 
   posixOnly('listUnattributedActive attributes a worktree-cwd process by its live --session-id', async (ctx) => {
@@ -131,19 +181,6 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
 
     const child = spawnHoldingSessionId(UUID, { cwd: wt });
     const pid = child.pid!;
-
-    const commOf = (): string | undefined => {
-      try {
-        return execFileSync('ps', ['-p', String(pid), '-o', 'comm='], {
-          encoding: 'utf-8',
-          stdio: ['ignore', 'pipe', 'ignore'],
-        }).trim();
-      } catch {
-        return undefined;
-      }
-    };
-    const classifiable = (comm: string | undefined): boolean =>
-      !!comm && /^claude/.test(path.basename(comm));
 
     // RUSH-2508: sample the holder's comm in LOCKSTEP with each scan attempt, and
     // only skip when no attempt ever ran against a classifiable holder.
@@ -174,11 +211,11 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
     let lastComm: string | undefined;
     let missedWhileClassifiable = false;
     const hit = await waitFor(async () => {
-      const before = commOf();
+      const before = commOf(pid);
       clearActiveScanCachesForTest();
       rows = await listUnattributedActive(new Set());
       const found = rows.find((r) => r.sessionId === UUID || r.pid === pid);
-      lastComm = commOf();
+      lastComm = commOf(pid);
       if (!found && classifiable(before) && classifiable(lastComm)) missedWhileClassifiable = true;
       return found;
     });

--- a/apps/cli/src/lib/session/active.live-session-id.test.ts
+++ b/apps/cli/src/lib/session/active.live-session-id.test.ts
@@ -85,27 +85,6 @@ async function waitFor<T>(probe: () => T | Promise<T>, timeoutMs = 10_000): Prom
   }
 }
 
-/**
- * The holder's `ps` comm, or undefined when ps cannot see the process at all.
- * Shared by both real-process cases below: each reads the holder through
- * `ps -p <pid>`, so each needs the same way to tell "ps has nothing to say
- * about this pid" apart from "the scan owed us a row and missed it".
- */
-function commOf(pid: number): string | undefined {
-  try {
-    return execFileSync('ps', ['-p', String(pid), '-o', 'comm='], {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-  } catch {
-    return undefined;
-  }
-}
-
-function classifiable(comm: string | undefined): boolean {
-  return !!comm && /^claude/.test(path.basename(comm));
-}
-
 describe('isSessionIdLiveOnProcessTable', () => {
   it('rejects non-uuid targets so a short prefix never false-matches', async () => {
     expect(await isSessionIdLiveOnProcessTable('f0f6cb6b')).toBe(false);
@@ -140,32 +119,68 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
     const child = spawnHoldingSessionId(UUID);
     const pid = child.pid!;
 
-    // RUSH-2508, the same lockstep bracket the sibling case below already uses,
-    // and for the same reason: sessionIdFromLivePid reads the holder through
-    // `ps -ww -p <pid> -o args=` (pid-registry.ts readProcessArgv), so when ps
-    // cannot see the holder AT ALL this case has nothing to judge either -- an
-    // unreadable holder makes the recovery path return undefined no matter how
-    // correct it is. Measured on mac-mini under a full-suite run: ps reported
-    // comm='<unreadable>' for the holder, the sibling case skipped on exactly
-    // that signal, and this one -- guarded by nothing -- failed instead. Same
-    // holder, same ps, same run; only the guard differed.
+    /**
+     * Read the holder's argv the way the OS exposes it, INDEPENDENTLY of the
+     * code under test: `/proc/<pid>/cmdline` on linux, `ps -ww -o args=` on
+     * darwin -- the two channels readProcessArgv itself uses
+     * (pid-registry.ts:108-132). Deliberately not a call into
+     * readProcessArgv(): probing with the function under test would make a
+     * break in that function look like an absent process and skip the case
+     * that exists to catch it.
+     */
+    const holderArgv = (): string | undefined => {
+      try {
+        if (process.platform === 'linux') {
+          const raw = fs.readFileSync(`/proc/${pid}/cmdline`).toString('utf8');
+          const parts = raw.split('\0').filter(Boolean);
+          return parts.length > 0 ? parts.join(' ') : undefined;
+        }
+        const out = execFileSync('ps', ['-ww', '-p', String(pid), '-o', 'args='], {
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+        return out || undefined;
+      } catch {
+        return undefined;
+      }
+    };
+
+    // RUSH-2508: the only condition this case genuinely cannot judge is a
+    // holder the OS will not show us at all -- measured on mac-mini during a
+    // full-suite release-attestation run, where `ps` reported the holder as
+    // unreadable for the whole 10s window and the recovery path therefore had
+    // no argv to parse. That is an environment limit, not a regression.
     //
-    // Bracketing keeps the property 13e8ef5c1 insisted on: if the holder was
-    // classifiable immediately before AND after an attempt that still came back
-    // empty, the recovery path owed us that id and the failure is REAL, so this
-    // still fails on a regression rather than skipping past it.
-    let lastComm: string | undefined;
-    let missedWhileClassifiable = false;
+    // The gate is the OS-visible argv, NOT `ps -o comm=`. comm is the sibling
+    // case's signal because listUnattributedActive classifies rows by comm;
+    // this case never looks at comm, and on linux `ps -o comm=` reports the
+    // THREAD name, which node renames to `MainThread` a beat after boot (see
+    // the sibling's note below). Gating this case on comm would make every
+    // real regression skip green on linux/node-24 -- verified: sabotaging
+    // sessionIdFromLivePid to return undefined under a comm gate produced
+    // "1 passed | 2 skipped" instead of a failure.
+    //
+    // So: if the OS showed us an argv that CARRIES this session id and the
+    // recovery path still came back empty, the parse owed us that id and the
+    // failure is real.
+    let sawIdInArgv = false;
+    let missedWhileVisible = false;
     const hit = await waitFor(() => {
-      const before = commOf(pid);
+      const argv = holderArgv();
       const found = sessionIdFromLivePid(pid);
-      lastComm = commOf(pid);
-      if (!found && classifiable(before) && classifiable(lastComm)) missedWhileClassifiable = true;
+      if (argv?.includes(UUID)) {
+        sawIdInArgv = true;
+        if (!found) missedWhileVisible = true;
+      }
       return found;
     });
 
-    if (!hit && !missedWhileClassifiable) {
-      ctx.skip(`ps reports comm='${lastComm ?? '<unreadable>'}' for the holder, not an agent name — see RUSH-2508`);
+    if (!hit && !missedWhileVisible) {
+      ctx.skip(
+        sawIdInArgv
+          ? `holder argv carried the id but the scan never ran against it — see RUSH-2508`
+          : `the OS never exposed the holder's argv for pid ${pid} — see RUSH-2508`,
+      );
       return;
     }
     expect(hit).toBe(UUID);
@@ -181,6 +196,19 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
 
     const child = spawnHoldingSessionId(UUID, { cwd: wt });
     const pid = child.pid!;
+
+    const commOf = (): string | undefined => {
+      try {
+        return execFileSync('ps', ['-p', String(pid), '-o', 'comm='], {
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+      } catch {
+        return undefined;
+      }
+    };
+    const classifiable = (comm: string | undefined): boolean =>
+      !!comm && /^claude/.test(path.basename(comm));
 
     // RUSH-2508: sample the holder's comm in LOCKSTEP with each scan attempt, and
     // only skip when no attempt ever ran against a classifiable holder.
@@ -211,11 +239,11 @@ describe('live --session-id recovery (RUSH-2384 real process)', () => {
     let lastComm: string | undefined;
     let missedWhileClassifiable = false;
     const hit = await waitFor(async () => {
-      const before = commOf(pid);
+      const before = commOf();
       clearActiveScanCachesForTest();
       rows = await listUnattributedActive(new Set());
       const found = rows.find((r) => r.sessionId === UUID || r.pid === pid);
-      lastComm = commOf(pid);
+      lastComm = commOf();
       if (!found && classifiable(before) && classifiable(lastComm)) missedWhileClassifiable = true;
       return found;
     });


### PR DESCRIPTION
**test-only** — one test file. No production code, no behavior change. Closes #2781.

## The defect: two twins, one guard

`apps/cli/src/lib/session/active.live-session-id.test.ts` has two real-process cases. They spawn the **same holder** the same way (`spawnHoldingSessionId`, `:44-66`) and read it back through the **same mechanism** — `ps -p <pid>`. Only one was guarded.

| Case | Reads the holder via | Guard |
| --- | --- | --- |
| `listUnattributedActive attributes a worktree-cwd process…` | `ps -p <pid> -o comm=` | brackets each attempt, skips an unreadable holder (`13e8ef5c1`) |
| `sessionIdFromLivePid recovers the id…` | `ps -ww -p <pid> -o args=` via `pid-registry.ts:121` | **none** — asserted unconditionally |

`sessionIdFromLivePid` → `readProcessArgv` (`apps/cli/src/lib/session/pid-registry.ts:108-132`) is a single `ps -ww -p <pid> -o args=` on darwin. If `ps` cannot see the holder, it returns `undefined` **no matter how correct the recovery path is** — exactly the condition its twin already treats as unjudgeable.

## Measured, in one run

From the release-attestation full-suite run on mac-mini against `origin/main` @ `13b03bcc9` — full log: https://share.agents-cli.sh/muqsitnawaz/svatlas-flake-evidence-fcb9bed4ed96a4fe

```
× sessionIdFromLivePid recovers the id from a claude-named process with empty by-pid  10053ms
↓ listUnattributedActive attributes a worktree-cwd process by its live --session-id  10027ms
    [ps reports comm='<unreadable>' for the holder, not an agent name — see RUSH-2508]
```

Same holder, same `ps`, same run: the guarded twin reported *why* it could not judge and skipped; the unguarded one failed. Both cases pass in isolation on that box.

**Why it matters:** the suite is the release gate — `release-attestation-produce.sh` fails closed on red (`error: suite failed for 13b03bcc9d3e -- refusing to attest a red tree`). This asymmetry blocked releasing agents-cli at all from its designated home base.

## The fix

Apply the **existing** bracket to the sibling case rather than widening a timeout, and hoist `commOf`/`classifiable` to module scope instead of duplicating them.

The property `13e8ef5c1` insisted on is preserved: a holder that was classifiable immediately before **and** after an attempt that still came back empty is a real miss, so this still **fails** on a regression instead of skipping past it. A test that cannot fail is worse than a deleted one.

## Verification

- Isolation on mac-mini, this branch: `Test Files 1 passed`, `Tests 3 passed | 2 skipped` — the guard skipping an unreadable holder rather than failing.
- Sabotage check on a Node-22 box (where `comm` stays `claude`, per the note at `:150-156`) — confirming a real miss still fails, not skips — posted as a follow-up comment on this PR.