### PR TITLE
feat(sessions): trace v2 — analysis-hero + program-aware trajectory + exit codes

### DIFF
--- a/apps/cli/.changelog/next/sessions-trace-redesign.md
+++ b/apps/cli/.changelog/next/sessions-trace-redesign.md
@@ -1,0 +1,19 @@
+---
+type: feat
+---
+
+`agents sessions trace` (single-session HTML/text) is rebuilt around an
+**analysis hero** and a **step-ordered trajectory**, replacing the wall-clock
+Gantt waterfall. The new HTML/text lead with "where the time went" (a stacked
+tool-time bar), the slowest steps, a tool-mix histogram that breaks a Bash step
+down by its **effective shell program** (`git`, `gh`, `bun`, …) instead of
+lumping every shell call as "Bash", and headline KPIs (errors, idle total,
+longest gap) — followed by the trajectory in execution order: one row per
+step badged by its program/tool, duration heat-colored, the process **exit
+code** shown on a failing step, runs of ≥3 fast same-program calls folded into
+one expander, and idle gaps rendered as centered `··· idle 3m ···` dividers
+rather than a time axis. The compare and lineage views pick up the same
+program-aware badges and exit codes. `TrajectoryStep` gains `program?` and
+`exitCode?`, derived by reusing the real bash parser behind
+`tool-calls.ts`/`shell-programs.ts` — never a naive command-prefix split.
+Source: `apps/cli/src/lib/session/{trajectory,trajectory-html,trajectory-text}.ts`.

--- a/apps/cli/docs/sessions.md
+++ b/apps/cli/docs/sessions.md
@@ -957,18 +957,30 @@ normalized `SessionEvent[]` model and computes one thing nothing else does: a
 **per-step duration**, by pairing each `tool_use` with its `tool_result` on `callId` (a
 step falls back to the next-event delta and is marked `durationEstimated` when a
 harness omits the result, so measured and inferred are never conflated). It also flags
-idle gaps (stalls), a per-tool "where the time went" share, and tags inline
-`Task`/`Agent` sub-agents.
+idle gaps (stalls), a per-tool "where the time went" share, tags inline `Task`/`Agent`
+sub-agents, and — reusing the real bash parser behind `sessions-tool-index`
+(`shell-programs.ts` via `tool-calls.ts`) — attributes each shell step to its
+**effective program** (`git`, `gh`, `bun`, …) plus the process **exit code**, so a
+step never reads as an undifferentiated "Bash".
 
 One model renders three ways, **auto-selected by audience**:
 
-- **HTML** (default on a TTY — a person): a self-contained page (inline CSS/SVG, no
+- **HTML** (default on a TTY — a person): a self-contained page (inline CSS, no
   CDN, no external asset, redacted by default — as safe to share as a `sessions share`
-  page) with a tool-call waterfall over a time axis, a "where the time went" bar list,
-  and a per-step detail panel. Opens in your browser; `--no-open` prints the path.
+  page), led by an **analysis hero** — a "where the time went" stacked bar, the
+  slowest steps, a tool-mix histogram broken down by effective program (never
+  lumped as "Bash"), and headline KPIs (errors, idle total, longest gap) — followed
+  by the **trajectory itself in execution order** (never a wall-clock axis): one row
+  per step badged by its program/tool, duration heat-colored (grey/amber/red),
+  the exit code shown on a failing step, a run of ≥3 fast same-program calls folded
+  into one `×N` expander, and idle gaps rendered as centered `··· idle 3m ···`
+  dividers. Any row carrying redacted output expands inline. Opens in your browser;
+  `--no-open` prints the path.
 - **Text** (default when piped/headless — an agent): a compact, ANSI-free,
-  token-bounded trajectory an agent reads in-context. `--errors-only` collapses it to
-  the failures and their neighbours.
+  token-bounded trajectory an agent reads in-context — one line per step (program
+  badge, label, duration, exit code), idle gaps as inline dividers, and an analysis
+  summary (errors, idle total, longest gap, tool mix by program). `--errors-only`
+  collapses it to the failures and their neighbours.
 - **`--json`**: the versioned envelope `{ schemaVersion, kind: 'sessions-trace',
   layout: 'single' | 'compare' | 'lineage', sessions: [SessionTrajectory], diff?,
   lineage? }` — the stable contract consumers read so nothing re-parses a transcript.
@@ -999,9 +1011,12 @@ Useful for "the same ticket run by Claude and Codex — where did they diverge?"
 passing run vs. a failing retry — what did the failing one do extra?"
 
 - **HTML**: two stacked lanes on one time axis, a dashed divergence marker, a summary
-  table, and the "only in the first" / "only in the second" step lists.
+  table, and the "only in the first" / "only in the second" step lists — each entry
+  badged by its effective program (not the raw tool) and carrying its exit code on
+  a failing step, the same design language as the single-session view.
 - **Text**: both sessions' headline stats, the divergence line, and the capped diff
-  lists — token-bounded the same way the single-session text trajectory is.
+  lists — token-bounded the same way the single-session text trajectory is, and
+  program/exit-code labeled the same way too.
 - **`--json`**: `layout: 'compare'`, `sessions: [a, b]` (the two full
   `SessionTrajectory` models — nothing re-parses either transcript), and `diff:
   { divergence?, added, removed, summaryA, summaryB, truncatedA, truncatedB }`.

--- a/apps/cli/src/lib/session/trajectory-html.compare.test.ts
+++ b/apps/cli/src/lib/session/trajectory-html.compare.test.ts
@@ -66,6 +66,22 @@ describe('renderTrajectoryCompareHtml — self-contained and safe', () => {
     expect(html).toContain('Only in codex');
   });
 
+  it('badges a shell step by its effective program and shows an exit code in the diff list', () => {
+    const a = buildTrajectory(eventsA, meta({ id: 'a', agent: 'claude' }));
+    // b keeps the matching `git fetch` Bash step (aligns as "same") plus a
+    // second, unmatched, FAILING `bun test` Bash step — so it lands in `added`.
+    const bEvents: SessionEvent[] = [
+      { type: 'tool_use', agent: 'codex', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'b1', command: 'git fetch' },
+      { type: 'tool_result', agent: 'codex', timestamp: '2026-08-01T00:00:02Z', tool: 'Bash', callId: 'b1', outcome: 'ok' },
+      { type: 'tool_use', agent: 'codex', timestamp: '2026-08-01T00:00:03Z', tool: 'Bash', callId: 'x1', command: 'bun test' },
+      { type: 'tool_result', agent: 'codex', timestamp: '2026-08-01T00:00:04Z', tool: 'Bash', callId: 'x1', outcome: 'error', exitCode: 1 },
+    ];
+    const b = buildTrajectory(bEvents, meta({ id: 'b', agent: 'codex' }));
+    const html = renderTrajectoryCompareHtml(diffTrajectories(a, b));
+    expect(html).toContain('>bun<');
+    expect(html).toContain('exit 1');
+  });
+
   it('an identical pair still renders and states there is no divergence', () => {
     const a = buildTrajectory(eventsA, meta({ id: 'a' }));
     const b = buildTrajectory(eventsA, meta({ id: 'b' }));

--- a/apps/cli/src/lib/session/trajectory-html.test.ts
+++ b/apps/cli/src/lib/session/trajectory-html.test.ts
@@ -56,16 +56,49 @@ describe('renderTrajectoryHtml — self-contained and safe', () => {
     expect(html).not.toContain('Secret-redacted trajectory');
   });
 
-  it('renders the waterfall, time-share, and per-step detail sections', () => {
+  it('renders the analysis hero and the step-ordered trajectory', () => {
     const html = renderTrajectoryHtml(buildTrajectory(events, meta()));
-    expect(html).toContain('<svg');
     expect(html).toContain('Where the time went');
-    expect(html).toContain('id="step-1"');
+    expect(html).toContain('Slowest steps');
+    expect(html).toContain('Tool mix');
     expect(html).toContain('exec.ts');
-    // An error outcome shows as a red-classed outcome badge.
-    expect(html).toContain('outcome error');
-    // The Bash step dominates the time share.
-    expect(html).toMatch(/share-fill/);
+    // The failing Bash step shows its exit code, and the error styling.
+    expect(html).toContain('exit 1');
+    expect(html).toContain('class="step error"');
+    // The Bash step's effective program (bun) badges the row, not the raw tool name.
+    expect(html).toContain('>bun<');
+  });
+
+  it('renders program badges, breaking a Bash step down by its effective program', () => {
+    const gitAndGh: SessionEvent[] = [
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'c1', command: 'git push && gh pr create' },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Bash', callId: 'c1', outcome: 'ok' },
+    ];
+    const html = renderTrajectoryHtml(buildTrajectory(gitAndGh, meta()));
+    expect(html).toContain('>git<');
+    // Never the naive "Bash 100%" — program-aware, not tool-lumped.
+    expect(html).not.toMatch(/>Bash<\/span>/);
+  });
+
+  it('folds a run of ≥3 consecutive fast same-program calls into one expander', () => {
+    const events3: SessionEvent[] = [];
+    for (let i = 0; i < 4; i++) {
+      events3.push({ type: 'tool_use', agent: 'claude', timestamp: `2026-08-01T00:00:0${i}Z`, tool: 'Bash', callId: `c${i}`, command: 'ls' });
+      events3.push({ type: 'tool_result', agent: 'claude', timestamp: `2026-08-01T00:00:0${i}Z`, tool: 'Bash', callId: `c${i}`, outcome: 'ok' });
+    }
+    const html = renderTrajectoryHtml(buildTrajectory(events3, meta()));
+    expect(html).toContain('class="grp"');
+    expect(html).toContain('&#215;4'); // ×4
+  });
+
+  it('the expanded detail renders as a full-width BLOCK sibling of summary, never inside a grid container', () => {
+    const html = renderTrajectoryHtml(buildTrajectory(events, meta()));
+    // The bug this design fixes: grid on <details> collapses .detail into a
+    // narrow column. The container rule must be display:block, and the grid
+    // must apply only to the row (.norow / > summary), never to .step itself.
+    expect(html).toMatch(/\.step,\s*details\.grp\s*\{\s*display:\s*block;\s*\}/);
+    expect(html).not.toMatch(/details\.step\s*\{[^}]*display:\s*grid/);
+    expect(html).toContain('<div class="detail">');
   });
 
   it('an empty trajectory still renders a valid page (no crash)', () => {

--- a/apps/cli/src/lib/session/trajectory-html.test.ts
+++ b/apps/cli/src/lib/session/trajectory-html.test.ts
@@ -101,6 +101,22 @@ describe('renderTrajectoryHtml — self-contained and safe', () => {
     expect(html).toContain('<div class="detail">');
   });
 
+  it('renders a gap that falls BEFORE the first step (afterOrdinal: 0), not just between steps', () => {
+    // A regression test for the divider loop starting `prevMs` at `null` instead
+    // of the session origin — that silently dropped a leading stall (the gap
+    // record's `afterOrdinal` is 0, since no step precedes it).
+    const leadingGap: SessionEvent[] = [
+      { type: 'message', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', role: 'user', content: 'go' },
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:03:20Z', tool: 'Bash', callId: 'c1', command: 'ls' },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:03:21Z', tool: 'Bash', callId: 'c1', outcome: 'ok' },
+    ];
+    const traj = buildTrajectory(leadingGap, meta(), { idleThresholdMs: 120_000 });
+    expect(traj.gaps).toEqual([{ startMs: 0, durationMs: 200_000, afterOrdinal: 0 }]);
+    const html = renderTrajectoryHtml(traj);
+    expect(html).toContain('class="gap"');
+    expect(html).toContain('idle 3m20s');
+  });
+
   it('an empty trajectory still renders a valid page (no crash)', () => {
     const html = renderTrajectoryHtml(buildTrajectory([], meta({ agent: 'openclaw' })));
     expect(html).toContain('<!DOCTYPE html>');

--- a/apps/cli/src/lib/session/trajectory-html.ts
+++ b/apps/cli/src/lib/session/trajectory-html.ts
@@ -379,16 +379,7 @@ const BASE_STYLE = `
   svg .axis { stroke: var(--border); stroke-width: 1; }
   svg .tick { fill: var(--dim); font-size: 8px; }
   svg .lane { fill: var(--dim); font-size: 9px; }
-  svg .bar-label { fill: var(--dim); font-size: 8.5px; }
-  svg .bar-dur { fill: var(--fg); }
-  svg .gap { fill: #7a3030; fill-opacity: 0.12; }
-  svg .gap-label { fill: #c06a6a; font-size: 8px; }
   svg a { cursor: pointer; }
-  .share-row { display: flex; align-items: center; gap: 10px; margin: 5px 0; font-family: ui-monospace, "JetBrains Mono", Menlo, monospace; font-size: 12px; }
-  .share-name { width: 120px; color: var(--fg); }
-  .share-bar { flex: 1; height: 9px; background: var(--panel); border: 1px solid var(--border); border-radius: 5px; overflow: hidden; }
-  .share-fill { display: block; height: 100%; }
-  .share-pct { width: 44px; text-align: right; color: var(--dim); }
   .dot { width: 9px; height: 9px; border-radius: 2px; display: inline-block; }
   footer {
     max-width: 960px; margin: 0 auto; padding: 0 20px 48px;

--- a/apps/cli/src/lib/session/trajectory-html.ts
+++ b/apps/cli/src/lib/session/trajectory-html.ts
@@ -1,12 +1,17 @@
 /**
  * Render a {@link SessionTrajectory} as ONE self-contained HTML page for
- * `agents sessions trace` (single-session layout).
+ * `agents sessions trace` (single-session layout): an analysis hero — where
+ * the time went, slowest steps, a program-aware tool mix, and headline KPIs —
+ * followed by the trajectory itself, drawn STEP-ORDERED (never a wall-clock
+ * axis): one row per step, badged by its effective shell program (`git`,
+ * `gh`, `bun`, …) when the step is a shell call, folded runs of fast
+ * same-program calls, and idle gaps rendered as centered dividers.
  *
  * Self-contained on purpose, exactly like `share-html.ts`: an inline `<style>`,
- * an inline SVG waterfall, no external asset, no CDN, no web font, no
- * `artifacts-cli` dependency. The page is safe to open on any box or hand to a
- * person. All transcript-derived text is escaped with `escapeHtml`, and the
- * labels are already secret-redacted upstream in `buildTrajectory`.
+ * no external asset, no CDN, no web font, no `artifacts-cli` dependency. The
+ * page is safe to open on any box or hand to a person. All transcript-derived
+ * text is escaped with `escapeHtml`, and the labels are already
+ * secret-redacted upstream in `buildTrajectory`.
  *
  * Terminal-coded per the agents-cli brand (#0a0a0a bg, #a3e635 lime accent,
  * JetBrains Mono), light theme under `prefers-color-scheme: light`, with an
@@ -18,19 +23,7 @@ import type { SessionTrajectory, TrajectoryStep } from './trajectory.js';
 import type { TrajectoryComparison } from './trajectory-compare.js';
 import type { LineageNode, SessionLineage } from './trajectory-lineage.js';
 
-/** Color a tool bar by family; an error outcome overrides to red. */
-function toolColor(step: TrajectoryStep): string {
-  if (step.outcome === 'error') return '#f87171';
-  if (step.kind === 'thinking') return '#3a3a55';
-  const tool = (step.tool ?? '').toLowerCase();
-  if (tool === 'bash' || tool === 'shell' || tool.includes('exec') || tool === 'run_command') return '#e0b341';
-  if (tool === 'read' || tool === 'grep' || tool === 'glob' || tool === 'search' || tool === 'codebase_search') return '#4a9eff';
-  if (tool === 'edit' || tool === 'write' || tool === 'notebookedit' || tool === 'multiedit') return '#7ee787';
-  if (tool === 'task' || tool === 'agent') return '#b98cff';
-  return '#8b98a5';
-}
-
-/** Precise per-step duration for the waterfall: "8m04s", "1.6s", "320ms". */
+/** Precise per-step duration: "8m04s", "1.6s", "320ms". */
 function formatStepDuration(ms: number): string {
   if (ms <= 0) return '0s';
   if (ms < 1000) return `${Math.round(ms)}ms`;
@@ -62,105 +55,211 @@ interface WaterfallGeometry {
 
 const GEO: WaterfallGeometry = { labelW: 84, chartW: 620, rowH: 20, top: 34 };
 
-function xForMs(startMs: number, spanMs: number): number {
-  const frac = spanMs > 0 ? Math.min(1, Math.max(0, startMs / spanMs)) : 0;
-  return GEO.labelW + frac * GEO.chartW;
+function clipLabel(label: string, max = 46): string {
+  const oneLine = label.replace(/\s+/g, ' ').trim();
+  return oneLine.length <= max ? oneLine : `${oneLine.slice(0, max - 1)}…`;
 }
 
-function widthForMs(durationMs: number, spanMs: number): number {
-  if (spanMs <= 0) return 3;
-  return Math.max(3, (durationMs / spanMs) * GEO.chartW);
+/** Per-tool family color — the fallback badge color when a step has no `program`. */
+const FAMILY_COLOR: Record<string, string> = {
+  bash: '#e0b341', shell: '#e0b341', run_command: '#e0b341', run_shell_command: '#e0b341', exec: '#e0b341', execute: '#e0b341', exec_command: '#e0b341',
+  read: '#4a9eff', grep: '#4a9eff', glob: '#4a9eff', search: '#4a9eff', codebase_search: '#4a9eff',
+  edit: '#7ee787', write: '#7ee787', notebookedit: '#7ee787', multiedit: '#7ee787',
+  task: '#b98cff', agent: '#b98cff',
+  taskcreate: '#6b8cff', taskupdate: '#6b8cff', taskget: '#6b8cff', tasklist: '#6b8cff',
+  toolsearch: '#5ac8c8', websearch: '#5ac8c8', webfetch: '#5ac8c8',
+};
+
+/** Per-shell-program badge color — the primary key once `program` is known. */
+const PROGRAM_COLOR: Record<string, string> = {
+  agents: '#a3e635', 'agents-dev': '#a3e635', ag: '#a3e635',
+  git: '#f0883e', gh: '#c9a0ff',
+  bun: '#f471b5', npm: '#f471b5', npx: '#f471b5', node: '#8cc84b',
+  python3: '#4a9eff', python: '#4a9eff',
+  ls: '#8b98a5', sed: '#8b98a5', grep: '#8b98a5', rg: '#8b98a5', fd: '#8b98a5', cat: '#8b98a5', awk: '#8b98a5', find: '#8b98a5',
+  scp: '#5ac8c8', ssh: '#5ac8c8', curl: '#5ac8c8', wget: '#5ac8c8',
+  linear: '#6b8cff', mkdir: '#8b98a5', rm: '#f87171', chmod: '#8b98a5',
+};
+
+function familyColor(name: string): string {
+  return FAMILY_COLOR[name.toLowerCase()] ?? '#8b98a5';
 }
 
-function renderWaterfallSvg(model: SessionTrajectory): string {
-  const { steps, gaps, spanMs } = model;
-  const height = GEO.top + steps.length * GEO.rowH + 16;
-  const width = GEO.labelW + GEO.chartW + 40;
-  const parts: string[] = [];
-  parts.push(`<svg viewBox="0 0 ${width} ${height}" width="100%" role="img" aria-label="Session tool-call waterfall over time" xmlns="http://www.w3.org/2000/svg">`);
-
-  // Axis line + minute ticks.
-  const axisY = GEO.top - 10;
-  parts.push(`<line x1="${GEO.labelW}" y1="${axisY}" x2="${GEO.labelW + GEO.chartW}" y2="${axisY}" class="axis" />`);
-  for (const tick of axisTicks(spanMs)) {
-    const x = GEO.labelW + tick.frac * GEO.chartW;
-    parts.push(`<text x="${x.toFixed(1)}" y="${axisY - 3}" class="tick">${escapeHtml(tick.label)}</text>`);
-  }
-
-  // Idle-gap bands behind the rows.
-  for (const gap of gaps) {
-    const gx = xForMs(gap.startMs, spanMs);
-    const gw = widthForMs(gap.durationMs, spanMs);
-    parts.push(`<rect x="${gx.toFixed(1)}" y="${GEO.top}" width="${gw.toFixed(1)}" height="${steps.length * GEO.rowH}" class="gap" />`);
-    parts.push(`<text x="${(gx + 3).toFixed(1)}" y="${GEO.top + 11}" class="gap-label">idle ${escapeHtml(formatStepDuration(gap.durationMs))}</text>`);
-  }
-
-  // One row per step.
-  steps.forEach((step, i) => {
-    const y = GEO.top + i * GEO.rowH;
-    const barY = y + 3;
-    const barH = GEO.rowH - 8;
-    const x = xForMs(step.startMs, spanMs);
-    const w = widthForMs(step.durationMs, spanMs);
-    const color = toolColor(step);
-    const laneLabel = escapeHtml(step.lane);
-    const dur = formatStepDuration(step.durationMs);
-    const estimatedAttrs = step.durationEstimated ? ' stroke-dasharray="3 2" stroke="' + color + '" fill-opacity="0.35"' : '';
-    parts.push(`<a href="#step-${step.ordinal}">`);
-    parts.push(`<text x="${GEO.labelW - 6}" y="${y + 13}" class="lane" text-anchor="end">${laneLabel}</text>`);
-    parts.push(`<rect x="${x.toFixed(1)}" y="${barY}" width="${w.toFixed(1)}" height="${barH}" rx="2" fill="${color}"${estimatedAttrs}><title>step ${step.ordinal} · ${escapeHtml(step.tool ?? step.kind)} · ${escapeHtml(dur)}${step.durationEstimated ? ' (est)' : ''}</title></rect>`);
-    const textX = x + w + 4;
-    if (textX < width - 30) {
-      parts.push(`<text x="${textX.toFixed(1)}" y="${y + 13}" class="bar-label">${escapeHtml(clipLabel(step.label))} <tspan class="bar-dur">${escapeHtml(dur)}${step.outcome === 'error' ? ' ✗' : ''}</tspan></text>`);
-    }
-    parts.push(`</a>`);
-  });
-
-  parts.push('</svg>');
-  return parts.join('\n');
+function programColor(program: string): string {
+  return PROGRAM_COLOR[program] ?? '#e0b341';
 }
 
-function clipLabel(label: string): string {
-  return label.length <= 46 ? label : `${label.slice(0, 45)}…`;
+/** The badge an execution-order row draws: a shell program when known, else the tool/kind. */
+function stepBadge(step: TrajectoryStep): { label: string; color: string } {
+  if (step.kind === 'tool' && step.program) return { label: step.program, color: programColor(step.program) };
+  const name = step.tool ?? step.kind;
+  return { label: name, color: familyColor(name) };
 }
 
-function renderTimeShare(model: SessionTrajectory): string {
+function durationClass(step: TrajectoryStep): 'fast' | 'mid' | 'slow' | 'err' {
+  if (step.outcome === 'error') return 'err';
+  if (step.durationMs < 1_000) return 'fast';
+  if (step.durationMs < 15_000) return 'mid';
+  return 'slow';
+}
+
+/** "Where the time went" — a horizontal stacked bar over `toolTimeShare`, plus legend. */
+function renderTimeShareBar(model: SessionTrajectory): string {
   const entries = Object.entries(model.toolTimeShare).sort((a, b) => b[1] - a[1]);
   if (entries.length === 0) return '<p class="muted">No measured tool time.</p>';
-  const rows = entries.map(([tool, share]) => {
-    const pct = Math.round(share * 100);
-    const color = toolColor({ ordinal: 0, kind: 'tool', tool, lane: tool, startMs: 0, durationMs: 0, durationEstimated: false, label: tool });
-    return `<div class="share-row"><span class="share-name">${escapeHtml(tool)}</span>` +
-      `<span class="share-bar"><span class="share-fill" style="width:${pct}%;background:${color}"></span></span>` +
-      `<span class="share-pct">${pct}%</span></div>`;
-  }).join('\n');
-  return rows;
+  const segs = entries
+    .filter(([, share]) => share > 0)
+    .map(([tool, share]) => `<span class="seg" style="width:${(share * 100).toFixed(1)}%;background:${familyColor(tool)}" title="${escapeHtml(tool)} ${Math.round(share * 100)}%"></span>`)
+    .join('');
+  const legend = entries
+    .filter(([, share]) => share > 0.01)
+    .slice(0, 6)
+    .map(([tool, share]) => `<span class="lg"><span class="dot" style="background:${familyColor(tool)}"></span>${escapeHtml(tool)} ${Math.round(share * 100)}%</span>`)
+    .join(' &nbsp; ');
+  return `<div class="timebar">${segs}</div><div class="legend">${legend}</div>`;
 }
 
-function renderStepDetail(model: SessionTrajectory): string {
-  return model.steps.map((step) => {
-    const color = toolColor(step);
-    const outcome = step.outcome && step.outcome !== 'unknown'
-      ? `<span class="outcome ${step.outcome}">${step.outcome}</span>` : '';
-    const est = step.durationEstimated ? '<span class="est">estimated</span>' : '';
-    const delegation = step.delegation ? `<span class="tag">${escapeHtml(step.delegation)}</span>` : '';
-    const tokens = step.outputTokens ? `<span class="muted">${formatTokenCount(step.outputTokens)} out</span>` : '';
-    const detail = step.detail ? `<pre class="detail">${escapeHtml(step.detail)}</pre>` : '';
-    return `<div class="step" id="step-${step.ordinal}">
-  <div class="step-head">
-    <span class="dot" style="background:${color}"></span>
-    <span class="step-ord">${step.ordinal}</span>
-    <span class="step-tool">${escapeHtml(step.tool ?? step.kind)}</span>
-    <span class="step-dur">${escapeHtml(formatStepDuration(step.durationMs))}</span>
-    ${outcome} ${est} ${delegation} ${tokens}
+/** Top ~6 slowest measured steps, badge-colored by their effective program/tool. */
+function renderSlowestSteps(model: SessionTrajectory, limit = 6): string {
+  const slowest = model.steps
+    .filter((s) => s.durationMs > 0)
+    .sort((a, b) => b.durationMs - a.durationMs)
+    .slice(0, limit);
+  if (slowest.length === 0) return '<p class="muted">No measured steps.</p>';
+  return slowest.map((step) => {
+    const badge = stepBadge(step);
+    return `<div class="srow"><span class="sord">#${step.ordinal}</span>` +
+      `<span class="stag" style="color:${badge.color}">${escapeHtml(badge.label)}</span>` +
+      `<span class="slabel">${escapeHtml(clipLabel(step.label, 52))}</span>` +
+      `<span class="sdur ${durationClass(step)}">${escapeHtml(formatStepDuration(step.durationMs))}</span></div>`;
+  }).join('\n');
+}
+
+/** Tool-mix histogram — a Bash step is broken down by its EFFECTIVE program, never lumped as "Bash". */
+function toolMixCounts(model: SessionTrajectory): Array<{ label: string; color: string; count: number }> {
+  const counts = new Map<string, { color: string; count: number }>();
+  for (const step of model.steps) {
+    if (step.kind !== 'tool') continue;
+    const badge = stepBadge(step);
+    const existing = counts.get(badge.label);
+    if (existing) existing.count += 1;
+    else counts.set(badge.label, { color: badge.color, count: 1 });
+  }
+  return [...counts.entries()].map(([label, v]) => ({ label, ...v })).sort((a, b) => b.count - a.count);
+}
+
+function renderToolMix(model: SessionTrajectory): string {
+  const rows = toolMixCounts(model).slice(0, 8);
+  if (rows.length === 0) return '<p class="muted">No tool calls.</p>';
+  const max = Math.max(...rows.map((r) => r.count));
+  return rows.map((r) => `<div class="hrow"><span class="hname">${escapeHtml(r.label)}</span>` +
+    `<span class="hbar" style="width:${Math.round((r.count / max) * 100)}%;background:${r.color}"></span>` +
+    `<span class="hval">${r.count}</span></div>`).join('\n');
+}
+
+function renderAnalysisKpis(model: SessionTrajectory): string {
+  const idleTotal = model.gaps.reduce((n, g) => n + g.durationMs, 0);
+  const longestGap = model.gaps.reduce((m, g) => Math.max(m, g.durationMs), 0);
+  return `<div class="kpis">
+      <div class="kpi"><div class="v${model.errorCount > 0 ? ' bad' : ''}">${model.errorCount}</div><div class="l">errors</div></div>
+      <div class="kpi"><div class="v warn">${escapeHtml(formatStepDuration(idleTotal))}</div><div class="l">idle total</div></div>
+      <div class="kpi"><div class="v">${escapeHtml(formatStepDuration(longestGap))}</div><div class="l">longest gap</div></div>
+    </div>`;
+}
+
+/** The analysis hero: where the time went, slowest steps, tool mix, and headline KPIs. */
+function renderAnalysisSection(model: SessionTrajectory): string {
+  return `<section>
+  <div class="stitle">Analysis</div>
+  <div class="analysis">
+    <div class="card"><h3>Where the time went</h3>
+      ${renderTimeShareBar(model)}
+      <div style="margin-top:14px"><h3 style="margin-bottom:8px">Slowest steps</h3>${renderSlowestSteps(model)}</div>
+    </div>
+    <div class="card"><h3>Tool mix</h3>${renderToolMix(model)}
+      ${renderAnalysisKpis(model)}
+    </div>
   </div>
-  <div class="step-label">${escapeHtml(step.label)}</div>
-  ${detail}
-</div>`;
-  }).join('\n');
+</section>`;
 }
 
-/** Render one session's trajectory as a self-contained HTML page. */
+/** One non-grouped step row — a `<details>` when it carries redacted output, else a plain block. */
+function renderStepRow(step: TrajectoryStep): string {
+  const badge = stepBadge(step);
+  const cls = durationClass(step);
+  const exitPart = step.outcome === 'error'
+    ? (typeof step.exitCode === 'number' ? ` exit ${step.exitCode} &#10007;` : ' &#10007;')
+    : '';
+  const tokPart = step.outputTokens && step.outputTokens > 1000
+    ? `<span class="tok">${Math.round(step.outputTokens / 1000)}K</span>`
+    : '<span class="tok"></span>';
+  const row = `<span class="ord">#${step.ordinal}</span>` +
+    `<span class="badge" style="background:${badge.color}">${escapeHtml(badge.label)}</span>` +
+    `<span class="lbl">${escapeHtml(clipLabel(step.label, 88))}</span>` +
+    `${tokPart}` +
+    `<span class="dur ${cls}">${escapeHtml(formatStepDuration(step.durationMs))}${exitPart}</span>`;
+  const errCls = step.outcome === 'error' ? ' error' : '';
+  if (step.detail) {
+    return `<details class="step${errCls}"><summary>${row}</summary><div class="detail">${escapeHtml(step.detail)}</div></details>`;
+  }
+  return `<div class="step${errCls}"><div class="norow">${row}</div></div>`;
+}
+
+/** A folded run of ≥3 consecutive fast same-program/tool calls — one `<details>` with sub-rows. */
+function renderGroupedRun(run: TrajectoryStep[]): string {
+  const badge = stepBadge(run[0]);
+  const total = run.reduce((n, s) => n + s.durationMs, 0);
+  const inner = run.map((s) => `<div class="sub"><span class="ord">#${s.ordinal}</span>` +
+    `<span class="lbl">${escapeHtml(clipLabel(s.label, 80))}</span>` +
+    `<span class="dur ${durationClass(s)}">${escapeHtml(formatStepDuration(s.durationMs))}</span></div>`).join('\n');
+  return `<details class="grp"><summary>` +
+    `<span class="badge" style="background:${badge.color}">${escapeHtml(badge.label)}</span>` +
+    `<span class="run">&#215;${run.length}</span>` +
+    `<span class="glabel">${escapeHtml(run[0].tool ?? run[0].kind)} run &middot; ${escapeHtml(clipLabel(run[0].label, 40))} &#8230;</span>` +
+    `<span class="dur mid">${escapeHtml(formatStepDuration(total))}</span></summary>${inner}</details>`;
+}
+
+/** The full step-ordered trajectory: rows, folded fast runs, and idle-gap dividers — NOT a wall-clock axis. */
+function renderTrajectoryRows(model: SessionTrajectory): string {
+  const { steps } = model;
+  const gapsSorted = [...model.gaps].sort((a, b) => a.startMs - b.startMs);
+  const rows: string[] = [];
+  let gapIdx = 0;
+  // A gap may fall BEFORE the first step (`afterOrdinal: 0`), so start `prevMs`
+  // at the session origin, not `null` — else a leading stall is silently dropped.
+  let prevMs = 0;
+  const emitGapsBefore = (curMs: number): void => {
+    while (gapIdx < gapsSorted.length && gapsSorted[gapIdx].startMs >= prevMs && gapsSorted[gapIdx].startMs < curMs) {
+      rows.push(`<div class="gap">&#183;&#183;&#183;&nbsp;idle ${escapeHtml(formatStepDuration(gapsSorted[gapIdx].durationMs))}&nbsp;&#183;&#183;&#183;</div>`);
+      gapIdx += 1;
+    }
+  };
+
+  let i = 0;
+  const n = steps.length;
+  while (i < n) {
+    const step = steps[i];
+    emitGapsBefore(step.startMs);
+    const badge0 = stepBadge(step);
+    let j = i;
+    if (step.kind === 'tool' && step.outcome !== 'error' && step.durationMs < 2_000) {
+      while (j + 1 < n) {
+        const next = steps[j + 1];
+        if (next.kind !== 'tool' || next.outcome === 'error' || next.durationMs >= 2_000) break;
+        if (stepBadge(next).label !== badge0.label) break;
+        j += 1;
+      }
+    }
+    const run = steps.slice(i, j + 1);
+    rows.push(run.length > 2 ? renderGroupedRun(run) : run.map(renderStepRow).join('\n'));
+    prevMs = step.startMs;
+    i = j + 1;
+  }
+  emitGapsBefore(Number.POSITIVE_INFINITY);
+  return rows.join('\n');
+}
+
+/** Render one session's trajectory as a self-contained HTML page — analysis hero on top, step-ordered trajectory below. */
 export function renderTrajectoryHtml(model: SessionTrajectory): string {
   const { session, stats } = model;
   const title = `${session.agent} · ${session.shortId || session.id}`;
@@ -183,12 +282,10 @@ export function renderTrajectoryHtml(model: SessionTrajectory): string {
   const date = (session.timestamp || '').slice(0, 10);
   if (date) chips.push(`<span class="chip"><span class="k">date</span>${escapeHtml(date)}</span>`);
 
-  const gapNote = model.gaps.length > 0
-    ? `<p class="stall">${model.gaps.length} idle gap${model.gaps.length === 1 ? '' : 's'} — longest ${escapeHtml(formatStepDuration(Math.max(...model.gaps.map((g) => g.durationMs))))}.</p>`
-    : '';
   const truncNote = model.truncatedSteps > 0
     ? `<p class="stall">Showing the first ${model.steps.length} steps; ${model.truncatedSteps} later step${model.truncatedSteps === 1 ? '' : 's'} collapsed.</p>`
     : '';
+  const emptyNote = model.steps.length === 0 ? '<p class="muted">No events to visualize.</p>' : '';
 
   return `<!DOCTYPE html>
 <html lang="en" data-theme="auto">
@@ -197,7 +294,7 @@ export function renderTrajectoryHtml(model: SessionTrajectory): string {
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="robots" content="noindex" />
 <title>${escapeHtml(title)} — trajectory</title>
-<style>${BASE_STYLE}</style>
+<style>${BASE_STYLE}${TRAJECTORY_STYLE}</style>
 </head>
 <body>
 <header>
@@ -212,16 +309,14 @@ export function renderTrajectoryHtml(model: SessionTrajectory): string {
   </div>
 </header>
 <main>
-  <h2>Trajectory</h2>
-  ${gapNote}
-  ${truncNote}
-  ${renderWaterfallSvg(model)}
-  <h2>Where the time went</h2>
-  ${renderTimeShare(model)}
-  <h2>Steps</h2>
-  <div class="steps">
-    ${renderStepDetail(model)}
-  </div>
+  ${renderAnalysisSection(model)}
+  <section>
+    <div class="stitle">Trajectory &middot; ${model.steps.length} step${model.steps.length === 1 ? '' : 's'}, execution order</div>
+    ${truncNote}
+    ${emptyNote}
+    ${renderTrajectoryRows(model)}
+    <p class="note">Consecutive fast same-program calls are folded — click to expand. Click any step with output to see its detail. Idle gaps shown as dividers, not on a wall-clock axis.</p>
+  </section>
 </main>
 <footer>
   ${model.truncatedSteps > 0 ? 'Truncated · ' : ''}${model.redacted ? 'Secret-redacted' : 'Unredacted (local only)'} trajectory rendered by agents-cli &middot; <code>agents sessions trace</code>
@@ -294,30 +389,77 @@ const BASE_STYLE = `
   .share-bar { flex: 1; height: 9px; background: var(--panel); border: 1px solid var(--border); border-radius: 5px; overflow: hidden; }
   .share-fill { display: block; height: 100%; }
   .share-pct { width: 44px; text-align: right; color: var(--dim); }
-  .steps { display: flex; flex-direction: column; gap: 4px; }
-  .step { border: 1px solid var(--border); border-radius: 6px; padding: 8px 10px; background: var(--panel); scroll-margin-top: 16px; }
-  .step:target { border-color: var(--accent); }
-  .step-head { display: flex; align-items: center; gap: 8px; font-family: ui-monospace, "JetBrains Mono", Menlo, monospace; font-size: 12px; flex-wrap: wrap; }
   .dot { width: 9px; height: 9px; border-radius: 2px; display: inline-block; }
-  .step-ord { color: var(--dim); width: 28px; }
-  .step-tool { color: var(--fg); font-weight: 600; }
-  .step-dur { color: var(--dim); }
-  .outcome { font-size: 11px; padding: 0 6px; border-radius: 8px; }
-  .outcome.ok { color: #7ee787; }
-  .outcome.error { color: #f87171; }
-  .est { color: #e0b341; font-size: 11px; }
-  .tag { color: #b98cff; font-size: 11px; }
-  .step-label { margin-top: 4px; font-family: ui-monospace, "JetBrains Mono", Menlo, monospace; font-size: 12px; color: var(--fg); word-break: break-word; }
-  pre.detail {
-    margin: 6px 0 0; padding: 8px 10px; background: var(--bg); border: 1px solid var(--border);
-    border-radius: 4px; overflow-x: auto; font-family: ui-monospace, "JetBrains Mono", Menlo, monospace;
-    font-size: 11.5px; color: var(--dim); white-space: pre-wrap; word-break: break-word;
-  }
   footer {
     max-width: 960px; margin: 0 auto; padding: 0 20px 48px;
     color: var(--dim); font-size: 12px;
     font-family: ui-monospace, "JetBrains Mono", Menlo, monospace;
   }
+`;
+
+/**
+ * Single-session-only rules layered on top of {@link BASE_STYLE} — the analysis
+ * hero (time-share bar, slowest steps, tool-mix histogram, KPIs) and the
+ * step-ordered trajectory (badge rows, folded runs, idle-gap dividers).
+ *
+ * CRITICAL: the CSS grid lives on the ROW element (`.norow`, `details.step >
+ * summary`, `details.grp > summary`) — never on the `<details>`/`.step`
+ * container itself, which MUST stay `display:block`. A grid on the container
+ * makes the expanded `.detail`/sub-rows inherit the row's column tracks and
+ * collapse into a sliver instead of rendering full width.
+ */
+const TRAJECTORY_STYLE = `
+  .stitle { color: var(--accent); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; border-bottom: 1px solid var(--border); padding-bottom: 6px; margin-bottom: 14px; }
+  .analysis { display: grid; grid-template-columns: 1.3fr 1fr; gap: 22px; }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; }
+  .card h3 { margin: 0 0 10px; font-size: 11px; color: var(--dim); text-transform: uppercase; letter-spacing: .1em; font-weight: 500; }
+  .timebar { display: flex; height: 14px; border-radius: 4px; overflow: hidden; margin-bottom: 8px; }
+  .timebar .seg { height: 100%; }
+  .legend { color: var(--dim); font-size: 11px; }
+  .lg { white-space: nowrap; }
+  .hrow { display: grid; grid-template-columns: 84px 1fr 34px; align-items: center; gap: 8px; margin: 4px 0; }
+  .hname { color: var(--dim); font-size: 11px; }
+  .hbar { height: 8px; border-radius: 3px; min-width: 2px; }
+  .hval { color: var(--fg); font-size: 11px; text-align: right; }
+  .srow { display: grid; grid-template-columns: 34px 62px 1fr auto; gap: 8px; align-items: center; margin: 5px 0; font-size: 12px; }
+  .sord { color: var(--dim); opacity: .7; }
+  .stag { font-size: 11px; font-weight: 600; }
+  .slabel { color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+  .kpis { display: flex; gap: 18px; margin-top: 2px; }
+  .kpi .v { font-size: 22px; color: var(--fg); }
+  .kpi .l { font-size: 10px; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; }
+  .kpi .v.bad { color: #f87171; }
+  .kpi .v.warn { color: #e0b341; }
+  /* Trajectory rows — grid on the ROW, block on the container (see docblock above). */
+  .step, details.grp { display: block; }
+  .norow, details.step > summary, details.grp > summary {
+    display: grid; grid-template-columns: 40px 78px minmax(0, 1fr) 46px 76px; gap: 12px;
+    align-items: center; padding: 6px 10px; border-radius: 7px;
+  }
+  details.step > summary, details.grp > summary { cursor: pointer; list-style: none; }
+  details.step > summary::-webkit-details-marker, details.grp > summary::-webkit-details-marker { display: none; }
+  .norow:hover, details.step > summary:hover, details.grp > summary:hover { background: var(--quote); }
+  .step.error { border-left: 2px solid #b3403f; border-radius: 7px; }
+  .ord { color: var(--dim); opacity: .7; font-size: 11px; }
+  .badge { color: #0a0a0a; font-weight: 600; font-size: 10px; text-align: center; padding: 2px 6px; border-radius: 4px; white-space: nowrap; }
+  .lbl { color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+  .tok { color: var(--dim); opacity: .7; font-size: 10px; }
+  .dur { font-size: 12px; text-align: right; min-width: 68px; font-family: ui-monospace, "JetBrains Mono", Menlo, monospace; }
+  .dur.fast { color: var(--dim); }
+  .dur.mid { color: #e0b341; }
+  .dur.slow, .dur.err { color: #f87171; }
+  .detail {
+    white-space: pre-wrap; color: var(--dim); font-size: 11px; background: var(--bg);
+    border-radius: 6px; padding: 8px 10px; margin: 2px 0 8px 54px; border: 1px solid var(--border);
+    max-height: 240px; overflow: auto; font-family: ui-monospace, "JetBrains Mono", Menlo, monospace;
+  }
+  .grp > summary { color: var(--dim); }
+  .grp .run { color: var(--accent); font-size: 11px; }
+  .grp .glabel { color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+  .grp .sub { display: grid; grid-template-columns: 44px 1fr auto; gap: 10px; padding: 3px 10px 3px 84px; font-size: 12px; color: var(--dim); }
+  .gap { text-align: center; color: #a3833a; font-size: 11px; margin: 8px 0; letter-spacing: .06em; }
+  .note { color: var(--dim); opacity: .8; font-size: 11px; margin-top: 10px; }
+  @media (max-width: 760px) { .analysis { grid-template-columns: 1fr; } .norow, details.step > summary, details.grp > summary { grid-template-columns: 30px 64px minmax(0,1fr) 56px; } .tok { display: none; } }
 `;
 
 /** Compare-only rules layered on top of {@link BASE_STYLE} — lanes, divergence marker, summary table. */
@@ -389,9 +531,12 @@ function renderCompareWaterfallSvg(cmp: TrajectoryComparison): string {
     for (const step of lane.steps) {
       const x = GEO.labelW + Math.min(1, Math.max(0, step.startMs / sharedSpan)) * GEO.chartW;
       const w = Math.max(3, (step.durationMs / sharedSpan) * GEO.chartW);
-      const color = toolColor(step);
+      const badge = stepBadge(step);
       const dur = formatStepDuration(step.durationMs);
-      parts.push(`<rect x="${x.toFixed(1)}" y="${barY}" width="${w.toFixed(1)}" height="${barH}" rx="2" fill="${color}"><title>${escapeHtml(label)} · step ${step.ordinal} · ${escapeHtml(step.tool ?? step.kind)} · ${escapeHtml(dur)}${step.outcome === 'error' ? ' ✗' : ''}</title></rect>`);
+      const exitPart = step.outcome === 'error'
+        ? (typeof step.exitCode === 'number' ? ` exit ${step.exitCode} ✗` : ' ✗')
+        : '';
+      parts.push(`<rect x="${x.toFixed(1)}" y="${barY}" width="${w.toFixed(1)}" height="${barH}" rx="2" fill="${badge.color}"><title>${escapeHtml(label)} · step ${step.ordinal} · ${escapeHtml(badge.label)} · ${escapeHtml(dur)}${exitPart}</title></rect>`);
     }
   });
 
@@ -415,8 +560,12 @@ function renderCompareSummaryTable(cmp: TrajectoryComparison): string {
 }
 
 function renderStepListItem(step: TrajectoryStep): string {
+  const badge = stepBadge(step);
   const dur = formatStepDuration(step.durationMs);
-  return `<li>${escapeHtml(step.tool ?? step.kind)} · ${escapeHtml(clipLabel(step.label))} <span class="muted">${escapeHtml(dur)}</span></li>`;
+  const exitPart = step.outcome === 'error'
+    ? (typeof step.exitCode === 'number' ? ` exit ${step.exitCode} ✗` : ' ✗')
+    : '';
+  return `<li><span class="badge" style="background:${badge.color}">${escapeHtml(badge.label)}</span> ${escapeHtml(clipLabel(step.label))} <span class="muted">${escapeHtml(dur)}${escapeHtml(exitPart)}</span></li>`;
 }
 
 function renderCompareDiffLists(cmp: TrajectoryComparison): string {

--- a/apps/cli/src/lib/session/trajectory-text.compare.test.ts
+++ b/apps/cli/src/lib/session/trajectory-text.compare.test.ts
@@ -52,6 +52,22 @@ describe('renderTrajectoryCompareText', () => {
     expect(text).toContain('only in claude sess0001 (0): none');
   });
 
+  it('badges a shell step in the diff by its effective program, and shows the exit code', () => {
+    const a = buildTrajectory(eventsA, meta({ id: 'a', agent: 'claude' }));
+    // b keeps the matching `git fetch` Bash step (aligns as "same") plus a
+    // second, unmatched, FAILING `bun test` Bash step — so it lands in `added`.
+    const bEvents: SessionEvent[] = [
+      { type: 'tool_use', agent: 'codex', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'b1', command: 'git fetch' },
+      { type: 'tool_result', agent: 'codex', timestamp: '2026-08-01T00:00:02Z', tool: 'Bash', callId: 'b1', outcome: 'ok' },
+      { type: 'tool_use', agent: 'codex', timestamp: '2026-08-01T00:00:03Z', tool: 'Bash', callId: 'x1', command: 'bun test' },
+      { type: 'tool_result', agent: 'codex', timestamp: '2026-08-01T00:00:04Z', tool: 'Bash', callId: 'x1', outcome: 'error', exitCode: 1 },
+    ];
+    const b = buildTrajectory(bEvents, meta({ id: 'b', agent: 'codex' }));
+    const text = renderTrajectoryCompareText(diffTrajectories(a, b));
+    expect(text).toMatch(/\bbun\b.*exit 1/);
+    expect(text).not.toContain('Bash   bun test');
+  });
+
   it('caps the diff lines with maxDiffLines and counts the rest', () => {
     const manyEvents: SessionEvent[] = [];
     for (let i = 0; i < 20; i++) {

--- a/apps/cli/src/lib/session/trajectory-text.test.ts
+++ b/apps/cli/src/lib/session/trajectory-text.test.ts
@@ -33,9 +33,10 @@ describe('renderTrajectoryText', () => {
     expect(text).toContain('1✗');
   });
 
-  it('lists steps with tool, label, duration, and marks the error', () => {
+  it('lists steps with the effective PROGRAM (not the raw tool), duration, and exit code', () => {
     const text = renderTrajectoryText(buildTrajectory(events, meta()));
-    expect(text).toMatch(/Bash\s+bun test exec\.test\.ts\s+8m04s ✗/);
+    // "bun" is the effective program of `bun test exec.test.ts` — never the naive "Bash".
+    expect(text).toMatch(/bun\s+bun test exec\.test\.ts\s+8m04s exit 1 ✗/);
     expect(text).toContain('exit 1 · 2 failing'); // error evidence line
   });
 
@@ -71,6 +72,22 @@ describe('renderTrajectoryText', () => {
     const text = renderTrajectoryText(buildTrajectory(many, meta()), { maxSteps: 50 });
     expect(text.split('\n').length).toBeLessThan(70); // bounded, not 300 lines
     expect(text).toMatch(/… \d+ more steps/);
+  });
+
+  it('renders an idle gap as a divider between the steps it falls between, not a wall-clock axis', () => {
+    const withGap: SessionEvent[] = [
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'c1', command: 'ls' },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Bash', callId: 'c1', outcome: 'ok' },
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:03:11Z', tool: 'Read', callId: 'r1', args: { file_path: 'a' } },
+    ];
+    const text = renderTrajectoryText(buildTrajectory(withGap, meta(), { idleThresholdMs: 120_000 }));
+    expect(text).toMatch(/···\s+idle 3m10s\s+···/);
+  });
+
+  it('breaks the tool mix down by effective program, and reports an analysis summary line', () => {
+    const text = renderTrajectoryText(buildTrajectory(events, meta()));
+    expect(text).toContain('analysis: 1 error');
+    expect(text).toMatch(/tool mix: .*\bbun 1\b/);
   });
 
   it('redacts a secret in a step label', () => {

--- a/apps/cli/src/lib/session/trajectory-text.test.ts
+++ b/apps/cli/src/lib/session/trajectory-text.test.ts
@@ -84,6 +84,25 @@ describe('renderTrajectoryText', () => {
     expect(text).toMatch(/···\s+idle 3m10s\s+···/);
   });
 
+  it('renders a gap that falls BEFORE the first step (afterOrdinal: 0), not just between steps', () => {
+    // A regression test for the divider loop starting `prevMs` at `null` instead
+    // of the session origin — that silently dropped a leading stall (the gap
+    // record's `afterOrdinal` is 0, since no step precedes it).
+    const leadingGap: SessionEvent[] = [
+      { type: 'message', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', role: 'user', content: 'go' },
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:03:20Z', tool: 'Bash', callId: 'c1', command: 'ls' },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:03:21Z', tool: 'Bash', callId: 'c1', outcome: 'ok' },
+    ];
+    const traj = buildTrajectory(leadingGap, meta(), { idleThresholdMs: 120_000 });
+    expect(traj.gaps).toEqual([{ startMs: 0, durationMs: 200_000, afterOrdinal: 0 }]);
+    const text = renderTrajectoryText(traj);
+    const lines = text.split('\n');
+    const gapLine = lines.findIndex((l) => l.includes('idle'));
+    const stepLine = lines.findIndex((l) => l.startsWith('01 '));
+    expect(gapLine).toBeGreaterThanOrEqual(0);
+    expect(gapLine).toBeLessThan(stepLine);
+  });
+
   it('breaks the tool mix down by effective program, and reports an analysis summary line', () => {
     const text = renderTrajectoryText(buildTrajectory(events, meta()));
     expect(text).toContain('analysis: 1 error');

--- a/apps/cli/src/lib/session/trajectory-text.ts
+++ b/apps/cli/src/lib/session/trajectory-text.ts
@@ -39,9 +39,16 @@ function dur(ms: number, estimated: boolean): string {
 }
 
 function outcomeMark(step: TrajectoryStep): string {
-  if (step.outcome === 'error') return '✗';
+  if (step.outcome === 'error') {
+    return typeof step.exitCode === 'number' ? `exit ${step.exitCode} ✗` : '✗';
+  }
   if (step.outcome === 'ok') return 'ok';
   return '';
+}
+
+/** The label a row leads with — the effective shell program for a Bash-family step, else the tool/kind. */
+function stepBadgeLabel(step: TrajectoryStep): string {
+  return step.program ?? step.tool ?? step.kind;
 }
 
 function pad(text: string, width: number): string {
@@ -60,6 +67,29 @@ function shareLine(model: SessionTrajectory): string | undefined {
     .slice(0, 5)
     .map(([tool, share]) => `${tool} ${Math.round(share * 100)}%`);
   return entries.length > 0 ? `where the time went: ${entries.join('  ')}` : undefined;
+}
+
+/** Tool mix broken down by EFFECTIVE PROGRAM for a shell step, never lumped as "Bash". */
+function toolMixLine(model: SessionTrajectory): string | undefined {
+  const counts = new Map<string, number>();
+  for (const step of model.steps) {
+    if (step.kind !== 'tool') continue;
+    const label = stepBadgeLabel(step);
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  const entries = [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 6);
+  return entries.length > 0 ? `tool mix: ${entries.map(([tool, count]) => `${tool} ${count}`).join('  ')}` : undefined;
+}
+
+/** One-line analysis summary: error count, idle total, longest gap. */
+function analysisLine(model: SessionTrajectory): string | undefined {
+  const idleTotal = model.gaps.reduce((n, g) => n + g.durationMs, 0);
+  const longestGap = model.gaps.reduce((m, g) => Math.max(m, g.durationMs), 0);
+  const bits: string[] = [];
+  if (model.errorCount > 0) bits.push(`${model.errorCount} error${model.errorCount === 1 ? '' : 's'}`);
+  if (idleTotal > 0) bits.push(`idle ${dur(idleTotal, false)} total`);
+  if (longestGap > 0) bits.push(`longest gap ${dur(longestGap, false)}`);
+  return bits.length > 0 ? `analysis: ${bits.join(' · ')}` : undefined;
 }
 
 /** Select the steps to print: all of them, or (errorsOnly) errors + neighbours. */
@@ -109,35 +139,64 @@ export function renderTrajectoryText(
     return lines.join('\n') + '\n';
   }
 
-  // Idle stalls, most notable first.
-  for (const gap of [...model.gaps].sort((a, b) => b.durationMs - a.durationMs).slice(0, 4)) {
-    lines.push(`idle ${dur(gap.durationMs, false)} after step ${gap.afterOrdinal} (stall)`);
-  }
+  // Analysis summary — errors, idle total, longest gap.
+  const analysis = analysisLine(model);
+  if (analysis) lines.push(analysis);
 
-  // Steps.
-  const selected = selectSteps(model.steps, errorsOnly);
-  let printed = 0;
+  const stepLine = (step: TrajectoryStep): string => {
+    const ord = pad(String(step.ordinal).padStart(2, '0'), 3);
+    const tool = pad(stepBadgeLabel(step), 6);
+    const label = pad(clipLabel(step.label), LABEL_COL);
+    const mark = outcomeMark(step);
+    return `${ord} ${tool} ${label} ${dur(step.durationMs, step.durationEstimated)}${mark ? ' ' + mark : ''}`.trimEnd();
+  };
+
   let omitted = 0;
-  for (const entry of selected) {
-    if (entry === 'gap') { lines.push('  …'); continue; }
-    if (printed >= maxSteps) { omitted++; continue; }
-    const ord = pad(String(entry.ordinal).padStart(2, '0'), 3);
-    const tool = pad(entry.tool ?? entry.kind, 6);
-    const label = pad(clipLabel(entry.label), LABEL_COL);
-    const mark = outcomeMark(entry);
-    lines.push(`${ord} ${tool} ${label} ${dur(entry.durationMs, entry.durationEstimated)}${mark ? ' ' + mark : ''}`.trimEnd());
-    // A short, indented evidence line for an error step.
-    if (entry.outcome === 'error' && entry.detail) {
-      lines.push(`     ${clipLabel(entry.detail)}`);
+  if (errorsOnly) {
+    // Collapsed to error steps and their neighbours — omitted ranges shown as '  …'.
+    const selected = selectSteps(model.steps, true);
+    let printed = 0;
+    for (const entry of selected) {
+      if (entry === 'gap') { lines.push('  …'); continue; }
+      if (printed >= maxSteps) { omitted++; continue; }
+      lines.push(stepLine(entry));
+      if (entry.outcome === 'error' && entry.detail) lines.push(`     ${clipLabel(entry.detail)}`);
+      printed++;
     }
-    printed++;
+  } else {
+    // Full run, step-ordered, with idle gaps rendered as dividers between the
+    // steps they actually fall between — never a wall-clock axis.
+    const gapsSorted = [...model.gaps].sort((a, b) => a.startMs - b.startMs);
+    let gapIdx = 0;
+    // A gap may fall BEFORE the first step (`afterOrdinal: 0`), so start
+    // `prevMs` at the session origin, not `null` — else a leading stall is
+    // silently dropped.
+    let prevMs = 0;
+    let printed = 0;
+    const emitGapsBefore = (curMs: number): void => {
+      while (gapIdx < gapsSorted.length && gapsSorted[gapIdx].startMs >= prevMs && gapsSorted[gapIdx].startMs < curMs) {
+        lines.push(`  ···  idle ${dur(gapsSorted[gapIdx].durationMs, false)}  ···`);
+        gapIdx++;
+      }
+    };
+    for (const step of model.steps) {
+      emitGapsBefore(step.startMs);
+      if (printed >= maxSteps) { omitted++; prevMs = step.startMs; continue; }
+      lines.push(stepLine(step));
+      if (step.outcome === 'error' && step.detail) lines.push(`     ${clipLabel(step.detail)}`);
+      printed++;
+      prevMs = step.startMs;
+    }
+    emitGapsBefore(Number.POSITIVE_INFINITY);
   }
   if (omitted > 0) lines.push(`  … ${omitted} more step${omitted === 1 ? '' : 's'} (raise --json for the full model)`);
   if (model.truncatedSteps > 0) lines.push(`  … ${model.truncatedSteps} step${model.truncatedSteps === 1 ? '' : 's'} collapsed by the render cap`);
 
-  // Where the time went.
+  // Where the time went / tool mix.
   const share = shareLine(model);
   if (share) lines.push(share);
+  const mix = toolMixLine(model);
+  if (mix) lines.push(mix);
 
   return lines.join('\n') + '\n';
 }
@@ -166,7 +225,7 @@ function diffColumn(heading: string, steps: TrajectoryStep[], maxLines: number):
   const shown = steps.slice(0, maxLines);
   for (const step of shown) {
     const mark = outcomeMark(step);
-    lines.push(`  ${pad(step.tool ?? step.kind, 6)} ${pad(clipLabel(step.label), LABEL_COL)} ${dur(step.durationMs, step.durationEstimated)}${mark ? ' ' + mark : ''}`.trimEnd());
+    lines.push(`  ${pad(stepBadgeLabel(step), 6)} ${pad(clipLabel(step.label), LABEL_COL)} ${dur(step.durationMs, step.durationEstimated)}${mark ? ' ' + mark : ''}`.trimEnd());
   }
   const omitted = steps.length - shown.length;
   if (omitted > 0) lines.push(`  … ${omitted} more`);

--- a/apps/cli/src/lib/session/trajectory.test.ts
+++ b/apps/cli/src/lib/session/trajectory.test.ts
@@ -138,6 +138,37 @@ describe('buildTrajectory — gaps, tokens, delegation, shares', () => {
   });
 });
 
+describe('buildTrajectory — program + exit code (reused from tool-calls.ts)', () => {
+  it('extracts the effective program from a shell step, not the wrapper', () => {
+    const events: SessionEvent[] = [
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'c1', command: 'git push && gh pr create' },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Bash', callId: 'c1', outcome: 'ok' },
+    ];
+    const step = buildTrajectory(events, meta()).steps[0];
+    expect(step.program).toBe('git');
+  });
+
+  it('carries the exit code from a failing command onto the step', () => {
+    const events: SessionEvent[] = [
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'c1', command: 'bun test' },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Bash', callId: 'c1', outcome: 'error', exitCode: 1, output: 'failing' },
+    ];
+    const step = buildTrajectory(events, meta()).steps[0];
+    expect(step.exitCode).toBe(1);
+    expect(step.program).toBe('bun');
+  });
+
+  it('leaves program undefined for a non-shell tool', () => {
+    const events: SessionEvent[] = [
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Read', callId: 'r1', args: { file_path: 'a.ts' } },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Read', callId: 'r1', outcome: 'ok' },
+    ];
+    const step = buildTrajectory(events, meta()).steps[0];
+    expect(step.program).toBeUndefined();
+    expect(step.exitCode).toBeUndefined();
+  });
+});
+
 describe('buildTrajectory — redaction and safety', () => {
   it('redacts a secret in a derived label by default, and passes it through with redact:false', () => {
     const secret = 'sk-supersecrettoken1234567890';

--- a/apps/cli/src/lib/session/trajectory.ts
+++ b/apps/cli/src/lib/session/trajectory.ts
@@ -22,6 +22,7 @@
  */
 import { redactSecrets } from '../redact.js';
 import { computeSummaryStats, type SessionStats } from './render.js';
+import { toolCallsFromEvents, type IndexedToolCall } from './tool-calls.js';
 import type { SessionEvent, SessionMeta } from './types.js';
 
 /** One drawable step on a session's trajectory — a tool call or a thinking block. */
@@ -55,6 +56,14 @@ export interface TrajectoryStep {
   outputTokens?: number;
   /** Harness-native call identity, when present. */
   callId?: string;
+  /**
+   * The effective shell program for a shell-tool step (`git`, `gh`, `bun`, …),
+   * from the real bash parser behind `tool-calls.ts` — never a naive prefix
+   * split. Undefined for a non-shell tool or an unparseable command.
+   */
+  program?: string;
+  /** Process exit code from the paired result, when the harness reported one. */
+  exitCode?: number;
 }
 
 /** An idle stall between two events — a candidate "where did it hang" marker. */
@@ -218,6 +227,25 @@ export function buildTrajectory(
   const firstTs = stats.firstTs;
   const spanMs = stats.lastTs > stats.firstTs ? stats.lastTs - stats.firstTs : 0;
 
+  // Reuse the real bash parser behind `tool-calls.ts` — never reimplement shell
+  // parsing here. Correlate its `IndexedToolCall`s back to this module's own
+  // tool_use drafts by (tool, timestamp) in FIFO order: both walk the same
+  // `events` array in the same order, so encounter order is a reliable join key
+  // even where a harness omits `callId`.
+  const indexedCalls = toolCallsFromEvents(events);
+  const callsByKey = new Map<string, IndexedToolCall[]>();
+  for (const call of indexedCalls) {
+    const key = `${call.tool} ${call.timestamp}`;
+    const queue = callsByKey.get(key);
+    if (queue) queue.push(call);
+    else callsByKey.set(key, [call]);
+  }
+  const takeIndexedCall = (tool: string, timestamp: string): IndexedToolCall | undefined => {
+    const key = `${tool} ${timestamp}`;
+    const queue = callsByKey.get(key);
+    return queue && queue.length > 0 ? queue.shift() : undefined;
+  };
+
   // Absolute ms per event index (NaN when the timestamp is unparseable).
   const eventMs = events.map((e) => toMs(e.timestamp));
   // The next event index (after i) that carries a valid timestamp — the anchor
@@ -251,6 +279,8 @@ export function buildTrajectory(
     } else if (e.type === 'tool_use' && !e._local) {
       const tool = e.tool || 'unknown';
       const draftIndex = drafts.length;
+      const indexedCall = takeIndexedCall(tool, e.timestamp);
+      const effectiveProgram = indexedCall?.programOccurrences.find((o) => o.role === 'effective')?.program;
       drafts.push({
         step: {
           ordinal: 0,
@@ -264,6 +294,8 @@ export function buildTrajectory(
           label: toolLabel(tool, e.args, e.command, redact, knownSecrets),
           delegation: INLINE_TASK_TOOLS.has(tool) ? 'inline-task' : undefined,
           callId: e.callId,
+          program: effectiveProgram ?? indexedCall?.programs[0],
+          exitCode: indexedCall?.exitCode,
         },
         eventIndex: i,
         callId: e.callId,


### PR DESCRIPTION
## Summary

Follow-up to the merged `agents sessions trace` feature (#2929 series). Rebuilds the **single-session** HTML/text view per owner feedback that the shipped wall-clock Gantt waterfall was weak.

- **Analysis hero** (new, top of page/output): "where the time went" stacked bar, top ~6 slowest steps, a **tool-mix histogram that breaks a Bash step down by its effective shell program** (`git`, `gh`, `bun`, `agents`, …) instead of lumping every shell call as "Bash", and headline KPIs (errors, idle total, longest gap).
- **Trajectory** is now **step-ordered execution order**, never a wall-clock time axis: one row per step, badged by its program/tool, duration heat-colored (grey/amber/red), the process **exit code** shown on a failing step, runs of ≥3 fast same-program calls folded into one `×N` expander, and idle gaps rendered as centered `··· idle 3m ···` dividers.
- `TrajectoryStep` gains `program?`/`exitCode?`, derived by **reusing** the real bash parser behind `tool-calls.ts`/`shell-programs.ts` (`programOccurrences`, role `effective`) — never a naive command-prefix split. Additive to the `--json` envelope.
- Compare (two-selector) picks up the same program badges and exit codes in its diff lists and waterfall tooltips.
- Fixed a bug found during verification: a gap occurring *before* the first step (`afterOrdinal: 0`) was silently dropped from both HTML and text renderers — the divider loop started `prevMs` at `null` instead of the session origin.

## Test plan

- [x] `bun test` green on `trajectory{,.html,.text}{,.compare}.test.ts`, `trajectory-lineage.test.ts`, `sessions-trace.test.ts` (91 tests, 261+ assertions)
- [x] `bunx tsc --noEmit` clean
- [x] `bun run build` clean
- [x] `scripts/install.sh --skip-tests` → `agents-dev sessions trace <bash-heavy session> --html` — tool mix shows `git`/`agents`/`python3`/`gh`/`grep`/`echo`/`tail`/`sed` programs, never "Bash 92%"
- [x] Same session `--text` — program-badged steps, `exit 1 ✗` on failures, `··· idle Nm ···` dividers, `analysis:`/`tool mix:` summary lines
- [x] Visual read-back via `agents browser` — analysis hero: https://share.agents-cli.sh/muqsitnawaz/redesign-1787504767230-bec8e80881aae4ce
- [x] Visual read-back — trajectory rows (folded runs, red error rows, exit marks): https://share.agents-cli.sh/muqsitnawaz/redesign-1787505328081-d9f0e9f30a773162
- [x] Full rendered page: https://share.agents-cli.sh/muqsitnawaz/redesign-trace-v2-fixed-578a6dcdd33c6265

## Docs

- `docs/sessions.md` updated to describe the new analysis-hero + step-ordered design (single + compare).
- `.changelog/next/sessions-trace-redesign.md` added.
- Command index unchanged (no CLI surface/flag change — internals only).