### PR TITLE
fix(ext): default the Fleet to the Sessions tab, not Agents

### DIFF
--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
+## [0.9.333] - 2026-08-23
+
+- **The Fleet opens on the Sessions tab, not Agents.** The Floor 3-pane shell
+  now defaults its center to `sessions` — the primary surface where an operator
+  sees the work being landed — instead of the Agents roster, matching the
+  "rank by progress, not liveness" doctrine. Source:
+  `ui/settings/components/mission-control/UnifiedAgentsPane.tsx`.
+
 ## [0.9.332] - 2026-08-23
 
 - **`scripts/release.sh` no longer loses the version when it re-enters under

--- a/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -647,7 +647,9 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   const [tick, setTick] = useState(0)
   // ---------- Floor 3-pane shell state ----------
   const floorPrefs0 = useRef(loadFloorPrefs()).current
-  const [center, setCenter] = useState<CenterMode>('agents')
+  // Sessions is the primary surface (the work an operator lands), so the Floor
+  // opens on it, not the Agents roster — matches "rank by progress" (root AGENTS.md).
+  const [center, setCenter] = useState<CenterMode>('sessions')
   // Dynamic task tabs: double-clicking a backlog ticket or an agent card opens a
   // closeable tab in the sub-tab strip. activeTaskTab === null means a fixed center
   // tab is showing; otherwise the named task tab owns the center pane.


### PR DESCRIPTION
## What
The Floor 3-pane shell (`UnifiedAgentsPane.tsx`) defaulted its center sub-tab to `agents`, so opening AGI EXT landed on the Agents roster. This defaults it to `sessions` — the primary surface where an operator sees the work being landed.

## Why
Matches the repo's stated doctrine (root AGENTS.md): rank by progress, not liveness. Sessions is where not-progressing work surfaces first; the Agents roster is secondary.

## Change
One-line default flip: `useState<CenterMode>('agents')` → `'sessions'`. `'sessions'` is a valid `CenterMode`; the center tab is **not** persisted in floor prefs (`loadFloorPrefs`/`saveFloorPrefs` store plain/sidebar/rail/right/pinned/hostPins/sidebarWidth only), so no migration is needed and no saved preference is overridden.

## Run evidence (headless UI test — a live-UI screenshot would require the running ext, which must not touch the user's machine)
Ran the Floor/Sessions pane tests in `apps/ext/ui` after the change:

```
bun test v1.3.14
 34 pass
 0 fail
 69 expect() calls
Ran 34 tests across 2 files. [203.00ms]
```
(FloorSubtabs.test.tsx + sessionsModel.test.ts — the sub-tab strip and the Sessions model both green with the new default.)

## Tests
No test asserted the old default (only fixtures use `center: 'agents'`), and a useState-initial-value assertion would be ceremony. CHANGELOG updated (0.9.333).
