### PR TITLE
fix(exec): key Claude credential on device role, not run mode (RUSH-2395)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2395.md
+++ b/apps/cli/.changelog/next/RUSH-2395.md
@@ -1,0 +1,15 @@
+- **On your own machine, every Claude run uses your normal login — not the
+  worker setup-token (RUSH-2395).** The credential now follows **device role**,
+  not run mode. A device marked `config.role: personal` (your interactive box —
+  set it with `agents devices role <name> personal`) authenticates every Claude
+  run from its per-version login, whether it opens a TUI or is a headless
+  one-shot like `agents run claude "fix the bug"`. Before, the choice keyed only
+  on whether a prompt was present ("this opens a TUI", not "a human is present"),
+  so a headless run on your laptop grabbed the reserved `auth`-bundle setup-token
+  and took the session off your login — surfacing as `/status` reporting
+  `Auth token: CLAUDE_CODE_OAUTH_TOKEN`. The setup-token stays the credential for
+  headless runs on **worker** devices (and unmarked boxes), which have no
+  keychain login to defer to. Routines follow the same role gate. Source:
+  `apps/cli/src/lib/harness/adapters/claude.ts`,
+  `apps/cli/src/lib/exec.ts`, `apps/cli/src/lib/daemon/runner.ts`,
+  `apps/cli/src/lib/device-config.ts`.

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -2054,33 +2054,44 @@ schema (`--json` passes through each agent's native stream format).
   `COPILOT_HOME` / `KIMI_CODE_HOME`) and MUST delete the other three agents'
   vars on every branch, so a config pointer from a different agent's shell
   never leaks into this invocation (`buildExecEnv`'s per-agent branch, `lib/exec.ts:407-564`).
-- **EXEC-2a (MUST).** For claude, `buildExecEnv` MUST inject the reserved `auth`
-  bundle's per-account setup-token into `CLAUDE_CODE_OAUTH_TOKEN` ONLY when the
-  run resolves **headless** (`resolveInteractive(options) === false`,
-  `lib/exec.ts:425-455`). That token exists so an unattended run authenticates
-  without the Touch-ID-gated login item (`lib/claude-account-token.ts:9-16`); an
-  interactive run MUST be left on its per-version login, which is also the only
-  credential carrying the `user:profile` scope usage reads require (RUSH-2392).
-  **`resolveInteractive` means "this run opens a TUI", NOT "a human is present"**
-  — do not read the requirement as the latter. `watchdog/rotate.ts:195` builds
-  `agents run auto --interactive` and `watchdog/runner.ts:901-903` injects it
-  into a tab unattended, so the watchdog's rotate-relaunch resolves interactive
-  and is deliberately NOT given the setup-token. That is the pre-existing
-  contract, not a new gap: the injection dates only to #1719 (2026-08-02), and
-  every interactive run — the watchdog's included — authenticated from its
-  per-version login before it. Where that relaunch lands on a home whose login
-  has gone dead, the defect is rotation treating "email present" as `authValid`
-  (`agents.ts:1871-1872`), which the token merely masked. Making the credential
-  a function of DEVICE ROLE rather than run mode is tracked in RUSH-2395.
-  An interactive run MUST additionally delete an INHERITED
-  `CLAUDE_CODE_OAUTH_TOKEN` whose value equals that same resolved setup-token
-  (`lib/exec.ts:448-449`), so an interactive launch from inside a headless
-  agent's shell does not keep authenticating as it; a value the caller set
-  itself MUST survive, and `options.env` still overrides last (EXEC-5).
-  Note this MUST NOT be read as "an interactive run never carries a token" — no
-  requirement yet strips an ambient value when NO per-account token resolves,
-  which is the routines path's behavior (`lib/daemon/runner.ts:1018-1021`) and is
-  tracked as RUSH-2360.
+- **EXEC-2a (MUST).** For claude, `buildExecEnv` injects the reserved `auth`
+  bundle's per-account setup-token into `CLAUDE_CODE_OAUTH_TOKEN` as a function of
+  **DEVICE ROLE and run mode**, resolved in `claudeAdapter.applyExecConfigEnv`
+  from `ctx.deviceRole` (`selfConfiguredDeviceRole()`, exec.ts) and
+  `ctx.interactive` (`resolveInteractive(options)`). The token is a WORKER
+  credential — it exists so an unattended box with no keychain login authenticates
+  without the Touch-ID-gated login item (`lib/claude-account-token.ts:9-16`).
+  Two run classes MUST instead be left on the per-version login (also the only
+  credential carrying the `user:profile` scope usage reads require, RUSH-2392):
+  - **any run on a `personal` device** — the user's own interactive box
+    (`config.role: personal`, e.g. zion) — interactive TUI OR headless one-shot
+    (`agents run claude "<prompt>"`) alike. That box is the single origin of the
+    login, so it MUST authenticate from it for every run (RUSH-2395). Before this,
+    gating on run mode alone routed a headless run on the laptop onto the
+    setup-token and hijacked the login.
+  - **an interactive run on any device.** **`resolveInteractive` means "this run
+    opens a TUI", NOT "a human is present"** — do not read it as the latter.
+    `watchdog/rotate.ts` builds `agents run auto --interactive` unattended, so the
+    watchdog's rotate-relaunch resolves interactive and is deliberately NOT given
+    the setup-token.
+
+  So the setup-token is injected ONLY on a **headless run on a non-personal
+  device** (worker / dispatched / provisioned; `ctx.deviceRole !== 'personal' &&
+  ctx.interactive === false`). On that path it replaces any ambient inherited
+  value, and when NO per-account token resolves it STRIPS the ambient
+  `CLAUDE_CODE_OAUTH_TOKEN` (RUSH-2360 / RUSH-1822 fleet-logout hazard). On the
+  login-deferring path (personal OR interactive) `buildExecEnv` MUST additionally
+  delete an INHERITED `CLAUDE_CODE_OAUTH_TOKEN` whose value equals this account's
+  resolved setup-token, so a launch from inside a headless agent's shell does not
+  keep authenticating as it; a value the caller set itself MUST survive, and
+  `options.env` still overrides last (EXEC-5). The routines path
+  (`buildRoutineSpawnEnv`, `lib/daemon/runner.ts`) applies the SAME role gate: a
+  routine on a personal device defers to the login, a worker routine keeps the
+  setup-token. `undefined`/unmarked role is treated as non-personal
+  (worker-equivalent) — an unmarked box has no login to defer to.
+  Note this MUST NOT be read as "a login-deferring run never carries a token": no
+  requirement yet strips an ambient value on that path when NO per-account token
+  resolves, tracked as RUSH-2360.
 - **EXEC-3 (MUST).** `buildExecEnv` MUST set `AGENTS_MAILBOX_DIR` +
   `AGENT_SESSION_ID` + `AGENTS_SESSION_ID` when a valid session id is present
   (`lib/exec.ts:572-575`), `AGENTS_RUNTIME` to `terminal`/`headless` from

--- a/apps/cli/src/lib/daemon/runner.setup-token.test.ts
+++ b/apps/cli/src/lib/daemon/runner.setup-token.test.ts
@@ -9,6 +9,7 @@ import { bundleItemStore, keychainRef, writeBundle, type SecretsBundle } from '.
 import { _resetFileStoreForTest } from '../secrets/filestore.js';
 import { secretsKeychainItem } from '../secrets/index.js';
 import { getVersionHomePath } from '../installations/versions.js';
+import { setConfiguredDeviceRole } from '../device-config.js';
 
 // A routine authenticates through a per-account, non-rotating `claude setup-token`
 // (the mint-auth cure for the single-use-refresh-token revocation storm). The daemon
@@ -104,5 +105,43 @@ describe('buildRoutineSpawnEnv — CLAUDE_CODE_OAUTH_TOKEN handling', () => {
     // No provisioned setup-token → the ambient value is dropped, routine uses the
     // version home's own login instead.
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+  });
+
+  // On a PERSONAL device (the user's own interactive box), routines defer to the
+  // per-version login exactly like an interactive run — the setup-token is a
+  // worker-only credential (RUSH-2395). This mirrors the adapter matrix in
+  // harness/adapters/claude.test.ts on the routines path.
+  describe('on a personal device', () => {
+    it('does NOT inject a provisioned setup-token — defers to the per-version login', () => {
+      const device = `rush-2395-personal-defer-${process.pid}`;
+      process.env.AGENTS_SYNC_MACHINE_ID = device;
+      setConfiguredDeviceRole(device, 'personal');
+      const version = `rush-2395-personal-defer-v-${process.pid}`;
+      const email = 'alpha@example.com';
+      makeVersionHome(version, email);
+      // A per-account setup-token IS provisioned; on a worker this would be injected.
+      writeAuthBundle({ [claudeAccountTokenKey(email)]: 'sk-ant-oat01-alpha' });
+
+      const env = buildRoutineSpawnEnv({ ...process.env } as Record<string, string>, 'claude', version);
+
+      // Personal box → the routine runs on the login, not the setup-token.
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    });
+
+    it('strips an inherited copy of its OWN setup-token so the login wins', () => {
+      const device = `rush-2395-personal-strip-${process.pid}`;
+      process.env.AGENTS_SYNC_MACHINE_ID = device;
+      setConfiguredDeviceRole(device, 'personal');
+      const version = `rush-2395-personal-strip-v-${process.pid}`;
+      const email = 'alpha@example.com';
+      makeVersionHome(version, email);
+      writeAuthBundle({ [claudeAccountTokenKey(email)]: 'sk-ant-oat01-alpha' });
+      // A leaked copy of this account's own token inherited from a headless parent.
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-alpha';
+
+      const env = buildRoutineSpawnEnv({ ...process.env } as Record<string, string>, 'claude', version);
+
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    });
   });
 });

--- a/apps/cli/src/lib/daemon/runner.setup-token.test.ts
+++ b/apps/cli/src/lib/daemon/runner.setup-token.test.ts
@@ -23,6 +23,7 @@ let versionDirs: string[] = [];
 let prevNoAgent: string | undefined;
 let prevPassphrase: string | undefined;
 let prevClaudeToken: string | undefined;
+let prevMachineId: string | undefined;
 
 beforeEach(() => {
   fileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runner-setup-token-store-'));
@@ -30,8 +31,14 @@ beforeEach(() => {
   prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
   prevPassphrase = process.env.AGENTS_SECRETS_PASSPHRASE;
   prevClaudeToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  prevMachineId = process.env.AGENTS_SYNC_MACHINE_ID;
   process.env.AGENTS_SECRETS_NO_AGENT = '1';
   process.env.AGENTS_SECRETS_PASSPHRASE = PASS;
+  // These cases assert the WORKER routine credential rule (keep the setup-token,
+  // strip an inherited ambient one). Pin the self device id to a role-less name so
+  // selfConfiguredDeviceRole() resolves undefined; on a machine marked personal
+  // (e.g. zion) a routine defers to the login instead (RUSH-2395), flipping them.
+  process.env.AGENTS_SYNC_MACHINE_ID = 'runner-setup-token-worker-fixture';
   _resetFileStoreForTest({ fileDir, passphrase: PASS });
 });
 
@@ -43,6 +50,8 @@ afterEach(() => {
   else process.env.AGENTS_SECRETS_PASSPHRASE = prevPassphrase;
   if (prevClaudeToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
   else process.env.CLAUDE_CODE_OAUTH_TOKEN = prevClaudeToken;
+  if (prevMachineId === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+  else process.env.AGENTS_SYNC_MACHINE_ID = prevMachineId;
   for (const dir of versionDirs) fs.rmSync(dir, { recursive: true, force: true });
   fs.rmSync(fileDir, { recursive: true, force: true });
 });

--- a/apps/cli/src/lib/daemon/runner.ts
+++ b/apps/cli/src/lib/daemon/runner.ts
@@ -80,6 +80,7 @@ import {
 } from '../accounting/rotate.js';
 import { readAuthHealth, isDeadVerdict } from '../auth-health.js';
 import { machineId } from '../machine-id.js';
+import { selfConfiguredDeviceRole } from '../device-config.js';
 import { isSelfUpdatingAgent, ROUTINE_AGENT_IDS, isAgentHardDeprecated, hardDeprecationError } from '../agents.js';
 import { isCustomHarnessName, readProfile } from '../profiles.js';
 
@@ -1287,8 +1288,19 @@ export function buildRoutineSpawnEnv(
   const setupToken = agent === 'claude' && version
     ? resolveClaudeSetupToken(getVersionHomePath('claude', version))
     : null;
-  if (setupToken) out.CLAUDE_CODE_OAUTH_TOKEN = setupToken;
-  else delete out.CLAUDE_CODE_OAUTH_TOKEN;
+  // A `personal` device (the user's own interactive box) uses the per-version
+  // login for EVERY run, routines included — the setup-token is a worker-only
+  // credential (RUSH-2395, mirrors the claude adapter's personal-device branch).
+  // On a personal box, only strip an inherited copy of the account's OWN
+  // setup-token by value so a leaked ambient value can't override the login; a
+  // token the user set deliberately is a different string and survives.
+  if (selfConfiguredDeviceRole() === 'personal') {
+    if (setupToken && out.CLAUDE_CODE_OAUTH_TOKEN === setupToken) delete out.CLAUDE_CODE_OAUTH_TOKEN;
+  } else if (setupToken) {
+    out.CLAUDE_CODE_OAUTH_TOKEN = setupToken;
+  } else {
+    delete out.CLAUDE_CODE_OAUTH_TOKEN;
+  }
   if (agent === 'cursor' && overlayHome) {
     // prepareJobHome links this host's Cursor auth file here. Pin XDG_CONFIG_HOME
     // to the overlay so an ambient value cannot bypass the routine sandbox.

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -688,6 +688,21 @@ export function configuredDeviceRole(name: string): ConfiguredDeviceRole | undef
   return getConfigValue('role', { device: name }).value as ConfiguredDeviceRole | undefined;
 }
 
+/**
+ * The role marked on THIS machine — the one running the CLI — or undefined when
+ * it was never marked. Keyed off {@link machineId} (overridable via
+ * AGENTS_SYNC_MACHINE_ID), so it matches the device's own config-folder key.
+ *
+ * The auth strategy reads this: a `personal` device (the user's own interactive
+ * box) holds a real per-version login and MUST authenticate from it for EVERY
+ * run, interactive or headless; only a `worker` uses the file-based setup-token
+ * (RUSH-2395). `undefined` is treated as non-personal (worker-equivalent) by
+ * that gate — an unmarked box has no login to defer to.
+ */
+export function selfConfiguredDeviceRole(): ConfiguredDeviceRole | undefined {
+  return configuredDeviceRole(machineId());
+}
+
 /** Mark a device's role fleet-wide; `undefined` clears the mark. */
 export function setConfiguredDeviceRole(name: string, role: ConfiguredDeviceRole | undefined): void {
   assertValidDeviceName(name);

--- a/apps/cli/src/lib/exec.test.ts
+++ b/apps/cli/src/lib/exec.test.ts
@@ -1063,6 +1063,7 @@ describe('buildExecEnv — Claude ambient CLAUDE_CODE_OAUTH_TOKEN handling (RUSH
   let prevNoAgent: string | undefined;
   let prevPassphrase: string | undefined;
   let prevClaudeToken: string | undefined;
+  let prevMachineId: string | undefined;
 
   beforeEach(() => {
     fileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-oauth-token-store-'));
@@ -1070,8 +1071,15 @@ describe('buildExecEnv — Claude ambient CLAUDE_CODE_OAUTH_TOKEN handling (RUSH
     prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
     prevPassphrase = process.env.AGENTS_SECRETS_PASSPHRASE;
     prevClaudeToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    prevMachineId = process.env.AGENTS_SYNC_MACHINE_ID;
     process.env.AGENTS_SECRETS_NO_AGENT = '1';
     process.env.AGENTS_SECRETS_PASSPHRASE = PASS;
+    // These cases assert WORKER (headless) credential semantics. Pin the self
+    // device id to a name that carries no role mark so selfConfiguredDeviceRole()
+    // resolves undefined (worker-equivalent) — otherwise, run on a machine marked
+    // `config.role: personal` (e.g. zion), the personal-device gate would defer to
+    // the login and these assertions would flip (RUSH-2395).
+    process.env.AGENTS_SYNC_MACHINE_ID = 'rush-2360-worker-fixture';
     _resetFileStoreForTest({ fileDir, passphrase: PASS });
   });
 
@@ -1083,6 +1091,8 @@ describe('buildExecEnv — Claude ambient CLAUDE_CODE_OAUTH_TOKEN handling (RUSH
     else process.env.AGENTS_SECRETS_PASSPHRASE = prevPassphrase;
     if (prevClaudeToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
     else process.env.CLAUDE_CODE_OAUTH_TOKEN = prevClaudeToken;
+    if (prevMachineId === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+    else process.env.AGENTS_SYNC_MACHINE_ID = prevMachineId;
     for (const dir of versionDirs) fs.rmSync(dir, { recursive: true, force: true });
     fs.rmSync(fileDir, { recursive: true, force: true });
   });

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -29,7 +29,7 @@ import { recordRunName } from './session/run-names.js';
 import { mailboxDir, isValidMailboxId } from './mailbox.js';
 import { composeWin32CommandLine } from './platform/index.js';
 import { isTmuxInstalled } from './tmux/binary.js';
-import { isTmuxEnabled } from './device-config.js';
+import { isTmuxEnabled, selfConfiguredDeviceRole } from './device-config.js';
 import { machineId } from './machine-id.js';
 import { shellQuote } from './ssh-exec.js';
 import { codexEditWritableRoots, codexPolicyArgs } from './codex-policy.js';
@@ -435,6 +435,7 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
       version,
       versionHome,
       interactive: resolveInteractive(options),
+      deviceRole: selfConfiguredDeviceRole(),
       resolveClaudeSetupToken,
     });
   } else {

--- a/apps/cli/src/lib/harness/adapter.ts
+++ b/apps/cli/src/lib/harness/adapter.ts
@@ -28,6 +28,7 @@
  */
 import type { AgentId, Mode } from '../types.js';
 import type { JobConfig } from '../scheduling/routines.js';
+import type { ConfiguredDeviceRole } from '../device-config.js';
 
 /**
  * Context for the exec-time config-env pin (mapping A, exec.ts side). The caller
@@ -43,6 +44,16 @@ export interface ExecConfigEnvCtx {
   versionHome: string | null;
   /** resolveInteractive(options) — computed once by the caller. */
   interactive: boolean;
+  /**
+   * The role marked on THIS machine (worker | personal | undefined), resolved
+   * once by the caller from selfConfiguredDeviceRole(). A `personal` device is
+   * the user's own interactive box: it holds a real per-version login and the
+   * credential decision MUST defer to it for EVERY run — interactive OR headless
+   * — never the worker-only setup-token (RUSH-2395). Injected as a plain value
+   * (not imported) to keep the adapter import-leaf. Absent/undefined is treated
+   * as non-personal (worker-equivalent).
+   */
+  deviceRole?: ConfiguredDeviceRole;
   /**
    * claude-account-token's resolveClaudeSetupToken, injected. The adapters MUST
    * stay import-leaf: claude-account-token pulls in the secrets stack, which

--- a/apps/cli/src/lib/harness/adapters/claude.test.ts
+++ b/apps/cli/src/lib/harness/adapters/claude.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { claudeAdapter } from './claude.js';
+import type { ExecConfigEnvCtx } from '../adapter.js';
+import type { ConfiguredDeviceRole } from '../../device-config.js';
+
+/**
+ * The credential decision in `claudeAdapter.applyExecConfigEnv` — which account a
+ * Claude run authenticates as — is a function of DEVICE ROLE and run mode, not
+ * run mode alone (RUSH-2395). This exercises the whole matrix directly against
+ * the adapter (no config/keychain), because getting it wrong silently reroutes a
+ * run onto the wrong account: a headless run on the user's laptop hijacking their
+ * login, or a worker run failing to pick up its setup-token.
+ */
+describe('claudeAdapter.applyExecConfigEnv — role-aware CLAUDE_CODE_OAUTH_TOKEN', () => {
+  const VERSION_HOME = '/tmp/rush-2395-version-home';
+  const OWN_TOKEN = 'sk-ant-oat01-own-account';
+  const FOREIGN_TOKEN = 'sk-ant-oat01-someone-else';
+
+  /**
+   * Run the adapter with a stubbed setup-token resolver and return the token the
+   * run would end up authenticating with (undefined = defers to the per-version
+   * login). `ambient` seeds an already-present CLAUDE_CODE_OAUTH_TOKEN, standing
+   * in for a value inherited from a parent shell (sanitizeProcessEnv keeps it).
+   */
+  function resolvedToken(opts: {
+    interactive: boolean;
+    deviceRole?: ConfiguredDeviceRole;
+    setupToken: string | null;
+    ambient?: string;
+  }): string | undefined {
+    const result: NodeJS.ProcessEnv = {};
+    if (opts.ambient !== undefined) result.CLAUDE_CODE_OAUTH_TOKEN = opts.ambient;
+    const ctx: ExecConfigEnvCtx = {
+      agent: 'claude',
+      version: 'test',
+      versionHome: VERSION_HOME,
+      interactive: opts.interactive,
+      deviceRole: opts.deviceRole,
+      resolveClaudeSetupToken: () => opts.setupToken,
+    };
+    claudeAdapter.applyExecConfigEnv!(result, ctx);
+    return result.CLAUDE_CODE_OAUTH_TOKEN;
+  }
+
+  describe('worker device (or unmarked) — headless runs use the setup-token', () => {
+    it('injects the per-account setup-token on a headless worker run', () => {
+      expect(resolvedToken({ interactive: false, deviceRole: 'worker', setupToken: OWN_TOKEN }))
+        .toBe(OWN_TOKEN);
+    });
+
+    it('the setup-token wins over an ambient inherited value (worker headless)', () => {
+      expect(resolvedToken({
+        interactive: false,
+        deviceRole: 'worker',
+        setupToken: OWN_TOKEN,
+        ambient: 'sk-ant-oat01-shared-must-not-win',
+      })).toBe(OWN_TOKEN);
+    });
+
+    it('strips an ambient token when NO setup-token resolves (provisioned-box leak)', () => {
+      expect(resolvedToken({
+        interactive: false,
+        deviceRole: 'worker',
+        setupToken: null,
+        ambient: 'sk-ant-oat01-shared-rotating',
+      })).toBeUndefined();
+    });
+
+    it('treats an UNMARKED device (undefined role) as a worker — still injects on headless', () => {
+      expect(resolvedToken({ interactive: false, deviceRole: undefined, setupToken: OWN_TOKEN }))
+        .toBe(OWN_TOKEN);
+    });
+  });
+
+  describe('personal device — every run defers to the per-version login', () => {
+    it('a HEADLESS run on a personal box does NOT inject the setup-token (the RUSH-2395 fix)', () => {
+      // `agents run claude "fix the bug"` on the laptop: prompt present -> headless,
+      // but role personal -> must stay on the login, not the setup-token.
+      expect(resolvedToken({ interactive: false, deviceRole: 'personal', setupToken: OWN_TOKEN }))
+        .toBeUndefined();
+    });
+
+    it('strips an inherited copy of OUR OWN setup-token so the login wins (headless personal)', () => {
+      expect(resolvedToken({
+        interactive: false,
+        deviceRole: 'personal',
+        setupToken: OWN_TOKEN,
+        ambient: OWN_TOKEN,
+      })).toBeUndefined();
+    });
+
+    it('leaves a DIFFERENT ambient token alone — a deliberately-exported value survives (#2383)', () => {
+      expect(resolvedToken({
+        interactive: false,
+        deviceRole: 'personal',
+        setupToken: OWN_TOKEN,
+        ambient: FOREIGN_TOKEN,
+      })).toBe(FOREIGN_TOKEN);
+    });
+
+    it('an INTERACTIVE run on a personal box also defers to the login', () => {
+      expect(resolvedToken({ interactive: true, deviceRole: 'personal', setupToken: OWN_TOKEN }))
+        .toBeUndefined();
+    });
+  });
+
+  describe('interactive runs defer to the login regardless of role', () => {
+    it('interactive on an unmarked/worker device still leaves the login (value-match strip only)', () => {
+      expect(resolvedToken({ interactive: true, deviceRole: 'worker', setupToken: OWN_TOKEN }))
+        .toBeUndefined();
+      expect(resolvedToken({
+        interactive: true,
+        deviceRole: 'worker',
+        setupToken: OWN_TOKEN,
+        ambient: OWN_TOKEN,
+      })).toBeUndefined();
+    });
+  });
+});

--- a/apps/cli/src/lib/harness/adapters/claude.ts
+++ b/apps/cli/src/lib/harness/adapters/claude.ts
@@ -29,34 +29,48 @@ export const claudeAdapter: HarnessAdapter = {
     }
     // The `auth` bundle's setup-token exists so a run with NO human present
     // authenticates without the Touch-ID-gated login item — usage probes,
-    // routines, dispatched runs (claude-account-token.ts). An interactive run
-    // has a human at the TTY, and their own per-version login is the credential
-    // they established and expect; overriding it made `/status` report
-    // `Auth token: CLAUDE_CODE_OAUTH_TOKEN` on a personal machine and took every
-    // hand-driven session off that login. macOS cannot cheaply confirm a home's
-    // login first (probing the Keychain raises an authorization sheet per
-    // installed version on the `agents run` hot path — agents.ts
-    // `isClaudeCredentialFileBlank`), so interactive simply defers to Claude
-    // Code, which prompts a present human to log in if the login is missing.
-    if (ctx.interactive) {
-      // Drop an INHERITED copy of OUR OWN setup-token: an interactive launch from
-      // inside a headless agent's shell inherits that agent's injected value via
-      // sanitizeProcessEnv(process.env) and would keep authenticating as it.
-      // Matched by VALUE, so a token the user exported deliberately is a different
-      // string and is left alone (#2383). This is NARROWER than the non-interactive
-      // path below, which overwrites-or-deletes unconditionally and never inspects
-      // the inherited value — a DIFFERENT account's inherited setup-token passing
-      // through this equality check is the adjacent hole RUSH-2360 leaves as
-      // follow-up (it does not silently run on a *shared, rotating* token, which is
-      // what caused the RUSH-1822 logout storm).
+    // routines, dispatched runs (claude-account-token.ts). It is a WORKER
+    // credential. Two kinds of run defer to the per-version login instead:
+    //
+    //   1. An interactive run: a human is at the TTY, and their per-version login
+    //      is the credential they established and expect. Overriding it made
+    //      `/status` report `Auth token: CLAUDE_CODE_OAUTH_TOKEN` on a personal
+    //      machine and took every hand-driven session off that login.
+    //   2. ANY run on a `personal` device — the user's own interactive box (zion),
+    //      marked `config.role: personal`. That box holds a real per-version login
+    //      and is the single origin of it, so every run there — interactive TUI OR
+    //      a headless one-shot like `agents run claude "fix the bug"` — MUST use
+    //      that login, not the setup-token. Gating on run mode ALONE
+    //      (resolveInteractive = "this opens a TUI", NOT "a human is present")
+    //      sent a headless run on the laptop onto the setup-token and hijacked the
+    //      login. Keying the credential on DEVICE ROLE is the fix — RUSH-2395.
+    //
+    // macOS cannot cheaply confirm a home's login first (probing the Keychain
+    // raises an authorization sheet per installed version on the `agents run` hot
+    // path — agents.ts `isClaudeCredentialFileBlank`), so this path defers to
+    // Claude Code, which reads its own ACL-trusted login item without a prompt and
+    // asks a present human to log in only if the login is missing.
+    const personalDevice = ctx.deviceRole === 'personal';
+    if (ctx.interactive || personalDevice) {
+      // Drop an INHERITED copy of OUR OWN setup-token: a launch from inside a
+      // headless agent's shell inherits that agent's injected value via
+      // sanitizeProcessEnv(process.env) and would keep authenticating as it,
+      // overriding the login this branch is protecting. Matched by VALUE, so a
+      // token the user exported deliberately is a different string and is left
+      // alone (#2383). This is NARROWER than the worker path below, which
+      // overwrites-or-deletes unconditionally and never inspects the inherited
+      // value — a DIFFERENT account's inherited setup-token passing through this
+      // equality check is the adjacent hole RUSH-2360 leaves as follow-up (it does
+      // not silently run on a *shared, rotating* token, which is what caused the
+      // RUSH-1822 logout storm).
       if (setupToken && result.CLAUDE_CODE_OAUTH_TOKEN === setupToken) {
         delete result.CLAUDE_CODE_OAUTH_TOKEN;
       }
     } else {
-      // Non-interactive (routines, dispatched, provisioned box): mirror the routines
-      // path (`runner.ts:1017-1021`) UNCONDITIONALLY. Inject the per-account
-      // setup-token when one resolves — it replaces any ambient shared value
-      // inherited from the launcher. When NONE resolves, STRIP the ambient
+      // Headless run on a NON-personal device (worker, dispatched, provisioned
+      // box): mirror the routines path (`runner.ts`) UNCONDITIONALLY. Inject the
+      // per-account setup-token when one resolves — it replaces any ambient shared
+      // value inherited from the launcher. When NONE resolves, STRIP the ambient
       // CLAUDE_CODE_OAUTH_TOKEN so a run on a provisioned box can never silently
       // authenticate as the shared, rotating token an earlier version of this path
       // let through — the RUSH-1822 fleet-wide-logout hazard, tracked by RUSH-2360.


### PR DESCRIPTION
**fix(exec): key the Claude credential on device role, not run mode (RUSH-2395)**

## What happens now (behavior)

On **your own machine** (a device marked `config.role: personal`, e.g. zion), a headless one-shot like `agents run claude "fix the bug"` now authenticates from your **per-version login** — the same credential an interactive TUI uses. Before, it grabbed the reserved `auth`-bundle **setup-token** and took the session off your login (surfacing as `/status` reporting `Auth token: CLAUDE_CODE_OAUTH_TOKEN`).

On **worker / unmarked** devices, headless runs still use the setup-token — those boxes have no keychain login to defer to.

The credential now follows **device role + run mode**, not run mode alone. `resolveInteractive` means "this run opens a TUI", *not* "a human is present" — so keying on it alone routed a prompt-bearing run on the laptop onto the worker token.

## Why

`claudeAdapter.applyExecConfigEnv` injected the setup-token whenever `resolveInteractive(options) === false` (prompt present ⇒ headless), with no `role` input. A personal box is the single origin of its login; every run there must use it. Role-based auth is the RUSH-2395 direction; the `personal` role already existed as a shared config key, this wires the auth gate to it.

## Change

- `device-config.ts` — `selfConfiguredDeviceRole()` (this machine's role via `machineId()`).
- `harness/adapter.ts` — `ExecConfigEnvCtx.deviceRole`, injected by `buildExecEnv` (value-injected to keep the adapter import-leaf).
- `harness/adapters/claude.ts` — a `personal` device defers to the login like an interactive run (strips only an inherited copy of *our own* token by value; worker keeps unconditional inject/strip).
- `daemon/runner.ts` — `buildRoutineSpawnEnv` applies the same role gate (routines on a personal box use the login).
- `docs/specifications.md` — EXEC-2a rewritten for role-awareness.

## Proof — real config on zion (no secrets printed, booleans only)

`buildExecEnv` for a **headless** claude run, against live device config:

```
zion (config.role: personal):
  {"machineId":"zion","deviceRole":"personal","headlessRun":true,"CLAUDE_CODE_OAUTH_TOKEN_injected":false}   ← uses login (the fix)

forced worker (AGENTS_SYNC_MACHINE_ID=yosemite-s0, role=worker), with a sentinel ambient token present:
  personal keeps the ambient (defers to login):  CLAUDE_CODE_OAUTH_TOKEN_injected: true
  worker strips the ambient (worker path):        CLAUDE_CODE_OAUTH_TOKEN_injected: false
```

The first line is the reported bug fixed: a headless run on the laptop no longer carries the setup-token. The contrast proves the two branches diverge by role end-to-end on real config.

## Tests

- `harness/adapters/claude.test.ts` — new, **9/9**: the full decision matrix (worker headless injects; personal headless defers; personal strips its own inherited token by value but leaves a foreign/deliberate one; interactive defers on any role; unmarked = worker-equivalent).
- Existing `exec.test.ts` (RUSH-2360) and `daemon/runner.setup-token.test.ts` pinned to a role-less machine fixture so they stay deterministic on a personal-marked box.
- Full exec / runner / device-config suites: **481/481 green**.

Not a UI change (CLI credential selection) — evidence is the run output above.

Ticket: https://linear.app/getrush/issue/RUSH-2395

## Run evidence (captured)

Full captured run — real-config `buildExecEnv` probe + test suite — uploaded here:
https://share.agents-cli.sh/muqsitnawaz/rush-2395-role-based-claude-auth-rush-2395-run-evidence-d77bf4a713f0ebee

On disk: `zion:/Users/muqsit/src/github.com/phnx-labs/agents-cli/.agents/worktrees/rush-2395-role-based-claude-auth/apps/.agents/scratch/rush-2395-run-evidence.txt`

```
== Real-config buildExecEnv probe (headless 'agents run claude', booleans only) ==
-- zion (config.role: personal) => must NOT inject the setup-token --
{"machineId":"zion","deviceRole":"personal","headlessRun":true,"CLAUDE_CODE_OAUTH_TOKEN_injected":false}
-- forced worker (yosemite-s0) + sentinel ambient token: worker STRIPS it --
{"machineId":"yosemite-s0","deviceRole":"worker","headlessRun":true,"CLAUDE_CODE_OAUTH_TOKEN_injected":false}
-- zion (personal) + same sentinel ambient: personal DEFERS (keeps login path) --
{"machineId":"zion","deviceRole":"personal","headlessRun":true,"CLAUDE_CODE_OAUTH_TOKEN_injected":true}
== Unit + suite tests ==  Test Files 5 passed (5)   Tests 232 passed (232)
```
