### PR TITLE
ci(tests): route required test job to crabbox-ci warm pool for same-repo PRs (RUSH-2773)

### DIFF
--- a/.github/workflows/tests-gate.test.ts
+++ b/.github/workflows/tests-gate.test.ts
@@ -39,8 +39,21 @@ describe('tests.yml required Linux gate', () => {
     expect(TESTS_YML).not.toContain('--deadline-sec');
   });
 
-  test('fork code stays on GitHub-hosted runners', () => {
-    expect(TESTS_YML).toMatch(/runs-on: ubuntu-latest/);
+  test('the required test job routes by PR provenance, forks stay GitHub-hosted', () => {
+    // Two lanes, one required `test` context (RUSH-2773): same-repo PRs run on
+    // the warm crabbox-ci pool, fork PRs fall back to ubuntu-latest and never
+    // reach the self-hosted host. The routing is a single `runs-on` expression
+    // keyed on GitHub-populated context a fork cannot forge.
+    expect(TESTS_YML).toContain(
+      'github.event.pull_request.head.repo.full_name == github.repository',
+    );
+    expect(TESTS_YML).toContain(
+      `fromJSON('["self-hosted", "crabbox-ci", "tailnet"]')`,
+    );
+    // The fork lane is the GitHub-hosted runner.
+    expect(TESTS_YML).toContain("|| 'ubuntu-latest'");
+    // crabbox-ci must never appear as a bare/static runs-on a fork PR could land
+    // on — only inside the provenance-guarded expression above.
     expect(TESTS_YML).not.toMatch(/runs-on: \[self-hosted/);
     expect(TESTS_YML).not.toMatch(/phnx-trusted/);
   });

--- a/.github/workflows/tests-windows-host-e2e.yml
+++ b/.github/workflows/tests-windows-host-e2e.yml
@@ -15,11 +15,17 @@ name: Windows-host e2e (tailnet)
 # resolveRemoteDevice can dial. The pool is an org runner group restricted to
 # agents-cli + agi-cli.
 #
-# LABEL RULE: `crabbox-ci` may only appear in workflows with trusted triggers
-# (push to main / schedule / workflow_dispatch). Never on pull_request — this
-# repo is public and the runner is self-hosted, so fork PRs must never execute
-# code on it. This workflow deliberately has NO pull_request trigger. Keep it
-# that way.
+# LABEL RULE: `crabbox-ci` may appear on a trusted trigger (push to main /
+# schedule / workflow_dispatch) with a bare `runs-on: [self-hosted, crabbox-ci,
+# tailnet]`, as this workflow does. On a `pull_request` trigger it may ONLY
+# appear inside a provenance-guarded `runs-on` expression that resolves fork PRs
+# to a GitHub-hosted runner — because this repo is public and the runner is
+# self-hosted, so fork code must never execute on it. tests.yml's required
+# `test` job is the one sanctioned pull_request user of the label (RUSH-2773):
+# `runs-on: ${{ (head.repo.full_name == github.repository) && fromJSON(...) ||
+# 'ubuntu-latest' }}`. This workflow deliberately has NO pull_request trigger, so
+# it keeps the bare array. Never put a bare `runs-on: [self-hosted, crabbox-ci]`
+# on a pull_request job — that is what would let fork code onto the host.
 #
 # Tool versions are NOT pinned here — setup-bun reads from package.json; dotnet
 # matches computer-helper-win.yml (build-win.sh cross-publishes the win-x64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,19 @@ concurrency:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    # Two lanes, ONE required-check context named `test` (RUSH-2773). Same-repo
+    # PRs run on the warm `crabbox-ci` org pool (ci-runner-fsn1, Hetzner) — bun
+    # is tool-cached and the microVM is already online, so the 16-19s
+    # checkout+setup-bun cold-start tax on ubuntu-latest disappears (RUSH-2788).
+    # Fork PRs stay on GitHub-hosted ubuntu-latest and NEVER touch the
+    # self-hosted host. The routing IS the `runs-on` expression:
+    # `github.repository` and `head.repo.full_name` are GitHub-populated context
+    # a fork cannot forge, so a fork PR always resolves to ubuntu-latest. The
+    # residual "fork rewrites this file to hardcode the label" vector is bounded
+    # by the repo's fork-PR approval policy (outside contributors gated); see the
+    # PR body. Keeping a single job preserves the `Tests / test` context that
+    # branch protection and release.sh depend on.
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted", "crabbox-ci", "tailnet"]') || 'ubuntu-latest' }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
**ci-only** — no `apps/cli/src` / package behavior change. Reviewer audience: maintainers. Wires the required `Tests / test` job onto the warm `crabbox-ci` Hetzner pool for same-repo PRs, keeping fork PRs on GitHub-hosted runners.

## What changed

- **`.github/workflows/tests.yml`** — the required `test` job's `runs-on` becomes one provenance-guarded expression instead of a static `ubuntu-latest`:
  ```yaml
  runs-on: ${{ (github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted", "crabbox-ci", "tailnet"]') || 'ubuntu-latest' }}
  ```
  Same-repo PRs land on the warm crabbox-ci pool (ci-runner-fsn1, bun tool-cached, microVM already online); fork PRs resolve to `ubuntu-latest`. **Still one job named `test`** → the `Tests / test` required context that branch protection and `release.sh` depend on is preserved byte-for-byte. Steps, 25-minute timeout, and cache keys unchanged.
- **`.github/workflows/tests-gate.test.ts`** — the fork-safety test now pins the two-lane provenance policy (the guard expression, the crabbox label array, the `ubuntu-latest` fork fallback, and that no bare `runs-on: [self-hosted` can appear), so a regression to a fork-reachable static label fails the gate.
- **`.github/workflows/tests-windows-host-e2e.yml`** — comment-only. Reconciles the `LABEL RULE` (previously "crabbox-ci: never on pull_request") to permit the *provenance-guarded* pull_request use tests.yml now makes, while still forbidding a bare `runs-on: [self-hosted, crabbox-ci]` on any pull_request job.

## Why this is fork-safe

- The routing **is** the `runs-on` expression. `github.repository` (always the base repo) and `github.event.pull_request.head.repo.full_name` are GitHub-populated context values a fork **cannot forge**, so an unmodified fork PR always resolves to `ubuntu-latest` — fork code never targets the self-hosted host.
- Residual vector: a `pull_request` from a fork runs the workflow from the merge tree, so a fork could *rewrite* this file to hardcode the label. That is bounded by the repo's fork-PR approval policy — `gh api repos/phnx-labs/agents-cli/actions/permissions/fork-pr-contributor-approval` → `{"approval_policy":"first_time_contributors"}`. Recommendation (owner's call, not in this PR): tighten to `all` external contributors for full isolation.

## Blocker check (RUSH-2773)

The crabbox-ci pool is an **org-level runner group that includes this repo** — quoted from `tests-windows-host-e2e.yml:14-15`: *"The pool is an org runner group restricted to agents-cli + agi-cli."* That workflow already targets `runs-on: [self-hosted, crabbox-ci, tailnet]` (line 55). The org runner-groups API 403'd (no `admin:org` scope), so I relied on the in-repo documentation + the sibling workflow. setup-bun on the pool is the established pattern (`tests-windows-host-e2e.yml:65` uses `oven-sh/setup-bun@v2`).

## Verification (real run captured)

ci-only. Ran the exact command the required job runs and captured the output:

```
$ bun test ./.github/workflows/
bun test v1.3.14 (0d9b296a)
 11 pass
 0 fail
 31 expect() calls
Ran 11 tests across 3 files. [20.00ms]
```

Captured run log on disk (full path): `yosemite-s0:/home/muqsit/.agents/repos/ci-sub60/.agents/worktrees/ci-lane/.agents/scratch/workflows-test-run.log`

The end-to-end runnable proof is CI on this PR itself: this same-repo PR should execute its `test` job on the **crabbox-ci lane** (the workflow runs from the PR merge tree). I will confirm which lane it landed on and quote the job/step wall times on RUSH-2788 and RUSH-2773.

Ticket: RUSH-2773 (wiring) · unlocks RUSH-2788 (sub-10s cache-hit budget)
