### PR TITLE
test(ext): follow canonical agent registry move

### DIFF
--- a/apps/ext/src/core/agents.cli.test.ts
+++ b/apps/ext/src/core/agents.cli.test.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { CLI_AGENT_IDS, CLI_AGENT_META } from './agents.cli';
 
 const CLI_LIB = path.resolve(__dirname, '..', '..', '..', 'cli', 'src', 'lib');
+const CLI_AGENTS = path.join(CLI_LIB, 'agent-spec', 'agents.ts');
 
 // A packaged source tree without apps/cli (e.g. an extension-only checkout)
 // has nothing to diff against — the guard only runs inside the monorepo.
@@ -26,8 +27,8 @@ const inMonorepo = fs.existsSync(path.join(CLI_LIB, 'types.ts'));
     expect([...CLI_AGENT_IDS].sort()).toEqual([...ids].sort());
   });
 
-  test('CLI_AGENT_META name/cliCommand match the AGENTS table in apps/cli/src/lib/agents.ts', () => {
-    const src = fs.readFileSync(path.join(CLI_LIB, 'agents.ts'), 'utf-8');
+  test('CLI_AGENT_META name/cliCommand match the canonical AGENTS table', () => {
+    const src = fs.readFileSync(CLI_AGENTS, 'utf-8');
     for (const [id, meta] of Object.entries(CLI_AGENT_META)) {
       // Each entry opens at 2-space indent (`  claude: {`) and closes with the
       // first `  },` back at that indent; nested objects sit deeper.

--- a/apps/ext/src/core/agents.cli.ts
+++ b/apps/ext/src/core/agents.cli.ts
@@ -2,7 +2,7 @@
 //
 // Source of truth:
 //   apps/cli/src/lib/types.ts   (the AgentId union)
-//   apps/cli/src/lib/agents.ts  (the AGENTS table: name, cliCommand)
+//   apps/cli/src/lib/agent-spec/agents.ts  (the AGENTS table: name, cliCommand)
 //
 // The extension cannot import the CLI in-process (the repo has no JS
 // workspaces; the CLI is ESM, the extension CommonJS), so the registry is
@@ -45,7 +45,7 @@ export interface CliAgentMeta {
   cliCommand: string;
 }
 
-/** Canonical per-agent metadata (apps/cli/src/lib/agents.ts AGENTS table). */
+/** Canonical per-agent metadata (apps/cli/src/lib/agent-spec/agents.ts AGENTS table). */
 export const CLI_AGENT_META: Record<CliAgentId, CliAgentMeta> = {
   claude: { name: 'Claude', cliCommand: 'claude' },
   codex: { name: 'Codex', cliCommand: 'codex' },


### PR DESCRIPTION
test-only: unblocks the AGI EXT 0.9.328 release by following the CLI registry's canonical source path after its module move.

## What changed

- Read the CLI `AGENTS` table from `apps/cli/src/lib/agent-spec/agents.ts` instead of the compatibility facade at `apps/cli/src/lib/agents.ts`.
- Update the snapshot's source-of-truth comments to name the canonical file.

## Why

The release suite stopped with `AGENTS table entry for 'claude'` because `apps/cli/src/lib/agents.ts` now only re-exports `agent-spec/agents.ts`. The snapshot data itself is unchanged.

## Verification

```text
bun test src/core/agents.cli.test.ts
2 pass
0 fail
56 expect() calls

bun run compile:ext
$ tsc -p ./
```

The original release run reached `1593 pass` and failed only this stale source-path assertion before any build or registry mutation.

## Tracking

- RUSH-2986: https://linear.app/getrush/issue/RUSH-2986/agi-ext-land-fleet-load-row-preview-and-reply-error-fixes

No user-visible surface changes; this PR only repairs the release-blocking anti-drift test and its source comments.
