### PR TITLE
fix(test): promote-home-base-probe matches the decoupled async merge line

### DIFF
--- a/apps/cli/scripts/promote-home-base-probe.test.ts
+++ b/apps/cli/scripts/promote-home-base-probe.test.ts
@@ -185,7 +185,10 @@ describe('release.sh: the promote preflight gates the mutating phases (RUSH-3026
     const lines = fs.readFileSync(RELEASE, 'utf-8').replace(/\r/g, '').split('\n');
     const call = lines.findIndex((l) => l.trim() === 'assert_promote_home_base');
     expect(call, 'assert_promote_home_base must be invoked').toBeGreaterThanOrEqual(0);
-    const merge = lines.findIndex((l) => /^\s*gh pr merge "\$PR_NUMBER" --squash/.test(l));
+    // The version-bump merge is now the async, post-publish `if … && gh pr merge …`
+    // form (RUSH-2395 decouple), so match `gh pr merge "$PR_NUMBER" --squash`
+    // anywhere on the line rather than anchored to start-of-line.
+    const merge = lines.findIndex((l) => /gh pr merge "\$PR_NUMBER" --squash/.test(l));
     const tag = lines.findIndex((l) => /^git push origin "v\$TARGET"$/.test(l));
     expect(merge).toBeGreaterThan(call);
     expect(tag).toBeGreaterThan(call);


### PR DESCRIPTION
**Fix-forward for a test broken by #2966 (RUSH-2395 decouple).** Test-only.

#2966 moved the version-bump merge into the async, post-publish `if … && gh pr merge "$PR_NUMBER" --squash …` form. `promote-home-base-probe.test.ts:188` anchored its merge regex to start-of-line (`^\s*gh pr merge`), so the `&& `-prefixed line stopped matching → `findIndex` returns -1 → the "merge after assert_promote_home_base" ordering assertion failed on the full suite.

I relaxed the **identical** regex in `signing-home-base-probe.test.ts` in #2966 but **missed this one**. It slipped past CI because this test reads `release.sh` via `fs.readFileSync(RELEASE)` at **runtime**, not a static `import` — so `ci-scope.ts`'s affected-test selection doesn't map a `release.sh` change to it, and the full-suite producer was the first thing to run it.

Fix mirrors the sibling: match `gh pr merge "$PR_NUMBER" --squash` anywhere on the line. **Intent preserved** — the merge still comes after `assert_promote_home_base`.

## Run result
```
Test Files  3 passed (3)
Tests  29 passed | 4 skipped (33)
```
Captured run: https://share.agents-cli.sh/muqsitnawaz/fix-promote-probe-regex-promote-probe-fix-df0dcf729e1540fe

Follow-up for the real gap (ci-scope blind to `fs.readFileSync(release.sh)` deps → these release-script tests aren't selected on a release.sh change): I'll file it.
