### PR TITLE
fix(menubar): stop mixed-Node relaunch loop

### DIFF
--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -160,24 +160,38 @@ describe('menubarPlistNeedsRepoint', () => {
   const nvmNode = '/Users/me/.nvm/versions/node/v24/bin/node';
   const bunNode = '/Users/me/.bun/bin/node';
 
+  const check = (overrides: Partial<Parameters<typeof menubarPlistNeedsRepoint>[0]>) =>
+    menubarPlistNeedsRepoint({
+      plistEntry: bun,
+      plistNode: bunNode,
+      plistNodeExists: true,
+      activeEntry: bun,
+      activeNode: bunNode,
+      ...overrides,
+    });
+
   it('re-points when the plist entry differs from the active install', () => {
-    expect(menubarPlistNeedsRepoint({ plistEntry: nvm, plistNode: nvmNode, activeEntry: bun, activeNode: bunNode })).toBe(true);
+    expect(check({ plistEntry: nvm, plistNode: nvmNode })).toBe(true);
   });
 
-  it('re-points when only the node interpreter drifted (same entry path)', () => {
-    expect(menubarPlistNeedsRepoint({ plistEntry: bun, plistNode: nvmNode, activeEntry: bun, activeNode: bunNode })).toBe(true);
+  it('keeps a valid recorded interpreter when the same install runs under another Node', () => {
+    expect(check({ plistNode: nvmNode })).toBe(false);
+  });
+
+  it('re-points when the recorded interpreter no longer exists', () => {
+    expect(check({ plistNode: nvmNode, plistNodeExists: false })).toBe(true);
   });
 
   it('does NOT re-point when the plist already matches the active install', () => {
-    expect(menubarPlistNeedsRepoint({ plistEntry: bun, plistNode: bunNode, activeEntry: bun, activeNode: bunNode })).toBe(false);
+    expect(check({})).toBe(false);
   });
 
   it('does NOT re-point (churn) when the active entry cannot be resolved (dev/tsx run)', () => {
-    expect(menubarPlistNeedsRepoint({ plistEntry: bun, plistNode: bunNode, activeEntry: null, activeNode: null })).toBe(false);
+    expect(check({ activeEntry: null, activeNode: null })).toBe(false);
   });
 
   it('re-points a plist that has no baked entry yet (older install)', () => {
-    expect(menubarPlistNeedsRepoint({ plistEntry: null, plistNode: null, activeEntry: bun, activeNode: bunNode })).toBe(true);
+    expect(check({ plistEntry: null, plistNode: null, plistNodeExists: false })).toBe(true);
   });
 });
 

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -455,12 +455,18 @@ function menubarSetupStale(): boolean {
 export function menubarPlistNeedsRepoint(opts: {
   plistEntry: string | null;
   plistNode: string | null;
+  plistNodeExists: boolean;
   activeEntry: string | null;
   activeNode: string | null;
 }): boolean {
   if (!opts.activeEntry) return false; // can't resolve the running install — don't churn
   if (opts.plistEntry !== opts.activeEntry) return true;
-  if (opts.activeNode && opts.plistNode !== opts.activeNode) return true;
+  // The entry path owns the helper. The same installed CLI may be invoked through
+  // several compatible Node interpreters (nvm, Homebrew, a parent process's
+  // process.execPath). Re-pointing merely because those valid interpreter paths
+  // differ makes every invocation replace and relaunch the shared helper. Keep the
+  // recorded interpreter until it disappears; then repoint to the active one.
+  if (opts.activeNode && (!opts.plistNode || !opts.plistNodeExists)) return true;
   return false;
 }
 
@@ -477,9 +483,11 @@ function readPlistEnvValue(key: string): string | null {
 
 /** True when the installed plist points at a different install than the active one. */
 function menubarSetupNeedsRepoint(): boolean {
+  const plistNode = readPlistEnvValue('AGENTS_NODE');
   return menubarPlistNeedsRepoint({
     plistEntry: readPlistEnvValue('AGENTS_ENTRY'),
-    plistNode: readPlistEnvValue('AGENTS_NODE'),
+    plistNode,
+    plistNodeExists: Boolean(plistNode) && fs.existsSync(plistNode as string),
     activeEntry: resolveCliEntry(),
     activeNode: process.execPath,
   });


### PR DESCRIPTION
Fixes a user-visible menu-bar relaunch loop when the same global agents-cli install is invoked through multiple valid Node interpreters.

## What changed

- Treat the installed CLI entry path as the menu-bar helper owner.
- Keep its recorded Node interpreter while that executable still exists.
- Repoint only when the owner entry changes or the recorded interpreter disappears.
- Add regression coverage for valid mixed-interpreter invocations and removed interpreters.

## Run evidence

[Focused test log: 47/47 passing](https://share.agents-cli.sh/muqsitnawaz/fix-menubar-node-repoint-rush-3005-focused-test-d9ec9f391d8d6820)

## Verification

- `bun run build` — passed.
- `bun run test src/lib/menubar/install-menubar.test.ts` — 47 tests passed.
- `bun run test:remote` — infrastructure could not provision a crabbox: Hetzner returned HTTP 403 `resource_limit_exceeded` (`server limit reached`).
- The local full suite reached unrelated environment failures in existing exec/install/PTY tests; the focused menu-bar suite remained green.

## Tracking

RUSH-3005

Pure bug fix; existing command and configuration surfaces are unchanged, so no docs or CHANGELOG update is required.
