### PR TITLE
docs(devices): document fleet.ignored in the agents-yaml schema; repair the profiles.test state mock (RUSH-3062)

### DIFF
--- a/apps/cli/schema/agents-yaml.schema.json
+++ b/apps/cli/schema/agents-yaml.schema.json
@@ -239,6 +239,19 @@
             "type": "string",
             "enum": ["approved", "ignored"]
           }
+        },
+        "ignored": {
+          "type": "array",
+          "description": "Nodes dismissed from auto-discovery (`agents devices ignore`), with provenance for `agents devices ignored`. Syncs fleet-wide; the discovery pending-diff subtracts it on every machine.",
+          "items": {
+            "type": "object",
+            "required": ["name", "ignoredAt", "ignoredOn"],
+            "properties": {
+              "name": { "type": "string", "description": "Tailscale node name that was dismissed." },
+              "ignoredAt": { "type": "string", "description": "ISO-8601 timestamp of the dismissal." },
+              "ignoredOn": { "type": "string", "description": "Machine id (hostname) that dismissed it." }
+            }
+          }
         }
       }
     },

--- a/apps/cli/src/lib/browser/profiles.test.ts
+++ b/apps/cli/src/lib/browser/profiles.test.ts
@@ -17,6 +17,7 @@ vi.mock('../state.js', () => ({
   META_HEADER: '',
   getUserAgentsDir: vi.fn(() => path.join(TEST_ROOT, '.agents')),
   getDevicesAutoLaunchPath: vi.fn(() => path.join(TEST_ROOT, 'auto-launch.json')),
+  getDevicesIgnoredPath: vi.fn(() => path.join(TEST_ROOT, 'ignored.json')),
   getDevicePinsPath: vi.fn(() => path.join(TEST_ROOT, 'pins.json')),
 }));
 


### PR DESCRIPTION
docs + test-only: two leftovers from the RUSH-3062 `fleet.ignored` move (42e1ff31d). No behavior change.

## What changed

- **`apps/cli/schema/agents-yaml.schema.json`** — documents the `fleet.ignored` entries (`{ name, ignoredAt, ignoredOn }`, all three required) so the yaml-language-server integration and editors know the key the CLI now writes.
- **`apps/cli/src/lib/browser/profiles.test.ts`** — the `../state.js` mock now exports `getDevicesIgnoredPath`. Since the move, `config-migration.ts` imports it (`config-migration.ts:47`), and the missing mock export made every test in this file throw inside the mock — caught by `ensureDeviceConfigMigrated` and logged as `device config migration failed` noise (observed on the main CI run for #2947), with the migration never actually running in those processes.

No changelog fragment: docs-only + test-only, and the `fleet.ignored` key itself shipped with its own entry (`.changelog/next/RUSH-3062-ignore.md`).

## Verification

- [profiles.test.ts: 93/93 green, no migration-failure noise](https://share.agents-cli.sh/muqsitnawaz/ignore4-schema-rush-3062-schema-tests-e62099921e51d908); schema JSON parses.

Ticket: [RUSH-3062](https://linear.app/phnx/issue/RUSH-3062)