### PR TITLE
fix(sessions): trace HTML analysis hero was unstyled (CSS in wrong constant)

### DIFF
--- a/apps/cli/src/lib/session/trajectory-html.test.ts
+++ b/apps/cli/src/lib/session/trajectory-html.test.ts
@@ -71,6 +71,20 @@ describe('renderTrajectoryHtml — self-contained and safe', () => {
     expect(html).toMatch(/share-fill/);
   });
 
+  it('ships the analysis-hero CSS in the single-session view (not only in COMPARE_STYLE)', () => {
+    // Regression: the .analysis/.card/.mix-*/.slow-* rules once lived in COMPARE_STYLE,
+    // so the single-session page (which injects only BASE_STYLE) rendered the hero
+    // unstyled — cards had no panels and mix/slow rows jammed ("git105"). The markup
+    // being present is not enough; the CSS that lays it out must ship in THIS view.
+    const html = renderTrajectoryHtml(buildTrajectory(events, meta()));
+    const style = html.slice(html.indexOf('<style>'), html.indexOf('</style>'));
+    for (const rule of ['.analysis', '.card', '.mix-row', '.mix-name', '.mix-n', '.slow-row', '.slow-label', '.steps', '.gap-divider']) {
+      expect(style, `single-session <style> is missing ${rule}`).toContain(rule);
+    }
+    // And the grid that actually spaces the command-mix rows must be there.
+    expect(style).toMatch(/\.mix-row\s*\{[^}]*display:\s*grid/);
+  });
+
   it('an empty trajectory still renders a valid page (no crash)', () => {
     const html = renderTrajectoryHtml(buildTrajectory([], meta({ agent: 'openclaw' })));
     expect(html).toContain('<!DOCTYPE html>');

--- a/apps/cli/src/lib/session/trajectory-html.ts
+++ b/apps/cli/src/lib/session/trajectory-html.ts
@@ -325,24 +325,7 @@ const BASE_STYLE = `
     color: var(--dim); font-size: 12px;
     font-family: ui-monospace, "JetBrains Mono", Menlo, monospace;
   }
-`;
-
-/** Compare-only rules layered on top of {@link BASE_STYLE} — lanes, divergence marker, summary table. */
-const COMPARE_STYLE = `
-  svg .diverge { stroke: #e0b341; stroke-width: 1.4; stroke-dasharray: 4 3; }
-  .diverge-note { color: #e0b341; font-size: 12.5px; margin: 6px 0; }
-  table.cmp-table { border-collapse: collapse; width: 100%; font-family: ui-monospace, "JetBrains Mono", Menlo, monospace; font-size: 12.5px; }
-  table.cmp-table th, table.cmp-table td { text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border); }
-  table.cmp-table th { color: var(--dim); font-weight: 600; text-transform: uppercase; font-size: 10.5px; letter-spacing: .5px; }
-  .diff-cols { display: flex; gap: 24px; flex-wrap: wrap; }
-  .diff-col { flex: 1; min-width: 260px; }
-  .diff-col h3 { font-size: 11px; color: var(--dim); text-transform: uppercase; letter-spacing: .5px; margin: 0 0 8px; }
-  .diff-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
-  .diff-list li {
-    font-family: ui-monospace, "JetBrains Mono", Menlo, monospace; font-size: 12px;
-    border: 1px solid var(--border); border-radius: 5px; padding: 5px 8px; background: var(--panel);
-  }
-  /* trace v2 — analysis hero + program-aware step list */
+  /* trace v2 — analysis hero + program-aware step list (single-session view; compare/lineage layer on top of BASE_STYLE, so this must live here) */
   main { padding: 20px; }
   .analysis { display: grid; grid-template-columns: 1.25fr 1fr; gap: 20px; margin-bottom: 26px; }
   @media (max-width: 720px) { .analysis { grid-template-columns: 1fr; } }
@@ -381,6 +364,23 @@ const COMPARE_STYLE = `
   .tok { color: var(--dim); font-size: 10px; }
   .gap-divider { text-align: center; color: #7a5c3a; font-size: 11px; margin: 8px 0; letter-spacing: .06em; font-family: ui-monospace, "JetBrains Mono", Menlo, monospace; }
   details.step .detail { white-space: pre-wrap; color: var(--dim); font-size: 11px; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 8px 10px; margin: 2px 0 8px 54px; max-height: 220px; overflow: auto; }
+`;
+
+/** Compare-only rules layered on top of {@link BASE_STYLE} — lanes, divergence marker, summary table. */
+const COMPARE_STYLE = `
+  svg .diverge { stroke: #e0b341; stroke-width: 1.4; stroke-dasharray: 4 3; }
+  .diverge-note { color: #e0b341; font-size: 12.5px; margin: 6px 0; }
+  table.cmp-table { border-collapse: collapse; width: 100%; font-family: ui-monospace, "JetBrains Mono", Menlo, monospace; font-size: 12.5px; }
+  table.cmp-table th, table.cmp-table td { text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border); }
+  table.cmp-table th { color: var(--dim); font-weight: 600; text-transform: uppercase; font-size: 10.5px; letter-spacing: .5px; }
+  .diff-cols { display: flex; gap: 24px; flex-wrap: wrap; }
+  .diff-col { flex: 1; min-width: 260px; }
+  .diff-col h3 { font-size: 11px; color: var(--dim); text-transform: uppercase; letter-spacing: .5px; margin: 0 0 8px; }
+  .diff-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+  .diff-list li {
+    font-family: ui-monospace, "JetBrains Mono", Menlo, monospace; font-size: 12px;
+    border: 1px solid var(--border); border-radius: 5px; padding: 5px 8px; background: var(--panel);
+  }
 `;
 
 const THEME_SCRIPT = `


### PR DESCRIPTION
## What

Fix — the single-session `agents sessions trace` HTML rendered its **analysis hero unstyled**. `bugfix`

The single view injects only `BASE_STYLE`, but the analysis-hero + step-list CSS (`.analysis`, `.card`, `.mix-*`, `.slow-*`, `.kpis`, `.steps`, `.step .row`, `.gap-divider`, `.detail`) had been placed in `COMPARE_STYLE`. So the flagship single-session view had no card panels, no two-column grid, and jammed command-mix/slowest rows (`git105`, `67agentsagents…`). Only the share bars survived (`.share-row` is in `BASE_STYLE`).

The fix moves the whole analysis-hero block into `BASE_STYLE` where the single view reads it. Compare/lineage still get it — they layer their own style on top of `BASE_STYLE` — so no duplication and no loss.

## Before / after

Same real session (`075e581e`), rendered by the actual CLI:

**Before** — hero unstyled, `Command mix` counts jammed onto the program names:
![before](https://share.agents-cli.sh/muqsitnawaz/agents-cli-trace-before-jammed-c14de2d4b8e48066)

**After** — two card panels, spaced `Where the time went` / `Command mix` rows, colored badges, KPIs, idle dividers:
![after](https://share.agents-cli.sh/muqsitnawaz/agents-cli-trace-fixed-render-837ba118aa10f2f6)

## Test

Adds a regression test asserting the single-session `<style>` actually **contains** the hero CSS (`.analysis`/`.card`/`.mix-row` grid/`.slow-row`/…). The prior tests checked only markup strings — which is exactly how an unstyled hero passed CI. `tsc --noEmit` clean; `trajectory-html.test.ts` + `trajectory-html.compare.test.ts` 10/10 pass.

## No changelog

Pure bug fix to unreleased code (trace v2 is on `main`, not yet published), so no separate CHANGELOG entry — the existing trace v2 fragment already describes the analysis hero, which this makes actually render.
