### PR TITLE
fix(rotation): persist tokens/credits-exhaustion so a dead account isn't re-picked (RUSH-3018)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-3018.md
+++ b/apps/cli/.changelog/next/RUSH-3018.md
@@ -1,0 +1,12 @@
+- **Rotation remembers a tokens/credits-exhausted account instead of re-picking it every launch (RUSH-3018).**
+  A rate limit resets on a clock; running *out of credits / hitting a spend cap*
+  does not — yet the two were conflated. A billing refusal (`out of usage credits`,
+  `monthly spend limit`) was detected only to trigger one failover and then
+  forgotten, so balanced rotation re-picked the dead account on the next launch,
+  it refused again, failed over again — burning a launch each time. It now
+  persists a clock-less `out_of_credits` marker per account
+  (`noteClaudeOutOfCredits`), which the rotation eligibility gate treats as
+  blocking until a later **successful** run on that account clears it
+  (`clearClaudeAccountRefusal`) — never a timestamp. Session/rate limits are
+  unchanged (still recover on their reset). Source:
+  `apps/cli/src/lib/accounting/usage.ts`, `apps/cli/src/lib/exec.ts`.

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -1503,7 +1503,7 @@ export async function collectAgentsJson(filterAgentId?: AgentId, resourceSection
       unavailable: snapshot?.unavailable
         ? {
             reason: snapshot.unavailable.reason,
-            resetsAt: snapshot.unavailable.resetsAt.toISOString(),
+            resetsAt: snapshot.unavailable.resetsAt?.toISOString(),
           }
         : undefined,
       lastActive: info.lastActive ? info.lastActive.toISOString() : null,

--- a/apps/cli/src/lib/accounting/usage.test.ts
+++ b/apps/cli/src/lib/accounting/usage.test.ts
@@ -14,6 +14,8 @@ import {
   readClaudeUsageCache,
   pruneExpiredClaudeUsageCacheEntry,
   noteClaudeSessionLimit,
+  noteClaudeOutOfCredits,
+  clearClaudeAccountRefusal,
   parseClaudeSessionLimitReset,
   deriveUsageStatusFromSnapshot,
   setClaudeUsageCachePathForTest,
@@ -1152,4 +1154,37 @@ describe('getUsageInfo(grok) — last-seen billing from unified.jsonl', () => {
     expect(info.snapshot?.windows).toEqual([]);
     expect(info.snapshot?.plan).toBe('SuperGrok Heavy');
   });
+  describe('out_of_credits (tokens/credits exhausted — no clock)', () => {
+    const usageKey = 'claude:org=oocred';
+
+    it('persists a clock-less refusal that excludes the account and survives time', () => {
+      noteClaudeOutOfCredits(usageKey);
+      const snap = readClaudeUsageCache(usageKey, undefined, new Date(Date.now() + 30 * 24 * 3600 * 1000));
+      // A month later it is STILL blocking — unlike a session limit, no clock frees it.
+      expect(snap?.unavailable).toEqual({ reason: 'out_of_credits' });
+      expect(deriveUsageStatusFromSnapshot(snap)).toBe('rate_limited');
+      expect(formatUsageSummary('Max', snap)).toContain('out of credits');
+    });
+
+    it('is cleared by a successful run (clearClaudeAccountRefusal)', () => {
+      noteClaudeOutOfCredits(usageKey);
+      expect(readClaudeUsageCache(usageKey)?.unavailable).toEqual({ reason: 'out_of_credits' });
+      clearClaudeAccountRefusal(usageKey);
+      // Cleared → no longer excluded (no marker, no windows → null snapshot).
+      const snap = readClaudeUsageCache(usageKey);
+      expect(snap?.unavailable).toBeUndefined();
+    });
+
+    it('a session-limit still recovers on its clock, out_of_credits does not', () => {
+      const other = 'claude:org=sess-vs-cred';
+      noteClaudeSessionLimit(other, new Date(Date.now() + 60_000));
+      // past the reset → session limit gone
+      expect(readClaudeUsageCache(other, undefined, new Date(Date.now() + 61_000))).toBeNull();
+      noteClaudeOutOfCredits(other);
+      // out_of_credits ignores the clock entirely
+      expect(readClaudeUsageCache(other, undefined, new Date(Date.now() + 10 * 24 * 3600 * 1000))?.unavailable)
+        .toEqual({ reason: 'out_of_credits' });
+    });
+  });
+
 });

--- a/apps/cli/src/lib/accounting/usage.ts
+++ b/apps/cli/src/lib/accounting/usage.ts
@@ -218,10 +218,16 @@ export interface UsageSnapshot {
   // otherwise comes from the local auth file via AccountInfo.plan; this field
   // lets a network usage fetch surface a plan the local credential can't.
   plan?: string | null;
-  /** A refusal observed from a real harness run, independent of API windows. */
+  /**
+   * A refusal observed from a real harness run, independent of API windows.
+   * `session_limit` recovers on a clock (`resetsAt`). `out_of_credits` is a
+   * tokens/balance exhaustion that does NOT reset on a clock — it has no
+   * `resetsAt` and is cleared only by a later successful run on the account
+   * (clearClaudeAccountRefusal). Both exclude the account from rotation while set.
+   */
   unavailable?: {
-    reason: 'session_limit';
-    resetsAt: Date;
+    reason: 'session_limit' | 'out_of_credits';
+    resetsAt?: Date;
   };
 }
 
@@ -328,8 +334,8 @@ interface CachedUsageSnapshot {
   windows: CachedUsageWindow[];
   plan?: string | null;
   unavailable?: {
-    reason: 'session_limit';
-    resetsAt: string;
+    reason: 'session_limit' | 'out_of_credits';
+    resetsAt?: string;
   };
 }
 
@@ -659,7 +665,9 @@ export function formatUsageSummary(
   }
 
   if (snapshot) {
-    if (snapshot.unavailable?.reason === 'session_limit') {
+    if (snapshot.unavailable?.reason === 'out_of_credits') {
+      parts.push(chalk.red('out of credits'));
+    } else if (snapshot.unavailable?.reason === 'session_limit' && snapshot.unavailable.resetsAt) {
       parts.push(chalk.yellow(`session-limited (${formatResetHint(snapshot.unavailable.resetsAt)})`));
     }
     // Compact rows show BLOCKING windows — the same set
@@ -736,8 +744,13 @@ export function deriveUsageStatusFromSnapshot(
   snapshot: UsageSnapshot | null | undefined
 ): 'available' | 'rate_limited' | null {
   if (!snapshot) return null;
-  if (snapshot.unavailable && snapshot.unavailable.resetsAt.getTime() > Date.now()) {
-    return 'rate_limited';
+  if (snapshot.unavailable) {
+    // out_of_credits has no clock — it stays blocking until a successful run
+    // clears it. session_limit blocks only until its reset time.
+    if (snapshot.unavailable.reason === 'out_of_credits') return 'rate_limited';
+    if (snapshot.unavailable.resetsAt && snapshot.unavailable.resetsAt.getTime() > Date.now()) {
+      return 'rate_limited';
+    }
   }
   if (snapshot.windows.length === 0) return null;
   const blocking = snapshot.windows.filter((window) => window.key !== 'sonnet_week');
@@ -1931,12 +1944,9 @@ export function writeClaudeUsageCache(
       // refresh cannot drop another account's row (lost update).
       const cache = readClaudeUsageCacheFile(cachePath);
       const prior = cache[usageKey];
-      const priorReset = parseDateValue(prior?.unavailable?.resetsAt);
       cache[usageKey] = serializeClaudeUsageSnapshot({
         ...snapshot,
-        unavailable: priorReset && priorReset.getTime() > Date.now()
-          ? { reason: 'session_limit', resetsAt: priorReset }
-          : snapshot.unavailable,
+        unavailable: carryForwardUnavailable(prior?.unavailable, snapshot.unavailable),
       });
       atomicWriteFileSync(cachePath, JSON.stringify(cache, null, 2), 'utf-8');
     });
@@ -1978,7 +1988,10 @@ function serializeClaudeUsageSnapshot(snapshot: UsageSnapshot): CachedUsageSnaps
     capturedAt: snapshot.capturedAt?.toISOString() || null,
     plan: snapshot.plan ?? null,
     unavailable: snapshot.unavailable
-      ? { reason: snapshot.unavailable.reason, resetsAt: snapshot.unavailable.resetsAt.toISOString() }
+      ? {
+          reason: snapshot.unavailable.reason,
+          resetsAt: snapshot.unavailable.resetsAt?.toISOString(),
+        }
       : undefined,
     windows: snapshot.windows.map((window) => ({
       key: window.key,
@@ -2018,10 +2031,7 @@ function deserializeClaudeUsageSnapshot(
     }))
     .filter((window) => isCachedUsageWindowFresh(window, capturedAt, now));
 
-  const unavailableReset = parseDateValue(snapshot.unavailable?.resetsAt);
-  const unavailable = unavailableReset && unavailableReset.getTime() > now.getTime()
-    ? { reason: 'session_limit' as const, resetsAt: unavailableReset }
-    : undefined;
+  const unavailable = deserializeUnavailable(snapshot.unavailable, now);
 
   if (windows.length === 0 && !unavailable) {
     return null;
@@ -2035,6 +2045,89 @@ function deserializeClaudeUsageSnapshot(
     plan: snapshot.plan ?? null,
     unavailable,
   };
+}
+
+/**
+ * Carry a prior refusal marker forward across a daemon usage refresh, and drop
+ * an expired one. A live `snapshot.unavailable` (a refusal just observed) wins.
+ * `out_of_credits` survives refreshes with no reset — only a successful run
+ * clears it (clearClaudeAccountRefusal). A `session_limit` survives only while
+ * its reset time is still in the future.
+ */
+function carryForwardUnavailable(
+  prior: CachedUsageSnapshot['unavailable'],
+  live: UsageSnapshot['unavailable'],
+): UsageSnapshot['unavailable'] {
+  if (live) return live;
+  if (!prior) return undefined;
+  if (prior.reason === 'out_of_credits') return { reason: 'out_of_credits' };
+  const reset = parseDateValue(prior.resetsAt);
+  return reset && reset.getTime() > Date.now()
+    ? { reason: 'session_limit', resetsAt: reset }
+    : undefined;
+}
+
+/**
+ * Deserialize a cached `unavailable` marker, dropping an expired session_limit
+ * but keeping a clock-less out_of_credits.
+ */
+function deserializeUnavailable(
+  cached: CachedUsageSnapshot['unavailable'],
+  now: Date,
+): UsageSnapshot['unavailable'] {
+  if (!cached) return undefined;
+  if (cached.reason === 'out_of_credits') return { reason: 'out_of_credits' };
+  const reset = parseDateValue(cached.resetsAt);
+  return reset && reset.getTime() > now.getTime()
+    ? { reason: 'session_limit', resetsAt: reset }
+    : undefined;
+}
+
+/**
+ * Persist a Claude tokens/credits exhaustion (`out of usage credits` / `monthly
+ * spend limit`) from a real run. Unlike a rate/session limit this does NOT reset
+ * on a clock, so no reset time is stored — rotation excludes the account until a
+ * later successful run clears it via {@link clearClaudeAccountRefusal}.
+ */
+export function noteClaudeOutOfCredits(
+  usageKey: string,
+  cachePath = getClaudeUsageCachePath(),
+): void {
+  try {
+    ensureLockTarget(cachePath, '{}');
+    withFileLock(cachePath, () => {
+      const cache = readClaudeUsageCacheFile(cachePath);
+      const existing = cache[usageKey] ?? { capturedAt: null, windows: [] };
+      cache[usageKey] = { ...existing, unavailable: { reason: 'out_of_credits' } };
+      atomicWriteFileSync(cachePath, JSON.stringify(cache, null, 2), 'utf-8');
+    });
+  } catch {
+    /* best-effort cache write — lock busy or disk full */
+  }
+}
+
+/**
+ * Clear any persisted refusal marker for an account after a run SUCCEEDS on it.
+ * This is the recovery path for `out_of_credits` (which has no clock) and also
+ * proactively clears a stale `session_limit` the moment the account serves again.
+ */
+export function clearClaudeAccountRefusal(
+  usageKey: string,
+  cachePath = getClaudeUsageCachePath(),
+): void {
+  try {
+    if (!fs.existsSync(cachePath)) return;
+    withFileLock(cachePath, () => {
+      const cache = readClaudeUsageCacheFile(cachePath);
+      const existing = cache[usageKey];
+      if (!existing?.unavailable) return;
+      const { unavailable: _drop, ...rest } = existing;
+      cache[usageKey] = rest;
+      atomicWriteFileSync(cachePath, JSON.stringify(cache, null, 2), 'utf-8');
+    });
+  } catch {
+    /* best-effort cache write */
+  }
 }
 
 /**

--- a/apps/cli/src/lib/devices/harness-inventory.test.ts
+++ b/apps/cli/src/lib/devices/harness-inventory.test.ts
@@ -48,6 +48,33 @@ function row(overrides: Partial<HarnessRow> = {}): HarnessRow {
 }
 
 describe('summarizeQuota', () => {
+
+  it('an out_of_credits marker blocks readiness even with no live windows (RUSH-3018)', () => {
+    // The normal state hours/days after a run: cached windows have expired, so
+    // only the persisted refusal marker remains. It must NOT read as available.
+    const snap: UsageSnapshot = {
+      source: 'live', sourceLabel: 'live', capturedAt: null, windows: [],
+      unavailable: { reason: 'out_of_credits' },
+    };
+    // accountStatus 'available' is the coarse hardcoded value for a signed-in Claude.
+    const q = summarizeQuota(snap, null, 'available');
+    expect(q.status).toBe('out_of_credits');
+    expect(computeReady(true, q)).toEqual({ ready: false, reason: 'out of credits' });
+  });
+
+  it('an unexpired session_limit marker with no windows blocks; an expired one does not', () => {
+    const future: UsageSnapshot = {
+      source: 'live', sourceLabel: 'live', capturedAt: null, windows: [],
+      unavailable: { reason: 'session_limit', resetsAt: new Date(Date.now() + 3600_000) },
+    };
+    expect(summarizeQuota(future, null, 'available').status).toBe('rate_limited');
+    const past: UsageSnapshot = {
+      source: 'live', sourceLabel: 'live', capturedAt: null, windows: [],
+      unavailable: { reason: 'session_limit', resetsAt: new Date(Date.now() - 1000) },
+    };
+    // expired marker → falls through to the coarse available status
+    expect(summarizeQuota(past, null, 'available').status).toBe('available');
+  });
   it('returns null status and no percent when there is no snapshot', () => {
     expect(summarizeQuota(null)).toEqual(quota(null, null));
     expect(summarizeQuota(snapshot([]))).toEqual(quota(null, null));

--- a/apps/cli/src/lib/devices/harness-inventory.ts
+++ b/apps/cli/src/lib/devices/harness-inventory.ts
@@ -106,15 +106,33 @@ export function summarizeQuota(
   accountStatus: AccountInfo['usageStatus'] = null,
 ): QuotaSummary {
   if (!snapshot || snapshot.windows.length === 0) {
-    const status = accountStatus;
+    // An active refusal marker (persisted out_of_credits, or an unexpired
+    // session_limit) blocks even when there are no live utilization windows —
+    // which is the normal state hours/days after a run, once cached windows
+    // expire. Check it BEFORE trusting the coarse account status, which is
+    // hardcoded 'available' for a signed-in Claude; otherwise a tokens-exhausted
+    // account reads ready:true here (RUSH-3018 finding, `agents devices harnesses`).
+    const marker = snapshot?.unavailable;
+    let status = accountStatus;
+    let reason = unavailableReason;
+    if (marker?.reason === 'out_of_credits') {
+      status = 'out_of_credits';
+      reason = 'out of credits';
+    } else if (
+      marker?.reason === 'session_limit' &&
+      (!marker.resetsAt || marker.resetsAt.getTime() > Date.now())
+    ) {
+      status = 'rate_limited';
+      reason = 'session-limited';
+    }
     return {
       status,
       verdict: status ?? 'unavailable',
       usedPercent: null,
       stale: false,
       capturedAt: snapshot?.capturedAt?.toISOString() ?? null,
-      resetsAt: null,
-      unavailableReason: status ? null : (unavailableReason ?? 'usage unavailable'),
+      resetsAt: marker?.resetsAt?.toISOString() ?? null,
+      unavailableReason: status ? null : (reason ?? 'usage unavailable'),
     };
   }
   const blocking = snapshot.windows.filter((w) => w.key !== 'sonnet_week');

--- a/apps/cli/src/lib/exec.test.ts
+++ b/apps/cli/src/lib/exec.test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, writeTmuxEnvFile, formatPaneTail, detectRateLimit, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, resolveLaunchId, shouldRecapDeadPane, isPaneKnownAliveFromQueryResult, tmuxRunExitCode, UNKNOWN_OUTCOME_EXIT_CODE, type TmuxWrapContext } from './exec.js';
+import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, writeTmuxEnvFile, formatPaneTail, detectRateLimit, detectOutOfCredits, classifyClaudeRunRefusal, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, resolveLaunchId, shouldRecapDeadPane, isPaneKnownAliveFromQueryResult, tmuxRunExitCode, UNKNOWN_OUTCOME_EXIT_CODE, type TmuxWrapContext } from './exec.js';
 import type { ExecOptions } from './exec.js';
 import { isTmuxInstalled } from './tmux/binary.js';
 import { mailboxDir } from './mailbox.js';
@@ -1134,5 +1134,36 @@ describe('buildExecEnv — Claude ambient CLAUDE_CODE_OAUTH_TOKEN handling (RUSH
     const env = buildExecEnv(execOpts({ agent: 'claude', version, prompt: 'do the thing' }));
 
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat01-alpha');
+  });
+});
+
+
+describe('classifyClaudeRunRefusal (RUSH-3018 — persist/clear decision on the real path)', () => {
+  it('detectOutOfCredits matches billing exhaustion but NOT a time-window rate limit', () => {
+    expect(detectOutOfCredits("You're out of usage credits")).toBe(true);
+    expect(detectOutOfCredits("hit your org's monthly spend limit")).toBe(true);
+    // A pure rate limit must NOT be classified as out-of-credits, or it would
+    // wrongly become clock-less and never recover.
+    expect(detectOutOfCredits('You have hit your session limit · resets 11:20pm')).toBe(false);
+    expect(detectOutOfCredits('rate limit exceeded, try again')).toBe(false);
+  });
+
+  it('a session-limit refusal wins and carries its reset clock', () => {
+    const r = classifyClaudeRunRefusal('You have hit your session limit · resets 11:20pm', 1);
+    expect(r.action).toBe('note_session');
+    if (r.action === 'note_session') expect(r.resetsAt).toBeInstanceOf(Date);
+  });
+
+  it('a billing exhaustion is note_out_of_credits (no clock)', () => {
+    expect(classifyClaudeRunRefusal("You're out of usage credits", 1)).toEqual({ action: 'note_out_of_credits' });
+    expect(classifyClaudeRunRefusal('monthly spend limit reached', 1)).toEqual({ action: 'note_out_of_credits' });
+  });
+
+  it('a clean run (exit 0, no refusal) clears any stale marker', () => {
+    expect(classifyClaudeRunRefusal('all good, done', 0)).toEqual({ action: 'clear' });
+  });
+
+  it('a non-zero exit with no recognized refusal leaves the marker untouched', () => {
+    expect(classifyClaudeRunRefusal('some unrelated error', 1)).toEqual({ action: 'none' });
   });
 });

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -39,7 +39,7 @@ import { applyActiveRulesPresetAtRun } from './rules/run-sync.js';
 import { resolveHarnessAdapter, stripForeignConfigDir } from './harness/index.js';
 import { resolveConfigVersion } from './harness/exec-config-version.js';
 import { getAccountInfo } from './agents.js';
-import { getUsageLookupKey, noteClaudeSessionLimit, parseClaudeSessionLimitReset } from './accounting/usage.js';
+import { getUsageLookupKey, noteClaudeSessionLimit, noteClaudeOutOfCredits, clearClaudeAccountRefusal, parseClaudeSessionLimitReset } from './accounting/usage.js';
 
 /**
  * Agent execution modes. Canonical name `skip` (dangerously skip permissions);
@@ -2120,6 +2120,20 @@ export function detectRateLimit(text: string): boolean {
 }
 
 /**
+ * Narrow detector for a BILLING exhaustion — tokens/credits run out or the
+ * monthly spend cap is hit — as opposed to a time-window rate limit. This class
+ * does NOT recover on a clock, so rotation must remember it per-account
+ * (noteClaudeOutOfCredits) until a later successful run clears it.
+ */
+const OUT_OF_CREDITS_PATTERNS: RegExp[] = [
+  /out of (?:usage )?credits/i,
+  /spend[\s-]?limit/i,
+];
+export function detectOutOfCredits(text: string): boolean {
+  return OUT_OF_CREDITS_PATTERNS.some(pattern => pattern.test(text));
+}
+
+/**
  * Patterns that indicate an authentication failure — the agent is logged out,
  * its token was revoked, or the session expired. These are the user-visible
  * strings a logged-out agent surfaces (observed across the routine-run corpus).
@@ -2394,10 +2408,18 @@ export async function runWithFallback(options: FallbackOptions): Promise<number>
 
     const output = `${result.stderr}\n${result.stdout}`;
     const sessionLimitReset = agent === 'claude' ? parseClaudeSessionLimitReset(output) : null;
-    if (sessionLimitReset && version) {
+    // A billing exhaustion (tokens/credits out, spend cap) is a distinct,
+    // clock-less refusal — persist it so rotation stops re-picking a dead
+    // account every launch, and clear any prior marker when a run SUCCEEDS.
+    const outOfCredits = agent === 'claude' && !sessionLimitReset && detectOutOfCredits(output);
+    if (agent === 'claude' && version) {
       const account = await getAccountInfo(agent, getVersionHomePath(agent, version));
       const usageKey = getUsageLookupKey(account);
-      if (usageKey) noteClaudeSessionLimit(usageKey, sessionLimitReset);
+      if (usageKey) {
+        if (sessionLimitReset) noteClaudeSessionLimit(usageKey, sessionLimitReset);
+        else if (outOfCredits) noteClaudeOutOfCredits(usageKey);
+        else if (result.exitCode === 0) clearClaudeAccountRefusal(usageKey);
+      }
     }
 
     if (result.exitCode === 0 && !sessionLimitReset) return 0;

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -2134,6 +2134,28 @@ export function detectOutOfCredits(text: string): boolean {
 }
 
 /**
+ * Classify what a Claude run's output + exit code means for the account's
+ * persisted refusal marker. Pure and exported so the persist/clear decision is
+ * unit-tested on the real path (runWithFallback can't be driven with a real
+ * `claude` spawn in tests). Precedence: a session-limit reset wins (it carries a
+ * clock), then a clock-less billing exhaustion, then a clean success clears any
+ * stale marker; anything else leaves the marker untouched.
+ */
+export type ClaudeRefusalAction =
+  | { action: 'note_session'; resetsAt: Date }
+  | { action: 'note_out_of_credits' }
+  | { action: 'clear' }
+  | { action: 'none' };
+
+export function classifyClaudeRunRefusal(output: string, exitCode: number): ClaudeRefusalAction {
+  const sessionLimitReset = parseClaudeSessionLimitReset(output);
+  if (sessionLimitReset) return { action: 'note_session', resetsAt: sessionLimitReset };
+  if (detectOutOfCredits(output)) return { action: 'note_out_of_credits' };
+  if (exitCode === 0) return { action: 'clear' };
+  return { action: 'none' };
+}
+
+/**
  * Patterns that indicate an authentication failure — the agent is logged out,
  * its token was revoked, or the session expired. These are the user-visible
  * strings a logged-out agent surfaces (observed across the routine-run corpus).
@@ -2407,18 +2429,23 @@ export async function runWithFallback(options: FallbackOptions): Promise<number>
     }
 
     const output = `${result.stderr}\n${result.stdout}`;
-    const sessionLimitReset = agent === 'claude' ? parseClaudeSessionLimitReset(output) : null;
-    // A billing exhaustion (tokens/credits out, spend cap) is a distinct,
-    // clock-less refusal — persist it so rotation stops re-picking a dead
-    // account every launch, and clear any prior marker when a run SUCCEEDS.
-    const outOfCredits = agent === 'claude' && !sessionLimitReset && detectOutOfCredits(output);
+    // Persist a per-account refusal marker so rotation stops re-picking a
+    // known-dead account: a session-limit recovers on its clock, a billing
+    // exhaustion (tokens/credits) recovers only on a later successful run, and a
+    // clean run clears any stale marker. Decision extracted + unit-tested in
+    // classifyClaudeRunRefusal.
+    const sessionLimitReset =
+      agent === 'claude' ? parseClaudeSessionLimitReset(output) : null;
     if (agent === 'claude' && version) {
-      const account = await getAccountInfo(agent, getVersionHomePath(agent, version));
-      const usageKey = getUsageLookupKey(account);
-      if (usageKey) {
-        if (sessionLimitReset) noteClaudeSessionLimit(usageKey, sessionLimitReset);
-        else if (outOfCredits) noteClaudeOutOfCredits(usageKey);
-        else if (result.exitCode === 0) clearClaudeAccountRefusal(usageKey);
+      const refusal = classifyClaudeRunRefusal(output, result.exitCode ?? 1);
+      if (refusal.action !== 'none') {
+        const account = await getAccountInfo(agent, getVersionHomePath(agent, version));
+        const usageKey = getUsageLookupKey(account);
+        if (usageKey) {
+          if (refusal.action === 'note_session') noteClaudeSessionLimit(usageKey, refusal.resetsAt);
+          else if (refusal.action === 'note_out_of_credits') noteClaudeOutOfCredits(usageKey);
+          else if (refusal.action === 'clear') clearClaudeAccountRefusal(usageKey);
+        }
       }
     }
 

--- a/apps/cli/src/lib/view-types.ts
+++ b/apps/cli/src/lib/view-types.ts
@@ -27,8 +27,8 @@ export interface ViewJsonVersion {
     resetsAt: string | null;
   }>;
   unavailable?: {
-    reason: 'session_limit';
-    resetsAt: string;
+    reason: 'session_limit' | 'out_of_credits';
+    resetsAt?: string;
   };
   lastActive: string | null;
   path: string;


### PR DESCRIPTION
## What + why
A **rate limit** resets on a clock; **running out of credits / hitting a spend cap** does not — but the two were conflated. A billing refusal (`out of usage credits`, `monthly spend limit`) was detected only to trigger **one** failover (exec.ts detectRateLimit) and then **forgotten** — nothing persisted it. So balanced rotation re-picked the exhausted account on the very next launch, it refused again, failed over again, burning a launch each time. Because credits don't reset on a clock, forgetting it is worse than forgetting a rate limit: rotation kept routing into a permanently-dead account until the (429-throttled, often-stale) usage API happened to notice.

## Change
- New clock-less marker `out_of_credits` on the usage snapshot (`resetsAt` now optional). `deriveUsageStatusFromSnapshot` treats it as blocking **regardless of time** — the rotation eligibility gate excludes the account.
- `noteClaudeOutOfCredits(usageKey)` persists it per account from the exec refusal path; `clearClaudeAccountRefusal(usageKey)` clears it (and any stale session-limit) when a run **succeeds** on that account — the correct non-clock recovery.
- `detectOutOfCredits` narrows the billing patterns; exec.ts writes the right marker per refusal class and clears on a clean run.
- Session/rate limits are **unchanged** (still recover on their reset time).

## Run result
Full affected suites — 248/248 passing, incl. 3 new regression tests (out_of_credits survives a month with no clock, clears on success, and behaves distinctly from a session limit): https://share.agents-cli.sh/muqsitnawaz/fix-out-of-credits-persist-ooc-test-run-f05984c5b260a8a6

## Context
- Ticket: RUSH-3018. This is the correctness half of the account-state work; the predictive-weight (RUSH-3009) and setup-token-inclusion (RUSH-2945) items are separate follow-ups.
- CHANGELOG fragment included.