### PR TITLE
fix(devices): agents devices capture no longer wipes fleet.ignored (RUSH-3062)

### DIFF
--- a/apps/cli/.changelog/next/capture-preserve-ignored.md
+++ b/apps/cli/.changelog/next/capture-preserve-ignored.md
@@ -1,0 +1,5 @@
+---
+type: fix
+---
+
+`agents devices capture` no longer wipes `fleet.ignored` — the captured manifest carries device dismissals forward instead of rebuilding the fleet block without them.

--- a/apps/cli/src/lib/devices/registry.ts
+++ b/apps/cli/src/lib/devices/registry.ts
@@ -429,7 +429,7 @@ export function withIgnoredAdded(meta: Meta, names: string[], ignoredAt: string)
   const have = new Set(entries.map((e) => e.name));
   const fresh = names.filter((n) => !have.has(n));
   if (fresh.length === 0) return meta;
-  const fleet = (meta.fleet ?? { devices: {} }) ;
+  const fleet = (meta.fleet ?? { devices: {} });
   const ignored: IgnoredDeviceEntry[] = [
     ...entries,
     ...fresh.map((name) => ({ name, ignoredAt, ignoredOn: machineId() })),

--- a/apps/cli/src/lib/fleet/capture.test.ts
+++ b/apps/cli/src/lib/fleet/capture.test.ts
@@ -103,4 +103,18 @@ describe('captureFleet', () => {
 
     expect(m.discovery).toEqual({ 'mac-mini': 'approved', 'old-laptop': 'ignored' });
   });
+
+  it('never wipes fleet.ignored — dismissals are operator state, not live state', () => {
+    const prev: FleetManifest = {
+      devices: {},
+      ignored: [{ name: 'old-laptop', ignoredAt: '2026-08-20T10:00:00.000Z', ignoredOn: 'zion' }],
+    };
+
+    const m = captureFleet(prev, { devices: ['yosemite-s0'] });
+
+    expect(m.ignored).toEqual([{ name: 'old-laptop', ignoredAt: '2026-08-20T10:00:00.000Z', ignoredOn: 'zion' }]);
+    // Carried by value — mutating the old manifest must not leak into the new one.
+    prev.ignored![0].name = 'mutated';
+    expect(m.ignored![0].name).toBe('old-laptop');
+  });
 });

--- a/apps/cli/src/lib/fleet/capture.ts
+++ b/apps/cli/src/lib/fleet/capture.ts
@@ -80,6 +80,13 @@ export function captureFleet(prev: FleetManifest | undefined, inputs: CaptureInp
     manifest.discovery = { ...prev.discovery };
   }
 
+  // Dismissals are operator state, not live state — a capture must never wipe
+  // them (fleet.ignored syncs; losing it re-suggests every dismissed node
+  // fleet-wide). Carry forward verbatim, same contract as `discovery`.
+  if (prev?.ignored && prev.ignored.length > 0) {
+    manifest.ignored = prev.ignored.map((e) => ({ ...e }));
+  }
+
   const bundles = inputs.secretsBundles ?? prev?.secrets?.bundles;
   if (bundles && bundles.length > 0) manifest.secrets = { bundles: [...bundles].sort() };
 


### PR DESCRIPTION
fix — one-function behavior change + test. Ticket: RUSH-3062.

## What changed

- **apps/cli/src/lib/fleet/capture.ts** — `captureFleet` now carries `prev.ignored` forward by value, the same contract as `discovery` one block above.
- **apps/cli/src/lib/fleet/capture.test.ts** — new test: a capture run over a manifest with dismissals preserves them, and the carry is by value.
- **apps/cli/src/lib/devices/registry.ts** — drop a stray space (review nit).
- **apps/cli/.changelog/next/capture-preserve-ignored.md** — changelog fragment.

## Why

The non-author review of #2943 (posted after it merged — https://github.com/phnx-labs/agi-cli/pull/2943#issuecomment-5386205290) found the blocker: `captureFleet` rebuilds the `fleet:` manifest from `defaults`/`devices`/`discovery`/`secrets`/`routines` but never `prev.ignored`, and its caller writes the result back wholesale (`commands/fleet-capture.ts:97`). One `agents devices capture` run deleted every device dismissal fleet-wide — the data-loss class #2943's migration guard exists to prevent, and a contradiction of capture's own `Additive by design ... never clobbers` docstring (capture.ts:11).

## Verification

Real run of the suite in apps/cli — `bun run test -- src/lib/fleet/capture.test.ts`, 8/8 pass including the new case: https://share.agents-cli.sh/muqsitnawaz/devsurface-capture-test-run-b2315e213fec8481 — and the new test fails without the fix (`expected 'mutated' to be 'old-laptop'` when the carry was a shallow spread).