### PR TITLE
test(session): cover the incremental-vs-full scan decision (RUSH-2843)

### DIFF
--- a/apps/cli/src/lib/session/__tests__/resumable-scan-decision.test.ts
+++ b/apps/cli/src/lib/session/__tests__/resumable-scan-decision.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  scanClaudeSessionResumable,
+  scanCodexSessionResumable,
+  scanClaudeSessionIncremental,
+  scanCodexSessionIncremental,
+  initClaudeParseState,
+  initCodexParseState,
+  serializeClaudeParserState,
+  serializeCodexParserState,
+  type ClaudeParserState,
+  type CodexParserState,
+} from '../discover.js';
+
+// RUSH-2843. scanClaudeSessionResumable / scanCodexSessionResumable are the ONE
+// place that decides incremental-vs-full reparse for a transcript, and until
+// this file existed neither was invoked by any test: they were module-private,
+// and the parity suites (incremental-parity.test.ts:283-285,
+// codex-incremental-parity.test.ts:222-253) computed the branch in the TEST
+// body — so they asserted that a full parse equals a full parse. The comment
+// there conceded it ("the resumable contract (B-2 will wire this) is: …").
+//
+// Every case below drives the real function and asserts the `mode` it returned,
+// so a wrong branch fails here instead of silently producing a session row that
+// carries another conversation's data. Real files, real fs, no mocks.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-resumable-'));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function jsonl(lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n';
+}
+
+/** A Claude transcript whose identity (first user timestamp) is `ts`. */
+function claudeLines(ts: string, text: string): object[] {
+  return [
+    { type: 'user', timestamp: ts, cwd: '/repo', message: { role: 'user', content: text } },
+    {
+      type: 'assistant',
+      timestamp: ts,
+      message: { id: `m-${text}`, content: [{ type: 'text', text: `reply ${text}` }], usage: { input_tokens: 5, output_tokens: 2 } },
+    },
+  ];
+}
+
+/** A Codex rollout whose identity (session_meta payload id) is `id`. */
+function codexLines(id: string, text: string): object[] {
+  return [
+    { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id, cwd: '/repo', model: 'gpt-5-codex' } },
+    { type: 'response_item', timestamp: '2026-06-28T00:00:30.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text }] } },
+  ];
+}
+
+/** Seed a file and return the continuation a prior indexing pass would have persisted. */
+async function seedClaude(fp: string, body: string): Promise<{ prior: ClaudeParserState; mtimeMs: number; size: number }> {
+  fs.writeFileSync(fp, body);
+  const fresh = serializeClaudeParserState(initClaudeParseState(), 0);
+  const step = await scanClaudeSessionIncremental(fp, 0, fresh);
+  const st = fs.statSync(fp);
+  return { prior: step.newState, mtimeMs: st.mtimeMs, size: st.size };
+}
+
+async function seedCodex(fp: string, body: string): Promise<{ prior: CodexParserState; mtimeMs: number; size: number }> {
+  fs.writeFileSync(fp, body);
+  const fresh = serializeCodexParserState(initCodexParseState(), 0);
+  const step = await scanCodexSessionIncremental(fp, 0, fresh);
+  const st = fs.statSync(fp);
+  return { prior: step.newState, mtimeMs: st.mtimeMs, size: st.size };
+}
+
+describe('scanClaudeSessionResumable — the full-vs-incremental decision', () => {
+  it('cold start (no prior continuation) parses FULL', async () => {
+    const fp = path.join(dir, 's.jsonl');
+    fs.writeFileSync(fp, jsonl(claudeLines('2026-06-28T00:00:00.000Z', 'one')));
+    const st = fs.statSync(fp);
+
+    const r = await scanClaudeSessionResumable(fp, null, st.mtimeMs, st.size);
+    expect(r.mode).toBe('full');
+    expect(r.scan.topic).toBe('one');
+  });
+
+  it('a genuine append with an unchanged identity resumes INCREMENTALLY, matching a full reparse', async () => {
+    const fp = path.join(dir, 's.jsonl');
+    const seed = await seedClaude(fp, jsonl(claudeLines('2026-06-28T00:00:00.000Z', 'one')));
+
+    fs.appendFileSync(fp, jsonl(claudeLines('2026-06-29T00:00:00.000Z', 'two')));
+    const st = fs.statSync(fp);
+
+    const inc = await scanClaudeSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs);
+    expect(inc.mode).toBe('incremental');
+
+    // The whole point of resuming is that it is indistinguishable from a full
+    // parse of the same bytes — so compare against one.
+    const full = await scanClaudeSessionResumable(fp, null, st.mtimeMs, st.size);
+    expect(full.mode).toBe('full');
+    expect(inc.scan).toEqual(full.scan);
+    expect(inc.newOffset).toBe(full.newOffset);
+  });
+
+  it('TRUNCATION — the file shrank below the stored offset — falls back to FULL', async () => {
+    const fp = path.join(dir, 's.jsonl');
+    const seed = await seedClaude(fp, jsonl(claudeLines('2026-06-28T00:00:00.000Z', 'a long original prompt')));
+
+    // A fresh, shorter session reusing the same path.
+    fs.writeFileSync(fp, jsonl(claudeLines('2026-06-30T00:00:00.000Z', 'short')));
+    const st = fs.statSync(fp);
+    expect(st.size).toBeLessThan(seed.prior.offset);
+
+    const r = await scanClaudeSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs);
+    expect(r.mode).toBe('full');
+    expect(r.scan.topic).toBe('short');
+  });
+
+  it('TRUNCATION with the identity UNCHANGED still falls back to FULL', async () => {
+    // The case above shrinks AND changes the first turn, so the identity check
+    // would force FULL on its own and the size guard is never the deciding
+    // factor — verified by mutation: deleting `currentFileSize > prior.offset`
+    // left that test green. Here the same session is rewritten shorter (its
+    // first user turn is byte-identical), so the size guard is the ONLY thing
+    // standing between a stale offset and a parse that reads past EOF.
+    const fp = path.join(dir, 's.jsonl');
+    const first = claudeLines('2026-06-28T00:00:00.000Z', 'kept');
+    const seed = await seedClaude(fp, jsonl([...first, ...claudeLines('2026-06-28T01:00:00.000Z', 'dropped later')]));
+
+    fs.writeFileSync(fp, jsonl(first));
+    const st = fs.statSync(fp);
+    expect(st.size).toBeLessThan(seed.prior.offset);
+
+    const r = await scanClaudeSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs);
+    expect(r.mode).toBe('full');
+    expect(r.scan.topic).toBe('kept');
+  });
+
+  it('A DIFFERENT SESSION rewritten LARGER at the same path falls back to FULL', async () => {
+    // The case size+mtime alone cannot catch, and the one that silently folds
+    // another conversation's bytes into this row if the identity check regresses.
+    const fp = path.join(dir, 's.jsonl');
+    const seed = await seedClaude(fp, jsonl(claudeLines('2026-06-28T00:00:00.000Z', 'original')));
+
+    const replacement = jsonl([
+      ...claudeLines('2026-07-01T00:00:00.000Z', 'a completely different and longer conversation'),
+      ...claudeLines('2026-07-01T00:05:00.000Z', 'with more turns so the file is bigger'),
+    ]);
+    fs.writeFileSync(fp, replacement);
+    const st = fs.statSync(fp);
+    expect(st.size).toBeGreaterThan(seed.prior.offset); // grew: the metadata gate would say "incremental"
+
+    const r = await scanClaudeSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs);
+    expect(r.mode).toBe('full');
+    // and the row is the NEW session, with no trace of the old one folded in
+    expect(r.scan.topic).toBe('a completely different and longer conversation');
+
+    const full = await scanClaudeSessionResumable(fp, null, st.mtimeMs, st.size);
+    expect(r.scan).toEqual(full.scan);
+  });
+
+  it('CLOCK REWIND — mtime moved backwards — falls back to FULL even though the file grew', async () => {
+    const fp = path.join(dir, 's.jsonl');
+    const seed = await seedClaude(fp, jsonl(claudeLines('2026-06-28T00:00:00.000Z', 'one')));
+
+    fs.appendFileSync(fp, jsonl(claudeLines('2026-06-29T00:00:00.000Z', 'two')));
+    const st = fs.statSync(fp);
+    expect(st.size).toBeGreaterThan(seed.prior.offset);
+
+    // priorFileMtimeMs is AHEAD of the file's current mtime.
+    const r = await scanClaudeSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs + 60_000);
+    expect(r.mode).toBe('full');
+  });
+
+  it('a prior continuation with no recorded identity falls back to FULL', async () => {
+    const fp = path.join(dir, 's.jsonl');
+    const seed = await seedClaude(fp, jsonl(claudeLines('2026-06-28T00:00:00.000Z', 'one')));
+    fs.appendFileSync(fp, jsonl(claudeLines('2026-06-29T00:00:00.000Z', 'two')));
+    const st = fs.statSync(fp);
+
+    const noIdentity: ClaudeParserState = { ...seed.prior, timestamp: undefined };
+    const r = await scanClaudeSessionResumable(fp, noIdentity, st.mtimeMs, st.size, seed.mtimeMs);
+    expect(r.mode).toBe('full');
+  });
+});
+
+describe('scanCodexSessionResumable — the full-vs-incremental decision', () => {
+  it('cold start (no prior continuation) parses FULL', async () => {
+    const fp = path.join(dir, 'r.jsonl');
+    fs.writeFileSync(fp, jsonl(codexLines('sess-1', 'one')));
+    const st = fs.statSync(fp);
+
+    const r = await scanCodexSessionResumable(fp, null, st.mtimeMs, st.size);
+    expect(r.mode).toBe('full');
+  });
+
+  it('a genuine append with an unchanged rollout id resumes INCREMENTALLY, matching a full reparse', async () => {
+    const fp = path.join(dir, 'r.jsonl');
+    const seed = await seedCodex(fp, jsonl(codexLines('sess-1', 'one')));
+
+    fs.appendFileSync(fp, jsonl([
+      { type: 'response_item', timestamp: '2026-06-28T00:02:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'two' }] } },
+    ]));
+    const st = fs.statSync(fp);
+
+    const inc = await scanCodexSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs);
+    expect(inc.mode).toBe('incremental');
+
+    const full = await scanCodexSessionResumable(fp, null, st.mtimeMs, st.size);
+    expect(full.mode).toBe('full');
+    expect(inc.scan).toEqual(full.scan);
+    expect(inc.newOffset).toBe(full.newOffset);
+  });
+
+  it('TRUNCATION — the rollout shrank below the stored offset — falls back to FULL', async () => {
+    const fp = path.join(dir, 'r.jsonl');
+    const seed = await seedCodex(fp, jsonl(codexLines('sess-1', 'a long original user turn')));
+
+    fs.writeFileSync(fp, jsonl(codexLines('sess-2', 'x')));
+    const st = fs.statSync(fp);
+    expect(st.size).toBeLessThan(seed.prior.offset);
+
+    const r = await scanCodexSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs);
+    expect(r.mode).toBe('full');
+  });
+
+  it('TRUNCATION with the rollout id UNCHANGED still falls back to FULL', async () => {
+    // Same reasoning as the Claude case: shrinking to a DIFFERENT rollout is
+    // caught by the id check alone, so that test cannot fail when the size
+    // guard is deleted. Keeping `sess-1` makes the size guard load-bearing.
+    const fp = path.join(dir, 'r.jsonl');
+    const first = codexLines('sess-1', 'kept');
+    const seed = await seedCodex(fp, jsonl([
+      ...first,
+      { type: 'response_item', timestamp: '2026-06-28T01:00:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'dropped later' }] } },
+    ]));
+
+    fs.writeFileSync(fp, jsonl(first));
+    const st = fs.statSync(fp);
+    expect(st.size).toBeLessThan(seed.prior.offset);
+
+    const r = await scanCodexSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs);
+    expect(r.mode).toBe('full');
+  });
+
+  it('A DIFFERENT ROLLOUT rewritten LARGER at the same path falls back to FULL', async () => {
+    const fp = path.join(dir, 'r.jsonl');
+    const seed = await seedCodex(fp, jsonl(codexLines('sess-1', 'original')));
+
+    fs.writeFileSync(fp, jsonl([
+      ...codexLines('sess-2', 'a completely different and longer rollout'),
+      { type: 'response_item', timestamp: '2026-07-01T00:05:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'with more turns so the file is bigger' }] } },
+    ]));
+    const st = fs.statSync(fp);
+    expect(st.size).toBeGreaterThan(seed.prior.offset);
+
+    const r = await scanCodexSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs);
+    expect(r.mode).toBe('full');
+
+    const full = await scanCodexSessionResumable(fp, null, st.mtimeMs, st.size);
+    expect(r.scan).toEqual(full.scan);
+  });
+
+  it('CLOCK REWIND — mtime moved backwards — falls back to FULL even though the rollout grew', async () => {
+    const fp = path.join(dir, 'r.jsonl');
+    const seed = await seedCodex(fp, jsonl(codexLines('sess-1', 'one')));
+
+    fs.appendFileSync(fp, jsonl([
+      { type: 'response_item', timestamp: '2026-06-28T00:02:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'two' }] } },
+    ]));
+    const st = fs.statSync(fp);
+    expect(st.size).toBeGreaterThan(seed.prior.offset);
+
+    const r = await scanCodexSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs + 60_000);
+    expect(r.mode).toBe('full');
+  });
+
+  it('a prior continuation with no recorded rollout id falls back to FULL', async () => {
+    const fp = path.join(dir, 'r.jsonl');
+    const seed = await seedCodex(fp, jsonl(codexLines('sess-1', 'one')));
+    fs.appendFileSync(fp, jsonl([
+      { type: 'response_item', timestamp: '2026-06-28T00:02:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'two' }] } },
+    ]));
+    const st = fs.statSync(fp);
+
+    const noIdentity: CodexParserState = { ...seed.prior, sessionId: undefined };
+    const r = await scanCodexSessionResumable(fp, noIdentity, st.mtimeMs, st.size, seed.mtimeMs);
+    expect(r.mode).toBe('full');
+  });
+});

--- a/apps/cli/src/lib/session/__tests__/resumable-scan-decision.test.ts
+++ b/apps/cli/src/lib/session/__tests__/resumable-scan-decision.test.ts
@@ -177,13 +177,25 @@ describe('scanClaudeSessionResumable — the full-vs-incremental decision', () =
   });
 
   it('a prior continuation with no recorded identity falls back to FULL', async () => {
+    // The file must yield NO identity either. An earlier version of this test
+    // only blanked prior.timestamp and left the file with a derivable one, so
+    // the *comparison* ('2026-06-28…' === undefined -> false) returned FULL and
+    // the `prior.timestamp !== undefined` clause was never the deciding factor —
+    // deleting that clause left the test green. With BOTH sides undefined,
+    // `undefined === undefined` is TRUE, so without the clause the scan resumes
+    // from a stale offset into a different session's bytes. That is reachable on
+    // real data: claudeSessionIdentityAt returns undefined when no user or
+    // assistant event appears within its 1 MiB budget (discover.ts:4209-4212).
     const fp = path.join(dir, 's.jsonl');
-    const seed = await seedClaude(fp, jsonl(claudeLines('2026-06-28T00:00:00.000Z', 'one')));
-    fs.appendFileSync(fp, jsonl(claudeLines('2026-06-29T00:00:00.000Z', 'two')));
-    const st = fs.statSync(fp);
+    const anonymous = (n: number) => [{ type: 'summary', summary: `preamble ${n}`, leafUuid: `u${n}` }];
+    const seed = await seedClaude(fp, jsonl(anonymous(1)));
+    expect(seed.prior.timestamp).toBeUndefined(); // the fixture really yields no identity
 
-    const noIdentity: ClaudeParserState = { ...seed.prior, timestamp: undefined };
-    const r = await scanClaudeSessionResumable(fp, noIdentity, st.mtimeMs, st.size, seed.mtimeMs);
+    fs.writeFileSync(fp, jsonl([...anonymous(1), ...anonymous(2), ...anonymous(3)]));
+    const st = fs.statSync(fp);
+    expect(st.size).toBeGreaterThan(seed.prior.offset); // grew: the metadata gate alone says "incremental"
+
+    const r = await scanClaudeSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs);
     expect(r.mode).toBe('full');
   });
 });
@@ -280,15 +292,23 @@ describe('scanCodexSessionResumable — the full-vs-incremental decision', () =>
   });
 
   it('a prior continuation with no recorded rollout id falls back to FULL', async () => {
+    // Same reasoning as the Claude twin: the rollout must yield NO id either,
+    // or the id COMPARISON returns FULL and the `prior.sessionId !== undefined`
+    // clause is never load-bearing. A rollout with no session_meta line never
+    // sets state.sessionId (discover.ts:4399), so both sides are undefined and
+    // `undefined === undefined` would flip canIncrement true without the clause.
     const fp = path.join(dir, 'r.jsonl');
-    const seed = await seedCodex(fp, jsonl(codexLines('sess-1', 'one')));
-    fs.appendFileSync(fp, jsonl([
-      { type: 'response_item', timestamp: '2026-06-28T00:02:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'two' }] } },
-    ]));
-    const st = fs.statSync(fp);
+    const turn = (text: string) => [
+      { type: 'response_item', timestamp: '2026-06-28T00:00:30.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text }] } },
+    ];
+    const seed = await seedCodex(fp, jsonl(turn('one')));
+    expect(seed.prior.sessionId).toBeUndefined(); // no session_meta -> no identity
 
-    const noIdentity: CodexParserState = { ...seed.prior, sessionId: undefined };
-    const r = await scanCodexSessionResumable(fp, noIdentity, st.mtimeMs, st.size, seed.mtimeMs);
+    fs.writeFileSync(fp, jsonl([...turn('one'), ...turn('two'), ...turn('three')]));
+    const st = fs.statSync(fp);
+    expect(st.size).toBeGreaterThan(seed.prior.offset);
+
+    const r = await scanCodexSessionResumable(fp, seed.prior, st.mtimeMs, st.size, seed.mtimeMs);
     expect(r.mode).toBe('full');
   });
 });

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -4163,7 +4163,7 @@ function freshClaudeParserState(): ClaudeParserState {
  *
  * `mode` is returned so the caller (and tests) can confirm which branch ran.
  */
-async function scanClaudeSessionResumable(
+export async function scanClaudeSessionResumable(
   filePath: string,
   prior: ClaudeParserState | null,
   currentFileMtimeMs: number,
@@ -4757,7 +4757,7 @@ async function codexSessionIdentityAt(filePath: string, maxBytes = 1_048_576): P
  * past the persisted offset AND its mtime did not go backwards; FULL (from byte
  * 0, fresh state) otherwise (cold start, truncation/rewrite, clock rewind).
  */
-async function scanCodexSessionResumable(
+export async function scanCodexSessionResumable(
   filePath: string,
   prior: CodexParserState | null,
   currentFileMtimeMs: number,


### PR DESCRIPTION
**test-only + two `export` keywords** — no behaviour change. Closes RUSH-2843.

## The gap

`scanClaudeSessionResumable` (`apps/cli/src/lib/session/discover.ts:4166`) and `scanCodexSessionResumable` (`:4760`) are the single place that decides whether a transcript is **reparsed from byte 0** or **resumed from a stored offset**. Neither was invoked by any test — both were module-private, and a repo-wide grep for either name returned exactly one file: `discover.ts` itself.

The suites named for that behaviour computed the branch **in the test body**:

```ts
// incremental-parity.test.ts:283-285
const reparse = newSize < first.newOffset
  ? await scanClaudeSessionIncremental(fp, 0, serializeClaudeParserState(initClaudeParseState(), 0))
  : await scanClaudeSessionIncremental(fp, first.newOffset, first.newState);
```

So they asserted that a full parse equals a full parse. Their own comment conceded it: *"The resumable contract (B-2 will wire this) is: on newSize < offset, discard the continuation and full-parse from scratch."* `codex-incremental-parity.test.ts:222-253` has the identical shape.

That left three silent-corruption guards unverified — each one produces a session row that looks fine while carrying another conversation's data.

## The change

Export both functions and drive all five branches through the real code, asserting the `mode: 'full' | 'incremental'` it returns: cold start · genuine append (plus scan parity against a full reparse) · truncation · **a different session rewritten larger at the same path** · clock rewind · a continuation with no recorded identity.

## Proof — mutation, one guard at a time

| Mutation | Result |
|---|---|
| drop the identity check (`canIncrement = true`) | `2 failed \| 12 passed` — *A DIFFERENT SESSION / ROLLOUT rewritten LARGER…* |
| drop the clock-rewind guard | `2 failed \| 12 passed` — *CLOCK REWIND…* |
| drop the truncation guard (`currentFileSize > prior.offset`) | `2 failed \| 12 passed` — *TRUNCATION with the identity UNCHANGED…* |
| drop `prior.<identity> !== undefined` | `2 failed \| 12 passed` — *no recorded identity…* (**this one survived at first — see below**) |

All four re-measured against the FINAL 14-test suite. An earlier version of this
table quoted `10 passed` for rows 1-2; those were stale figures from the 12-test
suite before the truncation fix added two cases. Corrected.

### The fourth mutation, and why it was missing

Review caught that dropping `prior.timestamp !== undefined` (`discover.ts:4190`)
and `prior.sessionId !== undefined` (`:4783`) left the suite **green at 14
passed** — a surviving mutant on a load-bearing clause.

Both "no recorded identity" fixtures blanked the PRIOR identity but left the
FILE with a derivable one, so what returned FULL was the identity COMPARISON at
`:4192`, not the clause under test. With BOTH sides `undefined`,
`undefined === undefined` is **true**, so without the clause the scan resumes
from a stale offset into a different session's bytes. Reachable on real data:
`claudeSessionIdentityAt` returns `undefined` when no user/assistant event
appears within its 1 MiB budget (`discover.ts:4209-4212`).

Fixed in `d245ed507`: both fixtures now yield no identity at all — Claude uses
summary-only lines (`state.timestamp` is set only by a user/assistant event,
`:3743`), Codex omits `session_meta` (`state.sessionId` only set at `:4399`).

Each mutant kills exactly the tests written for it. Source restored after each; `git diff` on `discover.ts` shows only the two `export` keywords.

**The truncation guard needed a second case to become load-bearing, and the first version of this PR missed it.** The obvious fixture shrinks the file *and* changes the first turn — so the identity check forces FULL on its own, and deleting `currentFileSize > prior.offset` left the suite green. The added cases rewrite the **same** session shorter, keeping its identity byte-identical, so the size guard is the only thing preventing a resume past EOF.

## Regression check

`resumable-scan-decision.test.ts` — 14 passed.
`incremental-parity` + `codex-incremental-parity` + `discover` — 66 passed, unchanged by the exports.

No CHANGELOG entry: no user-visible surface changes.

Closes RUSH-2843.

