### PR TITLE
refactor(cli): bake routine argv from AGENT_COMMANDS

### DIFF
--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
+  bakeRoutineArgv,
   buildJobCommand,
   buildRoutineSpawnEnv,
   dispatchesViaAgentsRun,
@@ -10,13 +11,13 @@ import {
   pinJobBinary,
   resolveRoutineLaunch,
 } from '../daemon/runner.js';
+import { ROUTINE_AGENT_IDS } from '../agents.js';
 import { readRunMeta } from '../scheduling/routines.js';
 import { getRunsDir } from '../state.js';
 import type { JobConfig } from '../scheduling/routines.js';
 import { getBinaryPath, getVersionDir } from '../installations/versions.js';
 import { rotationFailoverChain, type RotateCandidate, type RotateResult } from '../accounting/rotate.js';
-import { detectRateLimit } from '../exec.js';
-import { buildExecCommand } from '../exec.js';
+import { AGENT_COMMANDS, detectRateLimit, buildExecCommand } from '../exec.js';
 import * as activation from '../routine-activation.js';
 
 beforeEach(() => {
@@ -40,6 +41,30 @@ function baseJob(overrides: Partial<JobConfig> = {}): JobConfig {
     ...overrides,
   } as JobConfig;
 }
+
+describe('bakeRoutineArgv', () => {
+  it('pins the six daemon skeletons that used to live in ROUTINE_AGENT_COMMANDS', () => {
+    expect(ROUTINE_AGENT_IDS).toEqual(['claude', 'codex', 'cursor', 'kimi', 'droid', 'muse']);
+    expect(bakeRoutineArgv('claude')).toEqual([
+      'claude', '-p', '--verbose', '{prompt}', '--output-format', 'stream-json', '--permission-mode', 'plan',
+    ]);
+    expect(bakeRoutineArgv('codex')).toEqual(['codex', 'exec', '{prompt}', '--json']);
+    expect(bakeRoutineArgv('cursor')).toEqual(['cursor-agent', '-p', '{prompt}', '--output-format', 'stream-json']);
+    expect(bakeRoutineArgv('kimi')).toEqual(['kimi', '--prompt', '{prompt}', '--output-format', 'stream-json']);
+    expect(bakeRoutineArgv('droid')).toEqual(['droid', 'exec', '{prompt}', '-o', 'stream-json']);
+    expect(bakeRoutineArgv('muse')).toEqual(['muse', 'exec', '{prompt}', '--json']);
+  });
+
+  it('kimi keeps --prompt; AGENT_COMMANDS.kimi.promptFlag stays -p (not a silent merge)', () => {
+    expect(AGENT_COMMANDS.kimi.promptFlag).toBe('-p');
+    expect(bakeRoutineArgv('kimi')![1]).toBe('--prompt');
+  });
+
+  it('refuses harnesses the daemon does not fire locally', () => {
+    expect(bakeRoutineArgv('gemini')).toBeUndefined();
+    expect(bakeRoutineArgv('grok')).toBeUndefined();
+  });
+});
 
 describe('buildJobCommand', () => {
   it('cursor default/write mode trusts the configured workspace without using --yolo', () => {

--- a/apps/cli/src/lib/agent-spec/agents.ts
+++ b/apps/cli/src/lib/agent-spec/agents.ts
@@ -1170,27 +1170,26 @@ export const AGENTS: Record<AgentId, AgentRegistryConfig> = {
 export const ALL_AGENT_IDS: AgentId[] = Object.keys(AGENTS) as AgentId[];
 
 /**
- * CLI command templates per agent for daemon-fired routine jobs, with
- * {prompt} as a placeholder. Lives here (not runner.ts) so routines.ts can
- * import ROUTINE_AGENT_IDS for schedule-time validation without a circular
+ * Agents the routine daemon can fire locally. Lives here (not runner.ts) so
+ * routines.ts can import it for schedule-time validation without a circular
  * import (runner.ts already imports from routines.ts).
+ *
+ * This is a curated subset of AGENT_COMMANDS, not "every harness that can run
+ * headlessly". Expanding it is a product change (gemini is hard-deprecated and
+ * is deliberately absent). Argv itself is baked from AGENT_COMMANDS in
+ * daemon/runner.ts bakeRoutineArgv — do not reintroduce a second token table.
  */
-export const ROUTINE_AGENT_COMMANDS: Record<string, string[]> = {
-  claude: ['claude', '-p', '--verbose', '{prompt}', '--output-format', 'stream-json', '--permission-mode', 'plan'],
-  codex: ['codex', 'exec', '{prompt}', '--json'],
+export const ROUTINE_AGENT_IDS: readonly string[] = Object.freeze([
+  'claude',
+  'codex',
   // gemini is hard-deprecated (Antigravity replaced it) — no routine target. A
   // legacy gemini routine now fails validateJob loud instead of firing a
   // retired backend; the id survives only for reading old sessions/config.
-  cursor: ['cursor-agent', '-p', '{prompt}', '--output-format', 'stream-json'],
-  kimi: ['kimi', '--prompt', '{prompt}', '--output-format', 'stream-json'],
-  droid: ['droid', 'exec', '{prompt}', '-o', 'stream-json'],
-  muse: ['muse', 'exec', '{prompt}', '--json'],
-};
-
-/** Agents the routine daemon can actually run when firing locally, derived
- * from the command table above so the `--agent` help and validateJob's
- * schedule-time check can never drift from it. */
-export const ROUTINE_AGENT_IDS = Object.freeze(Object.keys(ROUTINE_AGENT_COMMANDS));
+  'cursor',
+  'kimi',
+  'droid',
+  'muse',
+]);
 
 /** Agents retained only for legacy reads, not install/import/sync targets. */
 export const HARD_DEPRECATED_AGENT_IDS: AgentId[] = ALL_AGENT_IDS.filter((id) => AGENTS[id].deprecated?.hard);

--- a/apps/cli/src/lib/daemon/runner.ts
+++ b/apps/cli/src/lib/daemon/runner.ts
@@ -80,7 +80,7 @@ import {
 } from '../accounting/rotate.js';
 import { readAuthHealth, isDeadVerdict } from '../auth-health.js';
 import { machineId } from '../machine-id.js';
-import { isSelfUpdatingAgent, ROUTINE_AGENT_COMMANDS, ROUTINE_AGENT_IDS, isAgentHardDeprecated, hardDeprecationError } from '../agents.js';
+import { isSelfUpdatingAgent, ROUTINE_AGENT_IDS, isAgentHardDeprecated, hardDeprecationError } from '../agents.js';
 
 /** Result of a completed job execution, including metadata and optional report. */
 export interface RunResult {
@@ -566,6 +566,50 @@ export function routineSpawnCwd(
   return ctx.absoluteCwd ?? os.homedir();
 }
 
+/**
+ * Bake the daemon-job argv skeleton from AGENT_COMMANDS.
+ *
+ * The two tables used to be independent copies of the same launch decision.
+ * Argv now comes from AGENT_COMMANDS.base / promptFlag / jsonFlags / modeFlags.
+ * Two documented exceptions, not a second table:
+ *   - kimi uses `--prompt` (long form). `-p` is the exec alias; combining
+ *     either with --plan/--auto/--yolo aborts, so routineModeArgs emits no
+ *     mode flag. The daemon has always spawned the long form.
+ *   - claude places `--verbose` (from jsonFlags) before the prompt and bakes
+ *     modeFlags.plan so claudeAdapter.routineModeArgs can splice
+ *     plan → acceptEdits / auto / skip.
+ *
+ * Returns undefined when `agent` is outside ROUTINE_AGENT_IDS (gemini, grok,
+ * and every other harness the daemon does not fire locally).
+ */
+export function bakeRoutineArgv(agent: string): string[] | undefined {
+  if (!ROUTINE_AGENT_IDS.includes(agent)) return undefined;
+  const template = AGENT_COMMANDS[agent as AgentId];
+  if (!template) return undefined;
+
+  const json = template.jsonFlags ?? [];
+  const cmd = [...template.base];
+
+  if (agent === 'kimi') {
+    cmd.push('--prompt', '{prompt}', ...json);
+    return cmd;
+  }
+
+  if (agent === 'claude') {
+    const verbose = json.includes('--verbose') ? ['--verbose'] : [];
+    const jsonRest = json.filter((flag) => flag !== '--verbose');
+    cmd.push(template.promptFlag as string, ...verbose, '{prompt}', ...jsonRest, ...(template.modeFlags.plan ?? []));
+    return cmd;
+  }
+
+  if (template.promptFlag === 'positional') {
+    cmd.push('{prompt}', ...json);
+  } else {
+    cmd.push(template.promptFlag, '{prompt}', ...json);
+  }
+  return cmd;
+}
+
 /** Build the full CLI argv for executing a job, applying mode, model, and permission flags. */
 export function buildJobCommand(config: JobConfig, resolvedPrompt: string, forwardAccount = true): string[] {
   // Workflow branch: delegate to `agents run <workflow>` which handles subagent
@@ -593,7 +637,7 @@ export function buildJobCommand(config: JobConfig, resolvedPrompt: string, forwa
     return cmd;
   }
 
-  const template = ROUTINE_AGENT_COMMANDS[agent];
+  const template = bakeRoutineArgv(agent);
   if (!template) {
     throw new Error(`Unsupported agent for daemon jobs: ${agent}`);
   }

--- a/apps/cli/src/lib/harness/adapter.ts
+++ b/apps/cli/src/lib/harness/adapter.ts
@@ -77,9 +77,10 @@ export interface ExecLaunchArgsCtx {
 
 /**
  * Context for the routine (daemon-job) launch-arg quirks (mapping B, runner.ts
- * side). This idiom mutates a pre-baked token array from ROUTINE_AGENT_COMMANDS,
- * distinct from buildExecCommand's declarative modeFlags — so it is a separate
- * method on the same adapter, one source of truth per harness across both.
+ * side). This idiom mutates a token array baked from AGENT_COMMANDS
+ * (bakeRoutineArgv), distinct from buildExecCommand's declarative modeFlags —
+ * so it is a separate method on the same adapter, one source of truth per
+ * harness across both.
  */
 export interface RoutineLaunchCtx {
   /** normalizeMode(config.mode) — the canonicalized mode. */
@@ -147,8 +148,8 @@ export interface HarnessAdapter {
 
   /**
    * This harness's routine (daemon-job) launch-arg quirks for buildJobCommand
-   * (runner.ts). Mutates the ROUTINE_AGENT_COMMANDS token array in place, exactly
-   * as the old per-agent arm did; runner appends model/reasoning flags after.
+   * (runner.ts). Mutates the bakeRoutineArgv token array in place, exactly as
+   * the old per-agent arm did; runner appends model/reasoning flags after.
    * Omitted for a harness with no routine launch quirks.
    */
   routineModeArgs?(cmd: string[], ctx: RoutineLaunchCtx): void;

--- a/apps/cli/src/lib/scheduling/routines.ts
+++ b/apps/cli/src/lib/scheduling/routines.ts
@@ -1304,7 +1304,7 @@ export function validateJob(config: Partial<JobConfig>): string[] {
     !ROUTINE_AGENT_IDS.includes(config.agent)
   ) {
     // The local daemon only knows how to build a command for the agents in
-    // ROUTINE_AGENT_IDS (runner.ts's AGENT_COMMANDS table) — anything else is a
+    // ROUTINE_AGENT_IDS (baked from AGENT_COMMANDS in runner.ts) — anything else is a
     // real, installable agent (it passed the ALL_AGENT_IDS check above) but one
     // the daemon can't fire itself, so reject it now instead of accepting the
     // routine and failing at fire time (runner.ts buildJobCommand: "Unsupported

--- a/apps/cli/tests/runner.test.ts
+++ b/apps/cli/tests/runner.test.ts
@@ -116,7 +116,7 @@ describe('buildJobCommand', () => {
   });
 
   describe('gemini (hard-deprecated — no longer a routine target, RUSH-2719)', () => {
-    it('buildJobCommand refuses gemini: it left ROUTINE_AGENT_COMMANDS', () => {
+    it('buildJobCommand refuses gemini: it is outside ROUTINE_AGENT_IDS', () => {
       expect(() => buildJobCommand(makeConfig({ agent: 'gemini' }), 'hello'))
         .toThrow('Unsupported agent for daemon jobs: gemini');
     });


### PR DESCRIPTION
refactor / no-behavior-change

Delete the second launch table `ROUTINE_AGENT_COMMANDS`. Daemon jobs now
bake argv from `AGENT_COMMANDS` (`bakeRoutineArgv` in `daemon/runner.ts`).
`ROUTINE_AGENT_IDS` stays the curated local-fire allowlist so `routines.ts`
does not import `exec.ts` (cycle).

## Why two tables existed
`AGENT_COMMANDS` (exec) and `ROUTINE_AGENT_COMMANDS` (daemon) encoded the
same launch decision. `runner.ts` already read `AGENT_COMMANDS[agent].modelFlag`.

## Exceptions kept on purpose
| Harness | Exception | Why |
|---|---|---|
| kimi | `--prompt`, not exec `-p` | Combining either with `--plan`/`--auto`/`--yolo` aborts. Tests pin both. |
| claude | `--verbose` before prompt + baked `--permission-mode plan` | `claudeAdapter.routineModeArgs` splices plan → acceptEdits/auto/skip. |

gemini stays out of `ROUTINE_AGENT_IDS` (hard-deprecated). Expanding the
allowlist is a product change, not this PR.

## Run
```
Test Files  6 passed (6)
      Tests  523 passed (523)
Duration  3.83s
```
Files: `src/lib/__tests__/runner.test.ts`, `tests/runner.test.ts`,
`src/lib/scheduling/routines.test.ts`, `src/lib/__tests__/exec.test.ts`,
`src/lib/exec.test.ts`, `src/lib/agent-modes.test.ts`.

Host: yosemite-s0. Internal refactor — no user-visible flag/CLI change, no CHANGELOG.