### PR TITLE
docs: repoint resolveVersion/isGlobalBinaryAgent citations to installations/store.ts

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -159,7 +159,7 @@ the installer only ever fetches the *current* release and the binary self-update
 place. `isSelfUpdatingAgent()` ([`src/lib/agents.ts`](src/lib/agents.ts)) is the single
 predicate for "no pinnable semver"; route every such decision through it, never a
 scattered `=== 'droid'`. Its narrower cousin `isGlobalBinaryAgent()`
-([`src/lib/installations/versions.ts`](src/lib/installations/versions.ts)) — computed by probing whether
+([`src/lib/installations/store.ts`](src/lib/installations/store.ts)) — computed by probing whether
 `getBinaryPath` ignores the version arg — is true only when the agent resolves to ONE
 global binary (droid). For those, `listInstalledVersions` collapses the phantom
 per-version dirs to a single canonical entry, `reconcileStaleLatestForAgent` folds the

--- a/apps/cli/docs/AGENT-CHEATSHEET.md
+++ b/apps/cli/docs/AGENT-CHEATSHEET.md
@@ -51,7 +51,7 @@ Every agent invocation goes through `buildExecEnv` → `execAgent` / `runWithFal
 
 ## 8. Self-updating vs pinnable agents
 
-Some harnesses (droid, grok, antigravity, cursor, hermes, kiro, goose) install via `curl | sh` / `brew` and the binary self-updates in place — no pinnable semver. Use `isSelfUpdatingAgent()` ([`src/lib/agents.ts`](../src/lib/agents.ts)) as the single predicate. `isGlobalBinaryAgent()` ([`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts)) is narrower: true only for droid.
+Some harnesses (droid, grok, antigravity, cursor, hermes, kiro, goose) install via `curl | sh` / `brew` and the binary self-updates in place — no pinnable semver. Use `isSelfUpdatingAgent()` ([`src/lib/agents.ts`](../src/lib/agents.ts)) as the single predicate. `isGlobalBinaryAgent()` ([`src/lib/installations/store.ts`](../src/lib/installations/store.ts)) is narrower: true only for droid.
 
 ## 9. Work on a worktree, never `main`
 

--- a/apps/cli/docs/version-management.md
+++ b/apps/cli/docs/version-management.md
@@ -441,7 +441,7 @@ explicit alternative detection path for consumers.
 |----------|------|---------|
 | `installVersion()` | versions.ts | Install agent CLI version |
 | `removeVersion()` | versions.ts | Remove installed version |
-| `resolveVersion()` | versions.ts | Find version from project/global config |
+| `resolveVersion()` | store.ts | Find version from project/global config |
 | `syncResourcesToVersion()` | versions.ts | Symlink resources into version home |
 | `switchConfigSymlink()` | shims.ts | Replace ~/.{agent} with symlink |
 | `createShim()` | shims.ts | Generate version-resolving wrapper |


### PR DESCRIPTION
docs-only — no code changed, no run needed.

Follow-up to #2799 (move 2 of the installations refactor), which moved `resolveVersion()` and `isGlobalBinaryAgent()` from `versions.ts` to `installations/store.ts`. The non-author review on #2799 flagged three doc citations left pointing at the old file. Audience: maintainers/agents navigating the repo by these function→file maps.

| File | Fix |
|---|---|
| `apps/cli/docs/version-management.md` | `resolveVersion()` table row: versions.ts → store.ts |
| `apps/cli/docs/AGENT-CHEATSHEET.md` | `isGlobalBinaryAgent()` link → store.ts |
| `apps/cli/AGENTS.md` | `isGlobalBinaryAgent()` link → store.ts |

Verified against source: `store.ts:644` (`resolveVersion`), `store.ts:349` (`isGlobalBinaryAgent`); `installVersion`/`removeVersion`/`syncResourcesToVersion` rows correctly remain on `versions.ts` (`versions.ts:1277,1818,2528`).