### PR TITLE
test(release): fix macOS ENOENT in promote-home-base-probe stub bin (unblocks Mac releases off non-CI boxes)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-3026-macos.md
+++ b/apps/cli/.changelog/next/RUSH-3026-macos.md
@@ -1,0 +1,8 @@
+- **`promote-home-base-probe.test.ts` no longer ENOENTs the whole file on macOS.**
+  The stub-bin helper symlinked `bash` from the Linux-only `/usr/bin/bash`; on
+  macOS (where bash lives at `/bin/bash` and `/usr/bin/bash` does not exist) the
+  symlink was never created, so `spawnSync(<bin>/bash, …)` returned a null exit
+  and `undefinedundefined` output — failing all four probe tests and, because the
+  attestation producer runs the full suite, blocking every release cut from a Mac
+  home base that isn't the CI image. Each of `bash`/`env`/`sh` now resolves from
+  per-OS candidate paths. Test-only.

--- a/apps/cli/scripts/promote-home-base-probe.test.ts
+++ b/apps/cli/scripts/promote-home-base-probe.test.ts
@@ -29,13 +29,17 @@ function stubBin(names: string[], overrides: Record<string, string> = {}): strin
   // The probe judges the box by what is on PATH, so the child PATH is the stub
   // dir ONLY — a real /usr/bin on it leaked the host's own jq into the
   // "missing tool" case. bash/env come in as symlinks so the stubs' shebangs
-  // and the probe itself still resolve.
-  for (const [name, target] of [
-    ['bash', '/usr/bin/bash'],
-    ['env', '/usr/bin/env'],
-    ['sh', '/bin/sh'],
+  // and the probe itself still resolve. Each has per-OS location candidates:
+  // macOS ships bash at /bin/bash (there is no /usr/bin/bash), while Linux has
+  // /usr/bin/bash — hardcoding one made this whole file ENOENT on macOS.
+  for (const [name, targets] of [
+    ['bash', ['/usr/bin/bash', '/bin/bash']],
+    ['env', ['/usr/bin/env', '/bin/env']],
+    ['sh', ['/bin/sh', '/usr/bin/sh']],
   ] as const) {
-    if (!names.includes(name) && fs.existsSync(target)) fs.symlinkSync(target, path.join(dir, name));
+    if (names.includes(name)) continue;
+    const target = targets.find((t) => fs.existsSync(t));
+    if (target) fs.symlinkSync(target, path.join(dir, name));
   }
   return dir;
 }


### PR DESCRIPTION
## What + why
`promote-home-base-probe.test.ts` symlinked `bash` from the **Linux-only** `/usr/bin/bash`. On macOS bash is at `/bin/bash` and `/usr/bin/bash` doesn't exist, so the stub was never created and `spawnSync(<bin>/bash, …)` returned a **null exit code** with `undefinedundefined` output — failing all 4 probe tests.

Because the release attestation producer runs the **full suite** and refuses a red tree, this blocked **every release cut from a Mac home base that isn't the CI image** — e.g. driving the release from **zion when mac-mini is offline** (tonight's situation). It passed on CI/Linux, so it was invisible until a non-CI Mac produced an attestation.

## Change
`bash`/`env`/`sh` now resolve from **per-OS candidate paths** in the test's stub-bin helper (`/bin/bash` on macOS, `/usr/bin/bash` on Linux). Plus a CHANGELOG fragment. No product code changed.

## Run result — ran it on the failing box (zion, Darwin 25.4.0)
Full captured run: https://share.agents-cli.sh/muqsitnawaz/fix-probe-test-macos-bash-probe-test-run-c021695d8655ad18

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```
Before this change on macOS/zion: 4 failed | 6 passed. After: 10 passed.

## Context
Relates RUSH-3026. This is the exact blocker stopping the RUSH-3018 fix from shipping while mac-mini (the default signing home base) is offline.