### PR TITLE
docs: repoint 37 stale code citations left behind by the daemon/installations directory moves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ and [`architecture.md`](apps/cli/docs/architecture.md).
   snapshots, the device registry). Where an action needs a UI-owned surface, the UI
   exposes a narrow endpoint the CLI drives (the `/inject` verb is the precedent) — the
   trigger stays in the CLI. Routines are covered by the same rule: `agents routines` +
-  the daemon's pid-claimed scheduler (`apps/cli/src/lib/daemon.ts`) are the only cron
+  the daemon's pid-claimed scheduler (`apps/cli/src/lib/daemon/daemon.ts`) are the only cron
   that fires them; a UI button may *request* a run, never *schedule* one. **Multiple
   devices are fine — shared queues are not.** Every device runs its own daemon, and
   an unrestricted routine MAY fire on all of them when its input is the firing

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -483,7 +483,7 @@ sessions/config; `agents add gemini`, `agents import gemini`, and
 ```
 src/
   index.ts             # CLI entry (commander.js)
-  commands/            # User-facing subcommands (one file — or a `<cmd>-*.ts` family, e.g. the 14 `sessions*.ts` files — per `agents <cmd>`)
+  commands/            # User-facing subcommands (one file — or a `<cmd>-*.ts` family, e.g. the `sessions*.ts` family — per `agents <cmd>`)
   lib/
     state.ts           # Path constants; agents.yaml read/write (serializeCentral preserves comments)
     manifest.ts        # Project/user agents.yaml Manifest read/write (comment-preserving Document round-trip; used by mcp add, etc.)

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -483,7 +483,7 @@ sessions/config; `agents add gemini`, `agents import gemini`, and
 ```
 src/
   index.ts             # CLI entry (commander.js)
-  commands/            # User-facing subcommands (one file per `agents <cmd>`)
+  commands/            # User-facing subcommands (one file — or a `<cmd>-*.ts` family, e.g. the 14 `sessions*.ts` files — per `agents <cmd>`)
   lib/
     state.ts           # Path constants; agents.yaml read/write (serializeCentral preserves comments)
     manifest.ts        # Project/user agents.yaml Manifest read/write (comment-preserving Document round-trip; used by mcp add, etc.)
@@ -491,7 +491,7 @@ src/
     capabilities.ts    # supports() — the per-agent write gate
     agents.ts          # Per-agent capability table
     subagents-registry.ts  # SUBAGENT_TARGETS — declarative per-agent subagent shape (dir/layout/transform); generic install/list/remove engine
-    versions.ts        # Install, remove, syncResourcesToVersion
+    installations/     # versions.ts (install, remove, syncResourcesToVersion), migrate.ts (one-shot idempotent migrations), store/resolve/strategies
     shims.ts           # Shim generation, config symlink switching
     hooks.ts           # hooks.yaml parser + per-agent registrar
     hooks/match.ts     # `matches:` predicate evaluator
@@ -499,7 +499,6 @@ src/
     monitors/          # `agents monitors` — event-triggered watchers (source→condition→action); native state-diff store; MonitorEngine runs in the daemon beside the cron scheduler. See docs/monitors.md
     projects.ts        # `agents projects` — named multi-repo project defs (~/.agents/projects/*.yaml) layered above the --project convention (resolveProjectRef in project-root.ts); project-status.ts rolls live sessions + merged PRs + artifacts into the progress card. Beta-gated. See docs/projects.md
     project-pull.ts    # `agents projects pull` — fleet fan-out logic: pullProjectTargets (sequential local fast-forward + per-target repo-slug verification), pullLocalArgs/encodePullTargets/decodePullTargets (the {path, expectedSlug} CLI-arg hop to each peer's hidden `pull-local` — bare paths would disable slug verification remotely AND break the fingerprint), buildPullEnvelope/parseProjectPullEnvelope (fail-closed AND fail-loud: a rejected envelope returns valid:false so the peer lands in parseFailed and exits non-zero, never a silent empty result set), printProjectPullSummary. Strict safe contract: dirty trees and non-default branches are blocked; missing checkouts are skipped, never cloned. See docs/projects.md §Pulling every reachable checkout
-    migrate.ts         # One-shot idempotent migrations
     session/           # `agents sessions` READER — discovery/parse/render of agent transcripts; also `migrate-targets.ts` (the `sessions migrate` target scorer); `db.ts` `queryResourceUsageStats`/`backfillResourceUsage` back `agents sessions stats` + `sessions backfill resources` (skill/command usage rollup, session_resource_usage + resource_scan_ledger); `claude-accounts.ts` attributes each Claude transcript to the account that produced it (account_key) and `insights.ts` extracts the cached multi-harness friction/correction/automation facets behind `agents sessions insights` (`agents insights` alias)
     terminal/          # Terminal launch engine — tab/split in iTerm/Ghostty/tmux/Terminal.app, local or --device;
                        #   preferred.ts resolves WHICH terminal for a GUI caller (from live sessions' host app)

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -663,7 +663,7 @@ efficiently — like the ssh/remote-browser pattern."
 ### 5. Scheduling — falls out of the existing daemon
 
 Scheduled fleet dispatch needs **no new machinery**: the routines scheduler
-(`src/lib/daemon.ts`) fires jobs on cron; a job whose command is `agents run …
+(`src/lib/daemon/daemon.ts`) fires jobs on cron; a job whose command is `agents run …
 --on <host>` is a scheduled remote dispatch. Online-gating is the same lazy SSH
 probe `ensureHostReady` already does (skip/retry if the one targeted host is
 unreachable) — no fleet poll. (We do **not** turn the scheduler into an RPC
@@ -889,7 +889,7 @@ just relocates the storm):
 | Incremental offset read | `src/lib/session/active.ts:200-248` |
 | Per-agent transcript dirs | `src/lib/session/discover.ts:getAgentSessionDirs` |
 | Cross-machine transcript transport | `src/commands/sessions-migrate.ts` (direct SSH, shipped) — the CRDT G-Set / R2 background-sync substrate this row originally named has been removed |
-| Scheduling | `src/lib/daemon.ts` (routines scheduler) |
+| Scheduling | `src/lib/daemon/daemon.ts` (routines scheduler) |
 | Task tracking store | `src/lib/cloud/store.ts` (free-text `provider`, reserved `provider_data`) |
 | Config schema | `src/lib/types.ts` (`Meta`) + `src/lib/state.ts` (`readMeta`) |
 | Config bootstrap on host | `agents repo pull user` (git-backed) + `scripts/sandbox.sh:218-239` |

--- a/apps/cli/docs/routines.md
+++ b/apps/cli/docs/routines.md
@@ -718,7 +718,7 @@ device manifest.
 ### Daemon-core housekeeping (not a routine you manage)
 
 The daemon's own housekeeping — session-cache warming, device probing, and the
-watchdog — runs as plain `setInterval` timers in `lib/daemon.ts`
+watchdog — runs as plain `setInterval` timers in `lib/daemon/daemon.ts`
 (`runActiveSessionsWarm`, `runDeviceProbeTick`, `runWatchdogTick`), not as
 entries under `agents routines`. This replaced an earlier `builtin-routines.ts`
 registry that surfaced them as `(built-in)`-tagged routines with
@@ -737,7 +737,7 @@ repairs every managed session's hook once at startup, and `agents run
 --resume`/`agents focus`/`agents go`/`agents tmux attach` each repair the ONE
 session they're about to attach to right before attaching
 (`ensureSessionHookRepaired`, `lib/tmux/session.ts`). A version-skew one-shot at
-upgrade time (`runMigration`, `lib/migrate.ts`) covers a machine that upgrades
+upgrade time (`runMigration`, `lib/installations/migrate.ts`) covers a machine that upgrades
 without immediately restarting its daemon.
 
 ### Legacy device allowlists

--- a/apps/cli/docs/secrets-agent-process-model.md
+++ b/apps/cli/docs/secrets-agent-process-model.md
@@ -30,7 +30,7 @@ process that holds unlocked bundles in memory behind a `0700` Unix socket, so
 concurrent agents stop re-prompting Touch ID per process. It currently runs as
 its own launchd user service, `com.phnx-labs.agents-secrets-agent`.
 
-The **routines daemon** (`src/lib/daemon.ts`, `com.phnx-labs.agents-daemon`)
+The **routines daemon** (`src/lib/daemon/daemon.ts`, `com.phnx-labs.agents-daemon`)
 already hosts a socket IPC service of the same shape — `BrowserIPCServer` — which
 prompted the question: *isn't the broker a second daemon we don't need? Fold it
 into the routines daemon.*

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -65,7 +65,7 @@ guarantee, the reference for the mechanism.
 guarantee.** The CLI registers **100 top-level names** across **81 distinct
 loaders** — the difference is aliases and multi-command modules (`ssh`/`devices`/`fleet`
 share one; `add`/`use`/`remove`/`rm`/`purge` another) — in `COMMAND_LOADERS`
-(`lib/startup/command-registry.ts:146`, *"Parity is non-negotiable: the name -> loader
+(`cli/command-registry.ts:146`, *"Parity is non-negotiable: the name -> loader
 map below mirrors exactly which module registers which top-level command on `main`"*).
 Five subsystems have a normative contract. Before relying on a behavior, check which
 row its surface sits in.
@@ -2023,7 +2023,7 @@ schema (`--json` passes through each agent's native stream format).
   (`lib/exec.ts:211-294`).
 - **Version home** — the isolated config directory for one installed agent
   version, `getVersionHomePath(agent, version)` = `<versionDir>/home`
-  (`lib/versions.ts:1054-1056`).
+  (`lib/installations/versions.ts:1054-1056`).
 - **Chain / fallback entry** — one `{ agent, version?, envOverride? }` in a
   `--fallback` sequence tried in order on rate-limit failure
   (`lib/exec.ts:2272-2281`).
@@ -2133,7 +2133,7 @@ schema (`--json` passes through each agent's native stream format).
 
 - **EXEC-13 (MUST).** Every installed agent version has an isolated home
   directory: `getVersionHomePath(agent, version)` =
-  `<historyDir>/versions/<agent>/<version>/home` (`lib/versions.ts:1050-1056`,
+  `<historyDir>/versions/<agent>/<version>/home` (`lib/installations/versions.ts:1050-1056`,
   doc comment: *"Each version has its own config isolation (like jobs
   sandbox)."*).
 - **EXEC-14 (MUST, scoped).** `buildExecEnv` realizes that isolation ONLY for
@@ -2182,7 +2182,7 @@ schema (`--json` passes through each agent's native stream format).
   (no global `~/.cursor` symlink swap — concurrent runs on different accounts do
   not clobber one another). `CREDENTIAL_FILE_SEGMENTS.cursor`
   (`lib/agents.ts`) verifies signed-in per home against that token, and
-  `seedActiveCursorLoginPerVersion` (`lib/migrate.ts`) migrates the legacy
+  `seedActiveCursorLoginPerVersion` (`lib/installations/migrate.ts`) migrates the legacy
   global token into the active account's home on upgrade. The versioned-alias
   shim mirrors the same `XDG_CONFIG_HOME` export (`CONFIG_ENV_ISOLATED_AGENTS`
   includes cursor). Cursor's HOME-relative `~/.cursor` (cli-config.json,
@@ -2308,7 +2308,7 @@ schema (`--json` passes through each agent's native stream format).
   "the remote's own exit code, or 1 if unknown".
 
   **Known cost (accepted).** The daemon reaps any session whose panes are all
-  dead every `DEAD_PANE_REAP_TICK_MS` (5 min, `lib/daemon.ts`). A cleanly
+  dead every `DEAD_PANE_REAP_TICK_MS` (5 min, `lib/daemon/daemon.ts`). A cleanly
   exited run is in that state between its pane dying and `paneExitStatus`
   reading it, so a tick landing inside that one-tmux-round-trip window leaves
   the pane unreadable and a genuinely successful run resolves `1`. Once the
@@ -2485,7 +2485,7 @@ themselves are normative in [§Secrets](#secrets) — SEC-6..SEC-14 govern.)
   MUST NOT throw out of `applyActiveRulesPresetAtRun` — every failure mode
   is caught and the function returns `false` (no write attempted), mirroring
   `syncResourcesToVersion`'s own catch-and-skip for rules
-  (`lib/rules/run-sync.ts:95-98,108-112`; `lib/versions.ts:2952-2960`).
+  (`lib/rules/run-sync.ts:95-98,108-112`; `lib/installations/versions.ts:2952-2960`).
 - **EXEC-47 (scope, not a bug).** The auto-apply is VERSION-scoped only —
   keyed by `(agent, version)`, matching `getActiveRulesPreset`. Per-model
   preset scoping (a different active preset per `--model` within the same
@@ -2719,7 +2719,7 @@ nothing but its own view cache.
 
 - **SING-1 (MUST).** Every fleet-affecting capability MUST have exactly one scheduler
   and one executor: the agi-cli daemon (`agents __daemon-run`,
-  `apps/cli/src/lib/daemon.ts`) or a CLI command the daemon or the user drives.
+  `apps/cli/src/lib/daemon/daemon.ts`) or a CLI command the daemon or the user drives.
   Status: **Current** for routines (`lib/scheduler.ts`) and rotate
   (`lib/watchdog/rotate.ts`). `agents daemon` is the user-facing runtime
   surface for this singular process (`start`/`stop`/`restart`/`reload`/
@@ -2747,7 +2747,7 @@ nothing but its own view cache.
   hook once at startup, `ensureSessionHookRepaired` (`lib/tmux/session.ts`)
   repairs a single session right before each of `agents run
   --resume`/`focus`/`go`/`tmux attach` attaches to it, and `runMigration`
-  (`lib/migrate.ts`) repairs the fleet again at upgrade time as the
+  (`lib/installations/migrate.ts`) repairs the fleet again at upgrade time as the
   version-skew one-shot.
 - **SING-1a (MUST).** Ordinary usage/auth consumers MUST be cache-only. This
   includes routing (`agents run` and teams), `view`, `versions`, `usage`, device
@@ -2786,7 +2786,7 @@ nothing but its own view cache.
   gates only the UI's view of an action MUST NOT exist.
 - **SING-4a (MUST).** A device-local `daemon.enabled: false` (`lib/device-config.ts`,
   `agents daemon disable`) MUST prevent every AUTO-start surface from bringing the
-  daemon up — `ensureDaemonStarted` (`lib/daemon.ts`) and every `routines`
+  daemon up — `ensureDaemonStarted` (`lib/daemon/daemon.ts`) and every `routines`
   auto-start call site (`add`, `start`, `catchup`, webhook triggers,
   `commands/routines.ts`). It MUST NOT stop an already-running daemon and MUST NOT
   block the explicit override (`agents daemon start`), mirroring `systemctl
@@ -2796,7 +2796,7 @@ nothing but its own view cache.
   `daemon.enabled` gates whether the daemon itself may be auto-started at all
   (the secrets broker, browser IPC, and watchdog with it).
 - **SING-5 (MUST).** Routines MUST fire only from the daemon's pid-claimed
-  `JobScheduler` (`lib/daemon.ts` — the pid-file claim exists precisely so a second
+  `JobScheduler` (`lib/daemon/daemon.ts` — the pid-file claim exists precisely so a second
   scheduler cannot double-fire). A UI MAY request an immediate run
   (`agents routines run <name>` or equivalent) but MUST NOT hold its own cron,
   countdown, or "run every N" for a routine.
@@ -2927,7 +2927,7 @@ a machine-wide process sweep.)
   never defer to it. The takeover target is the live owner of THIS state dir's pid file
   (`resolveLiveDaemonPid`) and nothing else — a daemon serving a DIFFERENT state dir
   (its own `HOME`, a test fixture) MUST be left completely untouched.
-  `claimDaemonInstance` (`lib/daemon.ts`) SIGTERMs the live pid-file owner and MUST
+  `claimDaemonInstance` (`lib/daemon/daemon.ts`) SIGTERMs the live pid-file owner and MUST
   wait for it to be provably dead — its graceful `handleShutdown` releasing the
   browser IPC binding (`await browserIPC.stop()`) and the secrets broker socket
   (`hostedBroker?.close()`), or a `killTree` escalation (POSITIVE pid, so the kill never
@@ -2935,7 +2935,7 @@ a machine-wide process sweep.)
   **before binding any of its own resources**. Binding before the incumbent's
   release recreates the two-brokers-on-one-socket orphan (`daemon.ts` broker
   hosting), so the pid file MUST NOT be written until the prior owner is dead.
-  `reapStrayDaemons` (`lib/daemon.ts`) reaps only registrants of THIS state dir's
+  `reapStrayDaemons` (`lib/daemon/daemon.ts`) reaps only registrants of THIS state dir's
   instance registry (`<daemonDir>/instances/`) — because the registry lives inside the
   daemon dir, a different state dir's daemons register elsewhere and are invisible, so
   the reaper is state-dir-scoped by construction, never `process.argv[1]`-scoped and
@@ -2956,16 +2956,16 @@ a machine-wide process sweep.)
   still the intended live process and adopt it, or reap the dangling daemon, browser,
   tunnel, or keychain-helper process without targeting an unrelated or detached routine
   process. The recovery layers are the state-directory lifetime self-check
-  (`lib/daemon.ts:925-957`), the state-directory-scoped daemon registry and
-  `reapStrayDaemons` (`lib/daemon.ts:348-394`), browser/tunnel orphan reaping
-  (`lib/daemon.ts:800-815`), the keychain helper reaper's pid/start-time identity
+  (`lib/daemon/daemon.ts:925-957`), the state-directory-scoped daemon registry and
+  `reapStrayDaemons` (`lib/daemon/daemon.ts:348-394`), browser/tunnel orphan reaping
+  (`lib/daemon/daemon.ts:800-815`), the keychain helper reaper's pid/start-time identity
   checks (`lib/secrets/reaper.ts:20-40`, `lib/secrets/reaper.ts:68-101`), and the
   orphaned-`watch-lock` reaper (RUSH-2419) that recovers the one deliberately
   long-lived helper when its owning daemon is provably dead
-  (`lib/secrets/reaper.ts:156-180`, wired into the reap tick at `lib/daemon.ts:911`).
+  (`lib/secrets/reaper.ts:156-180`, wired into the reap tick at `lib/daemon/daemon.ts:911`).
   Every daemon-owned process class — daemon, browser, tunnel, and keychain helper
   including the `watch-lock` watcher — has a recovery layer.
-- **SING-12 (MUST).** `stopDaemon` (`lib/daemon.ts`) MUST assert its postcondition,
+- **SING-12 (MUST).** `stopDaemon` (`lib/daemon/daemon.ts`) MUST assert its postcondition,
   not assume it: after the SIGTERM → grace → `killTree` sequence it MUST verify the
   browser IPC binding was released, the secrets broker socket was released (a stale
   socket present on disk but unreachable is the orphan of SING-11 — a still-live
@@ -2982,9 +2982,9 @@ a machine-wide process sweep.)
   and the daemon's instance-registry entry. The shutdown postcondition MUST name any
   survivor and MUST NOT report success merely because the daemon process exited. The
   graceful path already attempts all six releases in `handleShutdown`
-  (`lib/daemon.ts:1033-1054`); `stopDaemon` independently verifies the full inventory
-  via `stopResidueArtifacts` (`lib/daemon.ts:1596-1640`), consumed at
-  `lib/daemon.ts:1825-1831` on both the graceful and escalated `killTree` paths, and
+  (`lib/daemon/daemon.ts:1033-1054`); `stopDaemon` independently verifies the full inventory
+  via `stopResidueArtifacts` (`lib/daemon/daemon.ts:1596-1640`), consumed at
+  `lib/daemon/daemon.ts:1825-1831` on both the graceful and escalated `killTree` paths, and
   distinguishes residue from a provably dead owner (reclaimed) from state belonging to
   a live successor (left untouched) the same way the broker-socket branch above does
   (RUSH-2421, SING-GAP-5 resolved).
@@ -2992,9 +2992,9 @@ a machine-wide process sweep.)
   daemon start MUST NOT cycle through unbounded rapid retries: the service manager MUST
   enforce a restart interval and burst limit, and `ensureDaemonStarted` MUST stop
   initiating starts after a bounded number of consecutive failures until the circuit
-  breaker resets. `generateLaunchdPlist` sets `ThrottleInterval` (`lib/daemon.ts:1117`)
+  breaker resets. `generateLaunchdPlist` sets `ThrottleInterval` (`lib/daemon/daemon.ts:1117`)
   and `generateSystemdUnit` sets `StartLimitIntervalSec`/`StartLimitBurst`
-  (`lib/daemon.ts:1154-1155`); `isDaemonAutostartCircuitOpen` (`lib/daemon.ts:1253-1261`)
+  (`lib/daemon/daemon.ts:1154-1155`); `isDaemonAutostartCircuitOpen` (`lib/daemon/daemon.ts:1253-1261`)
   is the `consecutiveFailures`-driven circuit breaker `ensureDaemonStarted` consults,
   and `index.ts:255-256` adds top-level `uncaughtException`/`unhandledRejection`
   handlers so a startup crash always reaches the now-throttled supervisor rather than
@@ -3007,7 +3007,7 @@ a machine-wide process sweep.)
   receiver's signing secret resolves headlessly through the broker
   (`resolveReceiverSecrets`, `agentOnly: true` per SEC-13) — no
   `AGENTS_SECRETS_PASSPHRASE` and no `nohup`. Every receiver MUST be torn down on
-  shutdown (`handleShutdown`, `lib/daemon.ts`). A box that declares no receiver
+  shutdown (`handleShutdown`, `lib/daemon/daemon.ts`). A box that declares no receiver
   MUST bind nothing. A receiver whose bundle is locked or carries neither
   `GITHUB_WEBHOOK_SECRET` nor `LINEAR_WEBHOOK_SECRET` MUST fail LOUD — logged and
   skipped, never bound with an unverifiable signature — and MUST NOT take the
@@ -3060,7 +3060,7 @@ a machine-wide process sweep.)
   makes the newcomer the survivor: `claimDaemonInstance` SIGTERMs the incumbent,
   waits for it to be provably dead (releasing its broker + browser IPC), then binds,
   so exactly one daemon is ever alive and no two `JobScheduler`s run concurrently
-  (`lib/daemon.ts`, SING-11). The first-wins path where the newcomer exited and left
+  (`lib/daemon/daemon.ts`, SING-11). The first-wins path where the newcomer exited and left
   the incumbent running is gone.
 - **GIVEN** the incumbent daemon has an in-flight detached routine child running,
   **WHEN** takeover evicts that daemon, **THEN** the child survives (a different
@@ -3140,7 +3140,7 @@ a machine-wide process sweep.)
   it from the periodic keychain reaper, so an OOM-kill, a raw SIGKILL, or the daemon's own
   `killTree` escalation of a wedged daemon left it orphaned with no automatic recovery. The
   daemon now runs a separate orphaned-`watch-lock` reaper path (`planKeychainReap`,
-  `lib/secrets/reaper.ts:156-180`, wired into the reap tick at `lib/daemon.ts:911`), gated
+  `lib/secrets/reaper.ts:156-180`, wired into the reap tick at `lib/daemon/daemon.ts:911`), gated
   by `isWatchLockHelperCommand` (`lib/secrets/reaper.ts:262`): it kills a `watch-lock` only
   when the owning daemon is provably absent from the `ps` snapshot (`ppid === 1`, or the
   parent pid missing), behind the `ORPHAN_GRACE_SEC` grace and a fail-closed start-time
@@ -3152,7 +3152,7 @@ a machine-wide process sweep.)
   lifetime marker, heartbeat file, or instance-registry entry, which `handleShutdown`'s
   graceful path releases but the escalated (`killTree`) path left stale with no
   postcondition check. `stopDaemon` now runs `stopResidueArtifacts`
-  (`lib/daemon.ts:1596-1640`) unconditionally on both paths, reclaiming residue from a
+  (`lib/daemon/daemon.ts:1596-1640`) unconditionally on both paths, reclaiming residue from a
   provably dead owner and leaving alone anything a live successor owns
   (`daemon.test.ts` covers both the escalated-reclaim case and the live-owner-protection
   case). Both socket teardowns now await the real `net.Server` `'close'` event instead of
@@ -3166,9 +3166,9 @@ a machine-wide process sweep.)
   `StartLimitBurst`, and `ensureDaemonStarted` had no circuit breaker reading
   `consecutiveFailures` — so a daemon that failed on every startup restarted in an
   unbounded ~10s cycle. `generateLaunchdPlist` now sets `ThrottleInterval`
-  (`lib/daemon.ts:1117`), `generateSystemdUnit` sets `StartLimitIntervalSec`/
-  `StartLimitBurst` (`lib/daemon.ts:1154-1155`), and `isDaemonAutostartCircuitOpen`
-  (`lib/daemon.ts:1253-1261`) gates further auto-starts once
+  (`lib/daemon/daemon.ts:1117`), `generateSystemdUnit` sets `StartLimitIntervalSec`/
+  `StartLimitBurst` (`lib/daemon/daemon.ts:1154-1155`), and `isDaemonAutostartCircuitOpen`
+  (`lib/daemon/daemon.ts:1253-1261`) gates further auto-starts once
   `DAEMON_AUTOSTART_FAILURE_LIMIT` consecutive claims have failed, reported by
   `agents daemon doctor`/`status`. `index.ts:255-256` adds top-level
   `uncaughtException`/`unhandledRejection` handlers so a crash during startup always

--- a/apps/cli/docs/subagents.md
+++ b/apps/cli/docs/subagents.md
@@ -59,7 +59,7 @@ identically — the long tail should cost far less than the core.
 |------|--------|-------------------------------------|
 | **Tier 1 — core** | `claude`, `codex`, `cursor` | First-class. Full support; bespoke transform/format work where the native format demands it. New subagent capabilities land here first. |
 | **Tier 2 — established** | `openclaw`, `grok`, `droid`, `copilot`, `kiro`, `opencode` | Supported, ride the generic registry path. A bespoke `transform` only where the on-disk format differs — never bespoke install/list/remove logic. |
-| **Tier 3 — long-tail** | `goose`, `antigravity`, `kimi` | Config-only; spend the minimum. A new one is a single `SUBAGENT_TARGETS` entry. `kimi` is a plain `flatFile` writing Claude-shaped `<name>.md`; the pre-0.29.0 files agents-cli used to write there (a `<name>.yaml` + `<name>.system.md` pair and an `_agents-cli.yaml` index) are folded once by `migrateKimiSubagentsToMarkdown` in `lib/migrate.ts`, never by the target. |
+| **Tier 3 — long-tail** | `goose`, `antigravity`, `kimi` | Config-only; spend the minimum. A new one is a single `SUBAGENT_TARGETS` entry. `kimi` is a plain `flatFile` writing Claude-shaped `<name>.md`; the pre-0.29.0 files agents-cli used to write there (a `<name>.yaml` + `<name>.system.md` pair and an `_agents-cli.yaml` index) are folded once by `migrateKimiSubagentsToMarkdown` in `lib/installations/migrate.ts`, never by the target. |
 
 **Adding a standard integration (Tier 2/3) is one entry, not six edits.** Give the
 agent a `subagents` gate in `src/lib/agents.ts`, add one entry to `SUBAGENT_TARGETS`

--- a/apps/cli/docs/watchdog.md
+++ b/apps/cli/docs/watchdog.md
@@ -164,7 +164,7 @@ persisted result and never executes a pass.
 
 | File | Role |
 |---|---|
-| `lib/daemon.ts` | Sole automatic scheduler: one non-overlapping pass every three minutes. |
+| `lib/daemon/daemon.ts` | Sole automatic scheduler: one non-overlapping pass every three minutes. |
 | `lib/watchdog/runner.ts` | One tick: enumerate → classify → decide (deterministic + smart) → deliver → log. |
 | `lib/watchdog/watchdog.ts` | `WATCHDOG_SYSTEM_PROMPT`, playbook composition, prompt render, response parse. |
 | `lib/watchdog/read.ts` | Locate a transcript and read its tail; stall thresholds. |


### PR DESCRIPTION
docs-only — no behavior change. Audience: maintainers (these are the file:line citations agents follow when reading the spec).

## What changed

`lib/daemon.ts`, `lib/migrate.ts`, and `lib/versions.ts` were moved into `lib/daemon/` and `lib/installations/` some time ago, but 37 citations across 7 doc files were never repointed — including the normative `specifications.md` (29 of them). All now point at the real files:

| Stale citation | Now |
|---|---|
| `lib/daemon.ts` | `lib/daemon/daemon.ts` |
| `lib/migrate.ts` | `lib/installations/migrate.ts` |
| `lib/versions.ts` | `lib/installations/versions.ts` |
| `lib/startup/command-registry.ts:146` (`COMMAND_LOADERS`) | `cli/command-registry.ts:146` |

Also in `apps/cli/AGENTS.md`: the Source-layout tree listed `versions.ts`/`migrate.ts` as direct `lib/` children (contradicting the same file's own correct links at lines 58/162) — replaced with an `installations/` entry — and the `commands/` line claimed one file per command when `agents sessions` alone spans 14 `sessions*.ts` files.

Left alone: `docs/examples/sessions/claude/*` (21 matches) — captured session fixtures, recorded data rather than claims.

## Verification

- Every repointed target exists on this branch (`ls` over all four paths).
- `apps/cli/scripts/verify-docs.sh` passes (note: it checks markdown links only, not `file:line` citations — which is why this drift was invisible to CI).

Found by the /code:refactor evidence scan (docs-as-claims pass) run against origin/main.
