### PR TITLE
fix(exec): clear inherited lineage parent

### DIFF
--- a/apps/cli/src/lib/exec-lineage.test.ts
+++ b/apps/cli/src/lib/exec-lineage.test.ts
@@ -11,11 +11,14 @@ import { buildExecEnv } from './exec.js';
 describe('AGENTS_PARENT_SESSION_ID lineage', () => {
   const savedParent = process.env.AGENTS_SESSION_ID;
   const savedAgentParent = process.env.AGENT_SESSION_ID;
+  const savedLineageParent = process.env.AGENTS_PARENT_SESSION_ID;
   afterEach(() => {
     if (savedParent === undefined) delete process.env.AGENTS_SESSION_ID;
     else process.env.AGENTS_SESSION_ID = savedParent;
     if (savedAgentParent === undefined) delete process.env.AGENT_SESSION_ID;
     else process.env.AGENT_SESSION_ID = savedAgentParent;
+    if (savedLineageParent === undefined) delete process.env.AGENTS_PARENT_SESSION_ID;
+    else process.env.AGENTS_PARENT_SESSION_ID = savedLineageParent;
   });
 
   const PARENT = '11111111-1111-4111-8111-111111111111';
@@ -39,6 +42,7 @@ describe('AGENTS_PARENT_SESSION_ID lineage', () => {
   it('does not name a same-session resume as its own parent', () => {
     process.env.AGENTS_SESSION_ID = CHILD;
     delete process.env.AGENT_SESSION_ID;
+    process.env.AGENTS_PARENT_SESSION_ID = PARENT;
     const env = buildExecEnv({ agent: 'codex', cwd: process.cwd(), mode: 'auto', effort: 'auto', sessionId: CHILD });
     expect(env.AGENTS_PARENT_SESSION_ID).toBeUndefined();
   });
@@ -46,6 +50,7 @@ describe('AGENTS_PARENT_SESSION_ID lineage', () => {
   it('sets no parent when the spawner has no session', () => {
     delete process.env.AGENTS_SESSION_ID;
     delete process.env.AGENT_SESSION_ID;
+    process.env.AGENTS_PARENT_SESSION_ID = PARENT;
     const env = buildExecEnv({ agent: 'codex', cwd: process.cwd(), mode: 'auto', effort: 'auto', sessionId: CHILD });
     expect(env.AGENTS_PARENT_SESSION_ID).toBeUndefined();
   });

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -459,6 +459,7 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
   // every event the child emits. `options.sessionId` is the CHILD's id, so read the
   // spawner from the live env; guard a same-session resume from naming itself parent.
   // Local-spawn scope here; forwarding it across the `--device` SSH hop is Phase 4.
+  delete result.AGENTS_PARENT_SESSION_ID;
   const spawnerSessionId = process.env.AGENTS_SESSION_ID || process.env.AGENT_SESSION_ID;
   if (spawnerSessionId && spawnerSessionId !== options.sessionId) {
     result.AGENTS_PARENT_SESSION_ID = spawnerSessionId;


### PR DESCRIPTION
Clear a stale `AGENTS_PARENT_SESSION_ID` before deriving the direct spawner lineage.

## Verification
- Real focused run: [3 lineage tests passed](https://share.agents-cli.sh/muqsitnawaz/agents-cli-lineage-parent-fix-test-648f4b824e3ed60e).
- Reproduces the release attestation failure where a resumed session’s ambient parent leaked into same-session/no-spawner cases.

## Scope
Pure bug fix; no user-facing command or documentation surface changed.