### PR TITLE
feat(sessions): sessions trace compare — multi-session (PR2/3)

### DIFF
--- a/apps/cli/src/lib/session/trajectory-compare.ts
+++ b/apps/cli/src/lib/session/trajectory-compare.ts
@@ -3,14 +3,16 @@
  * the second selector turns the single-session trajectory into a **compare**.
  *
  * Aligns the two sessions' TOOL steps (thinking steps carry no comparable
- * identity) with a classic LCS edit script keyed on tool name, in order —
- * cheap, deterministic, and matches how a human reads "where did these two
- * runs diverge": the first point their tool sequence stops lining up.
+ * identity) with the `diff` package's `diffArrays` (already a dependency,
+ * `lib/diff-text.ts`), comparator-keyed on tool name, in order — cheap,
+ * deterministic, and matches how a human reads "where did these two runs
+ * diverge": the first point their tool sequence stops lining up.
  *
  * Pure and framework-free, exactly like `trajectory.ts`: takes two already-built
  * `SessionTrajectory` models (never re-parses a transcript) and returns a plain
  * diff object the HTML/text/JSON renderers project.
  */
+import { diffArrays } from 'diff';
 import type { SessionMeta } from './types.js';
 import type { SessionTrajectory, TrajectoryStep } from './trajectory.js';
 
@@ -65,39 +67,31 @@ type EditOp =
   | { type: 'add'; stepB: TrajectoryStep };
 
 /**
- * A textbook LCS edit script over two step sequences, equality keyed on tool
- * name. `dp[i][j]` = length of the LCS of `a[i:]` and `b[j:]`; backtracking
- * from `(0, 0)` prefers `same` whenever the tools match, and otherwise walks
- * toward whichever neighbour holds the longer common subsequence — the
- * standard minimal-edit-script tie-break.
+ * Turn `diffArrays`' run-length change objects into a per-step edit script.
+ *
+ * `diffArrays(a, b, { comparator })` (Myers' diff under the hood) returns
+ * consecutive-run chunks, not individual elements, and — per its own docs —
+ * an unchanged chunk's `value` is drawn from `b`, not `a`. Neither shape is
+ * what a divergence marker needs (a stepA/stepB PAIR per matched step, with
+ * both sides' own ordinals/timestamps), so this walks two cursors over the
+ * original arrays in lockstep with the run lengths `diffArrays` reports,
+ * recovering the exact `a[i]`/`b[j]` pairing for every `same` step.
  */
 function computeEditScript(a: TrajectoryStep[], b: TrajectoryStep[]): EditOp[] {
-  const n = a.length;
-  const m = b.length;
-  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
-  for (let i = n - 1; i >= 0; i--) {
-    for (let j = m - 1; j >= 0; j--) {
-      dp[i][j] = a[i].tool === b[j].tool ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
-    }
-  }
+  const changes = diffArrays(a, b, { comparator: (x, y) => x.tool === y.tool });
   const ops: EditOp[] = [];
   let i = 0;
   let j = 0;
-  while (i < n && j < m) {
-    if (a[i].tool === b[j].tool) {
-      ops.push({ type: 'same', stepA: a[i], stepB: b[j] });
-      i++;
-      j++;
-    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
-      ops.push({ type: 'remove', stepA: a[i] });
-      i++;
+  for (const change of changes) {
+    const count = change.count ?? change.value.length;
+    if (change.removed) {
+      for (let k = 0; k < count; k++) ops.push({ type: 'remove', stepA: a[i++] });
+    } else if (change.added) {
+      for (let k = 0; k < count; k++) ops.push({ type: 'add', stepB: b[j++] });
     } else {
-      ops.push({ type: 'add', stepB: b[j] });
-      j++;
+      for (let k = 0; k < count; k++) ops.push({ type: 'same', stepA: a[i++], stepB: b[j++] });
     }
   }
-  while (i < n) { ops.push({ type: 'remove', stepA: a[i] }); i++; }
-  while (j < m) { ops.push({ type: 'add', stepB: b[j] }); j++; }
   return ops;
 }
 

--- a/apps/cli/src/lib/session/trajectory-text.compare.test.ts
+++ b/apps/cli/src/lib/session/trajectory-text.compare.test.ts
@@ -52,6 +52,18 @@ describe('renderTrajectoryCompareText', () => {
     expect(text).toContain('only in claude sess0001 (0): none');
   });
 
+  it('applies redaction to both sessions before compare renders', () => {
+    const secret = 'sk-supersecrettoken1234567890';
+    const withSecret: SessionEvent[] = [
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'c1', command: `deploy --token ${secret}` },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Bash', callId: 'c1', outcome: 'ok' },
+    ];
+    const a = buildTrajectory(withSecret, meta({ id: 'a' }), { redact: true, knownSecrets: [secret] });
+    const b = buildTrajectory(eventsB, meta({ id: 'b', agent: 'codex' }), { redact: true, knownSecrets: [secret] });
+    const text = renderTrajectoryCompareText(diffTrajectories(a, b));
+    expect(text).not.toContain(secret);
+  });
+
   it('caps the diff lines with maxDiffLines and counts the rest', () => {
     const manyEvents: SessionEvent[] = [];
     for (let i = 0; i < 20; i++) {

--- a/apps/cli/src/lib/session/trajectory-text.compare.test.ts
+++ b/apps/cli/src/lib/session/trajectory-text.compare.test.ts
@@ -58,10 +58,28 @@ describe('renderTrajectoryCompareText', () => {
       { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'c1', command: `deploy --token ${secret}` },
       { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Bash', callId: 'c1', outcome: 'ok' },
     ];
+    // `b` deliberately shares NO tool with `a`. A step matched in both sessions
+    // is classified `same`, and the renderer prints no label for those — so
+    // comparing against a fixture that also runs Bash made the secret-bearing
+    // step invisible, and any assertion about it vacuous.
+    const noBash: SessionEvent[] = [
+      { type: 'tool_use', agent: 'codex', timestamp: '2026-08-01T00:00:00Z', tool: 'Grep', callId: 'd1', pattern: 'foo' },
+      { type: 'tool_result', agent: 'codex', timestamp: '2026-08-01T00:00:02Z', tool: 'Grep', callId: 'd1', outcome: 'ok' },
+    ];
     const a = buildTrajectory(withSecret, meta({ id: 'a' }), { redact: true, knownSecrets: [secret] });
-    const b = buildTrajectory(eventsB, meta({ id: 'b', agent: 'codex' }), { redact: true, knownSecrets: [secret] });
+    const b = buildTrajectory(noBash, meta({ id: 'b', agent: 'codex' }), { redact: true, knownSecrets: [secret] });
     const text = renderTrajectoryCompareText(diffTrajectories(a, b));
+
+    // Assert the redaction MARKER, not merely the absence of the secret.
+    // `not.toContain(secret)` alone passes with redaction fully disabled,
+    // because clipLabel truncates the label mid-token — the unredacted output is
+    // `deploy --token sk-supersecrettoken12345…`, which does not contain the
+    // whole secret string. The marker is present only when redaction actually
+    // ran, so this fails if it is bypassed.
+    expect(text).toContain('deploy --token [REDACTED]');
     expect(text).not.toContain(secret);
+    // And a prefix short enough to survive clipping, so a partial leak is caught too.
+    expect(text).not.toContain(secret.slice(0, 12));
   });
 
   it('caps the diff lines with maxDiffLines and counts the rest', () => {


### PR DESCRIPTION
## Summary
- Pass exactly two selectors to `agents sessions trace` and it renders a **compare**: the two sessions' tool sequences aligned by tool name (`diffTrajectories()`), the first divergence point, the steps unique to each session, and a per-session summary — in all three renderings (HTML, text, `--json`).
- New `apps/cli/src/lib/session/trajectory-compare.ts` — pure, unit-tested (edit-script alignment, divergence point, added/removed steps, per-session summary, diff-cap truncation). Alignment uses `diffArrays` from the `diff` package (already a dependency), comparator-keyed on tool name.
- `trajectory-html.ts` gains `renderTrajectoryCompareHtml()` (stacked lanes on a shared time axis, divergence marker, summary table, step diff lists) — refactored the single-layout CSS/script into shared `BASE_STYLE`/`THEME_SCRIPT` constants with no output change (existing tests still pass byte-for-byte).
- `trajectory-text.ts` gains `renderTrajectoryCompareText()` (both sessions' stats, the divergence line, capped diff columns).
- `sessions-trace.ts`: `--json` envelope grows `layout: 'single' | 'compare'` + optional `diff` block; three or more selectors, or `--tree`, still fail loud (lineage is PR3).
- Docs (`docs/sessions.md`, `docs/specifications.md` SES-IF-4d + new SES-GAP-11) and CHANGELOG updated.

## Test plan
- [x] `bun test` on the new/edited files — 40 pass, 0 fail (`trajectory-compare.test.ts`, `trajectory-html.compare.test.ts`, `trajectory-text.compare.test.ts`, `sessions-trace.test.ts`, plus the untouched single-layout tests confirming no regression).
- [x] `bunx tsc --noEmit` clean.
- [x] `docs/command-index.{md,json}` + `command-reference.html` regenerated — no diff (flag-level detail isn't indexed there).
- [x] E2E on two real local sessions via `scripts/install.sh --skip-tests` → `agents-dev`:
  - `agents-dev sessions trace f5b0ef02 86faee81 --text` — two lanes, divergence line, capped diff columns, redaction intact (`[HOME]` masked).
  - `agents-dev sessions trace f5b0ef02 86faee81 --json` — `layout: "compare"`, `sessions: [a, b]`, `diff: { divergence, added, removed, summaryA, summaryB, truncatedA, truncatedB }`.
  - `agents-dev sessions trace f5b0ef02 86faee81 --html -o compare.html --no-open` — rendered headlessly and screenshotted (not attached — local scratch, not uploaded); matches the design: two lanes, dashed divergence marker at "diverge after step 1/1", summary table (278 vs 29 tools, 16 vs 1 errors), and "only in claude f5b0ef02" / "only in claude 86faee81" step-diff lists.
  - Fail-loud paths verified: 3 selectors and `--tree` both exit 1 with the documented message; single-selector path unchanged.


## Note on the alignment change

The alignment started as a hand-rolled LCS table and was swapped to `diffArrays`. That is **not** output-neutral, so it is not labelled `refactor`. Both produce a *minimal* edit script — a 9,000-case fuzz over generated tool sequences finds the two scripts always the same **length** (0 count mismatches, both directions) — but when several minimal scripts exist they break ties differently, so they pick different ones:

| | differing / 9,000 | |
|---|---|---|
| edit-script length | **0** | both minimal, always |
| `removed` set contents | 937 | 10.4% |
| `added` set contents | 145 | 1.6% |
| divergence message | 638 | 7.1% |

The 7.1% is user-visible text: the same pair of runs can report `B — only in the first session` under one and `A — only in the second session` under the other. Run log: https://share.agents-cli.sh/muqsitnawaz/agents-cli-pr2929-alignment-fuzz-cebaefc3060343c5

Keeping the swap deliberately. The hand-rolled version allocated an `n x m` number table before doing anything — two sessions of a few thousand tool steps each is tens of megabytes to diff — while `diffArrays` is Myers' O(ND) and stays cheap exactly when the two runs are similar, which is the case this feature exists for. Neither alignment is more *correct*; when several minimal scripts exist, which one you get is arbitrary in both. The cost profile is not arbitrary.
