### PR TITLE
fix(test): import DIST_ENTRY into the daemon.test.ts slice (test-only)

### DIFF
--- a/apps/cli/src/lib/daemon/daemon.test.ts
+++ b/apps/cli/src/lib/daemon/daemon.test.ts
@@ -36,7 +36,7 @@ import {
 } from './daemon.js';
 import { secretsKeychainItem, setKeychainToken } from '../secrets/index.js';
 import { writeBundle } from '../secrets/bundles.js';
-import { installKeychainHermeticity } from './daemon.test-fixture.js';
+import { DIST_ENTRY, installKeychainHermeticity } from './daemon.test-fixture.js';
 
 const systemdQuote = (value: string): string =>
   `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;


### PR DESCRIPTION
One-line what + type: **test-only** — restores the `DIST_ENTRY` import the RUSH-2819 four-way split dropped from `daemon.test.ts`, which left the darwin-only launchd test crashing with `ReferenceError: DIST_ENTRY is not defined` at `daemon.test.ts:411`.

## Run evidence
Run on **zion (darwin)** at this branch's head, where the crashing test actually executes: **41/41 passed** — uploaded log: https://share.agents-cli.sh/muqsitnawaz/fix-daemon-test-dist-entry-dist-entry-fix-zion-run-b0c289f71656d246
Linux run: 39 passed / 2 darwin-skipped; `tsc --noEmit` clean.

## Why it slipped and why it blocks the release
- The split (d9a783cd8) moved `DIST_ENTRY` to `daemon.test-fixture.ts` but `daemon.test.ts` kept one use at :411 without importing it. vitest transforms without type-checking, so it's a latent ReferenceError that only fires when the test EXECUTES — darwin only. Linux PR CI passed, so it merged silently (committer 22:06 tonight) — the same macOS-only blind spot RUSH-2968 flagged.
- Every exact-tree release attestation of origin/main since 22:06 fails deterministically on this test — it is the current blocker for publishing 1.22.44 (evidence trail in RUSH-3007).

Diff is one line (`import { DIST_ENTRY, installKeychainHermeticity }`).