### PR TITLE
feat(devices): one-line fleet-synced description config key (RUSH-3062)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-3062-config.md
+++ b/apps/cli/.changelog/next/RUSH-3062-config.md
@@ -4,7 +4,7 @@
   `~/.agents/devices/<name>/agents.yaml` under `config.description`, so it
   syncs to every machine via `agents repo push/pull` exactly as `role` does,
   and any box may set it for any device (`shared` visibility). Because it
-  renders in device tables it is validated: a newline is rejected outright and
+  will be shown by the device-list renderer it is validated: a newline is rejected outright and
   the value is capped at 80 characters — over-long input fails with a readable
   error naming the cap, never a silent truncation. `notes` is unchanged: it
   stays the appended list of long-form operator scratch, and both key

--- a/apps/cli/.changelog/next/RUSH-3062-config.md
+++ b/apps/cli/.changelog/next/RUSH-3062-config.md
@@ -1,0 +1,12 @@
+- **New device config key `description` — a one-line, fleet-synced answer to
+  "what is this box FOR".** `agents devices config <name> description "gpu box
+  — cuda 12.4"` stores a single-line summary in the device's tracked
+  `~/.agents/devices/<name>/agents.yaml` under `config.description`, so it
+  syncs to every machine via `agents repo push/pull` exactly as `role` does,
+  and any box may set it for any device (`shared` visibility). Because it
+  renders in device tables it is validated: a newline is rejected outright and
+  the value is capped at 80 characters — over-long input fails with a readable
+  error naming the cap, never a silent truncation. `notes` is unchanged: it
+  stays the appended list of long-form operator scratch, and both key
+  descriptions now state the distinction. Source:
+  `apps/cli/src/lib/device-config.ts`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -416,6 +416,16 @@ keys, `role` is **shared**: it lives in that device's tracked
 push/pull`, because every box has to agree on where agents may land. The
 vocabulary is `worker | personal` only.
 
+`devices.<name>.description` (stored as `description`) is the free-text sibling
+of `role`: one line saying what the box is FOR — "gpu box — cuda 12.4", "release
+runner" — where `role` is the two-value placement switch. Like `role` it is
+**shared**: it lives in the device's tracked `devices/<name>/agents.yaml`
+`config.description` and syncs with `agents repo push/pull`, and any box may set
+it for any device. It renders in device tables, so it is validated as a single
+line capped at 80 characters — a newline or an over-long value is rejected
+loudly, never truncated. It is NOT `notes`: `notes` stays an appended list of
+long-form operator scratch that never renders in tables.
+
 `interactive.host` is a **user-level** preference: it lives in central
 `~/.agents/agents.yaml` under `config.interactiveHost`, syncs fleet-wide via
 `agents repo push/pull`, and answers "which device shows me artifacts?" It is

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -421,10 +421,11 @@ of `role`: one line saying what the box is FOR — "gpu box — cuda 12.4", "rel
 runner" — where `role` is the two-value placement switch. Like `role` it is
 **shared**: it lives in the device's tracked `devices/<name>/agents.yaml`
 `config.description` and syncs with `agents repo push/pull`, and any box may set
-it for any device. It renders in device tables, so it is validated as a single
+it for any device. The device-list renderer will show it (RUSH-3062, `surface`
+track), so it is validated as a single
 line capped at 80 characters — a newline or an over-long value is rejected
 loudly, never truncated. It is NOT `notes`: `notes` stays an appended list of
-long-form operator scratch that never renders in tables.
+long-form operator scratch that is never shown in device listings.
 
 `interactive.host` is a **user-level** preference: it lives in central
 `~/.agents/agents.yaml` under `config.interactiveHost`, syncs fleet-wide via

--- a/apps/cli/docs/concepts.md
+++ b/apps/cli/docs/concepts.md
@@ -234,7 +234,7 @@ reads the effective value back, `key value` sets it with validation,
 fleet-wide defaults layer. `--json` reports each key's `source` (`device` |
 `fleet` | `default`). Device-scope keys: `role` (`worker` \| `personal`; also
 `agents devices role`), `description` (one line saying what the box is for —
-synced fleet-wide, rendered in tables; capped at 80 chars, single line only),
+synced fleet-wide; capped at 80 chars, single line only),
 `agents.max-concurrent`, `scheduler.enabled`,
 `daemon.enabled`, `watchdog.enabled`, `tmux.enabled`,
 `browser.remote-control`, `browser.profile`, `notes` (an appended list of

--- a/apps/cli/docs/concepts.md
+++ b/apps/cli/docs/concepts.md
@@ -233,9 +233,12 @@ reads the effective value back, `key value` sets it with validation,
 <text>` appends a free-form operator note, and `--fleet` targets the
 fleet-wide defaults layer. `--json` reports each key's `source` (`device` |
 `fleet` | `default`). Device-scope keys: `role` (`worker` \| `personal`; also
-`agents devices role`), `agents.max-concurrent`, `scheduler.enabled`,
+`agents devices role`), `description` (one line saying what the box is for —
+synced fleet-wide, rendered in tables; capped at 80 chars, single line only),
+`agents.max-concurrent`, `scheduler.enabled`,
 `daemon.enabled`, `watchdog.enabled`, `tmux.enabled`,
-`browser.remote-control`, `browser.profile`, `notes`, the `ssh.*` profile
+`browser.remote-control`, `browser.profile`, `notes` (an appended list of
+long-form operator scratch — not the one-line `description`), the `ssh.*` profile
 overrides, `platform`, `auto-launch.*`. Keys only the owning box reads
 (`scheduler.enabled`, `daemon.enabled`, `tmux.enabled`,
 `browser.remote-control`, `browser.task-idle-minutes`, `browser.profile`) are

--- a/apps/cli/src/lib/device-config.test.ts
+++ b/apps/cli/src/lib/device-config.test.ts
@@ -136,6 +136,60 @@ describe('device-scope keys (per-device doc config:)', () => {
   });
 });
 
+describe('description key (one-line synced summary)', () => {
+  it('round-trips through devices/<host>/agents.yaml under config:, never central', async () => {
+    const { setConfigValue, getConfigValue, unsetConfigValue } = await freshModules();
+
+    setConfigValue('description', 'gpu box — cuda 12.4');
+
+    const doc = readDoc();
+    expect(doc).toContain('config:');
+    expect(doc).toContain('description: gpu box — cuda 12.4');
+    expect(readCentral()).not.toContain('description');
+
+    expect(getConfigValue('description')).toMatchObject({ value: 'gpu box — cuda 12.4', source: 'device' });
+
+    unsetConfigValue('description');
+    expect(getConfigValue('description').value).toBeUndefined();
+    expect(readDoc()).not.toContain('description');
+  });
+
+  it('is shared: any box may set it for a peer, landing in the peer’s tracked doc', async () => {
+    const { setConfigValue, getConfigValue } = await freshModules();
+
+    setConfigValue('description', 'release runner', { device: 'mac-mini' });
+
+    expect(readDoc('mac-mini')).toContain('description: release runner');
+    expect(readDoc()).not.toContain('description');
+    expect(getConfigValue('description', { device: 'mac-mini' }).value).toBe('release runner');
+  });
+
+  it('rejects a newline outright — never silently truncated', async () => {
+    const { setConfigValue } = await freshModules();
+    expect(() => setConfigValue('description', 'line one\nline two')).toThrow(/single line/);
+    expect(() => setConfigValue('description', 'line one\r\nline two')).toThrow(/single line/);
+  });
+
+  it('rejects an over-long value with a readable error naming the cap', async () => {
+    const { setConfigValue } = await freshModules();
+    const tooLong = 'x'.repeat(81);
+    expect(() => setConfigValue('description', tooLong)).toThrow(/at most 80 characters \(got 81\)/);
+    expect(() => setConfigValue('description', 'x'.repeat(80))).not.toThrow();
+  });
+
+  it('leaves notes untouched as an appended string-list', async () => {
+    const { setConfigValue, getConfigValue } = await freshModules();
+
+    setConfigValue('description', 'gpu box');
+    setConfigValue('notes', ['runs the releases']);
+    setConfigValue('notes', ['runs the releases', 'loud fans']);
+
+    expect(getConfigValue('notes')).toMatchObject({ value: ['runs the releases', 'loud fans'], source: 'device' });
+    expect(getConfigValue('description')).toMatchObject({ value: 'gpu box', source: 'device' });
+    expect(() => setConfigValue('notes', 'just a string')).toThrow(/expects a list of strings/);
+  });
+});
+
 describe('fleet-defaults layer (central fleet.defaults.config)', () => {
   it('--fleet writes land centrally under fleet.defaults.config', async () => {
     const { setConfigValue, getConfigValue, unsetConfigValue } = await freshModules();
@@ -297,6 +351,7 @@ describe('listConfig', () => {
       'browser.remote-control',
       'browser.task-idle-minutes',
       'daemon.enabled',
+      'description',
       'interactive.host',
       'notes',
       'platform',

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -253,7 +253,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     type: 'string-list',
     description:
       'Free-form operator notes about this device (one entry per `agents devices config <name> notes <text>`). ' +
-      'Long-form scratch, never rendered in tables — for the one-line synced summary of what the box is for, use `description`.',
+      'Long-form scratch, never shown in device listings — for the one-line synced summary of what the box is for, use `description`.',
   },
   {
     name: 'description',
@@ -262,12 +262,13 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     visibility: 'shared',
     type: 'string',
     description:
-      'One line saying what this device is FOR ("gpu box — cuda 12.4"), rendered in device tables and synced fleet-wide. ' +
+      'One line saying what this device is FOR ("gpu box — cuda 12.4"), synced fleet-wide. Kept to one short line ' +
+      'because the device-list renderer will show it (RUSH-3062, `surface` track). ' +
       'Replaces the value on each set; for appended long-form scratch use `notes`.',
     validate: (v) => {
       const s = v as string;
       if (s.includes('\n') || s.includes('\r')) return 'description must be a single line.';
-      if (s.length > 80) return `description must be at most 80 characters (got ${s.length}) — it renders in a table.`;
+      if (s.length > 80) return `description must be at most 80 characters (got ${s.length}) — it is a one-line table cell.`;
       return null;
     },
   },

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -251,7 +251,25 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     scope: 'device',
     visibility: 'shared',
     type: 'string-list',
-    description: 'Free-form operator notes about this device (one entry per `agents devices config <name> notes <text>`).',
+    description:
+      'Free-form operator notes about this device (one entry per `agents devices config <name> notes <text>`). ' +
+      'Long-form scratch, never rendered in tables — for the one-line synced summary of what the box is for, use `description`.',
+  },
+  {
+    name: 'description',
+    yamlKey: 'description',
+    scope: 'device',
+    visibility: 'shared',
+    type: 'string',
+    description:
+      'One line saying what this device is FOR ("gpu box — cuda 12.4"), rendered in device tables and synced fleet-wide. ' +
+      'Replaces the value on each set; for appended long-form scratch use `notes`.',
+    validate: (v) => {
+      const s = v as string;
+      if (s.includes('\n') || s.includes('\r')) return 'description must be a single line.';
+      if (s.length > 80) return `description must be at most 80 characters (got ${s.length}) — it renders in a table.`;
+      return null;
+    },
   },
   {
     name: 'ssh.user',


### PR DESCRIPTION
Add a one-line, fleet-synced `description` for a device — the operator's answer to "what is this box FOR". Part 2 of 4 for RUSH-3062.

## What changed

One entry added to the `CONFIG_KEYS` registry. Because that registry is what drives the config command, `agents devices config <name> description "<text>"` works with no command-file change.

- `scope: 'device'` + `visibility: 'shared'` puts it in the tracked per-device doc `~/.agents/devices/<name>/agents.yaml` under `config:` — the same store `role` uses, so `agents repo push` / `pull` carry it fleet-wide. Any box may set it for any device.
- Validated as a genuinely single line: a newline or carriage return is rejected, and the value is capped at 80 characters because it renders in a table. Both fail loud with a readable message — never silently truncated.
- `description` is **not** `notes`. `notes` stays the appended `string-list` of long-form operator scratch that is never rendered. Both key descriptions now state the distinction so a reader can tell which to reach for.

## Evidence — real run

```
$ bun run test -- src/lib/device-config.test.ts

 RUN  v4.1.9 .agents/worktrees/config/apps/cli

 Test Files  1 passed (1)
      Tests  44 passed (44)
   Duration  1.97s
```

Tests round-trip the key through the real config store — no mocking — and cover newline rejection, the length cap, and that `notes` still behaves as a string-list.

## Not in this PR

Rendering the description in `agents devices list`, and the `agents devices describe` sugar, are the `surface` track, which consumes this key once this merges. Design of record: `.agents/artifacts/2026-08-23/mockup-devices-inventory.md` on `devices-inventory-plan`.

Ticket: RUSH-3062
