### PR TITLE
fix(browser): do not attach leftover local chrome-data when tunnelling

### DIFF
--- a/apps/cli/.changelog/next/browser-tunnel-leftover-attach.md
+++ b/apps/cli/.changelog/next/browser-tunnel-leftover-attach.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+A leftover local `comet-local@endpoint-N` chrome-data on a worker is no longer renamed onto the declaring device's key and attached over localhost when the daemon should tunnel. Identity-bearing browsers stay on the declaring machine.

--- a/apps/cli/src/lib/browser/drivers/ssh.test.ts
+++ b/apps/cli/src/lib/browser/drivers/ssh.test.ts
@@ -37,6 +37,7 @@ import {
   isOwnTunnel,
   ensureRemoteBrowser,
   killRemoteBrowser,
+  persistRemoteLifecycle,
 } from './ssh.js';
 import { getPortOccupant } from '../chrome.js';
 
@@ -51,6 +52,16 @@ function decodeEncoded(cmd: string): string {
   if (!m) throw new Error(`not an EncodedCommand invocation: ${cmd}`);
   return Buffer.from(m[1], 'base64').toString('utf16le');
 }
+
+describe('persistRemoteLifecycle', () => {
+  it('does not launch or kill the remote browser when attaching to a declaring device', () => {
+    expect(persistRemoteLifecycle(true)).toEqual({ launchRemote: false, killOnCleanup: false });
+  });
+
+  it('launches and kills when the daemon owns the remote process', () => {
+    expect(persistRemoteLifecycle(false)).toEqual({ launchRemote: true, killOnCleanup: true });
+  });
+});
 
 describe('ssh driver CDP launch args', () => {
   it('never sets --remote-allow-origins=* (DNS-rebind / cross-origin CDP risk)', () => {

--- a/apps/cli/src/lib/browser/drivers/ssh.ts
+++ b/apps/cli/src/lib/browser/drivers/ssh.ts
@@ -41,6 +41,16 @@ export interface SSHConnectOptions {
   persistRemote?: boolean;
 }
 
+/** Lifecycle for a registry-driven tunnel vs a profile the daemon launched. */
+export function persistRemoteLifecycle(persistRemote: boolean): {
+  launchRemote: boolean;
+  killOnCleanup: boolean;
+} {
+  return persistRemote
+    ? { launchRemote: false, killOnCleanup: false }
+    : { launchRemote: true, killOnCleanup: true };
+}
+
 export async function connectSSH(
   endpoint: string,
   profile: BrowserProfile,
@@ -104,7 +114,8 @@ export async function connectSSH(
   // persistRemote skips the launch: launching would mint a logged-out
   // `--user-data-dir=/tmp/agents-browser-N` under a name that means a
   // credentialed browser on the declaring device.
-  if (!opts.persistRemote) {
+  const lifecycle = persistRemoteLifecycle(Boolean(opts.persistRemote));
+  if (lifecycle.launchRemote) {
     await ensureRemoteBrowser(user, host, profile.browser, remotePort, remoteOs, profile.binary);
   }
 
@@ -171,7 +182,7 @@ export async function connectSSH(
       // when we launched it. persistRemote is an attach to someone else's
       // declared browser; killing it would drop the logins the caller came
       // for. Fire-and-forget — cleanup stays synchronous.
-      if (!opts.persistRemote) {
+      if (lifecycle.killOnCleanup) {
         killRemoteBrowser(user, host, remoteOs, remotePort).catch(() => {});
       }
       tunnel.kill();

--- a/apps/cli/src/lib/browser/ipc.ts
+++ b/apps/cli/src/lib/browser/ipc.ts
@@ -247,9 +247,6 @@ export class BrowserIPCServer {
   private connections = new Set<net.Socket>();
   /** In-flight stop, so a second SIGTERM awaits the same close, never skips it. */
   private stopping: Promise<void> | null = null;
-  /** Device pick from an implicit start (`navigate` creating a task). */
-  private pendingPicked?: string;
-
   constructor(service: BrowserService) {
     this.service = service;
   }
@@ -440,7 +437,9 @@ export class BrowserIPCServer {
         };
       }
       request.task = resolved.task.name;
-      if (resolved.created && resolved.picked) this.pendingPicked = resolved.picked;
+      if (resolved.created && resolved.picked) {
+        (request as IPCRequest & { picked?: string }).picked = resolved.picked;
+      }
       return undefined;
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
@@ -456,8 +455,6 @@ export class BrowserIPCServer {
       const result = this.service.stageUpload(source);
       return { ok: true, path: result.path };
     }
-
-    this.pendingPicked = undefined;
 
     // Task-scoped actions: resolve identity / create / refuse once here.
     if (PAGE_RESOLVE_VERBS.has(request.action) || CLOSE_VERBS.has(request.action)) {
@@ -608,8 +605,7 @@ export class BrowserIPCServer {
           request.url,
           request.profile
         );
-        const picked = this.pendingPicked;
-        this.pendingPicked = undefined;
+        const picked = (request as IPCRequest & { picked?: string }).picked;
         return { ok: true, tabId: result.tabId, task: request.task, message: picked };
       }
 

--- a/apps/cli/src/lib/browser/resolve-target.test.ts
+++ b/apps/cli/src/lib/browser/resolve-target.test.ts
@@ -188,6 +188,21 @@ describe('migrateLegacyRuntimeDir', () => {
     );
   });
 
+  it('does not rename a leftover dir onto a remote key', async () => {
+    const { adoptLegacyRuntimeIfLocal, profileConnectionKey } = await import('./resolve-target.js');
+    const runtime = path.join(root, 'browser-runtime');
+    fs.mkdirSync(path.join(runtime, 'comet-local@endpoint-0', 'chrome-data'), { recursive: true });
+    fs.writeFileSync(path.join(runtime, 'comet-local@endpoint-0', 'chrome-data', 'Cookies'), 'local');
+
+    const remoteKey = profileConnectionKey('comet-local', 'zion');
+    adoptLegacyRuntimeIfLocal(false, 'comet-local', remoteKey, runtime);
+
+    expect(fs.existsSync(path.join(runtime, 'comet-local@endpoint-0', 'chrome-data', 'Cookies'))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(runtime, remoteKey))).toBe(false);
+  });
+
   it('does not merge several leftover endpoint dirs', async () => {
     const { migrateLegacyRuntimeDir, profileConnectionKey } = await import('./resolve-target.js');
     const runtime = path.join(root, 'browser-runtime');

--- a/apps/cli/src/lib/browser/resolve-target.ts
+++ b/apps/cli/src/lib/browser/resolve-target.ts
@@ -307,6 +307,22 @@ export function resolveBrowserTarget(
  * Only when exactly one legacy dir exists and the destination does not —
  * several endpoint dirs stay put so a multi-endpoint profile is not merged.
  */
+/**
+ * Adopt a leftover `@endpoint-N` runtime dir onto the new key ONLY for a
+ * local connect. Doing this for a tunnel key would rename this machine's
+ * pre-T2 logged-out chrome-data onto `comet-local@zion`, and connectProfile
+ * would then attach localhost CDP instead of tunnelling.
+ */
+export function adoptLegacyRuntimeIfLocal(
+  local: boolean,
+  profileName: string,
+  newKey: ConnectionKey,
+  runtimeRoot: string,
+): void {
+  if (!local) return;
+  migrateLegacyRuntimeDir(profileName, newKey, runtimeRoot);
+}
+
 export function migrateLegacyRuntimeDir(
   profileName: string,
   newKey: ConnectionKey,

--- a/apps/cli/src/lib/browser/service.ts
+++ b/apps/cli/src/lib/browser/service.ts
@@ -23,8 +23,8 @@ import { assertRemoteControlAllowedForRequest } from './remote-control.js';
 import { connectLocal } from './drivers/local.js';
 import { connectSSH, shellQuote } from './drivers/ssh.js';
 import {
+  adoptLegacyRuntimeIfLocal,
   isLegacyEndpointKey,
-  migrateLegacyRuntimeDir,
   resolveBrowserTarget,
   shouldForkProfile,
   type DeviceProbe,
@@ -506,11 +506,13 @@ export class BrowserService {
     }
     const taskLabel = deriveTaskLabel({ title: opts.title, url: opts.url });
 
-    const reused = await this.reuseProfileConnection(profileName, composite);
+    const reused = await this.reuseProfileConnection(profileName, composite, routed.local);
     let conn = reused?.conn;
     let effectiveKey: ConnectionKey = reused?.key ?? composite;
 
-    if (conn && shouldForkProfile(routed.kind, conn)) {
+    // Fork is a local Electron chrome-data mint. Never fork a tunnelled
+    // connection — that would launch a logged-out browser on THIS box.
+    if (conn && routed.local && shouldForkProfile(routed.kind, conn)) {
       if (this.forkingProfiles.has(composite)) {
         while (this.forkingProfiles.has(composite)) {
           await new Promise((r) => setTimeout(r, 50));
@@ -533,7 +535,12 @@ export class BrowserService {
         }
       }
     } else if (!conn) {
-      migrateLegacyRuntimeDir(profileName, composite, getBrowserRuntimeDir());
+      adoptLegacyRuntimeIfLocal(
+        routed.local,
+        profileName,
+        composite,
+        getBrowserRuntimeDir(),
+      );
       conn = await this.openConnection(
         effectiveProfile,
         routed.target,
@@ -2587,8 +2594,18 @@ export class BrowserService {
     opts: { persistRemote?: boolean } = {},
   ): Promise<ProfileConnection> {
     const existingInfo = getRunningChromeInfo(key);
+    const tunnelled = opts.persistRemote || target.startsWith('ssh:');
 
-    if (existingInfo) {
+    if (tunnelled) {
+      // A leftover local chrome-data / pid file under this key is the
+      // pre-T2 logged-out browser on THIS box. Attaching localhost CDP
+      // here is the original bug. Only a recorded SSH tunnel is ours to
+      // reuse, and connectSSH already does that via isOwnTunnel.
+      const meta = readProfileRuntimeMeta(key);
+      if (meta && meta.kind !== 'tunnel') {
+        clearProfileRuntime(key);
+      }
+    } else if (existingInfo) {
       try {
         const { wsUrl, browser } = await discoverBrowserWsUrl(
           existingInfo.port,
@@ -3524,9 +3541,13 @@ export class BrowserService {
   private async reuseProfileConnection(
     profileName: ProfileName,
     preferred: ConnectionKey,
+    local: boolean,
   ): Promise<{ conn: ProfileConnection; key: ConnectionKey } | undefined> {
     const preferredConn = await this.reuseHealthyConnection(preferred);
     if (preferredConn) return { conn: preferredConn, key: preferred };
+    // Leftover `@endpoint-N` connections are THIS machine's pre-T2 local
+    // browser. Reusing them on a tunnelled resolve is the original bug.
+    if (!local) return undefined;
 
     for (const key of [...this.connections.keys()]) {
       if (key === preferred) continue;
@@ -3582,11 +3603,11 @@ export class BrowserService {
     const key = routed.key;
     const effectiveProfile: BrowserProfile = routed.profile;
 
-    const reused = await this.reuseProfileConnection(profileName, key);
+    const reused = await this.reuseProfileConnection(profileName, key, routed.local);
     let conn = reused?.conn;
     const effectiveKey = reused?.key ?? key;
     if (!conn) {
-      migrateLegacyRuntimeDir(profileName, key, getBrowserRuntimeDir());
+      adoptLegacyRuntimeIfLocal(routed.local, profileName, key, getBrowserRuntimeDir());
       conn = await this.openConnection(
         effectiveProfile,
         routed.target,


### PR DESCRIPTION
Follow-up to #2991 (leftover-attach blocker from non-author review, landed after that PR merged).

A leftover `comet-local@endpoint-N` dir on a worker is the pre-T2 logged-out browser. #2991 renamed it onto `comet-local@zion` and `connectProfile` then attached localhost CDP — the original bug.

## Fix

- `adoptLegacyRuntimeIfLocal` only renames `@endpoint-N` for a local connect
- `connectProfile` skips localhost `getRunningChromeInfo` attach when tunnelling
- leftover non-tunnel runtime under a tunnel key is cleared
- `reuseProfileConnection` does not reuse leftover `@endpoint-N` connections on a tunnelled resolve
- Electron fork is local-only
- `persistRemoteLifecycle` tested: attach-only skips launch and skip-kill

## Run

`bun run test` in `apps/cli`, scoped to the changed files:

```
 ✓ src/lib/browser/drivers/ssh.test.ts (30 tests)
 ✓ src/lib/browser/resolve-target.test.ts (14 tests)
 ✓ src/lib/browser/hygiene.test.ts (5 tests)
 ✓ src/lib/browser/service.resolve.test.ts (10 tests)
 ✓ src/lib/browser/service.test.ts (76 tests)
 ✓ src/lib/browser/ipc.test.ts (21 tests)

 Test Files  6 passed (6)
      Tests  156 passed (156)
```
