### PR TITLE
fix(sessions): scope skill/command detection + drop unwired agent recap rung (RUSH-3011 review follow-up)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-3011-recap-reap.md
+++ b/apps/cli/.changelog/next/RUSH-3011-recap-reap.md
@@ -1,9 +1,10 @@
 - **Session rows show what the agent DID, and dead crash-orphans stop piling up (RUSH-3011).**
   The `agents sessions watch --json` row (which the AGI EXT Fleet reads) now carries a
   **recap** so a row reads as the agent's work, not its stale first prompt: `title` follows
-  a best-source-wins ladder — a `/rename`/harness `label` → a cached agent recap → the last
-  agent line → the first-prompt topic — and `recapSource` (`'label'|'agent'|'last'|'prompt'`)
-  names which rung won, so a session that produced work shows an agent-derived line. The first
+  a best-source-wins ladder — a `/rename`/harness `label` (which also holds an agent-generated
+  title) → the last agent line → the first-prompt topic — and `recapSource`
+  (`'label'|'last'|'prompt'`) names which rung won, so a session that produced work shows an
+  agent-derived line. The first
   user turn is cleaned into `userPromptClean`/`userPromptKind` (with `lastAgentLine` exposed)
   so a screenshot path folds to `[image]`, a pasted `$ cmd` to the command, and a `/skill`
   install path to `/<name>` — path noise never shows on the "You" line — and the recap card's

--- a/apps/cli/docs/sessions.md
+++ b/apps/cli/docs/sessions.md
@@ -36,8 +36,8 @@ is doing*, not the stale first prompt (`src/lib/session/active.ts`
 
 | Field | Meaning |
 | --- | --- |
-| `title` | The shown title, best-source-wins. Ladder: `label` → cached agent recap → last agent line → first-prompt topic. |
-| `recapSource` | Which rung produced `title`: `'label'` \| `'agent'` \| `'last'` \| `'prompt'`. A `'last'`/`'agent'` title is agent-derived; `'prompt'` is the last-resort fallback. |
+| `title` | The shown title, best-source-wins. Ladder: `label` (a `/rename` or agent-generated title) → last agent line → first-prompt topic. |
+| `recapSource` | Which rung produced `title`: `'label'` \| `'last'` \| `'prompt'`. A `'last'` title is agent-derived; `'prompt'` is the last-resort fallback. |
 | `userPromptClean` | The first user turn cleaned for a "You" line: a screenshot path folds to `[image]`, a pasted `$ cmd` to the command, a `/skill` install path to `/<name>`, so path noise never shows. |
 | `userPromptKind` | `'text'` \| `'image'` \| `'command'` \| `'skill'` — what that first turn was (`classifyUserPrompt`). |
 | `lastAgentLine` | The most recent assistant line (transcript tail) — the always-current signal of what the agent last said. |

--- a/apps/cli/src/lib/session/active.test.ts
+++ b/apps/cli/src/lib/session/active.test.ts
@@ -361,12 +361,7 @@ describe('deriveSessionRecap (recap ladder — show what the agent DID, not the 
     expect(r).toMatchObject({ title: 'ship the auth fix', recapSource: 'label' });
   });
 
-  it('prefers a supplied agent recap over the tail and prompt', () => {
-    const r = deriveSessionRecap({ topic: 'first prompt', tail: ['agent last line'] }, { agentRecap: 'refactored the parser' });
-    expect(r).toMatchObject({ title: 'refactored the parser', recapSource: 'agent' });
-  });
-
-  it('uses the last agent line when there is no label or recap (the always-current fix)', () => {
+  it('uses the last agent line when there is no label (the always-current fix)', () => {
     const r = deriveSessionRecap({ topic: 'add a widget', tail: ['opened PR #123', 'now fixing CI'] });
     expect(r).toMatchObject({ title: 'now fixing CI', recapSource: 'last', lastAgentLine: 'now fixing CI' });
   });
@@ -376,8 +371,8 @@ describe('deriveSessionRecap (recap ladder — show what the agent DID, not the 
     expect(r).toMatchObject({ title: 'add a widget', recapSource: 'prompt' });
   });
 
-  it('cleans an image-only first prompt into the userPrompt fields', () => {
-    const r = deriveSessionRecap({ topic: '', attachments: [{ mediaType: 'image/png' }] });
+  it('cleans an image-path first prompt into the userPrompt fields', () => {
+    const r = deriveSessionRecap({ topic: '/Users/muqsit/Screenshots/CleanShot 2026-08-20 at 1.png' });
     expect(r).toMatchObject({ userPromptClean: '[image]', userPromptKind: 'image' });
   });
 

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -289,12 +289,12 @@ export type ActiveStatus =
 /**
  * Which rung of the recap ladder produced a row's shown {@link ActiveSession.title}
  * (RUSH-3011), best-first:
- *   - `label`  — a `/rename` or harness-set label; always wins.
- *   - `agent`  — a cached agent recap/narrative (supplied by the caller).
- *   - `last`   — the last assistant line from the transcript tail.
+ *   - `label`  — a `/rename` or harness-set label (incl. an agent-generated
+ *                title, which lands in `label`); always wins.
+ *   - `last`   — the last assistant line from the transcript tail; agent-derived.
  *   - `prompt` — the first-user-prompt topic; the last-resort fallback.
  */
-export type RecapSource = 'label' | 'agent' | 'last' | 'prompt';
+export type RecapSource = 'label' | 'last' | 'prompt';
 
 export interface ActiveSession {
   context: ActiveContext;
@@ -315,10 +315,10 @@ export interface ActiveSession {
   /**
    * The row's shown title — WHAT the session is, best-source-wins (RUSH-3011).
    * The ladder ({@link deriveSessionRecap}): a `/rename` or harness `label` →
-   * a cached agent recap → the last agent line (`lastAgentLine`) → the
-   * first-prompt `topic`. A session whose agent did work shows an agent-derived
-   * line, not the stale first prompt. Folded on at the end of
-   * {@link getActiveSessions}; `recapSource` names which rung produced it.
+   * the last agent line (`lastAgentLine`) → the first-prompt `topic`. A session
+   * whose agent did work shows an agent-derived line, not the stale first
+   * prompt. Folded on at the end of {@link getActiveSessions}; `recapSource`
+   * names which rung produced it.
    */
   title?: string;
   /** Which ladder rung produced {@link title}. */
@@ -2515,27 +2515,24 @@ function recapLine(s: string | undefined, max = 120): string | undefined {
  * prompt (`userPromptClean`/`userPromptKind`) and the `lastAgentLine`. Pure over
  * one row; exported for tests and folded in by {@link foldRecap}.
  *
- * Ladder, best-first: a `/rename`/harness `label` → a cached agent recap
- * (`opts.agentRecap`, when a caller has one) → the last assistant line → the
- * first-prompt topic. Rungs 2–3 are agent-derived, so a session that produced
- * work stops showing its stale first prompt as the title.
+ * Ladder, best-first: a `/rename`/harness `label` → the last assistant line →
+ * the first-prompt topic. The `last` rung is agent-derived, so a session that
+ * produced work stops showing its stale first prompt as the title. (`topic` is
+ * the row's already-extracted first line, so image detection here is
+ * path-based; a pure-attachment turn with no first-line text stays on `prompt`.)
  */
 export function deriveSessionRecap(
-  row: Pick<ActiveSession, 'label' | 'topic' | 'tail' | 'attachments'>,
-  opts: { agentRecap?: string } = {},
+  row: Pick<ActiveSession, 'label' | 'topic' | 'tail'>,
 ): { title?: string; recapSource?: RecapSource; userPromptClean?: string; userPromptKind?: UserPromptKind; lastAgentLine?: string } {
   const lastAgentLine = recapLine(row.tail?.length ? row.tail[row.tail.length - 1] : undefined);
-  const hasImageAttachment = !!row.attachments?.some(a => a.mediaType?.startsWith('image'));
-  const { clean: userPromptClean, kind: userPromptKind } = classifyUserPrompt(row.topic ?? '', { hasImageAttachment });
+  const { clean: userPromptClean, kind: userPromptKind } = classifyUserPrompt(row.topic ?? '');
 
   const label = recapLine(row.label);
-  const agent = recapLine(opts.agentRecap);
   const prompt = recapLine(userPromptClean || row.topic);
 
   let title: string | undefined;
   let recapSource: RecapSource | undefined;
   if (label) { title = label; recapSource = 'label'; }
-  else if (agent) { title = agent; recapSource = 'agent'; }
   else if (lastAgentLine) { title = lastAgentLine; recapSource = 'last'; }
   else if (prompt) { title = prompt; recapSource = 'prompt'; }
 

--- a/apps/cli/src/lib/session/prompt.test.ts
+++ b/apps/cli/src/lib/session/prompt.test.ts
@@ -17,9 +17,21 @@ describe('classifyUserPrompt (a "You" line that drops path noise)', () => {
     expect(r).toEqual({ clean: '$ crabbox status', kind: 'command' });
   });
 
-  it('collapses a skill install path to /<name>', () => {
+  it('collapses a skill install path to /<name> — only the injected system line', () => {
     const r = classifyUserPrompt('Base directory for this skill: /home/u/.claude/skills/blog\n\nWrite a post');
     expect(r).toEqual({ clean: '/blog', kind: 'skill' });
+  });
+
+  it('does NOT treat an ordinary prose mention of a skills/ path as a skill invocation', () => {
+    const r = classifyUserPrompt('review the docs under ~/.agents/skills/blog and check the CHANGELOG');
+    expect(r.kind).toBe('text');
+    expect(r.clean).toContain('review the docs');
+  });
+
+  it('does NOT treat a markdown blockquote as a command', () => {
+    const r = classifyUserPrompt('> quoting the article: agents are the future — thoughts?');
+    expect(r.kind).toBe('text');
+    expect(r.clean).not.toMatch(/^\$/);
   });
 
   it('strips wrapper tags from plain text', () => {

--- a/apps/cli/src/lib/session/prompt.ts
+++ b/apps/cli/src/lib/session/prompt.ts
@@ -174,13 +174,18 @@ export interface ClassifiedPrompt {
 /**
  * A skill invocation injects a system line naming the skill's install directory:
  *   "Base directory for this skill: /home/.../skills/<name>"
- * Both forms collapse to "/<name>" so a row shows the skill, not the path.
+ * which collapses to "/<name>" so a row shows the skill, not the path. Anchored
+ * to that exact injected line — a bare `.../skills/<name>` mention in ordinary
+ * prose is NOT a skill invocation and must keep its real text.
  */
 const SKILL_BASEDIR_RE = /Base directory for this skill:\s*\S*[\/\\]skills[\/\\]([\w.-]+)/i;
-const SKILL_PATH_RE = /[\/\\]skills[\/\\]([\w.-]+)(?:[\/\\]|\b)/i;
 
-/** An explicit shell-prompt paste (`$ cmd` / `> cmd`). Only the command survives. */
-const COMMAND_PREFIX_RE = /^[$>»]\s+(\S.*)$/;
+/**
+ * An explicit shell-prompt paste (`$ cmd`). Only the command survives. Deliberately
+ * `$`-only: a leading `>` is a markdown blockquote far more often than a shell
+ * prompt, so matching it misread quoted prose as a command.
+ */
+const COMMAND_PREFIX_RE = /^\$\s+(\S.*)$/;
 
 /**
  * A filesystem path (absolute or `~`-rooted) ending in an image extension —
@@ -193,9 +198,9 @@ const IMAGE_PATH_RE = /[\/~][^\n]*?\.(?:png|jpe?g|gif|webp|heic|bmp|svg)\b/i;
  * Classify a raw first user turn into a display-ready `{ clean, kind }`, so a
  * Fleet/session row shows the user's actual intent rather than path noise:
  *
- *   - `skill`   — a `/skill` invocation's "Base directory for this skill: …"
- *                 (or a bare `…/skills/<name>` path) collapses to `/<name>`.
- *   - `command` — a `$ `/`> `-prefixed shell paste keeps only the first command.
+ *   - `skill`   — a `/skill` invocation's injected "Base directory for this
+ *                 skill: …" line collapses to `/<name>`.
+ *   - `command` — a `$ `-prefixed shell paste keeps only the first command.
  *   - `image`   — a screenshot/image path standing alone, or an image
  *                 attachment with no real accompanying text, becomes `[image]`.
  *   - `text`    — everything else: wrapper tags stripped (via
@@ -212,7 +217,7 @@ export function classifyUserPrompt(
 ): ClassifiedPrompt {
   const text = (raw ?? '').replace(/\r/g, '').trim();
 
-  const skill = text.match(SKILL_BASEDIR_RE) ?? text.match(SKILL_PATH_RE);
+  const skill = text.match(SKILL_BASEDIR_RE);
   if (skill) return { clean: `/${skill[1]}`, kind: 'skill' };
 
   const firstLine = text.split('\n').map(line => line.trim()).find(Boolean) ?? '';


### PR DESCRIPTION
## What

Follow-up to **#2940** (merged before its non-author review completed). Two independent `code-reviewer` passes both flagged the same two blockers on the merged code; this lands the fixes. `fix` (behavior correctness, no new surface).

## Blockers fixed

### 1. `classifyUserPrompt` destroyed real prompts that merely mention a `/skills/` path
`SKILL_PATH_RE` (`prompt.ts:180` on main) was unanchored — it matched `/skills/<name>` **anywhere** in prose, not just the injected system line, so an ordinary first turn collapsed to `/<name>`:

```
classifyUserPrompt("review the docs under ~/.agents/skills/blog and check the CHANGELOG") -> /blog   // before
```

That fed both the Fleet row title (`active.ts` recap ladder) and the `sessions render`/`preview` `Prompt:` line (`render.ts`). Dropped `SKILL_PATH_RE`; skill detection is now only the canonical injected `Base directory for this skill:` line (`SKILL_BASEDIR_RE`), which was already the tested path.

### 2. The `'agent'` recap rung was unwired dead code, documented as shipped
`foldRecap` — the only production caller of `deriveSessionRecap` — never passed `agentRecap`, so `recapSource: 'agent'` could never fire, yet `docs/sessions.md` + the CHANGELOG asserted a 4-rung ladder as live (the repo's own "no lying table" rule). Removed the rung: `RecapSource` is now `'label' | 'last' | 'prompt'`. `label` already holds agent-generated titles (the sibling RUSH-3011 change), and `'last'` (the last agent line) is the agent-derived rung — so "a session that did work shows an agent-derived title" still holds.

## Also (non-blocking, same review)

- `COMMAND_PREFIX_RE` restricted to `$` only — a leading `>` is a markdown blockquote far more often than a shell prompt, so it misread quoted prose as a fabricated command.
- `deriveSessionRecap` no longer passes the tail-window `hasImageAttachment` signal against the head-window `topic` (image detection is path-based on the active row), removing a mislabel where a text first-turn + a later tail image read as `[image]`.
- Added tests for both false-positive guards (prose `/skills/` mention stays text; `>` blockquote stays text).

## Tests

```
Test Files  5 passed (5)
     Tests  89 passed (89)
```
`bunx tsc --noEmit`: 0 errors. Scoped: `prompt.test.ts`, `active.test.ts`, `remote/watch.test.ts`, `render.test.ts`, `gen-changelog.test.ts`.

Ref RUSH-3011. `apps/ext/**` untouched.
