### PR TITLE
fix(cli): agents auth/org print clean errors instead of a raw Node stack trace

### DIFF
--- a/apps/cli/.changelog/next/auth-org-clean-errors.md
+++ b/apps/cli/.changelog/next/auth-org-clean-errors.md
@@ -1,0 +1,1 @@
+- `agents auth` and `agents org` now print a clean one-line error (and a structured `{"error"}` payload under `--json`) for signed-out, expired-token, and bad-input states, instead of dumping a raw Node stack trace.

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { setHelpSections } from '../lib/help.js';
+import { runOrDie } from '../lib/format.js';
 import {
   clearPrixSession,
   fetchWhoAmI,
@@ -98,12 +99,15 @@ function runAuthLogout(): void {
 export function registerAuthCommand(program: Command): void {
   const auth = program.command('auth').description('Sign in to your Rush account (shared by `agents org` and paid tiers)');
 
-  auth.command('login').description('Sign in via the device-code flow').action(async () => runAuthLogin());
+  auth.command('login').description('Sign in via the device-code flow').action(() => runOrDie(() => runAuthLogin()));
 
   auth.command('whoami').description('Show the signed-in account').option('--json', 'Machine-readable output')
-    .action((o: { json?: boolean }, command: Command) => runAuthWhoami(!!(o.json || command.optsWithGlobals().json)));
+    .action((o: { json?: boolean }, command: Command) => {
+      const json = !!(o.json || command.optsWithGlobals().json);
+      return runOrDie(() => runAuthWhoami(json), { json });
+    });
 
-  auth.command('logout').description('Clear the local `agents auth login` session').action(() => runAuthLogout());
+  auth.command('logout').description('Clear the local `agents auth login` session').action(() => runOrDie(() => runAuthLogout()));
 
   setHelpSections(auth, {
     examples: `agents auth login

--- a/apps/cli/src/commands/org.ts
+++ b/apps/cli/src/commands/org.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { setHelpSections } from '../lib/help.js';
+import { runOrDie } from '../lib/format.js';
 import {
   createSpace,
   createSpaceInvite,
@@ -132,35 +133,35 @@ export function registerOrgCommand(program: Command): void {
     .option('--slug <slug>', 'Override the derived slug')
     .option('--description <text>', 'Optional description')
     .option('--json', 'Machine-readable output')
-    .action((name: string, o: { slug?: string; description?: string; json?: boolean }, command: Command) => runCreate(name, { ...o, json: !!(o.json || command.optsWithGlobals().json) }));
+    .action((name: string, o: { slug?: string; description?: string; json?: boolean }, command: Command) => { const json = !!(o.json || command.optsWithGlobals().json); return runOrDie(() => runCreate(name, { ...o, json }), { json }); });
 
   org.command('list').description('List spaces you own or belong to').option('--json', 'Machine-readable output')
-    .action((o: { json?: boolean }, command: Command) => runList({ json: !!(o.json || command.optsWithGlobals().json) }));
+    .action((o: { json?: boolean }, command: Command) => { const json = !!(o.json || command.optsWithGlobals().json); return runOrDie(() => runList({ json }), { json }); });
 
   org.command('view [space]').description('Show one space (defaults to your only space)').option('--json', 'Machine-readable output')
-    .action((space: string | undefined, o: { json?: boolean }, command: Command) => runView(space, { json: !!(o.json || command.optsWithGlobals().json) }));
+    .action((space: string | undefined, o: { json?: boolean }, command: Command) => { const json = !!(o.json || command.optsWithGlobals().json); return runOrDie(() => runView(space, { json }), { json }); });
 
   org.command('invite <email>').description('Invite (or directly add) a member')
     .option('--role <role>', 'admin | member', 'member')
     .option('--space <id-or-slug>', 'Space to invite into (defaults to your only space)')
     .option('--json', 'Machine-readable output')
-    .action((email: string, o: { role?: string; space?: string; json?: boolean }, command: Command) => runInvite(email, { ...o, json: !!(o.json || command.optsWithGlobals().json) }));
+    .action((email: string, o: { role?: string; space?: string; json?: boolean }, command: Command) => { const json = !!(o.json || command.optsWithGlobals().json); return runOrDie(() => runInvite(email, { ...o, json }), { json }); });
 
   org.command('members [space]').description('List a space\'s members').option('--json', 'Machine-readable output')
-    .action((space: string | undefined, o: { json?: boolean }, command: Command) => runMembers(space, { json: !!(o.json || command.optsWithGlobals().json) }));
+    .action((space: string | undefined, o: { json?: boolean }, command: Command) => { const json = !!(o.json || command.optsWithGlobals().json); return runOrDie(() => runMembers(space, { json }), { json }); });
 
   org.command('role <email> <role>').description('Change a member\'s role (owner-only for admin)')
     .option('--space <id-or-slug>', 'Space to change (defaults to your only space)')
     .option('--json', 'Machine-readable output')
-    .action((email: string, role: string, o: { space?: string; json?: boolean }, command: Command) => runRole(email, role, { ...o, json: !!(o.json || command.optsWithGlobals().json) }));
+    .action((email: string, role: string, o: { space?: string; json?: boolean }, command: Command) => { const json = !!(o.json || command.optsWithGlobals().json); return runOrDie(() => runRole(email, role, { ...o, json }), { json }); });
 
   org.command('remove <email>').description('Remove a member from a space')
     .option('--space <id-or-slug>', 'Space to remove from (defaults to your only space)')
     .option('--json', 'Machine-readable output')
-    .action((email: string, o: { space?: string; json?: boolean }, command: Command) => runRemove(email, { ...o, json: !!(o.json || command.optsWithGlobals().json) }));
+    .action((email: string, o: { space?: string; json?: boolean }, command: Command) => { const json = !!(o.json || command.optsWithGlobals().json); return runOrDie(() => runRemove(email, { ...o, json }), { json }); });
 
   org.command('leave [space]').description('Leave a space you do not own').option('--json', 'Machine-readable output')
-    .action((space: string | undefined, o: { json?: boolean }, command: Command) => runLeave(space, { json: !!(o.json || command.optsWithGlobals().json) }));
+    .action((space: string | undefined, o: { json?: boolean }, command: Command) => { const json = !!(o.json || command.optsWithGlobals().json); return runOrDie(() => runLeave(space, { json }), { json }); });
 
   setHelpSections(org, {
     examples: `agents org create acme-team

--- a/apps/cli/src/lib/format.test.ts
+++ b/apps/cli/src/lib/format.test.ts
@@ -17,6 +17,7 @@ import {
   termLink,
   formatDie,
   dieFriction,
+  runOrDie,
 } from './format.js';
 import { _resetForTest } from './feed/events.js';
 
@@ -141,6 +142,40 @@ describe('formatDie (RUSH-1830 — machine-readable failures for --json callers)
   it('omits an absent hint from the json payload (no null/undefined key)', () => {
     const out = formatDie('nope', { json: true });
     expect(out.text).not.toContain('hint');
+  });
+});
+
+describe('runOrDie', () => {
+  it('turns a thrown Error into a clean die(message), not a rethrow (the auth/org stack-dump bug)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
+      throw new Error(`exit:${code}`);
+    });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      runOrDie(() => { throw new Error("Not signed in. Run 'agents auth login' first."); }),
+    ).rejects.toThrow('exit:1');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(String(errSpy.mock.calls[0][0])).toContain("Not signed in. Run 'agents auth login' first.");
+  });
+
+  it('keeps the structured {"error"} payload for a --json caller', async () => {
+    vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
+      throw new Error(`exit:${code}`);
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(
+      runOrDie(async () => { throw new Error('Signed-in token is no longer valid.'); }, { json: true }),
+    ).rejects.toThrow('exit:1');
+    expect(JSON.parse(String(logSpy.mock.calls[0][0]))).toEqual({ error: 'Signed-in token is no longer valid.' });
+  });
+
+  it('passes a successful action through untouched', async () => {
+    let ran = false;
+    await runOrDie(async () => { ran = true; });
+    expect(ran).toBe(true);
   });
 });
 

--- a/apps/cli/src/lib/format.ts
+++ b/apps/cli/src/lib/format.ts
@@ -60,6 +60,22 @@ export function die(msg: string, code = 1, opts: DieOptions = {}): never {
 }
 
 /**
+ * Await a command action and turn a thrown Error into a clean `die(message)`
+ * instead of Node's raw stack dump — bootstrap's parseAsync catch deliberately
+ * rethrows plain Errors as engineering bugs, so a command whose helpers throw
+ * user-actionable errors (auth, org) wraps its `.action(...)` call site with
+ * this. The helpers keep throwing so tests can assert on them. Pass `json`
+ * so a `--json` caller still gets the structured `{"error"}` payload.
+ */
+export async function runOrDie(fn: () => void | Promise<void>, opts: DieOptions = {}): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    die(err instanceof Error ? err.message : String(err), 1, opts);
+  }
+}
+
+/**
  * `die()` with a structured friction event attached. Use this at CLI error
  * chokepoints so the nightly routine can classify and rank recurring failures
  * without re-parsing transcripts. `surface` is the subsystem (teams, browser,


### PR DESCRIPTION
Bug fix — no behavior change beyond error rendering.

## What changed

`agents auth whoami` (and every `agents auth` / `agents org` subcommand) crashed with a raw Node stack trace on routine user states — signed out, expired token, bad `--role` input, a 401 from the API. The throws escaped `bootstrap.ts`'s `parseAsync` catch (which deliberately rethrows plain Errors as engineering bugs) and hit Node's default unhandled-rejection dump.

Fix: a shared `runOrDie` action wrapper in `lib/format.ts`, used at the `.action(...)` call sites in `commands/auth.ts` (3 actions) and `commands/org.ts` (8 actions). Helpers keep throwing so the existing tests still assert on them; the action boundary renders `die(message)` — a red one-liner for humans, the structured `{"error"}` payload for `--json` callers.

## Run result

Before/after terminal output + the 36-test run: https://share.agents-cli.sh/muqsitnawaz/auth-clean-errors-auth-clean-errors-evidence-ae97cc83986f1fad

```
$ agents auth whoami            # before: 12-line Node stack trace
Signed-in token is no longer valid (run 'rush login' again).
$ agents auth whoami --json
{"error":"Signed-in token is no longer valid (run 'rush login' again)."}
```

## Tests

- `format.test.ts`: 3 new `runOrDie` cases (Error → clean die, `--json` payload, success passthrough) reproducing the bug class.
- `auth.test.ts` / `org.test.ts`: unchanged, still green (36/36 across the three files).

CHANGELOG: queued as `.changelog/next/auth-org-clean-errors.md`.
