### PR TITLE
fix(test): publish-computer-helper-mac test times out on macOS, blocking every Mac-signed release (RUSH-3081)

### DIFF
--- a/apps/cli/scripts/publish-computer-helper-mac.test.ts
+++ b/apps/cli/scripts/publish-computer-helper-mac.test.ts
@@ -39,16 +39,27 @@ describe('publish-computer-helper-mac.sh', () => {
   });
 
   it('refuses a non-macOS host loudly rather than half-running', () => {
-    const r = spawnSync('bash', [PUBLISH], { encoding: 'utf-8' });
+    // Force the platform gate to see a NON-macOS host by shadowing `uname` on
+    // PATH, so this exercises the refusal path deterministically on ANY host.
+    // Running the real script unshadowed on a Mac would get PAST the gate and
+    // start the actual build+sign+notarize -- a 60s+ side-effecting operation
+    // that timed the test out on the one machine that signs releases (the
+    // attestation producer runs the full suite there), which is exactly the
+    // half-run this guard exists to prevent, now reproduced by the test itself.
+    const stub = fs.mkdtempSync(path.join(os.tmpdir(), 'uname-stub-'));
+    fs.writeFileSync(path.join(stub, 'uname'), '#!/bin/sh\necho Linux\n');
+    fs.chmodSync(path.join(stub, 'uname'), 0o755);
+
+    const r = spawnSync('bash', [PUBLISH], {
+      encoding: 'utf-8',
+      env: { ...process.env, PATH: `${stub}:${process.env.PATH ?? ''}` },
+    });
     const out = `${r.stdout}${r.stderr}`;
 
-    if (process.platform === 'darwin') {
-      // On a Mac it gets past the platform gate; it must not die claiming otherwise.
-      expect(out).not.toContain('macOS only');
-    } else {
-      expect(r.status).not.toBe(0);
-      expect(out).toContain('macOS only');
-    }
+    // The gate must fire first and loud, before any real work: non-zero exit and
+    // the "macOS only" refusal, never a half-run.
+    expect(r.status, `expected a loud refusal, got: ${out}`).not.toBe(0);
+    expect(out).toContain('macOS only');
   });
 
   it('sourcing the signing context is a no-op without the release-box pass files', () => {


### PR DESCRIPTION
**What:** a test that spawns the real macOS publish script times out on macOS, blocking the attestation producer (and thus every Mac-signed release). `test-only`.

## The bug
`scripts/publish-computer-helper-mac.test.ts > "refuses a non-macOS host loudly rather than half-running"` does `spawnSync('bash', [PUBLISH])` — it runs the **real** `publish-computer-helper-mac.sh` with no args. On Linux the platform gate (`uname -s != Darwin`) fires instantly → pass. On **macOS** the gate passes, so the script starts the actual **build + sign + notarize** (~68s) and the test **times out at 30000ms**.

That matters because `release-attestation-produce.sh` runs the **full suite on mac-mini** and refuses to attest a red tree — so this single macOS-only failure blocks *every* release that signs on a Mac. (Discovered while driving the 1.22.47 release: 12,882 tests passed, this one timed out.)

## The fix
Shadow `uname` on `PATH` with a stub that echoes `Linux`, so the test exercises the **refusal path deterministically on any host** and never enters the real publish. One assertion (non-zero exit + "macOS only"), no darwin/else split.

## Evidence
Test run (uploaded): https://share.agents-cli.sh/muqsitnawaz/fix-publish-mac-test-publish-mac-test-fixed-f779ec258ebfc77d
`vitest run scripts/publish-computer-helper-mac.test.ts` → **3 passed in 131ms** (was a 68s timeout on macOS). On-disk: `.agents/worktrees/fix-publish-mac-test/scratch/publish-mac-test-fixed.log`.

Ticket: RUSH-3081