### PR TITLE
test(ext/ui): preload happy-dom via bunfig so markdown-rendering tests pass standalone (RUSH-2974)

### DIFF
--- a/apps/ext/ui/AGENTS.md
+++ b/apps/ext/ui/AGENTS.md
@@ -27,6 +27,17 @@ Default to using Bun instead of Node.js.
 
 Use `bun test` to run tests.
 
+Run the ui suite from this directory (`apps/ext/ui`): `bunfig.toml` here
+preloads `test-setup.ts`, which registers happy-dom globals before any test
+file is imported. That is what lets tests render components whose dependencies
+bind to `window` at module-evaluation time — dompurify behind `renderMarkdown`
+(`settings/utils/markdown.ts`) — regardless of file ordering (RUSH-2974). Bun
+only reads `bunfig.toml` from the invocation cwd, so a run launched from
+`apps/ext` does not get the preload; a test that needs the DOM and must also
+survive such runs keeps the guarded registration idiom from `App.test.tsx`
+(register happy-dom only when `document` is undefined, before any component
+import).
+
 ```ts#index.test.ts
 import { test, expect } from "bun:test";
 

--- a/apps/ext/ui/bunfig.toml
+++ b/apps/ext/ui/bunfig.toml
@@ -1,0 +1,4 @@
+# Applies when bun runs with this directory as cwd (the ui suite's own
+# invocation: `bun test` / `bun test <file>` from apps/ext/ui).
+[test]
+preload = ["./test-setup.ts"]

--- a/apps/ext/ui/test-setup.ts
+++ b/apps/ext/ui/test-setup.ts
@@ -1,0 +1,15 @@
+// Suite-wide bun test preload (wired via bunfig.toml). Registers happy-dom
+// globals BEFORE any test file is imported, so modules that bind to `window`
+// at evaluation time — dompurify behind renderMarkdown
+// (settings/utils/markdown.ts) — work in every test regardless of file
+// ordering. Before this preload, tests rendering a markdown-bearing component
+// (FeedItem) only passed when another file happened to register happy-dom
+// first (RUSH-2974).
+//
+// Guarded because individual test files (App.test.tsx,
+// FeedItem.preview.test.tsx) keep their own guarded registration for runs
+// launched outside this directory, where bunfig.toml — and this preload —
+// are not picked up: registering twice throws.
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+if (typeof (globalThis as { document?: unknown }).document === 'undefined') GlobalRegistrator.register()


### PR DESCRIPTION
Fixes RUSH-2974 (https://linear.app/getrush/issue/RUSH-2974). Test-infrastructure change: a bun test preload (`bunfig.toml` + `test-setup.ts`) plus a doc note — no product code changed.

**Run evidence (uploaded log of the actual runs):** https://share.agents-cli.sh/muqsitnawaz/ext-md-tests-rush-2974-run-88a0af132fa766fc

## Problem

`renderMarkdown` (`apps/ext/ui/settings/utils/markdown.ts`) calls `DOMPurify.sanitize`, and dompurify binds to `window` at module-evaluation time. Most `apps/ext/ui` tests are deliberately DOM-free, so any test rendering a markdown-bearing component (FeedItem) threw `TypeError: DOMPurify.sanitize is not a function` unless another test file had registered happy-dom first — coverage that passed only by file ordering, which hid the compact-row bug fixed in PR #2854.

## Before (standalone, at HEAD)

```
$ cd apps/ext/ui && bun test settings/components/mission-control/FeedItem.openTerminal.test.tsx
TypeError: DOMPurify.sanitize is not a function. (In 'DOMPurify.sanitize(raw, {
    ALLOWED_TAGS: TODO_MARKDOWN_ALLOWED_TAGS, ...
 0 pass
 4 fail
```

## Fix

- `apps/ext/ui/bunfig.toml` — `[test] preload = ["./test-setup.ts"]`
- `apps/ext/ui/test-setup.ts` — registers happy-dom globals (guarded) before any test file is imported, so window-binding modules like dompurify evaluate correctly regardless of file ordering. No change to `FeedItem.openTerminal.test.tsx` was needed — the preload alone makes it pass standalone.
- `apps/ext/ui/AGENTS.md` — documents the preload and the remaining case: bun only reads `bunfig.toml` from the invocation cwd, so runs launched from `apps/ext` keep the guarded-registration idiom (`App.test.tsx`, `FeedItem.preview.test.tsx`), which stays harmless under the preload.

## After (see uploaded run log above)

```
$ cd apps/ext/ui && bun test settings/components/mission-control/FeedItem.openTerminal.test.tsx
 4 pass
 0 fail

$ cd apps/ext/ui && bun test
 453 pass
 0 fail
Ran 453 tests across 36 files.
```

Root `apps/ext` suite (`bun run test`, discovers ui/ without the preload): 1605 pass, 0 fail — unchanged behavior, the guarded idiom still covers that path.