### PR TITLE
docs(free): READMEs and auth copy - fully free, account optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ agents setup status                    # readiness for browser, computer, fleet,
 agents run claude "explain this repo"  # run any agent on your existing subscription
 ```
 
-`agents setup` is interactive and idempotent -- safe to re-run on any machine. Once core setup exists, it opens a status-aware menu for browser, computer, secrets, fleet, share, watchdog, and device preferences; each choice delegates to the same wizard available under `agents setup <capability>`. In CI or another non-TTY, bare setup prints the checklist without prompting. The `agi-cli.sh` one-liner installs this same canonical `@phnx-labs/agents-cli` package. Prefer bun? `bun install -g @phnx-labs/agents-cli` works too.
+Everything here — and every other command in this README — is free and needs no account; the optional `agents auth login` exists only for [team spaces](#sign-in). `agents setup` is interactive and idempotent -- safe to re-run on any machine. Once core setup exists, it opens a status-aware menu for browser, computer, secrets, fleet, share, watchdog, and device preferences; each choice delegates to the same wizard available under `agents setup <capability>`. In CI or another non-TTY, bare setup prints the checklist without prompting. The `agi-cli.sh` one-liner installs this same canonical `@phnx-labs/agents-cli` package. Prefer bun? `bun install -g @phnx-labs/agents-cli` works too.
 
 Full path -- installing harnesses, logging in, smoke-testing `agents teams`, and setting up your own fleet: [`apps/cli/docs/QUICKSTART.md`](apps/cli/docs/QUICKSTART.md).
 
@@ -900,7 +900,7 @@ agents setup mine remove jack --purge
 
 Under the hood, `init` drops a pure pass-through shim in `~/.agents/.cache/shims/<name>` (already on `PATH`) that sets `AGENTS_BRAND` and forwards every argument to the same binary — nothing is copied or forked. The brand's config lives in `~/.agents/agents.yaml` (`brands.<name>`), so it rides `agents repo push/pull` across your fleet. Disabling a command hides it **only** under that brand; plain `agents` / `ag` keep every command. Curated skills/plugins/MCP ride a per-brand [resource profile](apps/cli/docs/profiles.md). Full reference: [Make it yours](apps/cli/docs/mine.md).
 
-> Personal use is free and Apache-2.0. Redistributing a branded build commercially will require a license in a future release.
+> Branded builds are free for personal and commercial use alike. New versions ship under FSL-1.1-Apache-2.0: every user and company may use, modify, and redistribute; only offering agents-cli itself as a competing commercial product or service is barred, and each version automatically becomes Apache-2.0 two years after release.
 
 ---
 
@@ -1007,7 +1007,7 @@ agents browser profiles create cloud \
 
 ## Sign in
 
-`agents auth` signs this machine in to **Phoenix ID** — the Phoenix Labs account layer that spaces and plan tiers hang off. Sign-in is Google-only and runs a device-code flow: the CLI shows a code, your browser confirms it, and the CLI picks the session up.
+Signing in is **optional**. Every local feature — `agents run`, sessions, teams, fleet dispatch, secrets, browser, computer — works with no account. The one thing an account unlocks is **team spaces**, the hosted surface under `agents auth space`. `agents auth` signs this machine in to **Phoenix ID**, the Phoenix Labs account layer behind team spaces. Sign-in is Google-only and runs a device-code flow: the CLI shows a code, your browser confirms it, and the CLI picks the session up.
 
 ```bash
 agents auth login                        # shows a code, opens a Phoenix-branded page
@@ -1501,7 +1501,7 @@ Claude Code, Codex CLI, Antigravity, Grok Build, and others each have their own 
 
 ### Is it free?
 
-Yes. This developer tool is entirely free because we believe developers should have the best tools — fast and robust — so they can create the best products for their users.
+Yes — every feature, with no account and no signup. `agents run`, sessions, teams, fleet dispatch, secrets, browser, and computer automation all work the moment you install. The optional `agents auth login` exists only to unlock hosted team spaces (`agents auth space`); there are no paid tiers. This developer tool is entirely free because we believe developers should have the best tools — fast and robust — so they can create the best products for their users.
 
 ### Is this like `nvm` / `mise` / `asdf` for AI agents?
 
@@ -1594,4 +1594,4 @@ Commands in [`apps/cli/src/commands/`](apps/cli/src/commands/), libraries in [`a
 
 ## License
 
-Apache-2.0 -- see [LICENSE](./LICENSE).
+FSL-1.1-Apache-2.0 -- see [LICENSE](./LICENSE). Free for every user and company to use, modify, and redistribute; the only barred use is offering agents-cli itself as a competing commercial product or service. Each version automatically becomes Apache-2.0 two years after its release.

--- a/apps/cli/.changelog/next/free-forever-docs.md
+++ b/apps/cli/.changelog/next/free-forever-docs.md
@@ -1,0 +1,6 @@
+- **`agents auth` help no longer claims plan tiers.** The command's description
+  now reads "the account layer behind team spaces" — there are no plan tiers —
+  and its help notes state that signing in is optional: every local feature
+  works with no account, and team spaces are the one thing an account unlocks.
+  READMEs and docs updated to match, and license references now name
+  FSL-1.1-Apache-2.0. Source: `apps/cli/src/commands/auth.ts`.

--- a/apps/cli/docs/command-index.json
+++ b/apps/cli/docs/command-index.json
@@ -1316,7 +1316,7 @@
       "name": "auth",
       "path": "auth",
       "aliases": [],
-      "description": "Sign in to Phoenix ID — the account layer behind spaces and plan tiers",
+      "description": "Sign in to Phoenix ID — the account layer behind team spaces",
       "args": [],
       "options": [
         {
@@ -1331,7 +1331,7 @@
         }
       ],
       "examples": "agents auth login                         # device-code sign-in via your browser\nagents auth whoami                        # who this machine is signed in as\nagents auth space create \"Design Team\"    # start a space\nagents auth space invite ada@example.com  # add a teammate\nagents auth logout                        # clear this machine only",
-      "notes": "Sign-in is Google-only and opens a Phoenix-branded page; the CLI never sees a password.\nThe session lives in this machine's agents state dir, so logging out here signs out nothing else.\nPoint at a different backend with PHOENIX_ID_BASE (defaults to the production service).",
+      "notes": "Signing in is optional — every local feature works with no account; team spaces are what it unlocks.\nSign-in is Google-only and opens a Phoenix-branded page; the CLI never sees a password.\nThe session lives in this machine's agents state dir, so logging out here signs out nothing else.\nPoint at a different backend with PHOENIX_ID_BASE (defaults to the production service).",
       "subcommands": [
         {
           "name": "login",

--- a/apps/cli/docs/command-index.md
+++ b/apps/cli/docs/command-index.md
@@ -58,10 +58,10 @@ agents artifacts share update               Re-deploy the Worker script to the c
 agents artifacts unshare <targets...>       Alias of `agents artifacts share delete` — take down a published page (and by default its OG cover).
 ```
 
-## auth — Sign in to Phoenix ID — the account layer behind spaces and plan tiers
+## auth — Sign in to Phoenix ID — the account layer behind team spaces
 
 ```
-agents auth                            Sign in to Phoenix ID — the account layer behind spaces and plan tiers
+agents auth                            Sign in to Phoenix ID — the account layer behind team spaces
 agents auth login                      Sign in with the device-code flow
 agents auth logout                     Clear this machine's session (no other device is affected)
 agents auth space                      Spaces — share work with teammates

--- a/apps/cli/docs/command-reference.html
+++ b/apps/cli/docs/command-reference.html
@@ -454,17 +454,19 @@ agents run claude</code></pre><h4>Notes</h4><p class="notes">Switch writes the e
   lifecycle rule on their own schedule either way).
 
   agents artifacts share delete === agents artifacts unshare (same command, different name).</p></article>
-<article id="auth" data-search="auth auth  sign in to phoenix id — the account layer behind spaces and plan tiers -h, --help show help agents auth login                         # device-code sign-in via your browser
+<article id="auth" data-search="auth auth  sign in to phoenix id — the account layer behind team spaces -h, --help show help agents auth login                         # device-code sign-in via your browser
 agents auth whoami                        # who this machine is signed in as
 agents auth space create &quot;design team&quot;    # start a space
 agents auth space invite ada@example.com  # add a teammate
-agents auth logout                        # clear this machine only sign-in is google-only and opens a phoenix-branded page; the cli never sees a password.
+agents auth logout                        # clear this machine only signing in is optional — every local feature works with no account; team spaces are what it unlocks.
+sign-in is google-only and opens a phoenix-branded page; the cli never sees a password.
 the session lives in this machine&#39;s agents state dir, so logging out here signs out nothing else.
-point at a different backend with phoenix_id_base (defaults to the production service)."><div class="command-head"><h3><code>agents auth</code></h3></div><p>Sign in to Phoenix ID — the account layer behind spaces and plan tiers</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table><h4>Examples</h4><pre><code>agents auth login                         # device-code sign-in via your browser
+point at a different backend with phoenix_id_base (defaults to the production service)."><div class="command-head"><h3><code>agents auth</code></h3></div><p>Sign in to Phoenix ID — the account layer behind team spaces</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table><h4>Examples</h4><pre><code>agents auth login                         # device-code sign-in via your browser
 agents auth whoami                        # who this machine is signed in as
 agents auth space create &quot;Design Team&quot;    # start a space
 agents auth space invite ada@example.com  # add a teammate
-agents auth logout                        # clear this machine only</code></pre><h4>Notes</h4><p class="notes">Sign-in is Google-only and opens a Phoenix-branded page; the CLI never sees a password.
+agents auth logout                        # clear this machine only</code></pre><h4>Notes</h4><p class="notes">Signing in is optional — every local feature works with no account; team spaces are what it unlocks.
+Sign-in is Google-only and opens a Phoenix-branded page; the CLI never sees a password.
 The session lives in this machine&#39;s agents state dir, so logging out here signs out nothing else.
 Point at a different backend with PHOENIX_ID_BASE (defaults to the production service).</p></article>
 <article id="auth-login" data-search="login auth login  sign in with the device-code flow -h, --help show help  "><div class="command-head"><h3><code>agents auth login</code></h3></div><p>Sign in with the device-code flow</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table></article>

--- a/apps/cli/docs/mine.md
+++ b/apps/cli/docs/mine.md
@@ -2,7 +2,7 @@
 
 `agents setup mine` mints a **personally-named CLI** that _is_ agents-cli. Run it
 as `jack` instead of `agents`, hide the commands you don't want, and pin a curated
-set of skills/plugins — all under your own name. Free and Apache-2.0.
+set of skills/plugins — all under your own name. Free, under FSL-1.1-Apache-2.0.
 
 ```bash
 agents setup mine            # wizard: pick a name, choose what to turn off
@@ -77,5 +77,8 @@ agents --help        # unchanged — every command still there
   silently strips skills/plugins for the plain `agents` user. Note that running
   `<brand> sync` explicitly will materialize the brand's curated set into the
   shared homes — run `agents sync` to restore the full set.
-- **Commercial white-label** (redistributing a branded build to customers) will
-  require a license in a future release; personal use is free.
+- **White-label is free**, personal or commercial. The FSL-1.1-Apache-2.0
+  license lets every user and company use, modify, and redistribute branded
+  builds; only offering agents-cli itself as a competing commercial product or
+  service is barred, and each version automatically becomes Apache-2.0 two
+  years after release.

--- a/apps/cli/docs/observability.md
+++ b/apps/cli/docs/observability.md
@@ -1020,8 +1020,9 @@ feed:
       minLevel: important
 ```
 
-Sinks are **argv templates**, not built-in integrations — this CLI ships
-Apache-2.0 and must not depend on one person's tracker or messaging stack. The
+Sinks are **argv templates**, not built-in integrations — this CLI ships under
+the free FSL-1.1-Apache-2.0 license and must not depend on one person's tracker
+or messaging stack. The
 first element is spawned directly (no shell), so post text can never become shell
 syntax. Point the same mechanism at `jira`, `gh issue comment`, or a webhook
 script.

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -23,9 +23,10 @@ import { setHelpSections } from '../lib/help.js';
 import { runOrDie } from '../lib/format.js';
 
 /**
- * `agents auth` — sign in to Phoenix ID, the account layer behind teams and
- * plan tiers. Everything here goes through `lib/identity`; this file builds no
- * URLs and reads no credential files of its own.
+ * `agents auth` — sign in to Phoenix ID, the account layer behind team spaces.
+ * Signing in is optional: every local feature works with no account. Everything
+ * here goes through `lib/identity`; this file builds no URLs and reads no
+ * credential files of its own.
  */
 
 function sleep(ms: number): Promise<void> {
@@ -116,7 +117,7 @@ async function requireSpace(ref?: string): Promise<Awaited<ReturnType<typeof lis
 export function registerAuthCommand(program: Command): void {
   const auth = program
     .command('auth')
-    .description('Sign in to Phoenix ID — the account layer behind spaces and plan tiers');
+    .description('Sign in to Phoenix ID — the account layer behind team spaces');
 
   setHelpSections(auth, {
     examples: `agents auth login                         # device-code sign-in via your browser
@@ -124,7 +125,8 @@ agents auth whoami                        # who this machine is signed in as
 agents auth space create "Design Team"    # start a space
 agents auth space invite ada@example.com  # add a teammate
 agents auth logout                        # clear this machine only`,
-    notes: `Sign-in is Google-only and opens a Phoenix-branded page; the CLI never sees a password.
+    notes: `Signing in is optional — every local feature works with no account; team spaces are what it unlocks.
+Sign-in is Google-only and opens a Phoenix-branded page; the CLI never sees a password.
 The session lives in this machine's agents state dir, so logging out here signs out nothing else.
 Point at a different backend with PHOENIX_ID_BASE (defaults to the production service).`,
   });


### PR DESCRIPTION
Docs plus help-string copy in `apps/cli/src/commands/auth.ts` (no logic changed — live help run and passing test output attached below).

One story across README, docs, and `agents auth` help: the CLI is fully free, no account is needed for anything local, and the optional `agents auth login` exists only to unlock hosted team spaces. There are no plan tiers, so the copy no longer claims them. License references name **FSL-1.1-Apache-2.0** (free for every user and company to use, modify, and redistribute; only offering agents-cli itself as a competing commercial product or service is barred; each version automatically becomes Apache-2.0 two years after release) — the license files themselves land in the sibling license PR.

## Changes
- `apps/cli/src/commands/auth.ts` — docblock, `.description()`, and help notes: "the account layer behind team spaces", signing in is optional. Strings only.
- `README.md` (this is also the CLI README — `apps/cli/README.md` was promoted to root in #818) — Quickstart free/no-account line, Sign in section leads with "optional", "Is it free?" FAQ names what works with no account, branded-build note and License section reference FSL-1.1-Apache-2.0 and drop the "commercial white-label will require a license in a future release" promise.
- `apps/cli/docs/mine.md`, `apps/cli/docs/observability.md` — same license/free-story fixes.
- `apps/cli/docs/command-index.{md,json}`, `command-reference.html` — regenerated with `bun scripts/gen-command-index.ts` (they embed the auth description); `scripts/verify-command-index.sh` passes: `✓ command reference ... is up to date`.
- `apps/cli/.changelog/next/free-forever-docs.md` — changelog fragment.

Not touched (owned by the license teammate): LICENSE, package.json, CONTRIBUTING.md, AGENTS.md.

## Evidence — real runs, captured output uploaded
- `bun src/index.ts auth --help` on this branch — full captured output: https://share.agents-cli.sh/muqsitnawaz/docs-auth-help-after-3cc78a5cdc772402 (shows the new description "the account layer behind team spaces" and the "Signing in is optional" note; no plan-tiers claim).
- `bunx vitest run src/commands/auth.test.ts` — 13 passed (13), captured run log: https://share.agents-cli.sh/muqsitnawaz/docs-auth-test-run-0d7180b2c900bdab
- `scripts/verify-command-index.sh` (the CI staleness gate) passes on the regenerated index: `✓ command reference (docs/command-index.{md,json} + command-reference.html) is up to date`.
