### PR TITLE
fix(ext): make the Fleet panel load, and make every row say what its agent is doing

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [0.9.328] - 2026-08-20
 
+- **A "needs you" reply button on the Fleet feed no longer fails silently.**
+  Clicking an option on a row whose agent has no reachable reply channel — a
+  headless run with no terminal tab, or a session on a raw non-tmux TTY on another
+  box — called `replyToAgent`, which set an inline error and returned. But
+  `FeedItem` did not accept an `error` prop at all, so it rendered
+  `StructuredReply` without one: the error existed and only the detail pane could
+  show it. On the feed the click produced no visible change whatsoever, which
+  reads as a dead button. `FeedItem` now takes `error` and forwards it, and all
+  seven feed call sites pass it, so the row states why the reply could not be
+  delivered ("Runs on <host> — open it there to reply"). Source:
+  `ui/settings/components/mission-control/{FeedItem,UnifiedAgentsPane}.tsx`.
+
 - **Agent prose renders as markdown on the Fleet feed, and a card stops restating
   its own title.** `AgentDecision.tsx` imported no markdown renderer at all, so an
   agent's response rendered raw — literal `**bold**` and backticks in an unbroken

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [0.9.328] - 2026-08-20
 
+- **Agent prose renders as markdown on the Fleet feed, and a card stops restating
+  its own title.** `AgentDecision.tsx` imported no markdown renderer at all, so an
+  agent's response rendered raw — literal `**bold**` and backticks in an unbroken
+  wall of text; `StructuredReply.tsx` rendered its question the same way. Both now
+  go through the same `renderMarkdown` (marked + DOMPurify) every other surface
+  uses. Separately, a card's title IS the first line of its prompt, and the TASK
+  block below restated it: a single-line prompt rendered the identical string
+  twice and cost the card ~120px, so the first card ran ~500px and roughly one and
+  a half agents filled the pane. The block now renders only when the prompt has
+  more than that first line — compared by line count, not by text, because
+  `firstLine()` strips markdown and a text comparison leaves the duplicate in
+  place for exactly the cards that read worst. Source:
+  `ui/settings/components/mission-control/{FeedItem,AgentDecision,StructuredReply}.tsx`.
+
 - **The session detail panel stops stalling once a workspace has ~20 agents open.**
   Resolving a Claude transcript meant stat-ing one filename under every project dir
   of every Claude version root, with no cache, and the floor rebuild did that once

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -44,6 +44,17 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
   keeps its own 1s leaf heartbeat and overrides `since` for running and stalled
   agents. Source: `ui/settings/components/mission-control/UnifiedAgentsPane.tsx`.
 
+- **Every compact Fleet row now says what its agent is DOING, not just what it is
+  called.** A compact row's title is the agent's name, and the one-line preview
+  under it was gated on the full-card layout — so a compact row only ever showed
+  prose if that agent happened to have produced a response. Every other row read
+  `heartbeat-lastactivity  agents-cli  running` and nothing else. The preview now
+  renders on compact rows too, falling back down `sessionTaskLine`'s existing chain
+  (prompt -> summary -> response -> worktree slug) so a row is never contextless.
+  It stays exactly one line: when the agent has produced a response, that response
+  is the line rather than a second one being added beneath it. Full cards are
+  unchanged. Source: `ui/settings/components/mission-control/FeedItem.tsx`.
+
 - **The Fleet panel stops burying idle-but-unfinished work below running work
   (RUSH-2838).** The root `AGENTS.md` "Purpose" section makes idle-but-unfinished
   the highest-risk state — the one most likely to be silently abandoned — and says

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -41,12 +41,15 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
   exactly 343 x 20 = **6,860 `statx`, 740ms**. Nothing debounces the rebuild, so
   those walks stacked and the panel — which has no fetch, spinner or timeout of its
   own — simply rendered empty until they drained. `getSessionPathBySessionId` now
-  builds a filename index by listing each project dir once and memoises each
-  resolved path, so the same two cases cost **0 and 20 `statx`, ~70ms**. A candidate
-  from either cache is still confirmed with a single `stat`, so a transcript that
-  was deleted or moved re-resolves instead of serving a dead path, and a session
-  that starts writing after the index was built is picked up on the next lookup
-  past a 500ms window. Source: `src/vscode/sessions.vscode.ts`.
+  builds one shared filename index and memoises each resolved path. Measured with
+  the real concurrent caller pattern over four refreshes, 20 resolvable agents drop
+  from **15,196 to 1,478 `getdents64`** calls; 20 agents with no transcript drop
+  from **58,516 to 3,644 `getdents64`**, and the miss refresh falls from **501ms to
+  109ms**. A candidate from either cache is still confirmed with a single `stat`,
+  so a transcript that was deleted or moved re-resolves instead of serving a dead
+  path, and a session that starts writing after the index was built is picked up on
+  the next lookup past a 500ms window. Source:
+  `src/vscode/sessions.vscode.ts`.
 
 - **The Fleet payload no longer waits on the cloud API, and rebuilds stop
   stacking.** `pushFloorUpdate` awaited `getFloorTerminalDetailsForWebview` and

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -22,6 +22,17 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
   that starts writing after the index was built is picked up on the next lookup
   past a 500ms window. Source: `src/vscode/sessions.vscode.ts`.
 
+- **The Fleet payload no longer waits on the cloud API, and rebuilds stop
+  stacking.** `pushFloorUpdate` awaited `getFloorTerminalDetailsForWebview` and
+  `swarm.fetchTasks` together before posting either, and `fetchTasks` ends in an
+  HTTP request to the Prix API (`fetchCloudRuns`). The detail panel renders
+  entirely from the `terminals` message, so a slow cloud API held back the one
+  message it needs. The two now post independently. The rebuild is also wrapped
+  in `cachedInFlight` with a zero TTL, so the rebuilds triggered by every
+  session-stream fact coalesce instead of stacking — a zero TTL coalesces
+  concurrent callers without ever re-serving a stale snapshot. Source:
+  `src/vscode/settings.vscode.ts`, `src/core/cachedInFlight.ts`.
+
 - **The Fleet panel stops burying idle-but-unfinished work below running work
   (RUSH-2838).** The root `AGENTS.md` "Purpose" section makes idle-but-unfinished
   the highest-risk state — the one most likely to be silently abandoned — and says

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [0.9.328] - 2026-08-20
 
+- **The session detail panel stops stalling once a workspace has ~20 agents open.**
+  Resolving a Claude transcript meant stat-ing one filename under every project dir
+  of every Claude version root, with no cache, and the floor rebuild did that once
+  per agent terminal on every refresh. Measured on a real home (10 roots, 343
+  project dirs): 20 agents whose transcripts sit in the last root cost **5,911
+  `statx` + 1,192 `getdents64`, 726ms**; 20 agents with no transcript yet cost
+  exactly 343 x 20 = **6,860 `statx`, 740ms**. Nothing debounces the rebuild, so
+  those walks stacked and the panel — which has no fetch, spinner or timeout of its
+  own — simply rendered empty until they drained. `getSessionPathBySessionId` now
+  builds a filename index by listing each project dir once and memoises each
+  resolved path, so the same two cases cost **0 and 20 `statx`, ~70ms**. A candidate
+  from either cache is still confirmed with a single `stat`, so a transcript that
+  was deleted or moved re-resolves instead of serving a dead path, and a session
+  that starts writing after the index was built is picked up on the next lookup
+  past a 500ms window. Source: `src/vscode/sessions.vscode.ts`.
+
 - **The Fleet panel stops burying idle-but-unfinished work below running work
   (RUSH-2838).** The root `AGENTS.md` "Purpose" section makes idle-but-unfinished
   the highest-risk state — the one most likely to be silently abandoned — and says

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -33,6 +33,17 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
   concurrent callers without ever re-serving a stale snapshot. Source:
   `src/vscode/settings.vscode.ts`, `src/core/cachedInFlight.ts`.
 
+- **The Fleet feed stops re-deriving every agent once a second.** The list memo
+  folded in a `useNow(1000)` ticker, so every second the whole feed was re-adapted
+  — `derivePhase`, `splitActivity` and a per-agent question regex for each agent —
+  cascading through the memos downstream. A comment above it claimed the ticker was
+  "deliberately NOT a dependency of the agent adapters" while the dependency array
+  two lines below always said otherwise. It now ticks at 5s, the interval
+  `useNow`'s own docblock prescribes for a value folded into a list memo, and the
+  comment states what the code does. The visible live age is unchanged: `FeedItem`
+  keeps its own 1s leaf heartbeat and overrides `since` for running and stalled
+  agents. Source: `ui/settings/components/mission-control/UnifiedAgentsPane.tsx`.
+
 - **The Fleet panel stops burying idle-but-unfinished work below running work
   (RUSH-2838).** The root `AGENTS.md` "Purpose" section makes idle-but-unfinished
   the highest-risk state — the one most likely to be silently abandoned — and says

--- a/apps/ext/src/core/cachedInFlight.test.ts
+++ b/apps/ext/src/core/cachedInFlight.test.ts
@@ -38,6 +38,28 @@ describe('cachedInFlight', () => {
     expect(calls).toBe(2);
   });
 
+  test('a zero TTL still coalesces concurrent callers but never serves a stale value', async () => {
+    // The contract pushFloorUpdate relies on: overlapping floor rebuilds share
+    // one run, but a later refresh must always re-scan. Giving that call site a
+    // non-zero TTL would post a stale terminal snapshot to the panel.
+    const store = createTimedCache<number>();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 5));
+      return calls;
+    };
+    const concurrent = await Promise.all(
+      Array.from({ length: 4 }, () => cachedInFlight(store, 'floor', 0, fn, 1000)),
+    );
+    expect(concurrent).toEqual([1, 1, 1, 1]);
+    expect(calls).toBe(1);
+
+    // Same instant, but no longer in flight — must re-run rather than cache-hit.
+    expect(await cachedInFlight(store, 'floor', 0, fn, 1000)).toBe(2);
+    expect(calls).toBe(2);
+  });
+
   test('keys are independent — one host in flight does not block another', async () => {
     const store = createTimedCache<string>();
     const seen: string[] = [];

--- a/apps/ext/src/vscode/sessions.vscode.test.ts
+++ b/apps/ext/src/vscode/sessions.vscode.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { getClaudeProjectRoots, getSessionPathBySessionId } from './sessions.vscode';
+import { clearSessionPathCache, getClaudeProjectRoots, getSessionPathBySessionId } from './sessions.vscode';
 
 async function withTempHome(run: (home: string) => Promise<void> | void): Promise<void> {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'swarmify-sessions-home-'));
@@ -12,6 +12,26 @@ async function withTempHome(run: (home: string) => Promise<void> | void): Promis
     fs.rmSync(home, { recursive: true, force: true });
   }
 }
+
+/** Write an empty transcript for `sessionId` under `home` and return its path. */
+function writeTranscript(home: string, projectDir: string, sessionId: string, root = '.claude'): string {
+  const filePath = path.join(home, root, 'projects', projectDir, `${sessionId}.jsonl`);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, '{"type":"message"}\n');
+  return filePath;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Long enough to clear the resolver's miss-authority window, so a change made
+// on disk after an index was built is visible to the next lookup.
+const CACHE_SETTLE_MS = 600;
+
+beforeEach(() => {
+  // The resolver memoises across calls; without this each test would inherit
+  // the previous test's index and assert against the wrong home.
+  clearSessionPathCache();
+});
 
 describe('getSessionPathBySessionId', () => {
   test('includes .agents-system Claude version roots', async () => {
@@ -52,6 +72,81 @@ describe('getSessionPathBySessionId', () => {
       fs.writeFileSync(filePath, '{"type":"message"}\n');
 
       expect(await getSessionPathBySessionId(sessionId, 'claude', undefined, home)).toBe(filePath);
+    });
+  });
+
+  // The resolver caches a filename index and each resolved path so the floor
+  // rebuild stops issuing O(agents x projectDirs) stat calls. Each case below
+  // pins one clause of that caching that would otherwise fail silently.
+  describe('caching', () => {
+    test('re-resolves after a cached transcript is moved to another project dir', async () => {
+      await withTempHome(async (home) => {
+        const sessionId = '11111111-1111-1111-1111-111111111111';
+        const first = writeTranscript(home, 'repo-a', sessionId);
+        expect(await getSessionPathBySessionId(sessionId, 'claude', undefined, home)).toBe(first);
+
+        // Serving the cached path unconditionally would return the deleted file.
+        fs.rmSync(first);
+        const moved = writeTranscript(home, 'repo-b', sessionId);
+        await sleep(CACHE_SETTLE_MS);
+
+        expect(await getSessionPathBySessionId(sessionId, 'claude', undefined, home)).toBe(moved);
+      });
+    });
+
+    test('returns undefined once a cached transcript is deleted outright', async () => {
+      await withTempHome(async (home) => {
+        const sessionId = '22222222-2222-2222-2222-222222222222';
+        const filePath = writeTranscript(home, 'repo-a', sessionId);
+        expect(await getSessionPathBySessionId(sessionId, 'claude', undefined, home)).toBe(filePath);
+
+        fs.rmSync(filePath);
+        await sleep(CACHE_SETTLE_MS);
+
+        expect(await getSessionPathBySessionId(sessionId, 'claude', undefined, home)).toBeUndefined();
+      });
+    });
+
+    test('finds a session created after the index was built', async () => {
+      await withTempHome(async (home) => {
+        const sessionId = '33333333-3333-3333-3333-333333333333';
+        // Build the index while the transcript does not exist yet. A miss must
+        // not be cached, and the index must not stay authoritative forever.
+        fs.mkdirSync(path.join(home, '.claude', 'projects', 'repo-a'), { recursive: true });
+        expect(await getSessionPathBySessionId(sessionId, 'claude', undefined, home)).toBeUndefined();
+
+        const filePath = writeTranscript(home, 'repo-a', sessionId);
+        await sleep(CACHE_SETTLE_MS);
+
+        expect(await getSessionPathBySessionId(sessionId, 'claude', undefined, home)).toBe(filePath);
+      });
+    });
+
+    test('keeps the pre-cache search order when the same id exists in two roots', async () => {
+      await withTempHome(async (home) => {
+        const sessionId = '44444444-4444-4444-4444-444444444444';
+        // getClaudeProjectRoots yields ~/.claude/projects first, so the
+        // sequential walk returned that copy; the index must agree.
+        const versionRoot = path.join('.agents-system', 'versions', 'claude', '2.1.121', 'home', '.claude');
+        writeTranscript(home, 'repo-a', sessionId, versionRoot);
+        const preferred = writeTranscript(home, 'repo-a', sessionId);
+
+        const roots = await getClaudeProjectRoots(home);
+        expect(roots.indexOf(path.join(home, '.claude', 'projects'))).toBe(0);
+        expect(await getSessionPathBySessionId(sessionId, 'claude', undefined, home)).toBe(preferred);
+      });
+    });
+
+    test('resolves a second session in the same home without re-listing', async () => {
+      await withTempHome(async (home) => {
+        const a = '55555555-5555-5555-5555-555555555555';
+        const b = '66666666-6666-6666-6666-666666666666';
+        const pathA = writeTranscript(home, 'repo-a', a);
+        const pathB = writeTranscript(home, 'repo-b', b);
+
+        expect(await getSessionPathBySessionId(a, 'claude', undefined, home)).toBe(pathA);
+        expect(await getSessionPathBySessionId(b, 'claude', undefined, home)).toBe(pathB);
+      });
     });
   });
 });

--- a/apps/ext/src/vscode/sessions.vscode.ts
+++ b/apps/ext/src/vscode/sessions.vscode.ts
@@ -377,6 +377,68 @@ export async function getClaudeProjectRoots(homeDir: string = homedir()): Promis
   return roots;
 }
 
+// Resolving a Claude transcript means finding one filename under ~343 project
+// dirs spread across ~10 version roots. The floor rebuild calls this once per
+// agent terminal (terminals.vscode.ts:1068), so the naive stat-every-candidate
+// walk costs O(agents x projectDirs): measured on a real home, 20 agents in the
+// last root took 5,911 statx + 1,192 getdents64 (726ms), and 20 agents with no
+// transcript took exactly 343 x 20 = 6,860 statx (740ms). Nothing debounces the
+// rebuild, so those walks stack and the detail panel stays empty.
+//
+// Two caches remove that without changing what the function returns:
+//   - resolvedClaudePaths: sessionId -> path. A transcript does not move, so a
+//     hit costs one stat to confirm the file is still there. Only successful
+//     resolutions are cached; caching a miss would hide a session that has not
+//     written its transcript yet.
+//   - claudeFileIndex: filename -> path, built by listing each project dir once
+//     (~343 getdents). Every agent in the same refresh shares that one listing
+//     instead of issuing its own 343 stats.
+// How long a built index may be reused for a hit.
+const CLAUDE_INDEX_TTL_MS = 5_000;
+// How long a *miss* against the index is trusted. Past this the index is
+// rebuilt once and re-checked, so a session that started writing since the
+// build still resolves promptly. This must stay well under the reuse TTL:
+// without it a miss would wait out the full TTL, which would delay Copy
+// Session ID / Resume on a just-launched agent.
+const CLAUDE_INDEX_MISS_AUTHORITY_MS = 500;
+
+const resolvedClaudePaths = new Map<string, string>();
+
+let claudeFileIndex: { homeDir: string; builtAt: number; files: Map<string, string> } | null = null;
+
+async function buildClaudeFileIndex(homeDir: string): Promise<Map<string, string>> {
+  const files = new Map<string, string>();
+  for (const root of await getClaudeProjectRoots(homeDir)) {
+    for (const project of await safeReaddir(root)) {
+      if (!project.isDirectory()) continue;
+      const dir = path.join(root, project.name);
+      for (const entry of await safeReaddir(dir)) {
+        if (!entry.isFile()) continue;
+        // First writer wins, which is the root/project order the sequential
+        // walk returned on — the index must not pick a different duplicate.
+        if (!files.has(entry.name)) files.set(entry.name, path.join(dir, entry.name));
+      }
+    }
+  }
+  return files;
+}
+
+async function getClaudeFileIndex(homeDir: string, maxAgeMs: number): Promise<Map<string, string>> {
+  const now = Date.now();
+  if (claudeFileIndex && claudeFileIndex.homeDir === homeDir && now - claudeFileIndex.builtAt < maxAgeMs) {
+    return claudeFileIndex.files;
+  }
+  const files = await buildClaudeFileIndex(homeDir);
+  claudeFileIndex = { homeDir, builtAt: now, files };
+  return files;
+}
+
+/** Drop the Claude path caches. Exported so tests do not leak state between cases. */
+export function clearSessionPathCache(): void {
+  resolvedClaudePaths.clear();
+  claudeFileIndex = null;
+}
+
 export async function getSessionPathBySessionId(
   sessionId: string,
   agentType: 'claude' | 'codex' | 'gemini' | 'opencode' | 'cursor' | 'copilot' | 'antigravity' | 'grok' | 'kimi' | 'droid',
@@ -388,18 +450,30 @@ export async function getSessionPathBySessionId(
       // We know the exact filename: {sessionId}.jsonl
       // Just find it under ~/.claude/projects/*/ or shim paths
       const filename = `${sessionId}.jsonl`;
-      const roots = await getClaudeProjectRoots(homeDir);
+      const cacheKey = `${homeDir} ${sessionId}`;
 
-      // Search each root's project subdirectories for the file
-      for (const root of roots) {
-        const projects = await safeReaddir(root);
-        for (const project of projects) {
-          if (!project.isDirectory()) continue;
-          const filePath = path.join(root, project.name, filename);
-          if (await safeStat(filePath)) return filePath;
-        }
+      // Every candidate is confirmed with a single stat before it is returned.
+      // Neither cache can notice a transcript deleted or moved since it was
+      // populated, and one stat is the whole budget the old walk spent on its
+      // 343rd candidate anyway.
+      const confirm = async (candidate: string | undefined): Promise<string | undefined> =>
+        candidate && (await safeStat(candidate)) ? candidate : undefined;
+
+      const cached = await confirm(resolvedClaudePaths.get(cacheKey));
+      if (cached) return cached;
+      resolvedClaudePaths.delete(cacheKey);
+
+      let indexed = await confirm((await getClaudeFileIndex(homeDir, CLAUDE_INDEX_TTL_MS)).get(filename));
+      if (!indexed) {
+        // Re-check against an index no older than the miss-authority window.
+        // Rebuilding once here is shared by every other unresolved session in
+        // the same refresh; re-walking per session is what made this function
+        // O(agents x projectDirs) in the first place.
+        indexed = await confirm((await getClaudeFileIndex(homeDir, CLAUDE_INDEX_MISS_AUTHORITY_MS)).get(filename));
       }
-      return undefined;
+      if (!indexed) return undefined;
+      resolvedClaudePaths.set(cacheKey, indexed);
+      return indexed;
     }
     case 'codex': {
       const root = path.join(homedir(), '.codex', 'sessions');

--- a/apps/ext/src/vscode/sessions.vscode.ts
+++ b/apps/ext/src/vscode/sessions.vscode.ts
@@ -7,6 +7,7 @@ import type { Dirent, Stats } from 'fs';
 import { AgentSession } from '../core/sessions';
 import { runAgents } from '../core/agentsBin';
 import type { SqlJsStatic } from 'sql.js';
+import { cachedInFlight, createTimedCache } from '../core/cachedInFlight';
 
 // Cached SQL.js instance (lazy-loaded)
 let sqlJsPromise: Promise<SqlJsStatic | null> | null = null;
@@ -423,14 +424,30 @@ async function buildClaudeFileIndex(homeDir: string): Promise<Map<string, string
   return files;
 }
 
+// The floor rebuild starts one lookup per agent in a SINGLE tick
+// (terminals.vscode.ts:1063-1071 pushes each promise and only awaits the batch at
+// :1075). `claudeFileIndex` is assigned after its build resolves, so without
+// coalescing every one of those N callers sees a null-or-stale index and starts
+// its own walk: 20 agents built 20 identical indexes, ~6,920 readdir per refresh,
+// in steady state — trading the stat storm for a readdir storm.
+const claudeIndexBuilds = createTimedCache<Map<string, string>>();
+
 async function getClaudeFileIndex(homeDir: string, maxAgeMs: number): Promise<Map<string, string>> {
-  const now = Date.now();
-  if (claudeFileIndex && claudeFileIndex.homeDir === homeDir && now - claudeFileIndex.builtAt < maxAgeMs) {
+  const fresh = (at: number) => Date.now() - at < maxAgeMs;
+  if (claudeFileIndex && claudeFileIndex.homeDir === homeDir && fresh(claudeFileIndex.builtAt)) {
     return claudeFileIndex.files;
   }
-  const files = await buildClaudeFileIndex(homeDir);
-  claudeFileIndex = { homeDir, builtAt: now, files };
-  return files;
+  // ttl 0: never re-serve a stale build, but concurrent callers share one walk.
+  return cachedInFlight(claudeIndexBuilds, homeDir, 0, async () => {
+    // Re-check inside the coalesced section: a build that resolved between this
+    // caller's check above and its turn here is still fresh enough to reuse.
+    if (claudeFileIndex && claudeFileIndex.homeDir === homeDir && fresh(claudeFileIndex.builtAt)) {
+      return claudeFileIndex.files;
+    }
+    const files = await buildClaudeFileIndex(homeDir);
+    claudeFileIndex = { homeDir, builtAt: Date.now(), files };
+    return files;
+  });
 }
 
 /** Drop the Claude path caches. Exported so tests do not leak state between cases. */
@@ -466,8 +483,9 @@ export async function getSessionPathBySessionId(
       let indexed = await confirm((await getClaudeFileIndex(homeDir, CLAUDE_INDEX_TTL_MS)).get(filename));
       if (!indexed) {
         // Re-check against an index no older than the miss-authority window.
-        // Rebuilding once here is shared by every other unresolved session in
-        // the same refresh; re-walking per session is what made this function
+        // The rebuild is coalesced (getClaudeFileIndex), so every other
+        // unresolved session in the same refresh joins this one walk rather than
+        // starting its own — re-walking per session is what made this function
         // O(agents x projectDirs) in the first place.
         indexed = await confirm((await getClaudeFileIndex(homeDir, CLAUDE_INDEX_MISS_AUTHORITY_MS)).get(filename));
       }

--- a/apps/ext/src/vscode/settings.vscode.ts
+++ b/apps/ext/src/vscode/settings.vscode.ts
@@ -18,6 +18,7 @@ import { fetchAllTasks, detectAvailableSources } from './tasks.vscode';
 import { getBuiltInByTitle, configFromDef } from './agents.vscode';
 import { openSingleAgentWithQueue, runHeadlessAgent, focusSessionInTerminal } from './extension';
 import { generateClaudeSessionId } from '../core/prewarm.simple';
+import { cachedInFlight, createTimedCache } from '../core/cachedInFlight';
 import { nudgeSession } from '../mcp/watchdog-bridge';
 import { runAgents, resolveAgentsBin, bootstrapPath } from '../core/agentsBin';
 import { AgentLaunchMode, extractPlanFromSessionJson, planTextToSteps } from '../core/agents';
@@ -1112,19 +1113,36 @@ function cleanupFloorWatchers(): void {
 // feed shows the last good snapshot instead of blanking on a transient error.
 let lastFloorTasks: swarm.TaskSummary[] = [];
 
+// Coalesces concurrent floor rebuilds. Every session-stream fact triggers one
+// (extension.ts), and twenty live agents emit constantly, so without this the
+// rebuilds stack on top of each other and each one re-does the whole scan.
+// A zero TTL means a snapshot is never re-served stale — only genuinely
+// overlapping callers share a run.
+const floorPushes = createTimedCache<void>();
+
 async function pushFloorUpdate(workspacePath?: string): Promise<void> {
   if (!settingsPanel || !floorSubscribed) return;
-  const [floorTerminals, floorTasks] = await Promise.all([
-    getFloorTerminalDetailsForWebview(workspacePath),
-    swarm.fetchTasks(undefined, workspacePath),
-  ]);
-  if (!settingsPanel || !floorSubscribed) return;
-  lastFloorTasks = floorTasks;
-  // RUSH-2039: page the user when a session (Codex included) enters the
-  // approval-waiting state. Edge-triggered so it fires once per wait.
-  notifyNewlyWaiting(floorTerminals);
-  settingsPanel.webview.postMessage({ type: 'allTerminalsData', terminals: floorTerminals });
-  settingsPanel.webview.postMessage({ type: 'tasksData', tasks: floorTasks });
+  await cachedInFlight(floorPushes, workspacePath ?? '', 0, async () => {
+    // Terminals and tasks are posted independently. They used to be awaited
+    // together, which meant the detail panel — whose data is entirely in
+    // `terminals` — waited on `swarm.fetchTasks`, and that ends in an HTTP
+    // request to the Prix API (`fetchCloudRuns`). A slow cloud API held back
+    // the one message the panel actually needs.
+    const floorTerminals = await getFloorTerminalDetailsForWebview(workspacePath);
+    if (!settingsPanel || !floorSubscribed) return;
+    // RUSH-2039: page the user when a session (Codex included) enters the
+    // approval-waiting state. Edge-triggered so it fires once per wait.
+    notifyNewlyWaiting(floorTerminals);
+    settingsPanel.webview.postMessage({ type: 'allTerminalsData', terminals: floorTerminals });
+
+    // Tasks arrive in their own message whenever they are ready. fetchTasks
+    // already absorbs a cloud outage internally and resolves with local data,
+    // so this needs no error branch of its own.
+    const floorTasks = await swarm.fetchTasks(undefined, workspacePath);
+    if (!settingsPanel || !floorSubscribed) return;
+    lastFloorTasks = floorTasks;
+    settingsPanel.webview.postMessage({ type: 'tasksData', tasks: floorTasks });
+  });
 }
 
 /** Called by the window's session-stream follower; no filesystem watcher. */

--- a/apps/ext/ui/settings/components/mission-control/AgentDecision.tsx
+++ b/apps/ext/ui/settings/components/mission-control/AgentDecision.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Icon } from './icons'
 import { StructuredReply } from './StructuredReply'
 import type { FloorAgent } from './floorModel'
+import { renderMarkdown } from '../../utils/markdown'
 
 // The "needs you" decision block at the top of the right detail pane. Surfaces the
 // three things a NEEDS-YOU card used to omit (RUSH-1521): WHY it's blocked (the reason
@@ -54,7 +55,7 @@ export function AgentDecision({ agent: a, error, onOption, onFreeText, onAttach,
         {/* With a structured question, StructuredReply renders the text above its options —
             so only show .qt (the last turn) when there's no such question, avoiding a
             duplicated question line. */}
-        {!a.question && <div className="qt">{a.resp}</div>}
+        {!a.question && <div className="qt md">{renderMarkdown(a.resp)}</div>}
         {a.phase === 'stalled' && (
           <div className="opts">
             <button className="opt primary" onClick={onNudge}>

--- a/apps/ext/ui/settings/components/mission-control/FeedItem.preview.test.tsx
+++ b/apps/ext/ui/settings/components/mission-control/FeedItem.preview.test.tsx
@@ -117,4 +117,19 @@ describe('compact (plain) row preview line', () => {
     expect(html).toContain('Merged the three surfaces into one BacklogCenter.')
     expect(html).toContain('Collapse the ticket surfaces')
   })
+
+  test('a single-line prompt does not render twice: title AND task block', () => {
+    // The title IS firstLine(prompt), so a TASK block under it restated the same
+    // string and cost the card ~120px. Compare LINE COUNT, not text: firstLine()
+    // strips markdown, so `prompt !== firstLine(prompt)` is true for ANY
+    // single-line prompt containing markup — the cards that read worst.
+    const html = render(agent({ prompt: 'Make **discovery** natural' }), false)
+    expect(html).not.toContain('class="task')
+  })
+
+  test('a multi-line prompt still gets its task block — it carries more than the title', () => {
+    const html = render(agent({ prompt: 'Make discovery natural\n\nKeep the legacy keyword path behind a flag.' }), false)
+    expect(html).toContain('class="task')
+    expect(html).toContain('Keep the legacy keyword path behind a flag.')
+  })
 })

--- a/apps/ext/ui/settings/components/mission-control/FeedItem.preview.test.tsx
+++ b/apps/ext/ui/settings/components/mission-control/FeedItem.preview.test.tsx
@@ -1,0 +1,120 @@
+// FeedItem renders agent prose through renderMarkdown -> DOMPurify, which needs a
+// real DOM. Most tests here are deliberately DOM-free (renderToStaticMarkup), but
+// that is exactly why FeedItem had no working coverage: every render threw
+// "DOMPurify.sanitize is not a function". Registering happy-dom exercises the real
+// sanitizer rather than stubbing it out.
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+// Guarded exactly as App.test.tsx:4 does: registering twice throws, and whether
+// another file in the run got there first depends on file order.
+if (typeof (globalThis as { document?: unknown }).document === 'undefined') GlobalRegistrator.register()
+
+import { expect, test, describe } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { FloorAgent } from './floorModel'
+
+// Imported dynamically, AFTER the line above runs. A static import would be
+// hoisted above the registration, and dompurify binds to `window` at module
+// evaluation time — which is precisely why registering it alone did not work.
+const { FeedItem } = await import('./FeedItem')
+
+const noop = () => {}
+
+function agent(over: Partial<FloorAgent> = {}): FloorAgent {
+  return {
+    id: 'a1',
+    host: 'this-mac',
+    project: 'agents-cli',
+    name: 'heartbeat-lastactivity',
+    abbr: 'CC',
+    phase: 'running',
+    verb: '',
+    target: '',
+    tok: 40,
+    since: '15s',
+    lastActivityMs: 0,
+    files: 0,
+    tools: 0,
+    needs: false,
+    pinned: false,
+    pr: null,
+    prUrl: null,
+    ci: null,
+    ticket: '',
+    branch: '',
+    worktreeSlug: '',
+    worktreePath: '',
+    resp: '',
+    messages: [],
+    question: null,
+    reply: { kind: 'none', host: 'this-mac' },
+    todos: [],
+    summary: '',
+    recent: [],
+    sessionId: 'sess-abc',
+    ...over,
+  }
+}
+
+function render(a: FloorAgent, plain: boolean): string {
+  return renderToStaticMarkup(
+    <FeedItem
+      agent={a}
+      selected={false}
+      plain={plain}
+      onSelect={noop}
+      onOption={noop}
+      onFreeText={noop}
+      onAttach={noop}
+      onOpenPlan={noop}
+      onOpenTerminal={noop}
+    />,
+  )
+}
+
+// A compact row's title is the agent's NAME, so without a preview line the row
+// says what the agent is called and nothing about what it is doing. These pin
+// that every compact row carries exactly one such line.
+describe('compact (plain) row preview line', () => {
+  test('an agent that has said nothing still shows its prompt as the preview', () => {
+    const html = render(agent({ prompt: 'Trace where remote sessions lose their last-activity stamp' }), true)
+    expect(html).toContain('class="summary')
+    expect(html).toContain('Trace where remote sessions lose their last-activity stamp')
+  })
+
+  test('falls back down the chain to the summary when there is no prompt', () => {
+    const html = render(agent({ summary: 'Mapping the two half-wired dispatch paths' }), true)
+    expect(html).toContain('class="summary')
+    expect(html).toContain('Mapping the two half-wired dispatch paths')
+  })
+
+  test('falls back to the worktree slug when the agent has no narrative at all', () => {
+    // The contextless-card case: a waiting session with nothing to say still has
+    // to be distinguishable from every other waiting session.
+    const html = render(agent({ worktreeSlug: 'agents/heartbeat' }), true)
+    expect(html).toContain('class="summary')
+    expect(html).toContain('agents/heartbeat')
+  })
+
+  test('does NOT add a second preview line when the agent already has a response', () => {
+    // The response block IS the row's one line. Rendering the prompt underneath
+    // it makes the row a line taller for signal the operator already has.
+    const html = render(
+      agent({ resp: 'Merged the three surfaces into one BacklogCenter.', prompt: 'Collapse the ticket surfaces' }),
+      true,
+    )
+    expect(html).toContain('Merged the three surfaces into one BacklogCenter.')
+    // Assert on the preview ELEMENT, not the prompt text: the prompt also appears
+    // in the row's title tooltip, so a bare text match would pass either way.
+    expect(html).not.toContain('class="summary')
+  })
+
+  test('the full (non-compact) card is unaffected — it still shows both', () => {
+    const html = render(
+      agent({ resp: 'Merged the three surfaces into one BacklogCenter.', prompt: 'Collapse the ticket surfaces' }),
+      false,
+    )
+    expect(html).toContain('Merged the three surfaces into one BacklogCenter.')
+    expect(html).toContain('Collapse the ticket surfaces')
+  })
+})

--- a/apps/ext/ui/settings/components/mission-control/FeedItem.preview.test.tsx
+++ b/apps/ext/ui/settings/components/mission-control/FeedItem.preview.test.tsx
@@ -133,3 +133,43 @@ describe('compact (plain) row preview line', () => {
     expect(html).toContain('Keep the legacy keyword path behind a flag.')
   })
 })
+
+// A "needs you" row whose reply cannot be delivered used to look identical to one
+// that worked: replyToAgent set an inline error, but the feed never passed it to
+// StructuredReply, so the click produced no visible change at all.
+describe('reply delivery failure is visible on the feed row', () => {
+  const asking = (over = {}) => agent({
+    phase: 'waiting',
+    needs: true,
+    question: { kind: 'choice', text: 'Drop the old table?', options: ['Drop it', 'Keep it'], clusterKey: 'k' },
+    reply: { kind: 'none', host: 'yosemite-s1', reason: 'Runs on yosemite-s1 — open it there to reply' },
+    ...over,
+  })
+
+  test('renders the delivery error when one is supplied', () => {
+    const html = render({ ...asking(), } as FloorAgent, false)
+    expect(html).toContain('Drop it')  // the options render
+    const withErr = renderToStaticMarkup(
+      <FeedItem
+        agent={asking() as FloorAgent}
+        selected={false}
+        plain={false}
+        error="Runs on yosemite-s1 — open it there to reply"
+        onSelect={noop} onOption={noop} onFreeText={noop} onAttach={noop}
+        onOpenPlan={noop} onOpenTerminal={noop}
+      />,
+    )
+    expect(withErr).toContain('Runs on yosemite-s1')
+  })
+
+  test('the same row without an error shows no error text', () => {
+    const html = render(asking() as FloorAgent, false)
+    expect(html).not.toContain('open it there to reply')
+  })
+
+  test('a compact asking row does not also render a prose preview line', () => {
+    // The question IS the row's line; a summary above it makes two prose blocks.
+    const html = render(asking({ prompt: 'Migrate the policy_v1 RLS rules' }) as FloorAgent, true)
+    expect(html).not.toContain('class="summary')
+  })
+})

--- a/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
@@ -60,13 +60,20 @@ interface FeedItemProps {
   onOpenPlan: (agent: FloorAgent, plan: PlanFile) => void
   onOpenAttachment: (agent: FloorAgent, attachment: FloorAttachment) => void
   /**
+   * Inline delivery error for this agent's last reply attempt. StructuredReply
+   * has always accepted one; the feed never passed it, so clicking an option on
+   * an agent with no reachable channel (`reply.kind === 'none'`) set an error
+   * that only the detail pane could render — on the feed the button looked dead.
+   */
+  error?: string
+  /**
    * Open/resume this session in a live terminal (RUSH-1520). Present when the
    * agent carries a sessionId (or a local terminal id) the host can focus.
    */
   onOpenTerminal?: (agent: FloorAgent) => void
 }
 
-function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeText, onAttach, onOpenPlan, onOpenAttachment, onOpenTerminal }: FeedItemProps) {
+function FeedItemImpl({ agent: a, selected, plain, error, onSelect, onOption, onFreeText, onAttach, onOpenPlan, onOpenAttachment, onOpenTerminal }: FeedItemProps) {
   // Live heartbeat: only a running / stalled agent with a known last-activity stamp ticks.
   // The shared 1s ticker re-renders just this leaf, never the parent list.
   const now = useNow(1000)
@@ -296,6 +303,7 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
           <StructuredReply
             question={a.question}
             phase={a.phase}
+            error={error}
             onOption={(o) => onOption(a, o)}
             onFreeText={(t) => onFreeText(a, t)}
             onAttach={() => onAttach(a)}

--- a/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
@@ -109,7 +109,15 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const prompt = (a.prompt ?? '').trim()
   const title = !plain && prompt ? firstLine(prompt) : a.name
   const nameTitle = [prompt ? `${a.name} — ${prompt}` : a.name, a.sessionId ? `Session ${a.sessionId}` : ''].filter(Boolean).join('\n')
-  const showTask = !plain && !!prompt
+  // The title already IS the first line of the prompt, so the TASK block only earns its
+  // ~120px when the prompt has MORE than that first line. A single-line prompt ("Make
+  // discovery natural") rendered the identical string twice, so every card on the Fleet
+  // feed looked like it carried a task description and none did.
+  // Compare LINE COUNT, not text: firstLine() strips markdown (#, -, **bold**), so
+  // `prompt !== firstLine(prompt)` is true for ANY single-line prompt containing markup
+  // and would leave the duplicate in place for exactly the cards that read worst.
+  // AgentDecision.tsx:41 guards the same way against restating its question.
+  const showTask = !plain && !!prompt && prompt.trim().includes('\n')
   // Only show the rolling summary line when it adds signal beyond the task block, the
   // response body, and the now-line (it merely echoes the prompt when they match).
   const showSummary =
@@ -258,7 +266,7 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
         </div>
       )}
       {!plain && a.todos.length > 0 && <CardChecklist todos={a.todos} />}
-      {showSummary && <div className="summary">{taskLine}</div>}
+      {showSummary && <div className="summary md">{renderMarkdown(taskLine, { clamp: true })}</div>}
       {showNowline && (
         <div className={`nowline ${stalled ? 'stall' : ''}`}>
           <Icon name="chevR" size={11} /> <span className="v">{a.verb}</span> {a.target}

--- a/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
@@ -120,9 +120,20 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const showTask = !plain && !!prompt && prompt.trim().includes('\n')
   // Only show the rolling summary line when it adds signal beyond the task block, the
   // response body, and the now-line (it merely echoes the prompt when they match).
+  // Not gated on `plain`. A compact row whose agent has said nothing yet used to
+  // render a bare title — `heartbeat-lastactivity  agents-cli  running` — which
+  // says what the agent is CALLED and nothing about what it is DOING. The
+  // response block below (:218) only covers agents that have produced one, so
+  // every other compact row was contextless. sessionTaskLine's chain (prompt ->
+  // summary -> resp -> worktree) always yields something, and the three guards
+  // below already stop it echoing the response, the now-line, or the task block.
   const showSummary =
-    !plain && !!taskLine && taskLine !== a.resp.trim() && taskLine !== nowlineText &&
-    !(showTask && taskLine === prompt)
+    !!taskLine && taskLine !== a.resp.trim() && taskLine !== nowlineText &&
+    !(showTask && taskLine === prompt) &&
+    // A compact row gets exactly ONE preview line. When the agent has produced a
+    // response, that response is the line (:218) — adding the prompt beneath it
+    // makes the row a line taller for signal the operator already has.
+    !(plain && !!a.resp.trim())
   // The now-line is a LIVE-activity indicator — only meaningful while the agent is
   // actively working (running) or stuck mid-action (stalled). For an idle / needs-you /
   // done agent there's no live activity, and the verb is just the "Thinking..." fallback,

--- a/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
@@ -3,7 +3,7 @@ import { Icon } from './icons'
 import { FileIcon, ImageIcon } from './dispatchIcons'
 import { AgentAvatar, agentIdFromPrefix } from './AgentAvatar'
 import { StructuredReply, type ReplyCallbacks } from './StructuredReply'
-import { heartbeatLevel, linearIssueLabel, linearIssueUrl, sessionTaskLine, todoProgress, type FloorAgent, type FloorAttachment, type FloorTicket } from './floorModel'
+import { heartbeatLevel, linearIssueLabel, linearIssueUrl, NO_TOPIC, sessionTaskLine, todoProgress, type FloorAgent, type FloorAttachment, type FloorTicket } from './floorModel'
 import { sinceFromMs } from './floorAdapter'
 import { useNow } from './useNow'
 import { CardChecklist } from './TodoChecklist'
@@ -130,10 +130,17 @@ function FeedItemImpl({ agent: a, selected, plain, onSelect, onOption, onFreeTex
   const showSummary =
     !!taskLine && taskLine !== a.resp.trim() && taskLine !== nowlineText &&
     !(showTask && taskLine === prompt) &&
+    // sessionTaskLine falls back to the literal string 'No topic' when an agent
+    // has no prompt, summary, response, worktree or branch. A compact row
+    // rendered nothing there before; a line reading "No topic" is worse than the
+    // blank it replaces.
+    taskLine !== NO_TOPIC &&
     // A compact row gets exactly ONE preview line. When the agent has produced a
     // response, that response is the line (:218) — adding the prompt beneath it
-    // makes the row a line taller for signal the operator already has.
-    !(plain && !!a.resp.trim())
+    // makes the row a line taller for signal the operator already has. Same for a
+    // row that is asking something: StructuredReply below renders the question,
+    // and that question is the line that matters.
+    !(plain && (!!a.resp.trim() || (a.needs && !!a.question)))
   // The now-line is a LIVE-activity indicator — only meaningful while the agent is
   // actively working (running) or stuck mid-action (stalled). For an idle / needs-you /
   // done agent there's no live activity, and the verb is just the "Thinking..." fallback,

--- a/apps/ext/ui/settings/components/mission-control/StructuredReply.tsx
+++ b/apps/ext/ui/settings/components/mission-control/StructuredReply.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Icon } from './icons'
 import type { FloorPhase, StructuredQuestion } from './floorModel'
+import { renderMarkdown } from '../../utils/markdown'
 
 // Option-button reply block. Prototype structuredReply(): factory-floor.html:591-597.
 // Used inline in feed items and in the right-pane decision block (rendered by SHELL).
@@ -45,7 +46,7 @@ export function StructuredReply({ question, phase, onOption, onFreeText, onAttac
 
   return (
     <>
-      {questionText && <div className="qtext">{questionText}</div>}
+      {questionText && <div className="qtext md">{renderMarkdown(questionText)}</div>}
       <div className="opts">
         {options.map((o, i) => (
           <button

--- a/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.poll.test.ts
+++ b/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.poll.test.ts
@@ -1,7 +1,16 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+if (typeof globalThis.document === 'undefined') GlobalRegistrator.register()
+
 import { expect, test, describe } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { TerminalDetail } from '../../types'
 import { REMOTE_STALE_MS, THROUGHPUT_TICK_MS } from './floorRefresh'
+
+const { UnifiedAgentsPane } = await import('./UnifiedAgentsPane')
 
 // Source-level regression guards: the Floor must not reintroduce 3s local /
 // 45s remote setInterval polls or the 140ms throughput React timer.
@@ -86,4 +95,50 @@ describe('Floor poll / timer budget (no recurring probes)', () => {
       /Array\.isArray\(msg\.projects\)[\s\S]*?setManagedProjects\(msg\.projects as ManagedProject\[\]\)[\s\S]*?setProjectCommandError\(null\)/,
     )
   })
+})
+
+test('renders a single waiting question through the pane question-cluster path', () => {
+  const now = Date.now()
+  const terminal: TerminalDetail = {
+    id: 'terminal-1',
+    agentType: 'claude',
+    label: 'migration-agent',
+    autoLabel: null,
+    createdAt: now - 60_000,
+    index: 0,
+    sessionId: 'session-1',
+    firstUserMessage: 'Choose the migration strategy',
+    status: 'running',
+    lastActivityTimestamp: new Date(now).toISOString(),
+    currentActivity: 'Waiting for a migration decision',
+    waitingForInput: true,
+    recentToolCalls: [{
+      name: 'AskUserQuestion',
+      input: {
+        questions: [{
+          question: 'Drop the old table?',
+          header: 'Migration',
+          options: [
+            { label: 'Drop it', description: 'Remove the legacy table' },
+            { label: 'Keep it', description: 'Preserve the legacy table' },
+          ],
+        }],
+      },
+    }],
+  }
+
+  const html = renderToStaticMarkup(React.createElement(UnifiedAgentsPane, {
+    terminals: [terminal],
+    tasks: [],
+    tasksLoading: false,
+    unifiedTasks: [],
+    unifiedTasksLoading: false,
+    onDispatch: () => {},
+    search: '',
+    onSearch: () => {},
+  }))
+
+  expect(html).toContain('Drop the old table?')
+  expect(html).toContain('Drop it')
+  expect(html).toContain('Keep it')
 })

--- a/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -2206,6 +2206,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               selected={selectedFloorAgent?.id === c[0].id}
               plain={plain}
               onSelect={selectFloorAgent}
+              error={replyErrors.get(a.id)}
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
@@ -2230,6 +2231,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               selected={selectedFloorAgent?.id === a.id}
               plain={plain}
               onSelect={selectFloorAgent}
+              error={replyErrors.get(a.id)}
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
@@ -2254,6 +2256,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               selected={selectedFloorAgent?.id === a.id}
               plain={plain}
               onSelect={selectFloorAgent}
+              error={replyErrors.get(a.id)}
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
@@ -2322,6 +2325,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               selected={selectedFloorAgent?.id === a.id}
               plain={plain}
               onSelect={selectFloorAgent}
+              error={replyErrors.get(a.id)}
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
@@ -2349,6 +2353,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
                 selected={selectedFloorAgent?.id === a.id}
                 plain={plain}
                 onSelect={selectFloorAgent}
+                error={replyErrors.get(a.id)}
                 onOption={onAgentOption}
                 onFreeText={replyToAgent}
                 onAttach={onAttachScreenshot}
@@ -2392,6 +2397,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               selected={selectedFloorAgent?.id === a.id}
               plain={plain}
               onSelect={selectFloorAgent}
+              error={replyErrors.get(a.id)}
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}
@@ -2415,6 +2421,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               selected={selectedFloorAgent?.id === a.id}
               plain={plain}
               onSelect={selectFloorAgent}
+              error={replyErrors.get(a.id)}
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}

--- a/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1510,13 +1510,18 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   }, [panelHosts])
 
   // ---------- Floor view-model derivation ----------
-  // A once-a-second ticker (local useNow) drives the sync chip's live age (below). It is
-  // deliberately NOT a dependency of the agent adapters: at 100+ agents, re-adapting the
-  // whole feed every second (derivePhase / splitActivity / a per-agent question regex)
-  // is the dominant idle cost. The adapter instead captures Date.now() at data-change
-  // time only; each FeedItem's own leaf heartbeat (useNow) ticks the visible "since"
-  // label, so nothing freezes while unchanged agents stop being re-derived every second.
-  const nowMs = useNow(1000)
+  // This ticker IS a dependency of the agent adapters below — it bakes each
+  // agent's `since` string (floorAdapter.ts: sinceFromIso). An earlier comment
+  // here claimed the opposite; the dependency array two lines down always said
+  // otherwise, so at 1s the whole feed was re-adapted every second (derivePhase,
+  // splitActivity and a per-agent question regex for every agent), cascading
+  // through the memos that consume it.
+  //
+  // 5s is the interval useNow's own docblock prescribes for exactly this case.
+  // The visible live age does not get coarser: FeedItem holds its own 1s leaf
+  // heartbeat and overrides `since` for running and stalled agents, so only an
+  // idle row's age text lags, by at most five seconds.
+  const nowMs = useNow(5000)
 
   // Local agents (drop the synthetic watchdog row) + genuinely-remote sessions
   // (host !== 'this-mac' so we don't double count this machine's own agents).

--- a/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -2206,7 +2206,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               selected={selectedFloorAgent?.id === c[0].id}
               plain={plain}
               onSelect={selectFloorAgent}
-              error={replyErrors.get(a.id)}
+              error={replyErrors.get(c[0].id)}
               onOption={onAgentOption}
               onFreeText={replyToAgent}
               onAttach={onAttachScreenshot}

--- a/apps/ext/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/ext/ui/settings/components/mission-control/floorModel.ts
@@ -545,8 +545,12 @@ function firstNonEmpty(...values: Array<string | null | undefined>): string | un
  * prompt is preferred first so a card anchors to what the agent was ASKED to do, not
  * whatever it last said — the last message drifts as work progresses, the task doesn't.
  */
+/** Sentinel for a session with no prompt, summary, response, worktree or branch.
+ * Exported so callers can suppress it rather than render it as a topic. */
+export const NO_TOPIC = 'No topic'
+
 export function sessionTaskLine(a: FloorAgent): string {
-  return firstNonEmpty(a.prompt, a.summary, a.resp, a.worktreeSlug, a.branch) ?? 'No topic'
+  return firstNonEmpty(a.prompt, a.summary, a.resp, a.worktreeSlug, a.branch) ?? NO_TOPIC
 }
 
 /** Background/headless runs stay available through an explicit toggle, but do

--- a/apps/ext/ui/settings/preview/preview.tsx
+++ b/apps/ext/ui/settings/preview/preview.tsx
@@ -18,6 +18,11 @@ import { FloorRail } from '../components/mission-control/FloorRail'
 import { FloorControls, floorControlsMode } from '../components/mission-control/FloorControls'
 import { FloorSubtabs, openTaskTab, closeTaskTab, type FixedTab, type TaskTab } from '../components/mission-control/FloorSubtabs'
 import { FeedItem, TicketStrip } from '../components/mission-control/FeedItem'
+
+// Compact ('plain') rows are a real display preference, so the harness has to be
+// able to render them; every FeedItem below reads this instead of hardcoding
+// plain={PREVIEW_PLAIN}, which made the compact layout uninspectable.
+const PREVIEW_PLAIN = new URLSearchParams(location.search).get('plain') === '1'
 import { SessionsPane } from '../components/mission-control/SessionsPane'
 import { SavedViews } from '../components/mission-control/SavedViewsBar'
 import { DispatchPanel } from '../components/mission-control/DispatchPanel'
@@ -307,7 +312,7 @@ function AgentsFeed(props: { stale?: boolean; showNeeds?: boolean } = {}) {
       <FloorControls
         mode="agents"
         needsCount={2}
-        sidebarOpen rightOpen plain={false}
+        sidebarOpen rightOpen plain={PREVIEW_PLAIN}
         onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
         sort={srt} onSort={setSrt}
         ticketGroup="project" onTicketGroup={noop}
@@ -346,11 +351,11 @@ function AgentsFeed(props: { stale?: boolean; showNeeds?: boolean } = {}) {
             <Icon name="alert" size={11} /> NEEDS YOU · 5
             <span className="ln" />
           </div>
-          <FeedItem agent={idleThinkingAgent} selected={false} plain={false} {...feedHandlers} />
-          <FeedItem agent={twinA} selected={false} plain={false} {...feedHandlers} />
-          <FeedItem agent={twinB} selected={false} plain={false} {...feedHandlers} />
-          <FeedItem agent={askAgent} selected={false} plain={false} {...feedHandlers} />
-          <FeedItem agent={reviewAgent} selected={false} plain={false} {...feedHandlers} />
+          <FeedItem agent={idleThinkingAgent} selected={false} plain={PREVIEW_PLAIN} {...feedHandlers} />
+          <FeedItem agent={twinA} selected={false} plain={PREVIEW_PLAIN} {...feedHandlers} />
+          <FeedItem agent={twinB} selected={false} plain={PREVIEW_PLAIN} {...feedHandlers} />
+          <FeedItem agent={askAgent} selected={false} plain={PREVIEW_PLAIN} {...feedHandlers} />
+          <FeedItem agent={reviewAgent} selected={false} plain={PREVIEW_PLAIN} {...feedHandlers} />
         </>
       )}
 
@@ -380,7 +385,7 @@ function AgentsFeed(props: { stale?: boolean; showNeeds?: boolean } = {}) {
         ))}
       </div>
       {visibleRunning.map((a) => (
-        <FeedItem key={a.id} agent={a} selected={false} plain={false} {...feedHandlers} />
+        <FeedItem key={a.id} agent={a} selected={false} plain={PREVIEW_PLAIN} {...feedHandlers} />
       ))}
 
       <div className="backlog">
@@ -395,7 +400,7 @@ function AgentsFeed(props: { stale?: boolean; showNeeds?: boolean } = {}) {
 
       <div className="feed-sec">DONE TODAY · {done.length}<span className="ln" /></div>
       {done.map((a) => (
-        <FeedItem key={a.id} agent={a} selected={false} plain={false} {...feedHandlers} />
+        <FeedItem key={a.id} agent={a} selected={false} plain={PREVIEW_PLAIN} {...feedHandlers} />
       ))}
     </div>
   )
@@ -470,7 +475,7 @@ function Backlog() {
     <>
       <FloorControls
         mode="backlog"
-        sidebarOpen rightOpen plain={false}
+        sidebarOpen rightOpen plain={PREVIEW_PLAIN}
         onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
         sort="needs" onSort={noop}
         ticketGroup={group} onTicketGroup={setGroup}
@@ -545,7 +550,7 @@ function Subtabs() {
         <FloorControls
           mode={controlsMode}
           needsCount={2}
-          sidebarOpen rightOpen plain={false}
+          sidebarOpen rightOpen plain={PREVIEW_PLAIN}
           onToggleSidebar={noop} onToggleRight={noop} onTogglePlain={noop}
           sort={srt} onSort={setSrt}
           ticketGroup={tg} onTicketGroup={setTg}


### PR DESCRIPTION
**fix(ext) — the Fleet panel loads under multi-agent load, compact rows say what each agent is doing, and unreachable reply clicks explain why.**

## Tracking

- Linear: [RUSH-2986](https://linear.app/getrush/issue/RUSH-2986/agi-ext-land-fleet-load-row-preview-and-reply-error-fixes)

## What changed

- Claude transcript resolution now builds one coalesced filename index per refresh, memoises resolved paths, and confirms cached candidates still exist before returning them.
- The terminals payload posts without waiting for the cloud task request, and concurrent Fleet rebuild requests coalesce instead of stacking.
- The whole feed re-adapts every five seconds instead of every second; each visible running/stalled age keeps its existing one-second leaf ticker.
- Compact rows render exactly one useful preview line. Full cards stop duplicating a single-line title, and agent prose uses the existing sanitised markdown renderer.
- A failed reply from a Fleet row now renders the existing delivery reason inline instead of looking like a dead button.

## Measured result

The concurrent benchmark matches the real caller: 20 agents, 343 Claude project directories, four refreshes.

| Case | Before | Current branch |
| --- | ---: | ---: |
| Resolvable transcripts | 15,196 `getdents64` | 1,478 `getdents64` |
| No transcript yet | 58,516 `getdents64`, 501ms | 3,644 `getdents64`, 109ms |

The branch also passed `bun run compile:ext`; `apps/ext/ui` passed 452 tests with zero failures. The broader `apps/ext` run passed 1,589 tests with one pre-existing `CLI_AGENT_META` failure that reproduces on the base branch.

## Visual proof

Before — compact rows 2 and 3 have no preview:

![compact rows before](https://share.agents-cli.sh/muqsitnawaz/fix-agi-ext-usability-agi-ext-rows-before-18efa562cf5b1c5e)

After — every compact row carries one preview line:

![compact rows after](https://share.agents-cli.sh/muqsitnawaz/fix-agi-ext-usability-agi-ext-rows-after-595be65689e3ddd3)

The existing detail surface rendered through the real preview harness:

![Fleet detail panel](https://share.agents-cli.sh/muqsitnawaz/tmp-agi-ext-detail-current-0d90ddb4d9361ad3)

## Deliberately separate follow-ups

- RUSH-2973 — match the detail panel to the `agents sessions` picker.
- RUSH-2975 — make `Needs you first` actually reorder the feed.
- RUSH-2976 — add distinct loading, empty, and error states.
- RUSH-2978 — add a trailing-edge floor rebuild after a burst.
- RUSH-2979 — remove or implement the screenshot button's missing transport.
- RUSH-2980 — state an unreachable reply channel before the click.
