### PR TITLE
fix(test): promote-probe stub PATH resolves bash from per-OS candidates (test-only)

### DIFF
--- a/apps/cli/scripts/promote-home-base-probe.test.ts
+++ b/apps/cli/scripts/promote-home-base-probe.test.ts
@@ -30,12 +30,18 @@ function stubBin(names: string[], overrides: Record<string, string> = {}): strin
   // dir ONLY — a real /usr/bin on it leaked the host's own jq into the
   // "missing tool" case. bash/env come in as symlinks so the stubs' shebangs
   // and the probe itself still resolve.
-  for (const [name, target] of [
-    ['bash', '/usr/bin/bash'],
-    ['env', '/usr/bin/env'],
-    ['sh', '/bin/sh'],
+  // Interpreter locations differ by OS — bash is /usr/bin/bash on Linux but
+  // /bin/bash on macOS (no /usr/bin/bash there). Resolve each name from its
+  // candidates or runProbe spawns a nonexistent <stub>/bash on darwin and
+  // every test reads status:null (the exact all-Mac failure this fixes).
+  for (const [name, candidates] of [
+    ['bash', ['/usr/bin/bash', '/bin/bash']],
+    ['env', ['/usr/bin/env', '/bin/env']],
+    ['sh', ['/bin/sh', '/usr/bin/sh']],
   ] as const) {
-    if (!names.includes(name) && fs.existsSync(target)) fs.symlinkSync(target, path.join(dir, name));
+    if (names.includes(name)) continue;
+    const target = candidates.find((c) => fs.existsSync(c));
+    if (target) fs.symlinkSync(target, path.join(dir, name));
   }
   return dir;
 }


### PR DESCRIPTION
One-line what + type: **test-only** — `stubBin` in `promote-home-base-probe.test.ts` symlinked `bash` from `/usr/bin/bash`, which exists on Linux but not macOS (`/bin/bash` there), so on every Mac `runProbe` spawned a nonexistent `<stub>/bash` → ENOENT → `status: null`, `out: 'undefinedundefined'` — 4 of 10 tests deterministically red, killing every darwin full-suite attestation since the file merged (75f8faf84 tonight; Linux PR CI green, the same macOS blind spot as #2886).

## Run evidence
- **darwin (zion), the failing platform, at this branch**: Test Files 1 passed, **Tests 10 passed (10)** — was 4 failed at rest on a clean tip worktree before the fix.
- Linux (this box): 10/10.

## What changed
One hunk: bash/env/sh resolve from per-OS candidate lists (`/usr/bin/bash` then `/bin/bash`, etc.) with a comment naming the darwin failure shape. No behavior change on Linux (first candidate is the old path).

Context: third deterministic main breaker found during tonight's 1.22.44/1.22.46 release attestations (after #2886 DIST_ENTRY and #2896 probe-reap); currently blocks the 1.22.46 attestation on zion.