### PR TITLE
refactor(commands): one sessions-picker factory behind the browser/computer twins (move 6)

### DIFF
--- a/apps/cli/src/commands/browser-sessions-picker.ts
+++ b/apps/cli/src/commands/browser-sessions-picker.ts
@@ -7,12 +7,14 @@
  * Reuses the same `itemPicker` + `buildPreview` primitives as the ordinary
  * session picker (`sessions-picker.ts`) — same search/filter/quit help, and the
  * preview pane for a linked task IS the canonical session digest, not a
- * second renderer.
+ * second renderer. Interactive routing and the browse loop live in
+ * `sessions-picker-factory.ts` (shared with the computer twin).
  */
 import chalk from 'chalk';
 import { itemPicker } from '../lib/picker.js';
-import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import { isPromptCancelled } from './utils.js';
 import { buildPreview } from './sessions-picker.js';
+import { createSessionsPickerCommand } from './sessions-picker-factory.js';
 import {
   runBrowserSessions,
   buildBrowserSessionRows,
@@ -31,32 +33,6 @@ export interface BrowserSessionsCommandOpts {
   json?: boolean;
   /** Commander's `--no-interactive` convention: `false` opts out. */
   interactive?: boolean;
-}
-
-/** True when the interactive picker should open instead of the printed table:
- *  a real TTY, no `--json`/`--open`, and `--no-interactive` not set. */
-export function shouldOpenInteractiveBrowserSessions(opts: BrowserSessionsCommandOpts, isTTY: boolean): boolean {
-  return opts.interactive !== false && !opts.json && opts.open === undefined && isTTY;
-}
-
-/**
- * Shared entry point for `agents browser sessions` and `agents sessions
- * --browser`. Replaces direct calls to `runBrowserSessions` at both call
- * sites so the interactive routing decision lives in one place.
- */
-export async function runBrowserSessionsCommand(opts: BrowserSessionsCommandOpts): Promise<void> {
-  if (!shouldOpenInteractiveBrowserSessions(opts, isInteractiveTerminal())) {
-    runBrowserSessions({ profile: opts.profile, open: opts.open, json: opts.json });
-    return;
-  }
-
-  const rows = buildBrowserSessionRows(opts.profile);
-  if (rows.length === 0) {
-    console.log(`No browser captures found${opts.profile ? ` for profile "${opts.profile}"` : ''}.`);
-    return;
-  }
-
-  await browseAndOpen(rows);
 }
 
 const KIND_LABEL: Record<ArtifactKind, string> = {
@@ -145,43 +121,6 @@ function openAndReport(a: BrowserArtifact): void {
   if (!openArtifact(a.path)) console.error(`Could not open ${a.path}`);
 }
 
-/** Task-level picker with a captures preview, then an artifact drill-down when
- *  a task holds more than one capture. Loops until the user quits (esc) so a
- *  capture-heavy task can be browsed and opened repeatedly in one session. */
-async function browseAndOpen(rows: BrowserSessionRow[]): Promise<void> {
-  for (;;) {
-    let picked;
-    try {
-      picked = await itemPicker<BrowserSessionRow>({
-        message: 'Browser sessions:',
-        items: rows,
-        filter: (query) => (query.trim() ? rows.filter((r) => matchesBrowserSessionRow(r, query)) : rows),
-        labelFor: (row) => formatRowLabel(row),
-        buildPreview: (row) => buildRowPreview(row),
-        emptyMessage: 'No browser sessions match.',
-        enterHint: 'open capture',
-      });
-    } catch (err) {
-      if (isPromptCancelled(err)) return;
-      throw err;
-    }
-    if (!picked) return;
-
-    const row = picked.item;
-    if (row.artifacts.length === 0) {
-      console.log('No captures in this task yet.');
-      continue;
-    }
-    if (row.artifacts.length === 1) {
-      openAndReport(row.artifacts[0]);
-      continue;
-    }
-
-    const artifact = await pickArtifact(row);
-    if (artifact) openAndReport(artifact);
-  }
-}
-
 /** Second-level picker over one row's captures, newest first. Enter opens the
  *  highlighted capture; esc returns to the task list. */
 async function pickArtifact(row: BrowserSessionRow): Promise<BrowserArtifact | null> {
@@ -202,4 +141,44 @@ async function pickArtifact(row: BrowserSessionRow): Promise<BrowserArtifact | n
     if (isPromptCancelled(err)) return null;
     throw err;
   }
+}
+
+const browserSessionsPicker = createSessionsPickerCommand<BrowserSessionRow, BrowserSessionsCommandOpts>({
+  requireOpenUndefined: true,
+  runFlat: (opts) => runBrowserSessions({ profile: opts.profile, open: opts.open, json: opts.json }),
+  buildRows: (opts) => buildBrowserSessionRows(opts.profile),
+  emptyMessage: (opts) => `No browser captures found${opts.profile ? ` for profile "${opts.profile}"` : ''}.`,
+  message: 'Browser sessions:',
+  matches: matchesBrowserSessionRow,
+  labelFor: formatRowLabel,
+  buildPreview: buildRowPreview,
+  emptyFilterMessage: 'No browser sessions match.',
+  enterHint: 'open capture',
+  onOpen: async (row) => {
+    if (row.artifacts.length === 0) {
+      console.log('No captures in this task yet.');
+      return;
+    }
+    if (row.artifacts.length === 1) {
+      openAndReport(row.artifacts[0]);
+      return;
+    }
+    const artifact = await pickArtifact(row);
+    if (artifact) openAndReport(artifact);
+  },
+});
+
+/** True when the interactive picker should open instead of the printed table:
+ *  a real TTY, no `--json`/`--open`, and `--no-interactive` not set. */
+export function shouldOpenInteractiveBrowserSessions(opts: BrowserSessionsCommandOpts, isTTY: boolean): boolean {
+  return browserSessionsPicker.shouldOpen(opts, isTTY);
+}
+
+/**
+ * Shared entry point for `agents browser sessions` and `agents sessions
+ * --browser`. Replaces direct calls to `runBrowserSessions` at both call
+ * sites so the interactive routing decision lives in one place.
+ */
+export async function runBrowserSessionsCommand(opts: BrowserSessionsCommandOpts): Promise<void> {
+  await browserSessionsPicker.run(opts);
 }

--- a/apps/cli/src/commands/computer-sessions-picker.ts
+++ b/apps/cli/src/commands/computer-sessions-picker.ts
@@ -13,12 +13,12 @@
  * computer run has no on-disk artifact of its own to open (see
  * `lib/computer/sessions-list.ts`'s module docblock), so `enter` prints the
  * run's full action list rather than opening a file, and the picker keeps
- * browsing afterward instead of exiting.
+ * browsing afterward instead of exiting. Interactive routing and the browse
+ * loop live in `sessions-picker-factory.ts` (shared with the browser twin).
  */
 import chalk from 'chalk';
-import { itemPicker } from '../lib/picker.js';
-import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { buildPreview } from './sessions-picker.js';
+import { createSessionsPickerCommand } from './sessions-picker-factory.js';
 import {
   runComputerSessions,
   printComputerSessionRows,
@@ -40,33 +40,6 @@ export interface ComputerSessionsCommandOpts {
   interactive?: boolean;
   /** Pre-collected fleet rows. Omitted for the local ledger path. */
   rows?: ComputerRunRow[];
-}
-
-/** True when the interactive picker should open instead of the printed table:
- *  a real TTY, no `--json`, and `--no-interactive` not set. */
-export function shouldOpenInteractiveComputerSessions(opts: ComputerSessionsCommandOpts, isTTY: boolean): boolean {
-  return opts.interactive !== false && !opts.json && isTTY;
-}
-
-/**
- * Shared entry point for `agents computer sessions` and `agents sessions
- * --computer`. Mirrors `runBrowserSessionsCommand`'s interactive-routing
- * split so both call sites stay in lockstep.
- */
-export async function runComputerSessionsCommand(opts: ComputerSessionsCommandOpts): Promise<void> {
-  if (!shouldOpenInteractiveComputerSessions(opts, isInteractiveTerminal())) {
-    if (opts.rows) printComputerSessionRows(opts.rows, { limit: opts.limit, json: opts.json });
-    else runComputerSessions({ machine: opts.machine, limit: opts.limit, json: opts.json });
-    return;
-  }
-
-  const rows = opts.rows ?? buildComputerSessionRows({ machine: opts.machine });
-  if (rows.length === 0) {
-    console.log(`No computer actions recorded${opts.machine ? ` for machine "${opts.machine}"` : ''}.`);
-    return;
-  }
-
-  await browseComputerSessions(rows);
 }
 
 function rowLinkSummary(row: ComputerRunRow): string {
@@ -140,29 +113,33 @@ function printRunDetail(row: ComputerRunRow): void {
   console.log('');
 }
 
-/** Run-level picker with an action-list preview. Loops until the user quits
- *  (esc) so a session's whole run history can be browsed repeatedly in one
- *  sitting — mirroring `browseAndOpen`'s loop, minus the artifact drill-down
- *  a computer run has none of. */
-async function browseComputerSessions(rows: ComputerRunRow[]): Promise<void> {
-  for (;;) {
-    let picked;
-    try {
-      picked = await itemPicker<ComputerRunRow>({
-        message: 'Computer sessions:',
-        items: rows,
-        filter: (query) => (query.trim() ? rows.filter((r) => matchesComputerSessionRow(r, query)) : rows),
-        labelFor: (row) => formatRowLabel(row),
-        buildPreview: (row) => buildRowPreview(row),
-        emptyMessage: 'No computer sessions match.',
-        enterHint: 'view actions',
-      });
-    } catch (err) {
-      if (isPromptCancelled(err)) return;
-      throw err;
-    }
-    if (!picked) return;
+const computerSessionsPicker = createSessionsPickerCommand<ComputerRunRow, ComputerSessionsCommandOpts>({
+  runFlat: (opts) => {
+    if (opts.rows) printComputerSessionRows(opts.rows, { limit: opts.limit, json: opts.json });
+    else runComputerSessions({ machine: opts.machine, limit: opts.limit, json: opts.json });
+  },
+  buildRows: (opts) => opts.rows ?? buildComputerSessionRows({ machine: opts.machine }),
+  emptyMessage: (opts) => `No computer actions recorded${opts.machine ? ` for machine "${opts.machine}"` : ''}.`,
+  message: 'Computer sessions:',
+  matches: matchesComputerSessionRow,
+  labelFor: formatRowLabel,
+  buildPreview: buildRowPreview,
+  emptyFilterMessage: 'No computer sessions match.',
+  enterHint: 'view actions',
+  onOpen: printRunDetail,
+});
 
-    printRunDetail(picked.item);
-  }
+/** True when the interactive picker should open instead of the printed table:
+ *  a real TTY, no `--json`, and `--no-interactive` not set. */
+export function shouldOpenInteractiveComputerSessions(opts: ComputerSessionsCommandOpts, isTTY: boolean): boolean {
+  return computerSessionsPicker.shouldOpen(opts, isTTY);
+}
+
+/**
+ * Shared entry point for `agents computer sessions` and `agents sessions
+ * --computer`. Mirrors `runBrowserSessionsCommand`'s interactive-routing
+ * split so both call sites stay in lockstep.
+ */
+export async function runComputerSessionsCommand(opts: ComputerSessionsCommandOpts): Promise<void> {
+  await computerSessionsPicker.run(opts);
 }

--- a/apps/cli/src/commands/sessions-picker-factory.ts
+++ b/apps/cli/src/commands/sessions-picker-factory.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared interactive-routing + browse loop for the task-first session
+ * pickers (`browser-sessions-picker.ts`, `computer-sessions-picker.ts`).
+ *
+ * Each twin keeps its own row formatter, matcher, and enter-handler; this
+ * factory owns the TTY/`--json`/`--no-interactive` (and optional `--open`)
+ * gate, the empty-list message, and the cancel-aware `itemPicker` loop.
+ */
+import { itemPicker } from '../lib/picker.js';
+import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+
+/** Flag subset both twins share for the interactive-routing gate. */
+export interface SessionsPickerGateOpts {
+  interactive?: boolean;
+  json?: boolean;
+  /** Present only on the browser twin; computer never sets it. */
+  open?: string | boolean;
+}
+
+export interface SessionsPickerCommandSpec<TRow, TOpts extends SessionsPickerGateOpts> {
+  /**
+   * Browser requires `opts.open === undefined` so `--open` (bare or with a
+   * selector) falls through to the flat printer. Computer has no `--open`.
+   */
+  requireOpenUndefined?: boolean;
+  runFlat: (opts: TOpts) => void;
+  buildRows: (opts: TOpts) => TRow[];
+  emptyMessage: (opts: TOpts) => string;
+  message: string;
+  matches: (row: TRow, query: string) => boolean;
+  labelFor: (row: TRow) => string;
+  buildPreview: (row: TRow) => string;
+  emptyFilterMessage: string;
+  enterHint: string;
+  onOpen: (row: TRow) => void | Promise<void>;
+}
+
+export interface SessionsPickerCommand<TOpts extends SessionsPickerGateOpts> {
+  shouldOpen: (opts: TOpts, isTTY: boolean) => boolean;
+  run: (opts: TOpts) => Promise<void>;
+}
+
+export function shouldOpenInteractiveSessions(
+  opts: SessionsPickerGateOpts,
+  isTTY: boolean,
+  requireOpenUndefined = false,
+): boolean {
+  return (
+    opts.interactive !== false &&
+    !opts.json &&
+    (!requireOpenUndefined || opts.open === undefined) &&
+    isTTY
+  );
+}
+
+export async function browseSessionsUntilQuit<TRow>(spec: {
+  message: string;
+  rows: TRow[];
+  matches: (row: TRow, query: string) => boolean;
+  labelFor: (row: TRow) => string;
+  buildPreview: (row: TRow) => string;
+  emptyFilterMessage: string;
+  enterHint: string;
+  onOpen: (row: TRow) => void | Promise<void>;
+}): Promise<void> {
+  for (;;) {
+    let picked;
+    try {
+      picked = await itemPicker<TRow>({
+        message: spec.message,
+        items: spec.rows,
+        filter: (query) => (query.trim() ? spec.rows.filter((r) => spec.matches(r, query)) : spec.rows),
+        labelFor: spec.labelFor,
+        buildPreview: spec.buildPreview,
+        emptyMessage: spec.emptyFilterMessage,
+        enterHint: spec.enterHint,
+      });
+    } catch (err) {
+      if (isPromptCancelled(err)) return;
+      throw err;
+    }
+    if (!picked) return;
+    await spec.onOpen(picked.item);
+  }
+}
+
+export function createSessionsPickerCommand<TRow, TOpts extends SessionsPickerGateOpts>(
+  spec: SessionsPickerCommandSpec<TRow, TOpts>,
+): SessionsPickerCommand<TOpts> {
+  const shouldOpen = (opts: TOpts, isTTY: boolean): boolean =>
+    shouldOpenInteractiveSessions(opts, isTTY, spec.requireOpenUndefined === true);
+
+  return {
+    shouldOpen,
+    run: async (opts) => {
+      if (!shouldOpen(opts, isInteractiveTerminal())) {
+        spec.runFlat(opts);
+        return;
+      }
+      const rows = spec.buildRows(opts);
+      if (rows.length === 0) {
+        console.log(spec.emptyMessage(opts));
+        return;
+      }
+      await browseSessionsUntilQuit({
+        message: spec.message,
+        rows,
+        matches: spec.matches,
+        labelFor: spec.labelFor,
+        buildPreview: spec.buildPreview,
+        emptyFilterMessage: spec.emptyFilterMessage,
+        enterHint: spec.enterHint,
+        onOpen: spec.onOpen,
+      });
+    },
+  };
+}


### PR DESCRIPTION
refactor — no behavior change

Collapse the copy-pasted `browser-sessions-picker` / `computer-sessions-picker` wrappers onto one `createSessionsPickerCommand` factory (move 6 of the [core-module refactor plan](https://share.agents-cli.sh/muqsitnawaz/agents-cli-refactor-core-modules-9c2a843dcdc34c31)). Public names and signatures are unchanged — `shouldOpenInteractiveBrowserSessions`, `runBrowserSessionsCommand`, `shouldOpenInteractiveComputerSessions`, `runComputerSessionsCommand`. Importers (`browser.ts`, `computer.ts`, `sessions.ts`) are not touched.

## Wrappers before / after LOC

| File | Before | After |
|---|---|---|
| `commands/browser-sessions-picker.ts` | 205 | 184 |
| `commands/computer-sessions-picker.ts` | 168 | 145 |
| `commands/sessions-picker-factory.ts` | — | 117 (new) |

Each twin still owns its row formatter, matcher, and enter-handler. The factory owns the TTY / `--json` / `--no-interactive` gate (browser still requires `opts.open === undefined`; computer does not), the empty-list message, and the cancel-aware `itemPicker` loop.

## Proof of run

`bunx tsc --noEmit` green. Both picker test files unmodified. `bun test` on those files: 12 pass, 0 fail.

![tsc --noEmit and both picker test files green](https://gist.githubusercontent.com/muqsitnawaz/af5212203dec0ac7a24ce3bf33609deb/raw/gate.svg)

Run log: https://gist.github.com/muqsitnawaz/af5212203dec0ac7a24ce3bf33609deb
