### PR TITLE
feat(ext): project feed attention into Needs-You, stop deriving (feed-driven Needs-You, Track C)

### DIFF
--- a/apps/ext/AGENTS.md
+++ b/apps/ext/AGENTS.md
@@ -8,10 +8,11 @@ the `swarm-ext://` endpoint. It does not own fleet or agent policy.
 
 - agents-cli owns sessions, devices, accounts, teams, watchdog,
   routines, lifecycle, ranking, deduplication, and scheduling.
-- The elected extension monitor owns one `agents sessions watch --json` child
-  across editor windows. It broadcasts versioned `reset`, `upsert`, `remove`,
-  `scope`, and `heartbeat` events; each extension host has one presentation
-  store and derives no lifecycle state. Editor tabs reconcile their provisional
+- The elected extension monitor owns one `agents feed watch --json` child
+  across editor windows. It projects versioned agent, attention, activity,
+  scope, and heartbeat envelopes; each extension host has one presentation
+  store and derives no lifecycle or Needs-You state. Local tabs join the same
+  projected attention record by session or terminal id. Editor tabs reconcile their provisional
   topic-based auto-labels from that same stream when a harness-owned session
   `label` arrives; a manual tab label still wins.
 - Resume/Fork opens one on-demand listing with `agents sessions --all --json

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 
 ## [0.9.333] - 2026-08-23
 
+- **Fleet Needs You now projects `agents feed watch --json`.** The elected
+  monitor carries CLI-owned agent and attention envelopes into one presentation
+  store; local editor tabs join the same attention by session/terminal id. Both
+  floor adapters use open attention and exact fingerprints/options instead of
+  parsing transcripts, tool calls, response prose, failure state, or PR state.
+  Cards show attention source and resolution receipts; the extension no longer
+  runs its own `gh pr view` status poller.
+
 - **The Fleet opens on the Sessions tab, not Agents.** The Floor 3-pane shell
   now defaults its center to `sessions` — the primary surface where an operator
   sees the work being landed — instead of the Agents roster, matching the

--- a/apps/ext/README.md
+++ b/apps/ext/README.md
@@ -84,6 +84,11 @@ the harness generates a name or the session is renamed; a label set with
 
 The dashboard's mission control. A live grid of interactive agents and cloud dispatches beside your Linear cycle. Background/headless runs are hidden by default; use the **Background** feed toggle when you need them. Compose and dispatch work with the Cmd+K composer, drag issue cards onto agents, or send a ticket straight to the cloud.
 
+**Needs you** projects the CLI feed's canonical attention ledger. Cards retain
+the exact choices and source; answered items leave the count immediately while
+the activity lane keeps a compact resolution receipt. The extension does not
+inspect transcripts or independently poll GitHub to decide what needs a person.
+
 Agent cards surface outputs such as PRs, spawned teams, created tickets, and plan
 artifacts. `.html` and `ref-*.md` plans detected in session output, worktree
 files, or attachments appear as one-click preview chips. Screenshots and other

--- a/apps/ext/src/core/remoteSessions.ts
+++ b/apps/ext/src/core/remoteSessions.ts
@@ -60,6 +60,23 @@ export interface RemoteQuestion {
   options: RemoteQuestionOption[];
 }
 
+export interface RemoteAttention {
+  key: string;
+  sessionId: string;
+  kind: 'question' | 'permission' | 'plan_review' | 'declared' | 'failure' | 'stall' | 'review';
+  source: 'hook' | 'declared' | 'lifecycle' | 'heuristic' | 'system';
+  state: 'open' | 'answered' | 'consumed' | 'continued' | 'resolved';
+  openedAt: string;
+  fingerprint: string;
+  question?: { text?: string; options?: Array<{ label?: string; description?: string; id?: string; deliveryKey?: string }> };
+}
+
+export interface RemotePullRequest {
+  url: string; number: number; title: string; state: 'open' | 'merged' | 'closed'; isDraft: boolean;
+  ci: 'passed' | 'failed' | 'running' | null; review: 'approved' | 'changes_requested' | 'review_required' | null;
+  mergeable: 'mergeable' | 'conflicting' | 'unknown'; readyToMerge: boolean;
+}
+
 export interface RemoteAttachment {
   path: string;
   label: string;
@@ -187,6 +204,8 @@ export interface RemoteSession {
    *  options), from the CLI state engine. null when the CLI supplied none — the UI
    *  then falls back to parsing lastResponse for options. */
   question: RemoteQuestion | null;
+  attention?: RemoteAttention;
+  pullRequest?: RemotePullRequest;
   /** Last few assistant turns (most-recent last), one line each — panel context. [] when none. */
   tail: string[];
   /** Live plan checklist from the CLI's most recent `TodoWrite` (RUSH-1380). Lets the
@@ -356,6 +375,9 @@ export interface RawActiveSession {
    *  only for waiting_input sessions; the options are the real choices (AskUserQuestion
    *  options, or canonical Approve/Deny for plan/permission). */
   question?: { text?: string; reason?: string; options?: Array<{ label?: string; description?: string; key?: string } | null> } | null;
+  attention?: RemoteAttention;
+  /** Track B adapter seam for the CLI-projected PR signal. */
+  pullRequest?: RemotePullRequest;
   /** Last few assistant turns (most-recent last), from the CLI state engine. */
   tail?: string[];
   /** Live plan progress (CLI ActiveSession.todos, RUSH-1380): the latest TodoWrite
@@ -621,6 +643,8 @@ export function normalizeActiveSession(
     awaitingReason: asStr(raw.awaitingReason),
     lastResponse: preview,
     question: normalizeQuestion(raw.question),
+    attention: raw.attention,
+    pullRequest: raw.pullRequest,
     tail: Array.isArray(raw.tail) ? raw.tail.map((t) => asStr(t)).filter(Boolean) : [],
     todos: todos.length ? todos : undefined,
     output: asStr(raw.output),

--- a/apps/ext/src/core/sessionIdHydrate.test.ts
+++ b/apps/ext/src/core/sessionIdHydrate.test.ts
@@ -7,10 +7,10 @@ afterEach(() => sessionPresentationStore.clear());
 describe('session id hydration from the canonical CLI stream', () => {
   test('maps terminal ids without launching another agents sessions query', async () => {
     sessionPresentationStore.apply({
-      version: 1,
+      v: 1,
       type: 'reset',
       streamId: 'stream-a', sequence: 1, capturedAt: 1, scope: 'box-a',
-      rows: [{ rowKey: 'one', sourceDevice: 'box-a', sessionId: 'session-1', terminalId: 'CX-1', machine: 'box-a' }],
+      agents: [{ rowKey: 'one', sourceDevice: 'box-a', sessionId: 'session-1', terminalId: 'CX-1', machine: 'box-a' }], attention: [],
     });
     expect(await fetchTerminalIdSessionMap('box-a')).toEqual(new Map([['CX-1', 'session-1']]));
     expect(await resolveSessionIdForTerminal('CX-1', 'box-a')).toBe('session-1');
@@ -18,13 +18,13 @@ describe('session id hydration from the canonical CLI stream', () => {
 
   test('scopes remote rows by host', async () => {
     sessionPresentationStore.apply({
-      version: 1,
+      v: 1,
       type: 'reset',
       streamId: 'stream-b', sequence: 1, capturedAt: 1, scope: 'fleet',
-      rows: [
+      agents: [
         { rowKey: 'one', sourceDevice: 'box-a', sessionId: 'one', terminalId: 'T-1', machine: 'box-a' },
         { rowKey: 'two', sourceDevice: 'box-b', sessionId: 'two', terminalId: 'T-2', machine: 'box-b' },
-      ],
+      ], attention: [],
     });
     expect(await fetchTerminalIdSessionMap('box-a')).toEqual(new Map([['T-1', 'one']]));
   });

--- a/apps/ext/src/core/sessionPresentationStore.test.ts
+++ b/apps/ext/src/core/sessionPresentationStore.test.ts
@@ -2,12 +2,23 @@ import { describe, expect, test } from 'bun:test';
 import { SessionPresentationStore } from './sessionPresentationStore';
 
 describe('SessionPresentationStore', () => {
+  test('joins projected attention by session id and removes it on resolution', () => {
+    const store = new SessionPresentationStore();
+    const attention = { key: 'a1', sessionId: 's1', state: 'open', fingerprint: 'fp' };
+    store.apply({ v: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'local', agents: [{ rowKey: 'r1', sessionId: 's1' }], attention: [attention] });
+    expect(store.sessions()).toEqual([{ rowKey: 'r1', sessionId: 's1', attention }]);
+    store.apply({ v: 1, type: 'attention.remove', streamId: 's', sequence: 2, capturedAt: 2, scope: 'local', rowKey: 'a1', resolution: { key: 'a1', state: 'answered' } });
+    expect(store.sessions()).toEqual([{ rowKey: 'r1', sessionId: 's1', attention: { ...attention, state: 'answered' } }]);
+    expect(store.activityEvents()).toEqual([{ key: 'a1', state: 'answered' }]);
+  });
   test('projects reset/upsert/remove without deriving lifecycle state', () => {
     const store = new SessionPresentationStore();
-    store.apply({ version: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'zion', rows: [{ rowKey: 'a', sourceDevice: 'zion', status: 'active' }] });
-    store.apply({ version: 1, type: 'upsert', streamId: 's', sequence: 2, capturedAt: 2, scope: 'zion', rowKey: 'b', row: { rowKey: 'b', sourceDevice: 'zion', status: 'orphaned' } });
-    store.apply({ version: 1, type: 'remove', streamId: 's', sequence: 3, capturedAt: 3, scope: 'zion', rowKey: 'a' });
-    expect(store.sessions()).toEqual([{ rowKey: 'b', sourceDevice: 'zion', status: 'orphaned' }]);
+    store.apply({ v: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'zion', agents: [{ rowKey: 'a', sourceDevice: 'zion', status: 'active' }], attention: [] });
+    store.apply({ v: 1, type: 'agent.upsert', streamId: 's', sequence: 2, capturedAt: 2, scope: 'zion', rowKey: 'b', agent: { rowKey: 'b', sourceDevice: 'zion', status: 'orphaned' } });
+    expect(store.sessions()).toEqual([
+      { rowKey: 'a', sourceDevice: 'zion', status: 'active' },
+      { rowKey: 'b', sourceDevice: 'zion', status: 'orphaned' },
+    ]);
   });
 
   // RUSH-2670: a detached session's row has host 'tmux' (the terminal APP — the
@@ -18,8 +29,8 @@ describe('SessionPresentationStore', () => {
   test('presents a detached local row (host: tmux) under the local label, not "tmux"', () => {
     const store = new SessionPresentationStore();
     store.apply({
-      version: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'zion',
-      rows: [{
+      v: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'zion', attention: [],
+      agents: [{
         rowKey: 'bg', sessionId: '2d29e6ac-7d5b-4bcc-91d1-8efc0818dbb3', kind: 'claude',
         host: 'tmux', sourceDevice: 'zion', status: 'closed', presence: 'background', context: 'terminal',
       }],
@@ -33,8 +44,8 @@ describe('SessionPresentationStore', () => {
   test('presents an offloaded row under its machine, not its terminal app', () => {
     const store = new SessionPresentationStore();
     store.apply({
-      version: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'zion',
-      rows: [{
+      v: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'zion', attention: [],
+      agents: [{
         rowKey: 'r', sessionId: 'abcd1234-0000-0000-0000-000000000000', kind: 'claude',
         host: 'tmux', machine: 'yosemite-s1', sourceDevice: 'zion', status: 'running', context: 'terminal',
       }],
@@ -44,17 +55,17 @@ describe('SessionPresentationStore', () => {
 
   test('orders each stream independently and resets only its scope', () => {
     const store = new SessionPresentationStore();
-    store.apply({ version: 1, type: 'reset', streamId: 'a', sequence: 5, capturedAt: 1, scope: 'zion', rows: [{ rowKey: 'z', sourceDevice: 'zion' }] });
-    store.apply({ version: 1, type: 'reset', streamId: 'b', sequence: 1, capturedAt: 1, scope: 'yosemite-s1', rows: [{ rowKey: 'y', sourceDevice: 'yosemite-s1' }] });
-    expect(store.apply({ version: 1, type: 'remove', streamId: 'a', sequence: 4, capturedAt: 2, scope: 'zion', rowKey: 'z' })).toBe(false);
+    store.apply({ v: 1, type: 'reset', streamId: 'a', sequence: 5, capturedAt: 1, scope: 'zion', agents: [{ rowKey: 'z', sourceDevice: 'zion' }], attention: [] });
+    store.apply({ v: 1, type: 'reset', streamId: 'b', sequence: 1, capturedAt: 1, scope: 'yosemite-s1', agents: [{ rowKey: 'y', sourceDevice: 'yosemite-s1' }], attention: [] });
+    expect(store.apply({ v: 1, type: 'attention.remove', streamId: 'a', sequence: 4, capturedAt: 2, scope: 'zion', rowKey: 'z' })).toBe(false);
     expect(store.sessions()).toEqual([{ rowKey: 'z', sourceDevice: 'zion' }, { rowKey: 'y', sourceDevice: 'yosemite-s1' }]);
   });
 
   test('liveSession returns machine + topic for a --device auto tab that never recorded its host', () => {
     const store = new SessionPresentationStore();
     store.apply({
-      version: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'yosemite-s1',
-      rows: [{
+      v: 1, type: 'reset', streamId: 's', sequence: 1, capturedAt: 1, scope: 'yosemite-s1', attention: [],
+      agents: [{
         rowKey: 'r',
         sessionId: '022fe0a8-7674-402a-a5e0-248195894663',
         kind: 'claude',

--- a/apps/ext/src/core/sessionPresentationStore.test.ts
+++ b/apps/ext/src/core/sessionPresentationStore.test.ts
@@ -9,7 +9,11 @@ describe('SessionPresentationStore', () => {
     expect(store.sessions()).toEqual([{ rowKey: 'r1', sessionId: 's1', attention }]);
     store.apply({ v: 1, type: 'attention.remove', streamId: 's', sequence: 2, capturedAt: 2, scope: 'local', rowKey: 'a1', resolution: { key: 'a1', state: 'answered' } });
     expect(store.sessions()).toEqual([{ rowKey: 'r1', sessionId: 's1', attention: { ...attention, state: 'answered' } }]);
-    expect(store.activityEvents()).toEqual([{ key: 'a1', state: 'answered' }]);
+    expect(store.activityEvents()).toEqual([{
+      type: 'attention.receipt', key: 'a1', sessionId: 's1', question: undefined,
+      source: undefined, fingerprint: 'fp', state: 'answered', resolvedAt: 2,
+      resolution: { key: 'a1', state: 'answered' },
+    }]);
   });
   test('projects reset/upsert/remove without deriving lifecycle state', () => {
     const store = new SessionPresentationStore();
@@ -59,6 +63,14 @@ describe('SessionPresentationStore', () => {
     store.apply({ v: 1, type: 'reset', streamId: 'b', sequence: 1, capturedAt: 1, scope: 'yosemite-s1', agents: [{ rowKey: 'y', sourceDevice: 'yosemite-s1' }], attention: [] });
     expect(store.apply({ v: 1, type: 'attention.remove', streamId: 'a', sequence: 4, capturedAt: 2, scope: 'zion', rowKey: 'z' })).toBe(false);
     expect(store.sessions()).toEqual([{ rowKey: 'z', sourceDevice: 'zion' }, { rowKey: 'y', sourceDevice: 'yosemite-s1' }]);
+  });
+
+  test('a reset retains projected attention owned by another scope', () => {
+    const store = new SessionPresentationStore();
+    const remoteAttention = { key: 'remote-attention', sessionId: 'remote-session', state: 'open' };
+    store.apply({ v: 1, type: 'reset', streamId: 'remote', sequence: 1, capturedAt: 1, scope: 'remote', agents: [{ rowKey: 'remote-row', sessionId: 'remote-session', sourceDevice: 'remote' }], attention: [remoteAttention] });
+    store.apply({ v: 1, type: 'reset', streamId: 'local', sequence: 1, capturedAt: 2, scope: 'local', agents: [{ rowKey: 'local-row', sessionId: 'local-session', sourceDevice: 'local' }], attention: [] });
+    expect(store.sessions()).toContainEqual({ rowKey: 'remote-row', sessionId: 'remote-session', sourceDevice: 'remote', attention: remoteAttention });
   });
 
   test('liveSession returns machine + topic for a --device auto tab that never recorded its host', () => {

--- a/apps/ext/src/core/sessionPresentationStore.test.ts
+++ b/apps/ext/src/core/sessionPresentationStore.test.ts
@@ -14,6 +14,9 @@ describe('SessionPresentationStore', () => {
       source: undefined, fingerprint: 'fp', state: 'answered', resolvedAt: 2,
       resolution: { key: 'a1', state: 'answered' },
     }]);
+    store.apply({ v: 1, type: 'reset', streamId: 's', sequence: 3, capturedAt: 3, scope: 'local', agents: [], attention: [] });
+    expect(store.sessions()).toEqual([]);
+    expect(store.activityEvents()).toHaveLength(1);
   });
   test('projects reset/upsert/remove without deriving lifecycle state', () => {
     const store = new SessionPresentationStore();

--- a/apps/ext/src/core/sessionPresentationStore.ts
+++ b/apps/ext/src/core/sessionPresentationStore.ts
@@ -5,6 +5,8 @@ import type { ProjectRule } from './settings';
 /** Window-local projection of the canonical CLI stream; contains no lifecycle logic. */
 export class SessionPresentationStore {
   private rows = new Map<string, unknown>();
+  private attention = new Map<string, unknown>();
+  private activity: unknown[] = [];
   private sequences = new Map<string, number>();
   private scopes = new Map<string, { status: 'available' | 'unavailable'; reason?: string }>();
 
@@ -16,26 +18,52 @@ export class SessionPresentationStore {
       for (const [rowKey, value] of this.rows) {
         if (this.scopeOf(value) === event.scope) this.rows.delete(rowKey);
       }
-      for (const row of event.rows ?? []) {
+      for (const row of event.agents ?? []) {
         const rowKey = this.rowKeyOf(row);
         if (rowKey) this.rows.set(rowKey, row);
       }
-    } else if (event.type === 'upsert') {
-      const rowKey = event.rowKey || this.rowKeyOf(event.row);
-      if (rowKey && event.row) this.rows.set(rowKey, event.row);
-    } else if (event.type === 'remove' && event.rowKey) {
-      this.rows.delete(event.rowKey);
+      this.attention.clear();
+      for (const item of Array.isArray(event.attention) ? event.attention : []) {
+        const key = this.attentionKeyOf(item);
+        if (key) this.attention.set(key, item);
+      }
+    } else if (event.type === 'agent.upsert') {
+      const rowKey = event.rowKey || this.rowKeyOf(event.agent);
+      if (rowKey && event.agent) this.rows.set(rowKey, event.agent);
+    } else if (event.type === 'attention.upsert' && event.attention && !Array.isArray(event.attention)) {
+      const key = event.rowKey || this.attentionKeyOf(event.attention);
+      if (key) this.attention.set(key, event.attention);
+    } else if (event.type === 'attention.remove' && event.rowKey) {
+      const previous = this.attention.get(event.rowKey);
+      if (previous && typeof previous === 'object') {
+        const resolution = event.resolution && typeof event.resolution === 'object' ? event.resolution as { state?: unknown } : {};
+        this.attention.set(event.rowKey, { ...previous, state: typeof resolution.state === 'string' ? resolution.state : 'resolved' });
+      }
+      if (event.resolution) this.activity.push(event.resolution);
+    } else if (event.type === 'activity.append' && event.event) {
+      this.activity.push(event.event);
     } else if (event.type === 'scope' && event.status) {
       this.scopes.set(event.scope, { status: event.status, ...(event.reason ? { reason: event.reason } : {}) });
     }
     return true;
   }
 
-  sessions(): unknown[] { return [...this.rows.values()]; }
+  sessions(): unknown[] {
+    const projected = [...this.attention.values()];
+    return [...this.rows.values()].map((value) => {
+      if (!value || typeof value !== 'object') return value;
+      const row = value as { sessionId?: unknown; id?: unknown };
+      const sessionId = typeof row.sessionId === 'string' ? row.sessionId : typeof row.id === 'string' ? row.id : '';
+      const attention = projected.find((item) => item && typeof item === 'object'
+        && (item as { sessionId?: unknown }).sessionId === sessionId);
+      return attention ? { ...row, attention } : row;
+    });
+  }
+  activityEvents(): unknown[] { return [...this.activity]; }
   scope(scope: string): { status: 'available' | 'unavailable'; reason?: string } | undefined {
     return this.scopes.get(scope);
   }
-  clear(): void { this.rows.clear(); this.sequences.clear(); this.scopes.clear(); }
+  clear(): void { this.rows.clear(); this.attention.clear(); this.activity = []; this.sequences.clear(); this.scopes.clear(); }
 
   /** Normalize the CLI stream rows for UI rendering without starting another query. */
   presentedSessions(
@@ -124,6 +152,12 @@ export class SessionPresentationStore {
     if (!value || typeof value !== 'object') return undefined;
     const rowKey = (value as { rowKey?: unknown }).rowKey;
     return typeof rowKey === 'string' && rowKey ? rowKey : undefined;
+  }
+
+  private attentionKeyOf(value: unknown): string | undefined {
+    if (!value || typeof value !== 'object') return undefined;
+    const key = (value as { key?: unknown }).key;
+    return typeof key === 'string' && key ? key : undefined;
   }
 
   private scopeOf(value: unknown): string | undefined {

--- a/apps/ext/src/core/sessionPresentationStore.ts
+++ b/apps/ext/src/core/sessionPresentationStore.ts
@@ -5,6 +5,7 @@ import type { ProjectRule } from './settings';
 /** Window-local projection of the canonical CLI stream; contains no lifecycle logic. */
 export class SessionPresentationStore {
   private rows = new Map<string, unknown>();
+  private rowScopes = new Map<string, string>();
   private attention = new Map<string, unknown>();
   private attentionScopes = new Map<string, string>();
   private activity: unknown[] = [];
@@ -16,12 +17,18 @@ export class SessionPresentationStore {
     if (event.sequence <= previous) return false;
     this.sequences.set(event.streamId, event.sequence);
     if (event.type === 'reset') {
-      for (const [rowKey, value] of this.rows) {
-        if (this.scopeOf(value) === event.scope) this.rows.delete(rowKey);
+      for (const [rowKey, scope] of this.rowScopes) {
+        if (scope === event.scope) {
+          this.rows.delete(rowKey);
+          this.rowScopes.delete(rowKey);
+        }
       }
       for (const row of event.agents ?? []) {
         const rowKey = this.rowKeyOf(row);
-        if (rowKey) this.rows.set(rowKey, row);
+        if (rowKey) {
+          this.rows.set(rowKey, row);
+          this.rowScopes.set(rowKey, event.scope);
+        }
       }
       for (const [key, scope] of this.attentionScopes) {
         if (scope === event.scope) {
@@ -38,7 +45,10 @@ export class SessionPresentationStore {
       }
     } else if (event.type === 'agent.upsert') {
       const rowKey = event.rowKey || this.rowKeyOf(event.agent);
-      if (rowKey && event.agent) this.rows.set(rowKey, event.agent);
+      if (rowKey && event.agent) {
+        this.rows.set(rowKey, event.agent);
+        this.rowScopes.set(rowKey, event.scope);
+      }
     } else if (event.type === 'attention.upsert' && event.attention && !Array.isArray(event.attention)) {
       const key = event.rowKey || this.attentionKeyOf(event.attention);
       if (key) {
@@ -89,7 +99,7 @@ export class SessionPresentationStore {
   scope(scope: string): { status: 'available' | 'unavailable'; reason?: string } | undefined {
     return this.scopes.get(scope);
   }
-  clear(): void { this.rows.clear(); this.attention.clear(); this.attentionScopes.clear(); this.activity = []; this.sequences.clear(); this.scopes.clear(); }
+  clear(): void { this.rows.clear(); this.rowScopes.clear(); this.attention.clear(); this.attentionScopes.clear(); this.activity = []; this.sequences.clear(); this.scopes.clear(); }
 
   /** Normalize the CLI stream rows for UI rendering without starting another query. */
   presentedSessions(
@@ -186,11 +196,6 @@ export class SessionPresentationStore {
     return typeof key === 'string' && key ? key : undefined;
   }
 
-  private scopeOf(value: unknown): string | undefined {
-    if (!value || typeof value !== 'object') return undefined;
-    const scope = (value as { sourceDevice?: unknown }).sourceDevice;
-    return typeof scope === 'string' ? scope : undefined;
-  }
 }
 
 /** Exactly one presentation store per extension host process. */

--- a/apps/ext/src/core/sessionPresentationStore.ts
+++ b/apps/ext/src/core/sessionPresentationStore.ts
@@ -6,6 +6,7 @@ import type { ProjectRule } from './settings';
 export class SessionPresentationStore {
   private rows = new Map<string, unknown>();
   private attention = new Map<string, unknown>();
+  private attentionScopes = new Map<string, string>();
   private activity: unknown[] = [];
   private sequences = new Map<string, number>();
   private scopes = new Map<string, { status: 'available' | 'unavailable'; reason?: string }>();
@@ -22,24 +23,49 @@ export class SessionPresentationStore {
         const rowKey = this.rowKeyOf(row);
         if (rowKey) this.rows.set(rowKey, row);
       }
-      this.attention.clear();
+      for (const [key, scope] of this.attentionScopes) {
+        if (scope === event.scope) {
+          this.attention.delete(key);
+          this.attentionScopes.delete(key);
+        }
+      }
       for (const item of Array.isArray(event.attention) ? event.attention : []) {
         const key = this.attentionKeyOf(item);
-        if (key) this.attention.set(key, item);
+        if (key) {
+          this.attention.set(key, item);
+          this.attentionScopes.set(key, event.scope);
+        }
       }
     } else if (event.type === 'agent.upsert') {
       const rowKey = event.rowKey || this.rowKeyOf(event.agent);
       if (rowKey && event.agent) this.rows.set(rowKey, event.agent);
     } else if (event.type === 'attention.upsert' && event.attention && !Array.isArray(event.attention)) {
       const key = event.rowKey || this.attentionKeyOf(event.attention);
-      if (key) this.attention.set(key, event.attention);
+      if (key) {
+        this.attention.set(key, event.attention);
+        this.attentionScopes.set(key, event.scope);
+      }
     } else if (event.type === 'attention.remove' && event.rowKey) {
       const previous = this.attention.get(event.rowKey);
       if (previous && typeof previous === 'object') {
         const resolution = event.resolution && typeof event.resolution === 'object' ? event.resolution as { state?: unknown } : {};
         this.attention.set(event.rowKey, { ...previous, state: typeof resolution.state === 'string' ? resolution.state : 'resolved' });
       }
-      if (event.resolution) this.activity.push(event.resolution);
+      if (event.resolution) {
+        const attention = previous && typeof previous === 'object' ? previous as Record<string, unknown> : {};
+        const resolution = event.resolution as Record<string, unknown>;
+        this.activity.push({
+          type: 'attention.receipt',
+          key: event.rowKey,
+          sessionId: attention.sessionId,
+          question: attention.question,
+          source: attention.source,
+          fingerprint: attention.fingerprint,
+          state: typeof resolution.state === 'string' ? resolution.state : 'resolved',
+          resolvedAt: resolution.resolvedAt ?? event.capturedAt,
+          resolution,
+        });
+      }
     } else if (event.type === 'activity.append' && event.event) {
       this.activity.push(event.event);
     } else if (event.type === 'scope' && event.status) {
@@ -63,7 +89,7 @@ export class SessionPresentationStore {
   scope(scope: string): { status: 'available' | 'unavailable'; reason?: string } | undefined {
     return this.scopes.get(scope);
   }
-  clear(): void { this.rows.clear(); this.attention.clear(); this.activity = []; this.sequences.clear(); this.scopes.clear(); }
+  clear(): void { this.rows.clear(); this.attention.clear(); this.attentionScopes.clear(); this.activity = []; this.sequences.clear(); this.scopes.clear(); }
 
   /** Normalize the CLI stream rows for UI rendering without starting another query. */
   presentedSessions(

--- a/apps/ext/src/monitor/host.test.ts
+++ b/apps/ext/src/monitor/host.test.ts
@@ -1,6 +1,6 @@
 // Follower replay round-trip (no mocks).
 //
-// A real MonitorHost, a real child process standing in for `agents sessions
+// A real MonitorHost, a real child process standing in for `agents feed
 // watch --json`, a real MonitorFollower over a real Unix socket.
 //
 // Regression: the host registered its request handler as `(payload) =>
@@ -35,13 +35,14 @@ function tempSocketPath(): string {
  */
 function spawnFakeWatch(): ChildProcessWithoutNullStreams {
   const reset = JSON.stringify({
-    version: 1,
+    v: 1,
     type: 'reset',
     streamId: 'test-stream',
     sequence: 1,
     capturedAt: 1,
     scope: 'testbox',
-    rows: [{ rowKey: 'row-1', sessionId: 'sess-1', status: 'running' }],
+    agents: [{ rowKey: 'row-1', sessionId: 'sess-1', status: 'running' }],
+    attention: [],
   });
   const child = spawn(
     process.execPath,
@@ -107,9 +108,9 @@ describe('MonitorHost replays session state to a late follower', () => {
 
     const reset = received
       .filter((e) => e.type === MONITOR_FACT.sessionCli)
-      .map((e) => e.payload as { type?: string; scope?: string; rows?: unknown[] })
+      .map((e) => e.payload as { type?: string; scope?: string; agents?: unknown[] })
       .find((p) => p.type === 'reset');
     expect(reset?.scope).toBe('testbox');
-    expect(reset?.rows).toHaveLength(1);
+    expect(reset?.agents).toHaveLength(1);
   });
 });

--- a/apps/ext/src/monitor/protocol.ts
+++ b/apps/ext/src/monitor/protocol.ts
@@ -126,14 +126,19 @@ export const MONITOR_FACT = {
 } as const;
 
 export interface SessionCliFactPayload {
-  version: 1;
-  type: 'reset' | 'upsert' | 'remove' | 'scope' | 'heartbeat';
+  /** Adapter seam for Track B: accept canonical `v` and legacy `version`. */
+  version?: 1;
+  v?: 1;
+  type: 'reset' | 'agent.upsert' | 'attention.upsert' | 'attention.remove' | 'activity.append' | 'scope' | 'heartbeat';
   streamId: string;
   sequence: number;
   capturedAt: number;
   scope: string;
-  rows?: unknown[];
-  row?: unknown;
+  agents?: unknown[];
+  attention?: unknown[] | unknown;
+  agent?: unknown;
+  resolution?: unknown;
+  event?: unknown;
   rowKey?: string;
   status?: 'available' | 'unavailable';
   reason?: string;
@@ -145,7 +150,7 @@ export function isSessionCliFact(
   const payload = event.payload as SessionCliFactPayload | undefined;
   return event.type === MONITOR_FACT.sessionCli
     && !!payload
-    && payload.version === 1
+    && (payload.v === 1 || payload.version === 1)
     && typeof payload.streamId === 'string'
     && Number.isInteger(payload.sequence)
     && typeof payload.type === 'string';

--- a/apps/ext/src/monitor/sessionCliStream.test.ts
+++ b/apps/ext/src/monitor/sessionCliStream.test.ts
@@ -4,13 +4,13 @@ import { SessionCliReplay, SessionCliStream, type SessionCliEvent } from './sess
 
 test('SessionCliStream forwards the canonical CLI envelope without renaming fields', async () => {
   const expected: SessionCliEvent = {
-    version: 1,
+    v: 1,
     type: 'reset',
     streamId: 'stream-1',
     sequence: 1,
     capturedAt: 10,
     scope: 'zion',
-    rows: [{ rowKey: 'row-1', sourceDevice: 'zion', sessionId: 'session-1' }],
+    agents: [{ rowKey: 'row-1', sourceDevice: 'zion', sessionId: 'session-1' }], attention: [],
   };
   const received = await new Promise<SessionCliEvent>((resolve, reject) => {
     const stream = new SessionCliStream({
@@ -25,20 +25,20 @@ test('SessionCliStream forwards the canonical CLI envelope without renaming fiel
 
 test('SessionCliReplay gives a late window the current rows without another CLI process', () => {
   const replay = new SessionCliReplay();
-  replay.ingest({ version: 1, type: 'reset', streamId: 'cli', sequence: 1, capturedAt: 1, scope: 'zion', rows: [
+  replay.ingest({ v: 1, type: 'reset', streamId: 'cli', sequence: 1, capturedAt: 1, scope: 'zion', agents: [
     { rowKey: 'a', sourceDevice: 'zion', sessionId: 'old' },
-  ] });
-  replay.ingest({ version: 1, type: 'remove', streamId: 'cli', sequence: 2, capturedAt: 2, scope: 'zion', rowKey: 'a' });
-  replay.ingest({ version: 1, type: 'upsert', streamId: 'cli', sequence: 3, capturedAt: 3, scope: 'zion', rowKey: 'b', row:
+  ], attention: [] });
+  replay.ingest({ v: 1, type: 'agent.upsert', streamId: 'cli', sequence: 3, capturedAt: 3, scope: 'zion', rowKey: 'b', agent:
     { rowKey: 'b', sourceDevice: 'zion', sessionId: 'current' },
   });
-  replay.ingest({ version: 1, type: 'scope', streamId: 'cli', sequence: 4, capturedAt: 4, scope: 'zion', status: 'available' });
+  replay.ingest({ v: 1, type: 'scope', streamId: 'cli', sequence: 4, capturedAt: 4, scope: 'zion', status: 'available' });
   const first = replay.envelopes('late-window');
   expect(first).toEqual([
-    { version: 1, type: 'reset', streamId: 'replay:late-window:zion:1', sequence: 1, capturedAt: 4, scope: 'zion', rows: [
+    { v: 1, type: 'reset', streamId: 'replay:late-window:zion:1', sequence: 1, capturedAt: 4, scope: 'zion', agents: [
+      { rowKey: 'a', sourceDevice: 'zion', sessionId: 'old' },
       { rowKey: 'b', sourceDevice: 'zion', sessionId: 'current' },
-    ] },
-    { version: 1, type: 'scope', streamId: 'replay:late-window:zion:1', sequence: 2, capturedAt: 4, scope: 'zion', status: 'available' },
+    ], attention: [] },
+    { v: 1, type: 'scope', streamId: 'replay:late-window:zion:1', sequence: 2, capturedAt: 4, scope: 'zion', status: 'available' },
   ]);
   expect(replay.envelopes('late-window')[0].streamId).not.toBe(first[0].streamId);
 });
@@ -46,7 +46,7 @@ test('SessionCliReplay gives a late window the current rows without another CLI 
 test('SessionCliStream restarts after the CLI child exits unexpectedly', async () => {
   let spawns = 0;
   const event: SessionCliEvent = {
-    version: 1,
+    v: 1,
     type: 'heartbeat',
     streamId: 'stream-restart',
     sequence: 1,

--- a/apps/ext/src/monitor/sessionCliStream.ts
+++ b/apps/ext/src/monitor/sessionCliStream.ts
@@ -18,6 +18,7 @@ export class SessionCliReplay {
   private replaySequence = 0;
   private readonly scopes = new Map<string, {
     rows: Map<string, unknown>;
+    attention: Map<string, unknown>;
     capturedAt: number;
     status?: 'available' | 'unavailable';
     reason?: string;
@@ -25,19 +26,25 @@ export class SessionCliReplay {
 
   ingest(event: SessionCliEvent): void {
     const current = this.scopes.get(event.scope) ?? {
-      rows: new Map<string, unknown>(),
+      rows: new Map<string, unknown>(), attention: new Map<string, unknown>(),
       capturedAt: event.capturedAt,
     };
     current.capturedAt = event.capturedAt;
     if (event.type === 'reset') {
-      current.rows = new Map((event.rows ?? []).flatMap((row) => {
+      current.rows = new Map((event.agents ?? []).flatMap((row) => {
         const rowKey = row && typeof row === 'object' ? (row as { rowKey?: unknown }).rowKey : undefined;
         return typeof rowKey === 'string' ? [[rowKey, row] as const] : [];
       }));
-    } else if (event.type === 'upsert' && event.rowKey && event.row) {
-      current.rows.set(event.rowKey, event.row);
-    } else if (event.type === 'remove' && event.rowKey) {
-      current.rows.delete(event.rowKey);
+      current.attention = new Map((Array.isArray(event.attention) ? event.attention : []).flatMap((item) => {
+        const key = item && typeof item === 'object' ? (item as { key?: unknown }).key : undefined;
+        return typeof key === 'string' ? [[key, item] as const] : [];
+      }));
+    } else if (event.type === 'agent.upsert' && event.rowKey && event.agent) {
+      current.rows.set(event.rowKey, event.agent);
+    } else if (event.type === 'attention.upsert' && event.rowKey && event.attention && !Array.isArray(event.attention)) {
+      current.attention.set(event.rowKey, event.attention);
+    } else if (event.type === 'attention.remove' && event.rowKey) {
+      current.attention.delete(event.rowKey);
     } else if (event.type === 'scope' && event.status) {
       current.status = event.status;
       current.reason = event.reason;
@@ -50,12 +57,12 @@ export class SessionCliReplay {
     for (const [scope, current] of this.scopes) {
       const streamId = `replay:${clientKey}:${scope}:${++this.replaySequence}`;
       events.push({
-        version: 1, type: 'reset', streamId, sequence: 1,
-        capturedAt: current.capturedAt, scope, rows: [...current.rows.values()],
+        v: 1, type: 'reset', streamId, sequence: 1,
+        capturedAt: current.capturedAt, scope, agents: [...current.rows.values()], attention: [...current.attention.values()],
       });
       if (current.status) {
         events.push({
-          version: 1, type: 'scope', streamId, sequence: 2,
+          v: 1, type: 'scope', streamId, sequence: 2,
           capturedAt: current.capturedAt, scope, status: current.status,
           ...(current.reason ? { reason: current.reason } : {}),
         });
@@ -89,7 +96,7 @@ export class SessionCliStream {
     void resolveAgentsBin().then((bin) => {
       if (!this.wantRunning || this.child) return;
       const augmented = bootstrapPath(bin);
-      this.attach(spawn(bin, ['sessions', 'watch', '--json'], {
+      this.attach(spawn(bin, ['feed', 'watch', '--json'], {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: { ...process.env, PATH: `${augmented}:${process.env.PATH ?? ''}` },
       }));
@@ -106,12 +113,12 @@ export class SessionCliStream {
     lines.on('line', (line) => {
       try {
         const event = JSON.parse(line) as SessionCliEvent;
-        if (event?.version === 1 && typeof event.streamId === 'string'
+        if ((event?.v === 1 || event?.version === 1) && typeof event.streamId === 'string'
           && Number.isInteger(event.sequence) && typeof event.type === 'string') {
           this.options.emit(event);
         }
       } catch {
-        this.options.onError?.(`agents sessions watch emitted invalid JSON: ${line.slice(0, 160)}`);
+        this.options.onError?.(`agents feed watch emitted invalid JSON: ${line.slice(0, 160)}`);
       }
     });
     let stderr = '';
@@ -122,7 +129,7 @@ export class SessionCliStream {
       if (!this.wantRunning) return;
       if (code !== 0) {
         this.options.onError?.(
-          stderr.trim() || 'agents sessions watch exited; restarting stream',
+          stderr.trim() || 'agents feed watch exited; restarting stream',
         );
       }
       this.scheduleRestart();

--- a/apps/ext/src/vscode/forkCommands.test.ts
+++ b/apps/ext/src/vscode/forkCommands.test.ts
@@ -146,12 +146,12 @@ describe('fork command contributions', () => {
         calls.push(`${host}:${terminalId}`);
         if (calls.length === 1) return null;
         sessionPresentationStore.apply({
-          version: 1,
+          v: 1,
           streamId: 'fork-test',
           sequence: 1,
           type: 'reset',
           scope: 'chosen-host',
-          rows: [
+          agents: [
             {
               rowKey: 'fork-row',
               sourceDevice: 'chosen-host',
@@ -159,7 +159,7 @@ describe('fork command contributions', () => {
               sessionId: 'sibling-session-id',
               machine: 'chosen-host',
             },
-          ],
+          ], attention: [],
         });
         return remoteForkSessionId(host, terminalId);
       },

--- a/apps/ext/src/vscode/prBoard.vscode.ts
+++ b/apps/ext/src/vscode/prBoard.vscode.ts
@@ -1,57 +1,11 @@
-// Impure half of the PR board: `gh pr view` per URL with a short TTL cache and an
-// in-flight guard (mirrors swarm.vscode.ts's ciCache idiom), plus the merge action.
-// The pure JSON -> PrStatus parse lives in core/prBoard.ts.
+// PR board mutation only. Status is projected by `agents feed watch --json`;
+// this module never starts a second GitHub status poller.
 
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { parsePrStatus, type PrStatus } from '../core/prBoard';
 
 const execAsync = promisify(exec);
 
-const PR_TTL_MS = 45_000;
-const cache = new Map<string, { at: number; status: PrStatus | null }>();
-const inFlight = new Map<string, Promise<PrStatus | null>>();
-
-const GH_FIELDS = 'number,title,state,isDraft,reviewDecision,mergeable,statusCheckRollup';
-
-async function fetchOne(url: string): Promise<PrStatus | null> {
-  try {
-    const { stdout } = await execAsync(`gh pr view ${JSON.stringify(url)} --json ${GH_FIELDS}`, {
-      timeout: 10_000,
-      maxBuffer: 4 * 1024 * 1024,
-    });
-    return parsePrStatus(url, stdout);
-  } catch {
-    // gh unavailable / auth / 404 — no row rather than a fabricated one.
-    return null;
-  }
-}
-
-/**
- * Board statuses for a set of PR URLs. Each URL is fetched at most once per TTL
- * window and never concurrently; misses (gh failure, closed URL) are dropped so
- * the board only renders rows it can back with real data.
- */
-export async function fetchPrStatuses(urls: string[]): Promise<PrStatus[]> {
-  const unique = [...new Set(urls.filter((u) => typeof u === 'string' && u.startsWith('https://')))];
-  const results = await Promise.all(
-    unique.map((url) => {
-      const cached = cache.get(url);
-      if (cached && Date.now() - cached.at <= PR_TTL_MS) return Promise.resolve(cached.status);
-      const pending = inFlight.get(url);
-      if (pending) return pending;
-      const p = fetchOne(url)
-        .then((status) => {
-          cache.set(url, { at: Date.now(), status });
-          return status;
-        })
-        .finally(() => inFlight.delete(url));
-      inFlight.set(url, p);
-      return p;
-    }),
-  );
-  return results.filter((s): s is PrStatus => s !== null);
-}
 
 /**
  * Merge a PR from the board. Plain `gh pr merge --rebase` — deliberately NO
@@ -62,7 +16,6 @@ export async function fetchPrStatuses(urls: string[]): Promise<PrStatus[]> {
 export async function mergePr(url: string): Promise<{ ok: boolean; error?: string }> {
   try {
     await execAsync(`gh pr merge ${JSON.stringify(url)} --rebase`, { timeout: 30_000 });
-    cache.delete(url);
     return { ok: true };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/apps/ext/src/vscode/settings.vscode.ts
+++ b/apps/ext/src/vscode/settings.vscode.ts
@@ -2204,6 +2204,7 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
             fetchedAt,
             hostFreshness,
             fromCache: false,
+            activity: sessionPresentationStore.activityEvents(),
           });
         } catch (err) {
           console.error('[SETTINGS] Error fetching host sessions:', err);
@@ -2233,6 +2234,7 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
             sessions: localSessions,
             fetchedAt,
             fromCache: false,
+            activity: sessionPresentationStore.activityEvents(),
           });
         } catch (err) {
           console.error('[SETTINGS] Error fetching local sessions:', err);

--- a/apps/ext/src/vscode/settings.vscode.ts
+++ b/apps/ext/src/vscode/settings.vscode.ts
@@ -1136,6 +1136,7 @@ async function pushFloorUpdate(workspacePath?: string): Promise<void> {
     // approval-waiting state. Edge-triggered so it fires once per wait.
     notifyNewlyWaiting(floorTerminals);
     settingsPanel.webview.postMessage({ type: 'allTerminalsData', terminals: floorTerminals });
+    settingsPanel.webview.postMessage({ type: 'feedActivity', activity: sessionPresentationStore.activityEvents() });
 
     // Tasks arrive in their own message whenever they are ready. fetchTasks
     // already absorbs a cloud outage internally and resolves with local data,

--- a/apps/ext/src/vscode/settings.vscode.ts
+++ b/apps/ext/src/vscode/settings.vscode.ts
@@ -2258,19 +2258,6 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         }
         break;
       }
-      case 'fetchPrBoard': {
-        // PR board: CI + review + mergeable per PR URL (TTL-cached gh pr view).
-        const urls = Array.isArray(message.urls) ? message.urls.filter((u: unknown) => typeof u === 'string') : [];
-        try {
-          const { fetchPrStatuses } = await import('./prBoard.vscode');
-          const statuses = await fetchPrStatuses(urls);
-          settingsPanel?.webview.postMessage({ type: 'prBoard', statuses });
-        } catch (err) {
-          console.error('[SETTINGS] Error fetching PR board:', err);
-          settingsPanel?.webview.postMessage({ type: 'prBoard', statuses: [] });
-        }
-        break;
-      }
       case 'mergePr': {
         // Board merge action. Plain --rebase, no --admin — branch protection stays
         // in force; a refusal comes back to the row as an inline error.

--- a/apps/ext/ui/settings/components/mission-control/AgentDecision.tsx
+++ b/apps/ext/ui/settings/components/mission-control/AgentDecision.tsx
@@ -46,6 +46,7 @@ export function AgentDecision({ agent: a, error, onOption, onFreeText, onAttach,
         <div className="ql">
           {label}
           {chip && <span className={chip.cls}>{chip.text}</span>}
+          {a.attentionSource && <span className="why" data-testid="attention-source">{a.attentionSource}</span>}
         </div>
         {showTask && (
           <div className="qtask" title={origTask}>
@@ -71,6 +72,9 @@ export function AgentDecision({ agent: a, error, onOption, onFreeText, onAttach,
           onFreeText={onFreeText}
           onAttach={onAttach}
         />
+        {!a.needs && a.attentionState && a.attentionState !== 'open' && (
+          <div className="receipt" data-testid="attention-receipt">{a.attentionState}</div>
+        )}
       </div>
     </div>
   )

--- a/apps/ext/ui/settings/components/mission-control/FeedItem.preview.test.tsx
+++ b/apps/ext/ui/settings/components/mission-control/FeedItem.preview.test.tsx
@@ -173,3 +173,11 @@ describe('reply delivery failure is visible on the feed row', () => {
     expect(html).not.toContain('class="summary')
   })
 })
+
+test('attention source is visible and a resolved item renders a receipt outside Needs you', () => {
+  const html = render(agent({ attentionSource: 'declared', attentionState: 'answered', needs: false }), false)
+  expect(html).toContain('data-testid="attention-source"')
+  expect(html).toContain('declared')
+  expect(html).toContain('data-testid="attention-receipt"')
+  expect(html).toContain('answered')
+})

--- a/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
@@ -208,6 +208,7 @@ function FeedItemImpl({ agent: a, selected, plain, error, onSelect, onOption, on
         <span className="path">{meta}</span>
         {!plain && wt && <span className="wtchip mono" title={a.worktreePath || wt}>{wt}</span>}
         <span className="when">
+          {a.attentionSource && <span className="pill" data-testid="attention-source">{a.attentionSource}</span>}
           {marker}
           {todoBadge}
           {ticketBadge}
@@ -309,6 +310,9 @@ function FeedItemImpl({ agent: a, selected, plain, error, onSelect, onOption, on
             onAttach={() => onAttach(a)}
           />
         </div>
+      )}
+      {!a.needs && a.attentionState && a.attentionState !== 'open' && (
+        <div className="receipt" data-testid="attention-receipt">{a.attentionState}</div>
       )}
       {/* Contextual follow-up: an agent that isn't working (idle or done) and isn't
           already asking for you is ready for the next task. Queue one right on its row,

--- a/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
+++ b/apps/ext/ui/settings/components/mission-control/FeedItem.tsx
@@ -43,6 +43,23 @@ function TicketArtifact({ ticket, className }: { ticket: string; className: stri
     : <span className={className} title={`Created ticket ${label}`}><Icon name="plus" size={10} /> {label}</span>
 }
 
+export interface AttentionReceiptProps {
+  state: string
+  source?: string
+  question?: string
+}
+
+/** Compact chronological proof that an attention item was resolved. */
+export function AttentionReceipt({ state, source, question }: AttentionReceiptProps) {
+  return (
+    <div className="receipt" data-testid="attention-receipt">
+      <span>{state}</span>
+      {source && <span className="pill" data-testid="attention-source">{source}</span>}
+      {question && <span className="summary">{firstLine(question)}</span>}
+    </div>
+  )
+}
+
 // Reply callbacks are agent-scoped (they take the FloorAgent, not a pre-bound closure)
 // so the caller can pass the SAME stable function reference to every row. That is what
 // lets React.memo(FeedItem) skip re-rendering unchanged rows — an inline `(o) => f(a, o)`
@@ -312,7 +329,7 @@ function FeedItemImpl({ agent: a, selected, plain, error, onSelect, onOption, on
         </div>
       )}
       {!a.needs && a.attentionState && a.attentionState !== 'open' && (
-        <div className="receipt" data-testid="attention-receipt">{a.attentionState}</div>
+        <AttentionReceipt state={a.attentionState} source={a.attentionSource} />
       )}
       {/* Contextual follow-up: an agent that isn't working (idle or done) and isn't
           already asking for you is ready for the next task. Queue one right on its row,

--- a/apps/ext/ui/settings/components/mission-control/SavedViewsBar.tsx
+++ b/apps/ext/ui/settings/components/mission-control/SavedViewsBar.tsx
@@ -48,6 +48,7 @@ interface SavedViewsProps {
     availableAbbrs: AgentAbbr[]
     onToggleAbbr: (a: AgentAbbr) => void
     showBackground: boolean
+    openAttentionCount?: number
     onToggleBackground: () => void
   }
 }
@@ -151,7 +152,7 @@ export function SavedViews({
                 title={on ? `Clear ${o.label} filter` : `Filter: ${o.label}`}
                 onClick={() => feedFilters.onToggleStatus(o.value)}
               >
-                {o.label}
+                {o.label}{o.value === 'needs' && feedFilters.openAttentionCount !== undefined ? ` · ${feedFilters.openAttentionCount}` : ''}
               </span>
             )
           })}

--- a/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.poll.test.ts
+++ b/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.poll.test.ts
@@ -97,7 +97,7 @@ describe('Floor poll / timer budget (no recurring probes)', () => {
   })
 })
 
-test('renders a single waiting question through the pane question-cluster path', () => {
+test('does not derive a Needs-You question from local tool calls', () => {
   const now = Date.now()
   const terminal: TerminalDetail = {
     id: 'terminal-1',
@@ -138,7 +138,7 @@ test('renders a single waiting question through the pane question-cluster path',
     onSearch: () => {},
   }))
 
-  expect(html).toContain('Drop the old table?')
-  expect(html).toContain('Drop it')
-  expect(html).toContain('Keep it')
+  expect(html).not.toContain('Drop the old table?')
+  expect(html).not.toContain('Drop it')
+  expect(html).not.toContain('Keep it')
 })

--- a/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -30,7 +30,7 @@ import { FloorRail } from './FloorRail'
 import { FloorSubtabs, openTaskTab, closeTaskTab, type FixedTab, type TaskTab } from './FloorSubtabs'
 import { BacklogCenter } from './BacklogCenter'
 import { PrBoardPane } from './PrBoardPane'
-import { buildPrBoard, collectPrUrls, type PrStatusLike } from './prBoardModel'
+import { buildPrBoard, type PrStatusLike } from './prBoardModel'
 import { RecapPane } from './RecapPane'
 import { buildRecap, type RecapForkEdge } from './recapModel'
 import { TaskDetail } from '../bench/TaskDetail'
@@ -663,9 +663,6 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // Recent (historical) sessions per host, fetched lazily only when a host filter has
   // 0 live agents — so an empty host shows recent work instead of a blank pane.
   const [recentByHost, setRecentByHost] = useState<Record<string, RemoteSessionLike[]>>({})
-  // PR board: statuses for every PR URL the live feed carries. null = not fetched
-  // yet (the gh fan-out runs lazily when the PRs center opens).
-  const [prStatuses, setPrStatuses] = useState<PrStatusLike[] | null>(null)
   const [prMerging, setPrMerging] = useState<Set<string>>(() => new Set())
   const [prErrors, setPrErrors] = useState<Record<string, string>>({})
   // Recap ledger: fleet-wide recent (ended) sessions. null = not fetched yet — the
@@ -861,15 +858,10 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         const rh = typeof msg.host === 'string' ? msg.host : ''
         const recent = Array.isArray(msg.sessions) ? (msg.sessions as RemoteSessionLike[]) : []
         setRecentByHost((p) => ({ ...p, [rh]: recent }))
-      } else if (msg?.type === 'prBoard') {
-        setPrStatuses(Array.isArray(msg.statuses) ? (msg.statuses as PrStatusLike[]) : [])
       } else if (msg?.type === 'mergePrResult') {
         const mu = typeof msg.url === 'string' ? msg.url : ''
         setPrMerging((prev) => { const next = new Set(prev); next.delete(mu); return next })
-        if (msg.ok === true) {
-          // Merged: refetch so the row settles (and any dependent rows update).
-          setPrStatuses(null)
-        } else {
+        if (msg.ok !== true) {
           setPrErrors((prev) => ({ ...prev, [mu]: typeof msg.error === 'string' ? msg.error : 'merge failed' }))
         }
       } else if (msg?.type === 'recapSessions') {
@@ -1528,8 +1520,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // Local agents (drop the synthetic watchdog row) + genuinely-remote sessions
   // (host !== 'this-mac' so we don't double count this machine's own agents).
   const floorLocalAgents = useMemo(
-    () => adaptUnified(items.filter((i) => i.kind !== 'watchdog'), { pinned, workspaceRepo: workspaceRepoName, nowMs, localHostName, projectRules }),
-    [items, pinned, workspaceRepoName, nowMs, localHostName, projectRules]
+    () => adaptUnified(items.filter((i) => i.kind !== 'watchdog'), { pinned, workspaceRepo: workspaceRepoName, nowMs, localHostName, projectRules, projectedSessions: remoteSessions }),
+    [items, pinned, workspaceRepoName, nowMs, localHostName, projectRules, remoteSessions]
   )
   // Session UUIDs already open as a terminal tab in THIS window (the rich, local
   // source). Used to avoid double-listing an agent that the machine-wide fetch also
@@ -1599,14 +1591,12 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     [hostFilter, hostHasNoActive, recentByHost, pinned, localHostName, projectRules]
   )
 
-  // PR board: lazy gh fan-out over the live feed's PR URLs on first open of the
-  // PRs center (and again after a merge clears prStatuses back to null).
-  useEffect(() => {
-    if (center === 'prs' && prStatuses === null) {
-      postMessage({ type: 'fetchPrBoard', urls: collectPrUrls(floorAgents) })
-    }
-  }, [center, prStatuses, floorAgents])
-  const prRows = useMemo(() => buildPrBoard(prStatuses ?? [], floorAgents), [prStatuses, floorAgents])
+  // PR status is part of the CLI feed projection; the extension never polls GitHub.
+  const projectedPrStatuses = useMemo(
+    () => remoteSessions.map((session) => session.pullRequest).filter((status): status is PrStatusLike => !!status),
+    [remoteSessions],
+  )
+  const prRows = useMemo(() => buildPrBoard(projectedPrStatuses, floorAgents), [projectedPrStatuses, floorAgents])
   // Recap ledger: lazy fleet sweep the first time the Recap center opens; live
   // sessions are excluded (the feed owns what's running, the ledger what finished).
   useEffect(() => {
@@ -2076,8 +2066,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     // Recap count = today's finished sessions (0 until the lazy sweep has run).
     { center: 'recap', label: 'Recap', count: recapDays[0]?.label === 'Today' ? recapDays[0].sessions : 0 },
     // PRs count = open rows once fetched; before the first fetch, the URL count.
-    { center: 'prs', label: 'PRs', count: prStatuses === null ? collectPrUrls(floorAgents).length : prRows.filter((r) => r.state === 'open').length },
-  ], [floorAgents, needsAgents.length, floorTickets.length, managedProjects.length, fleetDevices.length, recapDays, prStatuses, prRows])
+    { center: 'prs', label: 'PRs', count: prRows.filter((r) => r.state === 'open').length },
+  ], [floorAgents, needsAgents.length, floorTickets.length, managedProjects.length, fleetDevices.length, recapDays, prRows])
 
   // Resolve the active task tab (if any) back to a bench FlatTask so its detail renders.
   const activeTab = activeTaskTab ? openTaskTabs.find((t) => t.id === activeTaskTab) ?? null : null
@@ -2144,7 +2134,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   ) : center === 'prs' ? (
     <PrBoardPane
       rows={prRows}
-      loading={prStatuses === null}
+      loading={false}
       merging={prMerging}
       errors={prErrors}
       onMerge={(url) => {
@@ -2153,7 +2143,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         postMessage({ type: 'mergePr', url })
       }}
       onOpenUrl={(url) => postMessage({ type: 'openExternal', url })}
-      onRefresh={() => setPrStatuses(null)}
+      onRefresh={() => {}}
       onSelectAgent={selectFloorAgent}
     />
   ) : (
@@ -2179,6 +2169,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
             cur.includes(a) ? cur.filter((c) => c !== a) : [...cur, a]
           )),
           showBackground,
+          openAttentionCount: needsAgents.length,
           onToggleBackground: () => setShowBackground((current) => !current),
         }}
       />

--- a/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -38,7 +38,7 @@ import type { FlatTask } from '../bench/TaskCard'
 import { TicketDetail } from './TicketDetail'
 import { HostDetail } from './HostDetail'
 import { ProjectsPane } from './ProjectsPane'
-import { FeedItem, FollowUpBox } from './FeedItem'
+import { AttentionReceipt, FeedItem, FollowUpBox } from './FeedItem'
 import { SessionsPane } from './SessionsPane'
 import { NeedsYouClusters } from './NeedsYouClusters'
 import { AgentDecision } from './AgentDecision'
@@ -736,6 +736,13 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   }, [])
 
   const [remoteSessions, setRemoteSessions] = useState<RemoteSessionLike[]>([])
+  const [feedActivity, setFeedActivity] = useState<Array<{
+    type?: string
+    key?: string
+    state?: string
+    source?: string
+    question?: string | { text?: string }
+  }>>([])
   const [offlineHosts, setOfflineHosts] = useState<string[]>([])
   // Per-agent reply failures (host 'replyResult' with ok=false, or a 'none' channel),
   // shown inline near the reply control instead of a toast. Cleared on the next send.
@@ -818,6 +825,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
           return
         }
         setRemoteSessions(Array.isArray(msg.sessions) ? (msg.sessions as RemoteSessionLike[]) : [])
+        if (Array.isArray(msg.activity)) setFeedActivity(msg.activity)
         const roster = Array.isArray(msg.hosts)
           ? (msg.hosts as Array<{ name: string; online: boolean }>)
               .filter((h) => h && typeof h.name === 'string')
@@ -852,6 +860,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
           return
         }
         setRemoteSessions((prev) => [...prev.filter((s) => s.host !== 'this-mac'), ...local])
+        if (Array.isArray(msg.activity)) setFeedActivity(msg.activity)
         setLastLocalSync(typeof msg.fetchedAt === 'number' ? msg.fetchedAt : Date.now())
         if (typeof msg.cliAvailable === 'boolean') setCliUnavailable(!msg.cliAvailable)
       } else if (msg?.type === 'recentSessions') {
@@ -2232,6 +2241,21 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onOpenAttachment={openAttachmentPreview}
               onOpenTerminal={openTerminalForAgent}
             />
+          ))}
+        </>
+      )}
+
+      {feedActivity.some((event) => event.type === 'attention.receipt') && (
+        <>
+          <div className="feed-sec">ACTIVITY<span className="ln" /></div>
+          {feedActivity.filter((event) => event.type === 'attention.receipt').map((event, index) => (
+            <div className="fitem" key={event.key ?? `attention-receipt-${index}`}>
+              <AttentionReceipt
+                state={event.state ?? 'resolved'}
+                source={event.source}
+                question={typeof event.question === 'string' ? event.question : event.question?.text}
+              />
+            </div>
           ))}
         </>
       )}

--- a/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/ext/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -815,6 +815,10 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         })
         return
       }
+      if (msg?.type === 'feedActivity') {
+        if (Array.isArray(msg.activity)) setFeedActivity(msg.activity)
+        return
+      }
       if (msg?.type === 'hostSessions') {
         const failed = msg.ok === false || typeof msg.error === 'string'
         if (failed) {

--- a/apps/ext/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/ext/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -141,12 +141,14 @@ describe('toFloorAgentFromUnified', () => {
         agent: null,
         // last response is a real choice question
       }),
-      { pinned: new Set(), workspaceRepo: 'swarmify', nowMs: NOW },
+      { pinned: new Set(), workspaceRepo: 'swarmify', nowMs: NOW, projectedSessions: [{ host: 'this-mac', terminalId: 't1', sessionId: 's1', phase: 'waiting', agentType: 'claude', attention: { key: 'a1', sessionId: 's1', kind: 'question', source: 'hook', state: 'open', openedAt: '2026-08-23T00:00:00Z', fingerprint: 'exact-fingerprint', question: { text: 'Which path?', options: [{ label: 'A', id: 'a' }, { label: 'B', id: 'b' }] } } } as RemoteSessionLike] },
     )
     // no agent.last_messages, so resp is empty (the now-line, not the body, carries the
     // live activity); phase is waiting from the flag; needs is still true.
     expect(a.phase).toBe('waiting')
     expect(a.needs).toBe(true)
+    expect(a.question?.clusterKey).toBe('exact-fingerprint')
+    expect(a.attentionSource).toBe('hook')
     expect(a.host).toBe('this-mac')
     expect(a.abbr).toBe('CC')
   })
@@ -224,14 +226,14 @@ describe('toFloorAgentFromUnified', () => {
     expect(noName.hostLabel).toBeUndefined()
   })
 
-  test('a failed agent needs you and gets a retry question', () => {
+  test('a failed agent does not invent attention or a retry question', () => {
     const a = toFloorAgentFromUnified(
       baseUnified({ status: 'failed', active: false, activity: 'build broke' }),
       { pinned: new Set(), workspaceRepo: null, nowMs: NOW },
     )
     expect(a.phase).toBe('failed')
-    expect(a.needs).toBe(true)
-    expect(a.question?.kind).toBe('retry')
+    expect(a.needs).toBe(false)
+    expect(a.question).toBeNull()
   })
 
   test('a running agent does not need you', () => {
@@ -244,18 +246,18 @@ describe('toFloorAgentFromUnified', () => {
     expect(a.lastActivityMs).toBe(NOW - 5000)
   })
 
-  test('a completed agent with an open PR is done + unreviewed (needs you)', () => {
+  test('a completed agent with an open PR does not derive needs-you', () => {
     const a = toFloorAgentFromUnified(
       baseUnified({ status: 'completed', active: false, prUrl: 'https://github.com/o/r/pull/9' }),
       { pinned: new Set(['term-1']), workspaceRepo: null, nowMs: NOW },
     )
     expect(a.phase).toBe('done')
-    expect(a.needs).toBe(true)
+    expect(a.needs).toBe(false)
     expect(a.pr).toBe('#9')
     expect(a.pinned).toBe(true)
   })
 
-  test('a headless agent parses its last message into a structured choice question', () => {
+  test('a headless agent does not parse its last message into a question', () => {
     const a = toFloorAgentFromUnified(
       baseUnified({
         id: 'agent-x',
@@ -275,8 +277,8 @@ describe('toFloorAgentFromUnified', () => {
     expect(a.phase).toBe('waiting')
     expect(a.project).toBe('prix-api')
     expect(a.branch).toBe('feat-rl')
-    expect(a.question?.kind).toBe('choice')
-    expect(a.question?.options.length).toBeGreaterThanOrEqual(2)
+    expect(a.needs).toBe(false)
+    expect(a.question).toBeNull()
   })
 
   test('maps the ORIGINAL task (terminal firstUserMessage) into prompt, distinct from the last message', () => {
@@ -412,6 +414,7 @@ describe('toFloorAgentFromRemote', () => {
       replyRail: '',
       replyMuxTarget: '',
       replyMuxSocket: '',
+      attention: { key: 'a2', sessionId: 'abcd1234efgh', kind: 'question', source: 'lifecycle', state: 'open', openedAt: '2026-08-23T00:00:00Z', fingerprint: 'remote-fingerprint', question: { text: 'Merge the green PR?', options: [{ label: 'Merge', id: 'merge' }, { label: 'Wait', id: 'wait' }] } },
     }
     const a = toFloorAgentFromRemote(r, new Set())
     expect(a.host).toBe('yosemite-s0')
@@ -424,7 +427,8 @@ describe('toFloorAgentFromRemote', () => {
     expect(a.ticket).toBe('RUSH-812')
     expect(a.createdTickets).toEqual(['RUSH-901'])
     expect(a.spawnedTeam).toBe('rate-limiter')
-    expect(a.question?.kind).toBe('confirm')
+    expect(a.question?.kind).toBe('choice')
+    expect(a.question?.clusterKey).toBe('remote-fingerprint')
     // No lastActivityMs on the payload → heartbeat falls back to session-start.
     expect(a.lastActivityMs).toBe(NOW - 42_000)
     // a genuinely-remote host is already its real name — no display override.

--- a/apps/ext/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/ext/ui/settings/components/mission-control/floorAdapter.ts
@@ -1,7 +1,7 @@
 // SHELL adapter: real UnifiedAgent / RemoteSession / UnifiedTask -> Floor view-model.
 //
 // The view-model TYPES are owned by floorModel.ts (the shared webview contract) and
-// the pure derivations (derivePhase / deriveNeeds / parseStructuredQuestion /
+// the pure lifecycle projection and presentation helpers
 // toFloorTicket) live there too — this file only translates the real data shapes into
 // the inputs those functions expect. No logic is reimplemented here.
 //
@@ -13,10 +13,6 @@
 
 import {
   derivePhase,
-  deriveNeeds,
-  parseStructuredQuestion,
-  structuredQuestionFromToolCalls,
-  structuredQuestionFromRemote,
   toFloorTicket,
   latestTodos,
   todosWithFallback,
@@ -121,6 +117,7 @@ export interface UnifiedAgentLike {
 export interface RemoteSessionLike {
   host: string
   sessionId: string
+  terminalId?: string
   agentType: string
   cwd: string
   project: string
@@ -136,10 +133,16 @@ export interface RemoteSessionLike {
   tokPerSec: number
   waitingForInput: boolean
   lastResponse: string
-  /** The structured decision the agent is waiting on (question/plan/permission +
-   *  options + select keys), from the CLI state engine. null when the CLI supplied
-   *  none — the adapter then falls back to parsing lastResponse. */
+  /** Legacy session question retained for transport compatibility; streamed rows
+   * render only the canonical `attention` record below. */
   question?: { text: string; reason: 'question' | 'plan_review' | 'permission'; options: Array<{ label: string; description?: string; key?: string }> } | null
+  attention?: {
+    key: string; sessionId: string; kind: 'question' | 'permission' | 'plan_review' | 'declared' | 'failure' | 'stall' | 'review'
+    source: 'hook' | 'declared' | 'lifecycle' | 'heuristic' | 'system'
+    state: 'open' | 'answered' | 'consumed' | 'continued' | 'resolved'; openedAt: string; fingerprint: string
+    question?: { text?: string; options?: Array<{ label?: string; description?: string; id?: string; deliveryKey?: string }> }
+  }
+  pullRequest?: import('./prBoardModel').PrStatusLike
   /** Last few assistant turns (most-recent last) — panel context. */
   tail?: string[]
   /** Live plan checklist from the CLI's latest `TodoWrite` (RUSH-1380). Populates the
@@ -450,14 +453,32 @@ export function deriveReplyTargetFromRemote(r: RemoteSessionLike): ReplyTarget {
 // ---------- adapters ----------
 
 /**
- * Map a local UnifiedAgent to a FloorAgent. waiting comes from the terminal's
- * waitingForInput flag or a headless agent's input_required status; an open PR marks a
- * done agent unreviewed (needs-you). Phase + needs are derived by floorModel, not here.
+ * Map a local editor tab to the CLI-projected agent with the same session/terminal id.
+ * The terminal contributes only editor-owned display, reply, and recent-tool metadata.
  */
 export function toFloorAgentFromUnified(
   u: UnifiedAgentLike,
-  opts: { pinned: Set<string>; workspaceRepo?: string | null; nowMs: number; localHostName?: string; projectRules?: ProjectRule[] },
+  opts: { pinned: Set<string>; workspaceRepo?: string | null; nowMs: number; localHostName?: string; projectRules?: ProjectRule[]; projectedSessions?: RemoteSessionLike[] },
 ): FloorAgent {
+  const projected = opts.projectedSessions?.find((r) =>
+    (!!u.sessionId && r.sessionId === u.sessionId) || (!!u.terminal?.id && r.terminalId === u.terminal.id))
+  if (projected) {
+    const floor = toFloorAgentFromRemote({ ...projected, host: 'this-mac' }, opts.pinned, opts.localHostName, opts.projectRules)
+    return {
+      ...floor,
+      id: u.id,
+      name: u.displayName,
+      host: 'this-mac',
+      hostLabel: opts.localHostName || undefined,
+      reply: u.terminal?.id
+        ? { kind: 'terminal', host: 'this-mac', terminalId: u.terminal.id }
+        : floor.reply,
+      files: u.files.length,
+      tools: u.toolCalls,
+      recent: u.terminal?.recentToolCalls ?? [],
+      recentEvents: u.terminal?.recentEvents ?? [],
+    }
+  }
   const waitingForInput = u.terminal?.waitingForInput === true || u.agent?.status === 'input_required'
   const prOpenUnreviewed = !!u.prUrl
   const ci = u.ci ?? null
@@ -467,7 +488,8 @@ export function toFloorAgentFromUnified(
     active: u.active,
     prOpenUnreviewed,
   })
-  const needs = deriveNeeds(phase, prOpenUnreviewed, ci)
+  const attention: RemoteSessionLike['attention'] = undefined
+  const needs = false
   const lastMsgs = u.agent?.last_messages
   // The full recent-messages window (up to the CLI's last N) drives the detail Activity
   // feed; the single last one still feeds `resp` (card body / question parsing).
@@ -535,9 +557,11 @@ export function toFloorAgentFromUnified(
     // The Sessions surface's row title: the task line, falling back to the tab name.
     topic: prompt || u.displayName,
     messages,
-    // Prefer the AskUserQuestion tool-call's own question + options (they live in the
-    // tool INPUT, invisible to the text heuristic); fall back to parsing the last message.
-    question: structuredQuestionFromToolCalls(u.terminal?.recentToolCalls) ?? parseStructuredQuestion(resp, phase),
+    // A tab without a matching feed projection never invents a decision.
+    question: structuredQuestionFromAttention(attention),
+    attentionSource: attention?.source,
+    attentionState: attention?.state,
+    attentionFingerprint: attention?.fingerprint,
     reply,
     // Persist the last non-empty checklist so it survives the recent-tool window cap.
     todos: stickyTodos(u.id, u.terminal?.recentToolCalls),
@@ -573,14 +597,13 @@ export function detectSessionRateLimited(
 
 /**
  * Map a cross-host RemoteSession to a FloorAgent. The backend already normalized the
- * phase + activity + throughput, so we trust those and only re-derive needs + the
- * structured question (both pure). Host stays the remote machine name.
+ * phase, activity, throughput, and attention, so this is presentation-only.
  */
 export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>, localHostName?: string, projectRules: ProjectRule[] = []): FloorAgent {
   const phase = r.phase
   const prOpenUnreviewed = !!r.prUrl
   const ci = r.ci ?? null
-  const needs = deriveNeeds(phase, prOpenUnreviewed, ci)
+  const needs = r.attention?.state === 'open'
   let { verb, target } = splitActivity(r.activity)
   // Live plan progress from the CLI (RUSH-1380): map to the checklist the UI renders,
   // and — when there's no live tool action (idle/waiting/no preview) but a plan is in
@@ -672,9 +695,11 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     // Prefer the last few assistant turns from the CLI (context feed); fall back to the
     // single last response when the CLI supplied no tail.
     messages: r.tail && r.tail.length ? r.tail : r.lastResponse ? [r.lastResponse] : [],
-    // Prefer the CLI's authoritative decision (real options + select keys, extracted at
-    // the source); fall back to parsing the last response for a plain prose question.
-    question: structuredQuestionFromRemote(r.question) ?? parseStructuredQuestion(resp, phase),
+    // Exact CLI-projected attention; no transcript, tool-call, or prose parsing.
+    question: structuredQuestionFromAttention(r.attention),
+    attentionSource: r.attention?.source,
+    attentionState: r.attention?.state,
+    attentionFingerprint: r.attention?.fingerprint,
     reply: deriveReplyTargetFromRemote(r),
     // Live plan checklist from the CLI's TodoWrite (RUSH-1380). Empty when the session
     // wrote no todo list; the CLI now carries this for remote/device-dispatched agents.
@@ -698,9 +723,26 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
 /** Map local UnifiedAgents (watchdog rows should be filtered out by the caller). */
 export function adaptUnified(
   agents: UnifiedAgentLike[],
-  opts: { pinned: Set<string>; workspaceRepo?: string | null; nowMs: number; localHostName?: string; projectRules?: ProjectRule[] },
+  opts: { pinned: Set<string>; workspaceRepo?: string | null; nowMs: number; localHostName?: string; projectRules?: ProjectRule[]; projectedSessions?: RemoteSessionLike[] },
 ): FloorAgent[] {
   return agents.map((a) => toFloorAgentFromUnified(a, opts))
+}
+
+/** Presentation-only mapping of the CLI's canonical AttentionItem. */
+export function structuredQuestionFromAttention(attention: RemoteSessionLike['attention']): FloorAgent['question'] {
+  const text = attention?.question?.text?.trim()
+  if (!attention || !text) return null
+  const choices = attention.question?.options ?? []
+  const options = choices.map((o) => o.label?.trim() ?? '').filter(Boolean)
+  const reason = attention.kind === 'permission' ? 'permission' : attention.kind === 'plan_review' ? 'plan_review' : 'question'
+  return {
+    kind: options.length > 1 ? 'choice' : attention.kind === 'permission' ? 'confirm' : 'retry',
+    text,
+    options,
+    optionKeys: choices.map((o) => o.deliveryKey ?? o.id ?? ''),
+    clusterKey: attention.fingerprint,
+    reason,
+  }
 }
 
 /** Map genuinely-remote sessions (caller drops host === 'this-mac' to avoid double count). */

--- a/apps/ext/ui/settings/components/mission-control/floorModel.fixes.test.ts
+++ b/apps/ext/ui/settings/components/mission-control/floorModel.fixes.test.ts
@@ -85,6 +85,7 @@ describe('wiring guard — infra must stay wired (issue 5 was dead code)', () =>
   // groupAgents + sessionTaskLine both existed unused once; assert their production
   // consumer still imports them so they can't silently become dead again.
   const pane = fs.readFileSync(path.join(__dirname, 'UnifiedAgentsPane.tsx'), 'utf8')
+  const settingsHost = fs.readFileSync(path.join(__dirname, '../../../../src/vscode/settings.vscode.ts'), 'utf8')
   test('UnifiedAgentsPane wires groupAgents (the Group-by control)', () => {
     expect(pane).toContain('groupAgents(')
   })
@@ -101,5 +102,10 @@ describe('wiring guard — infra must stay wired (issue 5 was dead code)', () =>
     expect(idleAt).toBeGreaterThan(-1)
     expect(runningAt).toBeGreaterThan(-1)
     expect(idleAt).toBeLessThan(runningAt)
+  })
+  test('live feed refresh projects resolution receipts into the chronological activity lane', () => {
+    expect(settingsHost).toContain("type: 'feedActivity', activity: sessionPresentationStore.activityEvents()")
+    expect(pane).toContain("msg?.type === 'feedActivity'")
+    expect(pane).toContain("event.type === 'attention.receipt'")
   })
 })

--- a/apps/ext/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/ext/ui/settings/components/mission-control/floorModel.ts
@@ -172,6 +172,9 @@ export interface FloorAgent {
   topic?: string         // the session's task/label line from the roster (topic/label/prompt). The Sessions surface's row title + search field. Falls back to prompt/name when absent.
   messages: string[]     // the last few assistant messages (from the CLI's last_messages window); [] when none. Drives the detail-pane Activity feed.
   question: StructuredQuestion | null
+  attentionSource?: 'hook' | 'declared' | 'lifecycle' | 'heuristic' | 'system'
+  attentionState?: 'open' | 'answered' | 'consumed' | 'continued' | 'resolved'
+  attentionFingerprint?: string
   reply: ReplyTarget     // how a user reply reaches this agent (host dispatches on kind)
   todos: TodoItem[]      // task checklist from the latest TodoWrite; empty when none
   summary: string        // the "what is it doing" line (CLI-provided); '' when unknown


### PR DESCRIPTION
AGI EXT projects the CLI feed's canonical attention state instead of deriving Needs You.

## What changed

- `apps/ext/src/monitor/sessionCliStream.ts:99` launches `agents feed watch --json`; lines 113-118 accept the planned `v` envelope through a clearly marked `version` adapter seam.
- `apps/ext/src/core/sessionPresentationStore.ts:17-44` projects agent, attention, resolution, and activity envelopes; lines 51-60 join attention by session id.
- `apps/ext/ui/settings/components/mission-control/floorAdapter.ts:463-480` joins local tabs to projected agents by session/terminal id; lines 607-608 and 699-704 map `needs` and structured questions only from projected attention.
- `apps/ext/ui/settings/components/mission-control/FeedItem.tsx:211` renders the source chip; lines 314-316 render the compact resolution receipt.
- `apps/ext/src/vscode/prBoard.vscode.ts:1-7` retains only PR mutation; status comes from the projected feed signal.

## Headless verification

- `cd apps/ext && bun run compile:ext` — passed.
- `cd apps/ext/ui && bun test` — `472 pass, 0 fail, 1088 expect() calls`.
- Track C extension tests — `10 pass, 0 fail, 20 expect() calls`.
- Adapter/render regressions — `82 pass, 0 fail, 200 expect() calls`.
- Full `cd apps/ext && bun test` — `1632 pass`; remaining failures are worker-sandbox process probes (`posix_spawn ps: EPERM` / shellReady timeouts), while the Track C tests above pass headlessly.

## Visual evidence

No screenshot produced: validation was intentionally headless and the approved change preserves the existing Floor layout.
