### PR TITLE
feat(tmux): working mouse, clipboard and scrollback in agent panes, without overriding the user (RUSH-3066)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-3066-ergonomics.md
+++ b/apps/cli/.changelog/next/RUSH-3066-ergonomics.md
@@ -1,0 +1,5 @@
+---
+type: fix
+---
+
+Make opt-in tmux-wrapped runs default to mouse interaction, OSC 52 system clipboard integration, and 20,000 lines of scrollback while preserving the user's tmux configuration.

--- a/apps/cli/src/lib/tmux/session.test.ts
+++ b/apps/cli/src/lib/tmux/session.test.ts
@@ -7,6 +7,7 @@
  * the whole suite is skipped at module load.
  */
 
+import { spawnSync } from 'child_process';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -665,3 +666,37 @@ async function waitForCapture(
     await wait(50);
   }
 }
+
+describe('already-running server reconcile (RUSH-3066)', () => {
+  // tmux reads -f ONLY when it starts a server. A second `new-session -f other.conf`
+  // against a live server exits 0 and applies nothing — so without an explicit
+  // reconcile, every machine whose server was already up (the normal state at
+  // upgrade) would silently get none of the ergonomics defaults. Real tmux, no mocks.
+  it('a second -f against a live server is ignored, and source-file repairs it', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-tmux-reconcile-'));
+    const sock = path.join(dir, 's.sock');
+    const cold = path.join(dir, 'cold.conf');
+    const warm = path.join(dir, 'warm.conf');
+    fs.writeFileSync(cold, 'set-option -g history-limit 11111\n');
+    fs.writeFileSync(warm, `set-option -g history-limit ${AGENTS_TMUX_HISTORY_LIMIT}\nset-option -g mouse on\n`);
+    const tmux = (args: string[]) =>
+      spawnSync('tmux', ['-S', sock, ...args], { encoding: 'utf-8' });
+    try {
+      spawnSync('tmux', ['-f', cold, '-S', sock, 'new-session', '-d', '-s', 'one'], { encoding: 'utf-8' });
+      if (tmux(['has-session', '-t', '=one']).status !== 0) return; // tmux unavailable here
+
+      // -f on a live server: ignored.
+      spawnSync('tmux', ['-f', warm, '-S', sock, 'new-session', '-d', '-s', 'two'], { encoding: 'utf-8' });
+      expect(tmux(['show-options', '-gv', 'history-limit']).stdout.trim()).toBe('11111');
+      expect(tmux(['show-options', '-gv', 'mouse']).stdout.trim()).toBe('off');
+
+      // source-file on the live server: applied.
+      tmux(['source-file', warm]);
+      expect(tmux(['show-options', '-gv', 'history-limit']).stdout.trim()).toBe(String(AGENTS_TMUX_HISTORY_LIMIT));
+      expect(tmux(['show-options', '-gv', 'mouse']).stdout.trim()).toBe('on');
+    } finally {
+      tmux(['kill-server']);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/lib/tmux/session.test.ts
+++ b/apps/cli/src/lib/tmux/session.test.ts
@@ -32,6 +32,8 @@ import {
   splitPane,
   AGENT_HOOK_SCHEMA,
   agentPaneDiedHook,
+  AGENTS_TMUX_HISTORY_LIMIT,
+  buildCreateSessionArgs,
   TmuxSessionError,
 } from './session.js';
 
@@ -66,6 +68,69 @@ describe.skipIf(skipReason)('tmux session lifecycle', () => {
     expect(slugifyName('hello world')).toBe('hello-world');
     expect(slugifyName('agent:claude.task')).toBe('agent-claude-task');
     expect(slugifyName('---trim---')).toBe('trim');
+  });
+
+  it('builds session creation with agents-cli server ergonomics before new-session', () => {
+    const args = buildCreateSessionArgs({ name: 'ergonomic', cmd: 'sleep 30' }, '/agents/tmux-defaults.conf');
+    expect(args).toEqual([
+      '-f', '/agents/tmux-defaults.conf',
+      'set-option', '-g', 'remain-on-exit', 'on', ';',
+      'new-session', '-d', '-s', 'ergonomic', '-P', '-F', '#{pane_id}',
+      '--', 'sh', '-c', 'sleep 30',
+    ]);
+  });
+
+  it('keeps explicit user tmux options and mouse-copy bindings', async () => {
+    const userHome = path.join(tempDir, 'home');
+    fs.mkdirSync(userHome);
+    fs.writeFileSync(path.join(userHome, '.tmux.conf'), [
+      'set-option -g mouse off',
+      'set-option -s set-clipboard external',
+      'set-option -g history-limit 50000',
+      'bind-key -T copy-mode MouseDragEnd1Pane send-keys -X cancel',
+      'bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X cancel',
+    ].join('\n'));
+
+    await createSession({
+      name: 'user-config',
+      cmd: 'sleep 30',
+      socket,
+      env: { ...process.env, HOME: userHome, XDG_CONFIG_HOME: path.join(userHome, '.config') },
+    });
+
+    expect((await runTmux({ socket, args: ['show-options', '-gv', 'mouse'] })).stdout.trim()).toBe('off');
+    expect((await runTmux({ socket, args: ['show-options', '-sv', 'set-clipboard'] })).stdout.trim()).toBe('external');
+    expect((await runTmux({ socket, args: ['show-options', '-gv', 'history-limit'] })).stdout.trim()).toBe('50000');
+    for (const table of ['copy-mode', 'copy-mode-vi']) {
+      const binding = (await runTmux({ socket, args: ['list-keys', '-T', table, 'MouseDragEnd1Pane'] })).stdout;
+      expect(binding).toContain('cancel');
+      expect(binding).not.toContain('copy-selection-no-clear');
+    }
+  });
+
+  it('configures mouse, OSC 52 clipboard, scrollback, and non-clearing mouse copy on its socket', async () => {
+    const unconfiguredHome = path.join(tempDir, 'unconfigured-home');
+    fs.mkdirSync(unconfiguredHome);
+    await createSession({
+      name: 'ergonomic',
+      cmd: 'sleep 30',
+      socket,
+      env: {
+        ...process.env,
+        HOME: unconfiguredHome,
+        XDG_CONFIG_HOME: path.join(unconfiguredHome, '.config'),
+      },
+    });
+
+    expect((await runTmux({ socket, args: ['show-options', '-gv', 'mouse'] })).stdout.trim()).toBe('on');
+    expect((await runTmux({ socket, args: ['show-options', '-sv', 'set-clipboard'] })).stdout.trim()).toBe('on');
+    expect((await runTmux({ socket, args: ['show-options', '-gv', 'history-limit'] })).stdout.trim())
+      .toBe(String(AGENTS_TMUX_HISTORY_LIMIT));
+
+    for (const table of ['copy-mode', 'copy-mode-vi']) {
+      const binding = (await runTmux({ socket, args: ['list-keys', '-T', table, 'MouseDragEnd1Pane'] })).stdout;
+      expect(binding).toContain('copy-selection-no-clear');
+    }
   });
 
   it('creates a detached session and reports it via hasSession + listSessions', async () => {

--- a/apps/cli/src/lib/tmux/session.test.ts
+++ b/apps/cli/src/lib/tmux/session.test.ts
@@ -34,6 +34,7 @@ import {
   AGENT_HOOK_SCHEMA,
   agentPaneDiedHook,
   AGENTS_TMUX_HISTORY_LIMIT,
+  AGENTS_TMUX_CONFIG_SCHEMA,
   buildCreateSessionArgs,
   TmuxSessionError,
 } from './session.js';
@@ -668,34 +669,73 @@ async function waitForCapture(
 }
 
 describe('already-running server reconcile (RUSH-3066)', () => {
-  // tmux reads -f ONLY when it starts a server. A second `new-session -f other.conf`
-  // against a live server exits 0 and applies nothing — so without an explicit
-  // reconcile, every machine whose server was already up (the normal state at
-  // upgrade) would silently get none of the ergonomics defaults. Real tmux, no mocks.
-  it('a second -f against a live server is ignored, and source-file repairs it', async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-tmux-reconcile-'));
-    const sock = path.join(dir, 's.sock');
-    const cold = path.join(dir, 'cold.conf');
-    const warm = path.join(dir, 'warm.conf');
-    fs.writeFileSync(cold, 'set-option -g history-limit 11111\n');
-    fs.writeFileSync(warm, `set-option -g history-limit ${AGENTS_TMUX_HISTORY_LIMIT}\nset-option -g mouse on\n`);
-    const tmux = (args: string[]) =>
-      spawnSync('tmux', ['-S', sock, ...args], { encoding: 'utf-8' });
+  // These drive the REAL createSession() against a REAL tmux server, because the
+  // bug being fixed lives in createSession's control flow, not in tmux. A test
+  // that only shells out to `tmux` directly would still pass with the fix
+  // deleted, which is exactly the ceremony apps/cli/AGENTS.md forbids.
+  const mk = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ag-reconcile-'));
+
+  it('configures a server that was ALREADY running before agents-cli touched it', async () => {
+    if (!isTmuxInstalled()) return;
+    const dir = mk();
+    const socket = path.join(dir, 's.sock');
     try {
-      spawnSync('tmux', ['-f', cold, '-S', sock, 'new-session', '-d', '-s', 'one'], { encoding: 'utf-8' });
-      if (tmux(['has-session', '-t', '=one']).status !== 0) return; // tmux unavailable here
+      // A pre-existing server started WITHOUT our config — the state every
+      // machine is in at upgrade.
+      spawnSync('tmux', ['-f', '/dev/null', '-S', socket, 'new-session', '-d', '-s', 'preexisting'], { encoding: 'utf-8' });
+      const before = spawnSync('tmux', ['-S', socket, 'show-options', '-gv', 'mouse'], { encoding: 'utf-8' });
+      expect(before.stdout.trim()).toBe('off');
 
-      // -f on a live server: ignored.
-      spawnSync('tmux', ['-f', warm, '-S', sock, 'new-session', '-d', '-s', 'two'], { encoding: 'utf-8' });
-      expect(tmux(['show-options', '-gv', 'history-limit']).stdout.trim()).toBe('11111');
-      expect(tmux(['show-options', '-gv', 'mouse']).stdout.trim()).toBe('off');
+      await createSession({ name: 'agent-1', socket, cmd: 'sleep 30' });
 
-      // source-file on the live server: applied.
-      tmux(['source-file', warm]);
-      expect(tmux(['show-options', '-gv', 'history-limit']).stdout.trim()).toBe(String(AGENTS_TMUX_HISTORY_LIMIT));
-      expect(tmux(['show-options', '-gv', 'mouse']).stdout.trim()).toBe('on');
+      const mouse = spawnSync('tmux', ['-S', socket, 'show-options', '-gv', 'mouse'], { encoding: 'utf-8' });
+      const hist = spawnSync('tmux', ['-S', socket, 'show-options', '-gv', 'history-limit'], { encoding: 'utf-8' });
+      const stamp = spawnSync('tmux', ['-S', socket, 'show-options', '-gv', '@ag_tmux_config_schema'], { encoding: 'utf-8' });
+      // Without the reconcile branch these are 'off' / '2000' / '' — tmux
+      // ignores -f on a server that is already up.
+      expect(mouse.stdout.trim()).toBe('on');
+      expect(hist.stdout.trim()).toBe(String(AGENTS_TMUX_HISTORY_LIMIT));
+      expect(stamp.stdout.trim()).toBe(String(AGENTS_TMUX_CONFIG_SCHEMA));
     } finally {
-      tmux(['kill-server']);
+      spawnSync('tmux', ['-S', socket, 'kill-server'], { encoding: 'utf-8' });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reconciles on the attachExisting path too', async () => {
+    if (!isTmuxInstalled()) return;
+    const dir = mk();
+    const socket = path.join(dir, 's.sock');
+    try {
+      spawnSync('tmux', ['-f', '/dev/null', '-S', socket, 'new-session', '-d', '-s', 'legacy'], { encoding: 'utf-8' });
+      await createSession({ name: 'legacy', socket, attachExisting: true });
+      const mouse = spawnSync('tmux', ['-S', socket, 'show-options', '-gv', 'mouse'], { encoding: 'utf-8' });
+      const stamp = spawnSync('tmux', ['-S', socket, 'show-options', '-gv', '@ag_tmux_config_schema'], { encoding: 'utf-8' });
+      expect(mouse.stdout.trim()).toBe('on');
+      expect(stamp.stdout.trim()).toBe(String(AGENTS_TMUX_CONFIG_SCHEMA));
+    } finally {
+      spawnSync('tmux', ['-S', socket, 'kill-server'], { encoding: 'utf-8' });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not source the user config twice on a cold start', async () => {
+    if (!isTmuxInstalled()) return;
+    const dir = mk();
+    const home = path.join(dir, 'home');
+    fs.mkdirSync(home, { recursive: true });
+    const marker = path.join(dir, 'sourced.log');
+    // A side-effectful user config, the way TPM's run-shell behaves.
+    fs.writeFileSync(path.join(home, '.tmux.conf'), `run-shell "echo x >> ${marker}"\n`);
+    const socket = path.join(dir, 's.sock');
+    try {
+      await createSession({ name: 'cold', socket, cmd: 'sleep 30', env: { ...process.env, HOME: home } });
+      // Give run-shell a moment to land.
+      await new Promise((r) => setTimeout(r, 400));
+      const fired = fs.existsSync(marker) ? fs.readFileSync(marker, 'utf-8').trim().split('\n').length : 0;
+      expect(fired).toBeLessThanOrEqual(1);
+    } finally {
+      spawnSync('tmux', ['-S', socket, 'kill-server'], { encoding: 'utf-8' });
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/apps/cli/src/lib/tmux/session.ts
+++ b/apps/cli/src/lib/tmux/session.ts
@@ -11,11 +11,59 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { runTmux, TmuxCommandError } from './binary.js';
 import { ensureTmuxDir, getDefaultSocketPath, getSessionMetaPath } from './paths.js';
 
 /** Tmux session names must not contain `.` or `:` — those are reserved for window/pane addressing. */
 const VALID_NAME = /^[A-Za-z0-9_-]{1,64}$/;
+
+/**
+ * Ten times tmux's 2,000-line default, while keeping per-pane memory bounded:
+ * history storage scales with pane width, so a 200-column pane retains at most
+ * four million grid cells rather than an unbounded agent transcript.
+ */
+export const AGENTS_TMUX_HISTORY_LIMIT = 20_000;
+
+let startupConfigSequence = 0;
+
+function tmuxConfigArgument(value: string): string {
+  return `"${value.replace(/([\\"$])/g, '\\$1')}"`;
+}
+
+/**
+ * tmux loads `-f` instead of its normal user config, so put agents-cli's
+ * defaults first and explicitly source the first user config tmux would have
+ * selected afterward. Configuration files execute in order; this makes these
+ * settings defaults while preserving every option or binding the user sets.
+ */
+function writeStartupConfig(env: NodeJS.ProcessEnv | undefined): string {
+  const effectiveEnv = env ?? process.env;
+  const home = effectiveEnv.HOME ?? os.homedir();
+  const candidates = [
+    path.join(home, '.tmux.conf'),
+    ...(effectiveEnv.XDG_CONFIG_HOME
+      ? [path.join(effectiveEnv.XDG_CONFIG_HOME, 'tmux', 'tmux.conf')]
+      : []),
+    path.join(home, '.config', 'tmux', 'tmux.conf'),
+  ];
+  const userConfig = candidates.find((candidate) => fs.existsSync(candidate));
+  const startupConfig = path.join(
+    ensureTmuxDir(),
+    `startup-${process.pid}-${startupConfigSequence++}.conf`,
+  );
+  const lines = [
+    'set-option -g mouse on',
+    'set-option -s set-clipboard on',
+    `set-option -g history-limit ${AGENTS_TMUX_HISTORY_LIMIT}`,
+    'bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-selection-no-clear',
+    'bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection-no-clear',
+  ];
+  if (userConfig) lines.push(`source-file -q ${tmuxConfigArgument(userConfig)}`);
+  fs.writeFileSync(startupConfig, `${lines.join('\n')}\n`, { mode: 0o600 });
+  return startupConfig;
+}
 
 /** Provenance written alongside each live tmux session. */
 export interface SessionMeta {
@@ -71,6 +119,24 @@ export interface ListedSession {
   windows: number;
   attached: boolean;
   meta?: SessionMeta;
+}
+
+/** Build the atomic server-configuration + session-creation command. */
+export function buildCreateSessionArgs(opts: CreateSessionOptions, startupConfig: string): string[] {
+  const args = [
+    '-f', startupConfig,
+    'set-option', '-g', 'remain-on-exit', 'on', ';',
+    'new-session', '-d', '-s', opts.name, '-P', '-F', '#{pane_id}',
+  ];
+  if (opts.width)  args.push('-x', String(opts.width));
+  if (opts.height) args.push('-y', String(opts.height));
+  if (opts.cwd)    args.push('-c', opts.cwd);
+  // Separator + child command. tmux passes the rest verbatim to exec, so no
+  // shell escaping is required — array args end-to-end.
+  if (opts.cmd) {
+    args.push('--', 'sh', '-c', opts.cmd);
+  }
+  return args;
 }
 
 export class TmuxSessionError extends Error {
@@ -139,24 +205,21 @@ export async function createSession(opts: CreateSessionOptions): Promise<Session
     await killSession(opts.name, socket);
   }
 
-  // Set remain-on-exit BEFORE the child command can finish — a fast-exiting
+  // Configure the agents-cli tmux server BEFORE the child command can finish — a fast-exiting
   // cmd (e.g. `echo BRIEF && true`) would otherwise collapse the only session,
   // exit the server, and the follow-up `set-option` would race with "no
   // server running". Server-wide (`-g`) is applied in the same tmux
   // invocation as new-session so they share one server lifetime.
   // `-P -F '#{pane_id}'` prints the new session's first pane id on stdout so we
   // can record the exact `%N` handle without a follow-up `list-panes`.
-  const args = ['set-option', '-g', 'remain-on-exit', 'on', ';', 'new-session', '-d', '-s', opts.name, '-P', '-F', '#{pane_id}'];
-  if (opts.width)  args.push('-x', String(opts.width));
-  if (opts.height) args.push('-y', String(opts.height));
-  if (opts.cwd)    args.push('-c', opts.cwd);
-  // Separator + child command. tmux passes the rest verbatim to exec, so no
-  // shell escaping is required — array args end-to-end.
-  if (opts.cmd) {
-    args.push('--', 'sh', '-c', opts.cmd);
+  const startupConfig = writeStartupConfig(opts.env);
+  const args = buildCreateSessionArgs(opts, startupConfig);
+  let res: Awaited<ReturnType<typeof runTmux>>;
+  try {
+    res = await runTmux({ socket, args, env: opts.env });
+  } finally {
+    fs.rmSync(startupConfig, { force: true });
   }
-
-  const res = await runTmux({ socket, args, env: opts.env });
   // Only the new-session command in the `;`-chained invocation emits output.
   const pane = /^%\d+$/.test(res.stdout.trim()) ? res.stdout.trim() : undefined;
 

--- a/apps/cli/src/lib/tmux/session.ts
+++ b/apps/cli/src/lib/tmux/session.ts
@@ -71,6 +71,11 @@ function writeStartupConfig(env: NodeJS.ProcessEnv | undefined): string {
     `startup-${process.pid}-${startupConfigSequence++}.conf`,
   );
   const lines = [
+    // Stamp the schema HERE as well as in reconcileServerConfig. Without it a
+    // cold start leaves the option unset, the post-new-session check sees a
+    // stale stamp, and the reconcile re-sources the user's config a second time
+    // on launch #1 — firing any run-shell side effect (TPM) twice.
+    `set-option -g ${CONFIG_SCHEMA_OPTION} ${AGENTS_TMUX_CONFIG_SCHEMA}`,
     'set-option -g mouse on',
     'set-option -s set-clipboard on',
     `set-option -g history-limit ${AGENTS_TMUX_HISTORY_LIMIT}`,
@@ -245,6 +250,13 @@ export async function createSession(opts: CreateSessionOptions): Promise<Session
   const existed = await hasSession(opts.name, socket);
   if (existed) {
     if (opts.attachExisting) {
+      // Reuse of a live session is precisely the already-running-server case,
+      // so it needs the same reconcile the create path gets — otherwise
+      // `agents tmux new --attach-existing` silently keeps a pre-fix server
+      // with none of these settings.
+      if ((await appliedConfigSchema(socket)) !== AGENTS_TMUX_CONFIG_SCHEMA) {
+        await reconcileServerConfig(socket, opts.env);
+      }
       const meta = readSessionMeta(opts.name);
       return meta ?? {
         name: opts.name,

--- a/apps/cli/src/lib/tmux/session.ts
+++ b/apps/cli/src/lib/tmux/session.ts
@@ -26,6 +26,19 @@ const VALID_NAME = /^[A-Za-z0-9_-]{1,64}$/;
  */
 export const AGENTS_TMUX_HISTORY_LIMIT = 20_000;
 
+/**
+ * Bump when the generated startup config changes, so an ALREADY-RUNNING server
+ * picks the new settings up. tmux reads `-f` only when it actually starts a
+ * server: a second `new-session -f other.conf` against a live server exits 0
+ * and silently applies nothing (verified against tmux 3.4). Since agents-cli
+ * uses one long-lived shared socket, the normal state at upgrade is a running
+ * server — so without this reconcile every existing machine would get none of
+ * these defaults, silently. Same shape as AGENT_HOOK_SCHEMA below.
+ */
+export const AGENTS_TMUX_CONFIG_SCHEMA = 1;
+/** Server-scoped user-option recording which AGENTS_TMUX_CONFIG_SCHEMA is applied. */
+const CONFIG_SCHEMA_OPTION = '@ag_tmux_config_schema';
+
 let startupConfigSequence = 0;
 
 function tmuxConfigArgument(value: string): string {
@@ -48,7 +61,11 @@ function writeStartupConfig(env: NodeJS.ProcessEnv | undefined): string {
       : []),
     path.join(home, '.config', 'tmux', 'tmux.conf'),
   ];
-  const userConfig = candidates.find((candidate) => fs.existsSync(candidate));
+  // tmux's own start_cfg() sources EVERY entry of TMUX_CONF that exists, not
+  // just the first — a user with both ~/.tmux.conf and ~/.config/tmux/tmux.conf
+  // gets both. Sourcing only the first would silently drop the second and break
+  // the "never override a user-set value" contract this file exists to keep.
+  const userConfigs = candidates.filter((candidate) => fs.existsSync(candidate));
   const startupConfig = path.join(
     ensureTmuxDir(),
     `startup-${process.pid}-${startupConfigSequence++}.conf`,
@@ -60,7 +77,9 @@ function writeStartupConfig(env: NodeJS.ProcessEnv | undefined): string {
     'bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-selection-no-clear',
     'bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection-no-clear',
   ];
-  if (userConfig) lines.push(`source-file -q ${tmuxConfigArgument(userConfig)}`);
+  for (const userConfig of userConfigs) {
+    lines.push(`source-file -q ${tmuxConfigArgument(userConfig)}`);
+  }
   fs.writeFileSync(startupConfig, `${lines.join('\n')}\n`, { mode: 0o600 });
   return startupConfig;
 }
@@ -173,6 +192,43 @@ export async function hasSession(name: string, socket?: string): Promise<boolean
   return res.code === 0;
 }
 
+/** Which AGENTS_TMUX_CONFIG_SCHEMA a live server has applied; undefined when none. */
+async function appliedConfigSchema(socket: string): Promise<number | undefined> {
+  const res = await runTmux({
+    socket,
+    args: ['show-options', '-gv', CONFIG_SCHEMA_OPTION],
+    throwOnError: false,
+  }).catch(() => null);
+  if (!res || res.code !== 0) return undefined;
+  const n = Number(res.stdout.trim());
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Apply the generated startup config to an already-running server and stamp it.
+ * Failure is surfaced, not swallowed: a server left without these settings is
+ * the silent no-op this exists to prevent.
+ */
+async function reconcileServerConfig(socket: string, env: NodeJS.ProcessEnv | undefined): Promise<void> {
+  const conf = writeStartupConfig(env);
+  try {
+    const res = await runTmux({ socket, args: ['source-file', conf], throwOnError: false, env });
+    if (res.code !== 0) {
+      throw new TmuxSessionError(
+        `could not apply agents-cli tmux settings to the running server (${res.stderr.trim() || `exit ${res.code}`})`,
+      );
+    }
+    await runTmux({
+      socket,
+      args: ['set-option', '-g', CONFIG_SCHEMA_OPTION, String(AGENTS_TMUX_CONFIG_SCHEMA)],
+      throwOnError: false,
+      env,
+    }).catch(() => {});
+  } finally {
+    fs.rmSync(conf, { force: true });
+  }
+}
+
 /**
  * Create a new detached session. Throws when the name is already taken unless
  * `replace` or `attachExisting` is set.
@@ -222,6 +278,15 @@ export async function createSession(opts: CreateSessionOptions): Promise<Session
   }
   // Only the new-session command in the `;`-chained invocation emits output.
   const pane = /^%\d+$/.test(res.stdout.trim()) ? res.stdout.trim() : undefined;
+
+  // If the server was ALREADY running, its `-f` was ignored, so the config above
+  // never applied. Re-source it — the generated file ends by sourcing the user's
+  // own tmux.conf, so re-applying preserves the same precedence a cold start
+  // gives. Gated on a generation stamp so a user config with side effects (tpm's
+  // run-shell, for one) is not re-executed on every single launch.
+  if (existed || (await appliedConfigSchema(socket)) !== AGENTS_TMUX_CONFIG_SCHEMA) {
+    await reconcileServerConfig(socket, opts.env);
+  }
 
   // Keep the agent pane around after its process exits (so runInTmux can read
   // the exit status and capture the final error), but do NOT keep that behavior


### PR DESCRIPTION
Give tmux-wrapped agent panes working mouse, clipboard and scrollback — without ever overriding a user who configured their own. Part 2 of 2 for RUSH-3066.

## Why

A wrapped agent inherited whatever the machine's tmux happened to do. With **no** user config that is tmux's stock defaults, measured on a Linux box: `mouse off`, `set-clipboard external`, `history-limit 2000`. So scrolling, mouse selection and copy/paste all behave worse inside an agent pane than in the terminal the user already had. That is the stated reason the wrap is being turned off by default in #2942; this makes turning it back on worth doing.

## What changed

The server starts with `-f` pointing at a generated startup config that sets `mouse on`, `set-clipboard on` (OSC 52), a 20,000-line `history-limit`, and copy-mode bindings using `copy-selection-no-clear` so a mouse drag actually copies and the selection survives the release.

**The precedence is the load-bearing part.** `-f` replaces tmux's normal user-config load, and tmux executes configuration files in order — so the generated file sets agents-cli's values first and then `source-file`s the user's own `tmux.conf` **last**. These are therefore defaults for someone who configured nothing, and never an override of a value the user set.

An earlier revision set the options unconditionally *after* tmux.conf was sourced, which silently clobbered a user's own settings. That is fixed and pinned by a test.

## Evidence — real run

Precedence, measured against two real tmux servers on this box:

```
# user HAS ~/.tmux.conf setting history-limit 50000
history-limit 50000      <- user's value preserved
mouse on
set-clipboard on

# no user config at all
history-limit 20000      <- agents-cli default applies
mouse on
set-clipboard on
```

```
$ bun run test -- src/lib/tmux/session.test.ts

 RUN  v4.1.9 .agents/worktrees/tmux-ergo2/apps/cli

 Test Files  1 passed (1)
      Tests  36 passed (36)
   Duration  6.28s
```

## Safety

Every option lands on the agents-cli socket (`getDefaultSocketPath()` → `getTmuxDir()/server.sock`), not the shared default socket, so a user's own tmux server is untouched. `remain-on-exit` keeps its existing exit-code contract.

Ticket: RUSH-3066
