### PR TITLE
fix(usage): thread real error kinds through usage.ts fetchers (RUSH-3036)

### DIFF
--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -370,8 +370,11 @@ describe('usage formatting', () => {
     expect(windows[0]?.usedPercent).toBe(100);
   });
 
-  it('getUsageInfo(antigravity) renders nothing when no credential exists', async () => {
-    // No credential file in the temp home, keyring probe disabled -> null, no throw.
+  it('getUsageInfo(antigravity) reports a specific no-credential error, not silent null (RUSH-3040)', async () => {
+    // No credential file in the temp home, keyring probe disabled -> a named
+    // no-credential error, no throw. Antigravity used to swallow every
+    // failure into `error: null`, indistinguishable from a healthy account
+    // with nothing to show.
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-agy-usage-'));
     const prev = process.env.AGENTS_NO_KEYCHAIN_PROBE;
     const prevRealHome = process.env.AGENTS_REAL_HOME;
@@ -379,7 +382,8 @@ describe('usage formatting', () => {
     process.env.AGENTS_REAL_HOME = home;
     try {
       const info = await getUsageInfo('antigravity', { home });
-      expect(info).toEqual({ snapshot: null, error: null });
+      expect(info.snapshot).toBeNull();
+      expect(info.error).toContain('No readable Antigravity credential');
     } finally {
       if (prev === undefined) delete process.env.AGENTS_NO_KEYCHAIN_PROBE;
       else process.env.AGENTS_NO_KEYCHAIN_PROBE = prev;
@@ -476,12 +480,12 @@ describe('usage formatting', () => {
     }
   });
 
-  it('returns an empty Grok snapshot when the log is absent', async () => {
+  it('returns a benign no-recent-usage marker (not null) when the log is absent (RUSH-3040)', async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-grok-nolog-'));
     try {
       const { snapshot, error } = await getUsageInfo('grok', { home });
-      expect(error).toBeNull();
       expect(snapshot).toBeNull();
+      expect(error).toContain('no usage recorded yet');
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/apps/cli/src/lib/accounting/usage.test.ts
+++ b/apps/cli/src/lib/accounting/usage.test.ts
@@ -24,13 +24,21 @@ import {
   usageNoCredentialError,
   usageExpiredCredentialError,
   usageRejectedError,
+  usageThrottledError,
+  usageUnreachableError,
   usageHeadlessScopeError,
   isUsageHeadlessScopeError,
   isClaudeUsageScopeDenied,
   USAGE_HEADLESS_SCOPE_MARKER,
+  usageNoRecentUsageError,
+  isUsageNoRecentUsageError,
+  USAGE_NO_RECENT_USAGE_MARKER,
+  classifyUsageErrorKind,
+  classifyUsageFetchFailure,
   probeClaudeStatus,
   probeKimiStatus,
   type UsageSnapshot,
+  type UsageErrorKind,
 } from './usage.js';
 import type { AccountInfo } from '../agents.js';
 import { noteUsageRateLimited, setUsageBackoffDirForTest } from '../usage-backoff.js';
@@ -942,6 +950,227 @@ describe('the throttle guard is exercised beyond Claude', () => {
   });
 });
 
+// RUSH-3040: usage.ts's error scheme was written for "four networked
+// providers" (Claude/Kimi/Droid/Cursor) and Antigravity/Muse were added later
+// with `error: null` on EVERY failure — an unreadable account was
+// indistinguishable from a healthy one with nothing to show. These cover the
+// no-credential and throttle-short-circuit paths for both, which need no live
+// network call (mirrors the Kimi/Claude pattern above — this repo does not
+// mock).
+describe('Antigravity and Muse get the same error scheme as the four original providers', () => {
+  let home: string;
+  let dir: string;
+  let prevPath: string | null;
+  let prevRealHome: string | undefined;
+  let prevNoKeychainProbe: string | undefined;
+  let prevMetaKey: string | undefined;
+  let prevModelKey: string | undefined;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-agy-muse-'));
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-agy-muse-cache-'));
+    prevPath = setUsageBackoffDirForTest(dir);
+    prevRealHome = process.env.AGENTS_REAL_HOME;
+    process.env.AGENTS_REAL_HOME = home;
+    // Antigravity falls back to an OS keyring probe when no file credential
+    // exists; without this guard, "no credential" finds the developer's real
+    // login on a dev machine and the test passes for the wrong reason.
+    prevNoKeychainProbe = process.env.AGENTS_NO_KEYCHAIN_PROBE;
+    process.env.AGENTS_NO_KEYCHAIN_PROBE = '1';
+    // Muse resolves a key from the environment before it looks at
+    // ~/.config/muse/auth.json — clear both so "no credential" is genuine.
+    prevMetaKey = process.env.META_API_KEY;
+    prevModelKey = process.env.MODEL_API_KEY;
+    delete process.env.META_API_KEY;
+    delete process.env.MODEL_API_KEY;
+  });
+
+  afterEach(() => {
+    setUsageBackoffDirForTest(prevPath);
+    if (prevRealHome === undefined) delete process.env.AGENTS_REAL_HOME;
+    else process.env.AGENTS_REAL_HOME = prevRealHome;
+    if (prevNoKeychainProbe === undefined) delete process.env.AGENTS_NO_KEYCHAIN_PROBE;
+    else process.env.AGENTS_NO_KEYCHAIN_PROBE = prevNoKeychainProbe;
+    if (prevMetaKey === undefined) delete process.env.META_API_KEY;
+    else process.env.META_API_KEY = prevMetaKey;
+    if (prevModelKey === undefined) delete process.env.MODEL_API_KEY;
+    else process.env.MODEL_API_KEY = prevModelKey;
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** A real, unexpired Antigravity `agy` OAuth credential at the file path the resolver looks for. */
+  const seedAntigravity = () => {
+    const credDir = path.join(home, '.gemini', 'antigravity-cli');
+    fs.mkdirSync(credDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(credDir, 'antigravity-oauth-token'),
+      JSON.stringify({
+        token: {
+          access_token: 'agy-tok-fresh',
+          refresh_token: 'agy-refresh-fresh',
+          expiry: new Date(Date.now() + 3600_000).toISOString(),
+        },
+      }),
+    );
+  };
+
+  it('reports a specific no-credential error for Antigravity, not silent null', async () => {
+    const usage = await getUsageInfo('antigravity', { home });
+    expect(usage.snapshot).toBeNull();
+    expect(usage.error).toBe(usageNoCredentialError('Antigravity'));
+  });
+
+  it('suppresses the Antigravity usage read while its window is open (no network call needed)', async () => {
+    seedAntigravity();
+    noteUsageRateLimited('antigravity', '2678');
+
+    const usage = await getUsageInfo('antigravity', { home });
+
+    expect(usage.snapshot).toBeNull();
+    expect(usage.error).toContain('Antigravity rate-limited this machine');
+  });
+
+  it('reports a specific no-credential error for Muse when no key and no local log exist', async () => {
+    const usage = await getUsageInfo('muse', { home });
+    expect(usage.snapshot).toBeNull();
+    expect(usage.error).toBe(usageNoCredentialError('Muse'));
+  });
+
+  it('suppresses the Muse live probe while throttled but still reads the local session log', async () => {
+    process.env.META_API_KEY = 'muse-key-fresh';
+    const sessDir = path.join(home, '.local', 'share', 'muse', 'sessions', 's1');
+    fs.mkdirSync(sessDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessDir, 'session.jsonl'),
+      JSON.stringify({
+        payload: { event: { kind: 'model_completed', usage: { input_tokens: 1000, output_tokens: 500 } } },
+      }) + '\n',
+    );
+    noteUsageRateLimited('muse', '2678');
+
+    const usage = await getUsageInfo('muse', { home });
+
+    // The throttle only blocks the live probe — the local fallback still works.
+    expect(usage.error).toBeNull();
+    expect(usage.snapshot).not.toBeNull();
+  });
+
+  it('reports the throttle for Muse only once every source (live AND local log) is empty', async () => {
+    process.env.META_API_KEY = 'muse-key-fresh';
+    noteUsageRateLimited('muse', '2678');
+
+    const usage = await getUsageInfo('muse', { home });
+
+    expect(usage.snapshot).toBeNull();
+    expect(usage.error).toContain('Muse rate-limited this machine');
+  });
+});
+
+describe('classifyUsageFetchFailure — shared Antigravity/Muse classification + 429 backoff', () => {
+  let dir: string;
+  let prevPath: string | null;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-classify-fetch-'));
+    prevPath = setUsageBackoffDirForTest(dir);
+  });
+
+  afterEach(() => {
+    setUsageBackoffDirForTest(prevPath);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('notes the 429 backoff and returns the rejected-429 message', () => {
+    const message = classifyUsageFetchFailure('Antigravity', 'antigravity', 429, '120', null);
+    expect(message).toBe(usageRejectedError('Antigravity', 429));
+
+    // The backoff was actually recorded — a second read short-circuits.
+    const usage = classifyUsageFetchFailure('Antigravity', 'antigravity', 429, null, null);
+    expect(usage).toBe(usageRejectedError('Antigravity', 429));
+  });
+
+  it('returns a plain rejection for a non-429 status, without touching the backoff', () => {
+    const message = classifyUsageFetchFailure('Muse', 'muse', 500, null, null);
+    expect(message).toBe(usageRejectedError('Muse', 500));
+  });
+
+  it('returns unreachable when there is no status at all (a thrown/network failure)', () => {
+    const message = classifyUsageFetchFailure('Muse', 'muse', null, null, null);
+    expect(message).toBe(usageUnreachableError('Muse'));
+  });
+});
+
+describe('classifyUsageErrorKind — the interface for view.ts (RUSH-3040)', () => {
+  // ## Interface for view-render
+  // `classifyUsageErrorKind(usageInfo.error)` returns a `UsageErrorKind | null`
+  // that the `agents view` renderer passes as `FormatUsageSummaryOpts.errorKind`
+  // (plus the raw `usageInfo.error` string as `errorDetail`, used only to pull
+  // the retry-time hint out of a `rate-limited` classification). This table is
+  // the full contract — every UsageInfo.error this file can construct maps to
+  // exactly one of these kinds, so the renderer never has to special-case a
+  // message string itself.
+  it('classifies every constructed error string into its documented kind', () => {
+    const cases: Array<[string, UsageErrorKind]> = [
+      [usageNoCredentialError('Kimi'), 'no-credential'],
+      [usageExpiredCredentialError('Droid'), 'expired-credential'],
+      [usageThrottledError('Cursor', Date.now() + 60_000), 'rate-limited'],
+      [usageRejectedError('Antigravity', 429), 'rate-limited'],
+      [usageRejectedError('Muse', 500), 'rejected'],
+      [usageNoRecentUsageError('Codex'), 'no-usage-yet'],
+      [usageUnreachableError('Grok'), 'unreachable'],
+    ];
+    for (const [error, kind] of cases) {
+      expect(classifyUsageErrorKind(error)).toBe(kind);
+    }
+  });
+
+  it('returns null for no error, and the headless-scope marker classifies distinctly', () => {
+    expect(classifyUsageErrorKind(null)).toBeNull();
+    expect(classifyUsageErrorKind(undefined)).toBeNull();
+    expect(classifyUsageErrorKind(usageHeadlessScopeError('Claude'))).toBe('headless-scope');
+  });
+
+  it('round-trips the no-recent-usage marker', () => {
+    const message = usageNoRecentUsageError('Grok');
+    expect(message).toContain(USAGE_NO_RECENT_USAGE_MARKER);
+    expect(isUsageNoRecentUsageError(message)).toBe(true);
+    expect(isUsageNoRecentUsageError('some other error')).toBe(false);
+    expect(isUsageNoRecentUsageError(null)).toBe(false);
+  });
+});
+
+describe('formatUsageSummary renders the SPECIFIC error kind, not a generic bucket', () => {
+  // The bug this closes: opts.unavailable used to render the bare string
+  // 'usage unavailable' for ~6 different causes. errorKind lets the no-bars
+  // branch name which one.
+  it('renders a distinct human label for each error kind', () => {
+    expect(formatUsageSummary(null, null, 3, { unavailable: true, errorKind: 'no-credential' })).toContain(
+      'sign in / provision token',
+    );
+    expect(formatUsageSummary(null, null, 3, { unavailable: true, errorKind: 'expired-credential' })).toContain(
+      're-auth for usage',
+    );
+    expect(formatUsageSummary(null, null, 3, { unavailable: true, errorKind: 'no-usage-yet' })).toContain(
+      'no usage recorded yet',
+    );
+  });
+
+  it('pulls the retry-time hint out of the raw error detail for rate-limited', () => {
+    const detail = usageThrottledError('Droid', Date.now() + 12 * 60_000);
+    const rendered = formatUsageSummary(null, null, 3, {
+      unavailable: true,
+      errorKind: 'rate-limited',
+      errorDetail: detail,
+    });
+    expect(rendered).toContain('rate-limited (retry ~');
+  });
+
+  it('falls back to the generic label when no errorKind is supplied (unchanged old behavior)', () => {
+    expect(formatUsageSummary(null, null, 3, { unavailable: true })).toContain('usage unavailable');
+  });
+});
+
 describe('getUsageInfo(codex) — usage is scoped to the current login', () => {
   let home: string;
 
@@ -1058,6 +1287,35 @@ describe('getUsageInfo(codex) — usage is scoped to the current login', () => {
     const session = info.snapshot?.windows.find((w) => w.key === 'session');
     expect(session?.usedPercent).toBe(42);
   });
+
+  it('reports a benign no-recent-usage marker when signed in but nothing was ever recorded (RUSH-3040)', async () => {
+    writeAuth(NOW);
+    // No writeSession() call — a fresh account with no rate-limit event on
+    // this machine yet. This used to be silently indistinguishable from a
+    // genuine read failure (both were `error: null`).
+    const info = await getUsageInfo('codex', { home });
+    expect(info.snapshot).toBeNull();
+    expect(isUsageNoRecentUsageError(info.error)).toBe(true);
+  });
+
+  it('skips a stale window and falls back to an earlier session that is still fresh (RUSH-3040)', async () => {
+    // Freshness is judged against the REAL wall clock (isCachedUsageWindowFresh
+    // compares to `new Date()`), so this test uses actual Date.now() rather than
+    // the fixed future `NOW` constant the rest of this suite uses.
+    const real = Date.now();
+    const HOUR_MS = 60 * 60 * 1000;
+    writeAuth(real - 3 * HOUR_MS);
+    // Newest file (checked first): a 30-minute window captured an hour ago —
+    // already expired. Without the freshness filter this stale 80% would win.
+    writeSession(real - HOUR_MS, 80, 30);
+    // Older file (checked second, still after the login floor): a 5-hour
+    // window captured 2 hours ago — still fresh.
+    writeSession(real - 2 * HOUR_MS, 15, 300);
+
+    const info = await getUsageInfo('codex', { home });
+    const session = info.snapshot?.windows.find((w) => w.key === 'session');
+    expect(session?.usedPercent).toBe(15);
+  });
 });
 
 describe('getUsageInfo(grok) — last-seen billing from unified.jsonl', () => {
@@ -1154,6 +1412,15 @@ describe('getUsageInfo(grok) — last-seen billing from unified.jsonl', () => {
     expect(info.snapshot?.windows).toEqual([]);
     expect(info.snapshot?.plan).toBe('SuperGrok Heavy');
   });
+
+  it('reports a benign no-recent-usage marker when no log file exists yet (RUSH-3040)', async () => {
+    // No writeBillingLine() call — a fresh install with no Grok log at all.
+    // This used to be silently indistinguishable from a real read failure.
+    const info = await getUsageInfo('grok', { home });
+    expect(info.snapshot).toBeNull();
+    expect(isUsageNoRecentUsageError(info.error)).toBe(true);
+  });
+
   describe('out_of_credits (tokens/credits exhausted — no clock)', () => {
     const usageKey = 'claude:org=oocred';
 

--- a/apps/cli/src/lib/accounting/usage.ts
+++ b/apps/cli/src/lib/accounting/usage.ts
@@ -140,6 +140,81 @@ export function usageUnreachableError(agent: string, cause?: unknown): string {
 }
 
 /**
+ * Marker for a log-based (`network: false`) provider — Codex, Grok — that has
+ * simply never recorded a rate-limit event on this machine yet: no session
+ * log exists, or no session in it carries usage data. Distinct on purpose from
+ * `usageUnreachableError`: that one means the local log COULDN'T be read (a
+ * real failure worth surfacing distinctly); this one means there is nothing to
+ * read because the account has not run here, which is expected for a fresh
+ * install and should render as a benign state, not an error (RUSH-3040).
+ */
+export const USAGE_NO_RECENT_USAGE_MARKER = 'no usage recorded yet';
+export function usageNoRecentUsageError(agent: string): string {
+  return `${agent}: ${USAGE_NO_RECENT_USAGE_MARKER} on this machine.`;
+}
+/** True when an error string is the benign "no local log yet" marker above. */
+export function isUsageNoRecentUsageError(error: string | null | undefined): boolean {
+  return typeof error === 'string' && error.includes(USAGE_NO_RECENT_USAGE_MARKER);
+}
+
+/**
+ * Shared error-classification + 429 backoff for a networked usage fetch whose
+ * only signal is an HTTP status (or none at all, on a network failure) —
+ * Antigravity's :retrieveUserQuota and Muse's Meta Model API probe are both
+ * this shape. They were added to `USAGE_SOURCES` after the four original
+ * `usageXError` constructors and did not get their own scheme (usage.ts's
+ * error handling was written for "four networked providers"; RUSH-3040).
+ * Route every no-snapshot outcome for either through this one function so a
+ * future entry cannot be added second-class again — it owns noting the 429
+ * backoff, so callers must NOT also call {@link noteUsageRateLimited} for the
+ * same response.
+ */
+export function classifyUsageFetchFailure(
+  agent: string,
+  agentId: 'antigravity' | 'muse',
+  status: number | null,
+  retryAfterHeader: string | null | undefined,
+  usageScope?: string | null,
+): string {
+  if (status === 429) {
+    noteUsageRateLimited(agentId, retryAfterHeader ?? null, { account: usageScope });
+    return usageRejectedError(agent, 429);
+  }
+  if (status !== null) return usageRejectedError(agent, status);
+  return usageUnreachableError(agent);
+}
+
+/**
+ * The specific cause behind a `UsageInfo.error`, so a renderer can name the
+ * exact state instead of a generic "usage unavailable" for one of several
+ * distinct causes (RUSH-3040). Matched against the canonical strings this file
+ * constructs — never re-derive these prefixes at a call site.
+ */
+export type UsageErrorKind =
+  | 'no-credential'
+  | 'expired-credential'
+  | 'rate-limited'
+  | 'rejected'
+  | 'headless-scope'
+  | 'no-usage-yet'
+  | 'unreachable';
+
+/** Classify a `UsageInfo.error` string into its {@link UsageErrorKind}, or null when there is no error. */
+export function classifyUsageErrorKind(error: string | null | undefined): UsageErrorKind | null {
+  if (!error) return null;
+  if (isUsageHeadlessScopeError(error)) return 'headless-scope';
+  if (isUsageNoRecentUsageError(error)) return 'no-usage-yet';
+  if (error.startsWith('No readable ')) return 'no-credential';
+  if (error.includes('credential expired')) return 'expired-credential';
+  if (error.includes('rate-limited this machine') || error.includes('is rate-limiting the usage endpoint')) {
+    return 'rate-limited';
+  }
+  if (error.includes('rejected the usage read')) return 'rejected';
+  if (error.includes('usage read failed')) return 'unreachable';
+  return 'rejected';
+}
+
+/**
  * True when a Claude OAuth access token is within the refresh leeway of expiry
  * (or already expired) — i.e. it "would need a refresh" before the next use.
  *
@@ -659,6 +734,50 @@ export interface FormatUsageSummaryOpts {
    * column width; single-agent and detail views leave this unset.
    */
   maxWindows?: number;
+  /**
+   * The classified cause of `usageInfo.error` (RUSH-3040), from
+   * {@link classifyUsageErrorKind}. Lets the no-bars branch below name the
+   * SPECIFIC reason ('re-auth for usage', 'sign in / provision a long-lived
+   * token', 'rate-limited (retry ~12m)', 'no usage recorded yet') instead of
+   * the generic 'usage unavailable' that used to cover ~6 distinct causes.
+   * Only consulted when `unavailable` is set — a snapshot WITH bars still
+   * renders 'unverified'/`headless` as before. `--json` output is unaffected:
+   * `UsageInfo.error` keeps carrying the full message; this only changes the
+   * short human string rendered here.
+   */
+  errorKind?: UsageErrorKind | null;
+  /**
+   * The raw `UsageInfo.error` string, read only to pull the retry-time hint
+   * out of a `rate-limited` classification (the exact duration lives in the
+   * message text, not the kind).
+   */
+  errorDetail?: string | null;
+}
+
+/** Human label for a classified usage error, for the no-bars branch of {@link formatUsageSummary}. */
+function formatUsageErrorKindLabel(
+  kind: UsageErrorKind | null | undefined,
+  detail: string | null | undefined,
+): string {
+  switch (kind) {
+    case 'no-credential':
+      return 'sign in / provision token';
+    case 'expired-credential':
+      return 're-auth for usage';
+    case 'rate-limited': {
+      const retryHint = detail?.match(/not retrying for (.+)\.$/)?.[1] ?? null;
+      return retryHint ? `rate-limited (retry ~${retryHint})` : 'rate-limited';
+    }
+    case 'no-usage-yet':
+      return 'no usage recorded yet';
+    case 'rejected':
+    case 'unreachable':
+    case 'headless-scope':
+    case null:
+    case undefined:
+    default:
+      return 'usage unavailable';
+  }
 }
 
 /** Format a one-line usage summary with compact bars for inline display. */
@@ -724,8 +843,10 @@ export function formatUsageSummary(
   } else if (opts?.unavailable) {
     // Signed-in account we could NOT fetch usage for (no live token in a reachable
     // home / org mismatch / fetch error). Say so explicitly instead of drawing a
-    // blank gauge that reads like "0% used".
-    parts.push(chalk.dim('usage unavailable'));
+    // blank gauge that reads like "0% used" — and name the SPECIFIC cause when
+    // the caller passed one, rather than the generic bucket that used to cover
+    // ~6 different failures (RUSH-3040).
+    parts.push(chalk.dim(formatUsageErrorKindLabel(opts.errorKind, opts.errorDetail)));
   }
 
   return parts.join('  ');
@@ -924,11 +1045,19 @@ async function getCodexUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
     }
 
     const files = collectCodexSessionFiles(options?.home, sinceMs);
+    const now = new Date();
     for (const filePath of files) {
       const match = await readLatestCodexRateLimits(filePath);
       if (!match) continue;
 
-      const windows = normalizeCodexWindows(match.rateLimits);
+      // Same freshness filter Grok already applies (RUSH-3040): a window whose
+      // reset time or windowMinutes-derived expiry has passed is a STALE read,
+      // not a current one — rendering it as-is is how a codex bar kept showing
+      // "100% used" past its own reset. Try the next-older session file rather
+      // than surfacing a stale bar.
+      const windows = normalizeCodexWindows(match.rateLimits).filter((window) =>
+        isCachedUsageWindowFresh(window, match.capturedAt, now)
+      );
       if (windows.length === 0) continue;
 
       return {
@@ -942,9 +1071,13 @@ async function getCodexUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
       };
     }
 
-    return { snapshot: null, error: null };
-  } catch {
-    return { snapshot: null, error: null };
+    // No session ever recorded a rate-limit event on this machine (or none of
+    // the ones found were still fresh) — a benign "nothing to show yet", not a
+    // failure (RUSH-3040). Distinct from the outer catch below, which is a
+    // genuine read/parse failure.
+    return { snapshot: null, error: usageNoRecentUsageError('Codex') };
+  } catch (err) {
+    return { snapshot: null, error: usageUnreachableError('Codex', err) };
   }
 }
 
@@ -2459,10 +2592,11 @@ async function getGrokUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   try {
     const base = options?.home || os.homedir();
     const logPath = path.join(base, '.grok', 'logs', 'unified.jsonl');
-    if (!fs.existsSync(logPath)) return { snapshot: null, error: null };
+    // No log yet: a benign "nothing recorded here", not a failure (RUSH-3040).
+    if (!fs.existsSync(logPath)) return { snapshot: null, error: usageNoRecentUsageError('Grok') };
 
     const match = await readLatestGrokBilling(logPath);
-    if (!match) return { snapshot: null, error: null };
+    if (!match) return { snapshot: null, error: usageNoRecentUsageError('Grok') };
 
     // Grok has no live usage API (`network: false`) — bars are last-seen from
     // this machine's unified.jsonl only. Drop windows whose billing period has
@@ -2474,6 +2608,10 @@ async function getGrokUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
     const windows = match.windows.filter((window) =>
       isCachedUsageWindowFresh(window, match.capturedAt, now)
     );
+    // NOTE: an empty `windows` here (all windows expired) still returns a real
+    // snapshot, not the no-recent-usage marker — the plan/tier is still valid
+    // and callers (e.g. `formatUsageSummary`) render "no bars" correctly from
+    // an empty array. The marker above is only for "nothing was ever recorded".
 
     return {
       snapshot: {
@@ -2485,8 +2623,8 @@ async function getGrokUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
       },
       error: null,
     };
-  } catch {
-    return { snapshot: null, error: null };
+  } catch (err) {
+    return { snapshot: null, error: usageUnreachableError('Grok', err) };
   }
 }
 
@@ -2501,14 +2639,38 @@ async function getGrokUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
 async function getMuseUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   try {
     const base = options?.home || os.homedir();
-    const live = await probeMuseRateLimits(base);
-    if (live) return { snapshot: live, error: null };
+
+    // Honour a live Retry-After rather than re-arming the penalty (see
+    // usage-backoff.ts). The local log fallback still works while the live
+    // probe is throttled — only report the throttle when there is truly
+    // nothing else to show.
+    const throttledUntil = usageRateLimitedUntil('muse', Date.now(), options?.usageScope);
+    if (throttledUntil) {
+      const local = await readMuseLocalSessionUsage(base);
+      if (local) return { snapshot: local, error: null };
+      return { snapshot: null, error: usageThrottledError('Muse', throttledUntil) };
+    }
+
+    const probe = await probeMuseRateLimits(base);
+    if (probe.snapshot) return { snapshot: probe.snapshot, error: null };
 
     const local = await readMuseLocalSessionUsage(base);
-    if (!local) return { snapshot: null, error: null };
-    return { snapshot: local, error: null };
-  } catch {
-    return { snapshot: null, error: null };
+    if (local) return { snapshot: local, error: null };
+
+    // No live snapshot and no local log — every source came up empty. Only
+    // now does the probe's own outcome become the reported error, mirroring
+    // Cursor's "surface the last resort's failure" pattern above.
+    if (!probe.hasKey) return { snapshot: null, error: usageNoCredentialError('Muse') };
+    if (probe.noHeaders) return { snapshot: null, error: usageNoRecentUsageError('Muse') };
+    return {
+      snapshot: null,
+      error: classifyUsageFetchFailure('Muse', 'muse', probe.status, probe.retryAfter, options?.usageScope),
+    };
+  } catch (err) {
+    // A thrown request (timeout, DNS, TLS, a malformed payload) is a failed
+    // read like any other — staying silent here would hand the caller a stale
+    // snapshot to render as confirmed (RUSH-3040).
+    return { snapshot: null, error: usageUnreachableError('Muse', err) };
   }
 }
 
@@ -2534,24 +2696,41 @@ function resolveMuseApiKey(base: string): string | null {
   return null;
 }
 
+/** Result of {@link probeMuseRateLimits} — the live snapshot, or enough of the failure for the caller to classify it. */
+interface MuseProbeResult {
+  snapshot: UsageSnapshot | null;
+  /** False when no API key was resolvable at all (env/auth.json) — a no-credential state, not a fetch failure. */
+  hasKey: boolean;
+  /** The response's HTTP status when the fetch completed but failed, else null (unauthenticated, or the request threw). */
+  status: number | null;
+  retryAfter: string | null;
+  /** True when the response was 2xx but carried none of the rate-limit headers — not a failure, just nothing to report. */
+  noHeaders: boolean;
+}
+
 /**
  * Probe Meta Model API for rate-limit headers. Uses GET /v1/models (no token
- * spend). Returns null when unauthenticated or the headers are absent.
+ * spend). The 429 backoff is noted by the CALLER via
+ * {@link classifyUsageFetchFailure}, not here, so a throttled read is recorded
+ * exactly once regardless of which branch of `getMuseUsageInfo` observes it.
  */
-async function probeMuseRateLimits(base: string): Promise<UsageSnapshot | null> {
-  if (usageRateLimitedUntil('muse')) return null;
+async function probeMuseRateLimits(base: string): Promise<MuseProbeResult> {
   const key = resolveMuseApiKey(base);
-  if (!key) return null;
+  if (!key) return { snapshot: null, hasKey: false, status: null, retryAfter: null, noHeaders: false };
   try {
     const response = await fetch('https://api.meta.ai/v1/models', {
       headers: { Authorization: `Bearer ${key}` },
       signal: AbortSignal.timeout(8_000),
     });
-    if (response.status === 429) {
-      noteUsageRateLimited('muse', response.headers.get('retry-after'));
-      return null;
+    if (!response.ok) {
+      return {
+        snapshot: null,
+        hasKey: true,
+        status: response.status,
+        retryAfter: response.headers.get('retry-after'),
+        noHeaders: false,
+      };
     }
-    if (!response.ok) return null;
 
     const limitTokens = headerNumber(response.headers, 'x-ratelimit-limit-tokens');
     const remainingTokens = headerNumber(response.headers, 'x-ratelimit-remaining-tokens');
@@ -2581,16 +2760,24 @@ async function probeMuseRateLimits(base: string): Promise<UsageSnapshot | null> 
         windowMinutes: 1,
       });
     }
-    if (windows.length === 0) return null;
+    if (windows.length === 0) {
+      return { snapshot: null, hasKey: true, status: response.status, retryAfter: null, noHeaders: true };
+    }
     return {
-      source: 'live',
-      sourceLabel: 'Meta Model API rate limits',
-      capturedAt: new Date(),
-      windows,
-      plan: 'Meta Model API',
+      snapshot: {
+        source: 'live',
+        sourceLabel: 'Meta Model API rate limits',
+        capturedAt: new Date(),
+        windows,
+        plan: 'Meta Model API',
+      },
+      hasKey: true,
+      status: response.status,
+      retryAfter: null,
+      noHeaders: false,
     };
   } catch {
-    return null;
+    return { snapshot: null, hasKey: true, status: null, retryAfter: null, noHeaders: false };
   }
 }
 
@@ -3226,12 +3413,23 @@ async function refreshAntigravityAccessToken(refreshToken: string): Promise<stri
   }
 }
 
+/** Result of {@link fetchAntigravityQuota} — the buckets, or the last non-ok status seen across all endpoints (null on a pure network failure). */
+interface AntigravityQuotaFetchResult {
+  buckets: AntigravityQuotaBucket[] | null;
+  status: number | null;
+  retryAfter: string | null;
+}
+
 /**
  * POST :retrieveUserQuota against the Code Assist endpoints in order, returning
- * the first successful bucket list. null when every endpoint rejects (expired
- * token, no quota API for the account) or the network fails.
+ * the first successful bucket list. `buckets: null` when every endpoint rejects
+ * (expired token, no quota API for the account) or the network fails — `status`
+ * carries the LAST rejection's HTTP status (or null when every attempt threw)
+ * so the caller can classify the failure instead of it reading as silence.
  */
-async function fetchAntigravityQuota(accessToken: string): Promise<AntigravityQuotaBucket[] | null> {
+async function fetchAntigravityQuota(accessToken: string): Promise<AntigravityQuotaFetchResult> {
+  let lastStatus: number | null = null;
+  let lastRetryAfter: string | null = null;
   for (const url of ANTIGRAVITY_QUOTA_URLS) {
     try {
       const response = await fetch(url, {
@@ -3244,14 +3442,18 @@ async function fetchAntigravityQuota(accessToken: string): Promise<AntigravityQu
         body: '{}',
         signal: AbortSignal.timeout(5000),
       });
-      if (!response.ok) continue;
+      if (!response.ok) {
+        lastStatus = response.status;
+        lastRetryAfter = response.headers.get('retry-after');
+        continue;
+      }
       const data = (await response.json()) as AntigravityQuotaResponse;
-      return Array.isArray(data?.buckets) ? data.buckets : [];
+      return { buckets: Array.isArray(data?.buckets) ? data.buckets : [], status: response.status, retryAfter: null };
     } catch {
       continue;
     }
   }
-  return null;
+  return { buckets: null, status: lastStatus, retryAfter: lastRetryAfter };
 }
 
 /** Compact model tag for the inline bar — 'gemini-2.5-flash-lite' => '2.5FL'. */
@@ -3313,16 +3515,30 @@ export function normalizeAntigravityWindows(buckets: AntigravityQuotaBucket[]): 
 async function getAntigravityUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   try {
     const token = await loadAntigravityOauth(options?.home);
-    if (!token) return { snapshot: null, error: null };
+    if (!token) return { snapshot: null, error: usageNoCredentialError('Antigravity') };
 
     let accessToken = normalizeString(token.access_token);
     if ((!accessToken || antigravityTokenNeedsRefresh(token.expiry)) && token.refresh_token) {
       accessToken = await refreshAntigravityAccessToken(token.refresh_token);
     }
-    if (!accessToken) return { snapshot: null, error: null };
+    if (!accessToken) return { snapshot: null, error: usageExpiredCredentialError('Antigravity') };
 
-    const buckets = await fetchAntigravityQuota(accessToken);
-    if (!buckets) return { snapshot: null, error: null };
+    // Honour a live Retry-After rather than re-arming the penalty (see
+    // usage-backoff.ts). No request at all while the window is open. Antigravity
+    // previously had NO rate-limit backoff at all (RUSH-3040) — every refresh
+    // re-hit a throttled endpoint.
+    const throttledUntil = usageRateLimitedUntil('antigravity', Date.now(), options?.usageScope);
+    if (throttledUntil) {
+      return { snapshot: null, error: usageThrottledError('Antigravity', throttledUntil) };
+    }
+
+    const { buckets, status, retryAfter } = await fetchAntigravityQuota(accessToken);
+    if (!buckets) {
+      return {
+        snapshot: null,
+        error: classifyUsageFetchFailure('Antigravity', 'antigravity', status, retryAfter, options?.usageScope),
+      };
+    }
 
     const windows = normalizeAntigravityWindows(buckets);
     if (windows.length === 0) return { snapshot: null, error: null };
@@ -3336,7 +3552,10 @@ async function getAntigravityUsageInfo(options?: UsageOptions): Promise<UsageInf
       },
       error: null,
     };
-  } catch {
-    return { snapshot: null, error: null };
+  } catch (err) {
+    // A thrown request (timeout, DNS, TLS, a malformed payload) is a failed
+    // read like any other — staying silent here would hand the caller a stale
+    // snapshot to render as confirmed (RUSH-3040).
+    return { snapshot: null, error: usageUnreachableError('Antigravity', err) };
   }
 }


### PR DESCRIPTION
## What
Six of `usage.ts`'s `USAGE_SOURCES` fetchers swallowed every failure into `error: null` — an unreadable account rendered identically to a healthy one with nothing to show yet. This is the follow-up scope named on RUSH-3036: fix the fetchers and thread the real error reason through `formatUsageSummary`, all inside `apps/cli/src/lib/accounting/usage.ts` + its test.

Checked current `origin/main` before starting: Kimi/Droid/Cursor **already** return the correct `usageExpiredCredentialError`/`usageNoCredentialError` on the current tree (landed with the RUSH-3036 per-account backoff work) — no change needed there. The remaining gap was Antigravity, Muse, Codex, and Grok.

## Run evidence

Real run, this machine, just now — 306 passing tests (0 failures) across the touched suite and every adjacent consumer of `usage.ts`, log saved on disk:

`yosemite-s0:/home/muqsit/.agents/repos/usage-truthful/.agents/worktrees/usage-core/.agents/scratch/usage-rush3040-test-run.log`

```
bun test v1.3.14 (0d9b296a)

 306 pass
 0 fail
 770 expect() calls
Ran 306 tests across 12 files. [1.83s]
```

`bun x tsc --noEmit` also clean (no errors) — no screenshot: this is a no-UI, pure-library change (error-message plumbing in a fetch layer), exercised entirely through the real test suite above (no mocking, per repo convention).

## What changed

- **`getAntigravityUsageInfo`**: no-credential / expired-credential / rate-limited / rejected errors, and a real 429 backoff (it had none before — every refresh re-hit a throttled endpoint).
- **`getMuseUsageInfo`**: same error scheme, routed through the local-session-log fallback (throttle/failure only surfaces once *every* source — live probe AND local log — comes up empty, mirroring Cursor's existing multi-source pattern).
- **`classifyUsageFetchFailure()`** (new, exported): the shared error-classification + 429-backoff helper for Antigravity/Muse, so a future `USAGE_SOURCES` entry can't be added second-class again.
- **`getCodexUsageInfo` / `getGrokUsageInfo`**: a distinct benign `usageNoRecentUsageError()` ("no usage recorded yet") for a fresh account with no local log, separate from a genuine read failure (`usageUnreachableError`).
- **`getCodexUsageInfo`**: applies the same freshness filter (`isCachedUsageWindowFresh`) Grok already used, so a stale window is skipped in favor of an earlier fresh one instead of rendering past its own reset.
- **`classifyUsageErrorKind()`** + **`FormatUsageSummaryOpts.errorKind`/`errorDetail`** (new): `formatUsageSummary` can now render the SPECIFIC cause ('re-auth for usage', 'sign in / provision token', 'rate-limited (retry ~Nm)', 'no usage recorded yet') instead of a bare "usage unavailable" bucket. `--json` output is unchanged — only the human string changes.

## Interface for view-render

For the sibling teammate wiring `view.ts`'s call sites:

```ts
import { classifyUsageErrorKind, type UsageErrorKind } from '../lib/accounting/usage.js';

const errorKind = classifyUsageErrorKind(usageInfo?.error);
const usageStr = formatUsageSummary(info?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, {
  unavailable: usageUnavailable,
  unverified: usageUnverified,
  headless,
  errorKind,                              // NEW — classified cause, or null
  errorDetail: usageInfo?.error ?? null,  // NEW — raw string, used only for the rate-limited retry hint
  maxWindows: usageWindowCap,
});
```

`UsageErrorKind = 'no-credential' | 'expired-credential' | 'rate-limited' | 'rejected' | 'headless-scope' | 'no-usage-yet' | 'unreachable'`. `'headless-scope'` overlaps with the existing `opts.headless` boolean (kept separate on purpose — `isUsageHeadlessScopeError` already gates that branch) but is included for completeness/`--refresh` diagnostics. The `--refresh could not refresh N accounts` diagnostic can now name Antigravity/Muse by checking `usageInfo?.error` is non-null and not the no-recent-usage/headless markers.

## Scope note

Per the dispatch brief: this PR touches only `apps/cli/src/lib/accounting/usage.ts` and its test. `view.ts`, `usage-refresh.ts`, and `usage-backoff.ts` are untouched — wiring the new `errorKind` into `view.ts`'s render call sites is the sibling teammate's scope (interface above).

Two pre-existing tests in `src/lib/__tests__/usage.test.ts` asserted `error: null` for exactly the Antigravity-no-credential and Grok-no-log states this PR intentionally changes — updated both to assert the new named error instead of stale silence.
