### PR TITLE
fix(session): preserve a parsed title when the transcript has no timestamp

### DIFF
--- a/apps/cli/src/lib/session/__tests__/discover.test.ts
+++ b/apps/cli/src/lib/session/__tests__/discover.test.ts
@@ -81,6 +81,37 @@ describe('routine archive discovery', () => {
   });
 });
 
+describe('timestamp-less Claude discovery', () => {
+  const sessionId = '22222222-3333-4444-8555-666666666666';
+  const projectDir = path.join(getHistoryDir(), 'versions', 'claude', 'test-timestampless', 'home', '.claude', 'projects', 'title-fallback');
+  const transcriptPath = path.join(projectDir, `${sessionId}.jsonl`);
+
+  afterEach(() => {
+    fs.rmSync(path.join(getHistoryDir(), 'versions', 'claude', 'test-timestampless'), { recursive: true, force: true });
+    const db = getDB();
+    db.prepare(`DELETE FROM sessions WHERE id = ?`).run(sessionId);
+    db.prepare(`DELETE FROM session_text WHERE session_id = ?`).run(sessionId);
+    db.prepare(`DELETE FROM scan_ledger WHERE file_path = ?`).run(transcriptPath);
+  });
+
+  it('keeps a parsed title when the transcript has no timestamp', async () => {
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({ type: 'user', cwd: '/workspace/title-fallback', sessionId, message: { role: 'user', content: 'first prompt' } }),
+        JSON.stringify({ type: 'ai-title', aiTitle: 'Generated session title', sessionId }),
+      ].join('\n') + '\n',
+      'utf-8',
+    );
+
+    const sessions = await discoverSessions({ agent: 'claude', all: true, limit: 100 });
+    const hit = sessions.find((session) => session.id === sessionId);
+
+    expect(hit?.label).toBe('Generated session title');
+  });
+});
+
 describe('buildFtsQuery', () => {
   it('returns empty expression for whitespace-only input', () => {
     expect(buildFtsQuery('').expr).toBe('');

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -1635,7 +1635,9 @@ async function readClaudeMeta(
       accountKey: acct.key,
       accountOrg: acct.orgName ?? undefined,
       model: scan.model,
-      label,
+      // Keep parsed ai-title/custom-title values even when the transcript has
+      // no timestamp and therefore takes this stat-backed fallback path.
+      label: label || scan.label,
       messageCount: scan.messageCount,
       toolCallCount: scan.toolCallCount,
       tokenCount: scan.tokenCount,


### PR DESCRIPTION
Keep a parsed session title when the transcript has no timestamp.

`readClaudeMeta` has two `label:` assignments. The timestamped branch (`discover.ts:1601`) already read `label: label || scan.label`; the stat-backed fallback read just `label`, so a transcript with no timestamp silently dropped the `customTitle`/`aiTitle` that `finalizeClaudeScan` had already parsed — and those sessions showed an unlabelled tab.

```diff
-      label,
+      // Keep parsed ai-title/custom-title values even when the transcript has
+      // no timestamp and therefore takes this stat-backed fallback path.
+      label: label || scan.label,
```

`||` rather than `??` is correct here: the rename-sourced `label` is normalized to `null`-or-non-empty (`discover.ts:1424`), and `scan.label`'s inputs are only set behind a trim-checked truthy guard (`discover.ts:3757-3763`), so neither operand can be `''` and there is no deliberately-blank title to protect.

## Evidence

39/39 in `discover.test.ts`, `tsc --noEmit` clean. The new test was mutation-checked: reverting the line to `label,` fails it with `expected undefined to be 'Generated session title'`.

## Note on this PR's history

This branch was 93 commits behind main. Three of its four commits — the AGI EXT tab-sync work, the `--host`→`--device` routing change, and a plan doc — had already merged under different SHAs and were dropped as duplicate cherry-picks on rebase. The earlier title and description referred to that larger scope; what actually remains is the single commit above.

Ticket: RUSH-3011
