### PR TITLE
fix(ext): release.sh keeps its arguments across the secrets re-entry (RUSH-2987)

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
+## [0.9.332] - 2026-08-23
+
+- **`scripts/release.sh` no longer loses the version when it re-enters under
+  `agents secrets exec` (RUSH-2987).** The argument parser shifts every argument
+  away, so the re-exec that picks up the marketplace PATs replayed an empty
+  `"$@"`: the re-entered script found no version, fell through to `usage 1`, and
+  every extension release died at the token step with a usage dump. The original
+  argv is captured before parsing and replayed verbatim. Source:
+  `scripts/release.sh`, covered by `scripts/release.test.sh`.
+
 ## [0.9.331] - 2026-08-23
 
 - **`Agents: New <Harness>` opens an agent again instead of asking which account

--- a/apps/ext/scripts/release.sh
+++ b/apps/ext/scripts/release.sh
@@ -45,6 +45,13 @@ STAY_HERE=0
 # the work instead of routing again.
 PUBLISH_PHASE=0
 
+# The parse loop below shifts every argument away, so `$@` is empty by the time
+# the secrets re-entry re-execs this script (RUSH-2987: the re-exec replayed an
+# empty argv, the re-entered script fell through to `usage 1`, and every release
+# died at the token step). Keep the original argv so the re-exec can replay it
+# verbatim.
+ORIGINAL_ARGV=("$@")
+
 usage() {
     sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
     exit "${1:-0}"
@@ -354,7 +361,8 @@ if { [ $PUBLISH_VSCE -eq 1 ] && [ -z "${VSCE_PAT:-}" ]; } || { [ $PUBLISH_OVSX -
             echo "       Then add VSCE_PAT and OVSX_PAT keys." >&2
             exit 1
         fi
-        EXT_RELEASE_SECRETS_EXEC=1 exec agents secrets exec vs-marketplace -- "$0" "$@"
+        # Replay ORIGINAL_ARGV, not "$@" — see the note at its definition.
+        EXT_RELEASE_SECRETS_EXEC=1 exec agents secrets exec vs-marketplace -- "$0" "${ORIGINAL_ARGV[@]}"
     fi
 fi
 

--- a/apps/ext/scripts/release.test.sh
+++ b/apps/ext/scripts/release.test.sh
@@ -44,6 +44,75 @@ else
     pass "release.sh contains no raw bun test invocation"
 fi
 
+# --- RUSH-2987: the secrets re-entry must carry the original arguments -----
+#
+# release.sh parses argv with a `while [ $# -gt 0 ]` loop that shifts every
+# argument away, then re-execs itself under `agents secrets exec` to pick up the
+# marketplace PATs. Replaying "$@" there replays an EMPTY argv: the re-entered
+# script finds no version, falls through to `usage 1`, and the release dies at
+# the token step with a usage dump. This drives the real script with stubbed
+# `agents`/`vsce`/`ovsx` and asserts the version reaches the re-exec.
+RELEASE_VERSION="$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$EXT_ROOT/CHANGELOG.md" | tr -d '#[] ')"
+if [ -z "$RELEASE_VERSION" ]; then
+    fail "could not read a released version out of CHANGELOG.md"
+else
+    STUB_DIR="$(mktemp -d)"
+    STUB_HOME="$(mktemp -d)"
+    REEXEC_ARGV="$STUB_DIR/reexec-argv"
+
+    # `agents secrets list` makes this box look like the publish host (no ssh
+    # routing); `agents secrets exec ... -- true` is the resolvability probe;
+    # any other exec is the re-entry, whose argv we record instead of running.
+    cat > "$STUB_DIR/agents" <<'STUB'
+#!/bin/bash
+if [ "${1:-}" = "secrets" ] && [ "${2:-}" = "list" ]; then
+    echo "vs-marketplace       2     never - no prompt"
+    exit 0
+fi
+if [ "${1:-}" = "secrets" ] && [ "${2:-}" = "exec" ]; then
+    shift 3                       # drop: secrets exec <bundle>
+    [ "${1:-}" = "--" ] && shift
+    if [ "${1:-}" = "true" ]; then exit 0; fi
+    printf '%s\n' "$@" > "$REEXEC_ARGV_PATH"
+    exit 0
+fi
+exit 0
+STUB
+
+    # Enough of vsce/ovsx to clear the collision + PAT pre-flights offline.
+    cat > "$STUB_DIR/vsce" <<'STUB'
+#!/bin/bash
+case "${1:-}" in
+    show)        echo '{"versions":[]}' ;;
+    verify-pat)  exit 0 ;;
+esac
+exit 0
+STUB
+    cat > "$STUB_DIR/ovsx" <<'STUB'
+#!/bin/bash
+echo '{}'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/agents" "$STUB_DIR/vsce" "$STUB_DIR/ovsx"
+
+    # HOME is redirected because release.sh prepends "$HOME/.bun/bin" to PATH
+    # before the marketplace check — a real vsce there would shadow the stub.
+    (
+        cd "$EXT_ROOT"
+        PATH="$STUB_DIR:$PATH" HOME="$STUB_HOME" \
+            REEXEC_ARGV_PATH="$REEXEC_ARGV" VSCE_PAT="" OVSX_PAT="" \
+            bash "$RELEASE_SH" "$RELEASE_VERSION"
+    ) >/dev/null 2>&1 || true
+
+    if [ ! -f "$REEXEC_ARGV" ]; then
+        fail "release.sh never reached the secrets re-entry (stub recorded nothing)"
+    elif grep -qx -- "$RELEASE_VERSION" "$REEXEC_ARGV"; then
+        pass "secrets re-entry replays the version ($RELEASE_VERSION) instead of an empty argv"
+    else
+        fail "secrets re-entry lost the version; re-exec argv was: $(tr '\n' ' ' < "$REEXEC_ARGV")"
+    fi
+fi
+
 echo
 if [ "$FAIL" -eq 0 ]; then
     echo "All tests passed."


### PR DESCRIPTION
**fix** — every AGI EXT release has been dying at the token step. Found while trying to ship 0.9.331.

## The bug

`release.sh` parses argv with a `while [ $# -gt 0 ]` loop (`scripts/release.sh:53-81`) that `shift`s every branch. By the time it re-execs itself under `agents secrets exec` to pick up the marketplace PATs, `$@` is empty:

```bash
EXT_RELEASE_SECRETS_EXEC=1 exec agents secrets exec vs-marketplace -- "$0" "$@"   # $@ is empty here
```

The re-entered script therefore has no version, hits `if [ -z "$BASE_VERSION" ]; then usage 1; fi` (`scripts/release.sh:83`), prints the usage block and exits 1.

It fails *late*, which is why it reads as mysterious: the changelog check, publish-host routing, the ssh hop to the publish box, and both marketplace collision checks all pass first, so the operator sees a full, correct release plan followed by a usage dump.

## The fix

Capture argv before the parser consumes it, replay that:

```diff
 PUBLISH_PHASE=0
 
+ORIGINAL_ARGV=("$@")
+
 usage() {
```
```diff
-        EXT_RELEASE_SECRETS_EXEC=1 exec agents secrets exec vs-marketplace -- "$0" "$@"
+        EXT_RELEASE_SECRETS_EXEC=1 exec agents secrets exec vs-marketplace -- "$0" "${ORIGINAL_ARGV[@]}"
```

## Run result

The test drives the **real** `release.sh` with stubbed `agents`/`vsce`/`ovsx` (no network, no credentials, `HOME` redirected so a real `vsce` on `$HOME/.bun/bin` cannot shadow the stub) and records the argv the re-exec is handed.

With the fix:

```text
$ bash scripts/release.test.sh
Running release.sh regression tests...
  PASS: release.sh passes bash -n syntax check
  PASS: package.json defines the canonical test command: bun test --timeout 30000
  PASS: release.sh delegates to the package test script
  PASS: release.sh contains no raw bun test invocation
  PASS: secrets re-entry replays the version (0.9.331) instead of an empty argv

All tests passed.
```

Reverted to the pre-fix `"$@"` line, same test, same command — it catches the bug rather than decorating it:

```text
  FAIL: secrets re-entry lost the version; re-exec argv was: .../apps/ext/scripts/release.sh

Some tests FAILED.
```

And the failure this fixes, from the 0.9.331 dry-run that surfaced it (`scripts/release.sh 0.9.331`, exit 1):

```text
Changelog entry for 0.9.331: found.
yosemite-s1 has no 'vs-marketplace' bundle - looking for a publish host...
Routing the publish to <publish-box> (holds the 'vs-marketplace' bundle).
Publish phase on <publish-box>.
Checking marketplace for existing swarmify.swarm-ext@0.9.331...
Checking Open VSX for existing swarmify.swarm-ext@0.9.331...

Ship swarmify.swarm-ext to the VS Code Marketplace and Open VSX.     <-- usage dump, exit 1
```

## Scope

Script + its test + CHANGELOG (0.9.332). No extension source touched, so no VSIX behavior change. Device name redacted above because this repo is public.

Tracking: https://linear.app/getrush/issue/RUSH-2987
