### PR TITLE
fix(ext): activate.sh never scripts a window reload on the interactive host (RUSH-2781)

### DIFF
--- a/apps/ext/scripts/activate.sh
+++ b/apps/ext/scripts/activate.sh
@@ -2,7 +2,7 @@
 #
 # Activate a freshly-installed extension in already-running editors, then prove it.
 #
-#   activate.sh <publisher.name>
+#   activate.sh <publisher.name> [--reload-windows]
 #
 # Installing writes the new version to disk, but a running editor loaded its
 # extension host once at window-open and keeps the OLD code until the window
@@ -17,12 +17,25 @@
 #
 # Reload is best-effort; the on-disk-mtime vs activation-time comparison is the
 # source of truth. A failed reload is reported, never silently assumed.
+#
+# On the fleet's interactive host (the machine the owner sits at) the script
+# only REPORTS stale windows — a scripted reload there discards in-window state
+# and steals the screen while the owner is using it (RUSH-2781). Pass
+# --reload-windows to reload anyway.
 
 set -uo pipefail
 
-EXT_FQN="${1:-}"
+EXT_FQN=""
+RELOAD_WINDOWS=0
+for ARG in "$@"; do
+    case "$ARG" in
+        --reload-windows) RELOAD_WINDOWS=1 ;;
+        -*) echo "Unknown flag: $ARG" >&2; exit 1 ;;
+        *)  EXT_FQN="$ARG" ;;
+    esac
+done
 if [ -z "$EXT_FQN" ]; then
-    echo "Usage: $0 <publisher.name>" >&2
+    echo "Usage: $0 <publisher.name> [--reload-windows]" >&2
     exit 1
 fi
 
@@ -122,6 +135,35 @@ EOF
     return 0
 }
 
+# Is THIS machine the fleet's interactive host (the one the owner sits at)?
+# Source of truth: `agents devices list --json`, the row with interactive:true.
+# Unknown — no agents CLI, no python3, or bad JSON — counts as interactive: a
+# wrongly-skipped reload costs one manual Cmd+Shift+P; a wrong reload steals
+# the owner's screen mid-use.
+is_interactive_host() {
+    command -v agents >/dev/null 2>&1 || return 0
+    command -v python3 >/dev/null 2>&1 || return 0
+    local name host
+    name="$(agents devices list --json 2>/dev/null | python3 -c '
+import json, sys
+try:
+    rows = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for r in rows:
+    if isinstance(r, dict) and r.get("interactive"):
+        print(r.get("name", ""))
+        break
+' 2>/dev/null)"
+    [ -z "$name" ] && return 0
+    if [ "$(uname -s)" = "Darwin" ]; then
+        host="$(scutil --get LocalHostName 2>/dev/null || hostname -s)"
+    else
+        host="$(hostname -s 2>/dev/null || hostname)"
+    fi
+    [ "$(printf %s "$host" | tr '[:upper:]' '[:lower:]')" = "$(printf %s "$name" | tr '[:upper:]' '[:lower:]')" ]
+}
+
 # Count windows whose host is stale (activated before INSTALL_EPOCH).
 stale_count() {
     local logdir="$1" install_ep="$2" eh ep n=0
@@ -136,6 +178,12 @@ stale_count() {
 echo
 echo "Activating $EXT_FQN in running editors..."
 OVERALL_STALE=0
+
+RELOAD_ALLOWED=1
+if [ "$RELOAD_WINDOWS" -eq 0 ] && is_interactive_host; then
+    RELOAD_ALLOWED=0
+    echo "  (interactive host — reporting only; pass --reload-windows to reload stale windows)"
+fi
 
 for CLI in code codium cursor; do
     command -v "$CLI" >/dev/null 2>&1 || continue
@@ -157,6 +205,8 @@ for CLI in code codium cursor; do
 
     if [ "$(stale_count "$LOGDIR" "$INSTALL_EP")" -eq 0 ]; then
         echo "  $CLI: already live (all windows activated after install)."
+    elif [ "$RELOAD_ALLOWED" -eq 0 ]; then
+        echo "  $CLI: stale window(s) — not reloading on the interactive host"
     else
         echo "  $CLI: stale window(s) -> reloading"
         if reload_editor_windows "$APP" "$PROC"; then

--- a/apps/ext/scripts/activate.test.sh
+++ b/apps/ext/scripts/activate.test.sh
@@ -69,6 +69,60 @@ else
 fi
 rm -f "$FUNCS"
 
+# RUSH-2781: a scripted reload on the interactive host steals the owner's
+# screen. The reload must be gated on is_interactive_host() and overridable
+# only via --reload-windows.
+if grep -q 'RELOAD_ALLOWED' "$ACTIVATE_SH" && grep -q -- '--reload-windows' "$ACTIVATE_SH"; then
+    pass "activate.sh gates reloads behind RELOAD_ALLOWED / --reload-windows"
+else
+    fail "activate.sh can still reload windows unconditionally"
+fi
+
+IHFUNCS="$(mktemp)"
+sed -n '/^is_interactive_host() {/,/^}/p' "$ACTIVATE_SH" > "$IHFUNCS"
+if [ ! -s "$IHFUNCS" ]; then
+    fail "could not extract is_interactive_host() from activate.sh"
+else
+    # shellcheck disable=SC1090
+    . "$IHFUNCS"
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+        THIS_HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s)"
+    else
+        THIS_HOST="$(hostname -s 2>/dev/null || hostname)"
+    fi
+
+    STUBS="$(mktemp -d)"
+    make_agents_stub() {
+        printf '#!/bin/bash\nprintf %%s '\''%s'\''\n' "$1" > "$STUBS/agents"
+        chmod +x "$STUBS/agents"
+    }
+
+    make_agents_stub "[{\"name\":\"$THIS_HOST\",\"interactive\":true}]"
+    if PATH="$STUBS:$PATH" is_interactive_host; then
+        pass "is_interactive_host: true when devices JSON marks this host interactive"
+    else
+        fail "is_interactive_host missed this host in the devices JSON"
+    fi
+
+    make_agents_stub '[{"name":"some-other-box","interactive":true},{"name":"x","interactive":false}]'
+    if PATH="$STUBS:$PATH" is_interactive_host; then
+        fail "is_interactive_host claimed interactive for another box's row"
+    else
+        pass "is_interactive_host: false when the interactive host is another box"
+    fi
+
+    make_agents_stub 'not json at all'
+    if PATH="$STUBS:$PATH" is_interactive_host; then
+        pass "is_interactive_host: unparseable devices JSON degrades to interactive (safe default)"
+    else
+        fail "is_interactive_host treated unparseable JSON as non-interactive"
+    fi
+
+    rm -rf "$STUBS"
+fi
+rm -f "$IHFUNCS"
+
 # A window loop that never runs must not be reported as live.
 if grep -q 'WINDOWS_SEEN' "$ACTIVATE_SH" \
    && grep -q 'UNVERIFIED' "$ACTIVATE_SH"; then


### PR DESCRIPTION
Fix — behavior change in a release script (no UI surface).

## What

RUSH-2781: during the 0.9.327 ext release, `apps/ext/scripts/activate.sh` scripted "Developer: Reload Window" on the **interactive host** (zion) while the owner was using it, discarding in-window state and stealing the screen.

`activate.sh` now:

- resolves the fleet's interactive host from `agents devices list --json` (the `interactive: true` row) and, on that machine, only **reports** stale windows — it never scripts a reload;
- accepts `--reload-windows` to restore the old behavior explicitly;
- degrades to report-only when the answer is unknowable (no `agents` CLI, no python3, unparseable JSON) — a wrongly-skipped reload costs one manual Cmd+Shift+P; a wrong reload steals the owner's screen.

Worker boxes keep the current auto-reload behavior.

## Run result

`bash apps/ext/scripts/activate.test.sh` on yosemite-s1:

```
PASS: activate.sh passes bash -n syntax check
PASS: newest_logdir skips a window-less CLI logs dir
PASS: newest_logdir returns empty when no logs dir holds a window
PASS: activate.sh gates reloads behind RELOAD_ALLOWED / --reload-windows
PASS: is_interactive_host: true when devices JSON marks this host interactive
PASS: is_interactive_host: false when the interactive host is another box
PASS: is_interactive_host: unparseable devices JSON degrades to interactive (safe default)
PASS: activate.sh reports UNVERIFIED when it inspected zero windows
All activate.sh regression tests passed.
```

Live smoke on this worker box (non-interactive; the fleet's `interactive: true` row is `zion`): `bash apps/ext/scripts/activate.sh swarmify.swarm-ext` exits 0 and does NOT print the report-only banner — reloads stay allowed off the interactive host.

## Notes

- CHANGELOG deliberately untouched: ext changelog sections are added by the release commit (`docs(ext): changelog for 0.9.327` pattern), not per-fix PRs.
- Ticket: RUSH-2781.
