### PR TITLE
fix(ext): the Fleet panel no longer buries idle-but-unfinished work below running work (RUSH-2838)

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
+## [0.9.328] - 2026-08-20
+
+- **The Fleet panel stops burying idle-but-unfinished work below running work
+  (RUSH-2838).** The root `AGENTS.md` "Purpose" section makes idle-but-unfinished
+  the highest-risk state — the one most likely to be silently abandoned — and says
+  no status surface may rank it below running. Three sites did exactly that, and
+  each had a passing test pinning the wrong order as correct. `PHASE_RANK` ranked
+  `idle` dead last, below `done`, so `Sort: Needs you` put an abandoned session at
+  the bottom of the list. `partitionFloorAgents` pushed idle sessions into the same
+  `active` bucket as running ones, so the feed rendered them interleaved with agents
+  that need nothing. And the Sessions surface's `Sort: Status` used a second,
+  hand-maintained rank table that had drifted into the opposite order from the
+  `Group: state` bands rendered fifty lines below it. Now: the feed grows an **IDLE**
+  section above **RUNNING**; `Sort: Needs you` orders
+  `waiting < failed < stalled < idle < running < done`; and `Sort: Status` defers to
+  that one shared `PHASE_RANK` instead of a copy, so the sort and the band grouping
+  can no longer disagree. No new field was needed to tell a finished idle session
+  from an abandoned one — `derivePhase` already maps a finished agent to `done` and
+  only an unfinished one to `idle`. Source:
+  `ui/settings/components/mission-control/floorModel.ts`,
+  `sessionsModel.ts`, `UnifiedAgentsPane.tsx`.
+
 ## [0.9.327] - 2026-08-17
 
 - **The markdown Reader renders again instead of a blank pane.** The reader

--- a/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1623,10 +1623,15 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     () => sortAgents(needsAgents.filter((a) => a.phase !== 'waiting' && a.phase !== 'failed'), floorSort),
     [needsAgents, floorSort]
   )
-  // One attention-ordered stream: NEEDS YOU -> RUNNING -> READY -> DONE, where
-  // status is a position, not a filter. Running and idle agents are the live
-  // lane; done (without an unreviewed PR — those are NEEDS YOU) is the terminal
-  // lane. idle is no longer dropped from the feed.
+  // One attention-ordered stream: NEEDS YOU -> IDLE -> RUNNING -> DONE, where status
+  // is a position, not a filter. Idle leads the live lane because an idle session is
+  // unfinished work that has stopped progressing — the highest abandonment risk — while
+  // a running one needs nothing from the operator (root AGENTS.md "Purpose"). done
+  // (without an unreviewed PR — those are NEEDS YOU) is the terminal lane.
+  const idleFeed = useMemo(
+    () => sortAgents(feedPartition.idle, floorSort),
+    [feedPartition, floorSort]
+  )
   const runningFeed = useMemo(
     () => sortAgents(feedPartition.active, floorSort),
     [feedPartition, floorSort]
@@ -1635,7 +1640,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     () => sortAgents(feedPartition.done, floorSort),
     [feedPartition, floorSort]
   )
-  const groupedFeed = useMemo(() => [...runningFeed, ...doneFeed], [runningFeed, doneFeed])
+  const groupedFeed = useMemo(() => [...idleFeed, ...runningFeed, ...doneFeed], [idleFeed, runningFeed, doneFeed])
 
   const floorRunning = useMemo(() => floorAgents.filter((a) => a.phase === 'running').length, [floorAgents])
   const floorTok = useMemo(() => floorAgents.reduce((s, a) => s + a.tok, 0) + liveThroughput, [floorAgents, liveThroughput])
@@ -2214,6 +2219,30 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
             />
           ))}
           {reviewNeedsAgents.map((a) => (
+            <FeedRow onOpenTask={openTaskFromAgent}
+              key={a.id}
+              agent={a}
+              selected={selectedFloorAgent?.id === a.id}
+              plain={plain}
+              onSelect={selectFloorAgent}
+              onOption={onAgentOption}
+              onFreeText={replyToAgent}
+              onAttach={onAttachScreenshot}
+              onOpenPlan={openPlanPreview}
+              onOpenAttachment={openAttachmentPreview}
+              onOpenTerminal={openTerminalForAgent}
+            />
+          ))}
+        </>
+      )}
+
+      {/* Idle sits ABOVE running: unfinished work that stopped progressing is the
+          state most likely to be silently abandoned, so the floor never buries it
+          below the agents that are fine on their own (root AGENTS.md "Purpose"). */}
+      {floorGroup === 'none' && idleFeed.length > 0 && (
+        <>
+          <div className="feed-sec" title="Unfinished work that has stopped progressing — the highest abandonment risk">IDLE · {idleFeed.length}<span className="ln" /></div>
+          {idleFeed.map((a) => (
             <FeedRow onOpenTask={openTaskFromAgent}
               key={a.id}
               agent={a}

--- a/apps/ext/ui/settings/components/mission-control/floorModel.fixes.test.ts
+++ b/apps/ext/ui/settings/components/mission-control/floorModel.fixes.test.ts
@@ -70,7 +70,7 @@ describe('issue 2 — one task-line seam', () => {
     const background = agent({ id: 'bg', context: 'headless' })
     expect(visibleFloorAgents([foreground, background], false)).toEqual([foreground])
     const partition = partitionFloorAgents([foreground])
-    expect(partition.needs.length + partition.active.length + partition.done.length).toBe(1)
+    expect(partition.needs.length + partition.idle.length + partition.active.length + partition.done.length).toBe(1)
   })
 
   test('worktreeSlugOf extracts the slug under .agents/worktrees/', () => {
@@ -90,5 +90,16 @@ describe('wiring guard — infra must stay wired (issue 5 was dead code)', () =>
   })
   test('UnifiedAgentsPane wires sessionTaskLine (the detail rail)', () => {
     expect(pane).toContain('sessionTaskLine(')
+  })
+  // The idle section's POSITION is the whole point of RUSH-2838 and no unit test can
+  // reach it (rendering the pane needs React), so pin it at the source: the idle rows
+  // must be emitted before the running rows, or the Fleet panel is burying
+  // idle-but-unfinished work below running again (root AGENTS.md "Purpose").
+  test('UnifiedAgentsPane renders the IDLE section ABOVE the RUNNING section', () => {
+    const idleAt = pane.indexOf('idleFeed.map(')
+    const runningAt = pane.indexOf('runningFeed.map(')
+    expect(idleAt).toBeGreaterThan(-1)
+    expect(runningAt).toBeGreaterThan(-1)
+    expect(idleAt).toBeLessThan(runningAt)
   })
 })

--- a/apps/ext/ui/settings/components/mission-control/floorModel.test.ts
+++ b/apps/ext/ui/settings/components/mission-control/floorModel.test.ts
@@ -461,7 +461,10 @@ describe('groupAgents', () => {
 })
 
 describe('sortAgents', () => {
-  test("'needs' orders by PHASE_RANK (waiting < failed < stalled < running < done < idle)", () => {
+  // Root AGENTS.md "Purpose": rank by PROGRESS, not liveness. Every phase that has
+  // STOPPED progressing outranks `running`, and `done` is the terminal state below
+  // both — so idle-but-unfinished work is never the bottom of the list (RUSH-2838).
+  test("'needs' orders by PHASE_RANK (waiting < failed < stalled < idle < running < done)", () => {
     const agents = [
       makeAgent({ id: 'idle', phase: 'idle' }),
       makeAgent({ id: 'done', phase: 'done' }),
@@ -471,9 +474,22 @@ describe('sortAgents', () => {
       makeAgent({ id: 'waiting', phase: 'waiting' }),
     ]
     const ordered = sortAgents(agents, 'needs').map((a) => a.id)
-    expect(ordered).toEqual(['waiting', 'failed', 'stalled', 'running', 'done', 'idle'])
+    expect(ordered).toEqual(['waiting', 'failed', 'stalled', 'idle', 'running', 'done'])
     const ranks = sortAgents(agents, 'needs').map((a) => PHASE_RANK[a.phase])
     expect(ranks).toEqual([...ranks].sort((x, y) => x - y))
+  })
+
+  test('idle-but-unfinished outranks running, and done is terminal below both', () => {
+    // The invariant itself, independent of the exact permutation above: an idle agent
+    // is unfinished work that stopped progressing (derivePhase sends a FINISHED agent
+    // to 'done'), so it is the one to raise — a running agent needs nothing.
+    expect(PHASE_RANK.idle).toBeLessThan(PHASE_RANK.running)
+    expect(PHASE_RANK.running).toBeLessThan(PHASE_RANK.done)
+    for (const stopped of ['waiting', 'failed', 'stalled', 'idle'] as const) {
+      expect(PHASE_RANK[stopped]).toBeLessThan(PHASE_RANK.running)
+    }
+    expect(derivePhase({ status: 'completed', waitingForInput: false, active: false, prOpenUnreviewed: false })).toBe('done')
+    expect(derivePhase({ status: 'running', waitingForInput: false, active: false, prOpenUnreviewed: false })).toBe('idle')
   })
 
   test("'tok' orders by throughput descending", () => {
@@ -925,7 +941,7 @@ describe('floor visibility and section counts', () => {
     expect(visibleFloorAgents([foreground, background], true).map((a) => a.id)).toEqual(['foreground', 'background'])
   })
 
-  test('every rendered card belongs to exactly one counted section', () => {
+  test('every rendered card belongs to exactly one counted section, and idle is its own section above active', () => {
     const agents = [
       makeAgent({ id: 'needs', needs: true, phase: 'waiting' }),
       makeAgent({ id: 'running', phase: 'running' }),
@@ -934,9 +950,13 @@ describe('floor visibility and section counts', () => {
     ]
     const sections = partitionFloorAgents(agents)
     expect(sections.needs.map((a) => a.id)).toEqual(['needs'])
-    expect(sections.active.map((a) => a.id)).toEqual(['running', 'idle'])
+    // Idle is unfinished work that stopped progressing — the highest abandonment risk
+    // — so it gets its own bucket and is NOT mixed in with running under 'active'
+    // (root AGENTS.md "Purpose"; RUSH-2838).
+    expect(sections.idle.map((a) => a.id)).toEqual(['idle'])
+    expect(sections.active.map((a) => a.id)).toEqual(['running'])
     expect(sections.done.map((a) => a.id)).toEqual(['done'])
-    expect(sections.needs.length + sections.active.length + sections.done.length).toBe(agents.length)
+    expect(sections.needs.length + sections.idle.length + sections.active.length + sections.done.length).toBe(agents.length)
   })
 })
 

--- a/apps/ext/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/ext/ui/settings/components/mission-control/floorModel.ts
@@ -469,16 +469,25 @@ export type TicketSort = 'priority' | 'id'
 
 // ---------- stable rank constants (data — final, not stubs) ----------
 
-/** Needs-you first ordering. Prototype: factory-floor.html:364.
- *  'stalled' sits just below failed: a wedged agent needs you, but a hard failure or an
- *  explicit question outranks it. */
+/** Needs-you first ordering, ranked by PROGRESS rather than liveness (root AGENTS.md
+ *  "Purpose"). Every phase that has STOPPED progressing outranks `running` — a running
+ *  agent is making progress and needs nothing from the operator — and `done` is the
+ *  terminal state below both. Within the stopped set, an explicit question or a hard
+ *  failure outranks a wedged agent, which outranks a silently-idle one; but `idle`
+ *  still sits ABOVE `running` and `done`, because idle-but-unfinished work is the
+ *  highest-abandonment risk, not the lowest.
+ *
+ *  `idle` means unfinished by construction — `derivePhase` maps a finished agent to
+ *  'done' (status 'completed') and only a stopped/dead-process one to 'idle' — so no
+ *  extra signal is needed to tell a finished idle session from an abandoned one.
+ *  Prototype: factory-floor.html:364. */
 export const PHASE_RANK: Record<FloorPhase, number> = {
   waiting: 0,
   failed: 1,
   stalled: 2,
-  running: 3,
-  done: 4,
-  idle: 5,
+  idle: 3,
+  running: 4,
+  done: 5,
 }
 
 /** A running agent silent this long is treated as stalled (amber). 2x -> dead (red). */
@@ -546,22 +555,34 @@ export function visibleFloorAgents(agents: FloorAgent[], showBackground: boolean
   return showBackground ? agents : agents.filter((a) => a.context !== 'headless')
 }
 
-/** Partition every visible card exactly once so rendered sections and counts
- * consume the same collections. */
+/**
+ * Partition every visible card exactly once so rendered sections and counts consume
+ * the same collections. The buckets are in ATTENTION order — needs > idle > active >
+ * done — because the floor ranks by progress, not by liveness (root AGENTS.md
+ * "Purpose").
+ *
+ * `idle` is its own bucket and is never folded into `active`: an idle session is
+ * unfinished work that has stopped progressing, the state most likely to be silently
+ * abandoned, while a running one needs nothing from the operator. `derivePhase` maps a
+ * finished agent to 'done', so every agent landing in `idle` here is unfinished.
+ */
 export function partitionFloorAgents(agents: FloorAgent[]): {
   needs: FloorAgent[]
+  idle: FloorAgent[]
   active: FloorAgent[]
   done: FloorAgent[]
 } {
   const needs: FloorAgent[] = []
+  const idle: FloorAgent[] = []
   const active: FloorAgent[] = []
   const done: FloorAgent[] = []
   for (const agent of agents) {
     if (agent.needs) needs.push(agent)
     else if (agent.phase === 'done') done.push(agent)
+    else if (agent.phase === 'idle') idle.push(agent)
     else active.push(agent)
   }
-  return { needs, active, done }
+  return { needs, idle, active, done }
 }
 
 /**

--- a/apps/ext/ui/settings/components/mission-control/sessionsModel.test.ts
+++ b/apps/ext/ui/settings/components/mission-control/sessionsModel.test.ts
@@ -118,13 +118,45 @@ describe('sortSessions — recency vs creation are distinct', () => {
   test('started orders by startedAtMs (s2 first) — a different order than recent', () => {
     expect(sortSessions([s1, s2], 'started', true).map((a) => a.id)).toEqual(['s2', 's1'])
   })
-  test('status orders reconnect ahead of running ahead of idle', () => {
+  // Root AGENTS.md "Purpose": rank by PROGRESS, not liveness. Idle-but-unfinished is
+  // the highest-abandonment-risk state, so it surfaces ABOVE running, never below it,
+  // and `done` is a distinct terminal state at the bottom (RUSH-2838).
+  test('status never buries idle below running, and done is terminal', () => {
     const rows = [
+      mk({ id: 'done', phase: 'done' }),
+      mk({ id: 'run', phase: 'running' }),
       mk({ id: 'idle', phase: 'idle' }),
       mk({ id: 'orph', liveStatus: 'orphaned', phase: 'idle' }),
-      mk({ id: 'run', phase: 'running' }),
     ]
-    expect(sortSessions(rows, 'status', true).map((a) => a.id)).toEqual(['orph', 'run', 'idle'])
+    expect(sortSessions(rows, 'status', true).map((a) => a.id)).toEqual(['orph', 'idle', 'run', 'done'])
+  })
+  test('status puts every stopped phase above running, most acute first', () => {
+    const rows = [
+      mk({ id: 'done', phase: 'done' }),
+      mk({ id: 'run', phase: 'running' }),
+      mk({ id: 'idle', phase: 'idle' }),
+      mk({ id: 'stalled', phase: 'stalled' }),
+      mk({ id: 'failed', phase: 'failed' }),
+      mk({ id: 'waiting', phase: 'waiting' }),
+      mk({ id: 'orph', liveStatus: 'orphaned', phase: 'idle' }),
+    ]
+    expect(sortSessions(rows, 'status', true).map((a) => a.id))
+      .toEqual(['orph', 'waiting', 'failed', 'stalled', 'idle', 'run', 'done'])
+  })
+  test('the status sort agrees with the band grouping it sits next to', () => {
+    // `Sort: Status` and the default `Group: state` are two views of one ranking, so a
+    // row cannot lead under one and trail under the other. Both are driven off
+    // PHASE_RANK / BAND_ORDER; this pins them together.
+    const rows = [
+      mk({ id: 'run', phase: 'running' }),
+      mk({ id: 'idle', phase: 'idle' }),
+      mk({ id: 'orph', liveStatus: 'orphaned', phase: 'idle' }),
+      mk({ id: 'done', phase: 'done' }),
+    ]
+    const bySort = sortSessions(rows, 'status', true).map((a) => sessionBand(a))
+    const byBand = groupSessions(rows, 'state', 'status', true).map((s) => s.band)
+    expect(bySort).toEqual(['reconnect', 'attention', 'active', 'done'])
+    expect(byBand).toEqual(['reconnect', 'attention', 'active', 'done'])
   })
   test('name sorts A→Z when desc (the shared default direction)', () => {
     const rows = [mk({ id: 'z', topic: 'zebra' }), mk({ id: 'a', topic: 'apple' })]

--- a/apps/ext/ui/settings/components/mission-control/sessionsModel.ts
+++ b/apps/ext/ui/settings/components/mission-control/sessionsModel.ts
@@ -7,6 +7,7 @@
 import {
   needsReconnect,
   sessionBand,
+  PHASE_RANK,
   type FloorAgent,
   type SessionBand,
   type SessionFilter,
@@ -66,21 +67,17 @@ export function scopeSessions(all: FloorAgent[], scope: SessionScope): FloorAgen
   })
 }
 
-// Lower rank sorts first under 'status'. reconnect is the acute case, then the
-// live states by urgency, then done.
-const STATUS_RANK: Record<string, number> = {
-  reconnect: 0,
-  waiting: 1,
-  running: 2,
-  stalled: 2,
-  idle: 3,
-  failed: 4,
-  done: 5,
-}
-
+// Lower rank sorts first under 'status'. reconnect is the acute case (detached but
+// alive, or crashed), so it takes rank 0; everything else defers to the shared
+// PHASE_RANK, shifted by one to leave room for it. PHASE_RANK is the single ordering
+// the whole floor ranks by — progress, not liveness (root AGENTS.md "Purpose") — so
+// `Sort: Status` puts idle-but-unfinished work above running and leaves `done`
+// terminal, matching BAND_ORDER below instead of contradicting it. This table used to
+// be a second, hand-maintained copy, which is how the two drifted into opposite
+// orders (RUSH-2838).
 function statusRank(a: FloorAgent): number {
-  if (needsReconnect(a)) return STATUS_RANK.reconnect!
-  return STATUS_RANK[a.phase] ?? 3
+  if (needsReconnect(a)) return 0
+  return PHASE_RANK[a.phase] + 1
 }
 
 /**


### PR DESCRIPTION
**Bug fix — the AGI EXT Fleet panel stops burying idle-but-unfinished work below running work.** Three ranking sites violated the invariant in the root `AGENTS.md`; each had a passing test pinning the wrong behaviour as correct. Ticket: RUSH-2838.

## What the user sees

![Fleet panel ordering, before and after](https://share.agents-cli.sh/muqsitnawaz/agents-cli-rush2838-before-after-259acd34c4bc6c20)

The picture above is the **real output of the changed functions** — `partitionFloorAgents`, `sortAgents`, `sortSessions` run over the same 7-session fleet before and after — not a mockup. Concretely:

| Surface | Before | After |
|---|---|---|
| Fleet feed sections | `NEEDS YOU` → `RUNNING · 5` (idle rows mixed in among the running ones, no idle section exists) → `DONE TODAY` | `NEEDS YOU` → **`IDLE · 3`** → `RUNNING · 2` → `DONE TODAY` |
| Fleet `Sort: Needs you` | `waiting, failed, stalled, running, done, idle` — idle dead last, *below* `done` | `waiting, failed, stalled, idle, running, done` |
| Sessions `Sort: Status` | `orph, wait, run-a, run-b, idle-a, idle-b, done` — idle rows 5–6, below both running rows | `orph, wait, idle-a, idle-b, run-a, run-b, done` |

## The invariant being restored

Root [`AGENTS.md` §Purpose](https://github.com/phnx-labs/agi-cli/blob/main/AGENTS.md):

> Idle-but-unfinished work is the **highest-risk** state, not the lowest, because it is the most likely to be silently abandoned with no progress ever made. So any status or attention surface … surfaces not-progressing work **first** … it never buries idle work below running work. `done` is a distinct terminal state from `idle`.

## The three sites

| # | Site | Was | Now |
|---|---|---|---|
| 1 | `floorModel.ts` `PHASE_RANK` (was `:475-482`) | `running:3, done:4, idle:5` — idle ranked below `done` | `stalled:2, idle:3, running:4, done:5` |
| 2 | `floorModel.ts` `partitionFloorAgents` (was `:551-565`) | `else active.push(agent)` — idle in the same bucket as running, undifferentiated, contradicting its own docstring at `:228-234` (*"Idle-but-unfinished work is the highest-abandonment risk, so it surfaces ABOVE running rather than below it"*) | a fourth `idle` bucket, ordered above `active`; `UnifiedAgentsPane.tsx` renders it as an `IDLE` section above `RUNNING` |
| 3 | `sessionsModel.ts` `STATUS_RANK` (was `:71-79`) | a second hand-maintained rank table (`running:2, stalled:2, idle:3, failed:4`) that had drifted into the **opposite** order from `BAND_ORDER` fifty lines below it in the same file (`:131-134`) — so the default `Group: state` grouping was right while `Sort: Status` was wrong | table deleted; `statusRank` returns `0` for reconnect and `PHASE_RANK[phase] + 1` otherwise, so the sort and the band grouping are two views of one ranking and cannot disagree again |

**No new field was invented.** The codebase already distinguishes finished-idle from abandoned-idle: `derivePhase` (`floorModel.ts:604-620`) maps `status: 'completed'` → `'done'` and only a stopped / dead-process agent → `'idle'`. So every agent reaching the `idle` bucket is unfinished by construction — exactly the `done`-vs-`idle` split the root `AGENTS.md` asserts. A new test pins that (`floorModel.test.ts`, `idle-but-unfinished outranks running, and done is terminal below both`).

## Verified by mutation, not by green

Each ranking was broken back to its old order and the rewritten tests were confirmed to **fail**. Real output:

```
===== MUTATION 1: PHASE_RANK back to the old order (idle last, below done) =====
(fail) sortAgents > 'needs' orders by PHASE_RANK (waiting < failed < stalled < idle < running < done)
(fail) sortAgents > idle-but-unfinished outranks running, and done is terminal below both
(fail) sortSessions — recency vs creation are distinct > status never buries idle below running, and done is terminal
(fail) sortSessions — recency vs creation are distinct > status puts every stopped phase above running, most acute first
(fail) sortSessions — recency vs creation are distinct > the status sort agrees with the band grouping it sits next to
 128 pass
 5 fail

===== MUTATION 2: partitionFloorAgents drops the idle bucket (idle back into 'active') =====
(fail) floor visibility and section counts > every rendered card belongs to exactly one counted section, and idle is its own section above active
 117 pass
 1 fail

===== MUTATION 3: the pane renders IDLE below RUNNING again =====
(fail) wiring guard — infra must stay wired (issue 5 was dead code) > UnifiedAgentsPane renders the IDLE section ABOVE the RUNNING section
 8 pass
 1 fail

===== MUTATION 4: STATUS_RANK back to its own table (running:2, idle:3, failed:4) =====
(fail) sortSessions — recency vs creation are distinct > status never buries idle below running, and done is terminal
(fail) sortSessions — recency vs creation are distinct > status puts every stopped phase above running, most acute first
(fail) sortSessions — recency vs creation are distinct > the status sort agrees with the band grouping it sits next to
 21 pass
 3 fail
```

Each mutation was reverted afterwards; `git status --short` on the source is clean.

## Test run

`bun test` from `apps/ext`:

| | before | after |
|---|---|---|
| pass | 1482 | **1486** |
| fail | 21 | 21 |
| errors | 19 | 19 |
| tests | 1506 | 1510 |

**The run is degraded in this checkout** and the claim is scoped to what actually ran: all 21 failures / 19 errors are pre-existing and unrelated — unresolvable `react`, `react/jsx-dev-runtime`, `@happy-dom/global-registrator`, and `gray-matter` packages for the `ui/settings` component tests, plus two unrelated failures (`CLI_AGENT_META name/cliCommand match the AGENTS table`, `Cursor: can read first user message from SQLite`). They are identical before and after. The three files this PR touches run clean: **142 pass, 0 fail**. `tsc --noEmit -p ui/tsconfig.json` is clean apart from a pre-existing `baseUrl` deprecation warning.

Because the react dependency is unresolvable here, the `IDLE`-above-`RUNNING` section order in `UnifiedAgentsPane.tsx` cannot be asserted by rendering the component. It is pinned instead in the file's existing `wiring guard` block, which reads the pane source — the same mechanism already used there for `groupAgents` and `sessionTaskLine`.

## Also in this PR

`apps/ext/CHANGELOG.md` gets a `0.9.328` entry — the Fleet panel ordering is user-visible.

## Not in this PR

`apps/ext/AGENTS.md` is unchanged: no documented surface, flag, or command changed, only the order in which existing sections render.
