### PR TITLE
fix(menubar): restore one-keystroke Cmd-Shift-V paste (prompt once for Accessibility)

### DIFF
--- a/apps/cli/.changelog/next/menubar-paste-prompt-once.md
+++ b/apps/cli/.changelog/next/menubar-paste-prompt-once.md
@@ -1,0 +1,5 @@
+---
+type: fix
+---
+
+Cmd-Shift-V once again pastes the clip reference in a single keystroke. 1.22.47 decoupled the paste from Accessibility so it never prompted — but that meant an ungranted machine silently fell back to copying the token to the clipboard, so you had to press Cmd-V yourself (two keystrokes). The helper now prompts for Accessibility **once** per launch to restore the one-keystroke auto-type, then falls back to the clipboard silently if you decline (no per-paste nagging). Because dev builds now use a distinct `.dev` bundle id and the release pins the helper's designated requirement, granting it once sticks across upgrades — so a single prompt is all it takes.

--- a/apps/cli/menubar/Sources/MenubarHelper/Clip.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Clip.swift
@@ -180,14 +180,13 @@ enum Clip {
     // terminals wrapped in Electron/webview accept the event.
     private static func inject(_ text: String) {
         guard ensureAccessibility() else {
-            // Paste NEVER depends on the grant: the clip is already persisted, so
-            // hand the reference over on the clipboard and let the user press
-            // Cmd-V. Auto-type is a convenience gated on Accessibility; the paste
-            // itself is not. Framed as a plain "copied" confirmation, not an error
-            // — the hotkey did its job — with an OPTIONAL hint about enabling
-            // auto-type. Crucially, ensureAccessibility() no longer pops a modal
-            // to reach this path, so a machine that hasn't granted (or whose grant
-            // lapsed) still pastes with no interruption.
+            // Accessibility isn't granted (and we've already prompted once this
+            // launch, so we won't nag again). The clip is already persisted, so we
+            // still deliver it — on the clipboard, for the user to press Cmd-V —
+            // rather than losing the paste. This is the two-keystroke fallback;
+            // the one-keystroke auto-type above is what runs once the grant is in
+            // place. Framed as a plain "copied" confirmation with a one-click link
+            // to the Accessibility pane so enabling auto-type is easy.
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(text, forType: .string)
             let appName = (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String) ?? "AGI Menu"
@@ -220,18 +219,28 @@ enum Clip {
         }
     }
 
+    // Set once we've shown the Accessibility prompt this launch, so a denied
+    // machine is asked at most once — not on every hotkey press.
+    private static var didPromptForAccessibility = false
+
     // Whether this process may synthesize keystrokes (Accessibility granted).
     //
-    // Probe WITHOUT kAXTrustedCheckOptionPrompt on purpose. That option re-shows
-    // the system "…would like to control this computer" modal on EVERY paste while
-    // untrusted, which turned an OPTIONAL convenience (auto-type) into an
-    // inescapable nag: any grant lapse — a re-signed dev build sharing the bundle
-    // id, a TCC reset — left it firing on every hotkey press, dozens of times a
-    // week. The paste does not need the grant (inject falls back to the clipboard),
-    // so a bare AXIsProcessTrusted() read is correct: auto-type stays on where the
-    // user has already granted, and nobody is ever prompted just to paste. A user
-    // who WANTS auto-type enables it from the notification's deep link, on demand.
+    // The WHOLE point of Cmd-Shift-V is a ONE-keystroke paste: auto-type the
+    // reference straight into the terminal. That needs Accessibility. So when the
+    // grant is missing we DO ask for it — but exactly ONCE per launch, via
+    // kAXTrustedCheckOptionPrompt. After that we fall back to the clipboard
+    // silently rather than re-nagging on every paste (the original bug was the
+    // modal firing on EVERY hotkey press — but that was caused by the grant being
+    // repeatedly REVOKED by ad-hoc dev builds sharing the bundle id, which the
+    // `.dev`-id split + the designated-requirement pin now prevent; once granted,
+    // the grant sticks, so a single prompt is enough to restore one-keystroke
+    // paste for good). Granted → true → auto-type; genuinely refused → clipboard
+    // fallback in inject().
     private static func ensureAccessibility() -> Bool {
-        return AXIsProcessTrusted()
+        if AXIsProcessTrusted() { return true }
+        if didPromptForAccessibility { return false }
+        didPromptForAccessibility = true
+        let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+        return AXIsProcessTrustedWithOptions(opts)
     }
 }


### PR DESCRIPTION
**What:** 1.22.47 accidentally turned Cmd-Shift-V into a two-keystroke paste on ungranted machines. This restores the one-keystroke auto-type. `fix` (user-visible).

## The regression (reported by the user)
1.22.47 decoupled the clip paste from Accessibility so it would never pop a modal. But that made an **ungranted** machine silently fall back to copying the token to the clipboard → the user then presses **Cmd-V** themselves. Two keystrokes. That defeats the point of the feature — Cmd-Shift-V is meant to **auto-type the reference in one keystroke**.

## The fix
`Clip.swift`: prompt for Accessibility **once per launch** (`kAXTrustedCheckOptionPrompt`, guarded by `didPromptForAccessibility`), then fall back to the clipboard silently if declined. So: granted → auto-type (one keystroke); first time ungranted → one prompt to grant it; declined → clipboard fallback, no per-paste nagging.

The original "modal on every paste" complaint was caused by ad-hoc dev builds **repeatedly revoking** the grant (same bundle id) — already fixed by the `.dev`-id split + the DR release gate in 1.22.47, so the grant now sticks and a single prompt restores one-keystroke paste for good.

## Evidence (real Mac build)
`swift build` of the changed `Clip.swift` on mac-mini → **Build complete!** (compiled `[26/31] Compiling MenubarHelper Clip.swift` → `Build complete! (27.16s)`). Log: https://share.agents-cli.sh/muqsitnawaz/agents-cli-paste-build-macmini-60af0012e521e7e4
Swift isn't compiled by the Linux PR CI (`test`) and this diff touches no TS, so the required job runs the unchanged suite; the runtime paste behavior is validated on a real install before the release ships it.

Ticket: RUSH-3076 follow-up (the one-keystroke UX the grant fix was in service of)