### PR TITLE
fix(devices): bound the fleet stats cache with a TTL; default list read becomes the writer (#2666)

### DIFF
--- a/apps/cli/.changelog/next/issue-2666.md
+++ b/apps/cli/.changelog/next/issue-2666.md
@@ -1,0 +1,12 @@
+- **`agents devices list` no longer serves fossilized load/mem numbers (#2666).** The
+  fleet stats cache (`.fleet-stats.json`) had no age bound and — since RUSH-2061
+  removed the daemon's N² fleet warm — no background writer, so the load/mem columns
+  froze at the last manual `--refresh` and re-rendered as current fleet state
+  indefinitely (observed: a 9-day-old row reporting an idle Mac at 1058% load). Cached
+  rows are now bounded by `STATS_STALE_MS` (3 minutes, the same window as the
+  agent-count mirror): a row past the bound is treated like a missing one — re-probed
+  live this call and rewritten — so the default `devices list` / `devices status` read
+  is itself the cache's writer and a stale value can never be presented as current.
+  This cache feeds the fleet scheduler, `--device auto` affinity, and the
+  session-start fleet banner. Source: `apps/cli/src/lib/devices/stats-cache.ts`,
+  `apps/cli/src/commands/ssh.ts`.

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -94,7 +94,7 @@ import {
   renderFleetWarnings,
   type FleetHealthRow,
 } from '../lib/devices/health-report.js';
-import { loadFleetStats, readStatsCache } from '../lib/devices/stats-cache.js';
+import { isFreshDeviceStats, loadFleetStats, readStatsCache } from '../lib/devices/stats-cache.js';
 import { collectLocalFleetInventory } from '../lib/devices/fleet-inventory.js';
 import { checkSyncStatus, countOrphans } from '../lib/drift.js';
 import { checkAllClis } from '../lib/teams/agents.js';
@@ -1880,7 +1880,7 @@ function registerDevicesCommands(program: Command): void {
         .map((t) => t.device);
       // Only spin when we'll actually ssh (forced, or a cold/partial cache).
       const cache = readStatsCache();
-      const willSsh = forceRefresh || probeable.some((d) => d.name !== self && !cache[d.name]);
+      const willSsh = forceRefresh || probeable.some((d) => d.name !== self && (!cache[d.name] || !isFreshDeviceStats(cache[d.name])));
       const spinner = willSsh && isInteractiveTerminal()
         ? ora(`Probing ${probeable.length} device${probeable.length === 1 ? '' : 's'}…`).start()
         : undefined;

--- a/apps/cli/src/lib/devices/stats-cache.test.ts
+++ b/apps/cli/src/lib/devices/stats-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { loadFleetStats } from './stats-cache.js';
+import { STATS_STALE_MS, isFreshDeviceStats, loadFleetStats } from './stats-cache.js';
 import type { DeviceStats } from './health.js';
 import type { DeviceProfile } from './registry.js';
 
@@ -30,6 +30,7 @@ describe('loadFleetStats', () => {
     const cache = { a: stat('a', 1000), b: stat('b', 1000) };
     const res = await loadFleetStats([dev('a'), dev('b')], {
       selfName: 'z', // not in the list — no local probe needed either
+      now: 2000,
       readCache: () => ({ ...cache }),
       writeCache: () => {},
       probeFleet: fakeProbe(2000, probed),
@@ -46,6 +47,7 @@ describe('loadFleetStats', () => {
     const cache = { z: stat('z', 1000) };
     const res = await loadFleetStats([dev('z')], {
       selfName: 'z',
+      now: 2000,
       readCache: () => ({ ...cache }),
       writeCache: () => {},
       probeFleet: fakeProbe(2000, probed),
@@ -63,6 +65,7 @@ describe('loadFleetStats', () => {
     const cache = { a: stat('a', 1000) };
     const res = await loadFleetStats([dev('a'), dev('b')], {
       selfName: 'z',
+      now: 2000,
       readCache: () => ({ ...cache }),
       writeCache: (e) => { written.push(e); },
       probeFleet: fakeProbe(2000, probed),
@@ -100,5 +103,39 @@ describe('loadFleetStats', () => {
       probeLocal: (async (h: string) => stat(h, 3000)) as never,
     });
     expect(res.stats.get('z')?.fetchedAt).toBe(3000);
+  });
+
+  // #2666: a cache entry older than STATS_STALE_MS must never be presented as
+  // current load — it is re-probed live and the fresh row rewrites the cache.
+  it('re-probes and rewrites a cache entry older than STATS_STALE_MS instead of serving it', async () => {
+    const now = 10_000_000;
+    const probed: string[] = [];
+    const written: Record<string, DeviceStats>[] = [];
+    const cache = {
+      fresh: stat('fresh', now - STATS_STALE_MS, 10),          // exactly on the bound — still served
+      stale: stat('stale', now - STATS_STALE_MS - 1, 1058),    // the fossilized 9-day-old shape
+    };
+    const res = await loadFleetStats([dev('fresh'), dev('stale')], {
+      selfName: 'z',
+      now,
+      readCache: () => ({ ...cache }),
+      writeCache: (e) => { written.push(e); },
+      probeFleet: fakeProbe(now, probed),
+      probeLocal: (async (h: string) => stat(h, now)) as never,
+    });
+    expect(probed).toEqual(['stale']);                    // stale re-probed, fresh untouched
+    expect(res.stats.get('stale')?.loadPercent).toBe(10); // the live number, not 1058
+    expect(res.stats.get('stale')?.fetchedAt).toBe(now);
+    expect(res.stats.get('fresh')?.fetchedAt).toBe(now - STATS_STALE_MS);
+    expect(written).toHaveLength(1);                      // the default read is the writer now
+    expect(Object.keys(written[0])).toEqual(['stale']);
+  });
+
+  it('isFreshDeviceStats bounds a row at STATS_STALE_MS', () => {
+    const now = 1_000_000;
+    expect(isFreshDeviceStats(stat('a', now), now)).toBe(true);
+    expect(isFreshDeviceStats(stat('a', now - STATS_STALE_MS), now)).toBe(true);
+    expect(isFreshDeviceStats(stat('a', now - STATS_STALE_MS - 1), now)).toBe(false);
+    expect(isFreshDeviceStats(stat('a', now - 9 * 24 * 3600_000), now)).toBe(false); // the observed 9d row
   });
 });

--- a/apps/cli/src/lib/devices/stats-cache.ts
+++ b/apps/cli/src/lib/devices/stats-cache.ts
@@ -15,10 +15,14 @@
  * - **`--refresh` / `--live`:** skip the cache and live-probe every device,
  *   rewriting the cache.
  *
- * The daemon warms this cache (~every 3 min, see `lib/daemon/daemon.ts
- * runFleetCacheWarm`), so in steady state a default read has zero
- * remote ssh round-trips and returns immediately with data that is at most a
- * few minutes old — surfaced to the user as an "as of …" freshness note.
+ * Every cached row is bounded by {@link STATS_STALE_MS}: a row older than the
+ * window is treated exactly like a missing one — re-probed live this call and
+ * rewritten — so the default read is itself the cache's writer and a value can
+ * never fossilize at the last manual `--refresh`. (The daemon used to warm this
+ * cache every ~3 min; RUSH-2061 removed that N² fleet probe, which left the
+ * unbounded read serving multi-day-old rows as current fleet state — the
+ * scheduler, `--device auto`, and the session-start banner all read these
+ * numbers. See #2666.)
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -28,6 +32,20 @@ import { probeFleetStats, probeLocalStats, type DeviceStats } from './health.js'
 import type { DeviceProfile } from './registry.js';
 
 const CACHE_FILE = '.fleet-stats.json';
+
+/**
+ * Freshness bound for a cached row. Matches the agent-count mirror's window
+ * (`AGENT_STATUS_STALE_MS` in `commands/ssh.ts`) so both columns of
+ * `devices list` / `fleet status` share one staleness model. A row older than
+ * this is never served as current — it is re-probed live (and the probe result
+ * rewrites the cache, unreachable boxes included).
+ */
+export const STATS_STALE_MS = 3 * 60_000;
+
+/** True when a cached row is still within {@link STATS_STALE_MS}. */
+export function isFreshDeviceStats(stats: DeviceStats, now: number = Date.now()): boolean {
+  return now - stats.fetchedAt <= STATS_STALE_MS;
+}
 
 interface StatsCacheFile {
   version: 1;
@@ -88,6 +106,8 @@ export interface LoadFleetStatsOptions {
   probeLocal?: typeof probeLocalStats;
   readCache?: typeof readStatsCache;
   writeCache?: typeof writeStatsCache;
+  /** Clock override for tests (drives the {@link STATS_STALE_MS} bound). */
+  now?: number;
 }
 
 /**
@@ -104,6 +124,7 @@ export async function loadFleetStats(
   const readCache = opts.readCache ?? readStatsCache;
   const writeCache = opts.writeCache ?? writeStatsCache;
   const self = opts.selfName;
+  const now = opts.now ?? Date.now();
   const cache = opts.forceRefresh ? {} : readCache();
 
   const stats = new Map<string, DeviceStats>();
@@ -117,10 +138,12 @@ export async function loadFleetStats(
       continue;
     }
     const cached = cache[d.name];
-    if (cached) {
+    if (cached && isFreshDeviceStats(cached, now)) {
       stats.set(d.name, cached);
       servedFromCache = true;
     } else {
+      // Missing OR beyond the staleness bound: a stale number rendered as
+      // current is worse than the probe's cost, so re-probe live (#2666).
       toProbe.push(d);
     }
   }


### PR DESCRIPTION
Fixes #2666 — `agents devices list` load/mem columns fossilized at the last manual `--refresh` and re-rendered as current fleet state forever (observed: a 9-day-old row reporting an idle Mac at 1058% load).

## Root cause (two composing defects)

1. **No TTL on the cache read.** `loadFleetStats` served any cached row regardless of age (`stats-cache.ts` old lines 113-121); `fetchedAt` was only used for the display note.
2. **No remaining writer.** RUSH-2061 rightly removed the daemon's N² fleet warm but moved only the agent-count column onto the bounded mirror; `.fleet-stats.json`'s only writers left were the user-invoked `--refresh`/`--live` paths.

## Fix — standardize at the source, no fallback

`loadFleetStats` now bounds every cached row with `STATS_STALE_MS = 3 * 60_000` (`apps/cli/src/lib/devices/stats-cache.ts:43`) — the same window as the sibling agent-count mirror (`AGENT_STATUS_STALE_MS`, `commands/ssh.ts:681`), so both columns share one staleness model. A row past the bound is treated exactly like a missing one: **re-probed live this call and rewritten**. That makes the default `devices list` / `devices status` read itself the cache's writer — no daemon, no second scheduler, no band-aid hiding the missing warm. An unreachable box degrades to a `reachable: false` row (rendered offline/`—`), never a confident stale number. The spinner predicate (`commands/ssh.ts:1883`) uses the same bound so a re-probing call shows "Probing…" instead of silently hanging.

**Downstream consumers this un-poisons:** this cache feeds the fleet scheduler, `--device auto` affinity, `factory/snapshot.ts` idle scoring, `sessions migrate` target scoring, and the session-start fleet banner that labels these numbers "live load / memory / headroom" — all of them were reading multi-day-old rows as current. The on-demand refresh keeps the file itself within the window for the raw `readStatsCache()` readers too.

## Before / after (real code path, no mocks)

Same repro both times: isolated `$HOME`, real on-disk `.fleet-stats.json` seeded with a 9-day-old row (`loadPercent: 1058`) for an unresolvable host, then one default (non-`--refresh`) `loadFleetStats` call with the real ssh probe.

**Before (origin/main):** the fossil is served as current and never rewritten —

```
cache row before: {"host":"ghost-box","reachable":true,"loadPercent":1058,...,"fetchedAt":1786575594977} (age 9d)
served row now : {"host":"ghost-box","reachable":true,"loadPercent":1058,"memPercent":50,"ncpu":18,"fetchedAt":1786575594977}
servedFromCache: true
```

**After (this branch):** the fossil is not served; a live probe runs and rewrites the cache —

```
cache row before: {"host":"ghost-box","reachable":true,"loadPercent":1058,...,"fetchedAt":1786575582872} (age 9d)
served row now : {"host":"ghost-box","reachable":false,"fetchedAt":1787353183390}
servedFromCache: false
cache row after: {"host":"ghost-box","reachable":false,"fetchedAt":1787353183390} (rewritten by the default read)
```

## Tests

New in `stats-cache.test.ts`: a beyond-TTL row is re-probed (the 1058 fixture is never presented as current load) and the fresh row is persisted; a row exactly on the bound is still served; `isFreshDeviceStats` boundary cases including the observed 9-day age. Existing cache-serving tests now pin an explicit clock. `bunx vitest run src/lib/devices/` — 28 files, 404 tests, all green; `tsc --noEmit` clean.

## Docs / companion audit

Module doc rewritten — it previously asserted the removed daemon warm as the design invariant. Changelog fragment at `.changelog/next/issue-2666.md`. Companion `.agents-system` audit: no hook/skill/command teaches the stale load/mem behavior (`skills/devices/SKILL.md` only covers `sync` reachability snapshots) — no companion edit needed.
