### PR TITLE
fix(webhooks): advertise /hooks/slack and say where a slash-command reply lands

### DIFF
--- a/apps/cli/.changelog/next/slack-endpoint-banner.md
+++ b/apps/cli/.changelog/next/slack-endpoint-banner.md
@@ -1,0 +1,7 @@
+- **`agents webhooks` now advertises `/hooks/slack`.** The receiver has accepted signed
+  Slack deliveries since the Slack bridge landed, but `agents webhooks serve` and
+  `agents daemon webhooks list` still printed only `/hooks/github, /hooks/linear` — the
+  one URL you must paste into the Slack app was missing from the banner. The slash-command
+  ack now also says "replying in this channel", matching where the reply actually posts
+  (a slash command carries no thread). Source: `apps/cli/src/commands/webhook.ts`,
+  `apps/cli/src/commands/daemon.ts`, `apps/cli/src/lib/triggers/webhook.ts`.

--- a/apps/cli/src/commands/daemon.ts
+++ b/apps/cli/src/commands/daemon.ts
@@ -852,7 +852,7 @@ function runWebhooksList(json: boolean): void {
     const port = hostedReceiverPort(r);
     const funnel = r.funnel ? chalk.cyan(` public :${r.funnel.publicPort}`) : chalk.gray(' localhost only');
     console.log(`  127.0.0.1:${String(port).padEnd(6)} ${chalk.gray(`bundle ${r.bundle}`)}${funnel}`);
-    console.log(chalk.gray(`    endpoints: /hooks/github, /hooks/linear · ${r.rateLimit ?? DEFAULT_WEBHOOK_RATE_LIMIT}/min per source`));
+    console.log(chalk.gray(`    endpoints: /hooks/github, /hooks/linear, /hooks/slack · ${r.rateLimit ?? DEFAULT_WEBHOOK_RATE_LIMIT}/min per source`));
   }
   console.log(chalk.gray(`\nConfig: ${getDaemonWebhooksConfigPath()}`));
   console.log(chalk.gray('Changes take effect on the next daemon restart.'));

--- a/apps/cli/src/commands/webhook.ts
+++ b/apps/cli/src/commands/webhook.ts
@@ -103,7 +103,7 @@ export function registerWebhooksCommand(program: Command): void {
         const address = server.address();
         const bound = typeof address === 'object' && address ? address.port : port;
         console.log(`${chalk.green('agents webhooks')} ${chalk.dim('→')} ${chalk.cyan(`http://${opts.bind ?? DEFAULT_HOST}:${bound}`)}`);
-        console.log(chalk.dim('signed · localhost by default · endpoints: /hooks/github, /hooks/linear · acks 202 then dispatches · Ctrl-C to stop'));
+        console.log(chalk.dim('signed · localhost by default · endpoints: /hooks/github, /hooks/linear, /hooks/slack · acks 202 then dispatches · Ctrl-C to stop'));
         console.log(chalk.dim('for a supervised receiver that survives reboot: agents daemon webhooks add --secrets-bundle <name>'));
 
         const shutdown = () => {

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -497,6 +497,21 @@ describe('startWebhookServer — slack', () => {
     }
   });
 
+  // A slash command carries no thread_ts, so the reply lands in the channel, not
+  // a thread — the ephemeral ack Slack renders to the caller must say so.
+  it('acks a signed slash command with an ephemeral ack naming the channel', async () => {
+    const server = startWebhookServer({ secrets: { slack: secret }, fire: { jobs: [] } });
+    await new Promise<void>((r) => server.once('listening', r));
+    try {
+      const body = Buffer.from('command=%2Fagents&text=AGI%3A+rebase&channel_id=C1&user_id=U9&team_id=T1');
+      const res = await slackSend(server, body, 'application/x-www-form-urlencoded');
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ response_type: 'ephemeral', text: 'On it — replying in this channel.' });
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
   it('acks a signed app_mention with 200 (before any dispatch)', async () => {
     const server = startWebhookServer({ secrets: { slack: secret }, fire: { jobs: [] } });
     await new Promise<void>((r) => server.once('listening', r));

--- a/apps/cli/src/lib/triggers/webhook.ts
+++ b/apps/cli/src/lib/triggers/webhook.ts
@@ -700,6 +700,7 @@ export interface WebhookServerOptions {
  * Start a localhost-bound receiver. It accepts only:
  *   POST /hooks/github  with X-Hub-Signature-256
  *   POST /hooks/linear  with Linear-Signature + fresh webhookTimestamp
+ *   POST /hooks/slack   with X-Slack-Signature + fresh X-Slack-Request-Timestamp
  *
  * **The ack is asynchronous (RUSH-2548).** Once a delivery has passed signature
  * verification, freshness, dedup, and rate limiting, the receiver writes
@@ -887,7 +888,7 @@ export function startWebhookServer(options: WebhookServerOptions): http.Server {
           res.writeHead(200, { 'content-type': 'application/json' });
           res.end(
             slack.type === 'slash_command'
-              ? JSON.stringify({ response_type: 'ephemeral', text: 'On it — replying in this thread.' })
+              ? JSON.stringify({ response_type: 'ephemeral', text: 'On it — replying in this channel.' })
               : '',
           );
           void settleDelivery(slackWebhook, slackId).finally(() => inFlight.delete(slackId));


### PR DESCRIPTION
**Two-string truth fix in the Slack webhook path shipped by #2785 — plus the live run that found them.**

## What changed

| Surface | Before | After |
|---|---|---|
| `agents webhooks serve` banner | `endpoints: /hooks/github, /hooks/linear` | `endpoints: /hooks/github, /hooks/linear, /hooks/slack` |
| `agents daemon webhooks list` | same omission | same fix |
| Slash-command ack | `On it — replying in this thread.` | `On it — replying in this channel.` |

`/hooks/slack` is the URL you paste into the Slack app manifest, and the CLI's own
output never named it. The ack was worse than cosmetic: `parseSlackBody` deliberately
leaves `thread_ts` unset for a slash command (`apps/cli/src/lib/triggers/webhook.ts:405`
— *"A slash command carries no thread; its reply posts to the channel"*), so the ack
promised threading the code does not do. The Events-API (`app_mention`) path still
threads on `thread_ts`/`ts` and is untouched.

New test pins the ack body: `webhook.test.ts` → *acks a signed slash command with an
ephemeral ack naming the channel*.

## Run result

Patched build (`tsx src/index.ts`) on yosemite-s1, real HMAC-signed deliveries against a
throwaway signing secret and a scratch `AGENTS_WEBHOOKS_DIR` handler:

![slack webhook receiver run](https://share.agents-cli.sh/muqsitnawaz/agents-cli-slack-webhook-run-984a15d66deab435)

Valid signature → 200 + ephemeral ack + handler fired with the project/user/channel/prompt
templated correctly. Bad signature → 401. Ten-minute-old timestamp with a valid HMAC →
401. `url_verification` → challenge echoed. `vitest src/lib/triggers` + daemon: 76 passed.
`tsc --noEmit`: clean.

## Context

Follow-up to #2785 (Slack bridge). No behavior change beyond the two strings and the
Slack endpoint now appearing in the two banners.
