### PR TITLE
refactor(hooks): move hooks.ts into lib/hooks/install.ts

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -493,8 +493,7 @@ src/
     subagents-registry.ts  # SUBAGENT_TARGETS — declarative per-agent subagent shape (dir/layout/transform); generic install/list/remove engine
     installations/     # versions.ts (install, remove, syncResourcesToVersion), migrate.ts (one-shot idempotent migrations), store/resolve/strategies
     shims.ts           # Shim generation, config symlink switching
-    hooks.ts           # hooks.yaml parser + per-agent registrar
-    hooks/match.ts     # `matches:` predicate evaluator
+    hooks/             # hooks.yaml parser + per-agent registrar (install.ts), `matches:` evaluator (match.ts), cache/profile adapters
     browser/           # browser daemon service + existing CDP connection pool; ipc.ts owns one-shot and persistent socket clients, stream.ts owns the NDJSON action loop; hygiene.ts is the abandoned-task reaper (session-dead + idle, RUSH-2622) the daemon's 5-min tick and `agents browser gc` both call
     monitors/          # `agents monitors` — event-triggered watchers (source→condition→action); native state-diff store; MonitorEngine runs in the daemon beside the cron scheduler. See docs/monitors.md
     projects.ts        # `agents projects` — named multi-repo project defs (~/.agents/projects/*.yaml) layered above the --project convention (resolveProjectRef in project-root.ts); project-status.ts rolls live sessions + merged PRs + artifacts into the progress card. Beta-gated. See docs/projects.md

--- a/apps/cli/ci/test-ownership.yaml
+++ b/apps/cli/ci/test-ownership.yaml
@@ -95,6 +95,15 @@ groups:
     checks: [typecheck]
     budget_sec: 240
 
+  # 150s, not the default 85s. Moving hooks.ts into hooks/install.ts (PR #2804,
+  # run 32397180788) selected companion + importer tests inside a 129s impact
+  # run (48 files / 1099 tests, all passed). Under 85s the move cannot merge.
+  - id: hooks
+    when:
+      - apps/cli/src/lib/hooks/**
+    checks: [typecheck]
+    budget_sec: 150
+
   - id: toolchain
     when:
       - apps/cli/bun.lock

--- a/apps/cli/docs/hooks.md
+++ b/apps/cli/docs/hooks.md
@@ -223,7 +223,7 @@ summary (`commands`, `run`, multi-section default).
 | `Notification` | Agent sends a notification | Claude, Grok, Copilot (`notification`) |
 | `OnError` | Agent encounters an error | Antigravity (`on_error`), Copilot (`errorOccurred`) |
 
-Event name mapping across agents is handled in `src/lib/hooks.ts`: `GEMINI_EVENT_MAP`, `ANTIGRAVITY_EVENT_MAP`, Grok's `eventMap`, `COPILOT_EVENT_MAP`, `KIRO_EVENT_MAP`, `GOOSE_EVENT_MAP`, `CURSOR_EVENT_MAP`, and `HERMES_EVENT_MAP`.
+Event name mapping across agents is handled in `src/lib/hooks/install.ts`: `GEMINI_EVENT_MAP`, `ANTIGRAVITY_EVENT_MAP`, Grok's `eventMap`, `COPILOT_EVENT_MAP`, `KIRO_EVENT_MAP`, `GOOSE_EVENT_MAP`, `CURSOR_EVENT_MAP`, and `HERMES_EVENT_MAP`.
 
 ## Version-home deduplication
 
@@ -273,7 +273,7 @@ All predicates live in `matches:`. They AND together — every declared predicat
 
 ## Script Resolution
 
-`resolveHookScriptPath(script)` in `src/lib/hooks.ts:35` resolves a script filename by checking, in order:
+`resolveHookScriptPath(script)` in `src/lib/hooks/install.ts` resolves a script filename by checking, in order:
 
 1. `~/.agents/hooks/<script>` (user dir)
 2. Each enabled extra repo's `hooks/` directory (insertion order)
@@ -294,7 +294,7 @@ hooks:
     enabled: false          # Disables the system-shipped hook
 ```
 
-`parseHookManifest()` in `src/lib/hooks.ts:704` strips entries where `enabled === false` from the returned map before the registrar sees them.
+`parseHookManifest()` in `src/lib/hooks/install.ts` strips entries where `enabled === false` from the returned map before the registrar sees them.
 
 ## Recipes
 

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -67,7 +67,7 @@ import {
   type ResourceDiff,
   type VersionResourceReport,
 } from '../lib/doctor-diff.js';
-import { checkVersionHookWiring, inspectDuplicateVersionHooks, registerHooksToSettings, repairManagedHookRuntimeArtifacts, type DuplicateVersionHook, type HookRuntimeRepairReport, type HookWiringReport } from '../lib/hooks.js';
+import { checkVersionHookWiring, inspectDuplicateVersionHooks, registerHooksToSettings, repairManagedHookRuntimeArtifacts, type DuplicateVersionHook, type HookRuntimeRepairReport, type HookWiringReport } from '../lib/hooks/install.js';
 import { isVersionIsolated } from '../lib/installations/versions.js';
 import { computeDrift, checkSyncStatus, countOrphans, computeSourceBehind, type SyncStatusRow, type OrphanRow } from '../lib/drift.js';
 import { readAuthHealthCache, summarizeHostAuth } from '../lib/auth-health.js';

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -583,7 +583,7 @@ export function registerFeedCommand(program: Command): void {
         if (activityInstall.error) setupWarnings.push(activityInstall.error);
         if (!hookInstall.error || !activityInstall.error) {
           const [{ iterHooksCapableVersions, parseHookManifest, registerHooksToSettings }, { getVersionHomePath }] = await Promise.all([
-            import('../lib/hooks.js'),
+            import('../lib/hooks/install.js'),
             import('../lib/installations/versions.js'),
           ]);
           const manifest = parseHookManifest({ warn: false });

--- a/apps/cli/src/commands/hooks.ts
+++ b/apps/cli/src/commands/hooks.ts
@@ -34,7 +34,7 @@ import {
   diffVersionHooks,
   iterHooksCapableVersions,
   removeHookFromVersion,
-} from '../lib/hooks.js';
+} from '../lib/hooks/install.js';
 import {
   listInstalledVersions,
   getGlobalDefault,

--- a/apps/cli/src/commands/inspect.test.ts
+++ b/apps/cli/src/commands/inspect.test.ts
@@ -26,7 +26,7 @@ import {
   type RoutineLiveState,
 } from './inspect.js';
 import { stripAnsi } from '../lib/session/width.js';
-import { listHookEntriesFromDir } from '../lib/hooks.js';
+import { listHookEntriesFromDir } from '../lib/hooks/install.js';
 import type { ManifestHook } from '../lib/types.js';
 import { getUserAgentsDir, getSystemAgentsDir } from '../lib/state.js';
 import { stringWidth } from '../lib/session/width.js';

--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -46,7 +46,7 @@ import {
   type ResourceEntry,
   type SkillResourceEntry,
 } from '../lib/resources.js';
-import { listHookEntriesFromDir } from '../lib/hooks.js';
+import { listHookEntriesFromDir } from '../lib/hooks/install.js';
 import { getResourceInventory, type ResourceInventory } from '../lib/resource-inventory.js';
 import { listMcpServerConfigs, discoverMcpConfigsFromRepo, type McpYamlConfig } from '../lib/mcp.js';
 import { discoverPlugins, discoverPluginsInDir, pluginResourceGroups, inspectPluginCapabilities, pluginCapabilityLabels, type PluginResourceGroup } from '../lib/plugins/plugins.js';

--- a/apps/cli/src/commands/packages.ts
+++ b/apps/cli/src/commands/packages.ts
@@ -45,7 +45,7 @@ import {
   discoverHooksFromRepo,
   installHooks,
   installHooksCentrally,
-} from '../lib/hooks.js';
+} from '../lib/hooks/install.js';
 import {
   discoverWorkflowsFromRepo,
   installWorkflowCentrally,

--- a/apps/cli/src/commands/prune.ts
+++ b/apps/cli/src/commands/prune.ts
@@ -41,7 +41,7 @@ import {
   listUnmanagedHooksInVersionHome,
   iterHooksCapableVersions,
   removeHookFromVersion,
-} from '../lib/hooks.js';
+} from '../lib/hooks/install.js';
 import {
   diffVersionPlugins,
   iterPluginsCapableVersions,

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -60,7 +60,7 @@ import {
   type AvailableResources,
 } from '../lib/installations/versions.js';
 import { capableAgents } from '../lib/capabilities.js';
-import { parseHookManifest, registerHooksToSettings } from '../lib/hooks.js';
+import { parseHookManifest, registerHooksToSettings } from '../lib/hooks/install.js';
 import { compileRulesForProject } from '../lib/rules/compile.js';
 import { runLaunchSync } from '../lib/project-launch.js';
 import { formatKeptProjectResources } from '../lib/project-resources.js';

--- a/apps/cli/src/lib/__tests__/hooks-layering.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks-layering.test.ts
@@ -44,7 +44,7 @@ vi.mock('../installations/versions.js', () => ({
   listInstalledVersions: () => [],
 }));
 
-import { normalizeHookTimeoutSeconds, parseHookManifest } from '../hooks.js';
+import { normalizeHookTimeoutSeconds, parseHookManifest } from '../hooks/install.js';
 
 describe('parseHookManifest layering', () => {
   beforeEach(() => {

--- a/apps/cli/src/lib/__tests__/hooks-nested-groups.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks-nested-groups.test.ts
@@ -25,7 +25,7 @@ vi.mock('../state.js', async (importOriginal) => {
   };
 });
 
-import { listHookEntriesFromDir, resolveHookScriptPath, registerHooksToSettings } from '../hooks.js';
+import { listHookEntriesFromDir, resolveHookScriptPath, registerHooksToSettings } from '../hooks/install.js';
 import { resolveHookSource } from '../staleness/writers/sources.js';
 import type { ManifestHook } from '../types.js';
 

--- a/apps/cli/src/lib/__tests__/hooks.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { execFileSync } from 'child_process';
 
-import { deduplicateVersionHookCommands, registerHooksToSettings, selectHookManifest, unmanagedHookNames, computeCodexHookTrustHash, toPortableCommand, pruneVersionHomeHookEntriesFromSettings } from '../hooks.js';
+import { deduplicateVersionHookCommands, registerHooksToSettings, selectHookManifest, unmanagedHookNames, computeCodexHookTrustHash, toPortableCommand, pruneVersionHomeHookEntriesFromSettings } from '../hooks/install.js';
 import { getHookShimPath } from '../hooks/cache.js';
 import * as TOML from 'smol-toml';
 import * as yaml from 'yaml';

--- a/apps/cli/src/lib/devices/doctor-findings.ts
+++ b/apps/cli/src/lib/devices/doctor-findings.ts
@@ -44,7 +44,7 @@ import { loginHint } from '../signin-badge.js';
 import { CONFIG_ENV_ISOLATED_AGENTS } from '../shims.js';
 import { padToWidth, stringWidth } from '../session/width.js';
 import type { AgentId } from '../types.js';
-import type { DuplicateVersionHook } from '../hooks.js';
+import type { DuplicateVersionHook } from '../hooks/install.js';
 import type { AgentsBinaryShadow } from '../binary-shadow.js';
 import type { RcSecretFinding } from '../secrets/rc-hygiene.js';
 import type { OwnerSinkStatus } from '../channels/owner-sink.js';

--- a/apps/cli/src/lib/devices/fleet-inventory.ts
+++ b/apps/cli/src/lib/devices/fleet-inventory.ts
@@ -11,7 +11,7 @@
 
 import { getAvailableResources, getVersionHomePath, isVersionIsolated, listInstalledVersions } from '../installations/versions.js';
 import { supports } from '../capabilities.js';
-import { checkVersionHookWiring } from '../hooks.js';
+import { checkVersionHookWiring } from '../hooks/install.js';
 import { getUserAgentsDir, getSystemAgentsDir, readMeta } from '../state.js';
 import { listNativeAccounts } from '../account-registry.js';
 import { readRepoState } from '../git.js';

--- a/apps/cli/src/lib/doctor-diff.ts
+++ b/apps/cli/src/lib/doctor-diff.ts
@@ -51,7 +51,7 @@ import { shouldInstallCommandAsSkill, commandSkillMatches, commandSkillName } fr
 import { gooseCommandMatches, gooseCommandsDir } from './goose-commands.js';
 import { supports } from './capabilities.js';
 import { listSkillsInVersionHome, getVersionSkillsDir } from './plugins/skills.js';
-import { listHookEntriesFromDir, type HookWiringReport } from './hooks.js';
+import { listHookEntriesFromDir, type HookWiringReport } from './hooks/install.js';
 import { getResourceInventory, type ResourceInventory } from './resource-inventory.js';
 
 const RULES_DOC_FILENAME = 'README.md';

--- a/apps/cli/src/lib/drift.ts
+++ b/apps/cli/src/lib/drift.ts
@@ -14,7 +14,7 @@ import { loadManifest, isStale } from './staleness/index.js';
 import { diffVersionResources, type VersionResourceReport, type SourceLayerBehind } from './doctor-diff.js';
 import { diffVersionCommands, iterCommandsCapableVersions } from './commands.js';
 import { diffVersionSkills, iterSkillsCapableVersions } from './plugins/skills.js';
-import { iterHooksCapableVersions, listUnmanagedHooksInVersionHome, checkVersionHookWiring } from './hooks.js';
+import { iterHooksCapableVersions, listUnmanagedHooksInVersionHome, checkVersionHookWiring } from './hooks/install.js';
 import { commitsBehindUpstream } from './git.js';
 import { getUserAgentsDir, getSystemAgentsDir, getEnabledExtraRepos } from './state.js';
 

--- a/apps/cli/src/lib/hooks-capability-completeness.test.ts
+++ b/apps/cli/src/lib/hooks-capability-completeness.test.ts
@@ -21,7 +21,7 @@ import { capableAgents } from './capabilities.js';
 
 describe('hooks capability <-> registrar completeness', () => {
   it('every hooks-capable agent has a branch in registerHooksToSettings', () => {
-    const hooksSource = fs.readFileSync(path.resolve(process.cwd(), 'src/lib/hooks.ts'), 'utf-8');
+    const hooksSource = fs.readFileSync(path.resolve(process.cwd(), 'src/lib/hooks/install.ts'), 'utf-8');
     const start = hooksSource.indexOf('export function registerHooksToSettings');
     expect(start).toBeGreaterThan(-1);
     // The function's final `return { registered: [], errors: [] };` (the

--- a/apps/cli/src/lib/hooks/install.test.ts
+++ b/apps/cli/src/lib/hooks/install.test.ts
@@ -49,7 +49,7 @@ interface VersionHooksReport {
 }
 
 function runVersionHooksInventory(agent: string, version: string): VersionHooksReport {
-  const modulePath = path.resolve(process.cwd(), 'src/lib/hooks.ts');
+  const modulePath = path.resolve(process.cwd(), 'src/lib/hooks/install.ts');
   const script = `
     const mod = await import(${JSON.stringify(modulePath)});
     console.log(JSON.stringify({
@@ -154,7 +154,7 @@ function seedClaudeVersionWithGeneratedShim(version: string, hookName: string, e
 /** Run checkVersionHookWiring (optionally after registerHooksToSettings) in a
  *  subprocess rooted at testHome, returning its JSON report. */
 function runWiring(agent: string, version: string, opts: { register?: boolean } = {}): WiringReport {
-  const modulePath = path.resolve(process.cwd(), 'src/lib/hooks.ts');
+  const modulePath = path.resolve(process.cwd(), 'src/lib/hooks/install.ts');
   const versionsPath = path.resolve(process.cwd(), 'src/lib/installations/versions.ts');
   const register = opts.register
     ? `
@@ -279,7 +279,7 @@ interface RuntimeRepairReport {
 }
 
 function runRuntime(scriptBody: string): string {
-  const modulePath = path.resolve(process.cwd(), 'src/lib/hooks.ts');
+  const modulePath = path.resolve(process.cwd(), 'src/lib/hooks/install.ts');
   const script = `
     const mod = await import(${JSON.stringify(modulePath)});
     ${scriptBody}
@@ -631,7 +631,7 @@ describe('repairManagedHookRuntimeArtifacts', () => {
 
 describe('installSessionTrackerHookSync — failure reasons are never empty', () => {
   it('returns installed:false with a NON-EMPTY error when the hook cannot be installed', async () => {
-    const { installSessionTrackerHookSync } = await import('./hooks.js');
+    const { installSessionTrackerHookSync } = await import('./install.js');
     // antigravity passes the CLI-side supports(agent,'hooks') gate, but the
     // session-tracker child declines it (no SessionStart hook event) and prints
     // the reason to STDOUT. Pre-fix, err.stderr was an empty-but-truthy Buffer,

--- a/apps/cli/src/lib/hooks/install.ts
+++ b/apps/cli/src/lib/hooks/install.ts
@@ -17,10 +17,10 @@ import * as TOML from 'smol-toml';
 import { execFile, execFileSync } from 'child_process';
 import { promisify } from 'util';
 import { fileURLToPath } from 'url';
-import { AGENTS, ALL_AGENT_IDS, agentConfigDirName, isAgentHardDeprecated } from './agents.js';
-import { supports, explainSkip, capableAgents } from './capabilities.js';
-import { getAgentsDir, getHooksDir as getSystemHooksDir, getUserHooksDir, getUserAgentsDir, getSystemAgentsDir, getProjectAgentsDir, getTrashHooksDir, getEnabledExtraRepos, getResolvedRulesDir, getUserRulesDir, getPerfDir } from './state.js';
-import { collectSubruleHooksFromState } from './rules/compose.js';
+import { AGENTS, ALL_AGENT_IDS, agentConfigDirName, isAgentHardDeprecated } from '../agents.js';
+import { supports, explainSkip, capableAgents } from '../capabilities.js';
+import { getAgentsDir, getHooksDir as getSystemHooksDir, getUserHooksDir, getUserAgentsDir, getSystemAgentsDir, getProjectAgentsDir, getTrashHooksDir, getEnabledExtraRepos, getResolvedRulesDir, getUserRulesDir, getPerfDir } from '../state.js';
+import { collectSubruleHooksFromState } from '../rules/compose.js';
 
 function getCentralHooksDir(): string { return getUserHooksDir(); }
 
@@ -278,10 +278,10 @@ import {
   isVersionIsolated,
   listInstalledVersions,
   resolveVersion,
-} from './installations/versions.js';
-import type { AgentId, HookCacheConfig, HookMatches, InstalledHook, ManifestHook } from './types.js';
-import { generateHookShim, getHookShimPath, isValidHookShimName, parseCacheConfig, removeHookShim } from './hooks/cache.js';
-import { getHookShimsDir } from './state.js';
+} from '../installations/versions.js';
+import type { AgentId, HookCacheConfig, HookMatches, InstalledHook, ManifestHook } from '../types.js';
+import { generateHookShim, getHookShimPath, isValidHookShimName, parseCacheConfig, removeHookShim } from './cache.js';
+import { getHookShimsDir } from '../state.js';
 
 export type HookEntry = { name: string; scriptPath: string; dataFile?: string };
 
@@ -3779,13 +3779,13 @@ export interface InstallSessionTrackerHookResult {
 
 function resolveSessionTrackerRoot(): string | null {
   const here = path.dirname(fileURLToPath(import.meta.url));
-  // Built/installed layout: dist/lib/ -> dist/session-tracker
-  const built = path.resolve(here, '..', 'session-tracker');
+  // Built/installed layout: dist/lib/hooks/ -> dist/session-tracker
+  const built = path.resolve(here, '..', '..', 'session-tracker');
   if (fs.existsSync(path.join(built, 'dist', 'hook.sh'))) {
     return built;
   }
-  // Source layout: apps/cli/src/lib/ -> repo root -> packages/session-tracker
-  const source = path.resolve(here, '..', '..', '..', '..', 'packages', 'session-tracker');
+  // Source layout: apps/cli/src/lib/hooks/ -> repo root -> packages/session-tracker
+  const source = path.resolve(here, '..', '..', '..', '..', '..', 'packages', 'session-tracker');
   if (fs.existsSync(path.join(source, 'src', 'hook.sh'))) {
     return source;
   }

--- a/apps/cli/src/lib/installations/versions.test.ts
+++ b/apps/cli/src/lib/installations/versions.test.ts
@@ -45,7 +45,7 @@ function runVersionSync(home: string, expression: string): unknown {
   const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
   const child = spawnSync(nodeExecPath(), [tsxBin, '-e', `
     import { listInstalledVersions, syncResourcesToVersion, buildRepoScopedSelection, getVersionHomePath, getBinaryPath } from ${JSON.stringify(moduleUrl)};
-    import { registerHooksToSettings } from ${JSON.stringify(pathToFileURL(path.resolve('src/lib/hooks.ts')).href)};
+    import { registerHooksToSettings } from ${JSON.stringify(pathToFileURL(path.resolve('src/lib/hooks/install.ts')).href)};
     const home = ${JSON.stringify(home)};
     const result = ${expression};
     console.log(JSON.stringify(result));

--- a/apps/cli/src/lib/installations/versions.ts
+++ b/apps/cli/src/lib/installations/versions.ts
@@ -67,7 +67,7 @@ import { INSTALLATION_RECORD_FILE } from './types.js';
 import { composeWin32CommandLine } from '../platform/index.js';
 import { listInstalledSubagents, transformSubagentForClaude, syncSubagentToOpenclaw } from '../subagents.js';
 import { listInstalledWorkflows, syncWorkflowToVersion } from '../workflows.js';
-import { parseHookManifest, registerHooksToSettings, selectHookManifest, pruneVersionHomeHookEntriesFromSettings, installSessionTrackerHookSync, installSessionTrackerHook } from '../hooks.js';
+import { parseHookManifest, registerHooksToSettings, selectHookManifest, pruneVersionHomeHookEntriesFromSettings, installSessionTrackerHookSync, installSessionTrackerHook } from '../hooks/install.js';
 import { supports, explainSkip, capableAgents } from '../capabilities.js';
 import { discoverPlugins, syncPluginToVersion, isPluginSynced, pluginSupportsAgent, cleanOrphanedPluginSkills, marketplaceSpecForName } from '../plugins/plugins.js';
 import { composeRulesFromState } from '../rules/compose.js';

--- a/apps/cli/src/lib/refresh.ts
+++ b/apps/cli/src/lib/refresh.ts
@@ -60,7 +60,7 @@ import {
   switchConfigSymlink,
   switchHomeFileSymlinks,
 } from './shims.js';
-import { parseHookManifest, registerHooksToSettings } from './hooks.js';
+import { parseHookManifest, registerHooksToSettings } from './hooks/install.js';
 import { isPromptCancelled } from './format.js';
 
 export interface RefreshOptions {

--- a/apps/cli/src/lib/resource-inventory.test.ts
+++ b/apps/cli/src/lib/resource-inventory.test.ts
@@ -46,7 +46,7 @@ interface InventoryReport {
 function runInventory(agent: string, version: string, opts: { register?: boolean } = {}): InventoryReport {
   const modulePath = path.resolve(process.cwd(), 'src/lib/resource-inventory.ts');
   const versionsPath = path.resolve(process.cwd(), 'src/lib/installations/versions.ts');
-  const hooksPath = path.resolve(process.cwd(), 'src/lib/hooks.ts');
+  const hooksPath = path.resolve(process.cwd(), 'src/lib/hooks/install.ts');
   const register = opts.register
     ? `
       const { getVersionHomePath } = await import(${JSON.stringify(versionsPath)});

--- a/apps/cli/src/lib/resource-inventory.ts
+++ b/apps/cli/src/lib/resource-inventory.ts
@@ -27,7 +27,7 @@ import {
   listHooksInVersionHome,
   listInstalledHooksWithScope,
   type HookWiringReport,
-} from './hooks.js';
+} from './hooks/install.js';
 
 /** Resource kinds the inventory can report. Only 'hooks' is implemented so far
  *  (RUSH-2238); the remaining kinds land with their follow-up tickets. */

--- a/apps/cli/src/lib/self-heal/checks/hook-runtime.ts
+++ b/apps/cli/src/lib/self-heal/checks/hook-runtime.ts
@@ -6,7 +6,7 @@
 
 import type { HealCheck, HealCtx, CheckResult } from '../types.js';
 import { resultOf } from '../types.js';
-import { repairManagedHookRuntimeArtifacts } from '../../hooks.js';
+import { repairManagedHookRuntimeArtifacts } from '../../hooks/install.js';
 
 export const hookRuntimeCheck: HealCheck = {
   id: 'hook-runtime',

--- a/apps/cli/src/lib/self-heal/self-heal.integration.test.ts
+++ b/apps/cli/src/lib/self-heal/self-heal.integration.test.ts
@@ -167,7 +167,7 @@ describe.skipIf(process.platform === 'win32')('runSelfHeal — generated hook ru
 
   it('repairs a missing wrapper once per shared path, post-verifies it, then becomes a no-op', () => {
     const registryPath = path.resolve(process.cwd(), 'src/lib/self-heal/registry.ts');
-    const hooksPath = path.resolve(process.cwd(), 'src/lib/hooks.ts');
+    const hooksPath = path.resolve(process.cwd(), 'src/lib/hooks/install.ts');
     const hookCachePath = path.resolve(process.cwd(), 'src/lib/hooks/cache.ts');
     const versionsPath = path.resolve(process.cwd(), 'src/lib/installations/versions.ts');
     const script = `
@@ -212,7 +212,7 @@ describe.skipIf(process.platform === 'win32')('runSelfHeal — generated hook ru
 
   it('surfaces one stable failure for an unusable destination without retrying in-pass', () => {
     const registryPath = path.resolve(process.cwd(), 'src/lib/self-heal/registry.ts');
-    const hooksPath = path.resolve(process.cwd(), 'src/lib/hooks.ts');
+    const hooksPath = path.resolve(process.cwd(), 'src/lib/hooks/install.ts');
     const hookCachePath = path.resolve(process.cwd(), 'src/lib/hooks/cache.ts');
     const script = `
       import { runSelfHeal } from ${JSON.stringify(registryPath)};

--- a/apps/cli/src/lib/staleness/prune.ts
+++ b/apps/cli/src/lib/staleness/prune.ts
@@ -44,7 +44,7 @@ import { getWriter, getDetector } from './registry.js';
  *   - hooks — a version-home hook script is coupled to a settings.json /
  *     hooks.json REGISTRATION. Pruning the last hook to zero would delete the
  *     script but must also GC its registration in the same pass, and that lands
- *     in `src/lib/hooks.ts` — a Windows-portable-path surface the CI windows leg
+ *     in `src/lib/hooks/install.ts` — a Windows-portable-path surface the CI windows leg
  *     gates on. Split to RUSH-2456 so this PR stays Linux-only-green; hook FILES
  *     are still reconciled by the in-write orphan sweep (versions.ts, gated on
  *     `hooksToSync > 0`).

--- a/apps/cli/src/lib/staleness/writers/hooks.ts
+++ b/apps/cli/src/lib/staleness/writers/hooks.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import type { AgentId } from '../../types.js';
 import { capableAgents } from '../../capabilities.js';
 import { safeJoin } from '../../paths.js';
-import { registerHooksToSettings } from '../../hooks.js';
+import { registerHooksToSettings } from '../../hooks/install.js';
 import type { ResourceWriter, WriteArgs, WriteResult, RemoveArgs, RemoveResult } from './types.js';
 import { resolveHookSource } from './sources.js';
 import { lazyAgentMap } from './lazy-map.js';

--- a/apps/cli/src/lib/sync-umbrella.bench.ts
+++ b/apps/cli/src/lib/sync-umbrella.bench.ts
@@ -110,7 +110,7 @@ import { listResources } from './resources.js';
 import { buildManifest, isStale, loadManifest } from './staleness/index.js';
 import { getDetector } from './staleness/registry.js';
 import { clearLayerCache } from './staleness/layers.js';
-import { parseHookManifest, registerHooksToSettings } from './hooks.js';
+import { parseHookManifest, registerHooksToSettings } from './hooks/install.js';
 
 const cwd = process.cwd();
 

--- a/apps/cli/tests/hook-doc-sidecar.test.ts
+++ b/apps/cli/tests/hook-doc-sidecar.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { listHookEntriesFromDir } from '../src/lib/hooks.js';
+import { listHookEntriesFromDir } from '../src/lib/hooks/install.js';
 
 let TMP: string;
 beforeEach(() => { TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'hook-sidecar-')); });

--- a/apps/cli/tests/hooks-soft-delete.test.ts
+++ b/apps/cli/tests/hooks-soft-delete.test.ts
@@ -37,7 +37,7 @@ import {
   diffVersionHooks,
   getVersionHooksDir,
   listHooksInVersionHome,
-} from '../src/lib/hooks.js';
+} from '../src/lib/hooks/install.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/apps/cli/tests/versions.test.ts
+++ b/apps/cli/tests/versions.test.ts
@@ -131,7 +131,7 @@ vi.mock('../src/lib/subagents.js', () => ({
   syncSubagentToOpenclaw: () => ({ success: false }),
 }));
 
-vi.mock('../src/lib/hooks.js', () => ({
+vi.mock('../src/lib/hooks/install.js', () => ({
   parseHookManifest: () => ({}),
   selectHookManifest: (manifest: object) => manifest,
   registerHooksToSettings: () => {},

--- a/packages/session-tracker/src/install-hook.ts
+++ b/packages/session-tracker/src/install-hook.ts
@@ -195,7 +195,7 @@ async function installHermes(opts: InstallOptions): Promise<InstallResult> {
   if (opts.dryRun) return { agent: 'hermes', installed: false, configPath };
   // Read-modify-write the YAML, preserving every sibling key (mcp_servers, …) —
   // mirrors the CLI's registerHooksForHermes. Hermes maps SessionStart to the
-  // `on_session_start` event (HERMES_EVENT_MAP in apps/cli/src/lib/hooks.ts).
+  // `on_session_start` event (HERMES_EVENT_MAP in apps/cli/src/lib/hooks/install.ts).
   let cfg: Record<string, unknown> = {};
   try {
     const parsed = YAML.parse(await fs.promises.readFile(configPath, 'utf8'));

--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -218,6 +218,17 @@ describe('selectImpact policy', () => {
     expect(plan.budget_sec).toBeGreaterThan(IMPACT_BUDGET_SEC);
   });
 
+  test('a hooks change carries the group budget, not the 85s default', () => {
+    const plan = selectImpact({
+      files: ['apps/cli/src/lib/hooks/install.ts'],
+      repoRoot: REPO,
+      related: false,
+    });
+    expect(plan.suite).toBe('selected');
+    expect(plan.budget_sec).toBe(150);
+    expect(plan.budget_sec).toBeGreaterThan(IMPACT_BUDGET_SEC);
+  });
+
   test('a daemon change carries the group budget, not the 85s default', () => {
     // runner.ts lives in daemon/; retargeting commands/routines.ts onto it
     // selects routines.test.ts (78 tests / 174s) inside a 213s impact run

--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -99,7 +99,7 @@ describe('classifyCiScope', () => {
   });
 
   test.each([
-    'apps/cli/src/lib/hooks.ts',
+    'apps/cli/src/lib/hooks/install.ts',
     'apps/cli/src/lib/hooks/loader.ts',
     'apps/cli/src/lib/platform/paths.ts',
     'apps/cli/src/lib/shims-windows.ts',


### PR DESCRIPTION
refactor — no behavior change

Third hub-drain slice after #2800 and #2803. Moves the hooks registrar out of the 190-file `src/lib` hub into `lib/hooks/install.ts`, next to `cache.ts` / `match.ts` / `profile.ts`.

No re-export shim at the old hub path. Session-tracker path walks gain one hop (`dist/lib/hooks/`).

## What moved

| Old hub path | New home |
|---|---|
| `src/lib/hooks.ts` | `src/lib/hooks/install.ts` |
| `src/lib/hooks.test.ts` | `src/lib/hooks/install.test.ts` |

## Run

```
Test Files  5 passed (5)
     Tests  162 passed (162)
  Duration  2.70s
```

Files: `hooks/install.test.ts`, `__tests__/hooks.test.ts`, `hooks-capability-completeness.test.ts`, `hooks/cache.test.ts`, `hooks/profile.test.ts`. Combined diff vs `origin/main` is 52/53 (rename + import retarget).
