### PR TITLE
docs(observability): drop the removed plan-tier gate section (RUSH-2581 review follow-up)

### DIFF
--- a/apps/cli/docs/observability.md
+++ b/apps/cli/docs/observability.md
@@ -1206,21 +1206,13 @@ agents insights --narrative                    # add a written read on the numbe
 | When you work | 24-slot local-time histogram of your messages |
 | Parallel sessions | overlapping pairs, and how many straddled two accounts |
 
-### Plan-tier gate (RUSH-2424)
+### No plan-tier gate
 
-The By-account breakdown and Friction section above are **paid**. On the free
-plan (see `apps/cli/src/lib/entitlement.ts`), the default report — grouped
-`--by account` — replaces the account table and the Friction section with a
-one-line notice: `Friction and account-split analysis are on the paid plan.`
-Top-line counts (scanned/analyzed totals), Top tools / Languages / Models,
-"What you changed", "When you work", and the harness-mix split stay free on
-every tier, as does `agents insights mix`/`agents perf` (separate command
-trees, never gated). Grouping by anything other than account (`--by agent`,
-`--by project`, `--by day`) is not gated — only the friction/correction facets
-within each group are stripped. `--narrative` is paid on every path. `--json`
-carries a `plan: {tierName, isPaid}` field and, when gated, `groups: null` (or
-the friction/correction facet keys stripped per group) plus a `notice` field —
-never a silently smaller report with no signal that anything was withheld.
+Every section of the report renders on every install, and `--json` carries the
+full facet set with no `plan`/`notice` fields. (A plan-tier gate briefly shipped
+in 1.22.42-1.22.43, reading the billing tier from the Rush/Prix backend; it was
+removed with the rest of that coupling pending the Phoenix-backed account layer,
+RUSH-2581.)
 
 ### Agent silent stalls (model goes quiet until you ping)
 


### PR DESCRIPTION
docs-only — pure doc edit, no run needed.

PR #2891's round-2 review (posted just after merge) found `docs/observability.md:1209-1223` still documenting the removed plan-tier gate — citing the deleted `entitlement.ts` and the removed `plan`/`notice` JSON fields. Replaced with a short no-gate note mirroring what `credential-management.md` already says. Audience: maintainers and end users of `agents insights`.

Linear: RUSH-2581.
