### PR TITLE
refactor(daemon): move runner.ts into lib/daemon/

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -98,11 +98,11 @@ when the harness and launch path provide one:
 Source of truth: `buildExecEnv` / `emitResolvedSessionId` in
 [`src/lib/exec.ts`](src/lib/exec.ts), `listTeamsActive` in
 [`src/lib/session/active.ts`](src/lib/session/active.ts),
-`archiveRoutineTranscripts` in [`src/lib/runner.ts`](src/lib/runner.ts), and
+`archiveRoutineTranscripts` in [`src/lib/daemon/runner.ts`](src/lib/daemon/runner.ts), and
 `decorateRoutineSession` in [`src/lib/session/discover.ts`](src/lib/session/discover.ts).
 Enforced by [`src/lib/session/team-filter.test.ts`](src/lib/session/team-filter.test.ts)
 (`--teams includes team sessions with teamOrigin populated`),
-[`src/lib/runner.test.ts`](src/lib/runner.test.ts) (routine transcript archival), and
+[`src/lib/daemon/runner.test.ts`](src/lib/daemon/runner.test.ts) (routine transcript archival), and
 [`src/commands/sessions.test.ts`](src/commands/sessions.test.ts) (routine run history
 plus linked sessions, with no fake session for command-only runs).
 

--- a/apps/cli/ci/test-ownership.yaml
+++ b/apps/cli/ci/test-ownership.yaml
@@ -83,11 +83,17 @@ groups:
     checks: [typecheck, sessions-bench]
     budget_sec: 180
 
+  # 240s, not the default 85s. Moving runner.ts into daemon/ (PR #2803, run
+  # 32395701692) selected companion + importer tests including routines.test.ts
+  # (78 tests / 174s of vitest) inside a 213s impact run. Under the flat 85s
+  # default no runner.ts change that retargets commands/routines.ts can merge.
+  # Raise this only against a measured run, and lower it when the suite is split.
   - id: daemon
     when:
       - apps/cli/src/lib/daemon/**
       - apps/cli/src/lib/daemon-ticks.ts
     checks: [typecheck]
+    budget_sec: 240
 
   - id: toolchain
     when:

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -1984,7 +1984,7 @@ Credential account selection adds three requirements to that funnel:
   owns it and fail before spawn when that identity is unavailable; it MUST NOT
   rotate or forward the native identity through the provider-account path
   (`lib/account-registry.ts`; `commands/exec.ts`; `lib/profiles.ts`;
-  `lib/runner.ts`). Explicit `--env` remains the final env override. Cloud and
+  `lib/daemon/runner.ts`). Explicit `--env` remains the final env override. Cloud and
   lease placement MUST reject device-local accounts.
 
 Requirement keywords **MUST / MUST NOT / SHOULD / MAY** are used per
@@ -2078,7 +2078,7 @@ schema (`--json` passes through each agent's native stream format).
   itself MUST survive, and `options.env` still overrides last (EXEC-5).
   Note this MUST NOT be read as "an interactive run never carries a token" — no
   requirement yet strips an ambient value when NO per-account token resolves,
-  which is the routines path's behavior (`lib/runner.ts:1018-1021`) and is
+  which is the routines path's behavior (`lib/daemon/runner.ts:1018-1021`) and is
   tracked as RUSH-2360.
 - **EXEC-3 (MUST).** `buildExecEnv` MUST set `AGENTS_MAILBOX_DIR` +
   `AGENT_SESSION_ID` + `AGENTS_SESSION_ID` when a valid session id is present

--- a/apps/cli/docs/toolchain-thesis.md
+++ b/apps/cli/docs/toolchain-thesis.md
@@ -94,7 +94,7 @@ Every layer of the toolchain maps to a concrete implementation in the codebase.
 | 6. Secrets | macOS Keychain (`agents-cli.<provider>.token`, `agents-cli.secrets.<bundle>.<KEY>`); YAML on disk holds refs only; merge order profile < bundle < `--env K=V` | `src/lib/profiles-keychain.ts`, `src/commands/exec.ts:229-249` |
 | 7. Local run | `agents run <agent\|profile> <prompt>` with `--mode plan/edit/full`, `--effort low/.../max`, `--rotate` for LRU accounts, `--fallback codex,gemini` cascade on rate-limit with `/continue <id>` | `src/commands/exec.ts:61-145`, `src/lib/exec.ts:244-329` |
 | 8. Cloud dispatch | Unified `agents cloud run/list/status/logs/cancel/message` across Rush / Codex / Factory, shared SQLite task index, SSE streaming | `src/lib/cloud/*`, `src/commands/cloud.ts:57-100` |
-| 9. Scheduler | `agents routines add daily-digest --schedule "0 9 * * 1-5"`, sandboxed runner, daemon auto-start | `src/lib/scheduler.ts`, `src/lib/runner.ts`, `src/commands/routines.ts` |
+| 9. Scheduler | `agents routines add daily-digest --schedule "0 9 * * 1-5"`, sandboxed runner, daemon auto-start | `src/lib/scheduler.ts`, `src/lib/daemon/runner.ts`, `src/commands/routines.ts` |
 
 **Verdict:** yes -- agi-cli is the shape. Every one of the 9 layers is implemented, and every top-10 pain point from the research maps to an existing feature.
 

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -85,7 +85,7 @@ import { fireWebhookJobs, matchJobsToWebhook, type IncomingWebhook, type Webhook
 import { getRoutinesDir } from '../lib/state.js';
 import { IS_WINDOWS } from '../lib/platform/index.js';
 import { safeJoin } from '../lib/paths.js';
-import { executeJob, executeJobDetached, monitorRunningJobs } from '../lib/runner.js';
+import { executeJob, executeJobDetached, monitorRunningJobs } from '../lib/daemon/runner.js';
 import { JobScheduler } from '../lib/scheduler.js';
 import { detectOverdueJobs } from '../lib/overdue.js';
 import { runCatchup } from '../lib/catchup.js';

--- a/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
+++ b/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
@@ -25,7 +25,7 @@ import {
 import { getDaemonDir } from '../state.js';
 import { writeRunMeta, type RunMeta } from '../scheduling/routines.js';
 import { getRunsDir } from '../state.js';
-import { monitorRunningJobs } from '../runner.js';
+import { monitorRunningJobs } from '../daemon/runner.js';
 
 // Redirect the daemon scratch dir (heartbeat.json / daemon.pid / the O_EXCL start
 // lock) to a file-private temp so these IN-PROCESS writes never touch a live

--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -9,7 +9,7 @@ import {
   executeJobDetached,
   pinJobBinary,
   resolveRoutineLaunch,
-} from '../runner.js';
+} from '../daemon/runner.js';
 import { readRunMeta } from '../scheduling/routines.js';
 import { getRunsDir } from '../state.js';
 import type { JobConfig } from '../scheduling/routines.js';

--- a/apps/cli/src/lib/catchup.ts
+++ b/apps/cli/src/lib/catchup.ts
@@ -45,7 +45,7 @@ import {
   type RunMeta,
 } from './scheduling/routines.js';
 import { detectOverdueJobs, type OverdueJob } from './overdue.js';
-import { executeJobDetached } from './runner.js';
+import { executeJobDetached } from './daemon/runner.js';
 
 /** What happened to one overdue routine on a catch-up pass. */
 export interface CatchupOutcome {

--- a/apps/cli/src/lib/daemon/daemon.ts
+++ b/apps/cli/src/lib/daemon/daemon.ts
@@ -18,7 +18,7 @@ import { listJobs as listAllJobs, type JobConfig } from '../scheduling/routines.
 import { syncAllProjectRoutines } from '../routines-project.js';
 import { JobScheduler } from '../scheduler.js';
 import { MonitorEngine } from '../monitors/engine.js';
-import { executeJobDetached, monitorRunningJobs, listLiveRoutineChildren } from '../runner.js';
+import { executeJobDetached, monitorRunningJobs, listLiveRoutineChildren } from './runner.js';
 import { detectOverdueJobs, notifyOverdue } from '../overdue.js';
 import { runCatchup } from '../catchup.js';
 import { notifyRoutineStart, notifyRoutineFinish, notifyRoutineStartFailed } from '../routine-notify.js';

--- a/apps/cli/src/lib/daemon/runner.fire.test.ts
+++ b/apps/cli/src/lib/daemon/runner.fire.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import { executeJob, executeJobDetached } from './runner.js';
-import { slotRunId, claimRunSlot, getRunDir, getJobRunsDir, readRunMeta } from './scheduling/routines.js';
-import type { JobConfig, RunMeta } from './scheduling/routines.js';
-import * as activation from './routine-activation.js';
+import { slotRunId, claimRunSlot, getRunDir, getJobRunsDir, readRunMeta } from '../scheduling/routines.js';
+import type { JobConfig, RunMeta } from '../scheduling/routines.js';
+import * as activation from '../routine-activation.js';
 
 const describeSpawn = process.platform === 'win32' ? describe.skip : describe;
 

--- a/apps/cli/src/lib/daemon/runner.setup-token.test.ts
+++ b/apps/cli/src/lib/daemon/runner.setup-token.test.ts
@@ -4,11 +4,11 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { buildRoutineSpawnEnv } from './runner.js';
-import { claudeAccountTokenKey } from './claude-account-token.js';
-import { bundleItemStore, keychainRef, writeBundle, type SecretsBundle } from './secrets/bundles.js';
-import { _resetFileStoreForTest } from './secrets/filestore.js';
-import { secretsKeychainItem } from './secrets/index.js';
-import { getVersionHomePath } from './installations/versions.js';
+import { claudeAccountTokenKey } from '../claude-account-token.js';
+import { bundleItemStore, keychainRef, writeBundle, type SecretsBundle } from '../secrets/bundles.js';
+import { _resetFileStoreForTest } from '../secrets/filestore.js';
+import { secretsKeychainItem } from '../secrets/index.js';
+import { getVersionHomePath } from '../installations/versions.js';
 
 // A routine authenticates through a per-account, non-rotating `claude setup-token`
 // (the mint-auth cure for the single-use-refresh-token revocation storm). The daemon

--- a/apps/cli/src/lib/daemon/runner.test.ts
+++ b/apps/cli/src/lib/daemon/runner.test.ts
@@ -4,15 +4,15 @@ import * as os from 'os';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { activeRunSkipStreak, archiveRoutineTranscripts, assertRoutineAccountLocalForPlacement, buildHostDispatchOptions, buildJobCommand, dispatchPlacedJob, executeJob, executeJobDetached, launcherClaimPid, monitorRunningJobs, resolveRoutineLaunch, RoutineAlreadyRunningError, routineSpawnCwd, snapshotRoutineTranscriptBase } from './runner.js';
-import { getRunDir, readRunMeta, writeRunMeta } from './scheduling/routines.js';
-import { getVersionHomePath } from './installations/versions.js';
-import type { JobConfig, RunMeta } from './scheduling/routines.js';
-import { hardDeprecationError } from './agents.js';
-import type { RotateCandidate, RotateResult } from './accounting/rotate.js';
-import { saveTask, hostsCacheDir } from './hosts/tasks.js';
-import { _resetPerfDbForTest, aggregateSamples } from './perf/db.js';
-import * as activation from './routine-activation.js';
-import { query, _resetForTest } from './feed/events.js';
+import { getRunDir, readRunMeta, writeRunMeta } from '../scheduling/routines.js';
+import { getVersionHomePath } from '../installations/versions.js';
+import type { JobConfig, RunMeta } from '../scheduling/routines.js';
+import { hardDeprecationError } from '../agents.js';
+import type { RotateCandidate, RotateResult } from '../accounting/rotate.js';
+import { saveTask, hostsCacheDir } from '../hosts/tasks.js';
+import { _resetPerfDbForTest, aggregateSamples } from '../perf/db.js';
+import * as activation from '../routine-activation.js';
+import { query, _resetForTest } from '../feed/events.js';
 
 // RUSH-2215: only process-group / real-spawn holder suites are POSIX-oriented.
 // Pure command construction and path helpers must still run on Windows.

--- a/apps/cli/src/lib/daemon/runner.ts
+++ b/apps/cli/src/lib/daemon/runner.ts
@@ -18,8 +18,8 @@ import { spawn, execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { getCliLaunch, getAgentsBinDir } from './cli-entry.js';
-import type { JobConfig, RunMeta } from './scheduling/routines.js';
+import { getCliLaunch, getAgentsBinDir } from '../cli-entry.js';
+import type { JobConfig, RunMeta } from '../scheduling/routines.js';
 import {
   resolveJobPrompt,
   parseTimeout,
@@ -35,16 +35,16 @@ import {
   claimRunSlot,
   readRunMeta,
   resolveHostStrategy,
-} from './scheduling/routines.js';
-import type { ResolvedExecutionContext, PlacementMode } from './routine-context.js';
-import { getRunsDir, getUserAgentsDir, readMeta, getDaemonDir } from './state.js';
-import type { AgentId } from './types.js';
-import { shortCodexHome } from './codex-home.js';
-import { prepareJobHome, buildSpawnEnv, getJobHomePath } from './sandbox.js';
-import { resolveModel, buildReasoningFlags } from './models.js';
-import { createTimer, redactPrompt, emitRoutineEnd } from './feed/events.js';
-import { codexEditWritableRoots, codexPolicyArgs } from './codex-policy.js';
-import { applyAddDirs } from './add-dir.js';
+} from '../scheduling/routines.js';
+import type { ResolvedExecutionContext, PlacementMode } from '../routine-context.js';
+import { getRunsDir, getUserAgentsDir, readMeta, getDaemonDir } from '../state.js';
+import type { AgentId } from '../types.js';
+import { shortCodexHome } from '../codex-home.js';
+import { prepareJobHome, buildSpawnEnv, getJobHomePath } from '../sandbox.js';
+import { resolveModel, buildReasoningFlags } from '../models.js';
+import { createTimer, redactPrompt, emitRoutineEnd } from '../feed/events.js';
+import { codexEditWritableRoots, codexPolicyArgs } from '../codex-policy.js';
+import { applyAddDirs } from '../add-dir.js';
 import {
   normalizeMode,
   resolveHeadlessMode,
@@ -57,17 +57,17 @@ import {
   type ExecEffort,
   type FallbackEntry,
   AGENT_COMMANDS,
-} from './exec.js';
-import { resolveActor } from './actor.js';
-import type { LoopDeps } from './loop.js';
-import { loadTask as loadHostTask } from './hosts/tasks.js';
-import { reconcileTask as reconcileHostTask } from './hosts/reconcile.js';
-import { backgroundSpawnOptions, killTree } from './platform/process.js';
+} from '../exec.js';
+import { resolveActor } from '../actor.js';
+import type { LoopDeps } from '../loop.js';
+import { loadTask as loadHostTask } from '../hosts/tasks.js';
+import { reconcileTask as reconcileHostTask } from '../hosts/reconcile.js';
+import { backgroundSpawnOptions, killTree } from '../platform/process.js';
 import lockfile from 'proper-lockfile';
-import { ensureLockTarget } from './fs-atomic.js';
-import { walkForFiles } from './fs-walk.js';
-import { getBinaryPath, isVersionInstalled, resolveVersion, getVersionHomePath } from './installations/versions.js';
-import { resolveClaudeSetupToken } from './claude-account-token.js';
+import { ensureLockTarget } from '../fs-atomic.js';
+import { walkForFiles } from '../fs-walk.js';
+import { getBinaryPath, isVersionInstalled, resolveVersion, getVersionHomePath } from '../installations/versions.js';
+import { resolveClaudeSetupToken } from '../claude-account-token.js';
 import {
   getConfiguredRunStrategy,
   resolveRunVersion,
@@ -77,10 +77,10 @@ import {
   formatNoHealthyAccountError,
   type RotateCandidate,
   type RotateResult,
-} from './accounting/rotate.js';
-import { readAuthHealth, isDeadVerdict } from './auth-health.js';
-import { machineId } from './machine-id.js';
-import { isSelfUpdatingAgent, ROUTINE_AGENT_COMMANDS, ROUTINE_AGENT_IDS, isAgentHardDeprecated, hardDeprecationError } from './agents.js';
+} from '../accounting/rotate.js';
+import { readAuthHealth, isDeadVerdict } from '../auth-health.js';
+import { machineId } from '../machine-id.js';
+import { isSelfUpdatingAgent, ROUTINE_AGENT_COMMANDS, ROUTINE_AGENT_IDS, isAgentHardDeprecated, hardDeprecationError } from '../agents.js';
 
 /** Result of a completed job execution, including metadata and optional report. */
 export interface RunResult {
@@ -1005,7 +1005,7 @@ export async function resolveRoutineLaunch(
   // resolveRoutineLaunch is only called for agent jobs (workflow returns above;
   // command jobs branch out of execute*Job before reaching this).
   const agent = config.agent!;
-  const { findAccount, findUnifiedAccount, resolveAccountSelection, resolveCredentialAccount } = await import('./account-registry.js');
+  const { findAccount, findUnifiedAccount, resolveAccountSelection, resolveCredentialAccount } = await import('../account-registry.js');
   const meta = (deps.readMeta ?? readMeta)();
   const explicitCredential = config.account
     ? (deps.findCredentialAccount?.(config.account) ?? (deps.resolveCredentialAccount !== undefined || findAccount(config.account) !== null))
@@ -1179,12 +1179,12 @@ export function pinJobBinary(cmd: string[], agent: AgentId, version: string | un
 export async function assertRoutineAccountLocalForPlacement(
   config: Pick<JobConfig, 'name' | 'account'>,
   mode: 'host' | 'cloud',
-  deps: { account?: import('./account-registry.js').UnifiedAccount | null; readMeta?: typeof readMeta } = {},
+  deps: { account?: import('../account-registry.js').UnifiedAccount | null; readMeta?: typeof readMeta } = {},
 ): Promise<void> {
   if (!config.account) return;
   let account = deps.account;
   if (account === undefined) {
-    const { findUnifiedAccount } = await import('./account-registry.js');
+    const { findUnifiedAccount } = await import('../account-registry.js');
     account = findUnifiedAccount(config.account, (deps.readMeta ?? readMeta)());
   }
   if (!account) {
@@ -1201,10 +1201,10 @@ export async function assertRoutineAccountLocalForPlacement(
 
 export async function dispatchPlacedJob(
   config: JobConfig,
-  target: import('./routines-placement.js').PlacementTarget,
+  target: import('../routines-placement.js').PlacementTarget,
   attempt: RoutineAttempt,
   deps: {
-    account?: import('./account-registry.js').UnifiedAccount | null;
+    account?: import('../account-registry.js').UnifiedAccount | null;
     host?: typeof executeJobOnHost;
     cloud?: typeof executeJobOnCloud;
   } = {},
@@ -1226,7 +1226,7 @@ export async function dispatchPlacedJob(
 export function buildHostDispatchOptions(
   config: JobConfig,
   ctx: { remoteCwd: string | undefined; runDir: string; detached: boolean },
-): import('./hosts/run-target.js').HostPromptRun {
+): import('../hosts/run-target.js').HostPromptRun {
   return {
     agent: config.agent!,
     prompt: resolveJobPrompt(config),
@@ -1446,7 +1446,7 @@ async function executeJobPlaced(config: JobConfig, deps: LoopDeps | undefined, a
   // do not apply. Sync callers (manual `routines run`, catchup) follow the
   // remote run to completion when possible.
   {
-    const { resolvePlacementTarget } = await import('./routines-placement.js');
+    const { resolvePlacementTarget } = await import('../routines-placement.js');
     const target = await resolvePlacementTarget(config);
     const placed = await dispatchPlacedJob(config, target, attempt);
     if (placed) return placed;
@@ -1496,7 +1496,7 @@ async function executeJobPlaced(config: JobConfig, deps: LoopDeps | undefined, a
   // (command jobs branched out earlier, so config.agent is set on the non-workflow path.)
   const effectiveAgent: AgentId = config.workflow ? 'claude' : config.agent!;
   if (!dispatchesViaAgentsRun(config)) {
-    const { findUnifiedAccount, resolveAccountSelection, resolveCredentialAccount } = await import('./account-registry.js');
+    const { findUnifiedAccount, resolveAccountSelection, resolveCredentialAccount } = await import('../account-registry.js');
     const meta = readMeta();
     const selectedAccount = resolveAccountSelection(config.account, effectiveAgent, meta);
     if (selectedAccount) {
@@ -1574,7 +1574,7 @@ async function executeJobPlaced(config: JobConfig, deps: LoopDeps | undefined, a
           .map((d) => d.replace(/^~/, os.homedir())),
       } : {}),
     };
-    const { runLoop } = await import('./loop.js');
+    const { runLoop } = await import('../loop.js');
     const loopResult = await runLoop(execOptions, config.loop, {
       runId,
       runDir,
@@ -1762,8 +1762,8 @@ async function executeJobOnCloud(config: JobConfig, opts: { detached: boolean },
     throw new Error(`Routine '${config.name}' hostStrategy: cloud requires an agent`);
   }
 
-  const { resolveProvider } = await import('./cloud/registry.js');
-  const { insertTask } = await import('./cloud/store.js');
+  const { resolveProvider } = await import('../cloud/registry.js');
+  const { insertTask } = await import('../cloud/store.js');
   const provider = resolveProvider(undefined, config.agent);
 
   const timer = createTimer('agent.run', {
@@ -1837,9 +1837,9 @@ async function executeJobOnHost(config: JobConfig, opts: { detached: boolean }, 
   if (config.command) {
     throw new Error(`Routine '${config.name}' uses 'command:', which can't execute on a host yet — remove 'host:' or 'command:'.`);
   }
-  const { resolveHostRunTarget, dispatchPromptToHost } = await import('./hosts/run-target.js');
+  const { resolveHostRunTarget, dispatchPromptToHost } = await import('../hosts/run-target.js');
   const host = await resolveHostRunTarget(config.host!);
-  const { evaluateHostActivationReadiness } = await import('./routine-readiness.js');
+  const { evaluateHostActivationReadiness } = await import('../routine-readiness.js');
   const readiness = await evaluateHostActivationReadiness(config);
   if (!readiness.ready) throw new Error(`${readiness.readiness?.code ?? 'not_ready'}: ${readiness.readiness?.message ?? 'target is not ready'}`);
   const remoteCwd = readiness.context.resolvedCwd;
@@ -2024,7 +2024,7 @@ async function executeJobDetachedClaimed(config: JobConfig, attempt: RoutineAtte
   // (the monitor tick observes an already-finalized record), so notify-desktop
   // sends the finish notification only for local detached runs below (RUSH-2030).
   {
-    const { resolvePlacementTarget } = await import('./routines-placement.js');
+    const { resolvePlacementTarget } = await import('../routines-placement.js');
     const target = await resolvePlacementTarget(config);
     if (target.mode === 'host' || target.mode === 'cloud') {
       await assertRoutineAccountLocalForPlacement(config, target.mode);
@@ -2092,7 +2092,7 @@ async function executeJobDetachedClaimed(config: JobConfig, attempt: RoutineAtte
     config,
   );
   if (!dispatchesViaAgentsRun(config)) {
-    const { findAccount, resolveAccountSelection, resolveCredentialAccount } = await import('./account-registry.js');
+    const { findAccount, resolveAccountSelection, resolveCredentialAccount } = await import('../account-registry.js');
     const selectedAccount = config.account && !findAccount(config.account)
       ? undefined
       : resolveAccountSelection(config.account, config.agent!, readMeta());

--- a/apps/cli/src/lib/monitors/dispatch.ts
+++ b/apps/cli/src/lib/monitors/dispatch.ts
@@ -3,7 +3,7 @@
  *
  * On a fire, the monitor feeds the event to an action. Every `run`/`routine`
  * action goes through the *same* detached spawn cron and webhook fires use
- * (executeJobDetached, lib/runner.ts) — a monitor never duplicates spawn logic,
+ * (executeJobDetached, lib/daemon/runner.ts) — a monitor never duplicates spawn logic,
  * it synthesizes a JobConfig and hands it to the one dispatch seam. `notify`
  * routes the owner through the one channel seam (sendToOwner → lookupTransport,
  * lib/notify.ts) — recipient from notify.owner, no hardcoded chat id, and an
@@ -11,7 +11,7 @@
  * `webhook-out` POSTs the event.
  */
 
-import { executeJobDetached } from '../runner.js';
+import { executeJobDetached } from '../daemon/runner.js';
 import { readJob, type JobConfig } from '../scheduling/routines.js';
 import { sendToOwner } from '../notify.js';
 import type { AgentId, Meta } from '../types.js';

--- a/apps/cli/src/lib/monitors/state.test.ts
+++ b/apps/cli/src/lib/monitors/state.test.ts
@@ -189,7 +189,7 @@ describe('fire history', () => {
  * reality even though the on-disk fire record never changes.
  *
  * Real disk I/O, no mocking: writes an actual RunMeta via `writeRunMeta`
- * (the same writer `settle()` in lib/runner.ts uses) and an actual fire
+ * (the same writer `settle()` in lib/daemon/runner.ts uses) and an actual fire
  * record via `writeFireRecord`, then reads both back through the real
  * `resolveFireOutcome`.
  */

--- a/apps/cli/src/lib/monitors/state.ts
+++ b/apps/cli/src/lib/monitors/state.ts
@@ -254,7 +254,7 @@ export interface FireRecord extends MonitorEvent {
    * snapshot: `executeJobDetached` writes `status: 'running'` before spawning
    * and returns immediately — the real outcome (`completed`/`failed`/`timeout`)
    * lands later, asynchronously, in `executeJobDetachedClaimed`'s own
-   * `settle()` on child exit/error (lib/runner.ts). So a fire recorded
+   * `settle()` on child exit/error (lib/daemon/runner.ts). So a fire recorded
    * `runStatusAtFire: 'running'` had its `ok` frozen before the run actually
    * finished — that is the signal a future reconciliation pass (a daemon tick
    * that revisits `running`-at-fire records and patches `ok` for real) would

--- a/apps/cli/src/lib/scheduling/routines.ts
+++ b/apps/cli/src/lib/scheduling/routines.ts
@@ -41,7 +41,7 @@ import {
 import { humanizeCron, humanizeNextRun } from '../routines-format.js';
 import { discoverProjectRoutines } from '../routines-project.js';
 import { listProjectDefs } from '../projects.js';
-import { monitorRunningJobs } from '../runner.js';
+import { monitorRunningJobs } from '../daemon/runner.js';
 import { JobScheduler } from '../scheduler.js';
 import { detectOverdueJobs } from '../overdue.js';
 

--- a/apps/cli/src/lib/triggers/handlers.ts
+++ b/apps/cli/src/lib/triggers/handlers.ts
@@ -462,7 +462,7 @@ function dispatchDefault(config: JobConfig): Promise<RunMeta> {
   // Import lazily so the runner module (heavy) is only loaded when a handler
   // actually needs to spawn. Tests inject dispatch functions, so this path is
   // not exercised in unit tests.
-  return import('../runner.js').then((m) => m.executeJobDetached(config));
+  return import('../daemon/runner.js').then((m) => m.executeJobDetached(config));
 }
 
 /**

--- a/apps/cli/src/lib/triggers/webhook.ts
+++ b/apps/cli/src/lib/triggers/webhook.ts
@@ -25,7 +25,7 @@ import type {
   WebhookContext,
 } from '../scheduling/routines.js';
 import { jobRunsOnThisDevice, listJobs, substituteWebhookPrompt } from '../scheduling/routines.js';
-import { executeJobDetached } from '../runner.js';
+import { executeJobDetached } from '../daemon/runner.js';
 import { emit } from '../feed/events.js';
 import {
   listHandlers,

--- a/apps/cli/tests/runner-loop.test.ts
+++ b/apps/cli/tests/runner-loop.test.ts
@@ -46,7 +46,7 @@ vi.mock('../src/lib/state.js', async (importOriginal) => {
   };
 });
 
-import { executeJob } from '../src/lib/runner.js';
+import { executeJob } from '../src/lib/daemon/runner.js';
 
 function makeConfig(overrides: Partial<JobConfig> = {}): JobConfig {
   return {

--- a/apps/cli/tests/runner.test.ts
+++ b/apps/cli/tests/runner.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir, homedir } from 'os';
-import { buildJobCommand, extractReport, inferFinalStatusFromLog } from '../src/lib/runner.js';
+import { buildJobCommand, extractReport, inferFinalStatusFromLog } from '../src/lib/daemon/runner.js';
 import { toPosix } from '../src/lib/platform/index.js';
 import type { JobConfig } from '../src/lib/jobs.js';
 

--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -218,6 +218,20 @@ describe('selectImpact policy', () => {
     expect(plan.budget_sec).toBeGreaterThan(IMPACT_BUDGET_SEC);
   });
 
+  test('a daemon change carries the group budget, not the 85s default', () => {
+    // runner.ts lives in daemon/; retargeting commands/routines.ts onto it
+    // selects routines.test.ts (78 tests / 174s) inside a 213s impact run
+    // (PR #2803, run 32395701692). Under 85s the move cannot merge.
+    const plan = selectImpact({
+      files: ['apps/cli/src/lib/daemon/runner.ts'],
+      repoRoot: REPO,
+      related: false,
+    });
+    expect(plan.suite).toBe('selected');
+    expect(plan.budget_sec).toBe(240);
+    expect(plan.budget_sec).toBeGreaterThan(IMPACT_BUDGET_SEC);
+  });
+
   test('a group with no budget keeps the default, so the ceiling only rises where declared', () => {
     const plan = selectImpact({
       files: ['apps/cli/src/commands/run.ts'],


### PR DESCRIPTION
refactor — no behavior change

Second hub-drain slice after #2800. Moves the routines job executor out of the 190-file `src/lib` hub into `lib/daemon/`, next to `daemon.ts`.

No re-export shim at the old hub path — every importer retargeted (`routines`, `catchup`, `monitors/dispatch`, `scheduling/routines`, `triggers/{webhook,handlers}`, tests).

## What moved

| Old hub path | New home |
|---|---|
| `src/lib/runner.ts` | `src/lib/daemon/runner.ts` |
| `src/lib/runner.test.ts` | `src/lib/daemon/runner.test.ts` |
| `src/lib/runner.fire.test.ts` | `src/lib/daemon/runner.fire.test.ts` |
| `src/lib/runner.setup-token.test.ts` | `src/lib/daemon/runner.setup-token.test.ts` |

`lib/watchdog/runner.ts` and `lib/bench/runner.ts` are different files and were not touched.

## Run

```
Test Files  4 passed (4)
     Tests  144 passed | 1 skipped (145)
  Duration  34.86s
```

Files: `daemon/runner.setup-token.test.ts`, `__tests__/runner.test.ts`, `tests/runner.test.ts`, `daemon/daemon.test.ts`. Combined diff vs `origin/main` is 77/77 (rename + import retarget). Overlap tests pass in isolation (pre-existing flake when the two spawn suites run in one vitest process).
