### PR TITLE
fix(ext): New <Harness> auto-selects the account again (RUSH-3057)

### DIFF
--- a/apps/ext/AGENTS.md
+++ b/apps/ext/AGENTS.md
@@ -16,9 +16,11 @@ the `swarm-ext://` endpoint. It does not own fleet or agent policy.
   --no-interactive --limit 60`, then calls `agents sessions resume <id>
   --vscodium` or `agents sessions fork <id>`.
 - `Agents: New <Harness>` passes the configured target to
-  `agents run <harness>@ --interactive`, so agents-cli resolves the device first
-  and the picker shows that device's installed versions/accounts. `(Pick Host)`
-  asks for the device before using the same account picker. `(Auto)` uses
+  `agents run <harness> --interactive --strategy balanced`, so agents-cli
+  resolves the device and the account without prompting — the everyday launch
+  opens an agent, never a question. `(Pick Host)` is the one explicit-choice
+  route: it asks for the device, then uses `agents run <harness>@` so the picker
+  shows that device's installed versions/accounts. `(Auto)` uses
   `agents run <harness> --strategy balanced`, so agents-cli chooses both. The
   generic automatic launch stays `agents run auto --interactive --device auto
   --strategy balanced --mode auto`. Launches also add `--project <slug>` when

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
+## [0.9.331] - 2026-08-23
+
+- **`Agents: New <Harness>` opens an agent again instead of asking which account
+  (RUSH-3057).** 0.9.329 put the account picker on the bare command, so the
+  keybinding everyone presses dozens of times a day emitted
+  `agents run claude@ --interactive --device auto --mode auto` and stopped on a
+  seven-row prompt before anything launched. The default is balanced rotation
+  again — `agents run <harness> --interactive --device auto --strategy balanced
+  --mode auto`, which already skips signed-out and rate-limited accounts — and
+  explicit choice moves to `(Pick Host)`, which asks for the device and then
+  shows that device's versions/accounts. `(Auto)` is unchanged. Source:
+  `src/core/launchTarget.ts`.
+
 ## [0.9.329] - 2026-08-20
 
 - **New Agent separates placement from account choice (RUSH-2961).**

--- a/apps/ext/README.md
+++ b/apps/ext/README.md
@@ -59,7 +59,7 @@ curl -fsSL https://raw.githubusercontent.com/phnx-labs/agents-cli/main/scripts/i
 
 Spawn any agent as a full-screen editor tab. Built-in support for Claude Code, Codex, Antigravity, OpenCode, and Cursor. Add custom agents through settings.
 
-**Where a new agent runs** is `agents.launch.defaultTarget`: `auto` (default — agents-cli picks the device), `local` (this machine), or `ask` (prompt every time). Under `auto`, mark your compute boxes once with `agents devices role <name> worker` and every `Agents: New <Harness>` rotates over those workers instead of the machine you are sitting at. Once the device is resolved, the command lists the versions/accounts installed there for you to choose. `Agents: New <Harness> (Pick Host)` asks for the device first and then shows that device's versions/accounts. `Agents: New <Harness> (Auto)` chooses both automatically.
+**Where a new agent runs** is `agents.launch.defaultTarget`: `auto` (default — agents-cli picks the device), `local` (this machine), or `ask` (prompt every time). Under `auto`, mark your compute boxes once with `agents devices role <name> worker` and every `Agents: New <Harness>` rotates over those workers instead of the machine you are sitting at. The device and the version/account are both chosen for you — the account by balanced rotation, which skips signed-out and rate-limited ones — so the command opens an agent without a prompt. `Agents: New <Harness> (Pick Host)` is the explicit route: it asks for the device first and then shows that device's versions/accounts to choose from. `Agents: New <Harness> (Auto)` chooses both automatically, ignoring the configured target.
 
 ### Session Persistence
 

--- a/apps/ext/src/core/agents.ts
+++ b/apps/ext/src/core/agents.ts
@@ -278,8 +278,8 @@ export function wrapNativeAgentCommand(command: string, isShell: boolean): strin
 // The launch contract (apps/ext/AGENTS.md § "Launch contract"): EVERY agent
 // runner launches through `agents run <agent> --interactive --mode auto`, on
 // this machine, an auto-picked host, or a picked host alike. Account selection
-// is supplied by the launch target: the default and Pick Host routes use the
-// trailing `@` picker, while Auto adds `--strategy balanced`. The
+// is supplied by the launch target: the default and Auto routes add
+// `--strategy balanced`, while only Pick Host uses the trailing `@` picker. The
 // only thing that is NOT a runner is 'shell' — a plain terminal, not an agent — so
 // it is the single exclusion. There is deliberately no per-harness allowlist: a
 // bare, strategy-less launch (into whatever account happens to be pinned) is never

--- a/apps/ext/src/core/launchTarget.test.ts
+++ b/apps/ext/src/core/launchTarget.test.ts
@@ -43,13 +43,13 @@ describe('launchOptsForTarget', () => {
 });
 
 describe('launchOptsForHarnessCommand', () => {
-  it('default auto-picks the device and asks for its account/version', () => {
-    expect(launchOptsForHarnessCommand('default', 'auto')).toEqual({ accountPicker: true });
+  it('default auto-picks the device and the account, with no prompt on either', () => {
+    expect(launchOptsForHarnessCommand('default', 'auto')).toEqual({});
   });
 
-  it('preserves explicit local or ask placement while still asking for the account/version', () => {
-    expect(launchOptsForHarnessCommand('default', 'local')).toEqual({ local: true, accountPicker: true });
-    expect(launchOptsForHarnessCommand('default', 'ask')).toEqual({ pickHost: true, accountPicker: true });
+  it('preserves explicit local or ask placement and never adds an account prompt', () => {
+    expect(launchOptsForHarnessCommand('default', 'local')).toEqual({ local: true });
+    expect(launchOptsForHarnessCommand('default', 'ask')).toEqual({ pickHost: true });
   });
 
   it('Pick Host asks for both layers while Auto asks for neither', () => {
@@ -77,17 +77,21 @@ describe('registered harness launch commands', () => {
   it('reads the configured default target when the command is invoked', () => {
     let target: 'auto' | 'local' = 'auto';
     const [registration] = harnessLaunchRegistrations('claude', 'agents.newClaude', () => target);
-    expect(registration.launchOptions()).toEqual({ agentKey: 'claude', accountPicker: true });
+    expect(registration.launchOptions()).toEqual({ agentKey: 'claude' });
     target = 'local';
-    expect(registration.launchOptions()).toEqual({ agentKey: 'claude', local: true, accountPicker: true });
+    expect(registration.launchOptions()).toEqual({ agentKey: 'claude', local: true });
   });
 
-  it('builds each active harness default as automatic device placement followed by the account picker', () => {
+  it('builds each active harness default as automatic device and balanced account, with no picker', () => {
     for (const agent of RUNNERS) {
       const [registration] = harnessLaunchRegistrations(agent.key, agent.commandId, () => 'auto');
-      expect(buildNewAgentLaunchCommand(registration.launchOptions())).toBe(
-        `agents run ${agent.key}@ --interactive --device auto --mode auto`,
+      const command = buildNewAgentLaunchCommand(registration.launchOptions());
+      expect(command).toBe(
+        `agents run ${agent.key} --interactive --device auto --strategy balanced --mode auto`,
       );
+      // The trailing `@` is what makes agents-cli stop and prompt. RUSH-3057:
+      // the everyday launch command must never carry it.
+      expect(command).not.toContain(`${agent.key}@`);
     }
   });
 
@@ -110,15 +114,15 @@ describe('registered harness launch commands', () => {
     }
   });
 
-  it('keeps configured local and prompted-device defaults on the picker path', () => {
+  it('keeps configured local and prompted-device defaults on the balanced path', () => {
     const [local] = harnessLaunchRegistrations('claude', 'agents.newClaude', () => 'local');
     expect(buildNewAgentLaunchCommand(local.launchOptions())).toBe(
-      'agents run claude@ --interactive --mode auto',
+      'agents run claude --interactive --strategy balanced --mode auto',
     );
 
     const [ask] = harnessLaunchRegistrations('claude', 'agents.newClaude', () => 'ask');
     expect(buildNewAgentLaunchCommand({ ...ask.launchOptions(), host: 'worker-box' })).toBe(
-      "agents run claude@ --interactive --host 'worker-box' --mode auto",
+      "agents run claude --interactive --host 'worker-box' --strategy balanced --mode auto",
     );
   });
 });

--- a/apps/ext/src/core/launchTarget.ts
+++ b/apps/ext/src/core/launchTarget.ts
@@ -73,9 +73,15 @@ export function launchOptsForTarget(target: LaunchTarget): LaunchTargetOpts {
 /**
  * Keep the three per-harness command variants distinct:
  *
- * - default: configured placement, then ask which device-local account to run;
+ * - default: configured placement, balanced account — no prompt at all;
  * - pick-host: ask for the device, then ask which account on it to run;
  * - auto: let agents-cli choose both the device and account without a prompt.
+ *
+ * The bare `New <Harness>` is the command bound to a keybinding and pressed
+ * dozens of times a day, so it must open an agent, not a question: RUSH-2961
+ * put the account picker on it and every launch then stopped on a seven-row
+ * prompt. Explicit choice lives on `(Pick Host)`, which is already the "I am
+ * being specific about this launch" route.
  */
 export function launchOptsForHarnessCommand(
   variant: HarnessLaunchVariant,
@@ -83,7 +89,7 @@ export function launchOptsForHarnessCommand(
 ): HarnessLaunchOpts {
   switch (variant) {
     case 'default':
-      return { ...launchOptsForTarget(defaultTarget), accountPicker: true };
+      return { ...launchOptsForTarget(defaultTarget) };
     case 'pick-host':
       return { pickHost: true, accountPicker: true };
     case 'auto':

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -382,9 +382,9 @@ async function pickLaunchHost(
 // --- The one launch engine --------------------------------------------------
 // Every "New agent" command routes through launchAgent. The command is just a
 // route: it fills in whichever of {agentKey, host} the user pinned, and the
-// engine resolves the rest. The per-harness default and Pick Host variants ask
-// agents-cli to show the chosen device's account/version picker; the explicit
-// (Auto) variant uses balanced rotation without a picker.
+// engine resolves the rest. Only the Pick Host variant asks agents-cli to show
+// the chosen device's account/version picker; the per-harness default and the
+// (Auto) variant both use balanced rotation and never prompt.
 /**
  * Everything a freshly created agent terminal needs beyond `createTerminal`.
  *
@@ -1500,7 +1500,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Per-harness launch commands — every one is a thin route into launchAgent.
   // For each non-shell agent:
-  //   New <Harness>              -> configured device target, then account/version picker
+  //   New <Harness>              -> configured device target + balanced account/version
   //   New <Harness> (Pick Host)  -> device picker, then account/version picker
   //   New <Harness> (Auto)       -> automatic device + balanced account/version
   for (const def of BUILT_IN_AGENTS) {


### PR DESCRIPTION
**fix** — `Agents: New <Harness>` opens an agent again instead of asking which account.

## What broke

0.9.329 (RUSH-2961, #2862) put the account picker on the bare per-harness command. Pressing `Agents: New Claude` emitted `agents run claude@ --interactive --device auto --project '<slug>' --mode auto`; the trailing `@` makes agents-cli print `accounts=picker` and stop on a seven-row prompt before anything launches. That reversed the invariant #1629 set on 2026-08-02 ("manual version picking is gone — balanced is the default").

## What changes

`launchOptsForHarnessCommand('default', …)` no longer sets `accountPicker`, so the default variant falls back to `--strategy balanced`:

| Command | Before | After |
|---|---|---|
| `New <Harness>` | `run <h>@ … --device auto` (prompt) | `run <h> … --device auto --strategy balanced` |
| `New <Harness> (Pick Host)` | `run <h>@ … --host <box>` (prompt) | unchanged — the explicit-choice route |
| `New <Harness> (Auto)` | `run <h> … --strategy balanced` | unchanged |

Explicit account choice is not lost: it lives on `(Pick Host)`, which is already the "I am being specific about this launch" command, and `agents run <harness>@` still works directly. No new palette commands (#1629 cut the trio sprawl deliberately).

## Run result

![RUSH-3057 run: every palette command post-fix, the CLI answering that command shape, the suite, and tsc](https://share.agents-cli.sh/muqsitnawaz/ext-default-balanced-account-rush-3057-run-1dc18bc8967d8473)

Accounts and device names are redacted in the capture because this repo is public.

Real command generation, driving the shipped module path (`harnessLaunchRegistrations` -> `buildNewAgentLaunchCommand`, the same call `launchAgent` makes) for every active harness:

```text
New CC          agents run claude --interactive --device auto --project 'agents-cli' --strategy balanced --mode auto
New CC (Pick Host)  agents run claude@ --interactive --host 'yosemite-s0' --project 'agents-cli' --mode auto
New CC (Auto)   agents run claude --interactive --device auto --project 'agents-cli' --strategy balanced --mode auto
New CX          agents run codex --interactive --device auto --project 'agents-cli' --strategy balanced --mode auto
New OC          agents run opencode --interactive --device auto --project 'agents-cli' --strategy balanced --mode auto
New CR          agents run cursor --interactive --device auto --project 'agents-cli' --strategy balanced --mode auto
New AG          agents run antigravity --interactive --device auto --project 'agents-cli' --strategy balanced --mode auto
New GK          agents run grok --interactive --device auto --project 'agents-cli' --strategy balanced --mode auto
New KM          agents run kimi --interactive --device auto --project 'agents-cli' --strategy balanced --mode auto
New DR          agents run droid --interactive --device auto --project 'agents-cli' --strategy balanced --mode auto
```

And the CLI answering that exact command shape — no prompt, account chosen:

```text
$ agents run claude --device auto --strategy balanced --mode plan "Reply with exactly: ok"
[agents] device=auto → local (load yosemite-s1:29%, yosemite-s0:3%) · accounts=balanced
[agents] balanced picked tech@prix.dev · claude@2.1.218 (7 of 8 healthy, usage unverified — no account could be refreshed)
[agents] rate-limit failover armed: claude@2.1.222, claude@2.1.221, claude@2.1.207
[agents] running claude@2.1.218 (session da7b7455)
ok
```

Compare the reported failure, which shows `accounts=picker` on the same command with `@`.

## Verification

- `bun test` in `apps/ext`: **1606 pass, 3 skip, 0 fail** across 139 files.
- `bun run compile:ext` (tsc): clean.
- A new assertion pins the regression directly: every active harness default must not contain `<harness>@`.

## Docs

- `apps/ext/AGENTS.md` launch contract, `apps/ext/README.md` launch-target section, `apps/ext/CHANGELOG.md` (0.9.331).

Tracking: https://linear.app/getrush/issue/RUSH-3057
