### PR TITLE
fix(rotation): quarantine session-limited accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ agents run claude@
 agents run codex@ "review this branch"
 ```
 
-`--strategy balanced` spreads work across available versions of the same agent -- useful when you have multiple accounts and want to avoid burning through one. When every account is rate-limited, the run exits nonzero naming each excluded account and the earliest window reset (use `--strategy pinned` to force the default) -- it never launches into an exhausted account.
+`--strategy balanced` spreads work across available versions of the same agent -- useful when you have multiple accounts and want to avoid burning through one. When a Claude run reports a session limit, agents-cli records the stated reset time, shows `session-limited` in `agents view`, and excludes that account until the reset. When every account is rate-limited, the run exits nonzero naming each excluded account and the earliest window reset (use `--strategy pinned` to force the default) -- it never launches into an exhausted account.
 
 ### Don't care which harness? `agents run auto`
 

--- a/apps/cli/.changelog/next/rush-2858-session-limit-rotation.md
+++ b/apps/cli/.changelog/next/rush-2858-session-limit-rotation.md
@@ -1,0 +1,1 @@
+- Fixed balanced Claude account rotation recording session-limit refusals until their stated reset, skipping those accounts, and surfacing `session-limited` in `agents view` instead of idle usage.

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -3399,8 +3399,9 @@ agents run auto --device yosemite-s0 "fix the flaky test"   # pin the device
         let exitCode: number;
         let ranAgent = agent;
         let ranVersion = defaultVersion;
-        if (fallback.length > 0) {
-          // fallback requires a prompt — enforced above, narrow the type here.
+        if (fallback.length > 0 || (rotationResult !== null && prompt !== undefined && !options.interactive)) {
+          // Fallback and balanced runs need captured output so a clean-exit
+          // session-limit refusal can update account availability.
           // The sink reports which chain entry actually executed (may differ from
           // the primary after a rate-limit handoff) so the audit record is honest.
           const sink: { agent?: AgentId; version?: string } = {};

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -1497,6 +1497,12 @@ export async function collectAgentsJson(filterAgentId?: AgentId, resourceSection
             resetsAt: w.resetsAt ? w.resetsAt.toISOString() : null,
           }))
         : [],
+      unavailable: snapshot?.unavailable
+        ? {
+            reason: snapshot.unavailable.reason,
+            resetsAt: snapshot.unavailable.resetsAt.toISOString(),
+          }
+        : undefined,
       lastActive: info.lastActive ? info.lastActive.toISOString() : null,
       path: getVersionDir(agentId, version),
       configuredModel: resolveConfiguredModel(agentId, version),

--- a/apps/cli/src/lib/accounting/rotate.test.ts
+++ b/apps/cli/src/lib/accounting/rotate.test.ts
@@ -29,7 +29,13 @@ import {
 } from './rotate.js';
 import { runWithFallback } from '../exec.js';
 import type { AgentId } from '../types.js';
-import type { UsageSnapshot, UsageWindowKey } from './usage.js';
+import {
+  noteClaudeSessionLimit,
+  readClaudeUsageCache,
+  setClaudeUsageCachePathForTest,
+  type UsageSnapshot,
+  type UsageWindowKey,
+} from './usage.js';
 
 /**
  * Build a healthy RotateCandidate (signed in, no live snapshot
@@ -347,6 +353,31 @@ process.exit(0);
     expect(code).toBe(1);
     // Ran the primary exactly once — a plain failure is surfaced, not retried.
     expect(fs.readFileSync(stateFile, 'utf8')).toBe('1');
+  });
+});
+
+describe('balanced excludes an account refused by Claude session quota (RUSH-2858)', () => {
+  it('uses the persisted real-run state instead of treating missing bars as 0%', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rotate-session-limit-'));
+    const previous = setClaudeUsageCachePathForTest(path.join(root, 'usage.json'));
+    try {
+      const limitedKey = 'claude:org=limited';
+      noteClaudeSessionLimit(limitedKey, new Date(Date.now() + 60 * 60 * 1000));
+      const limited = candidate({
+        version: '2.1.221',
+        usageKey: limitedKey,
+        usageSnapshot: readClaudeUsageCache(limitedKey),
+      });
+      const healthy = candidate({ version: '2.1.222' });
+
+      const result = pickBalancedCandidate([limited, healthy]);
+
+      expect(result?.picked.version).toBe('2.1.222');
+      expect(result?.excluded.map((entry) => entry.version)).toEqual(['2.1.221']);
+    } finally {
+      setClaudeUsageCachePathForTest(previous);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/cli/src/lib/accounting/rotate.ts
+++ b/apps/cli/src/lib/accounting/rotate.ts
@@ -203,7 +203,7 @@ export function isUsageVerified(candidate: RotateCandidate, nowMs: number = Date
 
 function hasUsageAvailable(candidate: RotateCandidate): boolean {
   const snapshot = candidate.usageSnapshot;
-  if (snapshot && snapshot.windows.length > 0) {
+  if (snapshot) {
     // Eligibility mirrors the `agents view` throttle badge exactly
     // (deriveUsageStatusFromSnapshot): an account maxed on ANY blocking window —
     // including the 5-hour session window — cannot serve the next request, so it
@@ -212,7 +212,8 @@ function hasUsageAvailable(candidate: RotateCandidate): boolean {
     // stayed "eligible" and the router kept launching into it while `ag view`
     // showed it rate-limited. Capacity *weighting* still ranks eligible accounts
     // by weekly headroom; this gate only decides can-it-run-right-now.
-    return deriveUsageStatusFromSnapshot(snapshot) !== 'rate_limited';
+    const status = deriveUsageStatusFromSnapshot(snapshot);
+    if (status !== null) return status !== 'rate_limited';
   }
 
   // No live snapshot: fall back to the coarse cached status.

--- a/apps/cli/src/lib/accounting/usage.test.ts
+++ b/apps/cli/src/lib/accounting/usage.test.ts
@@ -12,6 +12,7 @@ import {
   getUsageInfoForIdentity,
   writeClaudeUsageCache,
   readClaudeUsageCache,
+  pruneExpiredClaudeUsageCacheEntry,
   noteClaudeSessionLimit,
   parseClaudeSessionLimitReset,
   deriveUsageStatusFromSnapshot,
@@ -482,6 +483,20 @@ describe('observed Claude session limits', () => {
     const reset = new Date(NOW + 60_000);
     noteClaudeSessionLimit(usageKey, reset);
     expect(readClaudeUsageCache(usageKey, undefined, new Date(NOW + 60_001))).toBeNull();
+  });
+
+  it('stale expiry cleanup cannot erase a newer session-limit write', () => {
+    const reset = new Date(Date.now() + 60 * 60 * 1000);
+    noteClaudeSessionLimit(usageKey, reset);
+
+    // Models a reader that observed an expired row before the real-run writer
+    // replaced it: cleanup executes afterward and must re-read under its lock.
+    pruneExpiredClaudeUsageCacheEntry(usageKey, undefined, new Date());
+
+    expect(readClaudeUsageCache(usageKey)?.unavailable).toEqual({
+      reason: 'session_limit',
+      resetsAt: reset,
+    });
   });
 });
 

--- a/apps/cli/src/lib/accounting/usage.test.ts
+++ b/apps/cli/src/lib/accounting/usage.test.ts
@@ -12,6 +12,9 @@ import {
   getUsageInfoForIdentity,
   writeClaudeUsageCache,
   readClaudeUsageCache,
+  noteClaudeSessionLimit,
+  parseClaudeSessionLimitReset,
+  deriveUsageStatusFromSnapshot,
   setClaudeUsageCachePathForTest,
   deriveUsageHeadroom,
   formatUsageSummary,
@@ -440,6 +443,45 @@ describe('expired cached windows are unknown, not 0%', () => {
     // Self-cleaning: the dead entry is gone, not resurrected on the next read.
     const raw = JSON.parse(fs.readFileSync(path.join(cacheDir, 'claude-usage.json'), 'utf-8'));
     expect(raw[usageKey]).toBeUndefined();
+  });
+});
+
+describe('observed Claude session limits', () => {
+  let cacheDir: string;
+  let prevPath: string | null;
+  const usageKey = 'claude:org=session-limited-test';
+
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-session-limit-'));
+    prevPath = setClaudeUsageCachePathForTest(path.join(cacheDir, 'claude-usage.json'));
+  });
+
+  afterEach(() => {
+    setClaudeUsageCachePathForTest(prevPath);
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it('parses the real Claude refusal and persists it independently of usage windows', () => {
+    const now = Date.parse('2026-08-20T17:00:00-07:00');
+    const reset = parseClaudeSessionLimitReset(
+      "You've hit your session limit · resets 6:20pm (America/Los_Angeles)",
+      now,
+    );
+    expect(reset?.toISOString()).toBe('2026-08-21T01:20:00.000Z');
+
+    const persistedReset = new Date(Date.now() + 60 * 60 * 1000);
+    noteClaudeSessionLimit(usageKey, persistedReset);
+    const snapshot = readClaudeUsageCache(usageKey, undefined, new Date(now));
+    expect(snapshot?.windows).toEqual([]);
+    expect(snapshot?.unavailable).toEqual({ reason: 'session_limit', resetsAt: persistedReset });
+    expect(deriveUsageStatusFromSnapshot(snapshot)).toBe('rate_limited');
+    expect(formatUsageSummary('Max', snapshot)).toContain('session-limited');
+  });
+
+  it('drops the observed limit after its reset', () => {
+    const reset = new Date(NOW + 60_000);
+    noteClaudeSessionLimit(usageKey, reset);
+    expect(readClaudeUsageCache(usageKey, undefined, new Date(NOW + 60_001))).toBeNull();
   });
 });
 

--- a/apps/cli/src/lib/accounting/usage.ts
+++ b/apps/cli/src/lib/accounting/usage.ts
@@ -218,6 +218,11 @@ export interface UsageSnapshot {
   // otherwise comes from the local auth file via AccountInfo.plan; this field
   // lets a network usage fetch surface a plan the local credential can't.
   plan?: string | null;
+  /** A refusal observed from a real harness run, independent of API windows. */
+  unavailable?: {
+    reason: 'session_limit';
+    resetsAt: Date;
+  };
 }
 
 /** Usage data plus any error encountered while fetching. */
@@ -322,6 +327,10 @@ interface CachedUsageSnapshot {
   capturedAt: string | null;
   windows: CachedUsageWindow[];
   plan?: string | null;
+  unavailable?: {
+    reason: 'session_limit';
+    resetsAt: string;
+  };
 }
 
 /** Parsed rate-limit data extracted from a Codex session file. */
@@ -650,6 +659,9 @@ export function formatUsageSummary(
   }
 
   if (snapshot) {
+    if (snapshot.unavailable?.reason === 'session_limit') {
+      parts.push(chalk.yellow(`session-limited (${formatResetHint(snapshot.unavailable.resetsAt)})`));
+    }
     // Compact rows show BLOCKING windows — the same set
     // deriveUsageStatusFromSnapshot uses for the rate-limited badge — so an
     // account throttled by its month window (Droid meters on 5h/week/month)
@@ -723,7 +735,11 @@ export function formatUsageSummary(
 export function deriveUsageStatusFromSnapshot(
   snapshot: UsageSnapshot | null | undefined
 ): 'available' | 'rate_limited' | null {
-  if (!snapshot || snapshot.windows.length === 0) return null;
+  if (!snapshot) return null;
+  if (snapshot.unavailable && snapshot.unavailable.resetsAt.getTime() > Date.now()) {
+    return 'rate_limited';
+  }
+  if (snapshot.windows.length === 0) return null;
   const blocking = snapshot.windows.filter((window) => window.key !== 'sonnet_week');
   const windows = blocking.length > 0 ? blocking : snapshot.windows;
   const maxUsed = Math.max(...windows.map((window) => window.usedPercent));
@@ -1893,7 +1909,14 @@ export function writeClaudeUsageCache(
       // Re-read under the lock so a concurrent daemon tick / agents view
       // refresh cannot drop another account's row (lost update).
       const cache = readClaudeUsageCacheFile(cachePath);
-      cache[usageKey] = serializeClaudeUsageSnapshot(snapshot);
+      const prior = cache[usageKey];
+      const priorReset = parseDateValue(prior?.unavailable?.resetsAt);
+      cache[usageKey] = serializeClaudeUsageSnapshot({
+        ...snapshot,
+        unavailable: priorReset && priorReset.getTime() > Date.now()
+          ? { reason: 'session_limit', resetsAt: priorReset }
+          : snapshot.unavailable,
+      });
       atomicWriteFileSync(cachePath, JSON.stringify(cache, null, 2), 'utf-8');
     });
   } catch {
@@ -1933,6 +1956,9 @@ function serializeClaudeUsageSnapshot(snapshot: UsageSnapshot): CachedUsageSnaps
   return {
     capturedAt: snapshot.capturedAt?.toISOString() || null,
     plan: snapshot.plan ?? null,
+    unavailable: snapshot.unavailable
+      ? { reason: snapshot.unavailable.reason, resetsAt: snapshot.unavailable.resetsAt.toISOString() }
+      : undefined,
     windows: snapshot.windows.map((window) => ({
       key: window.key,
       label: window.label,
@@ -1971,7 +1997,12 @@ function deserializeClaudeUsageSnapshot(
     }))
     .filter((window) => isCachedUsageWindowFresh(window, capturedAt, now));
 
-  if (windows.length === 0) {
+  const unavailableReset = parseDateValue(snapshot.unavailable?.resetsAt);
+  const unavailable = unavailableReset && unavailableReset.getTime() > now.getTime()
+    ? { reason: 'session_limit' as const, resetsAt: unavailableReset }
+    : undefined;
+
+  if (windows.length === 0 && !unavailable) {
     return null;
   }
 
@@ -1981,7 +2012,69 @@ function deserializeClaudeUsageSnapshot(
     capturedAt,
     windows,
     plan: snapshot.plan ?? null,
+    unavailable,
   };
+}
+
+/**
+ * Persist a Claude session-limit refusal from a real run until its stated reset.
+ * This quota is not part of Anthropic's five-hour/weekly usage response.
+ */
+export function noteClaudeSessionLimit(
+  usageKey: string,
+  resetsAt: Date,
+  cachePath = getClaudeUsageCachePath(),
+): void {
+  try {
+    ensureLockTarget(cachePath, '{}');
+    withFileLock(cachePath, () => {
+      const cache = readClaudeUsageCacheFile(cachePath);
+      const existing = cache[usageKey] ?? { capturedAt: null, windows: [] };
+      cache[usageKey] = {
+        ...existing,
+        unavailable: { reason: 'session_limit', resetsAt: resetsAt.toISOString() },
+      };
+      atomicWriteFileSync(cachePath, JSON.stringify(cache, null, 2), 'utf-8');
+    });
+  } catch {
+    /* best-effort cache write — lock busy or disk full */
+  }
+}
+
+/** Parse Claude's `hit your session limit · resets …` refusal. */
+export function parseClaudeSessionLimitReset(text: string, nowMs = Date.now()): Date | null {
+  if (!/hit your session limit/i.test(text)) return null;
+  const match = /resets\s+([^.;!\n]+)/i.exec(text);
+  if (!match) return null;
+  const segment = match[1].trim();
+  const timeZone = /\(([A-Za-z_]+\/[A-Za-z_]+)\)/.exec(segment)?.[1];
+  const timePart = segment.replace(/\([A-Za-z_]+\/[A-Za-z_]+\)/, '').trim();
+  const absolute = Date.parse(timePart);
+  if (!Number.isNaN(absolute) && absolute > nowMs) return new Date(absolute);
+  const clock = /(\d{1,2})(?::(\d{2}))?\s*(am|pm)/i.exec(timePart);
+  if (!clock) return null;
+  let hour = Number(clock[1]) % 12;
+  if (clock[3].toLowerCase() === 'pm') hour += 12;
+  const minute = clock[2] ? Number(clock[2]) : 0;
+  try {
+    if (!timeZone) {
+      const result = new Date(nowMs);
+      result.setHours(hour, minute, 0, 0);
+      if (result.getTime() <= nowMs) result.setDate(result.getDate() + 1);
+      return result;
+    }
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone, hour12: false, year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit',
+    }).formatToParts(new Date(nowMs));
+    const part = (type: string) => Number(parts.find((item) => item.type === type)?.value ?? 0);
+    const wallNow = Date.UTC(part('year'), part('month') - 1, part('day'), part('hour') % 24, part('minute'));
+    const offset = wallNow - nowMs;
+    let result = Date.UTC(part('year'), part('month') - 1, part('day'), hour, minute) - offset;
+    if (result <= nowMs) result += 24 * 60 * 60 * 1000;
+    return new Date(result);
+  } catch {
+    return null;
+  }
 }
 
 /** Check whether a cached usage window is still relevant (not expired or reset). */

--- a/apps/cli/src/lib/accounting/usage.ts
+++ b/apps/cli/src/lib/accounting/usage.ts
@@ -1891,10 +1891,31 @@ export function readClaudeUsageCache(
 
   const snapshot = deserializeClaudeUsageSnapshot(cached, now);
   if (!snapshot) {
-    delete cache[usageKey];
-    writeClaudeUsageCacheFile(cache, cachePath);
+    pruneExpiredClaudeUsageCacheEntry(usageKey, cachePath, now);
   }
   return snapshot;
+}
+
+/** Delete an expired cache row only if it is still expired under the write lock. */
+export function pruneExpiredClaudeUsageCacheEntry(
+  usageKey: string,
+  cachePath = getClaudeUsageCachePath(),
+  now = new Date(),
+): void {
+  try {
+    ensureLockTarget(cachePath, '{}');
+    withFileLock(cachePath, () => {
+      // The row may have been refreshed after readClaudeUsageCache observed it.
+      // Re-read under the lock so stale cleanup cannot erase that newer write.
+      const latest = readClaudeUsageCacheFile(cachePath);
+      const current = latest[usageKey];
+      if (!current || deserializeClaudeUsageSnapshot(current, now)) return;
+      delete latest[usageKey];
+      atomicWriteFileSync(cachePath, JSON.stringify(latest, null, 2), 'utf-8');
+    });
+  } catch {
+    /* best-effort cache cleanup — lock busy or disk full */
+  }
 }
 
 /** Write a usage snapshot to the on-disk cache. */

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -38,6 +38,8 @@ import { applyAddDirs } from './add-dir.js';
 import { applyActiveRulesPresetAtRun } from './rules/run-sync.js';
 import { resolveHarnessAdapter, stripForeignConfigDir } from './harness/index.js';
 import { resolveConfigVersion } from './harness/exec-config-version.js';
+import { getAccountInfo } from './agents.js';
+import { getUsageLookupKey, noteClaudeSessionLimit, parseClaudeSessionLimitReset } from './accounting/usage.js';
 
 /**
  * Agent execution modes. Canonical name `skip` (dangerously skip permissions);
@@ -2390,12 +2392,20 @@ export async function runWithFallback(options: FallbackOptions): Promise<number>
       throw err;
     }
 
-    if (result.exitCode === 0) return 0;
+    const output = `${result.stderr}\n${result.stdout}`;
+    const sessionLimitReset = agent === 'claude' ? parseClaudeSessionLimitReset(output) : null;
+    if (sessionLimitReset && version) {
+      const account = await getAccountInfo(agent, getVersionHomePath(agent, version));
+      const usageKey = getUsageLookupKey(account);
+      if (usageKey) noteClaudeSessionLimit(usageKey, sessionLimitReset);
+    }
+
+    if (result.exitCode === 0 && !sessionLimitReset) return 0;
 
     const isLast = i === chain.length - 1;
-    if (isLast) return result.exitCode;
+    if (isLast) return result.exitCode || 1;
 
-    if (!detectRateLimit(result.stderr) && !detectRateLimit(result.stdout)) {
+    if (!sessionLimitReset && !detectRateLimit(result.stderr) && !detectRateLimit(result.stdout)) {
       return result.exitCode;
     }
 

--- a/apps/cli/src/lib/view-types.ts
+++ b/apps/cli/src/lib/view-types.ts
@@ -23,6 +23,10 @@ export interface ViewJsonVersion {
     usedPercent: number;
     resetsAt: string | null;
   }>;
+  unavailable?: {
+    reason: 'session_limit';
+    resetsAt: string;
+  };
   lastActive: string | null;
   path: string;
   configuredModel?: { model: string; source: ConfiguredModelSource } | null;


### PR DESCRIPTION
Fixes RUSH-2858 by quarantining Claude accounts after an observed session-limit refusal.

## What changed

- Persist the refusal separately from five-hour and weekly usage windows, through the stated reset.
- Route balanced headless runs through captured-output handling so Claude's clean-exit refusal is detected and converted to a nonzero failed attempt.
- Exclude the marked account from balanced selection and render `session-limited (<reset>)` in text plus structured `unavailable` data in JSON.
- Document the behavior and add the unreleased changelog fragment.

## Verification

Actual targeted run:

```text
Test Files  5 passed (5)
Tests       142 passed (142)
Duration    2.34s
```

Full local suite:

```text
Test Files  875 passed | 6 skipped (883)
Tests       12494 passed | 95 skipped (12592)
```

The full run's three failures were independently resolved/verified: the changelog entry moved to `.changelog/next`, and both ambient-lineage failures pass when `AGENTS_PARENT_SESSION_ID` is removed from the test process. The repository's remote sandbox could not provision because Hetzner returned `resource_limit_exceeded: server limit reached`; CI is the clean remote gate.

Run screenshot:

![142 passing tests](https://share.agents-cli.sh/muqsitnawaz/muqsit-rush-2858-tests-466facfa0c4760ac)

No graphical UI: this changes CLI text/JSON and account routing.

## Tracking

- [RUSH-2858](https://linear.app/getrush/issue/RUSH-2858/balanced-rotation-dispatches-to-session-limited-accounts-agents-view)
