### PR TITLE
fix(view): render specific usage states

### DIFF
--- a/apps/cli/src/commands/view.account.test.ts
+++ b/apps/cli/src/commands/view.account.test.ts
@@ -4,8 +4,10 @@ import {
   compareAccountOrderedVersions,
   joinViewColumns,
   pruneGroupKey,
+  viewUsageSummaryOptions,
   type AccountOrderedVersion,
 } from './view.js';
+import { formatUsageSummary } from '../lib/accounting/usage.js';
 import { padToWidth, stringWidth } from '../lib/session/width.js';
 
 describe('joinViewColumns — fixed multi-agent layout', () => {
@@ -71,6 +73,31 @@ describe('joinViewColumns — fixed multi-agent layout', () => {
   it('drops only trailing empty columns', () => {
     expect(joinViewColumns(['ver', 'model', '', ''])).toBe('ver  model');
     expect(joinViewColumns(['ver', '', 'acct'])).toBe('ver    acct');
+  });
+});
+
+describe('viewUsageSummaryOptions — truthful unavailable states', () => {
+  it('renders the specific usage error for a signed-in usage-capable harness', () => {
+    const error = 'Claude credential expired; re-authentication required for usage.';
+    const opts = viewUsageSummaryOptions('claude', true, { snapshot: null, error }, 2);
+
+    expect(formatUsageSummary(null, null, 3, opts)).toBe('re-auth for usage');
+  });
+
+  it('renders an unavailable state for a globally installed signed-in harness', () => {
+    const error = 'Codex usage is rate-limiting the usage endpoint; not retrying for 13 minutes.';
+    const opts = viewUsageSummaryOptions('codex', true, { snapshot: null, error }, 2);
+
+    expect(opts.unavailable).toBe(true);
+    expect(formatUsageSummary(null, null, 3, opts)).toBe('rate-limited (retry ~13 minutes)');
+  });
+
+  it('keeps the usage column blank for a harness with no usage concept', () => {
+    const error = 'usage read failed: unavailable';
+    const opts = viewUsageSummaryOptions('opencode', true, { snapshot: null, error }, 2);
+
+    expect(opts.unavailable).toBe(false);
+    expect(formatUsageSummary(null, null, 3, opts)).toBe('');
   });
 });
 

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -34,6 +34,7 @@ import { machineId } from '../lib/machine-id.js';
 import { authCacheKey, formatCheckedAge, readAuthHealthCache, type AuthHealth } from '../lib/auth-health.js';
 import {
   agentReportsUsage,
+  classifyUsageErrorKind,
   deriveUsageStatusFromSnapshot,
   formatUsageSection,
   formatUsageSummary,
@@ -43,6 +44,7 @@ import {
   getUsageLookupKey,
   isUsageHeadlessScopeError,
 } from '../lib/accounting/usage.js';
+import type { FormatUsageSummaryOpts, UsageInfo } from '../lib/accounting/usage.js';
 import { readManifest } from '../lib/manifest.js';
 import {
   listInstalledVersions,
@@ -87,6 +89,23 @@ import { renderHarnessDetail } from './harness.js';
 import { confirm } from '@inquirer/prompts';
 import { formatPath, isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { terminalWidth, truncateToWidth, stringWidth, padToWidth } from '../lib/session/width.js';
+
+export function viewUsageSummaryOptions(
+  agentId: AgentId,
+  signedIn: boolean,
+  usageInfo: UsageInfo | undefined,
+  maxWindows: number | undefined,
+): FormatUsageSummaryOpts {
+  const headless = isUsageHeadlessScopeError(usageInfo?.error);
+  return {
+    unavailable: agentReportsUsage(agentId) && signedIn && !usageInfo?.snapshot && !headless,
+    unverified: !headless && !!usageInfo?.snapshot && !!usageInfo.error,
+    headless,
+    maxWindows,
+    errorKind: classifyUsageErrorKind(usageInfo?.error),
+    errorDetail: usageInfo?.error ?? null,
+  };
+}
 
 /** Shared account identity formatter, re-exported for the view-specific tests. */
 export const accountColumnLabel = accountDisplayLabel;
@@ -651,15 +670,12 @@ async function showInstalledVersions(
         const info = rawInfo ? mergeCanonical(rawInfo) : undefined;
         const usageKey = getUsageLookupKey(info);
         const usageInfo = usageKey ? usageByKey.get(usageKey) : undefined;
-        const headless = isUsageHeadlessScopeError(usageInfo?.error);
-        const usageUnavailable = agentReportsUsage(agentId) && !!info?.signedIn && !usageInfo?.snapshot && !headless;
-        const usageUnverified = !headless && !!usageInfo?.snapshot && !!usageInfo.error;
-        const usageStr = formatUsageSummary(info?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, {
-          unavailable: usageUnavailable,
-          unverified: usageUnverified,
-          headless,
-          maxWindows: usageWindowCap,
-        });
+        const usageStr = formatUsageSummary(
+          info?.plan || null,
+          usageInfo?.snapshot || null,
+          maxPlanWidth,
+          viewUsageSummaryOptions(agentId, !!info?.signedIn, usageInfo, usageWindowCap),
+        );
         maxUsageWidth = Math.max(maxUsageWidth, stringWidth(usageStr));
         const statusStr = formatUsageStatusBadge(info?.usageStatus);
         maxStatusWidth = Math.max(maxStatusWidth, stringWidth(statusStr));
@@ -724,15 +740,12 @@ async function showInstalledVersions(
         }
         const hasEmail = !!vInfo?.email;
         const signedIn = !!vInfo?.signedIn;
-        const headless = isUsageHeadlessScopeError(usageInfo?.error);
-        const usageUnavailable = agentReportsUsage(agentId) && signedIn && !usageInfo?.snapshot && !headless;
-        const usageUnverified = !headless && !!usageInfo?.snapshot && !!usageInfo.error;
-        const usageStr = formatUsageSummary(vInfo?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, {
-          unavailable: usageUnavailable,
-          unverified: usageUnverified,
-          headless,
-          maxWindows: usageWindowCap,
-        });
+        const usageStr = formatUsageSummary(
+          vInfo?.plan || null,
+          usageInfo?.snapshot || null,
+          maxPlanWidth,
+          viewUsageSummaryOptions(agentId, signedIn, usageInfo, usageWindowCap),
+        );
         const hasUsage = usageStr.length > 0;
         // Only show lastActive for versions with an actual logged-in account.
         // Otherwise it reflects install time (misleading "just now" for fresh installs).
@@ -850,12 +863,12 @@ async function showInstalledVersions(
       gMaxStatusWidth = Math.max(gMaxStatusWidth, stringWidth(formatUsageStatusBadge(gInfo?.usageStatus)));
       const gUsageKey = getUsageLookupKey(gInfo);
       const gUsage = gUsageKey ? usageByKey.get(gUsageKey) : undefined;
-      const gHeadless = isUsageHeadlessScopeError(gUsage?.error);
-      const gUsageStr = formatUsageSummary(gInfo?.plan || null, gUsage?.snapshot || null, 3, {
-        unverified: !gHeadless && !!gUsage?.snapshot && !!gUsage.error,
-        headless: gHeadless,
-        maxWindows: usageWindowCap,
-      });
+      const gUsageStr = formatUsageSummary(
+        gInfo?.plan || null,
+        gUsage?.snapshot || null,
+        3,
+        viewUsageSummaryOptions(agentId, !!gInfo?.signedIn, gUsage, usageWindowCap),
+      );
       gMaxUsageWidth = Math.max(gMaxUsageWidth, stringWidth(gUsageStr));
       const gDisplay = accountColumnLabel(gInfo);
       if (gDisplay) gMaxEmail = Math.max(gMaxEmail, gDisplay.length);
@@ -874,12 +887,12 @@ async function showInstalledVersions(
       const parts = [`    ${verLabel}${padding}`];
       const gUsageKey = getUsageLookupKey(gInfo);
       const gUsage = gUsageKey ? usageByKey.get(gUsageKey) : undefined;
-      const gHeadless = isUsageHeadlessScopeError(gUsage?.error);
-      const gUsageStr = formatUsageSummary(gInfo?.plan || null, gUsage?.snapshot || null, 3, {
-        unverified: !gHeadless && !!gUsage?.snapshot && !!gUsage.error,
-        headless: gHeadless,
-        maxWindows: usageWindowCap,
-      });
+      const gUsageStr = formatUsageSummary(
+        gInfo?.plan || null,
+        gUsage?.snapshot || null,
+        3,
+        viewUsageSummaryOptions(agentId, !!gInfo?.signedIn, gUsage, usageWindowCap),
+      );
       const gActiveStr = gInfo ? formatLastActive(gInfo.lastActive) : '';
       if (gInfo?.email || gUsageStr || gActiveStr || gInfo?.signedIn) {
         const gDisplay = accountColumnLabel(gInfo);


### PR DESCRIPTION
Fixes the human `agents view` usage column to render the provider-specific unavailable state.

## What changed
- classify each `UsageInfo.error` once and pass both `errorKind` and raw `errorDetail` to `formatUsageSummary`
- apply the same unavailable gate to managed and globally installed (`Not Managed`) rows
- preserve blank usage cells for harnesses without a usage concept

## Dependency
- Implements the `## Interface for view-render` contract from #2912
- Based on fresh `origin/main`, whose `321016cd0` already exposes that formatter interface

## Run evidence
![Focused test run](https://github.com/user-attachments/assets/7714d269-a967-47ed-892c-3b514f1d57d2)

The screenshot shows 1 file / 17 tests passed.

## Verification
- `bun run test` — 893 files / 12,600 tests passed; one unrelated tmux timing assertion failed at `src/lib/tmux/session.test.ts:395`, then passed in isolation (2 passed)
- `bun run build` — passed

No docs/CHANGELOG: focused bug fix; no command, flag, or config surface changed.