### PR TITLE
fix(teams): observe AgentManager init rejection — unhandled ENOENT crashed green suites (RUSH-3036)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-3036-retention-flake.md
+++ b/apps/cli/.changelog/next/RUSH-3036-retention-flake.md
@@ -1,0 +1,1 @@
+- fix(teams): observe AgentManager's fire-and-forget init rejection so a lost init race (dir removed mid-mkdir) fails the awaiting caller instead of crashing the process as an unhandled rejection — the flake that failed two fully-green release attestation runs

--- a/apps/cli/src/lib/teams/agents.retention.test.ts
+++ b/apps/cli/src/lib/teams/agents.retention.test.ts
@@ -270,3 +270,25 @@ describe('isWorktreeClaimed distinguishes an orphan worktree from a live teammat
   // every test in it passed. The per-record ENOENT branch IS covered, by the
   // no-meta.json case in the test above.
 });
+
+describe('constructor init failure is observed, never an unhandled rejection (RUSH-3036)', () => {
+  it('a manager whose base dir cannot be created fails at the AWAITED call, not the process', async () => {
+    // The measured flake: afterEach removed the temp base while a constructed
+    // manager's fire-and-forget doInitialize() was still queued — the mkdir
+    // ENOENT became an unhandled rejection that failed a fully-green suite
+    // (exit 1, 12k tests passed) and blocked release attestation twice.
+    // A file inode where a directory is needed makes mkdir fail deterministically.
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-retention-'));
+    const asFile = path.join(base, 'not-a-dir');
+    fs.writeFileSync(asFile, '');
+    const mgr = new AgentManager(50, path.join(asFile, 'agents'));
+    // Give the fire-and-forget init a beat to reject; with the constructor's
+    // catch-marker this must NOT crash the suite as an unhandled rejection.
+    await new Promise((r) => setTimeout(r, 50));
+    // The error still surfaces where a caller actually awaits init.
+    // (rescanFromDisk awaits this.initialize(), which returns the same
+    // rejected promise the constructor fired.)
+    await expect(mgr.rescanFromDisk()).rejects.toThrow();
+    fs.rmSync(base, { recursive: true, force: true });
+  });
+});

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -1674,6 +1674,15 @@ export class AgentManager {
     this.defaultMode = resolvedDefaultMode;
 
     this.initPromise = this.doInitialize();
+    // Mark the deferred rejection as observed. Construction fires init
+    // fire-and-forget; every public method still surfaces a failed init at its
+    // own `await this.initialize()` (the same promise rejects for each new
+    // awaiter). Without this, an init that loses a race with its directory
+    // being removed — measured twice as an unhandled
+    // `ENOENT mkdir /tmp/agents-retention-*` that failed a fully-green suite
+    // (exit 1 with 12k tests passed) and blocked release attestation — crashes
+    // the process instead of failing the caller that actually cares.
+    this.initPromise.catch(() => {});
   }
 
   private async initialize(): Promise<void> {


### PR DESCRIPTION
**What + type:** bug fix — one-line product change + regression test. Kills the flaky unhandled rejection in `agents.retention.test.ts` that failed two fully-green release attestation runs (blocked shipping RUSH-3036's usage fix).

## The flake

`AgentManager`'s constructor fires `this.initPromise = this.doInitialize()` with **no rejection observer** (`apps/cli/src/lib/teams/agents.ts:1676`). When that init loses a race with its directory being removed — the retention test's `afterEach` `rmSync` vs a still-queued `mkdir` — the rejection is **unhandled**: vitest exits 1 with all 12,573 tests passing. `release-attestation-produce.sh` then refuses to attest ("red tree"), twice, at 15 min per run:

```
Test Files  894 passed | 6 skipped (900)
Tests       12573 passed | 95 skipped (12668)
Errors      1 error   ← Unhandled Rejection: ENOENT mkdir /tmp/agents-retention-IUqoVw
```

## Fix

`this.initPromise.catch(() => {})` in the constructor — marks the deferred rejection observed. Not a swallow: `.catch` creates a *new* promise; every public method still gets the rejection at its own `await this.initialize()` (agents.ts:1733, :1854, :1985, :2158 all re-await the same promise).

## Run result — test fails pre-fix, passes post-fix

New regression test constructs a manager whose agents dir cannot be created (file inode in the path) and asserts the failure surfaces at the awaited `rescanFromDisk()` call. Reverting only the product line reproduces the exact production crash:

```
⎯⎯ Unhandled Rejection ⎯⎯
Error: ENOTDIR: not a directory, mkdir '/tmp/agents-retention-iAgVnx/not-a-dir/agents'
Tests  10 passed (10)      ← green tests, red exit: the attestation killer
```

With the fix: `Test Files 1 passed / Tests 10 passed`, no unhandled errors. Full teams suite: `31 files / 261 tests passed`.

Ticket: RUSH-3036 (this unblocks shipping its release).
