### PR TITLE
docs(hooks): list permission_mode_not in the predicate set

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -67,9 +67,14 @@ migrator is the single source of truth for legacy handling.
 
 System + user `hooks.yaml` merged, user wins on same name. Per-entry `matches:`
 predicates (`prompt_contains`, `prompt_matches`, `tool_name`, `tool_args_match`,
-`cwd_includes`, `project_has`, `git_dirty`, `permission_mode`) AND together at
-fire time — `permission_mode` alone is fail-open on absence, since only some
-harnesses report the live mode in hook input. Per-entry
+`cwd_includes`, `project_has`, `git_dirty`, `permission_mode`,
+`permission_mode_not`) AND together at fire time — the two mode predicates are
+fail-open on absence, since only some harnesses report the live mode in hook
+input. Use `permission_mode_not` to gate a hook **off** in one mode:
+`permission_mode` is an allowlist, so expressing "everywhere except plan" through
+it means enumerating every other mode, and that enumeration silently stops
+matching when a harness adds or renames one — which for a guard means it quietly
+stops guarding. Per-entry
 `enabled: false` disables a system-shipped hook from the user side. The `agents:`
 field in `ManifestHook` is `@deprecated` — the capability table decides which
 agents register a hook.


### PR DESCRIPTION
`docs-only` — one sentence in an architecture doc, no code, nothing to run.

Follow-up the non-author review on #2930 flagged after merge: `permission_mode_not` landed in `match.ts`, `types.ts`, and `docs/hooks.md`, but `apps/cli/AGENTS.md:69` still enumerated the old eight predicates. The architecture doc was describing a narrower surface than the code — exactly the "docs stay in sync with behavior" convention in the root `CLAUDE.md`.

Adds the predicate to the list, and states *when* to reach for it: `permission_mode` is an allowlist, so "everywhere except plan" through it means enumerating every other mode, and that enumeration silently stops matching when a harness adds or renames one — which for a guard means it quietly stops guarding.
