### PR TITLE
fix(rotation): don't collapse balanced rotation onto a verified minority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Balanced rotation no longer pins every launch to one account when the usage
+  refresher is throttled (RUSH-2858).** `preferVerified` narrowed the candidate
+  pool to accounts with a <5-minute usage snapshot before the weighted-random
+  draw. Under Anthropic's per-machine 429 throttling of the usage endpoint,
+  exactly one account tends to be that fresh at any moment, so the "random"
+  draw ran over a one-element list and `--strategy balanced` launched the same
+  account/version every time — and launching into it kept its snapshot fresh,
+  locking the loop in while the other accounts were never picked or probed.
+  Verified-only narrowing now applies only when verified accounts cover at
+  least half the pool; below that, the whole pool competes, with fresh accounts
+  weighted by their confirmed numbers and stale/unknown ones at the default
+  full weight. Source: `apps/cli/src/lib/accounting/rotate.ts`
+  (`preferVerified`).
+
 - **`agents doctor --fix` names the exact removal command for a duplicate install it will not purge, and the multi-install banner only advertises `--fix` when it can really resolve the peer (RUSH-2705).** A healthy `>=1.22.30` duplicate
   global (for example a second install under nvm) was detected and nagged about on
   every command, but `--fix` deliberately never deletes it and ended on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@
   draw ran over a one-element list and `--strategy balanced` launched the same
   account/version every time — and launching into it kept its snapshot fresh,
   locking the loop in while the other accounts were never picked or probed.
-  Verified-only narrowing now applies only when verified accounts cover at
-  least half the pool; below that, the whole pool competes, with fresh accounts
-  weighted by their confirmed numbers and stale/unknown ones at the default
-  full weight. Source: `apps/cli/src/lib/accounting/rotate.ts`
-  (`preferVerified`).
+  For the weighted-random balanced chooser, verified-only narrowing now applies
+  only when verified accounts cover at least half the pool; below that, the
+  whole pool competes, with fresh accounts weighted by their confirmed numbers
+  and stale/unknown ones at the default full weight. The deterministic choosers
+  (`--strategy available`, run-auto harness classification) keep strict
+  verified-first narrowing — a deterministic pick cannot spread load, so
+  relaxing it would only reintroduce the stale-snapshot inversion. The
+  `usageUnverified` flag now reports whether the PICKED account's usage was
+  verified, not merely whether the whole pool was stale. Source:
+  `apps/cli/src/lib/accounting/rotate.ts` (`preferVerified`).
 
 - **`agents doctor --fix` names the exact removal command for a duplicate install it will not purge, and the multi-install banner only advertises `--fix` when it can really resolve the peer (RUSH-2705).** A healthy `>=1.22.30` duplicate
   global (for example a second install under nvm) was detected and nagged about on

--- a/apps/cli/src/lib/accounting/rotate.test.ts
+++ b/apps/cli/src/lib/accounting/rotate.test.ts
@@ -517,7 +517,11 @@ describe('routing refuses to decide on usage it cannot verify', () => {
 
     const picks = new Set<string>();
     for (let i = 0; i < 200; i++) {
-      picks.add(pickBalancedCandidate([fresh1, ...stale], NOW)!.picked.version);
+      const result = pickBalancedCandidate([fresh1, ...stale], NOW)!;
+      picks.add(result.picked.version);
+      // usageUnverified reports the PICK, not the pool: a stale pick out of a
+      // mixed pool must say so (the reviewer's truthfulness finding).
+      expect(result.usageUnverified).toBe(result.picked.version !== '2.1.219');
     }
 
     // Weighted-random over the whole pool: with near-equal weights, 200 draws
@@ -589,6 +593,24 @@ describe('--strategy available applies the same freshness rule as balanced', () 
 
     expect(result.usageUnverified).toBe(true);
     expect(result.picked.version).toBe('2.1.181'); // still the headroom sort
+  });
+
+  it('a verified MINORITY still wins the deterministic pick — no whole-pool relaxation here', () => {
+    // The reviewer's catch on the first cut of the RUSH-2858 fix: relaxing the
+    // verified-first narrowing for a verified minority is only safe for a
+    // WEIGHTED-RANDOM chooser (it spreads load). `available` picks the front of
+    // the headroom sort deterministically, so a whole-pool fallback would hand
+    // the slot to an unconfirmed stale "5% used" over an accurate 95% — the
+    // original yosemite-s1 inversion. One verified account among eight must
+    // still be the pick.
+    const verified = candidate({ version: '2.1.219', usageSnapshot: fresh(95) });
+    const stale = ['2.1.181', '2.1.207', '2.1.217', '2.1.218', '2.1.220', '2.1.221', '2.1.222']
+      .map((version) => candidate({ version, usageSnapshot: dayOld(5) }));
+
+    const result = pickAvailableCandidate([...stale, verified], null, NOW)!;
+
+    expect(result.picked.version).toBe('2.1.219');
+    expect(result.usageUnverified).toBe(false);
   });
 
   it('an explicit version preference is an instruction and still wins', () => {
@@ -710,6 +732,22 @@ describe('pickHarnessWeighted (run auto — the cross-harness layer, RUSH-2132)'
     ]);
     const [summary] = classifyHarnessCandidates(byHarness, NOW);
     // The day-old "5% used" is not evidence; the verified 80% account represents.
+    expect(summary.best!.version).toBe('2.1.219');
+  });
+
+  it('a verified minority of a large pool still represents the harness — deterministic, no relaxation', () => {
+    // Mirror of the `available` minority test: classify's `from[0]` chooser
+    // must keep verified-first narrowing even when verified accounts are a
+    // minority, or a stale-looking-empty account becomes the representative.
+    const stale = snapshotAt(new Date(NOW - 26 * 3600 * 1000), [{ key: 'week', usedPercent: 5 }]);
+    const byHarness = new Map<AgentId, RotateCandidate[]>([
+      ['claude', [
+        ...['2.1.181', '2.1.207', '2.1.217', '2.1.218', '2.1.220', '2.1.221', '2.1.222']
+          .map((version) => harnessAcct('claude', version, { usageSnapshot: stale })),
+        harnessAcct('claude', '2.1.219', { usageSnapshot: freshSnap(80) }),
+      ]],
+    ]);
+    const [summary] = classifyHarnessCandidates(byHarness, NOW);
     expect(summary.best!.version).toBe('2.1.219');
   });
 

--- a/apps/cli/src/lib/accounting/rotate.test.ts
+++ b/apps/cli/src/lib/accounting/rotate.test.ts
@@ -505,6 +505,42 @@ describe('routing refuses to decide on usage it cannot verify', () => {
     expect(['2.1.181', '2.1.207']).toContain(result.picked.version);
   });
 
+  it('a verified MINORITY does not capture every launch — the 429-throttled regime', () => {
+    // The 2026-08-20 incident: the usage endpoint 429-throttles a machine, so
+    // each refresh cycle confirms exactly one account. Narrowing to verified
+    // made `choose` run over a one-element list — the same account picked on
+    // every launch, which kept refreshing its own snapshot and locked the loop
+    // in. One fresh account among eight stale ones must not be a pin.
+    const fresh1 = candidate({ version: '2.1.219', usageSnapshot: fresh(10) });
+    const stale = ['2.1.181', '2.1.207', '2.1.217', '2.1.218', '2.1.220', '2.1.221', '2.1.222']
+      .map((version) => candidate({ version, usageSnapshot: dayOld(0) }));
+
+    const picks = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      picks.add(pickBalancedCandidate([fresh1, ...stale], NOW)!.picked.version);
+    }
+
+    // Weighted-random over the whole pool: with near-equal weights, 200 draws
+    // landing on one account has probability ~(1/8)^199 — a distribution with
+    // a single member means the narrowing collapse is back.
+    expect(picks.size).toBeGreaterThan(1);
+  });
+
+  it('verified coverage of half the pool still narrows to the verified set', () => {
+    // ceil(4/2) = 2 verified of 4: representative — stale candidates must not
+    // dilute a majority-confirmed picture.
+    const verifiedA = candidate({ version: '2.1.219', usageSnapshot: fresh(10) });
+    const verifiedB = candidate({ version: '2.1.220', usageSnapshot: fresh(20) });
+    const staleA = candidate({ version: '2.1.181', usageSnapshot: dayOld(0) });
+    const staleB = candidate({ version: '2.1.207', usageSnapshot: dayOld(0) });
+
+    for (let i = 0; i < 50; i++) {
+      const result = pickBalancedCandidate([staleA, verifiedA, staleB, verifiedB], NOW)!;
+      expect(['2.1.219', '2.1.220']).toContain(result.picked.version);
+      expect(result.usageUnverified).toBe(false);
+    }
+  });
+
   it('a verified rate-limited account is still excluded outright, not merely deprioritized', () => {
     const limited = candidate({ version: '2.1.170', usageSnapshot: fresh(100) });
     const ok = candidate({ version: '2.1.219', usageSnapshot: fresh(20) });

--- a/apps/cli/src/lib/accounting/rotate.ts
+++ b/apps/cli/src/lib/accounting/rotate.ts
@@ -87,9 +87,11 @@ export interface RotateResult {
   /** Candidates excluded (not signed in, or out of credits). */
   excluded: RotateCandidate[];
   /**
-   * True when NO candidate on this machine had usage data fresh enough to decide
-   * on, so the pick was made from unverified snapshots. Callers surface it —
-   * routing blind is a fact the operator needs, not an internal detail.
+   * True when the PICKED candidate's usage could not be verified fresh, so the
+   * route was decided on an unverified snapshot. Callers surface it — routing
+   * blind is a fact the operator needs, not an internal detail. (Previously
+   * this only reported the all-stale case; a stale pick out of a mixed pool
+   * was silently reported as verified.)
    */
   usageUnverified?: boolean;
 }
@@ -406,7 +408,12 @@ export function pickBalancedCandidate(
     if (!deduped.has(c)) excluded.push(c);
   }
 
-  const { picked, usageUnverified } = preferVerified(sorted, nowMs, weightedRandomByCapacity);
+  const { picked, usageUnverified } = preferVerified(
+    sorted,
+    nowMs,
+    weightedRandomByCapacity,
+    'representative',
+  );
   return { picked, healthy: sorted, excluded, usageUnverified };
 }
 
@@ -428,11 +435,20 @@ export function pickBalancedCandidate(
  * verified candidate while the rest are never picked and never probed: the
  * rotation degrades to a fixed pin that burns one account to its weekly cap
  * while its siblings idle (observed 2026-08-20 across yosemite-s0/s1 — the
- * "same version every time under --strategy balanced" incident). Verified-only
- * choice is therefore applied only when the verified set covers at least half
- * the pool; below that the whole pool competes, with fresh candidates weighted
- * by their confirmed numbers and stale/unknown ones at the default full weight
- * `capacityWeight` already assigns to "no signal".
+ * "same version every time under --strategy balanced" incident).
+ *
+ * The two failure modes belong to different CHOOSERS, so `narrowing` is picked
+ * per caller: `'representative'` (the weighted-random balanced path) narrows to
+ * verified only when they cover at least half the pool — below that the whole
+ * pool competes, fresh candidates keep their confirmed weights, stale/unknown
+ * ones get the full default weight `capacityWeight` assigns to "no signal", and
+ * the random roll spreads the load. `'any-verified'` (deterministic `from[0]`
+ * choosers: `--strategy available`, run-auto harness classification) keeps the
+ * original rule — narrow whenever ANY verified candidate exists — because a
+ * deterministic pick over the whole pool would hand the front slot back to an
+ * unconfirmed "48% used" over an accurate "90% used", the exact yosemite-s1
+ * inversion above, and a deterministic chooser cannot spread load anyway, so
+ * the singleton-collapse concern does not apply to it.
  *
  * `healthy` deliberately keeps every eligible candidate rather than just the
  * verified ones. Declining to *pick* an account on stale data and declining to
@@ -445,12 +461,16 @@ function preferVerified(
   pool: RotateCandidate[],
   nowMs: number,
   choose: (from: RotateCandidate[]) => RotateCandidate,
+  narrowing: 'any-verified' | 'representative' = 'any-verified',
 ): { picked: RotateCandidate; usageUnverified: boolean } {
   const verified = pool.filter((c) => isUsageVerified(c, nowMs));
-  const representative = verified.length >= Math.ceil(pool.length / 2);
+  const narrow =
+    verified.length > 0 &&
+    (narrowing === 'any-verified' || verified.length >= Math.ceil(pool.length / 2));
+  const picked = choose(narrow ? verified : pool);
   return {
-    picked: choose(representative ? verified : pool),
-    usageUnverified: verified.length === 0,
+    picked,
+    usageUnverified: !isUsageVerified(picked, nowMs),
   };
 }
 

--- a/apps/cli/src/lib/accounting/rotate.ts
+++ b/apps/cli/src/lib/accounting/rotate.ts
@@ -411,13 +411,28 @@ export function pickBalancedCandidate(
 }
 
 /**
- * Choose from the VERIFIED candidates when any exist, else from the whole pool.
+ * Choose from the VERIFIED candidates when they are a representative share of
+ * the pool (at least half), else from the whole pool.
  *
  * An eligible account whose usage we could not confirm is a guess, not a green
  * light: the snapshot reads "48% used" with equal confidence whether it was
  * captured a minute or three days ago, and a box whose refresh is failing stays
  * wrong indefinitely. Confirmed headroom therefore beats apparent headroom, even
  * when the unconfirmed number looks better.
+ *
+ * But narrowing to a verified MINORITY inverts the safety. When the usage
+ * endpoint 429-throttles a machine, each refresh cycle confirms roughly one
+ * account before backing off — so "verified" is a singleton, `choose` runs over
+ * a one-element list, and every launch lands on the same account. Launching
+ * into it refreshes that account's snapshot again, so it stays the only
+ * verified candidate while the rest are never picked and never probed: the
+ * rotation degrades to a fixed pin that burns one account to its weekly cap
+ * while its siblings idle (observed 2026-08-20 across yosemite-s0/s1 — the
+ * "same version every time under --strategy balanced" incident). Verified-only
+ * choice is therefore applied only when the verified set covers at least half
+ * the pool; below that the whole pool competes, with fresh candidates weighted
+ * by their confirmed numbers and stale/unknown ones at the default full weight
+ * `capacityWeight` already assigns to "no signal".
  *
  * `healthy` deliberately keeps every eligible candidate rather than just the
  * verified ones. Declining to *pick* an account on stale data and declining to
@@ -432,8 +447,9 @@ function preferVerified(
   choose: (from: RotateCandidate[]) => RotateCandidate,
 ): { picked: RotateCandidate; usageUnverified: boolean } {
   const verified = pool.filter((c) => isUsageVerified(c, nowMs));
+  const representative = verified.length >= Math.ceil(pool.length / 2);
   return {
-    picked: choose(verified.length > 0 ? verified : pool),
+    picked: choose(representative ? verified : pool),
     usageUnverified: verified.length === 0,
   };
 }


### PR DESCRIPTION
Fixes the "--strategy balanced opens the same version every time" incident (RUSH-2858, 2026-08-20).

## What changed
`preferVerified` (apps/cli/src/lib/accounting/rotate.ts) narrowed the candidate pool to accounts with a usage snapshot fresher than 5 minutes before the weighted-random draw. Under Anthropic's per-machine 429 throttling of the usage endpoint, exactly one account tends to be that fresh at any moment — so the draw ran over a one-element list and every launch landed on the same account. Launching into it refreshed its snapshot again, keeping it the sole verified candidate: rotation degraded to a fixed pin that burned one account to its weekly cap while seven idled at 0%.

Verified-only narrowing now applies only when the verified set covers **at least half the pool** (`verified.length >= ceil(pool.length / 2)`). Below that, the whole pool competes: fresh candidates keep their confirmed weights, stale/unknown ones get the full default weight `capacityWeight` already assigns to "no signal". The failover chain still reads the full `healthy` list, unchanged, and `usageUnverified` semantics are unchanged.

## Run result
Full rotation suite run in the worktree — 64/64 passing, including the two new regression tests. Captured run log: https://share.agents-cli.sh/muqsitnawaz/fix-rotation-verified-collapse-rotate-test-run-2d033d0e57955284

- new: "a verified MINORITY does not capture every launch — the 429-throttled regime" (1 fresh of 8 stale, 200 draws must hit >1 account)
- new: "verified coverage of half the pool still narrows to the verified set" (2 of 4 — the existing confirmed-beats-apparent behavior preserved; all prior 1-of-2 tests unchanged and green)

## Context
- Ticket: RUSH-2858 (root-cause comments there document the stale-snapshot/429 chain and this collapse mechanism)
- CHANGELOG entry under Unreleased