### PR TITLE
docs: list every ResourceKind in AGENTS.md and concepts.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,11 +84,14 @@ other **machines**. Deep reference: [`apps/cli/docs/concepts.md`](apps/cli/docs/
 and [`architecture.md`](apps/cli/docs/architecture.md).
 
 - **Resources** — the typed things an agent needs, one kind per subdirectory of a
-  DotAgents repo: `rules` (this `AGENTS.md` → `CLAUDE.md`/`GEMINI.md`/…), `commands`,
-  `skills`, `hooks`, `mcp`, `permissions`, `profiles`, `subagents`. Installed once in
-  `~/.agents/` and synced into each agent's native format. Resolution is **layered** —
-  project → user → extra repos → system; the highest layer wins a name collision, the
-  rest union (`apps/cli/src/lib/resources.ts`: `resolveResource`, `listResources`).
+  DotAgents repo (`ResourceKind` in `apps/cli/src/lib/resources.ts`): `rules` (this
+  `AGENTS.md` → `CLAUDE.md`/`GEMINI.md`/…), `commands`, `skills`, `hooks`, `mcp`,
+  `clis`, `permissions`, `subagents`, `workflows`, `profiles`, `routers`, `secrets`.
+  Installed once in `~/.agents/` and synced into each agent's native format.
+  Resolution is **layered** — project → user → extra repos → system; the highest
+  layer wins a name collision, the rest union (`resolveResource`, `listResources`).
+  `plugins` is a capability/sync kind (staleness `ALL_RESOURCE_KINDS`), not a
+  `ResourceKind` subdirectory.
 - **One execution engine.** Every agent invocation goes through one path —
   `buildExecEnv` → `execAgent` / `runWithFallback` in
   [`apps/cli/src/lib/exec.ts`](apps/cli/src/lib/exec.ts), entered via `agents run`. Each

--- a/apps/cli/docs/concepts.md
+++ b/apps/cli/docs/concepts.md
@@ -47,9 +47,12 @@ A **resource** is any named item inside a DotAgents repo. Resources are typed by
 | `rules` | Persistent memory / instructions for the agent | `AGENTS.md` → `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, … |
 | `mcp` | MCP server definitions (transport, command, args, env) | Merged into each agent's settings file |
 | `permissions` | Allow/deny tool permission groups | Converted to each agent's native format |
+| `clis` | Named host-CLI wrappers (`clis/<name>.yaml`) | YAML, listed by `agents clis` |
 | `profiles` | Model + endpoint + auth bundles | YAML, consumed by `agents run` and shims |
 | `routers` | Named, task-typed allowlists of harnesses x models/tiers x linked accounts (a router is a generalization of a profile) | YAML, consumed by the Agent Router |
 | `subagents` | Subagent workflow definitions | `.md` files |
+| `workflows` | Named workflow scripts (Rhai / harness-native) | Synced into each capable agent's workflow dir |
+| `secrets` | Named secret-bundle references (not the secret values) | YAML metadata; values live in `agents secrets` |
 
 Resources are installed once in `~/.agents/` and synced to every supported agent's native format automatically. Sync happens when you run `agents use`, `agents repos pull`, or explicitly via `agents sync`.
 


### PR DESCRIPTION
docs-only

Aligns the resource-kind list in root `AGENTS.md` and `apps/cli/docs/concepts.md` with `ResourceKind` in `apps/cli/src/lib/resources.ts`. The previous bullet omitted `clis`, `workflows`, `routers`, and `secrets`, and the concepts table omitted `clis` / `workflows` / `secrets`. `profiles` stays — it is a `ResourceKind`. `plugins` is a staleness/capability kind (`ALL_RESOURCE_KINDS`), not a DotAgents subdirectory, so it is named as such rather than folded into the subdirectory list.

No runtime change.

## Run

docs-only — no runtime surface to exercise. Diff is two markdown files against `origin/main` (`957dc1d66`).
