### PR TITLE
fix(browser): resolve profiles from the device registry and tunnel to the declaring host

### DIFF
--- a/apps/cli/.changelog/next/browser-registry-resolution.md
+++ b/apps/cli/.changelog/next/browser-registry-resolution.md
@@ -1,0 +1,5 @@
+---
+type: breaking
+---
+
+`agents browser` no longer asks the caller which machine a profile lives on. The daemon reads the device-declaration registry: a name this machine declares connects locally; a name only other machines declare is tunnelled to a reachable declaring device (and the command output names which one); a name nobody declares fails loudly, listing similar names, and never auto-creates a logged-out local browser. Identity-bearing profiles share one connection (no Electron fork, no second chrome-data). Runtime keys are `<profile>@<device>` instead of `<profile>@endpoint-N`; leftover `@endpoint-N` dirs are renamed onto the new key.

--- a/apps/cli/src/lib/browser/drivers/ssh.ts
+++ b/apps/cli/src/lib/browser/drivers/ssh.ts
@@ -31,15 +31,26 @@ export interface SSHConnection {
  */
 export type RemoteOs = 'windows' | 'posix';
 
+export interface SSHConnectOptions {
+  /**
+   * Attach to a browser another device already declared (identity-bearing or
+   * a fungible name we don't declare here). Do not launch a fresh remote
+   * chrome-data, and do not kill that browser when the tunnel closes — it
+   * holds the logins the caller is trying to reach.
+   */
+  persistRemote?: boolean;
+}
+
 export async function connectSSH(
   endpoint: string,
   profile: BrowserProfile,
   /**
-   * Runtime key (`<profile>@<endpoint>`) this connection is stored under. It
+   * Runtime key (`<profile>@<device>`) this connection is stored under. It
    * keys the tunnel's runtime record; `profile.name` is the bare, user-facing
    * name and appears only in messages (RUSH-2709).
    */
   key: ConnectionKey,
+  opts: SSHConnectOptions = {},
 ): Promise<SSHConnection> {
   const url = new URL(endpoint);
 
@@ -89,7 +100,13 @@ export async function connectSSH(
   // (the launch backgrounds/WMI-spawns regardless), so this does not spuriously
   // fail the reconnect path — only genuine launch failures reach the caller
   // instead of being swallowed and mis-reported later as a tunnel timeout.
-  await ensureRemoteBrowser(user, host, profile.browser, remotePort, remoteOs, profile.binary);
+  //
+  // persistRemote skips the launch: launching would mint a logged-out
+  // `--user-data-dir=/tmp/agents-browser-N` under a name that means a
+  // credentialed browser on the declaring device.
+  if (!opts.persistRemote) {
+    await ensureRemoteBrowser(user, host, profile.browser, remotePort, remoteOs, profile.binary);
+  }
 
   let tunnel: ChildProcess;
   if (occupant) {
@@ -106,7 +123,20 @@ export async function connectSSH(
     throw new Error(`SSH tunnel failed to establish to ${host}`);
   }
 
-  const { wsUrl, browser } = await discoverBrowserWsUrl(localPort, 'localhost', profile.name);
+  let wsUrl: string;
+  let browser: string;
+  try {
+    ({ wsUrl, browser } = await discoverBrowserWsUrl(localPort, 'localhost', profile.name));
+  } catch (err) {
+    tunnel.kill();
+    if (opts.persistRemote) {
+      const why = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Browser profile "${profile.name}" is declared on ${host}, but nothing is speaking CDP on port ${remotePort}: ${why}`,
+      );
+    }
+    throw err;
+  }
   try {
     verifyBrowserIdentity(browser, profile.browser, remotePort, host);
   } catch (err) {
@@ -137,11 +167,13 @@ export async function connectSSH(
     pid: tunnelPid,
     cleanup: () => {
       cdp.close();
-      // Kill the remote browser BEFORE tearing down the tunnel. It runs on a
-      // separate ssh connection (independent of the tunnel we're about to
-      // kill), so tunnel teardown can't cut it off. Fire-and-forget — cleanup
-      // stays synchronous, and killRemoteBrowser never rejects.
-      killRemoteBrowser(user, host, remoteOs, remotePort).catch(() => {});
+      // Kill the remote browser BEFORE tearing down the tunnel — but only
+      // when we launched it. persistRemote is an attach to someone else's
+      // declared browser; killing it would drop the logins the caller came
+      // for. Fire-and-forget — cleanup stays synchronous.
+      if (!opts.persistRemote) {
+        killRemoteBrowser(user, host, remoteOs, remotePort).catch(() => {});
+      }
       tunnel.kill();
       clearProfileRuntime(key);
     },

--- a/apps/cli/src/lib/browser/ipc.ts
+++ b/apps/cli/src/lib/browser/ipc.ts
@@ -247,6 +247,8 @@ export class BrowserIPCServer {
   private connections = new Set<net.Socket>();
   /** In-flight stop, so a second SIGTERM awaits the same close, never skips it. */
   private stopping: Promise<void> | null = null;
+  /** Device pick from an implicit start (`navigate` creating a task). */
+  private pendingPicked?: string;
 
   constructor(service: BrowserService) {
     this.service = service;
@@ -438,6 +440,7 @@ export class BrowserIPCServer {
         };
       }
       request.task = resolved.task.name;
+      if (resolved.created && resolved.picked) this.pendingPicked = resolved.picked;
       return undefined;
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
@@ -453,6 +456,8 @@ export class BrowserIPCServer {
       const result = this.service.stageUpload(source);
       return { ok: true, path: result.path };
     }
+
+    this.pendingPicked = undefined;
 
     // Task-scoped actions: resolve identity / create / refuse once here.
     if (PAGE_RESOLVE_VERBS.has(request.action) || CLOSE_VERBS.has(request.action)) {
@@ -479,7 +484,7 @@ export class BrowserIPCServer {
           fleetRemote: request.fleetRemote,
           actor: request.actor,
         });
-        return { ok: true, tabId: shown.tabId };
+        return { ok: true, tabId: shown.tabId, message: shown.picked };
       }
 
       case 'start': {
@@ -504,6 +509,7 @@ export class BrowserIPCServer {
           tabId: result.tabId,
           windowTargetId: result.windowId,
           skill: result.skill,
+          message: result.picked,
         };
       }
 
@@ -602,7 +608,9 @@ export class BrowserIPCServer {
           request.url,
           request.profile
         );
-        return { ok: true, tabId: result.tabId, task: request.task };
+        const picked = this.pendingPicked;
+        this.pendingPicked = undefined;
+        return { ok: true, tabId: result.tabId, task: request.task, message: picked };
       }
 
       case 'tab-add': {

--- a/apps/cli/src/lib/browser/resolve-target.test.ts
+++ b/apps/cli/src/lib/browser/resolve-target.test.ts
@@ -1,0 +1,203 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as yaml from 'yaml';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let root: string;
+let previousHome: string | undefined;
+
+function writeYaml(file: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, yaml.stringify(value));
+}
+
+function deviceFile(device: string): string {
+  return path.join(root, '.agents', 'devices', device, 'agents.yaml');
+}
+
+const chrome = { browser: 'chrome' as const, endpoints: ['cdp://127.0.0.1:9222'] };
+const comet = { browser: 'comet' as const, endpoints: ['cdp://localhost:9333'] };
+
+beforeEach(() => {
+  previousHome = process.env.HOME;
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-browser-resolve-target-'));
+  process.env.HOME = root;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.HOME;
+  else process.env.HOME = previousHome;
+  fs.rmSync(root, { recursive: true, force: true });
+  vi.resetModules();
+});
+
+describe('shouldForkProfile', () => {
+  it('never forks an identity-bearing profile, even Electron with live tasks', async () => {
+    const { shouldForkProfile } = await import('./resolve-target.js');
+    expect(
+      shouldForkProfile('identity', { electron: true, tasks: { size: 2 } }),
+    ).toBe(false);
+  });
+
+  it('forks a fungible Electron profile that already has a task', async () => {
+    const { shouldForkProfile } = await import('./resolve-target.js');
+    expect(
+      shouldForkProfile('fungible', { electron: true, tasks: { size: 1 } }),
+    ).toBe(true);
+    expect(
+      shouldForkProfile('fungible', { electron: true, tasks: { size: 0 } }),
+    ).toBe(false);
+    expect(
+      shouldForkProfile('fungible', { electron: false, tasks: { size: 1 } }),
+    ).toBe(false);
+  });
+});
+
+describe('sshEndpointForDeclaration', () => {
+  it('rewrites a loopback cdp:// declaration to ssh://<device>?port=N', async () => {
+    const { sshEndpointForDeclaration } = await import('./resolve-target.js');
+    expect(sshEndpointForDeclaration('zion', comet)).toBe('ssh://zion?port=9333');
+  });
+
+  it('adds os=windows when the declaring device is Windows', async () => {
+    const { sshEndpointForDeclaration } = await import('./resolve-target.js');
+    expect(sshEndpointForDeclaration('win-mini', chrome, undefined, 'Windows_NT')).toBe(
+      'ssh://win-mini?port=9222&os=windows',
+    );
+  });
+
+  it('leaves an already-ssh:// declaration alone', async () => {
+    const { sshEndpointForDeclaration } = await import('./resolve-target.js');
+    const config = { browser: 'custom' as const, endpoints: ['ssh://browser-host?port=9344'] };
+    expect(sshEndpointForDeclaration('zion', config)).toBe('ssh://browser-host?port=9344');
+  });
+});
+
+describe('resolveBrowserTarget', () => {
+  it('connects locally when THIS device declares the name', async () => {
+    const { machineId } = await import('../machine-id.js');
+    writeYaml(deviceFile(machineId()), { browser: { work: chrome } });
+    writeYaml(deviceFile('other'), { browser: { work: chrome } });
+
+    const { resolveBrowserTarget } = await import('./resolve-target.js');
+    const routed = resolveBrowserTarget('work');
+    expect(routed.local).toBe(true);
+    expect(routed.kind).toBe('fungible');
+    expect(routed.device).toBe(machineId());
+    expect(routed.target).toBe('cdp://127.0.0.1:9222');
+    expect(routed.key).toBe(`work@${machineId()}`);
+    expect(routed.picked).toBeUndefined();
+  });
+
+  it('tunnels to a reachable declaring device when this machine does not declare it', async () => {
+    writeYaml(deviceFile('mac-mini'), { browser: { 'comet-local': comet } });
+    writeYaml(deviceFile('zion'), { browser: { 'comet-local': comet } });
+
+    const { resolveBrowserTarget } = await import('./resolve-target.js');
+    const probed: string[] = [];
+    const routed = resolveBrowserTarget('comet-local', {
+      probe: (device) => {
+        probed.push(device);
+        return { reachable: true, os: 'Darwin' };
+      },
+    });
+    expect(routed.local).toBe(false);
+    expect(routed.kind).toBe('fungible');
+    expect(routed.device).toBe('mac-mini');
+    expect(routed.target).toBe('ssh://mac-mini?port=9333');
+    expect(routed.key).toBe('comet-local@mac-mini');
+    expect(routed.picked).toContain('mac-mini');
+    expect(routed.picked).toContain('zion');
+    expect(probed).toEqual(['mac-mini']);
+  });
+
+  it('skips an unreachable declaring device and picks the next sorted one', async () => {
+    writeYaml(deviceFile('aaa-down'), { browser: { agents: chrome } });
+    writeYaml(deviceFile('zzz-up'), { browser: { agents: chrome } });
+
+    const { resolveBrowserTarget } = await import('./resolve-target.js');
+    const routed = resolveBrowserTarget('agents', {
+      probe: (device) =>
+        device === 'zzz-up'
+          ? { reachable: true }
+          : { reachable: false, reason: 'ssh timed out' },
+    });
+    expect(routed.device).toBe('zzz-up');
+    expect(routed.target).toBe('ssh://zzz-up?port=9222');
+    expect(routed.picked).toBe('Using agents on zzz-up (declared on aaa-down, zzz-up)');
+  });
+
+  it('fails loud when every declaring device is unreachable — does not invent a local target', async () => {
+    writeYaml(deviceFile('zion'), { browser: { 'comet-local': comet } });
+
+    const { resolveBrowserTarget } = await import('./resolve-target.js');
+    expect(() =>
+      resolveBrowserTarget('comet-local', {
+        probe: () => ({ reachable: false, reason: 'No route to host' }),
+      }),
+    ).toThrow(/zion/);
+    expect(() =>
+      resolveBrowserTarget('comet-local', {
+        probe: () => ({ reachable: false, reason: 'No route to host' }),
+      }),
+    ).toThrow(/No route to host/);
+    expect(() =>
+      resolveBrowserTarget('comet-local', {
+        probe: () => ({ reachable: false, reason: 'No route to host' }),
+      }),
+    ).toThrow(/will not be launched/);
+  });
+
+  it('fails loud when nobody declares the name, listing similar names and their devices', async () => {
+    writeYaml(deviceFile('zion'), { browser: { 'comet-local': comet } });
+
+    const { resolveBrowserTarget, undeclaredProfileError } = await import('./resolve-target.js');
+    expect(() => resolveBrowserTarget('comet-locl')).toThrow(/comet-local/);
+    expect(() => resolveBrowserTarget('comet-locl')).toThrow(/zion/);
+    expect(() => resolveBrowserTarget('comet-locl')).toThrow(/not declared by any device/);
+    expect(undeclaredProfileError('ghost').message).toMatch(/No device declares a similar name/);
+  });
+
+  it('points at profiles claim when the name is a leftover central entry', async () => {
+    writeYaml(path.join(root, '.agents', 'agents.yaml'), {
+      browser: { 'comet-local': comet },
+    });
+
+    const { resolveBrowserTarget } = await import('./resolve-target.js');
+    expect(() => resolveBrowserTarget('comet-local')).toThrow(/profiles claim comet-local/);
+    expect(() => resolveBrowserTarget('comet-local')).not.toThrow(/will not be launched/);
+  });
+});
+
+describe('migrateLegacyRuntimeDir', () => {
+  it('renames a single leftover @endpoint-N dir onto the new key', async () => {
+    const { migrateLegacyRuntimeDir, profileConnectionKey } = await import('./resolve-target.js');
+    const runtime = path.join(root, 'browser-runtime');
+    const legacy = path.join(runtime, 'comet-local@endpoint-0', 'chrome-data');
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.writeFileSync(path.join(legacy, 'Cookies'), 'keep-me');
+
+    const next = profileConnectionKey('comet-local', 'zion');
+    migrateLegacyRuntimeDir('comet-local', next, runtime);
+
+    expect(fs.existsSync(path.join(runtime, 'comet-local@endpoint-0'))).toBe(false);
+    expect(fs.readFileSync(path.join(runtime, next, 'chrome-data', 'Cookies'), 'utf8')).toBe(
+      'keep-me',
+    );
+  });
+
+  it('does not merge several leftover endpoint dirs', async () => {
+    const { migrateLegacyRuntimeDir, profileConnectionKey } = await import('./resolve-target.js');
+    const runtime = path.join(root, 'browser-runtime');
+    fs.mkdirSync(path.join(runtime, 'work@endpoint-0'), { recursive: true });
+    fs.mkdirSync(path.join(runtime, 'work@endpoint-1'), { recursive: true });
+
+    migrateLegacyRuntimeDir('work', profileConnectionKey('work', 'here'), runtime);
+
+    expect(fs.existsSync(path.join(runtime, 'work@endpoint-0'))).toBe(true);
+    expect(fs.existsSync(path.join(runtime, 'work@endpoint-1'))).toBe(true);
+    expect(fs.existsSync(path.join(runtime, 'work@here'))).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/browser/resolve-target.ts
+++ b/apps/cli/src/lib/browser/resolve-target.ts
@@ -1,0 +1,340 @@
+/**
+ * Registry-driven browser target resolution.
+ *
+ * The profile KIND is not a field: it falls out of how many devices declare
+ * the name ({@link profileKind}). This module answers where a name should
+ * connect, and never claims a leftover central profile (that race is T1).
+ *
+ * Three outcomes, no fourth:
+ *   1. THIS device declares the name → connect locally.
+ *   2. Only OTHER devices declare it → tunnel to a reachable declaring device.
+ *   3. Nobody declares it → fail loud. Never auto-create a local browser
+ *      under a name that means a logged-in browser somewhere else.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { machineId } from '../machine-id.js';
+import {
+  centralBrowserProfiles,
+  declaringDevices,
+  profileKind,
+  profileRegistry,
+  type ProfileDeclaration,
+} from './registry.js';
+import { parseEndpointUrl, resolveEndpoint } from './profiles.js';
+import {
+  connectionKey,
+  parseConnectionKey,
+  type BrowserProfile,
+  type ConnectionKey,
+} from './types.js';
+import type { BrowserProfileConfig } from '../types.js';
+import { probeHost } from '../hosts/ready.js';
+
+export type DeviceProbeResult =
+  | { reachable: true; os?: string }
+  | { reachable: false; reason: string };
+
+export type DeviceProbe = (device: string) => DeviceProbeResult;
+
+export interface ResolvedBrowserTarget {
+  name: string;
+  kind: 'identity' | 'fungible';
+  /** Device the daemon will talk to. */
+  device: string;
+  local: boolean;
+  key: ConnectionKey;
+  /** `cdp:` locally, `ssh:` when tunnelling to a declaring device. */
+  target: string;
+  profile: BrowserProfile;
+  /**
+   * Human line when the daemon picked a remote device. Command output
+   * surfaces this so the caller knows WHERE the browser actually lives.
+   */
+  picked?: string;
+}
+
+/** Fork only fungible Electron profiles; identity-bearing ones share one connection. */
+export function shouldForkProfile(
+  kind: 'identity' | 'fungible',
+  conn: { electron?: boolean; tasks: { size: number } },
+): boolean {
+  if (kind === 'identity') return false;
+  return Boolean(conn.electron && conn.tasks.size > 0);
+}
+
+export function profileFromDeclaration(
+  name: string,
+  declaration: ProfileDeclaration,
+): BrowserProfile {
+  const config = declaration.config;
+  return {
+    name,
+    description: config.description,
+    browser: config.browser,
+    binary: config.binary,
+    electron: config.electron,
+    targetFilter: config.targetFilter,
+    endpoints: config.endpoints,
+    defaultEndpoint: config.defaultEndpoint,
+    chrome: config.chrome,
+    secrets: config.secrets,
+    viewport: config.viewport,
+    logDir: config.logDir,
+    logHost: config.logHost,
+  };
+}
+
+/** Runtime key: profile name plus the resolved device. Drops `@endpoint-N`. */
+export function profileConnectionKey(profileName: string, device: string): ConnectionKey {
+  return connectionKey(profileName, device);
+}
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  const row = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 0; i < a.length; i++) {
+    let prev = row[0]!;
+    row[0] = i + 1;
+    for (let j = 0; j < b.length; j++) {
+      const cur = row[j + 1]!;
+      const cost = a[i] === b[j] ? 0 : 1;
+      row[j + 1] = Math.min(row[j]! + 1, row[j + 1]! + 1, prev + cost);
+      prev = cur;
+    }
+  }
+  return row[b.length]!;
+}
+
+/** Declared names that look like `query` — used in the undeclared error. */
+export function similarProfileNames(query: string, names: string[]): string[] {
+  const q = query.toLowerCase();
+  const maxDist = Math.max(2, Math.floor(q.length / 4));
+  return names
+    .filter((name) => {
+      const x = name.toLowerCase();
+      if (x === q) return false;
+      if (x.includes(q) || q.includes(x)) return Math.min(x.length, q.length) >= 3;
+      return levenshtein(x, q) <= maxDist;
+    })
+    .sort();
+}
+
+function lines(...parts: string[]): string {
+  return parts.filter((part) => part != null && part !== '').join('\n');
+}
+
+export function undeclaredProfileError(name: string): Error {
+  const central = centralBrowserProfiles();
+  if (central[name]) {
+    return new Error(
+      lines(
+        `Browser profile "${name}" is not declared by any device.`,
+        `It still lives in the central agents.yaml browser: map.`,
+        `Claim it on the machine that hosts that browser with: agents browser profiles claim ${name}`,
+      ),
+    );
+  }
+
+  const registry = profileRegistry();
+  const similar = similarProfileNames(name, [...registry.keys()]);
+  const similarLines = similar.map((candidate) => {
+    const devices = (registry.get(candidate) ?? []).map((entry) => entry.device);
+    return devices.length > 0
+      ? `  ${candidate} (declared on ${devices.join(', ')})`
+      : `  ${candidate}`;
+  });
+
+  return new Error(
+    lines(
+      `Browser profile "${name}" is not declared by any device.`,
+      ...(similarLines.length > 0
+        ? ['Similar names:', ...similarLines]
+        : ['No device declares a similar name.']),
+      `Create it on the machine that hosts the browser: agents browser profiles create ${name} --browser <chrome|comet|chromium|brave|edge|arc|custom>`,
+      `Or, if it is a leftover central profile, claim it: agents browser profiles claim ${name}`,
+    ),
+  );
+}
+
+export function unreachableDeclaringDevicesError(
+  name: string,
+  devices: string[],
+  failures: string[],
+): Error {
+  return new Error(
+    lines(
+      `Browser profile "${name}" is declared on ${devices.join(', ')}, but none of those devices are reachable.`,
+      ...failures.map((line) => `  ${line}`),
+      `A local browser will not be launched — that would be a logged-out copy of an identity-bearing profile.`,
+    ),
+  );
+}
+
+/**
+ * Build the SSH endpoint used to tunnel to a declaring device's own browser.
+ *
+ * A `cdp://localhost:N` declaration on that device is THIS machine's loopback
+ * if used as-is — that is the original bug. Rewrite it to `ssh://<device>?port=N`.
+ * An already-`ssh://` declaration is used as written.
+ */
+function isWindowsOs(os?: string): boolean {
+  if (!os) return false;
+  const normalized = os.toLowerCase();
+  return (
+    normalized.includes('windows') ||
+    normalized === 'win32' ||
+    normalized === 'win64' ||
+    normalized === 'windows_nt'
+  );
+}
+
+export function sshEndpointForDeclaration(
+  device: string,
+  config: BrowserProfileConfig,
+  endpointName?: string,
+  os?: string,
+): string {
+  const profile = profileFromDeclaration('_', { device, config });
+  const resolved = resolveEndpoint(profile, endpointName);
+  if (resolved.target.startsWith('ssh:')) return resolved.target;
+  const parsed = parseEndpointUrl(resolved.target);
+  const port = parsed?.port ?? 9222;
+  const osQuery = isWindowsOs(os) ? '&os=windows' : '';
+  return `ssh://${device}?port=${port}${osQuery}`;
+}
+
+function defaultProbe(device: string): DeviceProbeResult {
+  try {
+    const result = probeHost(device);
+    if (result.reachable) return { reachable: true, os: result.os };
+    return { reachable: false, reason: `ssh to ${device} failed` };
+  } catch (error) {
+    return {
+      reachable: false,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Decide where `name` connects. Never claims a central leftover. Never
+ * falls back to a local browser when the name is declared elsewhere.
+ */
+export function resolveBrowserTarget(
+  name: string,
+  opts: {
+    endpointName?: string;
+    here?: string;
+    probe?: DeviceProbe;
+  } = {},
+): ResolvedBrowserTarget {
+  const here = opts.here ?? machineId();
+  const kind = profileKind(name);
+  const declarations = profileRegistry().get(name) ?? [];
+  if (kind === null || declarations.length === 0) {
+    throw undeclaredProfileError(name);
+  }
+
+  const devices = declaringDevices(name);
+  const local = declarations.find((entry) => entry.device === here);
+
+  if (local) {
+    const profile = profileFromDeclaration(name, local);
+    const resolved = resolveEndpoint(profile, opts.endpointName);
+    return {
+      name,
+      kind,
+      device: here,
+      local: true,
+      key: profileConnectionKey(name, here),
+      target: resolved.target,
+      profile: {
+        ...profile,
+        binary: resolved.binary,
+        targetFilter: resolved.targetFilter,
+      },
+    };
+  }
+
+  const probe = opts.probe ?? defaultProbe;
+  const candidates = [...declarations].sort((a, b) => a.device.localeCompare(b.device));
+  const failures: string[] = [];
+
+  for (const declaration of candidates) {
+    const result = probe(declaration.device);
+    if (!result.reachable) {
+      failures.push(`${declaration.device}: ${result.reason}`);
+      continue;
+    }
+    const profile = profileFromDeclaration(name, declaration);
+    const resolved = resolveEndpoint(profile, opts.endpointName);
+    const target = sshEndpointForDeclaration(
+      declaration.device,
+      declaration.config,
+      opts.endpointName,
+      result.os,
+    );
+    const picked =
+      candidates.length > 1
+        ? `Using ${name} on ${declaration.device} (declared on ${devices.join(', ')})`
+        : `Using ${name} on ${declaration.device}`;
+    return {
+      name,
+      kind,
+      device: declaration.device,
+      local: false,
+      key: profileConnectionKey(name, declaration.device),
+      target,
+      profile: {
+        ...profile,
+        binary: resolved.binary,
+        targetFilter: resolved.targetFilter,
+      },
+      picked,
+    };
+  }
+
+  throw unreachableDeclaringDevicesError(name, devices, failures);
+}
+
+/**
+ * Rename a leftover `<name>@endpoint-N` runtime dir to the new
+ * `<name>@<device>` key so logins in chrome-data are not orphaned.
+ *
+ * Only when exactly one legacy dir exists and the destination does not —
+ * several endpoint dirs stay put so a multi-endpoint profile is not merged.
+ */
+export function migrateLegacyRuntimeDir(
+  profileName: string,
+  newKey: ConnectionKey,
+  runtimeRoot: string,
+): void {
+  const dest = path.join(runtimeRoot, newKey);
+  if (fs.existsSync(dest)) return;
+  if (!fs.existsSync(runtimeRoot)) return;
+
+  const legacy = fs.readdirSync(runtimeRoot).filter((entry) => {
+    const parsed = parseConnectionKey(entry);
+    return (
+      parsed.profile === profileName &&
+      parsed.endpoint !== undefined &&
+      /^endpoint-\d+$/.test(parsed.endpoint) &&
+      parsed.fork === undefined
+    );
+  });
+  if (legacy.length !== 1) return;
+  fs.renameSync(path.join(runtimeRoot, legacy[0]!), dest);
+}
+
+/** True when a live key is a leftover `@endpoint-N` key of `profileName`. */
+export function isLegacyEndpointKey(key: string, profileName: string): boolean {
+  const parsed = parseConnectionKey(key);
+  return (
+    parsed.profile === profileName &&
+    parsed.endpoint !== undefined &&
+    /^endpoint-\d+$/.test(parsed.endpoint)
+  );
+}

--- a/apps/cli/src/lib/browser/service.test.ts
+++ b/apps/cli/src/lib/browser/service.test.ts
@@ -7,6 +7,7 @@ import * as yaml from 'yaml';
 import * as state from '../state.js';
 import * as profiles from './profiles.js';
 import { query, _resetForTest } from '../feed/events.js';
+import { machineId } from '../machine-id.js';
 
 const TEST_HOME = path.join(tmpdir(), 'agents-cli-browser-service-test');
 const TEST_AGENTS_DIR = path.join(TEST_HOME, '.agents');
@@ -58,11 +59,29 @@ function reset() {
   fs.mkdirSync(path.join(TEST_AGENTS_DIR, 'browser', 'profiles'), { recursive: true });
 }
 
-function writeProfile(name: string, endpoints: string[], browserType = 'chrome'): void {
+function writeProfile(
+  name: string,
+  endpoints: string[],
+  browserType = 'chrome',
+  device = machineId(),
+): void {
   const profile = { name, browser: browserType, endpoints };
   fs.writeFileSync(
     path.join(TEST_AGENTS_DIR, 'browser', 'profiles', `${name}.yaml`),
     yaml.stringify(profile)
+  );
+  const file = path.join(TEST_AGENTS_DIR, 'devices', device, 'agents.yaml');
+  let doc: { browser?: Record<string, { browser: string; endpoints: string[] }> } = {};
+  if (fs.existsSync(file)) {
+    doc = (yaml.parse(fs.readFileSync(file, 'utf8')) as typeof doc) ?? {};
+  }
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    yaml.stringify({
+      ...doc,
+      browser: { ...doc.browser, [name]: { browser: browserType, endpoints } },
+    }),
   );
 }
 
@@ -837,8 +856,8 @@ function makeTargetedConn(
 }
 
 /** Seed a live connection so `start` reuses it instead of launching a browser. */
-function attach(service: any, profile: string, conn: unknown): void {
-  (service as { connections: Map<string, unknown> }).connections.set(`${profile}@endpoint-0`, conn);
+function attach(service: any, profile: string, conn: unknown, key = `${profile}@endpoint-0`): void {
+  (service as { connections: Map<string, unknown> }).connections.set(key, conn);
 }
 
 function createTargetCount(calls: Array<{ method: string }>): number {
@@ -1541,5 +1560,89 @@ describe('BrowserService.reapAbandoned — abandoned-task reaper (RUSH-2622)', (
     expect(result.closed).toEqual([]);
     expect(result.skipped).toBe(1);
     expect(targets).toHaveLength(1);
+  });
+});
+
+describe('BrowserService.start — registry resolution', () => {
+  it('fails loud when nobody declares the name, and launches no browser', async () => {
+    writeProfile('comet-local', ['cdp://localhost:9333']);
+    const service = new BrowserService();
+    const before = fs.existsSync(TEST_BROWSER_DIR)
+      ? fs.readdirSync(TEST_BROWSER_DIR)
+      : [];
+
+    await expect(service.start('comet-locl')).rejects.toThrow(/comet-local/);
+    await expect(service.start('comet-locl')).rejects.toThrow(/not declared by any device/);
+
+    const after = fs.existsSync(TEST_BROWSER_DIR) ? fs.readdirSync(TEST_BROWSER_DIR) : [];
+    expect(after.filter((entry) => entry.includes('comet-locl'))).toEqual([]);
+    expect(after.filter((entry) => entry.includes('chrome-data'))).toEqual(
+      before.filter((entry) => entry.includes('chrome-data')),
+    );
+  });
+
+  it('fails loud when the only declaring device is unreachable, and launches no browser', async () => {
+    writeProfile('comet-local', ['cdp://localhost:9333'], 'comet', 'zion');
+    const service = new BrowserService();
+
+    await expect(
+      service.start('comet-local', {
+        probe: () => ({ reachable: false, reason: 'No route to host' }),
+      }),
+    ).rejects.toThrow(/zion/);
+    await expect(
+      service.start('comet-local', {
+        probe: () => ({ reachable: false, reason: 'No route to host' }),
+      }),
+    ).rejects.toThrow(/will not be launched/);
+
+    expect(
+      fs.existsSync(TEST_BROWSER_DIR)
+        ? fs.readdirSync(TEST_BROWSER_DIR).filter((entry) => entry.startsWith('comet-local'))
+        : [],
+    ).toEqual([]);
+  });
+
+  it('two concurrent callers of an identity-bearing profile share one connection and one chrome-data dir', async () => {
+    writeProfile('signed-in', ['cdp://localhost:9333'], 'comet');
+    const service = new BrowserService();
+    const { conn } = makeTargetedConn('signed-in@endpoint-0', {
+      browser: 'comet',
+      pages: [{ targetId: 'win', url: 'https://github.com' }],
+    });
+    (conn as { electron: boolean }).electron = true;
+    (conn as { tasks: Map<string, unknown> }).tasks.set('seed', {
+      id: 'seed',
+      name: 'seed',
+      profile: 'signed-in@endpoint-0',
+      tabs: { t1: 'win' },
+      currentTabId: 't1',
+      createdAt: Date.now(),
+      lastActionAt: Date.now(),
+      pid: 4242,
+    });
+    attach(service, 'signed-in', conn);
+
+    const chromeData = path.join(TEST_BROWSER_DIR, 'signed-in@endpoint-0', 'chrome-data');
+    fs.mkdirSync(chromeData, { recursive: true });
+    fs.writeFileSync(path.join(chromeData, 'Cookies'), 'identity');
+
+    await Promise.all([
+      service.start('signed-in'),
+      service.start('signed-in'),
+    ]);
+
+    const map = (service as unknown as { connections: Map<string, unknown> }).connections;
+    expect(map.size).toBe(1);
+
+    const chromeDataDirs = fs.readdirSync(TEST_BROWSER_DIR).filter((entry) => {
+      try {
+        return fs.statSync(path.join(TEST_BROWSER_DIR, entry, 'chrome-data')).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+    expect(chromeDataDirs).toEqual(['signed-in@endpoint-0']);
+    expect(fs.readFileSync(path.join(chromeData, 'Cookies'), 'utf8')).toBe('identity');
   });
 });

--- a/apps/cli/src/lib/browser/service.ts
+++ b/apps/cli/src/lib/browser/service.ts
@@ -22,6 +22,13 @@ import { killChrome, getRunningChromeInfo, launchBrowser, allocatePort } from '.
 import { assertRemoteControlAllowedForRequest } from './remote-control.js';
 import { connectLocal } from './drivers/local.js';
 import { connectSSH, shellQuote } from './drivers/ssh.js';
+import {
+  isLegacyEndpointKey,
+  migrateLegacyRuntimeDir,
+  resolveBrowserTarget,
+  shouldForkProfile,
+  type DeviceProbe,
+} from './resolve-target.js';
 import { clearProfileRuntime, listProfileCacheDirs, readProfileRuntimeMeta, isProcessAlive } from './runtime-state.js';
 import { resolveDomainSkill, type ResolvedDomainSkill } from './domain-skills.js';
 import {
@@ -38,7 +45,6 @@ import {
   type ReapResult,
   type ProfileName,
   type ConnectionKey,
-  connectionKey,
   asConnectionKey,
   parseConnectionKey,
   keyBelongsToProfile,
@@ -414,7 +420,8 @@ export class BrowserService {
    * Live browsers, keyed by {@link ConnectionKey} — NOT by profile name. The
    * branded key type is what makes `connections.get(someProfileName)` (the
    * RUSH-2709 miss that made `status --profile <name>` return empty for a
-   * running `<name>@endpoint-0`) fail to compile.
+   * running `<name>@<device>`) fail to compile. Keys are `<profile>@<device>`
+   * (legacy leftover `<profile>@endpoint-N` dirs are still recognized).
    */
   private connections = new Map<ConnectionKey, ProfileConnection>();
   private forkingProfiles = new Set<string>();
@@ -449,6 +456,8 @@ export class BrowserService {
       fleetRemote?: boolean;
       /** Explicit human label (`--title`). */
       title?: string;
+      /** Injected reachability probe — production uses ssh; tests pass a fake. */
+      probe?: DeviceProbe;
     } = {}
   ): Promise<{
     task: string;
@@ -457,8 +466,12 @@ export class BrowserService {
     windowId?: string;
     /** BARE profile name — what the caller asked for, never the runtime key. */
     profile: ProfileName;
-    /** Runtime key the task actually landed on (`<profile>@<endpoint>`). */
+    /** Runtime key the task actually landed on (`<profile>@<device>`). */
     key: ConnectionKey;
+    /** Device the daemon connected to. */
+    device: string;
+    /** Set when the daemon picked a remote declaring device. */
+    picked?: string;
     skill?: ResolvedDomainSkill;
   }> {
     // Consent gate, before anything is resolved or launched. This is the
@@ -467,27 +480,16 @@ export class BrowserService {
     // …) able to open a browser on a machine whose owner never opted in.
     assertRemoteControlAllowedForRequest(opts.fleetRemote, { actor: opts.actor });
 
-    const profile = await getProfile(profileName);
-    if (!profile) {
-      throw new Error(`Profile "${profileName}" not found`);
-    }
-
-    // Pick the endpoint preset. Throws with the candidate list if the user
-    // passed an unknown name. The runtime key `<profile>@<endpoint>` is what
-    // the connection map + per-profile runtime dirs are keyed on, so a single
-    // YAML profile can run at multiple endpoints concurrently.
-    //
-    // `effectiveProfile.name` stays BARE. Overwriting it with the runtime key
-    // here (pre-RUSH-2709) is what leaked `comet-local@endpoint-0` into every
-    // listing and made `status --profile comet-local` miss its own browser.
-    // The key travels as its own argument instead.
-    const resolved = resolveEndpoint(profile, opts.endpointName);
-    const composite = connectionKey(profileName, resolved.name);
-    const effectiveProfile: BrowserProfile = {
-      ...profile,
-      binary: resolved.binary,
-      targetFilter: resolved.targetFilter,
-    };
+    // Registry decides WHERE. Three outcomes, no fourth: local if this
+    // device declares the name; tunnel to a declaring device otherwise;
+    // fail loud if nobody does. Never auto-create a local browser under a
+    // name that means a logged-in browser somewhere else.
+    const routed = resolveBrowserTarget(profileName, {
+      endpointName: opts.endpointName,
+      probe: opts.probe,
+    });
+    const composite = routed.key;
+    const effectiveProfile: BrowserProfile = routed.profile;
 
     const taskId = generateTaskId();
     let taskName: string;
@@ -504,10 +506,11 @@ export class BrowserService {
     }
     const taskLabel = deriveTaskLabel({ title: opts.title, url: opts.url });
 
-    let conn = await this.reuseHealthyConnection(composite);
-    let effectiveKey: ConnectionKey = composite;
+    const reused = await this.reuseProfileConnection(profileName, composite);
+    let conn = reused?.conn;
+    let effectiveKey: ConnectionKey = reused?.key ?? composite;
 
-    if (conn && conn.electron && conn.tasks.size > 0) {
+    if (conn && shouldForkProfile(routed.kind, conn)) {
       if (this.forkingProfiles.has(composite)) {
         while (this.forkingProfiles.has(composite)) {
           await new Promise((r) => setTimeout(r, 50));
@@ -530,9 +533,20 @@ export class BrowserService {
         }
       }
     } else if (!conn) {
-      conn = await this.openConnection(effectiveProfile, resolved.target, composite, profileName);
+      migrateLegacyRuntimeDir(profileName, composite, getBrowserRuntimeDir());
+      conn = await this.openConnection(
+        effectiveProfile,
+        routed.target,
+        composite,
+        profileName,
+        { persistRemote: !routed.local },
+      );
+      effectiveKey = composite;
     }
-    if (conn && !conn.profile) conn.profile = profileName;
+    if (!conn) {
+      throw new Error(`Could not connect to profile "${profileName}"`);
+    }
+    if (!conn.profile) conn.profile = profileName;
 
     // Browsers launch with --no-startup-window (session-cookie persistence,
     // see launchBrowser), so a bare `start` with no --url would otherwise
@@ -665,7 +679,16 @@ export class BrowserService {
       if (resolved) skill = resolved;
     }
 
-    return { task: taskId, name: taskName, tabId, profile: profileName, key: effectiveKey, skill };
+    return {
+      task: taskId,
+      name: taskName,
+      tabId,
+      profile: profileName,
+      key: effectiveKey,
+      device: routed.device,
+      picked: routed.picked,
+      skill,
+    };
   }
 
   /**
@@ -923,7 +946,7 @@ export class BrowserService {
   }
 
   async stopProfile(profileRef: ProfileName | ConnectionKey): Promise<void> {
-    // Connections are keyed by the runtime key `<profile>@<endpoint>` (see
+    // Connections are keyed by the runtime key `<profile>@<device>` (see
     // start()) while callers pass the bare profile name (or, occasionally, an
     // exact key). A plain `connections.get(profileRef)` therefore missed every
     // real remote connection, so `cleanup()` never ran — leaving the SSH tunnel
@@ -1890,8 +1913,9 @@ export class BrowserService {
    * `profileName` is a {@link ProfileName} — a BARE name, never a runtime key.
    * Every candidate is selected by the one rule ({@link keyBelongsToProfile}),
    * and a scoped query that finds no live connection falls through to disk, so
-   * `status --profile comet-local` reports the LIVE `comet-local@endpoint-0`
-   * instead of the empty list it used to return (RUSH-2709).
+   * `status --profile comet-local` reports the LIVE `comet-local@<device>`
+   * (and leftover `comet-local@endpoint-0` dirs) instead of the empty list
+   * it used to return (RUSH-2709).
    */
   async status(profileRef?: ProfileName | ConnectionKey): Promise<ProfileStatus[]> {
     // Reconnect live browsers after a daemon restart so status is not empty
@@ -2552,15 +2576,15 @@ export class BrowserService {
    * already resolved the endpoint and built the `effectiveProfile` with
    * the per-endpoint binary/targetFilter overrides applied; we just use it.
    *
-   * `key` is the runtime key (`<profile>@<endpoint>`) and is what every on-disk
-   * lookup uses, so per-endpoint pid/port files don't collide when the same app
-   * runs locally and remotely at the same time. It is a SEPARATE argument
-   * because `effectiveProfile.name` stays the bare, user-facing name (RUSH-2709).
+   * `key` is the runtime key (`<profile>@<device>`) and is what every on-disk
+   * lookup uses. It is a SEPARATE argument because `effectiveProfile.name`
+   * stays the bare, user-facing name (RUSH-2709).
    */
   private async connectProfile(
     effectiveProfile: BrowserProfile,
     target: string,
     key: ConnectionKey,
+    opts: { persistRemote?: boolean } = {},
   ): Promise<ProfileConnection> {
     const existingInfo = getRunningChromeInfo(key);
 
@@ -2599,7 +2623,7 @@ export class BrowserService {
       }
     }
 
-    const conn = await this.connectEndpoint(effectiveProfile, target, key);
+    const conn = await this.connectEndpoint(effectiveProfile, target, key, opts);
     if (!conn) {
       throw new Error(`Could not connect to endpoint ${target} for profile "${effectiveProfile.name}"`);
     }
@@ -2610,6 +2634,7 @@ export class BrowserService {
     profile: BrowserProfile,
     endpoint: string,
     key: ConnectionKey,
+    opts: { persistRemote?: boolean } = {},
   ): Promise<ProfileConnection | null> {
     const url = new URL(endpoint);
 
@@ -2629,7 +2654,9 @@ export class BrowserService {
     }
 
     if (url.protocol === 'ssh:') {
-      const conn = await connectSSH(endpoint, profile, key);
+      const conn = await connectSSH(endpoint, profile, key, {
+        persistRemote: opts.persistRemote,
+      });
       await this.enableDomains(conn.cdp);
       return {
         cdp: conn.cdp,
@@ -2809,7 +2836,14 @@ export class BrowserService {
     createIfMissing: boolean;
     title?: string;
     url?: string;
-  }): Promise<{ conn: ProfileConnection; task: Task; key: ConnectionKey; created: boolean } | null> {
+  }): Promise<{
+    conn: ProfileConnection;
+    task: Task;
+    key: ConnectionKey;
+    created: boolean;
+    picked?: string;
+    device?: string;
+  } | null> {
     if (opts.task) {
       const found = await this.findTask(opts.task, opts.profile);
       return { ...found, created: false };
@@ -2875,7 +2909,12 @@ export class BrowserService {
       sessionId: opts.sessionId,
       title: opts.title,
     });
-    return { ...(await this.findTask(started.name, started.profile)), created: true };
+    return {
+      ...(await this.findTask(started.name, started.profile)),
+      created: true,
+      picked: started.picked,
+      device: started.device,
+    };
   }
 
   private listTasksForCaller(caller: {
@@ -3048,7 +3087,14 @@ export class BrowserService {
 
     let resolved;
     try {
-      resolved = resolveEndpoint(profile, endpointFromKey);
+      // Legacy keys encode the preset (`endpoint-0`). New keys encode the
+      // declaring device, which is not a preset name — resolve via registry.
+      if (endpointFromKey && /^endpoint-\d+$/.test(endpointFromKey)) {
+        resolved = resolveEndpoint(profile, endpointFromKey);
+      } else {
+        const routed = resolveBrowserTarget(bare);
+        resolved = { name: routed.device, target: routed.target };
+      }
     } catch {
       return null;
     }
@@ -3470,14 +3516,37 @@ export class BrowserService {
     return undefined;
   }
 
+  /**
+   * Reuse a live connection for this profile: the new `<name>@<device>` key
+   * first, then any leftover `<name>@endpoint-N` key still in the map so a
+   * browser started before the key collapse is not abandoned.
+   */
+  private async reuseProfileConnection(
+    profileName: ProfileName,
+    preferred: ConnectionKey,
+  ): Promise<{ conn: ProfileConnection; key: ConnectionKey } | undefined> {
+    const preferredConn = await this.reuseHealthyConnection(preferred);
+    if (preferredConn) return { conn: preferredConn, key: preferred };
+
+    for (const key of [...this.connections.keys()]) {
+      if (key === preferred) continue;
+      if (!isLegacyEndpointKey(key, profileName)) continue;
+      if (parseConnectionKey(key).fork !== undefined) continue;
+      const conn = await this.reuseHealthyConnection(key);
+      if (conn) return { conn, key };
+    }
+    return undefined;
+  }
+
   /** Connect a profile at `target`, register it under `key`, and arm downloads. */
   private async openConnection(
     profile: BrowserProfile,
     target: string,
     key: ConnectionKey,
     profileName: ProfileName,
+    opts: { persistRemote?: boolean } = {},
   ): Promise<ProfileConnection> {
-    const conn = await this.connectProfile(profile, target, key);
+    const conn = await this.connectProfile(profile, target, key, opts);
     conn.key = key;
     conn.profile = profileName;
     this.connections.set(key, conn);
@@ -3500,31 +3569,43 @@ export class BrowserService {
   async showUrl(
     profileName: ProfileName,
     url: string,
-    opts: { endpointName?: string; fleetRemote?: boolean; actor?: string } = {},
-  ): Promise<{ profile: ProfileName; key: ConnectionKey; tabId: string }> {
+    opts: { endpointName?: string; fleetRemote?: boolean; actor?: string; probe?: DeviceProbe } = {},
+  ): Promise<{ profile: ProfileName; key: ConnectionKey; tabId: string; device: string; picked?: string }> {
     // Same consent gate as start(): this opens a browser, so a fleet-remote
     // caller needs the target machine's opt-in.
     assertRemoteControlAllowedForRequest(opts.fleetRemote, { actor: opts.actor });
 
-    const profile = await getProfile(profileName);
-    if (!profile) throw new Error(`Profile "${profileName}" not found`);
+    const routed = resolveBrowserTarget(profileName, {
+      endpointName: opts.endpointName,
+      probe: opts.probe,
+    });
+    const key = routed.key;
+    const effectiveProfile: BrowserProfile = routed.profile;
 
-    const resolved = resolveEndpoint(profile, opts.endpointName);
-    const key = connectionKey(profileName, resolved.name);
-    const effectiveProfile: BrowserProfile = {
-      ...profile,
-      binary: resolved.binary,
-      targetFilter: resolved.targetFilter,
-    };
-
-    const conn =
-      (await this.reuseHealthyConnection(key)) ??
-      (await this.openConnection(effectiveProfile, resolved.target, key, profileName));
+    const reused = await this.reuseProfileConnection(profileName, key);
+    let conn = reused?.conn;
+    const effectiveKey = reused?.key ?? key;
+    if (!conn) {
+      migrateLegacyRuntimeDir(profileName, key, getBrowserRuntimeDir());
+      conn = await this.openConnection(
+        effectiveProfile,
+        routed.target,
+        key,
+        profileName,
+        { persistRemote: !routed.local },
+      );
+    }
 
     // createPageTarget refuses Arc with an actionable error rather than crashing it.
     const created = await this.createPageTarget(conn, { url });
     this.invalidateTargetCache(conn);
-    return { profile: profileName, key, tabId: created.targetId };
+    return {
+      profile: profileName,
+      key: effectiveKey,
+      tabId: created.targetId,
+      device: routed.device,
+      picked: routed.picked,
+    };
   }
 
   async getHistory(limit = 10): Promise<HistoricalTask[]> {


### PR DESCRIPTION
Registry-driven `agents browser` resolution: the daemon tunnels to the declaring device; identity profiles share one connection. Not docs-only.

## What

T2 of the browser topology change. After this, `agents browser navigate --url ...` on any box asks the T1 registry who declared the profile name, instead of attaching to that box's own `cdp://localhost`.

Three outcomes, no fourth:

1. This device declares the name → connect locally (unchanged).
2. Only other devices declare it → the daemon opens the existing `connectSSH` path to a reachable declaring device, attach-only (do not launch a logged-out remote chrome-data, do not kill the remote browser on tunnel close). The IPC `message` names the pick.
3. Nobody declares it → fail loud, list similar names and their declaring devices. Leftover central `browser:` entries point at `agents browser profiles claim`. Never auto-create a local browser under that name.

Identity-bearing profiles never fork a second Electron chrome-data. Runtime keys are `<profile>@<device>` instead of `<profile>@endpoint-N`; a single leftover `@endpoint-N` dir is renamed onto the new key.

## Run

`bun run test` in `apps/cli`, scoped to the changed files:

```
 ✓ src/lib/browser/drivers/ssh.test.ts (28 tests)
 ✓ src/lib/browser/resolve-target.test.ts (13 tests)
 ✓ src/lib/browser/hygiene.test.ts (5 tests)
 ✓ src/lib/browser/service.resolve.test.ts (10 tests)
 ✓ src/lib/browser/service.test.ts (76 tests)
 ✓ src/lib/browser/ipc.test.ts (21 tests)

 Test Files  6 passed (6)
      Tests  153 passed (153)
 Duration  2.92s
```

New tests assert:

- undeclared name errors, names similar declaring devices, and creates no chrome-data
- unreachable declaring device errors and launches no browser
- two concurrent callers of an identity-bearing Electron profile share one connection and one chrome-data dir

## Live resolution on this fleet (yosemite-m2, real `~/.agents`)

```
ERR comet-local
Browser profile "comet-local" is not declared by any device.
It still lives in the central agents.yaml browser: map.
Claim it on the machine that hosts that browser with: agents browser profiles claim comet-local

OK default {"local":true,"device":"yosemite-m2","kind":"fungible","target":"cdp://127.0.0.1:9226","key":"default@yosemite-m2"}
```

That is the T1 invariant this track must not break: nothing claims implicitly. `comet-local` is still central.

## Live logged-in tab on zion — unverified

The acceptance row (from yosemite-s0, `navigate https://github.com/notifications` lands a logged-in tab on zion) needs two things this run does not have:

- `comet-local` claimed on zion (`agents browser profiles claim comet-local` run **on zion** — T1, explicit operator claim)
- Comet actually speaking CDP on zion:9333 — probed 2026-04-24: binary exists at `/Applications/Comet.app/.../Comet`, `curl http://127.0.0.1:9333/json/version` failed with connection refused

T2 correctly refuses to mint a logged-out Comet under that name. Do not treat a local launch as the proof.

## `@endpoint-` leftovers this track does not own

`grep -rn "@endpoint-" apps/cli/src` still hits files T2 must not edit:

- `apps/cli/src/commands/browser.ts` (T3/T4)
- `apps/cli/src/lib/browser/types.ts` + `types.test.ts` (T1)
- `apps/cli/src/lib/browser/profiles.ts` + `profiles.test.ts` (T1)
- `apps/cli/src/lib/browser/runtime-state.test.ts`, `local.test.ts`, `login-detection.test.ts`
- session db tests under `apps/cli/src/lib/session/`

Hits in `service.ts` / `service.test.ts` / `resolve-target.ts` are leftover-key compatibility (status still finds a running `@endpoint-0` dir) plus the rename.

T4: print IPC `response.message` on `browser start` / `browser navigate` so the picked device is visible in command output (`Using comet-local on zion`).