### PR TITLE
fix(webhooks): a run.agent handler could never dispatch — routine activation gate skipped it

### DIFF
--- a/apps/cli/.changelog/next/slack-handler-dispatch.md
+++ b/apps/cli/.changelog/next/slack-handler-dispatch.md
@@ -1,0 +1,15 @@
+- **Slack/webhook handlers that run an agent actually dispatch now.** A `run.agent` or
+  `run.workflow` webhook handler was gated by the *routine* activation manifest
+  (`~/.agents/devices/<machine>/agents.yaml`). A handler is not a routine, so its name
+  could never be a member — on any box that had materialized that manifest, every
+  delivery was recorded `skipped` with an empty allowlist (`can only run on: `) while the
+  receiver logged it as `fired`, and `agents routines enable <handler>` refuses the name,
+  so there was no way out. Verified live: a real HMAC-signed `/agents` slash command
+  reached the public receiver, acked 200, and started no agent. The job now carries
+  `dispatchedBy: 'webhook'`, the same escape RUSH-2681 gave monitors; a handler's
+  `routine:` delegate still keeps its gate.
+- **`{{slack.response_url}}` is now available to handler prompts.** It was parsed off the
+  wire but never reached the `{{slack.*}}` namespace. Slack accepts a POST there for 30
+  minutes with no token and no channel membership, so it is the only reply that works
+  before the app has been invited to a channel — the shipped example handler now uses it.
+  Source: `apps/cli/src/lib/triggers/handlers.ts`, `apps/cli/src/lib/scheduling/routines.ts`.

--- a/apps/cli/ci/test-ownership.yaml
+++ b/apps/cli/ci/test-ownership.yaml
@@ -118,6 +118,17 @@ groups:
     checks: [typecheck]
     budget_sec: 240
 
+  # 180s, not the default 85s. scheduling/routines.ts is the JobConfig hub, so a
+  # change there selects the routines/runner/daemon/monitors companions and their
+  # importers (PR #2837, run 32434389380: 28 files / 715 tests, all passed, inside
+  # a 153s impact run). Under the flat 85s default no scheduling change can merge.
+  # Raise this only against a measured run, and lower it when the suite is split.
+  - id: scheduling
+    when:
+      - apps/cli/src/lib/scheduling/**
+    checks: [typecheck]
+    budget_sec: 180
+
   # 150s, not the default 85s. Moving hooks.ts into hooks/install.ts (PR #2804,
   # run 32397180788) selected companion + importer tests inside a 129s impact
   # run (48 files / 1099 tests, all passed). Under 85s the move cannot merge.

--- a/apps/cli/docs/examples/slack/slack-agent.yml
+++ b/apps/cli/docs/examples/slack/slack-agent.yml
@@ -3,7 +3,7 @@
 # Copy to ~/.agents/webhooks/slack-agent.yml. A slash command (/agents AGI: …) or
 # an @mention of your Slack app reaches POST /hooks/slack, and this handler runs an
 # agent scoped to the project named in the message, on this machine. The agent then
-# replies in the same Slack thread with `agents send --channel slack`.
+# replies to the same Slack conversation.
 #
 # See docs/routines.md → "Slack — tag an agent, it replies in your thread" for the
 # one-time setup (secrets bundle, Funnel, the Slack app manifest in this directory).
@@ -36,6 +36,24 @@ run:
 
     You are running on the machine that holds this project's context. If prior
     conversation would help, read it first: `agents sessions -p {{slack.project}}`.
-    Do the work, then reply in the Slack thread with your result:
+    Do the work, then reply.
 
-    agents send --channel slack --to {{slack.channel}} --thread {{slack.thread_ts}} --text "<one- or two-line result>"
+    REPLY — a slash command carries `{{slack.response_url}}`. Slack accepts a POST
+    there for 30 minutes with no token and no channel membership, so this is the
+    reply that works even before the app has been invited to the channel:
+
+      curl -s -X POST '{{slack.response_url}}' \
+        -H 'Content-type: application/json' \
+        -d '{"response_type":"in_channel","text":"<one- or two-line result>"}'
+
+    An @mention delivery has no response_url (the field is empty). Reply into the
+    thread with the Web API instead — this needs the bot in that channel and a
+    SLACK_BOT_TOKEN in the receiver's secrets bundle:
+
+      agents secrets exec <bundle> -- sh -c 'curl -s -X POST https://slack.com/api/chat.postMessage \
+        -H "Authorization: Bearer $SLACK_BOT_TOKEN" -H "Content-type: application/json" \
+        -d "{\"channel\":\"{{slack.channel}}\",\"thread_ts\":\"{{slack.thread_ts}}\",\"text\":\"<result>\"}"'
+
+    `agents send --channel slack` is a third option, but it routes through the Rush
+    daemon's Slack Socket Mode gateway rather than this app's token — use it only
+    where that gateway is signed in.

--- a/apps/cli/docs/routines.md
+++ b/apps/cli/docs/routines.md
@@ -411,7 +411,9 @@ handler trusts.
 [`docs/examples/slack/`](examples/slack/) are ready to paste — then:
 
 ```bash
-# 1. Signing secret (verify inbound) + bot token (post the reply / real ts):
+# 1. Signing secret (verify inbound). The bot token is only needed for an
+#    @mention reply, which posts through the Slack Web API into the thread —
+#    a slash command replies via `{{slack.response_url}}` and needs no token:
 agents secrets add slack SLACK_SIGNING_SECRET <from Slack "Basic Information">
 agents secrets add slack SLACK_BOT_TOKEN <xoxb-… from "OAuth & Permissions">
 

--- a/apps/cli/docs/routines.md
+++ b/apps/cli/docs/routines.md
@@ -370,7 +370,7 @@ The receiver verifies Slack's `v0` request signature (with a 5-minute replay
 guard), answers the one-time `url_verification` handshake, and parses both slash
 commands and `app_mention` events. It exposes a `{{slack.*}}` substitution
 namespace — `prompt`, `project`, `channel`, `thread_ts`, `user`, `text`,
-`command` — where `project` and `prompt` come from a `PROJECT: rest` prefix in
+`command`, `response_url` — where `project` and `prompt` come from a `PROJECT: rest` prefix in
 the message (`AGI: rebase …` → project `AGI`, prompt `rebase …`). A handler may
 template its `project`/`cwd` from that namespace, so one handler serves every
 project:
@@ -389,14 +389,20 @@ run:
     Request: {{slack.prompt}}
 
     Read the project's prior context if useful (`agents sessions -p {{slack.project}}`),
-    do the work, then reply in the Slack thread with:
-    agents send --channel slack --to {{slack.channel}} --thread {{slack.thread_ts}} --text "<your result>"
+    do the work, then reply. A slash command carries a `response_url`, which Slack
+    accepts for 30 minutes with no token and no channel membership:
+    curl -s -X POST '{{slack.response_url}}' -H 'Content-type: application/json' \
+      -d '{"response_type":"in_channel","text":"<your result>"}'
 ```
 
-The reply reuses the existing outbound Slack channel — no bot code — so it needs
-`rush` logged in with a live Slack gateway (the same requirement as any
-`agents send --channel slack`). Restrict a handler to one channel with
-`channel: C0…`, or drop the `command`/`channel` filters to match every mention.
+`response_url` is empty on an `@mention` delivery — that reply goes into the thread
+through the Slack Web API (`chat.postMessage` with `SLACK_BOT_TOKEN`, which needs the
+bot in that channel), or through `agents send --channel slack`, which routes via the
+Rush daemon's Slack gateway rather than this app's token and so needs `rush` logged
+in there. The full example is in
+[`docs/examples/slack/slack-agent.yml`](examples/slack/slack-agent.yml). Restrict a
+handler to one channel with `channel: C0…`, or drop the `command`/`channel` filters
+to match every mention.
 
 Route with `{{slack.project}}`, not `{{slack.prompt}}`. The project token is a
 single bare word (no slashes, never `..`), so it is safe in `project:`/`cwd:`;

--- a/apps/cli/src/lib/scheduling/routines.ts
+++ b/apps/cli/src/lib/scheduling/routines.ts
@@ -475,16 +475,16 @@ export interface JobConfig {
    * `lib/monitors/config.ts`) — re-gating here was double-gating on the wrong
    * key.
    *
-   * Deliberately narrow: a monitor's `routine` action fires a REAL routine, which
-   * keeps its activation gate, so a routine defined but not activated on this
-   * device is still refused.
+   * Deliberately narrow: a monitor's or webhook handler's `routine` action fires a
+   * REAL routine, which keeps its activation gate, so a routine defined but not
+   * activated on this device is still refused.
    *
    * Runtime-only, enforced at both ends of the schema boundary: `writeJob`
    * strips it, and `readJobFileResult` refuses a definition that carries it
    * (a hand-authored one would otherwise fire on every box regardless of
    * activation, since the daemon's load path never calls `validateJob`).
    */
-  dispatchedBy?: 'monitor';
+  dispatchedBy?: 'monitor' | 'webhook';
 }
 
 /**
@@ -769,13 +769,16 @@ export function finalizeRunMeta(
  * `yosemite-s0` all agree. Every fire path (cron scheduler, webhook,
  * catchup/overdue, manual run) gates on this.
  *
- * A monitor-dispatched job ({@link JobConfig.dispatchedBy} `=== 'monitor'`) skips
+ * A monitor- or webhook-dispatched job ({@link JobConfig.dispatchedBy} set) skips
  * the routine activation manifest: it is not a routine, so its name can never be
  * a member and the lookup could only ever answer "not activated here"
- * (RUSH-2681). Its ownership was already decided by the monitor's `device:` pin.
+ * (RUSH-2681 for monitors; the same hole broke every `run.agent`/`run.workflow`
+ * webhook handler, which the receiver logged as `fired` while the run record read
+ * `skipped` with an empty allowlist). Ownership was already decided upstream — by
+ * the monitor's `device:` pin, or by the one box the webhook was delivered to.
  */
 export function jobRunsOnThisDevice(config: Pick<JobConfig, 'name' | 'devices' | 'dispatchedBy'>): boolean {
-  if (config.dispatchedBy !== 'monitor') {
+  if (config.dispatchedBy === undefined) {
     const activated = routineEnabledOnThisDevice(config.name);
     if (activated !== null) return activated;
   }
@@ -1087,7 +1090,7 @@ export function readJobFileResult(filePath: string): RoutineReadResult {
   // written back (writeJob deletes it), so its presence here means hand-authored
   // state, not drift.
   if (Object.prototype.hasOwnProperty.call(parsed, 'dispatchedBy')) {
-    return { config: null, problem: '`dispatchedBy:` is a runtime-only monitor marker, not a routine field — routine is inert' };
+    return { config: null, problem: '`dispatchedBy:` is a runtime-only monitor/webhook marker, not a routine field — routine is inert' };
   }
 
   return {

--- a/apps/cli/src/lib/triggers/handlers.test.ts
+++ b/apps/cli/src/lib/triggers/handlers.test.ts
@@ -346,6 +346,40 @@ describe('handler config layer', () => {
       }
     });
 
+    // A handler is not a routine, so its name can never be a member of this
+    // device's routine activation manifest. Without the marker the gate answered
+    // "not activated here" and executeJobDetached recorded `skipped` with an empty
+    // allowlist ("can only run on: "), while the receiver logged the delivery as
+    // `fired` — a live Slack slash command reached the box and no agent ever ran.
+    it('marks an agent handler webhook-dispatched so the routine activation gate cannot skip it', async () => {
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'slack-agent',
+        source: 'slack',
+        run: { agent: 'claude', prompt: 'go' },
+      };
+      const dispatched: JobConfig[] = [];
+      await handlerMod.executeHandler(handler, linearWebhook(), {
+        dispatchAgent: async (config) => {
+          dispatched.push(config);
+          return {
+            jobName: handler.name, runId: 'run-dispatchedby', agent: 'claude', pid: 1,
+            status: 'running', startedAt: new Date().toISOString(),
+            completedAt: null, exitCode: null,
+          };
+        },
+      });
+      expect(dispatched[0].dispatchedBy).toBe('webhook');
+
+      // Materialize a device activation manifest that does NOT list the handler —
+      // the state this box was in when a real signed slash command was skipped.
+      // Without the marker the gate reads false here and the run never starts.
+      const { replaceEnabledRoutines } = await import('../routine-activation.js');
+      const { jobRunsOnThisDevice } = await import('../scheduling/routines.js');
+      replaceEnabledRoutines(['some-other-routine']);
+      expect(jobRunsOnThisDevice({ name: 'slack-agent' })).toBe(false);
+      expect(jobRunsOnThisDevice(dispatched[0])).toBe(true);
+    });
+
     it('passes run.env through to the dispatched job config', async () => {
       const handler: import('./handlers.js').WebhookHandler = {
         name: 'env-handler',
@@ -725,6 +759,26 @@ describe('handler config layer', () => {
         thread_ts: '1712345678.000100',
         user: 'U9',
       });
+    });
+
+    // response_url is Slack's own reply channel for a slash command: it takes a
+    // POST for 30 minutes with no token and no channel membership, so it is the
+    // only reply that works before the app has been invited anywhere. It was
+    // parsed off the wire but never reached the {{slack.*}} namespace, so a
+    // handler prompt could not use it.
+    it('exposes {{slack.response_url}} so a slash-command reply needs no token or channel membership', () => {
+      const webhook: IncomingWebhook = {
+        source: 'slack', event: '/agents',
+        payload: {
+          type: 'slash_command', command: '/agents', channel: 'C0AGI', user: 'U9',
+          text: 'AGI: go', response_url: 'https://hooks.slack.com/commands/T1/123/abc',
+        },
+      };
+      const ctx = handlerMod.buildWebhookContext(webhook) as { slack: import('./handlers.js').SlackMessageContext };
+      expect(ctx.slack.response_url).toBe('https://hooks.slack.com/commands/T1/123/abc');
+      // An event delivery carries none — the field is present and empty, never undefined.
+      const mention = handlerMod.buildWebhookContext(slackWebhook()) as { slack: import('./handlers.js').SlackMessageContext };
+      expect(mention.slack.response_url).toBe('');
     });
 
     it('leaves project empty and keeps the whole text when there is no PROJECT: prefix', () => {

--- a/apps/cli/src/lib/triggers/handlers.ts
+++ b/apps/cli/src/lib/triggers/handlers.ts
@@ -371,6 +371,13 @@ export interface SlackMessageContext {
   user: string;
   /** Slash command name (`/agents`), or '' for an event delivery. */
   command: string;
+  /**
+   * Slash-command reply URL (`https://hooks.slack.com/commands/…`), or '' for an
+   * event delivery. Slack accepts a POST here for 30 minutes with no token and no
+   * channel membership, so it is the only reply path that works before the app has
+   * been invited to a channel.
+   */
+  response_url: string;
 }
 
 const asString = (v: unknown): string => (typeof v === 'string' ? v : '');
@@ -395,6 +402,7 @@ export function parseSlackMessage(payload: SlackPayload): SlackMessageContext {
     thread_ts: asString(payload.thread_ts),
     user: asString(payload.user),
     command: asString(payload.command),
+    response_url: asString(payload.response_url),
   };
 }
 
@@ -537,6 +545,13 @@ async function executeHandlerAction(
       ...(substitutedCwd ? { cwd: substitutedCwd } : {}),
       ...(hostFields.host ? { host: hostFields.host } : {}),
       ...(hostFields.hostStrategy ? { hostStrategy: hostFields.hostStrategy } : {}),
+      // A handler is not a routine, so its name can never appear in this device's
+      // routine activation manifest — without this marker the gate answered "not
+      // activated here" and every delivery was skipped while the receiver logged
+      // `fired` (the same shape as RUSH-2681's monitor bug). The `routine:`
+      // delegate below deliberately omits it: that fires a REAL routine, which
+      // keeps its own activation gate.
+      dispatchedBy: 'webhook',
     };
     const dispatch = handler.run.agent
       ? (opts.dispatchAgent ?? dispatchDefault)


### PR DESCRIPTION
**Bug fix: a Slack/webhook handler that runs an agent could never dispatch.** Found by taking the merged bridge (#2785) live against a real Slack app.

## What was broken

A handler with `run.agent` / `run.workflow` was gated by the **routine** activation manifest (`~/.agents/devices/<machine>/agents.yaml`). A handler is not a routine, so its name can never be a member — on any box that has materialized that manifest, `jobRunsOnThisDevice` returns false and `executeJobDetached` records:

```
status: "skipped"   errorMessage: "Job 'slack-agent' can only run on: "
```

…an empty allowlist, while the receiver logs the same delivery as `fired`. And there is no way out: `agents routines enable slack-agent` answers `No routine named 'slack-agent'.`

This is exactly RUSH-2681's monitor bug in the webhook path — `routines.ts:772-776` even predicts it ("it is not a routine, so its name can never be a member and the lookup could only ever answer 'not activated here'").

## Fix

| Change | File |
|---|---|
| Synthesized job carries `dispatchedBy: 'webhook'`; the gate consults the manifest only for a job with no dispatch marker | `handlers.ts`, `scheduling/routines.ts` |
| `{{slack.response_url}}` reaches handler prompts — parsed off the wire since the bridge landed, never exposed | `handlers.ts` |
| Example handler replies via `response_url` (no token, no channel membership needed); `routines.md` no longer implies `SLACK_BOT_TOKEN` is required for a slash command | `docs/examples/slack/slack-agent.yml`, `docs/routines.md` |

A handler's `routine:` delegate deliberately keeps its gate — that fires a REAL routine.

## Run result

Live on yosemite-s1: a real HMAC-signed `/agents` slash command over the public Funnel URL, against a real Slack app (`agents`, workspace Phoenix), before and after.

![before/after](https://share.agents-cli.sh/muqsitnawaz/agents-cli-slack-handler-dispatch-f5baa47da9ec0471)

Same request, shipped 1.22.42 → `skipped`, no agent. Patched → `running`, account rotation and failover engage, and the dispatched agent does real work (`agents routines logs slack-agent` shows it searching prior sessions and calling Slack `auth.test` with the bundle token, `{"ok":true,"team":"Phoenix"}`).

Tests: `src/lib/triggers` + `src/lib/scheduling` + `routine-activation` = 203 passed. The new regression test fails without the fix (`expected undefined to be 'webhook'`) and materializes a real device manifest so it cannot pass vacuously.

## Context

Follow-up to #2785 and #2825. Related doc gap: RUSH-2933 (`agents send --channel slack` routes through the Rush daemon's Socket Mode gateway, not this app's token).
