### PR TITLE
docs(memories): 2026-08-20 — sub-60s goal, release unwedge, 1.22.41 shipped

### DIFF
--- a/.agents/memories/2026-08-20.md
+++ b/.agents/memories/2026-08-20.md
@@ -1,0 +1,27 @@
+# 2026-08-20
+
+### 08:02 · claude@yosemite-s1 · e5f8d788 · RUSH-2781
+- Measured the post-RUSH-2666 required check with a live probe instead of trusting the corpus: picked a real ticket, fixed `apps/ext/scripts/activate.sh` (never script a window reload on the fleet's interactive host; `--reload-windows` overrides; unknown state degrades to report-only), and stopwatched delivery.
+- outcome: PR #2784 open → all required checks green in 49s (test 43s = 16s fixed setup + 27s selected tests; gitleaks 18s parallel), merged; RUSH-2781 Done.
+
+### 08:30 · claude@yosemite-s1 · e5f8d788 · RUSH-2788
+- Owner re-set the CI/release bar: **most runs reliably under 60 seconds, releases included** — supersedes the P99≤90s / cache-hit≤10s pair as the operative goal (those remain as the written acceptance criteria in `apps/cli/CLAUDE.md`).
+- The remaining levers, ranked: (1) the 16-19s fixed GitHub-runner overhead — only a self-hosted lane removes it (RUSH-2773); (2) wide-diff selection pulling minutes of tests (RUSH-2819, filed today); (3) the RUSH-2732 env-flavored flake class, which taxes release attestation hardest.
+
+### 09:03 · claude@yosemite-s1 (team ci-sub60, teammate red-tests) · e5f8d788 · RUSH-2761
+- Unwedged the release train's first blocker: the "environment-dependent" `project-key.test.ts` failure was a **real product bug** — `repoRootForCwd` never bounded its upward `.git` search at `$HOME`, so host state (a stray `/tmp/.git`) leaked into results. Bounded the walk per the documented intent in `shims.ts`. The `sessions-bookmark` timeout was real discovery cost under load, not a hang (30s → 90s, matching suite precedent).
+- outcome: PR #2788 merged; main attestable again.
+
+### 09:52 · claude@yosemite-s1 · e5f8d788 · RUSH-2761
+- Found and named a standing coverage gap: **the required PR check runs Linux-only, so darwin-only breaks merge green and surface later at macOS release attestation.** PR #2789 shipped two the same morning (`browser.use.test.ts` pinned `binary: '/bin/true'`, which does not exist on macOS, and a `.changelog/` fragment committed without regenerating `CHANGELOG.md`).
+- outcome: PR #2791 (portable `process.execPath` fixture) and sibling PR #2792 (re-queue the changelog entry as a `.changelog/next/` fragment rather than deleting it) merged, both with green CI + non-author APPROVE. Until a macOS leg or attest-on-merge exists, darwin breakage is a known escape route past the gate.
+
+### 09:45 · claude@yosemite-s0 (team ci-sub60, teammate ci-lane) · — · RUSH-2773
+- Safety decision: **refused to route required PR checks onto the trusted `crabbox-ci` runner pool.** The pool has tailnet + fleet SSH reach and the repo's own design forbids it on every `pull_request` trigger — a `runs-on` provenance expression is not an isolation boundary (a fork PR runs its own workflow tree). PR #2787 was closed after non-author REQUEST-CHANGES even though it proved the prize: a real required check ran green in **29s** on runner ci-runner-fsn1-phnx-2.
+- The design-sanctioned path is registering the untrusted Firecracker executor (merged in #2745, no tailnet/creds) as its own Actions lane; that scope decision is with the owner.
+
+### 16:03 · claude@yosemite-s1 · e5f8d788 · RUSH-2761
+- **1.22.41 shipped end-to-end**: attested (origin/main + release-commit trees), release PR #2790 merged, `v1.22.41` tagged, published 16:03:51Z, six fleet boxes verified running the installed version. All three helpers (computer-mac, keychain, menubar) reused by content digest — zero rebuilds, as designed.
+- Release mechanics, measured: **~2-3 min with attestations in hand** (the ≤180s promote path is real); **~9 min per attestation** (full 12.4k-test suite + sign on mac-mini); publish then sat blocked **~5.6h** because the `npmjs.com` bundle on mac-mini is macOS-keychain-backed and a headless SSH session cannot read (or persist writes into) a locked login keychain.
+- Two durable fixes recorded: (1) owner authorized replacing mac-mini's keychain-backed `npmjs.com` bundle with a **file-backed, headless-readable** copy — headless releases no longer wedge on Touch ID; (2) `release.sh` reads the attestation store from `RELEASE_ATTESTATION_DIR` (default `$REPO_ROOT/.release-attestations`) — a producer writing to a different `--dir` must export that variable for the release run, or phase [2/6] fails with "missing exact attestation key".
+- CI state after the day's work, last 26 successful PR runs: **mean 72s · median 66s · min 19s (docs) · max 4.1m (wide refactor) · p90 116s**. The median sits at the 60s line; the runner floor and wide-diff selection are what remain.

--- a/.agents/memories/README.md
+++ b/.agents/memories/README.md
@@ -33,7 +33,7 @@ no shipped change or artifact could be cited, are marked as such rather than inv
 
 ## Index
 
-Coverage: **41 active days**, 2026-06-24 → 2026-08-10.
+Coverage: **42 active days**, 2026-06-24 → 2026-08-20 (gap 08-11 → 08-19 not yet backfilled).
 
 - **Jun 24 – Jul 06** — Swarmify → Agency.Li rename; reducing Touch ID prompts (secrets
   broker); native cloud providers; agents teams; routines; the `.agents` DotAgents repo;
@@ -51,3 +51,7 @@ Coverage: **41 active days**, 2026-06-24 → 2026-08-10.
   `--host`, `--device` sole target (RUSH-2494); CLI surface consolidation; DeepInfra;
   events-one-engine (PR #2550); daemon services + monitors ownership; browser sessions in
   DB; dev-install no-shadow (`agents-dev`); Factory → AGI EXT rename; this backfill.
+- **Aug 20** — sub-60s CI/release goal set; release train unwedged (repoRootForCwd home
+  bug, darwin-only escapes past the Linux-only gate); 1.22.41 shipped end-to-end;
+  headless npm token on mac-mini (file-backed); trusted-pool PR lane refused as
+  fork-unsafe (29s check proven, untrusted-executor lane pending owner decision).


### PR DESCRIPTION
docs-only — project decision log for 2026-08-20 in .agents/memories/ (per the README convention), plus the README coverage index. Records: the owner's sub-60s CI/release goal; the repoRootForCwd home-boundary bug; the Linux-only-gate darwin escape class; the trusted-pool refusal + untrusted-lane decision pending; 1.22.41 shipped with measured timings; the RELEASE_ATTESTATION_DIR and headless npm-token fixes. No code changes.