### PR TITLE
fix(browser): close the remote-control consent bypass on every implicit-create verb

### DIFF
--- a/apps/cli/.changelog/next/RUSH-browser-consent-gate.md
+++ b/apps/cli/.changelog/next/RUSH-browser-consent-gate.md
@@ -1,4 +1,4 @@
-- **Security: the remote browser-control consent gate no longer has a hole.**
+- **Security: the remote browser-control consent gate now covers the whole launch path.**
   `agents browser remote-control off` (the default) was only enforced on the
   `browser start` command, but `navigate`, `click`, `screenshot`, `evaluate` and
   the other page verbs open a browser implicitly when the caller has no live

--- a/apps/cli/.changelog/next/RUSH-browser-consent-gate.md
+++ b/apps/cli/.changelog/next/RUSH-browser-consent-gate.md
@@ -5,8 +5,12 @@
   task. A `browser navigate --device <box>` therefore opened a browser on a
   machine whose owner never opted in, while `browser start --device <box>` was
   correctly refused. The gate now sits in the daemon at the two points that can
-  open a browser (`BrowserService.start` and the create branch of
-  `resolveOrCreateTask`), so every implicit-create verb is covered. The consent
+  launch a browser (`BrowserService.start` and the create branch of
+  `resolveOrCreateTask`), so every implicit-LAUNCH verb is covered. It does not
+  cover *attaching*: a request naming an existing task (`--task`, or the
+  single-match-by-caller path) returns before the gate and can drive that task's
+  tabs. That is pre-existing and tracked separately — `remote-control off` means
+  "no new browser", not "no access". The consent
   marker rides the IPC request rather than the daemon's environment: a daemon
   auto-started by a fleet-remote CLI inherits `AGENTS_FLEET_REMOTE=1`
   permanently, and reading that would have refused every later local drive.

--- a/apps/cli/.changelog/next/RUSH-browser-consent-gate.md
+++ b/apps/cli/.changelog/next/RUSH-browser-consent-gate.md
@@ -1,0 +1,14 @@
+- **Security: the remote browser-control consent gate no longer has a hole.**
+  `agents browser remote-control off` (the default) was only enforced on the
+  `browser start` command, but `navigate`, `click`, `screenshot`, `evaluate` and
+  the other page verbs open a browser implicitly when the caller has no live
+  task. A `browser navigate --device <box>` therefore opened a browser on a
+  machine whose owner never opted in, while `browser start --device <box>` was
+  correctly refused. The gate now sits in the daemon at the two points that can
+  open a browser (`BrowserService.start` and the create branch of
+  `resolveOrCreateTask`), so every implicit-create verb is covered. The consent
+  marker rides the IPC request rather than the daemon's environment: a daemon
+  auto-started by a fleet-remote CLI inherits `AGENTS_FLEET_REMOTE=1`
+  permanently, and reading that would have refused every later local drive.
+  Source: `src/lib/browser/service.ts`, `src/lib/browser/remote-control.ts`,
+  `src/lib/browser/ipc.ts`, `src/lib/browser/types.ts`.

--- a/apps/cli/docs/browser.md
+++ b/apps/cli/docs/browser.md
@@ -346,17 +346,28 @@ whether it allows it:
 
 Consent is a **per-device setting** (the `browser.remote-control` config key,
 in this machine's `devices/<machine>/agents.yaml` `config:`) and **off by
-default**: a `browser --device <this-machine>` drive from elsewhere is refused
-with a message naming how to enable it, until the owner runs
+default**: a `browser --device <this-machine>` request that would **open** a
+browser is refused with a message naming how to enable it, until the owner runs
 `agents browser remote-control on` here. The key is machine-local — only this
 box can set it. Local drives (no `--device`) are never gated.
 
-The gate lives in the browser daemon, at the two points that can actually open a
-browser (`BrowserService.start` and the create branch of `resolveOrCreateTask`),
+The gate lives in the browser daemon, at the two points that can actually launch
+a browser (`BrowserService.start` and the create branch of `resolveOrCreateTask`),
 not on the `browser start` command. It has to: `navigate`, `click`, `screenshot`
-and the other page verbs create a browser implicitly when the caller has no live
+and the other page verbs launch a browser implicitly when the caller has no live
 task, so gating the one command left every one of them ungated. Read-only queries
 (`status`, `tabs`, `profiles list`) are not gated.
+
+**What this does NOT cover.** The gate is on *launching*, not on *attaching*. A
+request that resolves to a task which already exists — `--task <name>`, or the
+single-match-by-caller-identity path in `resolveOrCreateTask` — returns before
+the gate and can then drive that task's tabs. So on a machine whose browser is
+already running with live tasks, a remote `browser tab-add --device <box> --task
+<name>` can still act in the owner's authenticated profile with consent off, and
+`status` is ungated by design so task names are discoverable. This is
+pre-existing behaviour, not introduced or closed here; closing it means gating
+the attach path (`findTask` and its consumers) as well, which is tracked
+separately. Treat `remote-control off` as "no new browser", not as "no access".
 
 The marker travels **on the request**, not in the daemon's environment. The
 daemon is shared and long-lived, and one auto-started by a fleet-remote CLI

--- a/apps/cli/docs/browser.md
+++ b/apps/cli/docs/browser.md
@@ -346,10 +346,22 @@ whether it allows it:
 
 Consent is a **per-device setting** (the `browser.remote-control` config key,
 in this machine's `devices/<machine>/agents.yaml` `config:`) and **off by
-default**: a `browser --device <this-machine> start` from elsewhere is refused
+default**: a `browser --device <this-machine>` drive from elsewhere is refused
 with a message naming how to enable it, until the owner runs
 `agents browser remote-control on` here. The key is machine-local — only this
-box can set it. Local starts (no `--device`) are never gated.
+box can set it. Local drives (no `--device`) are never gated.
+
+The gate lives in the browser daemon, at the two points that can actually open a
+browser (`BrowserService.start` and the create branch of `resolveOrCreateTask`),
+not on the `browser start` command. It has to: `navigate`, `click`, `screenshot`
+and the other page verbs create a browser implicitly when the caller has no live
+task, so gating the one command left every one of them ungated. Read-only queries
+(`status`, `tabs`, `profiles list`) are not gated.
+
+The marker travels **on the request**, not in the daemon's environment. The
+daemon is shared and long-lived, and one auto-started by a fleet-remote CLI
+inherits `AGENTS_FLEET_REMOTE=1` for its whole life — a daemon that read its own
+environment would refuse every later *local* drive on the machine.
 
 ### Navigation
 

--- a/apps/cli/src/commands/browser.ts
+++ b/apps/cli/src/commands/browser.ts
@@ -936,9 +936,11 @@ function registerTaskCommands(browser: Command): void {
     .option('--duration <sec>', 'Recording duration cap in seconds (with --record; default 60)', (v) => parseInt(v, 10))
     .option('--max-mb <mb>', 'Recording size cap in MB (with --record; default 25)', (v) => parseInt(v, 10))
     .action(async (opts) => {
-      // Consent gate: a fleet-remote `browser --device <this-machine> start` may
-      // only open a browser here if the owner opted in. Refuse before we resolve
-      // or auto-create any profile. Local starts are never gated.
+      // Fast-fail copy of the consent gate, so a refused start never resolves or
+      // auto-creates a profile. The AUTHORITATIVE gate is in the daemon
+      // (BrowserService.start / resolveOrCreateTask, via
+      // assertRemoteControlAllowedForRequest) — it has to be, because the page
+      // verbs create a browser implicitly and never reach this command.
       try {
         assertRemoteControlAllowed();
       } catch (err) {

--- a/apps/cli/src/lib/browser/ipc.test.ts
+++ b/apps/cli/src/lib/browser/ipc.test.ts
@@ -357,7 +357,6 @@ describe('remote-control consent gate over IPC', () => {
       await server.stop();
     }
   }, 20_000);
-});
 
   it('refuses a fleet-remote START — the gate at BrowserService.start, not the task one', async () => {
     // `start` is NOT in PAGE_CREATE_VERBS/PAGE_RESOLVE_VERBS: ipc.ts routes it

--- a/apps/cli/src/lib/browser/ipc.test.ts
+++ b/apps/cli/src/lib/browser/ipc.test.ts
@@ -381,7 +381,12 @@ describe('remote-control consent gate over IPC', () => {
       expect(response.ok).toBe(false);
       // Consent is refused BEFORE the unknown-profile error, so the message is the
       // consent one — proving the gate ran first, as the first statement of start().
+      // This positive match is what carries the test: mutate the start gate and it
+      // reports the profile-not-found error instead.
       expect(response.error).toMatch(/remote-control on/);
+      // Intent, not coverage: vitest stops at the first failed expect, so the
+      // positive above always fails first in a mutant and this never discriminates.
+      // Do not count it when reasoning about what is covered.
       expect(response.error).not.toMatch(/not found/);
     } finally {
       await server.stop();

--- a/apps/cli/src/lib/browser/ipc.test.ts
+++ b/apps/cli/src/lib/browser/ipc.test.ts
@@ -359,43 +359,12 @@ describe('remote-control consent gate over IPC', () => {
   }, 20_000);
 });
 
-describe('stampCallerIdentity — consent marker', () => {
-  it('marks a request dispatched here by a fleet hop', async () => {
-    const { stampCallerIdentity } = await import('./ipc.js');
-    const out = stampCallerIdentity({ action: 'navigate' } as never, { AGENTS_FLEET_REMOTE: '1' });
-    expect(out.fleetRemote).toBe(true);
-  });
-
-  it('marks it even when the identity is already complete (the early-return trap)', async () => {
-    const { stampCallerIdentity } = await import('./ipc.js');
-    const out = stampCallerIdentity(
-      { action: 'navigate', actor: 'a', launchId: 'l', sessionId: 's' } as never,
-      { AGENTS_FLEET_REMOTE: '1' },
-    );
-    expect(out.fleetRemote).toBe(true);
-  });
-
-  it('a client cannot clear a marker the environment sets', async () => {
-    const { stampCallerIdentity } = await import('./ipc.js');
-    const out = stampCallerIdentity(
-      { action: 'navigate', fleetRemote: false } as never,
-      { AGENTS_FLEET_REMOTE: '1' },
-    );
-    expect(out.fleetRemote).toBe(true);
-  });
-
-  it('leaves a local request unmarked', async () => {
-    const { stampCallerIdentity } = await import('./ipc.js');
-    expect(stampCallerIdentity({ action: 'navigate' } as never, {}).fleetRemote).toBeFalsy();
-  });
-});
-
-// The bypass this closes: `assertRemoteControlAllowed` was called only from the
-// `browser start` COMMAND, but 18 page verbs create a browser implicitly through
-// resolveOrCreateTask -> start(). A fleet-remote `navigate` therefore opened a
-// browser on a machine whose owner never ran `browser remote-control on`.
-describe('remote-control consent gate over IPC', () => {
-  it('refuses a fleet-remote navigate when consent is off, and creates nothing', async () => {
+  it('refuses a fleet-remote START — the gate at BrowserService.start, not the task one', async () => {
+    // `start` is NOT in PAGE_CREATE_VERBS/PAGE_RESOLVE_VERBS: ipc.ts routes it
+    // straight to service.start(), so it never touches resolveOrCreateTask. Every
+    // other consent test here goes through `navigate` and is therefore absorbed by
+    // the resolveOrCreateTask gate — which left the start-gate line uncovered, and
+    // that is the gate covering the originally reported bypass.
     const { BrowserIPCServer } = await import('./ipc.js');
     const { BrowserService } = await import('./service.js');
     const service = new BrowserService();
@@ -403,42 +372,18 @@ describe('remote-control consent gate over IPC', () => {
     await server.start();
     try {
       const response = await sendIPCRequest({
-        action: 'navigate',
-        url: 'https://example.com',
+        action: 'start',
+        profile: 'definitely-not-a-real-profile',
         fleetRemote: true,
-        // A complete identity, so stampCallerIdentity takes its early return —
-        // the marker still has to survive, which is why it is stamped above it.
         actor: 'yosemite-s0',
         launchId: 'l1',
         sessionId: 's1',
       } as never);
       expect(response.ok).toBe(false);
+      // Consent is refused BEFORE the unknown-profile error, so the message is the
+      // consent one — proving the gate ran first, as the first statement of start().
       expect(response.error).toMatch(/remote-control on/);
-      const connections = (service as unknown as { connections: Map<string, unknown> }).connections;
-      expect(connections.size).toBe(0);
-    } finally {
-      await server.stop();
-    }
-  }, 20_000);
-
-  it('does not gate a local navigate — no marker, no refusal', async () => {
-    const { BrowserIPCServer } = await import('./ipc.js');
-    const { BrowserService } = await import('./service.js');
-    const service = new BrowserService();
-    const server = new BrowserIPCServer(service);
-    await server.start();
-    try {
-      const response = await sendIPCRequest({
-        action: 'navigate',
-        url: 'https://example.com',
-        profile: 'definitely-not-a-real-profile',
-        actor: 'zion',
-        launchId: 'l1',
-        sessionId: 's1',
-      } as never);
-      // It fails for its own reason (no such profile), NEVER the consent refusal.
-      expect(response.ok).toBe(false);
-      expect(response.error).not.toMatch(/remote-control on/);
+      expect(response.error).not.toMatch(/not found/);
     } finally {
       await server.stop();
     }

--- a/apps/cli/src/lib/browser/ipc.test.ts
+++ b/apps/cli/src/lib/browser/ipc.test.ts
@@ -302,3 +302,176 @@ describe('gc action — reaper over IPC', () => {
     }
   }, 20_000);
 });
+
+// The bypass this closes: `assertRemoteControlAllowed` was called only from the
+// `browser start` COMMAND, but 18 page verbs create a browser implicitly through
+// resolveOrCreateTask -> start(). A fleet-remote `navigate` therefore opened a
+// browser on a machine whose owner never ran `browser remote-control on`.
+describe('remote-control consent gate over IPC', () => {
+  it('refuses a fleet-remote navigate when consent is off, and creates nothing', async () => {
+    const { BrowserIPCServer } = await import('./ipc.js');
+    const { BrowserService } = await import('./service.js');
+    const service = new BrowserService();
+    const server = new BrowserIPCServer(service);
+    await server.start();
+    try {
+      const response = await sendIPCRequest({
+        action: 'navigate',
+        url: 'https://example.com',
+        fleetRemote: true,
+        // A complete identity, so stampCallerIdentity takes its early return —
+        // the marker still has to survive, which is why it is stamped above it.
+        actor: 'yosemite-s0',
+        launchId: 'l1',
+        sessionId: 's1',
+      });
+      expect(response.ok).toBe(false);
+      expect(response.error).toMatch(/remote-control on/);
+      // Refused before anything was opened.
+      const connections = (service as unknown as { connections: Map<string, unknown> }).connections;
+      expect(connections.size).toBe(0);
+    } finally {
+      await server.stop();
+    }
+  }, 20_000);
+
+  it('does not gate a local navigate — no marker, no refusal', async () => {
+    const { BrowserIPCServer } = await import('./ipc.js');
+    const { BrowserService } = await import('./service.js');
+    const service = new BrowserService();
+    const server = new BrowserIPCServer(service);
+    await server.start();
+    try {
+      const response = await sendIPCRequest({
+        action: 'navigate',
+        url: 'https://example.com',
+        profile: 'definitely-not-a-real-profile',
+        actor: 'zion',
+        launchId: 'l1',
+        sessionId: 's1',
+      });
+      // It fails for its own reason (no such profile), NEVER the consent refusal.
+      expect(response.ok).toBe(false);
+      expect(response.error).not.toMatch(/remote-control on/);
+    } finally {
+      await server.stop();
+    }
+  }, 20_000);
+});
+
+describe('stampCallerIdentity — consent marker', () => {
+  it('marks a request dispatched here by a fleet hop', async () => {
+    const { stampCallerIdentity } = await import('./ipc.js');
+    const out = stampCallerIdentity({ action: 'navigate' } as never, { AGENTS_FLEET_REMOTE: '1' });
+    expect(out.fleetRemote).toBe(true);
+  });
+
+  it('marks it even when the identity is already complete (the early-return trap)', async () => {
+    const { stampCallerIdentity } = await import('./ipc.js');
+    const out = stampCallerIdentity(
+      { action: 'navigate', actor: 'a', launchId: 'l', sessionId: 's' } as never,
+      { AGENTS_FLEET_REMOTE: '1' },
+    );
+    expect(out.fleetRemote).toBe(true);
+  });
+
+  it('a client cannot clear a marker the environment sets', async () => {
+    const { stampCallerIdentity } = await import('./ipc.js');
+    const out = stampCallerIdentity(
+      { action: 'navigate', fleetRemote: false } as never,
+      { AGENTS_FLEET_REMOTE: '1' },
+    );
+    expect(out.fleetRemote).toBe(true);
+  });
+
+  it('leaves a local request unmarked', async () => {
+    const { stampCallerIdentity } = await import('./ipc.js');
+    expect(stampCallerIdentity({ action: 'navigate' } as never, {}).fleetRemote).toBeFalsy();
+  });
+});
+
+// The bypass this closes: `assertRemoteControlAllowed` was called only from the
+// `browser start` COMMAND, but 18 page verbs create a browser implicitly through
+// resolveOrCreateTask -> start(). A fleet-remote `navigate` therefore opened a
+// browser on a machine whose owner never ran `browser remote-control on`.
+describe('remote-control consent gate over IPC', () => {
+  it('refuses a fleet-remote navigate when consent is off, and creates nothing', async () => {
+    const { BrowserIPCServer } = await import('./ipc.js');
+    const { BrowserService } = await import('./service.js');
+    const service = new BrowserService();
+    const server = new BrowserIPCServer(service);
+    await server.start();
+    try {
+      const response = await sendIPCRequest({
+        action: 'navigate',
+        url: 'https://example.com',
+        fleetRemote: true,
+        // A complete identity, so stampCallerIdentity takes its early return —
+        // the marker still has to survive, which is why it is stamped above it.
+        actor: 'yosemite-s0',
+        launchId: 'l1',
+        sessionId: 's1',
+      } as never);
+      expect(response.ok).toBe(false);
+      expect(response.error).toMatch(/remote-control on/);
+      const connections = (service as unknown as { connections: Map<string, unknown> }).connections;
+      expect(connections.size).toBe(0);
+    } finally {
+      await server.stop();
+    }
+  }, 20_000);
+
+  it('does not gate a local navigate — no marker, no refusal', async () => {
+    const { BrowserIPCServer } = await import('./ipc.js');
+    const { BrowserService } = await import('./service.js');
+    const service = new BrowserService();
+    const server = new BrowserIPCServer(service);
+    await server.start();
+    try {
+      const response = await sendIPCRequest({
+        action: 'navigate',
+        url: 'https://example.com',
+        profile: 'definitely-not-a-real-profile',
+        actor: 'zion',
+        launchId: 'l1',
+        sessionId: 's1',
+      } as never);
+      // It fails for its own reason (no such profile), NEVER the consent refusal.
+      expect(response.ok).toBe(false);
+      expect(response.error).not.toMatch(/remote-control on/);
+    } finally {
+      await server.stop();
+    }
+  }, 20_000);
+});
+
+describe('stampCallerIdentity — consent marker', () => {
+  it('marks a request dispatched here by a fleet hop', async () => {
+    const { stampCallerIdentity } = await import('./ipc.js');
+    const out = stampCallerIdentity({ action: 'navigate' } as never, { AGENTS_FLEET_REMOTE: '1' });
+    expect(out.fleetRemote).toBe(true);
+  });
+
+  it('marks it even when the identity is already complete (the early-return trap)', async () => {
+    const { stampCallerIdentity } = await import('./ipc.js');
+    const out = stampCallerIdentity(
+      { action: 'navigate', actor: 'a', launchId: 'l', sessionId: 's' } as never,
+      { AGENTS_FLEET_REMOTE: '1' },
+    );
+    expect(out.fleetRemote).toBe(true);
+  });
+
+  it('a client cannot clear a marker the environment sets', async () => {
+    const { stampCallerIdentity } = await import('./ipc.js');
+    const out = stampCallerIdentity(
+      { action: 'navigate', fleetRemote: false } as never,
+      { AGENTS_FLEET_REMOTE: '1' },
+    );
+    expect(out.fleetRemote).toBe(true);
+  });
+
+  it('leaves a local request unmarked', async () => {
+    const { stampCallerIdentity } = await import('./ipc.js');
+    expect(stampCallerIdentity({ action: 'navigate' } as never, {}).fleetRemote).toBeFalsy();
+  });
+});

--- a/apps/cli/src/lib/browser/ipc.ts
+++ b/apps/cli/src/lib/browser/ipc.ts
@@ -9,6 +9,7 @@ import { startDaemon, stopDaemon } from '../daemon/daemon.js';
 import { getCliVersion } from '../version.js';
 import { compareVersions } from '../agent-spec/primitives.js';
 import { getDaemonLogPath } from '../daemon/daemon.js';
+import { isFleetRemoteInvocation } from './remote-control.js';
 import { resolveCallerIdentity } from './caller-identity.js';
 import { actionable } from './service.js';
 import type { IPCRequest, IPCResponse, RefNodeJson } from './types.js';
@@ -419,6 +420,7 @@ export class BrowserIPCServer {
         actor: request.actor,
         launchId: request.launchId,
         sessionId: request.sessionId,
+        fleetRemote: request.fleetRemote,
         createIfMissing,
         title: request.title,
         url: request.url,
@@ -476,6 +478,7 @@ export class BrowserIPCServer {
           actor: request.actor,
           launchId: request.launchId,
           sessionId: request.sessionId,
+          fleetRemote: request.fleetRemote,
           title: request.title,
         });
         return {
@@ -977,14 +980,26 @@ export async function sendIPCRequest(
  * Fill actor / launchId / sessionId from the calling process when the request
  * left them blank. Explicit values on the request always win.
  */
-export function stampCallerIdentity(request: IPCRequest): IPCRequest {
-  if (request.actor && request.launchId && request.sessionId) return request;
+export function stampCallerIdentity(
+  request: IPCRequest,
+  env: NodeJS.ProcessEnv = process.env,
+): IPCRequest {
+  // The consent marker is stamped FIRST, above the identity early-return: a
+  // request that already carries a full identity (every streamed request does)
+  // would otherwise skip stamping entirely and reach the daemon unmarked.
+  // OR-ed, never overwritten — a client may assert the marker but must not be
+  // able to clear one this environment sets.
+  const fleetRemote = isFleetRemoteInvocation(env) || request.fleetRemote === true;
+  const marked: IPCRequest =
+    request.fleetRemote === fleetRemote ? request : { ...request, fleetRemote };
+
+  if (marked.actor && marked.launchId && marked.sessionId) return marked;
   const id = resolveCallerIdentity();
   return {
-    ...request,
-    actor: request.actor ?? id.actor,
-    launchId: request.launchId ?? id.launchId,
-    sessionId: request.sessionId ?? id.sessionId,
+    ...marked,
+    actor: marked.actor ?? id.actor,
+    launchId: marked.launchId ?? id.launchId,
+    sessionId: marked.sessionId ?? id.sessionId,
   };
 }
 

--- a/apps/cli/src/lib/browser/remote-control.test.ts
+++ b/apps/cli/src/lib/browser/remote-control.test.ts
@@ -3,7 +3,9 @@ import {
   FLEET_REMOTE_ENV,
   isFleetRemoteInvocation,
   assertRemoteControlAllowed,
+  assertRemoteControlAllowedForRequest,
 } from './remote-control.js';
+import { vi, afterEach } from 'vitest';
 
 describe('isFleetRemoteInvocation', () => {
   it('is true only when the marker env is exactly "1"', () => {
@@ -38,5 +40,37 @@ describe('assertRemoteControlAllowed', () => {
     expect(() =>
       assertRemoteControlAllowed({ env: { [FLEET_REMOTE_ENV]: '1' }, enabled: false }),
     ).toThrow(/A fleet machine tried to drive/);
+  });
+});
+
+// The daemon-side gate. This is the authoritative one: `browser start` was the
+// only gated COMMAND, but 18 page verbs create a browser implicitly, so every
+// one of them could open a browser on a machine that never opted in.
+describe('assertRemoteControlAllowedForRequest', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('never gates a local request', () => {
+    expect(() => assertRemoteControlAllowedForRequest(undefined, { enabled: false })).not.toThrow();
+    expect(() => assertRemoteControlAllowedForRequest(false, { enabled: false })).not.toThrow();
+  });
+
+  it('refuses a fleet-remote request when consent is off, naming the actor and the fix', () => {
+    expect(() =>
+      assertRemoteControlAllowedForRequest(true, { enabled: false, actor: 'yosemite-s0' }),
+    ).toThrow(/yosemite-s0.*browser --device.*agents browser remote-control on/s);
+  });
+
+  it('allows a fleet-remote request once the owner opted in', () => {
+    expect(() => assertRemoteControlAllowedForRequest(true, { enabled: true })).not.toThrow();
+  });
+
+  it('IGNORES the daemon own environment — a leaked marker must not gate local drives', () => {
+    // The browser daemon is shared and long-lived, and startDetached passes
+    // `env: opts.env ?? process.env`. A daemon auto-started by a fleet-remote CLI
+    // therefore inherits AGENTS_FLEET_REMOTE=1 for its whole life. If this gate
+    // read process.env it would refuse every subsequent LOCAL drive on this
+    // machine until the daemon restarted.
+    vi.stubEnv(FLEET_REMOTE_ENV, '1');
+    expect(() => assertRemoteControlAllowedForRequest(undefined, { enabled: false })).not.toThrow();
   });
 });

--- a/apps/cli/src/lib/browser/remote-control.ts
+++ b/apps/cli/src/lib/browser/remote-control.ts
@@ -9,8 +9,15 @@
  * `browser.remote-control` config key, never synced).
  *
  * Local invocations (no marker) are never gated — this only governs cross-machine
- * drives. Read-only queries are not gated here; the gate sits at the drive entry
- * point (`browser start`), the one command that opens/attaches a browser.
+ * drives. Read-only queries are not gated.
+ *
+ * The authoritative gate is {@link assertRemoteControlAllowedForRequest}, called
+ * inside the browser daemon at the two points that can OPEN a browser
+ * (`BrowserService.start` and the create branch of `resolveOrCreateTask`). It has
+ * to live there because ~18 page verbs (`navigate`, `click`, `screenshot`, …)
+ * create a browser implicitly, and gating only the `browser start` command left
+ * every one of them ungated. {@link assertRemoteControlAllowed} remains as a
+ * fast-fail CLI-side check so a refused `start` never auto-creates a profile.
  */
 
 import { getConfigValue } from '../device-config.js';
@@ -53,5 +60,35 @@ export function assertRemoteControlAllowed(opts?: {
     `${who} tried to drive this machine's browser over \`browser --device\`, but remote ` +
       `browser control is off here. To allow it, run on THIS machine:\n` +
       `  agents browser remote-control on`,
+  );
+}
+
+/**
+ * The daemon-side consent gate.
+ *
+ * Reads ONLY the per-request marker, never `process.env`: the browser daemon is
+ * shared and long-lived, and it may have been auto-started by a fleet-remote CLI
+ * that leaked `AGENTS_FLEET_REMOTE=1` into its environment permanently. Reading
+ * the daemon's env would then refuse every subsequent LOCAL drive on this
+ * machine until the daemon restarted.
+ *
+ * `actor` is likewise the caller's forwarded identity, not the daemon's.
+ */
+export function assertRemoteControlAllowedForRequest(
+  fleetRemote: boolean | undefined,
+  opts: { actor?: string; enabled?: boolean } = {},
+): void {
+  if (!fleetRemote) return;
+  const enabled = opts.enabled ?? remoteControlEnabled();
+  if (enabled) return;
+  throw new Error(remoteControlRefusal(opts.actor || 'A fleet machine'));
+}
+
+/** The refusal text, shared by the CLI-side and daemon-side gates. */
+export function remoteControlRefusal(who: string): string {
+  return (
+    `${who} tried to drive this machine's browser over \`browser --device\`, but remote ` +
+    `browser control is off here. To allow it, run on THIS machine:\n` +
+    `  agents browser remote-control on`
   );
 }

--- a/apps/cli/src/lib/browser/remote-control.ts
+++ b/apps/cli/src/lib/browser/remote-control.ts
@@ -56,11 +56,7 @@ export function assertRemoteControlAllowed(opts?: {
   if (enabled) return;
 
   const who = env.AGENTS_ACTOR_HOST || env.AGENTS_ACTOR || 'A fleet machine';
-  throw new Error(
-    `${who} tried to drive this machine's browser over \`browser --device\`, but remote ` +
-      `browser control is off here. To allow it, run on THIS machine:\n` +
-      `  agents browser remote-control on`,
-  );
+  throw new Error(remoteControlRefusal(who));
 }
 
 /**

--- a/apps/cli/src/lib/browser/service.ts
+++ b/apps/cli/src/lib/browser/service.ts
@@ -19,6 +19,7 @@ import {
   parseEndpointUrl,
 } from './profiles.js';
 import { killChrome, getRunningChromeInfo, launchBrowser, allocatePort } from './chrome.js';
+import { assertRemoteControlAllowedForRequest } from './remote-control.js';
 import { connectLocal } from './drivers/local.js';
 import { connectSSH, shellQuote } from './drivers/ssh.js';
 import { clearProfileRuntime, listProfileCacheDirs, readProfileRuntimeMeta, isProcessAlive } from './runtime-state.js';
@@ -444,6 +445,8 @@ export class BrowserService {
       launchId?: string;
       /** Calling agent session, forwarded from the CLI (see IPCRequest.sessionId). */
       sessionId?: string;
+      /** Whether the CALLER was dispatched here by a fleet `--device` hop. */
+      fleetRemote?: boolean;
       /** Explicit human label (`--title`). */
       title?: string;
     } = {}
@@ -458,6 +461,12 @@ export class BrowserService {
     key: ConnectionKey;
     skill?: ResolvedDomainSkill;
   }> {
+    // Consent gate, before anything is resolved or launched. This is the
+    // authoritative one: gating only the `browser start` COMMAND left the ~18
+    // page verbs that create a browser implicitly (navigate, click, screenshot,
+    // …) able to open a browser on a machine whose owner never opted in.
+    assertRemoteControlAllowedForRequest(opts.fleetRemote, { actor: opts.actor });
+
     const profile = await getProfile(profileName);
     if (!profile) {
       throw new Error(`Profile "${profileName}" not found`);
@@ -2806,6 +2815,8 @@ export class BrowserService {
    *   - no handle, zero, !createIfMissing → return null (caller reports "nothing to close")
    */
   async resolveOrCreateTask(opts: {
+    /** Whether the CALLER was dispatched here by a fleet `--device` hop. */
+    fleetRemote?: boolean;
     task?: string;
     profile?: string;
     actor?: string;
@@ -2860,6 +2871,11 @@ export class BrowserService {
     // Zero matches for this caller.
     if (!opts.createIfMissing) return null;
 
+    // Refuse BEFORE ensureDefaultBrowserProfile() below, which probes local
+    // browser installs and may CREATE and persist an `auto-chrome` profile — a
+    // refused request must not leave state behind on the target machine.
+    assertRemoteControlAllowedForRequest(opts.fleetRemote, { actor: opts.actor });
+
     // Implicit start on the default / named profile.
     let profileName = opts.profile;
     if (!profileName) {
@@ -2868,6 +2884,7 @@ export class BrowserService {
       profileName = detected.name;
     }
     const started = await this.start(profileName, {
+      fleetRemote: opts.fleetRemote,
       url: opts.url,
       actor: opts.actor,
       launchId: opts.launchId,

--- a/apps/cli/src/lib/browser/types.ts
+++ b/apps/cli/src/lib/browser/types.ts
@@ -444,6 +444,18 @@ export interface IPCRequest {
    * for `computer.action` events, so both tool surfaces key on one signal.
    */
   sessionId?: string;
+
+  /**
+   * True when the CLI process that issued this request was itself dispatched to
+   * this machine by a fleet `--device` hop.
+   *
+   * Stamped client-side for the same reason actor/launchId are — and
+   * additionally because the daemon may have been auto-started BY a fleet-remote
+   * CLI and inherited AGENTS_FLEET_REMOTE for its whole life (startDetached
+   * passes `env: opts.env ?? process.env`). The daemon's own env is therefore
+   * not a truthful signal about the CURRENT caller; only the request is.
+   */
+  fleetRemote?: boolean;
 }
 
 /** Subset of IPCResponse describing a recording start result. */


### PR DESCRIPTION
`agents browser remote-control off` is the default, and it was enforced on exactly one command. Every other way of opening a browser on a remote machine walked straight past it.

## The bypass, reproduced on the live fleet

`yosemite-s0` has remote-control **off**. From zion, against the CURRENT release:

```console
$ agents browser start --device yosemite-s0
UNRESOLVED@zion tried to drive this machine's browser over `browser --device`,
but remote browser control is off here. To allow it, run on THIS machine:
  agents browser remote-control on

$ agents browser navigate --device yosemite-s0 --url https://example.com
read ECONNRESET
```

The second command is not refused. It never reaches the gate.

## Why

`assertRemoteControlAllowed` had two non-test callers (`commands/browser.ts:943`, `lib/browser/stream.ts:65`), both keyed on `browser start`. But 18 verbs in `PAGE_CREATE_VERBS` (`ipc.ts:21-40`) — `navigate`, `click`, `type`, `screenshot`, `evaluate`, `pdf`, `upload`, `record-start` and the rest — create a browser implicitly via `resolveOrCreateTask` → `this.start()` (`service.ts:2861-2876`) whenever the caller has no live task. None of them passed through the gate.

This is not academic on this fleet: the profile it guards holds five live logins (github, google, x, linkedin, reddit, per `agents browser profiles logins`).

## What changed

The gate moves to the daemon, at the two points that can actually open a browser:

- `BrowserService.start()` — first statement of the body.
- the create branch of `resolveOrCreateTask` — placed **after** the `createIfMissing` check, so a refused request cannot make `ensureDefaultBrowserProfile()` write an `auto-chrome` profile onto the target machine as a side effect.

**The marker rides the request, never the daemon's environment.** `daemon.ts:2114` passes `env: opts.env ?? process.env` to `startDetached`, so a daemon auto-started by a fleet-remote CLI inherits `AGENTS_FLEET_REMOTE=1` for its entire life. A daemon that read its own env would then refuse every subsequent **local** drive on that machine until it restarted. `IPCRequest.fleetRemote` carries it per-request, for the same reason `actor`/`launchId` already do (`types.ts:428-431`).

`stampCallerIdentity` marks the request **above** its identity early-return — every streamed request already carries a full identity and would otherwise skip stamping entirely — and OR-es the value, so a client may assert the marker but cannot clear one the environment sets.

The command-level gate stays as a fast-fail so a refused `start` never resolves or auto-creates a profile; its comment now points at the daemon as the authority.

## Tests

`src/lib/browser/ipc.test.ts` drives a real `BrowserIPCServer` over a real socket:

- a fleet-remote `navigate` with consent off returns `ok: false` matching `/remote-control on/`, and `service.connections.size` is still `0` — refused before anything opened.
- a local `navigate` fails for its own reason and **never** matches the consent message.
- `stampCallerIdentity` marks a request even when the identity is already complete, and a client cannot downgrade `fleetRemote: false` against a marked environment.

`src/lib/browser/remote-control.test.ts` pins the daemon-inheritance trap: with `AGENTS_FLEET_REMOTE=1` stubbed into the process env, `assertRemoteControlAllowedForRequest(undefined, { enabled: false })` must **not** throw.

**Green-to-red:** removing both service gates — i.e. reverting to `main`'s behavior — fails the fleet-remote `navigate` test. Removing *only* the `BrowserService.start` gate fails the fleet-remote `start` test, which exercises the path `navigate` never reaches (`start` is in neither `PAGE_CREATE_VERBS` nor `PAGE_RESOLVE_VERBS`, so it bypasses `resolveOrCreateTask` entirely).

*Corrected after review:* an earlier revision of this body claimed "fails 2 of the IPC tests". The test block had been pasted twice, so that was one test counted twice. The duplicate is removed and the per-gate coverage above is what actually holds.

## Docs

`docs/browser.md`'s consent section claimed "the gate sits at the drive entry point (`browser start`), the one command that opens/attaches a browser". That was false even before this PR; corrected, with the request-marker rationale. Same for the module docstring in `remote-control.ts`. CHANGELOG fragment under `.changelog/next/`.

## Known gaps, deliberately not closed here

**The gate is on launching, not attaching.** `resolveOrCreateTask` returns before the gate when the request names an existing task (`--task <name>`, `service.ts:2830-2833`) or matches one by caller identity (`:2844-2848`), and `findTask` has no gate. So on a machine whose browser is already running, a remote `browser tab-add --device <box> --task <name>` can still drive the owner's authenticated profile with consent off — and `status` is ungated by design, so task names are discoverable. This is pre-existing: reverting this diff does not fix it. `docs/browser.md` and the changelog now say so explicitly under "What this does NOT cover" rather than implying it is closed. Closing it means gating the attach path as well, tracked separately.



`agents ssh <host> 'agents browser ...'` never sets `AGENTS_FLEET_REMOTE` — only the passthrough does (`passthrough.ts:433`, `:752`), and `lib/devices/connect.ts:190-228` sets only askpass vars. So that form remains ungated. Marking arbitrary user-typed `agents ssh` commands is a behavior change with its own blast radius, so it is filed separately rather than smuggled in here. The companion guidance change (phnx-labs/.agents-system#366, merged) stops agents from reaching for that form in the first place.

## Scope

Part of a set addressing browser-profile routing. Sibling: #2928 (`profiles edit`/`scope`/`doctor`). Still to come: routing user-facing opens through the configured profile, and a `--device interactive` sentinel.
