### PR TITLE
test(version): make getCliVersionFresh actually testable (RUSH-2862)

### DIFF
--- a/apps/cli/src/lib/version.test.ts
+++ b/apps/cli/src/lib/version.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { getCliVersion, installLayoutFromBin } from './version.js';
 
@@ -9,22 +11,42 @@ describe('version', () => {
     expect(v.length).toBeGreaterThan(0);
   });
 
-  // getCliVersionFresh's contract — "re-reads package.json, unlike the memoized
-  // getCliVersion" — has NO honest unit test today, so this file ships none.
-  //
-  // The first two attempts both claimed to test it and could not:
-  //   expect(getCliVersionFresh()).toBe(getCliVersion())   // two functions agreeing
-  //   expect(getCliVersionFresh()).toBe(<independent read>) // same thing, one hop
-  // Both hold for `getCliVersionFresh = () => getCliVersion()`, the exact
-  // regression the contract exists to prevent, because version.ts:109 and :133
-  // read the IDENTICAL hardcoded path — so with the file unchanged mid-test,
-  // cached and fresh are equal by construction. Priming the memo does not help.
-  //
-  // A real test has to swap package.json under a running process. That needs an
-  // injectable base path: the path is hardcoded, and the file is shared by every
-  // parallel vitest fork, so mutating it here would corrupt other tests. Tracked
-  // as RUSH-2862. A test that cannot fail is worse than an absent one — it
-  // reports the contract as guarded when it is not.
+  // getCliVersionFresh's contract — "re-reads package.json every call, unlike
+  // the memoized getCliVersion" — used to have NO honest unit test, because
+  // both functions read the same hardcoded path: with package.json unchanged
+  // mid-test, cached and fresh are equal by construction, including for the
+  // exact regression the contract exists to prevent
+  // (`getCliVersionFresh = () => getCliVersion()`). RUSH-2862 made the
+  // package.json path an optional parameter (production call sites still use
+  // the zero-arg form) so a test can swap the file a running module reads
+  // without touching the real, fork-shared apps/cli/package.json.
+  it('getCliVersionFresh follows an on-disk change; getCliVersion stays memoized (RUSH-2862)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-version-test-'));
+    const pkgJsonPath = path.join(dir, 'package.json');
+    fs.writeFileSync(pkgJsonPath, JSON.stringify({ version: '1.0.0-fixture-a' }));
+
+    try {
+      // cached is module-level state, so get an unshared module instance —
+      // otherwise the static import above (already exercised by the previous
+      // test) has already memoized the real repo version.
+      vi.resetModules();
+      const mod = await import('./version.js');
+
+      // Prime the memo from the fixture at version A.
+      expect(mod.getCliVersion(pkgJsonPath)).toBe('1.0.0-fixture-a');
+
+      // Mutate the fixture package.json on disk to version B.
+      fs.writeFileSync(pkgJsonPath, JSON.stringify({ version: '2.0.0-fixture-b' }));
+
+      // Fresh MUST re-read and follow the on-disk change...
+      expect(mod.getCliVersionFresh(pkgJsonPath)).toBe('2.0.0-fixture-b');
+      // ...while the memoized getter MUST stay at whatever it cached first,
+      // proving the two are genuinely distinct reads, not one hop apart.
+      expect(mod.getCliVersion(pkgJsonPath)).toBe('1.0.0-fixture-a');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 // Regression guard for the Bun single-file binary: `import.meta.url` is a virtual

--- a/apps/cli/src/lib/version.ts
+++ b/apps/cli/src/lib/version.ts
@@ -102,13 +102,19 @@ export function resolveInstalledLayout(): InstallLayout | null {
  * binary can't read its own bundled package.json), fall back to the on-disk
  * install found via the launcher symlink so callers like the menu bar don't see
  * a bogus `unknown`.
+ *
+ * `pkgJsonPath` is an optional override of the shipping package.json path,
+ * accepted by both this function and {@link getCliVersionFresh}. Every
+ * production call site uses the zero-argument form and gets the real on-disk
+ * path below; the parameter exists only so a unit test can point both
+ * functions at a fixture package.json instead of the real one shared by every
+ * parallel test fork.
  */
-export function getCliVersion(): string {
+export function getCliVersion(
+  pkgJsonPath: string = path.join(__dirname, '..', '..', 'package.json')
+): string {
   if (cached) return cached;
-  cached =
-    readVersionAt(path.join(__dirname, '..', '..', 'package.json')) ??
-    readInstalledPackageVersion() ??
-    'unknown';
+  cached = readVersionAt(pkgJsonPath) ?? readInstalledPackageVersion() ?? 'unknown';
   return cached;
 }
 
@@ -128,10 +134,8 @@ function readInstalledPackageVersion(): string | null {
  * is now stale and should reload onto the new code (self-healing). Returns
  * 'unknown' on any error.
  */
-export function getCliVersionFresh(): string {
-  return (
-    readVersionAt(path.join(__dirname, '..', '..', 'package.json')) ??
-    readInstalledPackageVersion() ??
-    'unknown'
-  );
+export function getCliVersionFresh(
+  pkgJsonPath: string = path.join(__dirname, '..', '..', 'package.json')
+): string {
+  return readVersionAt(pkgJsonPath) ?? readInstalledPackageVersion() ?? 'unknown';
 }


### PR DESCRIPTION
**What + type:** test-only — makes an existing untestable contract (getCliVersionFresh bypasses the cache) actually verifiable, no behavior change.

## Why the old form could not fail

getCliVersion (memoized) and getCliVersionFresh (uncached) both read the identical hardcoded path:

\`\`\`ts
// before — version.ts:109 and :133
readVersionAt(path.join(__dirname, \x27..\x27, \x27..\x27, \x27package.json\x27)) ?? …
\`\`\`

With package.json unchanged mid-test, cached and fresh are equal by construction — including for the exact regression the contract exists to prevent: getCliVersionFresh = () => getCliVersion(). Two prior attempts both fell into this and were removed; the test file carried a comment explaining why there was no test, naming this ticket.

## The fix

Made the package.json path an optional parameter on both functions, defaulting to the real on-disk path:

\`\`\`ts
export function getCliVersion(
  pkgJsonPath: string = path.join(__dirname, \x27..\x27, \x27..\x27, \x27package.json\x27)
): string {
  if (cached) return cached;
  cached = readVersionAt(pkgJsonPath) ?? readInstalledPackageVersion() ?? \x27unknown\x27;
  return cached;
}

export function getCliVersionFresh(
  pkgJsonPath: string = path.join(__dirname, \x27..\x27, \x27..\x27, \x27package.json\x27)
): string {
  return readVersionAt(pkgJsonPath) ?? readInstalledPackageVersion() ?? \x27unknown\x27;
}
\`\`\`

Every production call site (doctor.ts, secrets.ts, agent.ts, ssh-tunnel.ts, download.ts, install-menubar.ts, snapshot.ts, ipc.ts, daemon-ticks.ts) calls both with zero arguments, so behavior is unchanged there. The new test writes its own fixture package.json in a mkdtempSync dir — the real, fork-shared apps/cli/package.json is never touched.

The test primes the memo from a fixture at version A, rewrites the fixture to version B, then asserts getCliVersionFresh follows B while getCliVersion stays at A — using vi.resetModules() + a fresh dynamic import(\x27./version.js\x27) since cached is module-level state already primed by the file's first test.

## Mutation proof

Replaced getCliVersionFresh's body with return getCliVersion(); and reran the suite:

\`\`\`
FAIL  src/lib/version.test.ts > version > getCliVersionFresh follows an on-disk change; getCliVersion stays memoized (RUSH-2862)
AssertionError: expected \x271.0.0-fixture-a\x27 to be \x272.0.0-fixture-b\x27 // Object.is equality

Expected: \"2.0.0-fixture-b\"
Received: \"1.0.0-fixture-a\"
\`\`\`

Reverted; git diff on version.ts shows only the intended parameter change.

## Verification

- src/lib/version.test.ts: 4 passed
- Full set of production consumers of version.js + their test files (doctor, ssh, secrets, secrets/agent, computer/ssh-tunnel, computer/download, menubar/install-menubar, menubar/snapshot, browser/ipc, daemon-ticks): 302 passed, 13 skipped (pre-existing, unrelated)
- tsc --noEmit -p tsconfig.json: exit 0

No CHANGELOG entry — internal testability change only, no user-visible surface.

Linked: RUSH-2862