### PR TITLE
fix(test): cap vitest workers under the attestation producer so the release suite stops flaking (RUSH-3015)

### DIFF
--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -16,12 +16,25 @@ import { shouldEnableCiTestProfile } from './tests/hermetic-guards';
 const isWin = process.platform === 'win32';
 const ignoreUnhandledPoolErrors = isWin || shouldEnableCiTestProfile(process.env);
 
+// RUSH-3081/RUSH-3015: the attestation producer (release-attestation-produce.sh,
+// AGENTS_ATTEST_PRODUCER=1) runs the FULL suite on the signing Mac (mac-mini),
+// which is a shared box usually under concurrent load. With the default forks
+// pool spawning a worker per core, these real-CLI / real-service integration
+// tests contend on shared state and flake (1-2 different tests per run out of
+// ~13k) and workers OOM/crash — observed failing ~every producer run across ~10
+// attempts, blocking releases. Cap producer concurrency so the suite runs stably
+// enough to attest. Only the producer is affected (a signing-Mac full-suite run);
+// normal CI on dedicated crabboxes (CI=true, not AGENTS_ATTEST_PRODUCER) keeps
+// full parallelism and its 90s budget.
+const isAttestProducer = process.env.AGENTS_ATTEST_PRODUCER === '1';
+
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
     pool: 'forks',
     ...(isWin ? { maxWorkers: 2, minWorkers: 1 } : {}),
+    ...(isAttestProducer && !isWin ? { maxWorkers: 4, minWorkers: 1 } : {}),
     // Hermeticity (#910): every fork gets a temp-pinned broker socket, events
     // sink, and broker-off defaults BEFORE the test file's imports run.
     setupFiles: ['./tests/setup.ts'],


### PR DESCRIPTION
**What:** the release attestation producer's full-suite run flakes on the signing Mac because the forks pool had no worker cap on macOS. This caps it for the producer only. `test-infra`.

## The problem (measured, ~10 producer runs)
`release-attestation-produce.sh` runs the **full suite on mac-mini** (the only signing Mac) and refuses to attest a red tree. mac-mini is a shared box under concurrent load, and `vitest.config.ts` capped `maxWorkers` **only on Windows** — so on macOS the forks pool spawns a worker per core. Under that parallelism the real-CLI / real-service integration tests contend on shared state and **flake** (1-2 *different* tests per run out of ~13k) and workers **OOM/crash**. Observed failing on essentially **every** producer run across ~10 attempts, blocking every Mac-signed release (the RUSH-3015 producer-reliability gap).

## The fix
Cap the producer's fork concurrency (`maxWorkers: 4`) gated on `AGENTS_ATTEST_PRODUCER=1` — the flag `release-attestation-produce.sh` already exports. Only the signing-Mac full-suite run is affected; **normal CI on dedicated crabboxes** (`CI=true`, not the producer flag) keeps full parallelism and its 90s budget.

## Evidence (run result)
Verification run (uploaded): https://share.agents-cli.sh/muqsitnawaz/fix-worker-cap-worker-cap-verify-c088b46f67b9daac
`AGENTS_ATTEST_PRODUCER=1 vitest run …` → config loads clean, **20/20 pass** with the cap active. The real proof is the next producer run going green on mac-mini, which I'm driving right after this merges.

Ticket: RUSH-3015 (producer reliability)