### PR TITLE
fix(browser): profiles rename must repoint browser.viewer, not just browser.profile

### DIFF
--- a/apps/cli/.changelog/next/RUSH-browser-profiles-rename.md
+++ b/apps/cli/.changelog/next/RUSH-browser-profiles-rename.md
@@ -8,7 +8,12 @@
   store it already lives in), moves every cache dir belonging to the old name, and
   repoints both `browser.profile` and `browser.viewer` when either pointed there — a dangling `browser.viewer` sends every artifact back to the OS default handler, which is the exact bug the viewer seam was built to fix. Refuses while the profile is in
   use, because moving a `--user-data-dir` out from under a running browser
-  corrupts it. Source: `src/lib/browser/profiles.ts`, `src/commands/browser.ts`.
+  corrupts it; refuses when the name exists in BOTH stores, since rewriting one
+  would leave the other listed under the old name with its data already moved
+  away; and validates every destination BEFORE moving any of them, so a
+  collision on the second endpoint cannot strand the first one's logins under a
+  name with no config entry. `os` joins `default` as a name a profile may not
+  take — it is the reserved `browser.viewer` value meaning the OS handler. Source: `src/lib/browser/profiles.ts`, `src/commands/browser.ts`.
 - **Profile-name validation is shared between `create` and `rename`.** The shape
   rule lived inline in `profiles create`, so a second caller would have accepted
   names `create` rejects. Now `assertRegistrableProfileName`, which also refuses

--- a/apps/cli/.changelog/next/RUSH-browser-profiles-rename.md
+++ b/apps/cli/.changelog/next/RUSH-browser-profiles-rename.md
@@ -6,7 +6,7 @@
   live. On a real agent browser that is gigabytes of session state and every
   account it has ever signed into. `rename` moves the config (staying in whichever
   store it already lives in), moves every cache dir belonging to the old name, and
-  repoints `browser.profile` when it pointed there. Refuses while the profile is in
+  repoints both `browser.profile` and `browser.viewer` when either pointed there — a dangling `browser.viewer` sends every artifact back to the OS default handler, which is the exact bug the viewer seam was built to fix. Refuses while the profile is in
   use, because moving a `--user-data-dir` out from under a running browser
   corrupts it. Source: `src/lib/browser/profiles.ts`, `src/commands/browser.ts`.
 - **Profile-name validation is shared between `create` and `rename`.** The shape

--- a/apps/cli/src/commands/browser.ts
+++ b/apps/cli/src/commands/browser.ts
@@ -659,6 +659,17 @@ function registerProfilesCommands(browser: Command): void {
       if (res.repointedViewer) {
         console.log(`  browser.viewer now points at ${to}`);
       }
+      if (res.stalePins.length > 0) {
+        const devices = [...new Set(res.stalePins.map((p) => p.device))];
+        const one = devices.length === 1;
+        console.error(
+          `warning: ${devices.join(', ')} still ${one ? 'pins' : 'pin'} "${from}" in ` +
+            `${one ? 'its' : 'their'} own device config. Fix with:`,
+        );
+        for (const pin of res.stalePins) {
+          console.error(`  agents config set ${pin.key} ${to} --device ${pin.device}`);
+        }
+      }
     });
 
   profiles

--- a/apps/cli/src/commands/browser.ts
+++ b/apps/cli/src/commands/browser.ts
@@ -656,6 +656,9 @@ function registerProfilesCommands(browser: Command): void {
       if (res.repointedDefault) {
         console.log(`  browser.profile now points at ${to}`);
       }
+      if (res.repointedViewer) {
+        console.log(`  browser.viewer now points at ${to}`);
+      }
     });
 
   profiles

--- a/apps/cli/src/lib/browser/profiles.test.ts
+++ b/apps/cli/src/lib/browser/profiles.test.ts
@@ -1448,6 +1448,22 @@ describe('renameProfile', () => {
     expect(store.browser!['comet-local']).toBeUndefined();
   });
 
+  it('repoints browser.profile, or the next browser start falls back to auto-detect', async () => {
+    // #2962 added two tests for browser.viewer while the sibling repoint three
+    // lines up had none — deleting it broke nothing.
+    const store: ProfileStore = {
+      browser: { old: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9540'] } },
+    };
+    wire(store);
+    const { setConfigValue, getConfigValue } = await import('../device-config.js');
+    setConfigValue('browser.profile', 'old');
+
+    const res = await renameProfile('old', 'fresh');
+
+    expect(res.repointedDefault).toBe(true);
+    expect(getConfigValue('browser.profile').value).toBe('fresh');
+  });
+
   it('repoints browser.viewer too, or artifacts silently go back to the OS browser', async () => {
     // The gap this closes: `browser.viewer` is a separate key from
     // `browser.profile`. Left dangling, resolveViewer falls back to the OS
@@ -1481,6 +1497,74 @@ describe('renameProfile', () => {
 
     expect(res.repointedViewer).toBe(false);
     expect(getConfigValue('browser.viewer').value).toBe('other');
+  });
+
+  it('refuses while the profile is in use, so a live browser keeps its data dir', async () => {
+    // The guard that prevents actual corruption, and it had no test: moving a
+    // --user-data-dir out from under a running browser corrupts it. Driven
+    // through the real isProfileInUse, which counts a profile in use when its
+    // tasks.json is non-empty.
+    const store: ProfileStore = {
+      browser: { live: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9534'] } },
+    };
+    wire(store);
+    const { getBrowserRuntimeDir } = await import('./profiles.js');
+    const dir = path.join(getBrowserRuntimeDir(), 'live@endpoint-0');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'Cookies'), 'live-session');
+    fs.writeFileSync(path.join(dir, 'tasks.json'), JSON.stringify(['a-running-task']));
+
+    await expect(renameProfile('live', 'renamed')).rejects.toThrow(/in use/);
+
+    // Nothing moved, config untouched.
+    expect(fs.readFileSync(path.join(dir, 'Cookies'), 'utf8')).toBe('live-session');
+    expect(store.browser!.live).toBeDefined();
+  });
+
+  it('moves NOTHING when any destination dir is taken', async () => {
+    // The stranding bug: the dest check used to sit inside the move loop, so
+    // dir N was validated only after dirs 0..N-1 had moved. A collision on the
+    // second endpoint left the first one's logins under a name with no config
+    // entry, and the error named only the squatter.
+    const store: ProfileStore = {
+      browser: { multi: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9530'] } },
+    };
+    wire(store);
+    const { getBrowserRuntimeDir } = await import('./profiles.js');
+    const root = getBrowserRuntimeDir();
+    for (const d of ['multi@endpoint-0', 'multi@endpoint-1', 'target@endpoint-1']) {
+      fs.mkdirSync(path.join(root, d), { recursive: true });
+    }
+    fs.writeFileSync(path.join(root, 'multi@endpoint-0', 'Cookies'), 'keep-me');
+
+    await expect(renameProfile('multi', 'target')).rejects.toThrow(/Nothing was moved/);
+
+    // The first dir must still be where it started, with its data.
+    expect(fs.readFileSync(path.join(root, 'multi@endpoint-0', 'Cookies'), 'utf8')).toBe('keep-me');
+    expect(fs.existsSync(path.join(root, 'target@endpoint-0'))).toBe(false);
+    expect(store.browser!.multi).toBeDefined();
+  });
+
+  it('refuses a name that exists in BOTH stores rather than orphaning one', async () => {
+    // Rewriting one store while moving the data leaves the other listed under
+    // the old name with its dir gone — the exact state this command prevents,
+    // produced by this command.
+    const store: ProfileStore = {
+      browser: { dup: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9531'] } },
+      deviceBrowser: { dup: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9532'] } },
+    };
+    wire(store);
+    await expect(renameProfile('dup', 'fresh')).rejects.toThrow(/BOTH/);
+    expect(store.browser!.dup).toBeDefined();
+    expect(store.deviceBrowser!.dup).toBeDefined();
+  });
+
+  it('refuses `os`, the reserved browser.viewer value', async () => {
+    const store: ProfileStore = {
+      browser: { a: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9533'] } },
+    };
+    wire(store);
+    await expect(renameProfile('a', 'os')).rejects.toThrow(/reserved browser\.viewer value/);
   });
 
   it('keeps a local profile local', async () => {

--- a/apps/cli/src/lib/browser/profiles.test.ts
+++ b/apps/cli/src/lib/browser/profiles.test.ts
@@ -1559,6 +1559,28 @@ describe('renameProfile', () => {
     expect(store.deviceBrowser!.dup).toBeDefined();
   });
 
+  it('the escape command the dual-store error names actually works', async () => {
+    // The error used to say `scope <name> local`, which is a NO-OP in exactly
+    // this state: moveProfileScope computes from='local' whenever a local entry
+    // exists, so from === to short-circuits and reports success. A user whose
+    // first instruction silently does nothing takes the second one — and
+    // `profiles delete` drops the cached runtime dirs by default. This asserts
+    // the advice, not just the refusal.
+    const store: ProfileStore = {
+      browser: { dup2: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9535'] } },
+      deviceBrowser: { dup2: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9536'] } },
+    };
+    wire(store);
+
+    const err = await renameProfile('dup2', 'fresh2').catch((e) => e as Error);
+    expect(err.message).toContain('profiles scope dup2 fleet');
+
+    // Follow it literally, then retry.
+    await moveProfileScope('dup2', 'fleet');
+    expect(store.deviceBrowser?.dup2).toBeUndefined();
+    await expect(renameProfile('dup2', 'fresh2')).resolves.toMatchObject({ scope: 'fleet' });
+  });
+
   it('refuses `os`, the reserved browser.viewer value', async () => {
     const store: ProfileStore = {
       browser: { a: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9533'] } },

--- a/apps/cli/src/lib/browser/profiles.test.ts
+++ b/apps/cli/src/lib/browser/profiles.test.ts
@@ -14,6 +14,9 @@ vi.mock('../state.js', () => ({
   writeMeta: vi.fn(),
   // device-config.js (the browser.profile store) reads/writes through these.
   updateMeta: vi.fn(),
+  // setConfigValue writes under this lock; the real one just runs fn() when
+  // uncontended, which is always true in a single-process test.
+  withMetaLock: vi.fn((fn: () => unknown) => fn()),
   META_HEADER: '',
   getUserAgentsDir: vi.fn(() => path.join(TEST_ROOT, '.agents')),
   getDevicesAutoLaunchPath: vi.fn(() => path.join(TEST_ROOT, 'auto-launch.json')),
@@ -1443,6 +1446,41 @@ describe('renameProfile', () => {
     expect(fs.readFileSync(path.join(newDir, 'Cookies'), 'utf8')).toBe('pretend-session');
     expect(store.browser!.agents).toBeDefined();
     expect(store.browser!['comet-local']).toBeUndefined();
+  });
+
+  it('repoints browser.viewer too, or artifacts silently go back to the OS browser', async () => {
+    // The gap this closes: `browser.viewer` is a separate key from
+    // `browser.profile`. Left dangling, resolveViewer falls back to the OS
+    // default handler — the exact bug the viewer seam was built to fix,
+    // reintroduced by a rename.
+    const store: ProfileStore = {
+      browser: { old: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9520'] } },
+    };
+    wire(store);
+    const { setConfigValue, getConfigValue } = await import('../device-config.js');
+    setConfigValue('browser.viewer', 'old');
+
+    const res = await renameProfile('old', 'fresh');
+
+    expect(res.repointedViewer).toBe(true);
+    expect(getConfigValue('browser.viewer').value).toBe('fresh');
+  });
+
+  it('leaves browser.viewer alone when it points somewhere else', async () => {
+    const store: ProfileStore = {
+      browser: {
+        old: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9521'] },
+        other: { browser: 'chrome', endpoints: ['cdp://127.0.0.1:9522'] },
+      },
+    };
+    wire(store);
+    const { setConfigValue, getConfigValue } = await import('../device-config.js');
+    setConfigValue('browser.viewer', 'other');
+
+    const res = await renameProfile('old', 'fresh');
+
+    expect(res.repointedViewer).toBe(false);
+    expect(getConfigValue('browser.viewer').value).toBe('other');
   });
 
   it('keeps a local profile local', async () => {

--- a/apps/cli/src/lib/browser/profiles.ts
+++ b/apps/cli/src/lib/browser/profiles.ts
@@ -737,7 +737,12 @@ export function assertRegistrableProfileName(name: string): void {
 export async function renameProfile(
   from: ProfileName,
   to: ProfileName,
-): Promise<{ scope: ProfileScope; movedDirs: string[]; repointedDefault: boolean }> {
+): Promise<{
+  scope: ProfileScope;
+  movedDirs: string[];
+  repointedDefault: boolean;
+  repointedViewer: boolean;
+}> {
   if (from === to) throw new Error(`"${from}" is already its own name.`);
 
   const meta = readMeta();
@@ -788,16 +793,25 @@ export async function renameProfile(
     });
   }
 
-  // The pointer is a separate key; leaving it behind would silently fall back to
-  // auto-detect on the next `browser start`.
+  // Both pointers are separate keys. Leaving `browser.profile` behind falls back
+  // to auto-detect on the next `browser start`; leaving `browser.viewer` behind
+  // sends every artifact back to the OS default handler — which is the exact bug
+  // the viewer seam was built to fix, reintroduced by a rename.
+  const { setConfigValue, getConfigValue } = await import('../device-config.js');
+
   let repointedDefault = false;
   if (getConfiguredDefaultProfileName() === from) {
-    const { setConfigValue } = await import('../device-config.js');
     setConfigValue('browser.profile', to);
     repointedDefault = true;
   }
 
-  return { scope, movedDirs, repointedDefault };
+  let repointedViewer = false;
+  if (getConfigValue('browser.viewer').value === from) {
+    setConfigValue('browser.viewer', to);
+    repointedViewer = true;
+  }
+
+  return { scope, movedDirs, repointedDefault, repointedViewer };
 }
 
 export async function moveProfileScope(

--- a/apps/cli/src/lib/browser/profiles.ts
+++ b/apps/cli/src/lib/browser/profiles.ts
@@ -719,6 +719,15 @@ export function assertRegistrableProfileName(name: string): void {
         `not a profile name. Pick another name.`,
     );
   }
+  // `browser.viewer: os` means "use the OS default handler". A profile by that
+  // name turns the opt-out into a pointer at a profile — silently, since both
+  // are just strings in the same key.
+  if (name === 'os') {
+    throw new Error(
+      `"os" is the reserved browser.viewer value meaning the OS default handler, ` +
+        `not a profile name. Pick another name.`,
+    );
+  }
 }
 
 /**
@@ -742,6 +751,8 @@ export async function renameProfile(
   movedDirs: string[];
   repointedDefault: boolean;
   repointedViewer: boolean;
+  /** Peers still pinning the OLD name, and which key each used. */
+  stalePins: Array<{ device: string; key: 'browser.profile' | 'browser.viewer' }>;
 }> {
   if (from === to) throw new Error(`"${from}" is already its own name.`);
 
@@ -761,20 +772,47 @@ export async function renameProfile(
     );
   }
 
+  // A name can exist in BOTH stores (local wins in allProfileConfigs). Rewriting
+  // only one leaves the other listed under the OLD name with its data dir already
+  // moved away — the abandoned-`--user-data-dir` state this command exists to
+  // prevent, produced by this command, and previously reported as a clean
+  // success. Refuse instead: which copy the user means is genuinely ambiguous,
+  // and `profiles scope` is the tool for collapsing the duplicate first.
+  if (local && fleet) {
+    throw new Error(
+      `"${from}" exists in BOTH this machine's store and the fleet-synced one. ` +
+        `Renaming would move its browser data while leaving one copy behind under the old name. ` +
+        `Collapse the duplicate first: agents browser profiles scope ${from} local  ` +
+        `(or delete the copy you do not want).`,
+    );
+  }
+
   const config = (local ?? fleet)!;
   const scope: ProfileScope = local ? 'local' : 'fleet';
 
   // Move the on-disk state BEFORE the config, so a crash between the two leaves
   // a profile whose dirs are already where the new name expects them rather than
   // a config pointing at dirs that no longer exist.
-  const movedDirs: string[] = [];
+  // PRE-FLIGHT every destination before moving ANY of them. With the check
+  // inside the loop, dir N was validated only after dirs 0..N-1 had already
+  // moved: a collision on the second endpoint left the first one's logins
+  // stranded under a name with no config entry, and the error named only the
+  // squatter. Nothing repaired that, and the user was never told.
+  const plan: Array<{ dir: string; dest: string }> = [];
   for (const dir of listProfileCacheDirs(from)) {
     const base = path.basename(dir);
     const suffix = base.slice(from.length);
     const dest = path.join(path.dirname(dir), `${to}${suffix}`);
     if (fs.existsSync(dest)) {
-      throw new Error(`Cannot rename: ${dest} already exists. Move or remove it first.`);
+      throw new Error(
+        `Cannot rename: ${dest} already exists. Nothing was moved. Remove or rename it first.`,
+      );
     }
+    plan.push({ dir, dest });
+  }
+
+  const movedDirs: string[] = [];
+  for (const { dir, dest } of plan) {
     fs.renameSync(dir, dest);
     movedDirs.push(dest);
   }
@@ -811,7 +849,18 @@ export async function renameProfile(
     repointedViewer = true;
   }
 
-  return { scope, movedDirs, repointedDefault, repointedViewer };
+  // A fleet rename changes the name on every machine, but each machine's own
+  // config doc is separate — a peer pinning the old name is left dangling. Not
+  // rewritten from here: that would be a cross-machine mutation, and on a peer
+  // the pin may be correct (a LOCAL profile of the same name). Reported instead.
+  const { devicesPinningBrowserProfile } = await import('../device-config.js');
+  const { machineId } = await import('../machine-id.js');
+  const stalePins =
+    scope === 'fleet'
+      ? devicesPinningBrowserProfile(from).filter((p) => p.device !== machineId())
+      : [];
+
+  return { scope, movedDirs, repointedDefault, repointedViewer, stalePins };
 }
 
 export async function moveProfileScope(

--- a/apps/cli/src/lib/browser/profiles.ts
+++ b/apps/cli/src/lib/browser/profiles.ts
@@ -779,11 +779,17 @@ export async function renameProfile(
   // success. Refuse instead: which copy the user means is genuinely ambiguous,
   // and `profiles scope` is the tool for collapsing the duplicate first.
   if (local && fleet) {
+    // `scope <name> fleet`, NOT local: moveProfileScope computes `from` as
+    // 'local' whenever a local entry exists, so asking for local is a no-op that
+    // reports success and leaves the duplicate. Sending the user there and then
+    // to `profiles delete` — which drops the cached runtime dirs by default —
+    // walked a data-preservation command into a data-destroying one.
     throw new Error(
       `"${from}" exists in BOTH this machine's store and the fleet-synced one. ` +
-        `Renaming would move its browser data while leaving one copy behind under the old name. ` +
-        `Collapse the duplicate first: agents browser profiles scope ${from} local  ` +
-        `(or delete the copy you do not want).`,
+        `Renaming would move its browser data while leaving one copy behind under the old name.\n` +
+        `  Collapse the duplicate first:  agents browser profiles scope ${from} fleet\n` +
+        `  Then rename.  (To drop a copy instead, agents browser profiles delete ${from} --keep-cache ` +
+        `keeps the browser data.)`,
     );
   }
 

--- a/apps/cli/src/lib/device-config.test.ts
+++ b/apps/cli/src/lib/device-config.test.ts
@@ -594,3 +594,41 @@ describe('listConfiguredDeviceRoles (roster reaches doc-less devices)', () => {
     });
   });
 });
+
+describe('devicesPinningBrowserProfile', () => {
+  // These pins cannot be written through setConfigValue from here — the browser
+  // keys are machine-local, so only the owning device can set them (it errors
+  // with "can only be read or set on the device itself"). They reach this
+  // machine by SYNC, as a device doc. So the fixture writes the doc, which is
+  // the real-world shape.
+  function writeDeviceDoc(device: string, body: string): void {
+    const dir = path.join(TMP, '.agents', 'devices', device);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'agents.yaml'), body);
+  }
+
+  it('reports WHICH key each device pinned, not just that it matched', async () => {
+    // A caller telling the user to fix `browser.profile` on a device that
+    // actually pinned `browser.viewer` leaves the real pin broken AND sets a
+    // second key nobody asked for. `profiles rename` prints these verbatim.
+    writeDeviceDoc('peerbox', 'config:\n  defaultBrowserProfile: demo\n');
+    writeDeviceDoc('otherbox', 'config:\n  browserViewer: demo\n');
+    writeDeviceDoc('bothbox', 'config:\n  defaultBrowserProfile: demo\n  browserViewer: demo\n');
+
+    const { devicesPinningBrowserProfile } = await freshModules();
+    const hits = devicesPinningBrowserProfile('demo');
+
+    expect(hits).toEqual([
+      { device: 'bothbox', key: 'browser.profile' },
+      { device: 'bothbox', key: 'browser.viewer' },
+      { device: 'otherbox', key: 'browser.viewer' },
+      { device: 'peerbox', key: 'browser.profile' },
+    ]);
+  });
+
+  it('ignores devices pinning a different profile', async () => {
+    writeDeviceDoc('peerbox', 'config:\n  defaultBrowserProfile: something-else\n');
+    const { devicesPinningBrowserProfile } = await freshModules();
+    expect(devicesPinningBrowserProfile('demo')).toEqual([]);
+  });
+});

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -751,6 +751,42 @@ export function setConfiguredDeviceRole(name: string, role: ConfiguredDeviceRole
  * fleet-wide `role` default would silently miss a doc-less device and drop it
  * from the worker allowlist. Mirrors {@link loadAutoLaunchPreferences}.
  */
+/**
+ * Devices whose OWN config pins one of the browser profile keys to `profile`.
+ *
+ * Used by `profiles rename` to warn rather than silently leave a peer pointing at
+ * a name that no longer exists. Deliberately read-only: rewriting another
+ * machine's device doc from here would be a cross-machine mutation nobody asked
+ * for, and the pin may well be correct there (a local profile of the same name).
+ */
+export function devicesPinningBrowserProfile(
+  profile: string,
+): Array<{ device: string; key: 'browser.profile' | 'browser.viewer' }> {
+  ensureDeviceConfigMigrated();
+  // Reports WHICH key each device used, not just that it matched. A caller
+  // telling the user to fix `browser.profile` on a device that actually pinned
+  // `browser.viewer` leaves the real pin broken and sets a second key nobody
+  // asked for.
+  const hits: Array<{ device: string; key: 'browser.profile' | 'browser.viewer' }> = [];
+  const devicesRoot = path.join(getUserAgentsDir(), 'devices');
+  let names: string[] = [];
+  try {
+    names = fs
+      .readdirSync(devicesRoot, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    return hits;
+  }
+  for (const name of names.sort()) {
+    const cfg = readDeviceDocConfig(name);
+    // A device can pin BOTH; each needs its own fix line.
+    if (cfg.defaultBrowserProfile === profile) hits.push({ device: name, key: 'browser.profile' });
+    if (cfg.browserViewer === profile) hits.push({ device: name, key: 'browser.viewer' });
+  }
+  return hits;
+}
+
 export function listConfiguredDeviceRoles(roster?: string[]): Record<string, ConfiguredDeviceRole> {
   ensureDeviceConfigMigrated();
   const out: Record<string, ConfiguredDeviceRole> = {};

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -743,15 +743,6 @@ export function setConfiguredDeviceRole(name: string, role: ConfiguredDeviceRole
 }
 
 /**
- * Every device with an effective role, keyed by device name. Layers like every
- * other device-scope key: the fleet default (central fleet.defaults.config)
- * applies fleet-wide and the per-device doc wins on conflict. `roster` (the
- * registered device names) lets a fleet default reach devices that have no doc
- * of their own; without it only devices with docs are considered — so a
- * fleet-wide `role` default would silently miss a doc-less device and drop it
- * from the worker allowlist. Mirrors {@link loadAutoLaunchPreferences}.
- */
-/**
  * Devices whose OWN config pins one of the browser profile keys to `profile`.
  *
  * Used by `profiles rename` to warn rather than silently leave a peer pointing at
@@ -787,6 +778,15 @@ export function devicesPinningBrowserProfile(
   return hits;
 }
 
+/**
+ * Every device with an effective role, keyed by device name. Layers like every
+ * other device-scope key: the fleet default (central fleet.defaults.config)
+ * applies fleet-wide and the per-device doc wins on conflict. `roster` (the
+ * registered device names) lets a fleet default reach devices that have no doc
+ * of their own; without it only devices with docs are considered — so a
+ * fleet-wide `role` default would silently miss a doc-less device and drop it
+ * from the worker allowlist. Mirrors {@link loadAutoLaunchPreferences}.
+ */
 export function listConfiguredDeviceRoles(roster?: string[]): Record<string, ConfiguredDeviceRole> {
   ensureDeviceConfigMigrated();
   const out: Record<string, ConfiguredDeviceRole> = {};


### PR DESCRIPTION
Gap I shipped in #2961 and found while auditing my own diff.

## The bug

`renameProfile` repointed `browser.profile` but not `browser.viewer` — a separate key added by #2937. Left dangling, `resolveViewer` finds no such profile:

```
[viewer] profile "comet-local" is not configured — using the OS browser.
```

So after renaming your agent browser, every rendered artifact goes back to the OS default handler. On the machine this was reported from that is Arc — **precisely the bug the viewer seam exists to fix, reintroduced by a rename.** It fails loudly rather than silently, so it is a gap rather than data loss. Still wrong.

## Run result

Captured from a real run against a temp `HOME` (`src/index.ts`, not a fixture):

```console
--- BEFORE ---
browser.profile = "demo"
browser.viewer = "demo"

--- RENAME ---
$ agents browser profiles rename demo agents
Renamed demo -> agents (fleet)
  moved 1 browser data dir — logins preserved
  browser.profile now points at agents
  browser.viewer now points at agents

--- AFTER (viewer must follow, not dangle) ---
browser.profile = "agents"
browser.viewer = "agents"
cookies: SESSION
```

Before this change the last line of the RENAME block did not exist and `browser.viewer` still read `"demo"` — a profile that no longer exists.

## Tests

`101 passed`. Two new: the viewer follows the rename, and a viewer pointing at a *different* profile is left alone. Mutation-checked — dropping the repoint fails the first.

Also adds `withMetaLock` to this file's `state.js` mock. `setConfigValue` writes under that lock and the harness never exported it, so any test touching config from here failed with `No "withMetaLock" export is defined`.

## Process note

**#2961 merged before its review finished.** I armed a merge-on-green watcher *before* spawning the reviewer, and it fired on a PR with zero comments — so a change that moves user data on disk landed unreviewed. That is my sequencing error, not a repo problem. The review is running against `origin/main` now; anything else it finds gets the same fix-forward treatment.

I have not repeated the pattern here: **no auto-merge is armed on this PR.** It waits for a non-author verdict.
