### PR TITLE
fix(ext): crash restore no longer double-opens/resumes prewarm sessions

### DIFF
--- a/apps/ext/AGENTS.md
+++ b/apps/ext/AGENTS.md
@@ -39,8 +39,11 @@ the `swarm-ext://` endpoint. It does not own fleet or agent policy.
   re-keys it to the harness the CLI picked — the `sh` prefix is load-bearing,
   since `armShellAdoptionForTerminal` only arms for it. An unregistered tab is
   invisible to Copy Session ID / Resume / Fork and is not restored after a
-  window reload. Crash restore reopens only mappings still returned by the CLI's
-  canonical session list, so reaped stale transcripts are not resurrected.
+  window reload. Crash restore runs `restoreAgentTerminals` (the debounced
+  persisted-terminals store) first, then the eager prewarm mappings via
+  `restoreTerminals`, which reopens only mappings the CLI's canonical session
+  list still returns AND that the first pass did not already reopen — so reaped
+  transcripts are not resurrected and no session is opened or resumed twice.
 - Other reads use their CLI noun: `devices list/status/accounts`, `teams ...
   --json`, `watchdog status/history`, and `routines ... --json`. Ticket reads
   use `linear tasks --json` and `gh issue list` (the former `agents tickets`

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -30,7 +30,9 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
   Fleet Focus, background Attach, remote tmux focus, command-palette Resume,
   and unclean-shutdown recovery now share one registered editor-terminal path.
   Restored tabs keep `AGENT_TERMINAL_ID` and session identity, while mappings
-  absent from the CLI's reaped session list are folded away. Source:
+  absent from the CLI's reaped session list are folded away. Crash restore
+  dedupes the eager prewarm mappings against the tabs the persisted-terminals
+  pass already reopened, so no session is opened or resumed twice. Source:
   `src/vscode/{extension,settings,prewarm}.vscode.ts`.
 
 - **`Agents: New <Harness>` opens an agent again instead of asking which account

--- a/apps/ext/src/core/remoteSessions.test.ts
+++ b/apps/ext/src/core/remoteSessions.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
-  buildRemoteFocusCommand,
   mapStatusToPhase,
   normalizeHost,
   resolveSessionHost,
@@ -803,25 +802,6 @@ describe('normalizeActiveSession — todos plan progress (RUSH-1380)', () => {
       FETCHED_AT
     );
     expect(s.todos).toBeUndefined();
-  });
-});
-
-describe('buildRemoteFocusCommand — attach a remote session over SSH', () => {
-  test('ssh -t into the peer and focus the session in-place with --local', () => {
-    const cmd = buildRemoteFocusCommand('abc12345', 'yosemite-s0');
-    expect(cmd.startsWith('ssh -t ')).toBe(true);
-    expect(cmd).toContain(`'yosemite-s0'`); // host is quoted, not dropped
-    expect(cmd).toContain('agents sessions resume');
-    expect(cmd).toContain('abc12345');
-    expect(cmd).toContain('--local');
-  });
-
-  test('single-quotes an injected session id so it can never break out of the arg', () => {
-    const cmd = buildRemoteFocusCommand("a'; echo pwned", 'peer');
-    // The raw quote+semicolon breakout is escaped, never present verbatim...
-    expect(cmd).not.toContain("a'; echo");
-    // ...and the escaped-quote sequence ('\'') is what appears instead.
-    expect(cmd).toContain(`'\\''`);
   });
 });
 

--- a/apps/ext/src/core/remoteSessions.ts
+++ b/apps/ext/src/core/remoteSessions.ts
@@ -19,21 +19,6 @@ import type { ProjectRule } from '../shared/project';
 export { resolveProject, normalizeHost, worktreeSlugOf };
 export type { ProjectRule } from '../shared/project';
 
-/**
- * Build the command that opens/attaches a session living on a REMOTE device.
- * We `ssh -t` into the peer and let its own `agents sessions resume <id> --local`
- * resolve the session in-place — attach its live tmux pane, or resume it in the
- * ssh TTY when it's headless. `--local` is correct because the caller already
- * knows the session is on `host`, so a cross-host sweep from the peer is wasted
- * work. The local (this-mac) path does NOT use this — it spawns
- * `agents sessions resume` detached so it opens a native terminal tab.
- */
-export function buildRemoteFocusCommand(sessionId: string, host: string): string {
-  const shq = (s: string) => `'${s.replace(/'/g, `'\\''`)}'`;
-  const remote = `agents sessions resume ${shq(sessionId)} --local`;
-  return `ssh -t ${shq(host)} ${shq(remote)}`;
-}
-
 /** Mirror of floorModel.FloorPhase (kept in sync by hand; not imported). */
 export type RemotePhase = 'running' | 'idle' | 'waiting' | 'failed' | 'done';
 

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -302,8 +302,8 @@ async function detachAgentToBackground(): Promise<void> {
 }
 
 // Bring a backgrounded/parked agent to the foreground: pick from the CLI's
-// active-session list (presence background/parked) and open a terminal running
-// `agents sessions attach <id>`, which resumes the session interactively in that tab.
+// active-session list (presence background/parked) and reopen it as a registered
+// editor tab via the shared resume helper, so it resumes its real session there.
 async function attachAgentFromBackground(): Promise<void> {
   const sessions = sessionPresentationStore.presentedSessions(LOCAL_MACHINE_ID, LOCAL_LABEL)
     .filter((session) => session.host === LOCAL_LABEL);
@@ -976,7 +976,20 @@ export async function activate(context: vscode.ExtensionContext) {
     .then(() => restoreAgentTerminals(context))
     .then(async () => {
       const { restoreTerminals } = await import('./prewarm.vscode');
-      await restoreTerminals(context, { listRestorableSessionIds, openAgentSessionTerminal });
+      await restoreTerminals(context, {
+        listRestorableSessionIds,
+        // restoreAgentTerminals ran first in this chain and registered every tab
+        // it reopened; hand restoreTerminals those keys so it skips them and only
+        // reopens the eager-prewarm residual the debounced store missed.
+        trackedKeys: () => {
+          const all = terminals.getAllTerminals();
+          return {
+            terminalIds: new Set(all.map((entry) => entry.id)),
+            sessionIds: new Set(all.map((entry) => entry.sessionId).filter((id): id is string => Boolean(id))),
+          };
+        },
+        openAgentSessionTerminal,
+      });
     })
     .then(() => {
       // Adopt any SH terminals that are already running an agent CLI

--- a/apps/ext/src/vscode/prewarm.vscode.test.ts
+++ b/apps/ext/src/vscode/prewarm.vscode.test.ts
@@ -5,25 +5,45 @@ mock.module('vscode', () => ({ window: {} }));
 const { restoreTerminals } = await import('./prewarm.vscode');
 
 describe('restoreTerminals', () => {
-  test('reopens stored crash mappings that remain in the CLI session list', async () => {
+  test('reopens only the residual crash mappings — skips reaped and already-restored sessions', async () => {
     const updates: Array<[string, unknown]> = [];
     const opened: Array<{ id: string; terminalId?: string; agent: string }> = [];
     const values = new Map<string, unknown>([
       ['prewarm.cleanShutdown', false],
       ['prewarm.mappings', [
+        // Residual: in the CLI list, and NOT already reopened by restoreAgentTerminals.
         {
           terminalId: 'CL42',
           sessionId: 'session-live',
           agentType: 'claude',
-          createdAt: Date.now(),
+          createdAt: 100,
           workingDirectory: '/workspace/project',
         },
+        // Reaped: no longer in the CLI session list -> must not be resurrected.
         {
           terminalId: 'CD17',
           sessionId: 'session-reaped',
           agentType: 'codex',
           createdAt: 1,
           workingDirectory: '/workspace/old',
+        },
+        // Already restored by restoreAgentTerminals (its terminalId is tracked)
+        // -> must be skipped so we don't double-open + double-resume it.
+        {
+          terminalId: 'CL08',
+          sessionId: 'session-doubled-by-tid',
+          agentType: 'claude',
+          createdAt: 50,
+          workingDirectory: '/workspace/a',
+        },
+        // Already restored under a different terminalId, same session id
+        // -> the sessionId guard must still skip it.
+        {
+          terminalId: 'CL99',
+          sessionId: 'session-doubled-by-sid',
+          agentType: 'claude',
+          createdAt: 60,
+          workingDirectory: '/workspace/b',
         },
       ]],
     ]);
@@ -41,7 +61,14 @@ describe('restoreTerminals', () => {
 
     const restored = await restoreTerminals(context, {
       async listRestorableSessionIds() {
-        return new Set(['session-live']);
+        // Every candidate except the reaped one is still a real session.
+        return new Set(['session-live', 'session-doubled-by-tid', 'session-doubled-by-sid']);
+      },
+      trackedKeys() {
+        return {
+          terminalIds: new Set(['CL08']),
+          sessionIds: new Set(['session-doubled-by-sid']),
+        };
       },
       async openAgentSessionTerminal(_context, session) {
         opened.push(session);
@@ -49,6 +76,7 @@ describe('restoreTerminals', () => {
       },
     });
 
+    // Only the residual session opens; reaped + both already-tracked are skipped.
     expect(restored).toBe(1);
     expect(opened).toEqual([{
       id: 'session-live',

--- a/apps/ext/src/vscode/prewarm.vscode.ts
+++ b/apps/ext/src/vscode/prewarm.vscode.ts
@@ -320,6 +320,16 @@ export function wasCleanShutdown(context: vscode.ExtensionContext): boolean {
  */
 export interface TerminalRestoreActions {
   listRestorableSessionIds(): Promise<Set<string>>;
+  /**
+   * The terminal ids and session ids that already have a live/tracked tab —
+   * i.e. everything `restoreAgentTerminals` (the debounced persisted-terminals
+   * path) already reopened on this same crash. Prewarm mappings are written
+   * eagerly per `registerAgentTerminal`, while that store is a 500ms debounce
+   * (`schedulePersist`), so the two overlap: without this guard both paths
+   * reopen and re-resume the same session, racing two `agents sessions resume`
+   * processes onto one transcript (the RUSH-2477 thundering-herd class).
+   */
+  trackedKeys(): { terminalIds: Set<string>; sessionIds: Set<string> };
   openAgentSessionTerminal(
     context: vscode.ExtensionContext,
     session: { id: string; shortId: string; agent: string; cwd?: string; terminalId?: string },
@@ -343,9 +353,14 @@ export async function restoreTerminals(
 
   console.log(`[PREWARM] Detected crash - ${mappings.length} terminals to restore`);
   const restorableIds = await actions.listRestorableSessionIds();
+  // Only reopen mappings `restoreAgentTerminals` did NOT already restore on this
+  // crash. Its debounced store lags the eager prewarm mappings by up to 500ms, so
+  // this path exists to catch that residual window — not to double every tab.
+  const tracked = actions.trackedKeys();
   let restored = 0;
   for (const mapping of mappings) {
     if (!restorableIds.has(mapping.sessionId)) continue;
+    if (tracked.terminalIds.has(mapping.terminalId) || tracked.sessionIds.has(mapping.sessionId)) continue;
     const opened = await actions.openAgentSessionTerminal(context, {
       id: mapping.sessionId,
       shortId: mapping.sessionId.slice(0, 8),


### PR DESCRIPTION
## What + type

`fix(ext)` — crash restore was **double-opening and double-resuming** every prewarm-agent session. This closes that regression and removes the dead code it left behind. Scoped to `apps/ext/` only.

## Background

The #1/#3a editor-tab work landed on `main` (commit `ea6a6b4c3` / merged PR #2945). That change wired the newly-implemented `restoreTerminals` into activation immediately after the pre-existing `restoreAgentTerminals`, over an **overlapping store, with no dedup** — the exact defect a non-author review flagged before it merged. This PR is that fix.

## The bug (on current main)

- `restoreAgentTerminals` already reopens persisted agent tabs on a crash and resumes them — as editor tabs, deduped on `trackedIds`, RUSH-2477 stagger-bounded (`apps/ext/src/vscode/extension.ts:5006-5008`, `5086-5108`).
- `restoreTerminals` then reopens the crash mappings with **no guard** (`apps/ext/src/vscode/prewarm.vscode.ts:347-357` on main; wired at `extension.ts:979`).
- The stores overlap: `registerAgentTerminal` writes a prewarm crash mapping (`extension.ts:422-428`) for the same terminals `terminals.register` persists. So a crash reopened a second tab and raced a second `agents sessions resume` onto one transcript — the DB-lock / thundering-herd class RUSH-2477 exists to prevent.

## The fix

- `restoreTerminals` now takes a `trackedKeys()` accessor (`prewarm.vscode.ts`) and **skips any mapping whose terminalId or sessionId is already tracked** — i.e. everything `restoreAgentTerminals` reopened on this same crash. It still restores the genuine residual: the terminals-persist store is a **500ms debounce** (`terminals.vscode.ts:185-196`) while prewarm mappings are written **eagerly** in `registerAgentTerminal`, so a session created in the last <=500ms before a crash is caught only here.
- Activation supplies the tracked keys from `terminals.getAllTerminals()` after `restoreAgentTerminals` has run (`extension.ts`).
- Removed the now-orphaned `buildRemoteFocusCommand` + its test (dead once Fleet focus moved to the shared editor-tab helper in #2945), and refreshed a stale attach comment.

## Tests

- `prewarm.vscode.test.ts` extended: 4 crash mappings in → only the residual one opens; the reaped one, the already-tracked-by-terminalId one, and the already-tracked-by-sessionId one are all skipped (`[PREWARM] Detected crash - 4 terminals to restore` → `restored === 1`).

## Run evidence

Captured headless on worker `yosemite-s1` — no editor window launched:

[Headless test-run screenshot →](https://share.agents-cli.sh/muqsitnawaz/t1-continue-t1-crash-dedup-bdc81899bde9dd35)

```
# bun test src/vscode/prewarm.vscode.test.ts src/core/remoteSessions.test.ts
 91 pass · 0 fail
# bun test   (full apps/ext suite, headless)
 1636 pass · 3 skip · 0 fail · 143 files
# tsc --noEmit -p tsconfig.json
 exit rc=0, 0 errors
```
