### PR TITLE
ci(deps): bump actions/cache to v6.1.0 on Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
             --github-output "$GITHUB_OUTPUT"
           bun scripts/ci-scope.ts --validate-manifest
       - name: Restore exact-tree proof
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: impact-proof.json
           key: impact-proof-${{ runner.os }}-${{ steps.plan.outputs.tree }}-${{ steps.plan.outputs.policy_digest }}


### PR DESCRIPTION
ci / no-behavior-change

Supersedes stale dependabot #2757 (191 commits behind). One SHA pin in
`.github/workflows/tests.yml` Restore exact-tree proof:

`actions/cache@1bd1e32` (v4.2.0) → `actions/cache@55cc834` (v6.1.0)

Same SHA already used by `tests-windows-host-e2e.yml`. Inputs unchanged.
GitHub-hosted `ubuntu-latest` is past the v5 Node 24 / runner 2.327.1 floor.

Non-author review of #2757 (same diff vs main) was READY TO MERGE.
This PR is that one-liner rebased onto current main.

CI on this PR is the run evidence.
