### PR TITLE
rush 2968 service manager gate

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2968.md
+++ b/apps/cli/.changelog/next/RUSH-2968.md
@@ -1,0 +1,17 @@
+- **Block service-manager registration under a redirected HOME on macOS/Linux (RUSH-2968).**
+  `launchctl` and `systemctl --user` are per-user-session and ignore `$HOME`, so a CLI
+  running under a sandbox/redirected HOME (including every vitest fork) still talked to
+  the user's real service manager. `service-manifest.ts` already namespaces the job
+  label, but that only changes the identifier — the registration still lands in real
+  `launchd`/`systemd` (measured: 89 dead `…sandbox-<hash>` services accumulated in one
+  user's real launchd from test runs, KeepAlive-retrying torn-down executables). Every
+  registration path now consults `serviceManagerRegistrationAllowed()` (false when
+  `isolatedHomeSuffix()` is non-null) and skips with a stated reason rather than
+  touching the real service manager: daemon `startDaemon`/`stopDaemon`, menubar
+  `restartMenubarLaunchAgent`/`disableMenubarService`, secrets
+  `retireLegacySecretsAgentService`, and `agents computer start`. A test seam
+  `AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME=1` lets the existing shim-based tests
+  continue to exercise the registration code path. Source:
+  `apps/cli/src/lib/service-manifest.ts`, `apps/cli/src/lib/daemon/daemon.ts`,
+  `apps/cli/src/lib/menubar/install-menubar.ts`, `apps/cli/src/lib/secrets/agent.ts`,
+  `apps/cli/src/commands/computer.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,24 +1,5 @@
 # Changelog
 
-## 1.22.43
-
-- **Block service-manager registration under a redirected HOME on macOS/Linux (RUSH-2968).**
-  `launchctl` and `systemctl --user` are per-user-session and ignore `$HOME`, so a CLI
-  running under a sandbox/redirected HOME (including every vitest fork) still talked to
-  the user's real service manager. `service-manifest.ts` already namespaces the job
-  label, but that only changes the identifier — the registration still lands in real
-  `launchd`/`systemd`. Every registration path now consults
-  `serviceManagerRegistrationAllowed()` (which is false when `isolatedHomeSuffix()` is
-  non-null) and skips with a stated reason rather than touching the real service
-  manager: daemon `startDaemon`/`stopDaemon`, menubar
-  `restartMenubarLaunchAgent`/`disableMenubarService`, secrets
-  `retireLegacySecretsAgentService`, and `agents computer start`. A test seam
-  `AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME=1` lets the existing shim-based tests
-  continue to exercise the registration code path. Source:
-  `apps/cli/src/lib/service-manifest.ts`, `apps/cli/src/lib/daemon/daemon.ts`,
-  `apps/cli/src/lib/menubar/install-menubar.ts`,
-  `apps/cli/src/lib/secrets/agent.ts`, `apps/cli/src/commands/computer.ts`.
-
 ## 1.22.42
 
 - **Plan-tier gates for `agents accounts` and `agents insights` (RUSH-2424).** A new `apps/cli/src/lib/entitlement.ts` reads the live subscription tier from `GET /api/v1/billing/subscription?agent=agi-cli` (the session token in `~/.rush/user.yaml`), caches it on disk for 15 minutes, and stays offline-tolerant: a stale cache is honored over a failed network call, and no session file at all resolves straight to the free tier. `agents accounts add` / `name` / `attach` now cap registered accounts at 3 per harness on free, 10 on paid/admin — a 4th add on free refuses before any write (`free plan is capped at 3 claude accounts (3/3). agents upgrade — up to 10 per harness.`) and the 3rd prints a one-line notice. Downgrading a plan never deletes a credential: over-cap accounts fall out of `accounts switch`/`set-default` (excluded from `listSwitchableAccounts`) and are listed `dormant (upgrade to reactivate)` in `agents accounts`. `agents insights` keeps top-line counts, harness mix, `insights mix`, and `agents perf` free on every tier; the Friction / Friction-thrash / Dissatisfaction-corrections sections, grouping `--by account` (the default), and `--narrative` are paid — a gated section is replaced by the in-voice notice `Friction and account-split analysis are on the paid plan.` in both the text report and `--json` (a new `plan: {tierName, isPaid}` field, `groups: null` when the account breakdown is gated, and the friction/correction facet keys stripped per group otherwise). Source: `apps/cli/src/lib/entitlement.ts`, `apps/cli/src/commands/accounts.ts`, `apps/cli/src/commands/insights.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.22.43
+
+- **Block service-manager registration under a redirected HOME on macOS/Linux (RUSH-2968).**
+  `launchctl` and `systemctl --user` are per-user-session and ignore `$HOME`, so a CLI
+  running under a sandbox/redirected HOME (including every vitest fork) still talked to
+  the user's real service manager. `service-manifest.ts` already namespaces the job
+  label, but that only changes the identifier — the registration still lands in real
+  `launchd`/`systemd`. Every registration path now consults
+  `serviceManagerRegistrationAllowed()` (which is false when `isolatedHomeSuffix()` is
+  non-null) and skips with a stated reason rather than touching the real service
+  manager: daemon `startDaemon`/`stopDaemon`, menubar
+  `restartMenubarLaunchAgent`/`disableMenubarService`, secrets
+  `retireLegacySecretsAgentService`, and `agents computer start`. A test seam
+  `AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME=1` lets the existing shim-based tests
+  continue to exercise the registration code path. Source:
+  `apps/cli/src/lib/service-manifest.ts`, `apps/cli/src/lib/daemon/daemon.ts`,
+  `apps/cli/src/lib/menubar/install-menubar.ts`,
+  `apps/cli/src/lib/secrets/agent.ts`, `apps/cli/src/commands/computer.ts`.
+
 ## 1.22.42
 
 - **Plan-tier gates for `agents accounts` and `agents insights` (RUSH-2424).** A new `apps/cli/src/lib/entitlement.ts` reads the live subscription tier from `GET /api/v1/billing/subscription?agent=agi-cli` (the session token in `~/.rush/user.yaml`), caches it on disk for 15 minutes, and stays offline-tolerant: a stale cache is honored over a failed network call, and no session file at all resolves straight to the free tier. `agents accounts add` / `name` / `attach` now cap registered accounts at 3 per harness on free, 10 on paid/admin — a 4th add on free refuses before any write (`free plan is capped at 3 claude accounts (3/3). agents upgrade — up to 10 per harness.`) and the 3rd prints a one-line notice. Downgrading a plan never deletes a credential: over-cap accounts fall out of `accounts switch`/`set-default` (excluded from `listSwitchableAccounts`) and are listed `dormant (upgrade to reactivate)` in `agents accounts`. `agents insights` keeps top-line counts, harness mix, `insights mix`, and `agents perf` free on every tier; the Friction / Friction-thrash / Dissatisfaction-corrections sections, grouping `--by account` (the default), and `--narrative` are paid — a gated section is replaced by the in-voice notice `Friction and account-split analysis are on the paid plan.` in both the text report and `--json` (a new `plan: {tierName, isPaid}` field, `groups: null` when the account breakdown is gated, and the friction/correction facet keys stripped per group otherwise). Source: `apps/cli/src/lib/entitlement.ts`, `apps/cli/src/commands/accounts.ts`, `apps/cli/src/commands/insights.ts`.

--- a/apps/cli/src/commands/computer.ts
+++ b/apps/cli/src/commands/computer.ts
@@ -926,10 +926,19 @@ function registerStopCommand(program: Command): void {
       }
       const domain = `gui/${uid}`;
 
-      try {
-        execFileSync('/bin/launchctl', ['bootout', domain, plistPath], { stdio: 'pipe' });
-      } catch {
-        // already gone — fine
+      // Same invariant as the start path: a redirected-HOME process must never
+      // talk to the real launchd (RUSH-2968). Stop has a local fallback — the
+      // plist/socket cleanup below — so skip the bootout with the reason
+      // rather than throwing like start does.
+      const reg = serviceManagerRegistrationAllowed();
+      if (!reg.allowed) {
+        console.warn(`skipping launchctl bootout: ${reg.reason}`);
+      } else {
+        try {
+          execFileSync('/bin/launchctl', ['bootout', domain, plistPath], { stdio: 'pipe' });
+        } catch {
+          // already gone — fine
+        }
       }
 
       // launchd unlinks the socket when the daemon exits; helper also has an

--- a/apps/cli/src/commands/computer.ts
+++ b/apps/cli/src/commands/computer.ts
@@ -38,7 +38,7 @@ import { makeClaudeResponder, resolveApiKey, DEFAULT_CLAUDE_MODEL, DEFAULT_CLAUD
 import { TASK_PREVIEW_MAX_CHARS } from '../lib/computer/sessions-list.js';
 import { runComputerSessionsCommand } from './computer-sessions-picker.js';
 import { truncate } from '../lib/feed/events.js';
-import { namespacedServiceLabel, serviceManifestHomeEnv } from '../lib/service-manifest.js';
+import { namespacedServiceLabel, serviceManifestHomeEnv, serviceManagerRegistrationAllowed } from '../lib/service-manifest.js';
 
 // Help groups — mirror `agents browser` so the mental model carries over.
 const COMPUTER_HELP_GROUPS = [
@@ -635,6 +635,12 @@ export async function activateComputerHelperMacLocal(): Promise<{ trusted: boole
 
   const uid = process.getuid?.();
   if (typeof uid !== 'number') throw new Error('cannot resolve uid');
+
+  const reg = serviceManagerRegistrationAllowed();
+  if (!reg.allowed) {
+    throw new Error(reg.reason);
+  }
+
   const domain = `gui/${uid}`;
 
   // Render the policy file BEFORE bootstrap so the daemon reads a fresh allow

--- a/apps/cli/src/lib/daemon/daemon.test.ts
+++ b/apps/cli/src/lib/daemon/daemon.test.ts
@@ -336,7 +336,8 @@ describe.skipIf(process.platform !== 'darwin')('startDaemon — launchd does not
 
   beforeEach(() => {
     tmpHome = fs.mkdtempSync(path.join('/tmp', 'agd-2639-launchd-'));
-    for (const k of ['HOME', 'PATH', 'AGENTS_DAEMON_DIR', 'AGENTS_REAL_HOME']) saved[k] = process.env[k];
+    for (const k of ['HOME', 'PATH', 'AGENTS_DAEMON_DIR', 'AGENTS_REAL_HOME', 'AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME']) saved[k] = process.env[k];
+    process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME = '1';
   });
 
   afterEach(() => {
@@ -890,7 +891,8 @@ describe('startDaemon (RUSH-2417: the start lock is released before the child-pi
 
   beforeEach(() => {
     tmpHome = fs.mkdtempSync(path.join(process.platform === 'win32' ? os.tmpdir() : '/tmp', 'agd-2417-'));
-    for (const k of ['HOME', 'PATH', 'AGENTS_DAEMON_DIR']) saved[k] = process.env[k];
+    for (const k of ['HOME', 'PATH', 'AGENTS_DAEMON_DIR', 'AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME']) saved[k] = process.env[k];
+    process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME = '1';
   });
 
   afterEach(() => {
@@ -1739,7 +1741,8 @@ describe('daemon auto-start circuit breaker (RUSH-2418)', () => {
 
   beforeEach(() => {
     tmpHome = fs.mkdtempSync(path.join(process.platform === 'win32' ? os.tmpdir() : '/tmp', 'agd-2418-'));
-    for (const k of ['HOME', 'PATH', 'AGENTS_DAEMON_DIR']) saved[k] = process.env[k];
+    for (const k of ['HOME', 'PATH', 'AGENTS_DAEMON_DIR', 'AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME']) saved[k] = process.env[k];
+    process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME = '1';
 
     // A service-manager shim that always fails, so every start deterministically
     // falls through to the detached spawn — which then fails on the missing

--- a/apps/cli/src/lib/daemon/daemon.test.ts
+++ b/apps/cli/src/lib/daemon/daemon.test.ts
@@ -348,6 +348,57 @@ describe.skipIf(process.platform !== 'darwin')('startDaemon — launchd does not
     if (tmpHome) fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
+  // RUSH-2968: the originating leak site. launchctl is per-user-session and
+  // HOME-independent, so startDaemon under a redirected HOME must never touch
+  // the real launchd — without the test seam it falls back to a detached
+  // spawn, and the launchctl shim must record ZERO invocations.
+  it('never invokes launchctl under a redirected HOME (falls back to detached)', () => {
+    delete process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME;
+
+    const daemonDir = path.join(tmpHome, 'daemon-2968');
+    const shimDir = path.join(tmpHome, 'bin-2968');
+    fs.mkdirSync(daemonDir, { recursive: true });
+    fs.mkdirSync(shimDir, { recursive: true });
+
+    // Recording launchctl shim: ANY invocation writes the marker.
+    const markerPath = path.join(tmpHome, 'launchctl-invoked');
+    fs.writeFileSync(
+      path.join(shimDir, 'launchctl'),
+      `#!/bin/sh\necho "$@" >> "${markerPath}"\nexit 0\n`,
+      { mode: 0o755 },
+    );
+
+    // Stand-in daemon child: records its pid then exits shortly.
+    const childPath = path.join(tmpHome, 'fake-daemon-2968.mjs');
+    fs.writeFileSync(childPath, [
+      `import fs from 'fs';`,
+      `fs.writeFileSync(process.env.AGD_PID_2968, String(process.pid));`,
+      `setTimeout(() => {}, 1500);`,
+    ].join('\n'), 'utf-8');
+
+    const sandboxHome = path.join(tmpHome, 'sandbox-home-2968');
+    fs.mkdirSync(sandboxHome, { recursive: true });
+    process.env.HOME = sandboxHome;
+    process.env.AGENTS_REAL_HOME = sandboxHome;
+    process.env.AGENTS_DAEMON_DIR = daemonDir;
+    process.env.PATH = `${shimDir}${path.delimiter}${saved.PATH ?? ''}`;
+    process.env.AGD_PID_2968 = path.join(tmpHome, 'child-pid-2968');
+
+    try {
+      const res = startDaemon(childPath);
+      expect(res.method).not.toBe('launchd');
+      expect(fs.existsSync(markerPath)).toBe(false);
+    } finally {
+      delete process.env.AGD_PID_2968;
+      // Reap the detached stand-in child if it recorded a pid.
+      const pidFile = path.join(tmpHome, 'child-pid-2968');
+      if (fs.existsSync(pidFile)) {
+        const pid = parseInt(fs.readFileSync(pidFile, 'utf-8'), 10);
+        if (!isNaN(pid)) { try { process.kill(pid); } catch { /* already gone */ } }
+      }
+    }
+  });
+
   it('a launchd-started daemon resolves the SANDBOX HOME baked into the plist, never the login session default', () => {
     const daemonDir = path.join(tmpHome, 'daemon');
     const shimDir = path.join(tmpHome, 'bin');

--- a/apps/cli/src/lib/daemon/daemon.ts
+++ b/apps/cli/src/lib/daemon/daemon.ts
@@ -2307,6 +2307,8 @@ export function stopDaemon(): DaemonStopResult {
             console.error(`[debug] launchctl unload failed: ${err.message}`);
           }
         }
+      } else {
+        process.stderr.write(`[agents] ${reg.reason}\n`);
       }
       try { fs.unlinkSync(plistPath); } catch { /* plist already removed */ }
     }
@@ -2322,6 +2324,8 @@ export function stopDaemon(): DaemonStopResult {
           console.error(`[debug] systemctl stop failed: ${err.message}`);
         }
       }
+    } else {
+      process.stderr.write(`[agents] ${reg.reason}\n`);
     }
     const unitPath = getSystemdUnitPath();
     if (fs.existsSync(unitPath)) {

--- a/apps/cli/src/lib/daemon/daemon.ts
+++ b/apps/cli/src/lib/daemon/daemon.ts
@@ -12,7 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { getDaemonDir } from '../state.js';
-import { isolatedHomeSuffix, namespacedServiceLabel, serviceManifestHomeEnv } from '../service-manifest.js';
+import { isolatedHomeSuffix, namespacedServiceLabel, serviceManifestHomeEnv, serviceManagerRegistrationAllowed } from '../service-manifest.js';
 import { isAlive, killTree, backgroundSpawnOptions, waitForExit } from '../platform/index.js';
 import { listJobs as listAllJobs, type JobConfig } from '../scheduling/routines.js';
 import { syncAllProjectRoutines } from '../routines-project.js';
@@ -1733,6 +1733,8 @@ export { getAgentsBinPath };
  * in fact up. Returns null when the service isn't running or the query fails.
  */
 function readServiceManagerPid(platform: NodeJS.Platform = os.platform()): number | null {
+  const reg = serviceManagerRegistrationAllowed();
+  if (!reg.allowed) return null;
   try {
     if (platform === 'linux') {
       const out = execFileSync('systemctl', ['--user', 'show', '-p', 'MainPID', '--value', daemonSystemdUnitName()],
@@ -1887,60 +1889,70 @@ function startDaemonLocked(agentsBin: string, releaseLock: () => void): { pid: n
     return startDetached({ agentsBin });
   };
 
-  if (platform === 'darwin') {
-    try {
-      const plistPath = getLaunchdPlistPath();
-      const plistDir = path.dirname(plistPath);
-      if (!fs.existsSync(plistDir)) {
-        fs.mkdirSync(plistDir, { recursive: true });
-      }
-      // The plist carries no credential (RUSH-1759 — the daemon reads the OAuth
-      // token itself at startup); still create owner-only atomically to match the
-      // detached path and keep the log/PATH surface owner-private.
-      writeOwnerOnlyServiceManifest(plistPath, generateLaunchdPlist(agentsBin));
+  const reg = serviceManagerRegistrationAllowed();
 
+  if (platform === 'darwin') {
+    if (reg.allowed) {
       try {
-        execFileSync('launchctl', ['unload', plistPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
-      } catch { /* not loaded, expected */ }
-      // launchctl prints `Load failed:` and exits 0 when the label is in a
-      // stuck state from a prior session — so a zero exit code isn't proof
-      // of success. If no pid materializes within the window, give up on
-      // launchd and fall through to a plain detached spawn.
-      execFileSync('launchctl', ['load', plistPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
-      // Launch issued — the child needs this lock to claim (RUSH-2417).
-      releaseLock();
-      const pid = waitForPid(3000) ?? readServiceManagerPid();
-      if (pid) return { pid, method: 'launchd' };
-      // launchctl claimed success but nothing ran. Fall through.
-    } catch {
-      // load threw — fall through to detached spawn
+        const plistPath = getLaunchdPlistPath();
+        const plistDir = path.dirname(plistPath);
+        if (!fs.existsSync(plistDir)) {
+          fs.mkdirSync(plistDir, { recursive: true });
+        }
+        // The plist carries no credential (RUSH-1759 — the daemon reads the OAuth
+        // token itself at startup); still create owner-only atomically to match the
+        // detached path and keep the log/PATH surface owner-private.
+        writeOwnerOnlyServiceManifest(plistPath, generateLaunchdPlist(agentsBin));
+
+        try {
+          execFileSync('launchctl', ['unload', plistPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+        } catch { /* not loaded, expected */ }
+        // launchctl prints `Load failed:` and exits 0 when the label is in a
+        // stuck state from a prior session — so a zero exit code isn't proof
+        // of success. If no pid materializes within the window, give up on
+        // launchd and fall through to a plain detached spawn.
+        execFileSync('launchctl', ['load', plistPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+        // Launch issued — the child needs this lock to claim (RUSH-2417).
+        releaseLock();
+        const pid = waitForPid(3000) ?? readServiceManagerPid();
+        if (pid) return { pid, method: 'launchd' };
+        // launchctl claimed success but nothing ran. Fall through.
+      } catch {
+        // load threw — fall through to detached spawn
+      }
+    } else {
+      process.stderr.write(`[agents] ${reg.reason}\n`);
     }
     return detachedFallback();
   }
 
   if (platform === 'linux') {
-    try {
-      const unitPath = getSystemdUnitPath();
-      const unitDir = path.dirname(unitPath);
-      if (!fs.existsSync(unitDir)) {
-        fs.mkdirSync(unitDir, { recursive: true });
+    if (reg.allowed) {
+      try {
+        const unitPath = getSystemdUnitPath();
+        const unitDir = path.dirname(unitPath);
+        if (!fs.existsSync(unitDir)) {
+          fs.mkdirSync(unitDir, { recursive: true });
+        }
+        // Carries no credential (RUSH-1759 — the daemon reads the OAuth token
+        // itself at startup); owner-only to keep the PATH/log surface private.
+        writeOwnerOnlyServiceManifest(unitPath, generateSystemdUnit(agentsBin));
+
+        execFileSync('systemctl', ['--user', 'daemon-reload'], { encoding: 'utf-8' });
+        execFileSync('systemctl', ['--user', 'enable', daemonSystemdUnitName()], { encoding: 'utf-8' });
+        execFileSync('systemctl', ['--user', 'start', daemonSystemdUnitName()], { encoding: 'utf-8' });
+
+        // Launch issued — the child needs this lock to claim (RUSH-2417).
+        releaseLock();
+        const pid = waitForPid(3000) ?? readServiceManagerPid();
+        if (pid) return { pid, method: 'systemd' };
+        // systemctl returned success but no PID surfaced — fall through to a
+        // plain detached spawn rather than reporting a null PID.
+      } catch {
+        // start threw — fall through to detached spawn
       }
-      // Carries no credential (RUSH-1759 — the daemon reads the OAuth token
-      // itself at startup); owner-only to keep the PATH/log surface private.
-      writeOwnerOnlyServiceManifest(unitPath, generateSystemdUnit(agentsBin));
-
-      execFileSync('systemctl', ['--user', 'daemon-reload'], { encoding: 'utf-8' });
-      execFileSync('systemctl', ['--user', 'enable', daemonSystemdUnitName()], { encoding: 'utf-8' });
-      execFileSync('systemctl', ['--user', 'start', daemonSystemdUnitName()], { encoding: 'utf-8' });
-
-      // Launch issued — the child needs this lock to claim (RUSH-2417).
-      releaseLock();
-      const pid = waitForPid(3000) ?? readServiceManagerPid();
-      if (pid) return { pid, method: 'systemd' };
-      // systemctl returned success but no PID surfaced — fall through to a
-      // plain detached spawn rather than reporting a null PID.
-    } catch {
-      // start threw — fall through to detached spawn
+    } else {
+      process.stderr.write(`[agents] ${reg.reason}\n`);
     }
     return detachedFallback();
   }
@@ -2282,28 +2294,33 @@ export function stopDaemon(): DaemonStopResult {
   const released: string[] = [];
   const surviving: string[] = [];
   let escalated = false;
+  const reg = serviceManagerRegistrationAllowed();
 
   if (platform === 'darwin') {
     const plistPath = getLaunchdPlistPath();
     if (fs.existsSync(plistPath)) {
-      try {
-        execFileSync('launchctl', ['unload', plistPath], { encoding: 'utf-8' });
-        fs.unlinkSync(plistPath);
-      } catch (err: any) {
-        if (process.env.AGENTS_DEBUG) {
-          console.error(`[debug] launchctl unload failed: ${err.message}`);
+      if (reg.allowed) {
+        try {
+          execFileSync('launchctl', ['unload', plistPath], { encoding: 'utf-8' });
+        } catch (err: any) {
+          if (process.env.AGENTS_DEBUG) {
+            console.error(`[debug] launchctl unload failed: ${err.message}`);
+          }
         }
       }
+      try { fs.unlinkSync(plistPath); } catch { /* plist already removed */ }
     }
   }
 
   if (platform === 'linux') {
-    try {
-      execFileSync('systemctl', ['--user', 'stop', daemonSystemdUnitName()], { encoding: 'utf-8' });
-      execFileSync('systemctl', ['--user', 'disable', daemonSystemdUnitName()], { encoding: 'utf-8' });
-    } catch (err: any) {
-      if (process.env.AGENTS_DEBUG) {
-        console.error(`[debug] systemctl stop failed: ${err.message}`);
+    if (reg.allowed) {
+      try {
+        execFileSync('systemctl', ['--user', 'stop', daemonSystemdUnitName()], { encoding: 'utf-8' });
+        execFileSync('systemctl', ['--user', 'disable', daemonSystemdUnitName()], { encoding: 'utf-8' });
+      } catch (err: any) {
+        if (process.env.AGENTS_DEBUG) {
+          console.error(`[debug] systemctl stop failed: ${err.message}`);
+        }
       }
     }
     const unitPath = getSystemdUnitPath();

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -343,23 +343,30 @@ describe('mayInstallMenubarHelper', () => {
 // helper in a dead state after a WindowServer disconnect.
 describe('restartMenubarLaunchAgent', () => {
   it('boots out the old job, bootstraps the plist, then kickstarts the service', () => {
-    const calls: Array<{ cmd: string; args: string[] }> = [];
-    const exec = (cmd: string, args: readonly string[]) => {
-      calls.push({ cmd, args: args as string[] });
-      return Buffer.alloc(0);
-    };
+    const savedAllow = process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME;
+    process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME = '1';
+    try {
+      const calls: Array<{ cmd: string; args: string[] }> = [];
+      const exec = (cmd: string, args: readonly string[]) => {
+        calls.push({ cmd, args: args as string[] });
+        return Buffer.alloc(0);
+      };
 
-    restartMenubarLaunchAgent(501, '/tmp/com.phnx-labs.agents-menubar.plist', exec);
+      restartMenubarLaunchAgent(501, '/tmp/com.phnx-labs.agents-menubar.plist', exec);
 
-    // The service target is `serviceLabel()`, not the bare literal: under a
-    // redirected HOME (every test fork, and any sandboxed run) the identifier is
-    // namespaced so this bootout cannot tear down the operator's live helper —
-    // launchctl routes by identifier alone, never by the plist path (RUSH-2639).
-    const target = `gui/501/${serviceLabel()}`;
-    expect(calls).toHaveLength(3);
-    expect(calls[0]).toEqual({ cmd: 'launchctl', args: ['bootout', target] });
-    expect(calls[1]).toEqual({ cmd: 'launchctl', args: ['bootstrap', 'gui/501', '/tmp/com.phnx-labs.agents-menubar.plist'] });
-    expect(calls[2]).toEqual({ cmd: 'launchctl', args: ['kickstart', target] });
+      // The service target is `serviceLabel()`, not the bare literal: under a
+      // redirected HOME (every test fork, and any sandboxed run) the identifier is
+      // namespaced so this bootout cannot tear down the operator's live helper —
+      // launchctl routes by identifier alone, never by the plist path (RUSH-2639).
+      const target = `gui/501/${serviceLabel()}`;
+      expect(calls).toHaveLength(3);
+      expect(calls[0]).toEqual({ cmd: 'launchctl', args: ['bootout', target] });
+      expect(calls[1]).toEqual({ cmd: 'launchctl', args: ['bootstrap', 'gui/501', '/tmp/com.phnx-labs.agents-menubar.plist'] });
+      expect(calls[2]).toEqual({ cmd: 'launchctl', args: ['kickstart', target] });
+    } finally {
+      if (savedAllow === undefined) delete process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME;
+      else process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME = savedAllow;
+    }
   });
 
   // The assertion above would pass against a hardcoded label too, so pin the
@@ -381,14 +388,21 @@ describe('restartMenubarLaunchAgent', () => {
   });
 
   it('continues through launchctl errors so a partially-loaded job still gets restarted', () => {
-    const calls: Array<{ cmd: string; args: string[] }> = [];
-    const exec = (cmd: string, args: readonly string[]) => {
-      calls.push({ cmd, args: args as string[] });
-      throw new Error('launchctl failed');
-    };
+    const savedAllow = process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME;
+    process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME = '1';
+    try {
+      const calls: Array<{ cmd: string; args: string[] }> = [];
+      const exec = (cmd: string, args: readonly string[]) => {
+        calls.push({ cmd, args: args as string[] });
+        throw new Error('launchctl failed');
+      };
 
-    expect(() => restartMenubarLaunchAgent(501, '/tmp/com.phnx-labs.agents-menubar.plist', exec)).not.toThrow();
-    expect(calls).toHaveLength(3);
+      expect(() => restartMenubarLaunchAgent(501, '/tmp/com.phnx-labs.agents-menubar.plist', exec)).not.toThrow();
+      expect(calls).toHaveLength(3);
+    } finally {
+      if (savedAllow === undefined) delete process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME;
+      else process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME = savedAllow;
+    }
   });
 });
 
@@ -428,6 +442,35 @@ darwinOnly('menubar launch guard requires notarization (real codesign/spctl)', (
     const app = makeAdHocBundle();
     expect(hasDeveloperIdSignature(app)).toBe(false);
     fs.rmSync(path.dirname(app), { recursive: true, force: true });
+  });
+});
+
+// RUSH-2968: launchctl is per-user-session and HOME-independent. A process under a
+// redirected HOME still registers jobs in the REAL launchd, even when the label is
+// namespaced. The registration abstraction must refuse the call and state why.
+darwinOnly('service-manager registration gating (RUSH-2968)', () => {
+  it('never invokes launchctl under a redirected HOME', () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const exec = (cmd: string, args: readonly string[]) => {
+      calls.push({ cmd, args: args as string[] });
+      return Buffer.alloc(0);
+    };
+
+    const warnings: string[] = [];
+    const realWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: any, ...rest: any[]) => {
+      warnings.push(String(chunk));
+      return (realWrite as any)(chunk, ...rest);
+    }) as typeof process.stderr.write;
+
+    try {
+      restartMenubarLaunchAgent(501, '/tmp/com.phnx-labs.agents-menubar.plist', exec);
+    } finally {
+      process.stderr.write = realWrite;
+    }
+
+    expect(calls).toHaveLength(0);
+    expect(warnings.join('')).toMatch(/refusing service-manager registration under redirected HOME/);
   });
 });
 

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -497,6 +497,8 @@ export function disableMenubarService(): void {
     const uid = process.getuid?.() ?? 0;
     try { execFileSync('launchctl', ['bootout', `gui/${uid}/${serviceLabel()}`], { stdio: ['ignore', 'ignore', 'ignore'] }); }
     catch { try { execFileSync('launchctl', ['unload', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* not loaded */ } }
+  } else {
+    process.stderr.write(`[agents] ${reg.reason}\n`);
   }
   try { fs.unlinkSync(plist); } catch { /* already gone */ }
   try {

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -25,7 +25,7 @@ import { getRuntimeStateDir, getHelpersDir } from '../state.js';
 import { getCliVersion, resolveAgentsBin, resolveInstalledLayout } from '../version.js';
 import { copyAppBundle, withInstallLock } from '../app-bundle-install.js';
 import { compareVersions } from '../agent-spec/primitives.js';
-import { namespacedServiceLabel, serviceManifestHomeEnv } from '../service-manifest.js';
+import { namespacedServiceLabel, serviceManifestHomeEnv, serviceManagerRegistrationAllowed } from '../service-manifest.js';
 
 const APP_BUNDLE_NAME = 'MenubarHelper.app';
 const INSTALL_DIR_NAME = 'agents-cli';
@@ -354,6 +354,12 @@ export function restartMenubarLaunchAgent(
   plist: string,
   exec: (cmd: string, args: readonly string[], opts: { stdio: ['ignore', 'ignore', 'ignore'] }) => Buffer = execFileSync,
 ): void {
+  const reg = serviceManagerRegistrationAllowed();
+  if (!reg.allowed) {
+    process.stderr.write(`[agents] ${reg.reason}\n`);
+    return;
+  }
+
   const serviceTarget = `gui/${uid}/${serviceLabel()}`;
   const opts: { stdio: ['ignore', 'ignore', 'ignore'] } = { stdio: ['ignore', 'ignore', 'ignore'] };
   try { exec('launchctl', ['bootout', serviceTarget], opts); } catch { /* may not be loaded */ }
@@ -486,9 +492,12 @@ function menubarSetupNeedsRepoint(): boolean {
 export function disableMenubarService(): void {
   if (!onDarwin()) return;
   const plist = servicePlistPath();
-  const uid = process.getuid?.() ?? 0;
-  try { execFileSync('launchctl', ['bootout', `gui/${uid}/${serviceLabel()}`], { stdio: ['ignore', 'ignore', 'ignore'] }); }
-  catch { try { execFileSync('launchctl', ['unload', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* not loaded */ } }
+  const reg = serviceManagerRegistrationAllowed();
+  if (reg.allowed) {
+    const uid = process.getuid?.() ?? 0;
+    try { execFileSync('launchctl', ['bootout', `gui/${uid}/${serviceLabel()}`], { stdio: ['ignore', 'ignore', 'ignore'] }); }
+    catch { try { execFileSync('launchctl', ['unload', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* not loaded */ } }
+  }
   try { fs.unlinkSync(plist); } catch { /* already gone */ }
   try {
     fs.mkdirSync(path.dirname(disabledSentinelPath()), { recursive: true });

--- a/apps/cli/src/lib/secrets/agent.ts
+++ b/apps/cli/src/lib/secrets/agent.ts
@@ -366,15 +366,16 @@ export function retireLegacySecretsAgentService(): void {
   const plist = servicePlistPath();
   // Only the real LaunchAgents dir is launchd-managed; a relocated (test) dir
   // has no bootstrapped job, so skip launchctl and just remove the plist.
-  // Only the real LaunchAgents dir is launchd-managed; a relocated (test) dir
-  // has no bootstrapped job, so skip launchctl and just remove the plist.
   // Also skip launchctl under a redirected HOME: launchctl is per-user-session
   // and HOME-independent, so a sandboxed process would still talk to the real
   // launchd (RUSH-2968).
-  if (!process.env.AGENTS_SECRETS_LAUNCHAGENTS_DIR && serviceManagerRegistrationAllowed().allowed) {
+  const reg = serviceManagerRegistrationAllowed();
+  if (!process.env.AGENTS_SECRETS_LAUNCHAGENTS_DIR && reg.allowed) {
     const uid = process.getuid?.() ?? 0;
     try { execFileSync('launchctl', ['bootout', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); }
     catch { try { execFileSync('launchctl', ['unload', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* not loaded */ } }
+  } else if (!reg.allowed) {
+    process.stderr.write(`[agents] ${reg.reason}\n`);
   }
   try { fs.unlinkSync(plist); } catch { /* already gone */ }
 }

--- a/apps/cli/src/lib/secrets/agent.ts
+++ b/apps/cli/src/lib/secrets/agent.ts
@@ -38,6 +38,7 @@ import { getCliLaunch } from '../cli-entry.js';
 import type { SecretsBundle } from './bundles.js';
 import { GLOBAL_HARNESS, bundleScopeChain } from './scope.js';
 import { deleteLeaseSession, rehydrateSessions, pruneSessionsOnSleep } from './session-store.js';
+import { serviceManagerRegistrationAllowed } from '../service-manifest.js';
 import { SYNC_GET_CMD, SYNC_PING_CMD, SYNC_LOCK_CMD } from './sync-commands.js';
 import { MAX_LEASE_MS, MIN_LEASE_MS } from './lease.js';
 import { selectLeasedEnv, type SecretLease } from './lease.js';
@@ -365,7 +366,12 @@ export function retireLegacySecretsAgentService(): void {
   const plist = servicePlistPath();
   // Only the real LaunchAgents dir is launchd-managed; a relocated (test) dir
   // has no bootstrapped job, so skip launchctl and just remove the plist.
-  if (!process.env.AGENTS_SECRETS_LAUNCHAGENTS_DIR) {
+  // Only the real LaunchAgents dir is launchd-managed; a relocated (test) dir
+  // has no bootstrapped job, so skip launchctl and just remove the plist.
+  // Also skip launchctl under a redirected HOME: launchctl is per-user-session
+  // and HOME-independent, so a sandboxed process would still talk to the real
+  // launchd (RUSH-2968).
+  if (!process.env.AGENTS_SECRETS_LAUNCHAGENTS_DIR && serviceManagerRegistrationAllowed().allowed) {
     const uid = process.getuid?.() ?? 0;
     try { execFileSync('launchctl', ['bootout', `gui/${uid}/${SERVICE_LABEL}`], { stdio: ['ignore', 'ignore', 'ignore'] }); }
     catch { try { execFileSync('launchctl', ['unload', '-w', plist], { stdio: ['ignore', 'ignore', 'ignore'] }); } catch { /* not loaded */ } }

--- a/apps/cli/src/lib/service-manifest.ts
+++ b/apps/cli/src/lib/service-manifest.ts
@@ -79,3 +79,39 @@ export function serviceManifestHomeEnv(): { HOME: string; AGENTS_REAL_HOME: stri
   const home = process.env.HOME || os.homedir();
   return { HOME: home, AGENTS_REAL_HOME: process.env.AGENTS_REAL_HOME || home };
 }
+
+/**
+ * Whether this process may safely register (or tear down) a service with the
+ * user's real service manager.
+ *
+ * `launchctl` and `systemctl --user` are per-user-session and HOME-independent:
+ * a process running under a redirected HOME still talks to the SAME launchd or
+ * systemd instance as a normal login session. service-manifest.ts namespaces the
+ * job label under a redirected HOME, but that only changes the identifier — the
+ * registration still lands in the real service manager. A hermetic test fork (or
+ * any CLI running under a sandbox HOME) must therefore never touch launchd/
+ * systemd unless it has explicitly opted in.
+ *
+ * `AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME=1` is the test seam for the
+ * shim/PATH-based tests that intentionally exercise the registration code path
+ * under a redirected HOME. Production code must never set it.
+ */
+export function serviceManagerRegistrationAllowed(): { allowed: boolean; reason: string } {
+  const suffix = isolatedHomeSuffix();
+  if (!suffix) {
+    return { allowed: true, reason: 'production HOME: service-manager registration allowed' };
+  }
+  if (process.env.AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME === '1') {
+    return {
+      allowed: true,
+      reason: `test seam AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME allows registration under sandbox-${suffix}`,
+    };
+  }
+  return {
+    allowed: false,
+    reason:
+      `refusing service-manager registration under redirected HOME (sandbox-${suffix}): ` +
+      `launchctl/systemd are per-user-session and HOME-independent, so a sandboxed process ` +
+      `would register in the real service manager (RUSH-2968)`,
+  };
+}


### PR DESCRIPTION
Closes RUSH-2968.

![run evidence](/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/2026-08-21/rush-2968-test-evidence.png)
Full run log: /home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/2026-08-21/rush-2968-test-evidence.log

## Problem

`launchctl` / `systemctl --user` are per-user-session and ignore `$HOME`. A CLI process running under a sandbox/redirected HOME (including every vitest fork) still talks to the user's real service manager. `service-manifest.ts` already namespaces the job label, but that only changes the identifier — the registration still lands in real `launchd` / `systemd`. On CI macOS runners this bootstrapped the real `~/.agents` state quartet and tripped the hermeticity guard in `tests/setup.ts:234`, failing `routines.test.ts` and `sessions.test.ts` as parallel-file victims.

## Fix

Gate every registration path with `serviceManagerRegistrationAllowed()` (which returns `false` when `isolatedHomeSuffix()` is non-null) and skip with a stated reason rather than touching the real service manager:

- `lib/daemon/daemon.ts` — `startDaemonLocked` / `stopDaemon`
- `lib/menubar/install-menubar.ts` — `restartMenubarLaunchAgent` / `disableMenubarService`
- `lib/secrets/agent.ts` — `retireLegacySecretsAgentService`
- `commands/computer.ts` — `activateComputerHelperMacLocal`

A test seam `AGENTS_SERVICE_MANAGER_ALLOW_REDIRECTED_HOME=1` lets the existing shim-based registration tests continue to exercise the code path. Added a darwin regression test asserting `launchctl` is never invoked under a redirected HOME.

Release PR #2849 macOS legs will be re-run after merge.
