### PR TITLE
docs(ext): queue RUSH-2961 for 0.9.329

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
-## [0.9.328] - 2026-08-20
+## [0.9.329] - 2026-08-20
 
 - **New Agent separates placement from account choice (RUSH-2961).**
   `Agents: New <Harness>` lets agents-cli resolve the configured device target,
@@ -12,6 +12,8 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
   asks for the device and then the account; `(Auto)` keeps choosing both.
   Source: `src/core/launchTarget.ts`, `src/core/agents.ts`,
   `src/vscode/extension.ts`.
+
+## [0.9.328] - 2026-08-20
 
 - **A "needs you" reply button on the Fleet feed no longer fails silently.**
   Clicking an option on a row whose agent has no reachable reply channel — a


### PR DESCRIPTION
Docs-only release bookkeeping for RUSH-2961. Audience: extension maintainers.

## What changed

- Moves the already-merged RUSH-2961 extension note into a new `0.9.329` section.
- Leaves the previously published `0.9.328` notes unchanged.

## Why

VS Code Marketplace and Open VSX both currently serve `0.9.328`; RUSH-2961 merged afterward. The official extension release script requires a matching changelog section before publishing `0.9.329`.

## Verification

Docs-only. Both public registry APIs returned `0.9.328`; `git diff --check` passed.

Tracking: https://linear.app/getrush/issue/RUSH-2961/agi-ext-new-agent-auto-picks-device-but-prompts-for-versionaccount
Implementation: https://github.com/phnx-labs/agi-cli/pull/2862
