### PR TITLE
fix(cli): unwedge release attestation — two red tests on main (RUSH-2761)

### DIFF
--- a/apps/cli/src/commands/__tests__/sessions-bookmark.cli.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-bookmark.cli.test.ts
@@ -78,6 +78,10 @@ describe('agents sessions bookmark (real CLI parse)', () => {
   // SSH-fanout peer — the flag silently did nothing and `--active --bookmarks`
   // returned the whole fleet. That is the exact command the browser's own `y`
   // copy-cmd hands to an agent.
+  // `--active` discovers real local session state (tmux panes, live processes)
+  // in addition to the fixtures this test seeds — on a busy fleet box that scan
+  // is genuinely slow, and this test drives it through several real CLI spawns.
+  // The default 30s budget is tuned for a lightweight spawn, not this cost.
   it('narrows --active to bookmarked sessions, not just in the browser', () => {
     const registry = path.join(home, '.agents', '.cache', 'terminals', 'live-terminals.json');
     fs.mkdirSync(path.dirname(registry), { recursive: true });
@@ -111,8 +115,11 @@ describe('agents sessions bookmark (real CLI parse)', () => {
     // Leave the store clean for the other cases in this file.
     run(['sessions', 'bookmark', bookmarked, '--remove']);
     fs.rmSync(registry, { force: true });
-  });
+  }, 90_000);
 
+  // Same real-discovery cost as above, across four real CLI spawns (one to
+  // index the routine archive, three `--active` queries) — see the comment
+  // on the previous test.
   it('narrows real --active JSON output to all or one named routine', () => {
     const routineName = 'nightly-review';
     const routineId = 'dddddddd-0000-0000-0000-000000000004';
@@ -199,7 +206,7 @@ describe('agents sessions bookmark (real CLI parse)', () => {
     expect(named.map((row) => row.sessionId)).toEqual([routineId]);
 
     fs.rmSync(registry, { force: true });
-  });
+  }, 90_000);
 
   it('bookmarks a complete id with no transcript row — a live session may not be indexed yet', () => {
     const fresh = 'cccccccc-0000-0000-0000-000000000003';

--- a/apps/cli/src/lib/project-key.ts
+++ b/apps/cli/src/lib/project-key.ts
@@ -55,6 +55,12 @@ export function repoRootForCwd(dir: string, home: string = os.homedir()): string
   let current = path.resolve(dir);
   for (;;) {
     if (fs.existsSync(path.join(current, '.git'))) return current === stop ? undefined : current;
+    // Never climb past $HOME: an ancestor of home (/tmp, /, ...) is not part of
+    // any project this cwd belongs to, and treating one as the repo root would
+    // let unrelated host state (e.g. a stray /tmp/.git) swallow every loose
+    // directory under home. Mirrors the shim's own home boundary — see
+    // shims.ts shimExecTail.
+    if (current === stop) return undefined;
     const parent = path.dirname(current);
     if (parent === current) return undefined;
     current = parent;


### PR DESCRIPTION
bugfix — restores two red tests on `main` so `release-attestation-produce.sh` can attest again (RUSH-2761); 50+ commits are stuck unreleased since v1.22.40.

## Run evidence

Full real test-run log (both files, 3x each, plus a per-test verbose breakdown): https://share.agents-cli.sh/muqsitnawaz/red-tests-rush-2761-test-run-7a55476daf3d4aae

## What broke

**`apps/cli/src/lib/project-key.test.ts`** — `falls back to the directory itself when nothing above it is a repo` failed with `expected '/tmp' to be undefined`.

`repoRootForCwd` walks up from a cwd looking for `.git`, and was meant to stop at `$HOME` — the shim's own mirrored comment says so explicitly (`shims.ts:364-366`: *"Stop before $HOME so a dotfiles repo at $HOME is not treated as the project root"*). But the TS implementation only special-cased finding `.git` *exactly at* home; it never actually bounded the walk there, so it kept climbing past home into ancestor directories. This host has a stray `/tmp/.git` (unrelated leftover state), so the walk found it and returned `/tmp` instead of `undefined`.

Fix: stop the walk once `current === home`, matching the documented/intended boundary. `project-key.ts:53-65`.

**`apps/cli/src/commands/__tests__/sessions-bookmark.cli.test.ts`** — `narrows real --active JSON output to all or one named routine` timed out at 30000ms (measured 39545ms), then a vitest worker fork error.

This is a real-CLI-spawn test (no mocking) that drives `agents sessions --active --local --json` several times. `--active` discovery scans real local session state (tmux panes, live processes) regardless of the fake `HOME` the test seeds — confirmed by spawning it manually with an isolated `HOME` and watching it still report this box's actual tmux socket and real live sessions. On a busy fleet host that scan is genuinely slow and the cost scales with how busy the *host* is, not with the test's own fixtures — not a hang, a legitimate real-discovery cost crossing the default 30s budget under load.

Fix: bump the two tests that drive multiple real `--active` spawns to a 90s budget — matching the existing 60s precedent for other real-CLI-spawn tests in this suite (`message.host-route.integration.test.ts`, `sessions.test.ts`, `exec.test.ts`).

## Verification

Both files run green, 3x each, in this worktree AND at a fully detached checkout of `origin/main` + this diff (`git worktree add --detach`):

```
project-key.test.ts:              19 passed (19)  — 3x, ~3.1-3.2s each
sessions-bookmark.cli.test.ts:    12 passed (12)  — 3x, ~36-37s each (real CLI spawns)
detached checkout, both files:    31 passed (31)  — 3x, ~36-37s each
```

Also ran the broader consumer suite (`codex-policy`, `feed/activity`, `feed-ranking`, `projects`, `commands/feed`, `commands/sessions`) since `project-key.ts` is a shared cwd→project fold — 268 tests, all green, no regressions from bounding the walk at home.

## Files changed

- `apps/cli/src/lib/project-key.ts` — bound `repoRootForCwd`'s upward walk at `$HOME` (real product bug)
- `apps/cli/src/commands/__tests__/sessions-bookmark.cli.test.ts` — 90s timeout on the two tests that drive several real `--active` spawns (test-only)

RUSH-2761