### PR TITLE
fix(sessions): trace idle-gap + honest --no-redact footer (review follow-up to #2923)

### DIFF
--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -977,7 +977,9 @@ The command surface (bare `sessions [query]`, `preview`, `tail`, `resume`, `deta
   (`{ schemaVersion, kind: 'sessions-trace', layout: 'single' | 'compare', sessions:
   SessionTrajectory[], diff? }`), never the `SessionMeta[]` list or the `{ session,
   events }` render detail shape. A `SessionTrajectory` MUST carry `spanMs`, `steps[]`,
-  `gaps[]`, `toolTimeShare`, `errorCount`, and `stats`; each `TrajectoryStep` MUST
+  `gaps[]`, `toolTimeShare`, `errorCount`, `stats`, and `redacted` — the last
+  recording whether the model was built with redaction on, so a renderer states
+  the true redaction status instead of asserting one; each `TrajectoryStep` MUST
   carry `startMs`, `durationMs`, and `durationEstimated`, where per-step `durationMs`
   is **derived** by pairing a `tool_use` with its `tool_result`/`error` on `callId`
   (never persisted onto `SessionEvent` or the `tool_calls` index), and

--- a/apps/cli/src/lib/session/trajectory-html.test.ts
+++ b/apps/cli/src/lib/session/trajectory-html.test.ts
@@ -47,6 +47,13 @@ describe('renderTrajectoryHtml — self-contained and safe', () => {
     ];
     const html = renderTrajectoryHtml(buildTrajectory(withSecret, meta(), { redact: true, knownSecrets: [secret] }));
     expect(html).not.toContain(secret);
+    expect(html).toContain('Secret-redacted trajectory');
+  });
+
+  it('footer tells the truth under --no-redact (not a false "Secret-redacted" claim)', () => {
+    const html = renderTrajectoryHtml(buildTrajectory(events, meta(), { redact: false }));
+    expect(html).toContain('Unredacted (local only) trajectory');
+    expect(html).not.toContain('Secret-redacted trajectory');
   });
 
   it('renders the waterfall, time-share, and per-step detail sections', () => {

--- a/apps/cli/src/lib/session/trajectory-html.ts
+++ b/apps/cli/src/lib/session/trajectory-html.ts
@@ -224,7 +224,7 @@ export function renderTrajectoryHtml(model: SessionTrajectory): string {
   </div>
 </main>
 <footer>
-  ${model.truncatedSteps > 0 ? 'Truncated · ' : ''}Secret-redacted trajectory rendered by agents-cli &middot; <code>agents sessions trace</code>
+  ${model.truncatedSteps > 0 ? 'Truncated · ' : ''}${model.redacted ? 'Secret-redacted' : 'Unredacted (local only)'} trajectory rendered by agents-cli &middot; <code>agents sessions trace</code>
 </footer>
 <script>${THEME_SCRIPT}</script>
 </body>

--- a/apps/cli/src/lib/session/trajectory.test.ts
+++ b/apps/cli/src/lib/session/trajectory.test.ts
@@ -97,6 +97,20 @@ describe('buildTrajectory — gaps, tokens, delegation, shares', () => {
     expect(buildTrajectory(events, meta(), { idleThresholdMs: 120_000 }).gaps).toHaveLength(0);
   });
 
+  it('a long tool execution (tool_use→its own result) is NOT an idle gap', () => {
+    // A single 8m04s `bun test`: the span between the tool_use and its result is
+    // the tool running, not the agent stalling — it must not be a gap.
+    const events: SessionEvent[] = [
+      { type: 'message', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', role: 'user', content: 'go' },
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:02Z', tool: 'Bash', callId: 'c1', command: 'bun test' },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:08:06Z', tool: 'Bash', callId: 'c1', outcome: 'ok' },
+    ];
+    const traj = buildTrajectory(events, meta(), { idleThresholdMs: 120_000 });
+    expect(traj.gaps).toHaveLength(0);
+    // The duration still lands on the step itself.
+    expect(traj.steps.find((s) => s.tool === 'Bash')!.durationMs).toBe(8 * 60_000 + 4_000);
+  });
+
   it('attributes output tokens from the nearest following usage event', () => {
     const events: SessionEvent[] = [
       { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'c1', command: 'ls' },
@@ -131,10 +145,12 @@ describe('buildTrajectory — redaction and safety', () => {
       { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'c1', command: `curl -H "authorization: Bearer ${secret}" https://x` },
       { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Bash', callId: 'c1', outcome: 'ok' },
     ];
-    const redacted = buildTrajectory(events, meta(), { redact: true, knownSecrets: [secret] }).steps[0];
-    expect(redacted.label).not.toContain(secret);
-    const raw = buildTrajectory(events, meta(), { redact: false, knownSecrets: [secret] }).steps[0];
-    expect(raw.label).toContain(secret);
+    const redacted = buildTrajectory(events, meta(), { redact: true, knownSecrets: [secret] });
+    expect(redacted.steps[0].label).not.toContain(secret);
+    expect(redacted.redacted).toBe(true);
+    const raw = buildTrajectory(events, meta(), { redact: false, knownSecrets: [secret] });
+    expect(raw.steps[0].label).toContain(secret);
+    expect(raw.redacted).toBe(false);
   });
 
   it('empty events (unparseable harness like OpenClaw) yields an empty trajectory, not a crash', () => {

--- a/apps/cli/src/lib/session/trajectory.ts
+++ b/apps/cli/src/lib/session/trajectory.ts
@@ -83,6 +83,8 @@ export interface SessionTrajectory {
    * here, so this is the truthful "how many calls failed" for the trajectory view.
    */
   errorCount: number;
+  /** True when derived labels/details were secret-redacted (false under `--no-redact`). */
+  redacted: boolean;
   /** Reused wholesale from `computeSummaryStats` — turns, tools, tokens, span. */
   stats: SessionStats;
   /** Steps dropped by the `maxSteps` cap, surfaced so truncation is never silent. */
@@ -344,6 +346,11 @@ export function buildTrajectory(
     return ordinal;
   };
   for (let k = 1; k < orderedTs.length; k++) {
+    // A span that OPENS on a `tool_use` is that tool executing (waiting on its
+    // own result), not the agent sitting idle — so it is not a stall. Counting
+    // it double-reports a long `bun test` as both its step duration and a fake
+    // "idle" gap. Only spans that open after a completed boundary are idle.
+    if (events[orderedTs[k - 1].index].type === 'tool_use') continue;
     const delta = orderedTs[k].ms - orderedTs[k - 1].ms;
     if (delta > idleThreshold) {
       gaps.push({
@@ -371,5 +378,5 @@ export function buildTrajectory(
 
   const errorCount = steps.reduce((n, s) => (s.outcome === 'error' ? n + 1 : n), 0);
 
-  return { session: meta, spanMs, steps, gaps, toolTimeShare, errorCount, stats, truncatedSteps };
+  return { session: meta, spanMs, steps, gaps, toolTimeShare, errorCount, redacted: redact, stats, truncatedSteps };
 }


### PR DESCRIPTION
## What

Two non-author-review findings on #2923 (`agents sessions trace`), landed as a follow-up because #2923 merged before these were applied.

### 1. Idle-gap detection counted a tool's own execution as a stall (real bug)
`buildTrajectory` walked *every* consecutive event pair for idle gaps, including the span between a `tool_use` and its own `tool_result`. A long `bun test` (e.g. 8m04s) was therefore double-reported: once as the step's `durationMs`, once as `idle 8m04s (stall)` — corrupting the feature's headline "where did it hang" signal a triaging agent reads via `--text --errors-only`. Fix: a gap opens only when the earlier event is a *completed* boundary; a span opening on a `tool_use` is that tool running, not the agent idle.

### 2. HTML footer lied under `--no-redact`
The footer always said "Secret-redacted" even when `--no-redact` produced an unredacted page. `SessionTrajectory` now carries a `redacted` flag; the footer reads "Unredacted (local only)" when redaction was off (and the flag enriches the `--json` envelope).

## Verified end-to-end (real session `1aa78f9c`, full log attached below)

```
### Fix #1 — a long tool execution is NO LONGER reported as an idle stall
stall lines now: 1   (before the fix, long Bash/test steps produced spurious 'idle' stalls)
JSON gaps: [{"startMs":2378294,"durationMs":142288,"afterOrdinal":246}]   # one GENUINE 2m22s agent-idle gap, not a tool run

### Fix #2 — honest footer
--no-redact  ->  "Unredacted (local only) trajectory"
default      ->  "Secret-redacted trajectory"

### Regression tests
 Test Files  2 passed (2)
      Tests  18 passed (18)
```

Full captured run: https://share.agents-cli.sh/muqsitnawaz/trace-review-fixes-fix-evidence-8b0eae7d0af2c670

`tsc --noEmit` clean. Real session, no mocking.

## Type
Bug fix — corrects a false stall signal and a false footer string. No new surface; docs/CHANGELOG for the feature shipped with #2923.
