### PR TITLE
fix(ext): one shared vscode test double, and changelog 0.9.334

### DIFF
--- a/apps/ext/AGENTS.md
+++ b/apps/ext/AGENTS.md
@@ -111,5 +111,13 @@ bun test
 Use `scripts/build.sh <version>` and `scripts/release.sh <version>` for packaged
 builds/releases; do not hand-roll `tsc`, `vsce publish`, or `ovsx publish`.
 
+A test that needs the `vscode` module registers the shared double —
+`mock.module('vscode', () => vscodeDouble({ …surface… }))` from
+`src/testing/vscodeDouble.ts`. bun's mock registry is process-global and
+last-registration-wins, so a hand-rolled partial double strips API constants
+(`TerminalExitReason`, `ConfigurationTarget`) from every *other* file in the
+same run — the failure lands somewhere else and passes standalone.
+`src/testing/vscodeDouble.test.ts` fails on the next hand-rolled one.
+
 Tests sit beside source and exercise real command boundaries. User-visible
 changes update this file, `README.md`, and `CHANGELOG.md`.

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
+## [0.9.334] - 2026-08-23
+
+- **A device reset no longer wipes every other device's Needs-You items.** The
+  presentation store handled a `reset` envelope by calling `attention.clear()`,
+  so one device re-sending its scope emptied the attention map for the whole
+  fleet and cards vanished until each of the other devices happened to reset
+  too. Attention (and agent rows) are now tracked by the scope the envelope
+  arrived on, and a reset clears only that scope. Rows previously inferred
+  their scope from the payload's `sourceDevice` field, which meant a row
+  without one was never evicted; the recorded scope replaces that inference.
+  Source: `src/core/sessionPresentationStore.ts`.
+
+- **Resolution receipts survive the session leaving the list, and carry what
+  was resolved.** `attention.remove` used to push the raw resolution object
+  into the activity lane, so once the session's row aged out there was nothing
+  left tying the receipt to a session or a question. The lane now records a
+  typed `attention.receipt` — session id, question, source, fingerprint, state,
+  and resolved-at — built from the attention item being removed. The card's
+  receipt renders the attention source alongside the state. Source:
+  `src/core/sessionPresentationStore.ts`,
+  `ui/settings/components/mission-control/FeedItem.tsx`.
+
+- **Receipts appear as they happen instead of on the next reload.** The floor
+  push sent agent rows but never the activity lane, so a resolution only became
+  visible when the webview was rebuilt. Every floor update now posts
+  `feedActivity` and the Fleet pane applies it. Source:
+  `src/vscode/settings.vscode.ts`,
+  `ui/settings/components/mission-control/UnifiedAgentsPane.tsx`.
+
+- **The watchdog history view no longer drops `undelivered` events.** The CLI
+  watchdog now records a nudge it could not confirm delivery for as
+  `undelivered` rather than booking it as a delivered nudge; the extension's log
+  parser rejected the unknown kind and silently discarded those lines. Source:
+  `src/core/watchdogLog.ts`.
+
 ## [0.9.333] - 2026-08-23
 
 - **Fleet Needs You now projects `agents feed watch --json`.** The elected

--- a/apps/ext/src/core/swarm.skills.test.ts
+++ b/apps/ext/src/core/swarm.skills.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { vscodeDouble } from '../testing/vscodeDouble';
 
 let tempDir: string;
 let fakeExtensionPath: string;
@@ -42,7 +43,7 @@ function setupMocks() {
     };
   });
 
-  mock.module('vscode', () => ({
+  mock.module('vscode', () => vscodeDouble({
     window: {
       showWarningMessage: () => {},
       showErrorMessage: () => {},

--- a/apps/ext/src/testing/vscodeDouble.test.ts
+++ b/apps/ext/src/testing/vscodeDouble.test.ts
@@ -1,0 +1,57 @@
+// Guard: every `vscode` module mock in the tree must be built by vscodeDouble.
+//
+// bun's mock registry is process-global and last-registration-wins, so a single
+// hand-rolled partial double silently strips API constants from every other
+// test file in the same run. That is not a local failure — it shows up as a
+// different file's assertions throwing, which is exactly how the Cmd+W teardown
+// tests went red in the suite while passing standalone. This test fails on the
+// next hand-rolled one instead.
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { VSCODE_API_CONSTANTS, vscodeDouble } from './vscodeDouble';
+
+const SRC = path.join(__dirname, '..');
+
+function sourceFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    return /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+}
+
+describe('vscodeDouble', () => {
+  test('merges the shared API constants under the caller surface', () => {
+    const double = vscodeDouble({ window: { showErrorMessage: () => {} } });
+    expect(double.TerminalExitReason.User).toBe(3);
+    expect(double.ConfigurationTarget.Global).toBe(1);
+    expect(typeof double.window.showErrorMessage).toBe('function');
+  });
+
+  test('every vscode module mock in the tree is built by vscodeDouble', () => {
+    const offenders = sourceFiles(SRC)
+      .filter((file) => file !== path.join(__dirname, 'vscodeDouble.test.ts'))
+      .filter((file) => {
+        const text = fs.readFileSync(file, 'utf8');
+        const registrations = text.match(/mock\.module\(\s*'vscode'\s*,[\s\S]{0,40}/g) ?? [];
+        // `() => vscodeDouble(...)` is the only accepted factory.
+        return registrations.some((r) => !r.includes('vscodeDouble('));
+      })
+      .map((file) => path.relative(SRC, file));
+
+    expect(offenders).toEqual([]);
+  });
+
+  test('the mirrored TerminalExitReason values match the VS Code API', () => {
+    // Stable since API 1.77; terminalReadiness compares against .User.
+    expect(VSCODE_API_CONSTANTS.TerminalExitReason).toEqual({
+      Unknown: 0,
+      Shutdown: 1,
+      Process: 2,
+      User: 3,
+      Extension: 4,
+    });
+  });
+});

--- a/apps/ext/src/testing/vscodeDouble.test.ts
+++ b/apps/ext/src/testing/vscodeDouble.test.ts
@@ -31,13 +31,22 @@ describe('vscodeDouble', () => {
   });
 
   test('every vscode module mock in the tree is built by vscodeDouble', () => {
+    // Counted, not substring-matched: a registration is compliant only when it
+    // matches the canonical factory EXACTLY. A looser "does this text contain
+    // vscodeDouble(" check passes on a registration that merely mentions it in
+    // a comment, and a quote-agnostic search is needed because `"vscode"` is
+    // just as valid a specifier as `'vscode'`. Any registration the strict
+    // pattern misses makes the counts differ, which flags the file.
+    const ANY_REGISTRATION = /mock\.module\(\s*['"]vscode['"]/g;
+    const CANONICAL_REGISTRATION = /mock\.module\(\s*['"]vscode['"]\s*,\s*\(\)\s*=>\s*vscodeDouble\(/g;
+
     const offenders = sourceFiles(SRC)
       .filter((file) => file !== path.join(__dirname, 'vscodeDouble.test.ts'))
       .filter((file) => {
         const text = fs.readFileSync(file, 'utf8');
-        const registrations = text.match(/mock\.module\(\s*'vscode'\s*,[\s\S]{0,40}/g) ?? [];
-        // `() => vscodeDouble(...)` is the only accepted factory.
-        return registrations.some((r) => !r.includes('vscodeDouble('));
+        const all = text.match(ANY_REGISTRATION)?.length ?? 0;
+        const canonical = text.match(CANONICAL_REGISTRATION)?.length ?? 0;
+        return all !== canonical;
       })
       .map((file) => path.relative(SRC, file));
 

--- a/apps/ext/src/testing/vscodeDouble.ts
+++ b/apps/ext/src/testing/vscodeDouble.ts
@@ -1,0 +1,37 @@
+// The one `vscode` module double every test registers with `mock.module`.
+//
+// bun's module-mock registry is process-global and the LAST file to register a
+// specifier wins for every module that already imported it — the registration
+// is not scoped to the file that made it. Each test file used to hand-roll its
+// own partial `vscode` object, so which parts of the API existed during a suite
+// run was decided by whichever mocking file happened to load last. That is how
+// `terminalReadiness.close.test.ts` passed on its own and failed all six of its
+// assertions in the suite: `watchdog.vscode.test.ts` sorts last and its double
+// has no `TerminalExitReason`, so `shouldTearDownAgentOnClose`'s
+// `vscode.TerminalExitReason.User` read threw.
+//
+// API *constants* are the part that must not vary — they are fixed by the VS
+// Code API, not by what a given test is exercising. They live here once and are
+// merged into every double, so the winning registration always carries the full
+// set. Per-file spies (a `window` that records the messages it was shown, a
+// `workspace` backed by a temp dir) stay in the test that asserts on them.
+
+/**
+ * Enum values fixed by the VS Code extension API, mirrored for tests that run
+ * without an extension host. `TerminalExitReason` has been stable since API
+ * 1.77, `ConfigurationTarget` since 1.0.
+ */
+export const VSCODE_API_CONSTANTS = {
+  TerminalExitReason: { Unknown: 0, Shutdown: 1, Process: 2, User: 3, Extension: 4 },
+  ConfigurationTarget: { Global: 1, Workspace: 2, WorkspaceFolder: 3 },
+} as const;
+
+/**
+ * Build a `vscode` double: the shared API constants plus whatever surface this
+ * test drives. Pass the result to `mock.module('vscode', () => vscodeDouble({…}))`.
+ */
+export function vscodeDouble<T extends Record<string, unknown>>(
+  surface: T = {} as T,
+): T & typeof VSCODE_API_CONSTANTS {
+  return { ...VSCODE_API_CONSTANTS, ...surface };
+}

--- a/apps/ext/src/vscode/agentlinks.vscode.test.ts
+++ b/apps/ext/src/vscode/agentlinks.vscode.test.ts
@@ -2,12 +2,13 @@ import { describe, test, expect, mock } from 'bun:test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { vscodeDouble } from '../testing/vscodeDouble';
 
 // agentlinks.vscode imports 'vscode' at module load. The code paths exercised
 // here (createSymlinksInDirectory + ensureSymlinksOnWorkspaceOpen with an empty
 // mapping set) only touch fs/path, so an empty stub satisfies the import without
 // needing the (cross-file, process-global) ripgrep mock.
-mock.module('vscode', () => ({}));
+mock.module('vscode', () => vscodeDouble());
 
 // hasEffectiveConfig/loadWorkspaceConfig read VS Code workspace config, which is
 // unavailable in the test host. loadWorkspaceConfig is a counting stub so the

--- a/apps/ext/src/vscode/htmlReader.test.ts
+++ b/apps/ext/src/vscode/htmlReader.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, mock, test } from 'bun:test';
 import * as path from 'path';
+import { vscodeDouble } from '../testing/vscodeDouble';
 
-mock.module('vscode', () => ({
+mock.module('vscode', () => vscodeDouble({
   Uri: {
     file: (fsPath: string) => ({ fsPath, scheme: 'file', toString: () => `file://${fsPath}` }),
   },

--- a/apps/ext/src/vscode/prewarm.vscode.test.ts
+++ b/apps/ext/src/vscode/prewarm.vscode.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test';
+import { vscodeDouble } from '../testing/vscodeDouble';
 
-mock.module('vscode', () => ({ window: {} }));
+mock.module('vscode', () => vscodeDouble({ window: {} }));
 
 const { restoreTerminals } = await import('./prewarm.vscode');
 

--- a/apps/ext/src/vscode/swarmifyConfig.vscode.test.ts
+++ b/apps/ext/src/vscode/swarmifyConfig.vscode.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, mock } from 'bun:test';
+import { vscodeDouble } from '../testing/vscodeDouble';
 
 // swarmifyConfig.vscode imports 'vscode' at module load; the scheduler under
 // test does not touch it, so an empty stub is enough to satisfy the import.
-mock.module('vscode', () => ({}));
+mock.module('vscode', () => vscodeDouble());
 
 const { createCoalescingScheduler } = await import('./swarmifyConfig.vscode');
 

--- a/apps/ext/src/vscode/terminalReadiness.close.test.ts
+++ b/apps/ext/src/vscode/terminalReadiness.close.test.ts
@@ -5,22 +5,20 @@
 // pin the decision and the injected-stop wiring without a real extension host.
 
 import { describe, expect, mock, test } from 'bun:test';
+import { VSCODE_API_CONSTANTS, vscodeDouble } from '../testing/vscodeDouble';
 
-// Only the vscode surface these functions touch. TerminalExitReason mirrors the
-// real enum values (stable since API 1.77): Unknown 0, Shutdown 1, Process 2,
-// User 3, Extension 4.
-mock.module('vscode', () => ({
+// Only the vscode surface these functions touch; TerminalExitReason and the
+// other API constants come from the shared double.
+mock.module('vscode', () => vscodeDouble({
   window: {
     onDidChangeTerminalShellIntegration: () => ({ dispose: () => {} }),
     onDidCloseTerminal: () => ({ dispose: () => {} }),
   },
-  TerminalExitReason: { Unknown: 0, Shutdown: 1, Process: 2, User: 3, Extension: 4 },
 }));
 
-const vscode = await import('vscode');
 const { shouldTearDownAgentOnClose, maybeTearDownAgentOnClose } = await import('./terminalReadiness');
 
-const R = (vscode as unknown as { TerminalExitReason: Record<string, number> }).TerminalExitReason;
+const R = VSCODE_API_CONSTANTS.TerminalExitReason;
 
 describe('shouldTearDownAgentOnClose', () => {
   test('true ONLY for a genuine user close', () => {

--- a/apps/ext/src/vscode/terminalReadiness.followerRouting.test.ts
+++ b/apps/ext/src/vscode/terminalReadiness.followerRouting.test.ts
@@ -7,8 +7,9 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type * as vscode from 'vscode';
+import { vscodeDouble } from '../testing/vscodeDouble';
 
-mock.module('vscode', () => ({
+mock.module('vscode', () => vscodeDouble({
   window: {
     onDidChangeTerminalShellIntegration: () => ({ dispose: () => {} }),
     onDidCloseTerminal: () => ({ dispose: () => {} }),

--- a/apps/ext/src/vscode/terminals.vscode.test.ts
+++ b/apps/ext/src/vscode/terminals.vscode.test.ts
@@ -1,8 +1,10 @@
 import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import type * as vscode from 'vscode';
+import { vscodeDouble } from '../testing/vscodeDouble';
 
-// Minimal vscode mock
-mock.module('vscode', () => ({
+// Only the vscode surface these terminals paths touch; API constants come from
+// the shared double so a suite run does not depend on file load order.
+mock.module('vscode', () => vscodeDouble({
   window: {
     terminals: [],
     onDidCloseTerminal: () => ({ dispose: () => {} }),
@@ -12,7 +14,6 @@ mock.module('vscode', () => ({
   },
   workspace: { workspaceFolders: undefined },
   TabInputTerminal: class {},
-  window2: undefined,
 }));
 
 mock.module('./agents.vscode', () => ({

--- a/apps/ext/src/vscode/watchdog.vscode.test.ts
+++ b/apps/ext/src/vscode/watchdog.vscode.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { vscodeDouble } from '../testing/vscodeDouble';
 
 // Minimal vscode mock — the palette handlers show status-bar / error messages;
 // the migration receives its VS Code boundary functions explicitly so this
@@ -6,7 +7,7 @@ import { describe, test, expect, beforeEach, mock } from 'bun:test';
 const statusMessages: string[] = [];
 const errorMessages: string[] = [];
 
-mock.module('vscode', () => ({
+mock.module('vscode', () => vscodeDouble({
   window: {
     state: { focused: true },
     setStatusBarMessage: (msg: string) => {
@@ -19,7 +20,6 @@ mock.module('vscode', () => ({
     },
   },
   workspace: {},
-  ConfigurationTarget: { Global: 1, Workspace: 2 },
 }));
 
 const watchdog = await import('./watchdog.vscode');

--- a/apps/ext/tsconfig.json
+++ b/apps/ext/tsconfig.json
@@ -12,5 +12,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", ".vscode-test", "src/**/*.test.ts"]
+  "exclude": ["node_modules", ".vscode-test", "src/**/*.test.ts", "src/testing/**"]
 }


### PR DESCRIPTION
## Why

The Marketplace is on **0.9.331**. `CHANGELOG.md` already had `0.9.332` and `0.9.333` sections — neither ever published, because the ext suite has been **red since the Cmd+W teardown tests landed in 0.9.332** and `scripts/release.sh` runs `bun run test` before it builds.

Four more commits landed after the `0.9.333` section with **no changelog entry at all** (`110b66f68`, `20eede639`, `d5032e40b`, `c9ac9ae58`).

## The test failure

`src/vscode/terminalReadiness.close.test.ts` passed standalone and failed all six assertions in the suite:

```
TypeError: undefined is not an object (evaluating 'R.User')
  at src/vscode/terminalReadiness.close.test.ts:54:15
```

Nine test files each hand-rolled a partial `vscode` object for `mock.module`. bun's mock registry is **process-global and last-registration-wins** — it is not scoped to the registering file — so whichever mocking file sorted last decided which parts of the API existed for the entire run. `watchdog.vscode.test.ts` sorts last and its double has no `TerminalExitReason`, so `shouldTearDownAgentOnClose`'s `vscode.TerminalExitReason.User` read threw.

Every pairing reproduced it, in either argument order:

```
agentlinks.vscode              -> 6 fails
htmlReader                     -> 6 fails
prewarm.vscode                 -> 6 fails
swarmifyConfig.vscode          -> 6 fails
terminals.vscode               -> 6 fails
watchdog.vscode                -> 6 fails
terminalReadiness.followerRouting -> 6 fails
```

## The fix

API *constants* are fixed by the VS Code API, not by what a given test exercises, so they live once in `src/testing/vscodeDouble.ts` and are merged into every double — the winning registration always carries the full set. Per-file spies (a `window` that records messages, a temp-dir `workspace`) stay in the test that asserts on them. All nine registrations now go through `vscodeDouble({ … })`.

`src/testing/vscodeDouble.test.ts` guards it: it scans the tree for `mock.module('vscode', …)` and fails on any factory that is not `vscodeDouble(`. Verified against a negative control — reverting one file to a bare object fails the guard with that file named.

`src/testing/**` is excluded from `tsc` so the helper does not ship in `out/`.

## Evidence

Before (`bun run test`):
```
1640 pass, 3 skip, 6 fail
```

After:
```
1649 pass, 3 skip, 0 fail
Ran 1652 tests across 145 files. [18.26s]
```

`bun run compile:ext` clean; `out/testing` does not exist.

## Changelog 0.9.334

Documents the four unrecorded commits: the scoped-attention-reset fix (a device reset was calling `attention.clear()` and wiping every other device's Needs-You items), typed `attention.receipt` records that survive the session leaving the list, live receipt push via `feedActivity`, and the watchdog log parser accepting the new `undelivered` event kind.

Test-only + build-config changes carry no changelog entry, per the repo's docs exemption.