### PR TITLE
fix(runner): never let the routine reaper SIGKILL its own process

### DIFF
--- a/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
+++ b/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
@@ -240,7 +240,13 @@ describe('monitorRunningJobs — pid-reuse + max wall-clock', () => {
     expect(updated.completedAt).not.toBeNull();
   });
 
-  it('finalizes a run that exceeds the 24h max wall-clock', () => {
+  // The reaper must never SIGKILL the process doing the reaping. This case runs
+  // monitorRunningJobs() against a record whose pid IS this process and whose
+  // start time is past the 24h cap -- the exact shape that made the vitest
+  // worker kill itself (rc=137, "Worker exited unexpectedly") before
+  // terminateRoutineTree() guarded `pid === process.pid`. Reaching the
+  // assertions at all is the proof: a self-kill never gets here.
+  it('finalizes an over-cap run without killing the reaping process itself', () => {
     const meta: RunMeta = {
       jobName: '__selfheal-wallclock__',
       runId: 'test-wall-1',

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -492,6 +492,16 @@ async function runWithAttempt<T>(
 
 function terminateRoutineTree(pid: number | null): void {
   if (!pid) return;
+  // Never take THIS process down. Both kills below are unconditional SIGKILLs,
+  // so a RunMeta naming the reaper's own pid -- a reused pid, a record written
+  // by the process now doing the reaping, or a hand-written fixture -- makes the
+  // reaper SIGKILL itself, and via `-pid` its whole process group with it. There
+  // is no recovery from that: the run is never finalized, and on the daemon it
+  // takes the scheduler down mid-sweep. daemon.ts:457 already refuses to evict an
+  // incumbent whose pid is `process.pid` for exactly this reason; the reap path
+  // needs the same guard. Skipping the kill still lets the caller finalize the
+  // run record, which is the part that matters.
+  if (pid === process.pid) return;
   if (process.platform === 'win32') {
     killTree(pid);
     return;


### PR DESCRIPTION
**bug fix** — one guard in `apps/cli/src/lib/runner.ts`, plus the test that pins it. This is why `bun run test` exits 1 on `main`, and therefore why agents-cli cannot currently be released.

## The bug

`terminateRoutineTree()` (`apps/cli/src/lib/runner.ts:493-508`) fires two unconditional SIGKILLs — `process.kill(-pid, 'SIGKILL')` for the process group, then `process.kill(pid, 'SIGKILL')` — with no check that `pid` is somebody else. Hand it a `RunMeta` naming the reaping process and it kills itself, taking its process group with it.

## How it surfaces

`daemon-self-heal.test.ts:243-247` writes a `RunMeta` with `pid: process.pid` and `startedAt` 25 hours ago, then calls `monitorRunningJobs()`. The reaper correctly identifies an over-cap run and terminates it — and that run is the vitest worker itself.

The worker dies by SIGKILL before any test reports, so the file never appears in the results at all:

```
 Test Files  866 passed | 8 skipped (875)     <-- 874 of 875 accounted for
      Tests  12289 passed | 111 skipped (12420)
     Errors  1 error
Error: [vitest-pool]: Worker forks emitted error.
Caused by: Error: Worker exited unexpectedly
```

The missing file is `src/lib/__tests__/daemon-self-heal.test.ts`. Zero assertions fail — the suite is red purely because a worker was killed. Reproduced on **macOS** (mac-mini) and **linux/node-24** (yosemite-s1) alike, in isolation and in the full suite.

**Why CI is green anyway:** the required `test` job runs only impact-selected files, and nothing recently touched the daemon/runner paths mapped to this one. But the *full* suite is the release gate — `release-attestation-produce.sh` fails closed on a red tree — so this quietly made the package unreleasable from its home base.

## Why the guard goes in the product, not the fixture

Rewriting the test to use some other pid would hide a real defect. A reaper that SIGKILLs itself mid-sweep leaves the run it was finalizing pinned at `running` forever, and on the daemon it takes the scheduler down with it. Pid reuse alone can produce the same shape in production — and "pid-reuse safety" is one of the properties this very test file exists to cover.

`daemon.ts:457` already refuses to evict an incumbent whose pid is `process.pid`:

```ts
if (existing !== null && existing !== process.pid) {
  evictIncumbentDaemon(existing);
}
```

This applies that same rule on the reap path. Skipping the kill still lets the caller finalize the run record — which is exactly what the test asserts.

## Run result

Full before/after: https://share.agents-cli.sh/muqsitnawaz/svatlas-reaper-evidence-f45fc00284c3d1d7

Measured on yosemite-s1 (linux, node v24.11.1):

| State | Result |
| --- | --- |
| `origin/main` @ `9bc9fc1fd` | `Worker exited unexpectedly`, `Errors 1`, rc=1 |
| this branch | `Test Files 1 passed`, `Tests 20 passed (20)`, rc=0 |
| this branch, guard line deleted again | `Worker exited unexpectedly`, rc=1 |

The third row is the causation check: removing only `if (pid === process.pid) return;` brings the crash straight back.