### PR TITLE
fix(sessions): trace steps read by what the command did, not the cd prefix

### DIFF
--- a/apps/cli/.changelog/next/trace-readable-shell-labels.md
+++ b/apps/cli/.changelog/next/trace-readable-shell-labels.md
@@ -1,0 +1,19 @@
+---
+type: fix
+---
+
+- **`agents sessions trace` steps read by what the command DID, not their `cd`
+  prefix.** A shell step's label now strips the leading throwaway statements —
+  `cd <repo> &&`, `export X=Y;`, `set -e`, `source …`, and bare `VAR=val`
+  assignments — so `cd /long/path && git fetch origin` renders as
+  `git fetch origin`, and a multi-line script whose first line is `cd <repo>`
+  shows its real command instead. Before this, most rows in a coding session
+  rendered an identical `cd [HOME]/…/<repo>` and the trajectory was unreadable;
+  now every row is distinct and agrees with its program badge. Pipelines are left
+  intact and a command that is nothing but `cd` is shown as-is. Fixed at the
+  model (`buildTrajectory`), so the HTML, text, and `--json` renderings all
+  benefit. Source: `apps/cli/src/lib/session/trajectory.ts`.
+- **Trace durations roll into hours past 60 minutes.** An overnight idle gap now
+  reads `24h01m` instead of `1441m18s`, in both the HTML and the compact text
+  renderings. Source: `apps/cli/src/lib/session/trajectory-html.ts`,
+  `trajectory-text.ts`.

--- a/apps/cli/docs/sessions.md
+++ b/apps/cli/docs/sessions.md
@@ -959,7 +959,11 @@ step falls back to the next-event delta and is marked `durationEstimated` when a
 harness omits the result, so measured and inferred are never conflated). It also flags
 idle gaps (stalls), a per-program "where the time went" share (a shell call reads by
 its effective program — `git`, `bun`, `gh` — never a single opaque `Bash`), and tags
-inline `Task`/`Agent` sub-agents.
+inline `Task`/`Agent` sub-agents. Each step's one-line label reads by what the command
+DID: a leading `cd <repo> &&`, `export X=Y;`, `set -e`, or bare assignment is stripped
+so `cd /long/path && git fetch` shows as `git fetch` (agreeing with the badge) instead
+of an identical `cd …` on every row. Durations roll into hours past 60 minutes
+(`24h01m`, not `1441m18s`).
 
 One model renders three ways, **auto-selected by audience**:
 

--- a/apps/cli/src/lib/session/trajectory-html.test.ts
+++ b/apps/cli/src/lib/session/trajectory-html.test.ts
@@ -85,6 +85,19 @@ describe('renderTrajectoryHtml — self-contained and safe', () => {
     expect(style).toMatch(/\.mix-row\s*\{[^}]*display:\s*grid/);
   });
 
+  it('renders a multi-hour idle gap in hours, not runaway minutes', () => {
+    // A completed step, then a >1h idle gap — the HTML gap divider (and the KPI)
+    // must read "2h05m", not "125m…".
+    const overnight: SessionEvent[] = [
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'b', command: 'git status' },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Bash', callId: 'b', outcome: 'ok' },
+      { type: 'message', agent: 'claude', timestamp: '2026-08-01T02:05:01Z', role: 'user', content: 'back' },
+    ];
+    const html = renderTrajectoryHtml(buildTrajectory(overnight, meta()));
+    expect(html).toContain('idle 2h05m'); // the gap divider, in hours
+    expect(html).not.toMatch(/idle 125m/); // never runaway minutes
+  });
+
   it('an empty trajectory still renders a valid page (no crash)', () => {
     const html = renderTrajectoryHtml(buildTrajectory([], meta({ agent: 'openclaw' })));
     expect(html).toContain('<!DOCTYPE html>');

--- a/apps/cli/src/lib/session/trajectory-html.ts
+++ b/apps/cli/src/lib/session/trajectory-html.ts
@@ -30,12 +30,19 @@ function toolColor(step: TrajectoryStep): string {
   return '#8b98a5';
 }
 
-/** Precise per-step duration for the waterfall: "8m04s", "1.6s", "320ms". */
+/** Precise per-step duration for the waterfall: "2h01m", "8m04s", "1.6s", "320ms". */
 function formatStepDuration(ms: number): string {
   if (ms <= 0) return '0s';
   if (ms < 1000) return `${Math.round(ms)}ms`;
   if (ms < 60_000) return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
   const totalSec = Math.round(ms / 1000);
+  // Beyond an hour, minutes-only reads as "1441m18s" for an overnight idle gap —
+  // roll into hours so a long stall is legible at a glance.
+  if (totalSec >= 3600) {
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    return `${h}h${String(m).padStart(2, '0')}m`;
+  }
   const m = Math.floor(totalSec / 60);
   const s = totalSec % 60;
   return `${m}m${String(s).padStart(2, '0')}s`;

--- a/apps/cli/src/lib/session/trajectory-text.test.ts
+++ b/apps/cli/src/lib/session/trajectory-text.test.ts
@@ -40,6 +40,20 @@ describe('renderTrajectoryText', () => {
     expect(text).toContain('exit 1 · 2 failing'); // error evidence line
   });
 
+  it('renders a multi-hour idle stall in hours, not runaway minutes', () => {
+    // A completed step, then nothing for 2h05m — an overnight stall. Minutes-only
+    // used to print "125m…"; it should read as hours.
+    const overnight: SessionEvent[] = [
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'b', command: 'git status' },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Bash', callId: 'b', outcome: 'ok' },
+      { type: 'message', agent: 'claude', timestamp: '2026-08-01T02:05:01Z', role: 'user', content: 'back' },
+    ];
+    const idleLine = renderTrajectoryText(buildTrajectory(overnight, meta()))
+      .split('\n').find((l) => l.startsWith('idle'))!;
+    expect(idleLine).toBe('idle 2h05m after step 1 (stall)');
+    expect(idleLine).not.toMatch(/125m/); // not runaway minutes
+  });
+
   it('errorsOnly collapses to the error step and its neighbours', () => {
     const text = renderTrajectoryText(buildTrajectory(events, meta()), { errorsOnly: true });
     // Step 2 is the error (a `bun test`, tagged by its program); steps 1 and 3 are neighbours.

--- a/apps/cli/src/lib/session/trajectory-text.ts
+++ b/apps/cli/src/lib/session/trajectory-text.ts
@@ -25,7 +25,7 @@ export interface RenderTrajectoryTextOptions {
 const DEFAULT_MAX_STEPS = 80;
 const LABEL_COL = 40;
 
-/** Precise, compact per-step duration: "8m04s", "1.6s", "320ms", "—" for zero. */
+/** Precise, compact per-step duration: "2h01m", "8m04s", "1.6s", "320ms", "—" for zero. */
 function dur(ms: number, estimated: boolean): string {
   if (ms <= 0) return estimated ? '~0s' : '0s';
   let s: string;
@@ -33,7 +33,13 @@ function dur(ms: number, estimated: boolean): string {
   else if (ms < 60_000) s = `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
   else {
     const totalSec = Math.round(ms / 1000);
-    s = `${Math.floor(totalSec / 60)}m${String(totalSec % 60).padStart(2, '0')}s`;
+    // Beyond an hour, roll into hours so an overnight stall reads "24h01m", not
+    // "1441m18s" (matches the HTML renderer's formatStepDuration).
+    if (totalSec >= 3600) {
+      s = `${Math.floor(totalSec / 3600)}h${String(Math.floor((totalSec % 3600) / 60)).padStart(2, '0')}m`;
+    } else {
+      s = `${Math.floor(totalSec / 60)}m${String(totalSec % 60).padStart(2, '0')}s`;
+    }
   }
   return estimated ? `~${s}` : s;
 }

--- a/apps/cli/src/lib/session/trajectory.test.ts
+++ b/apps/cli/src/lib/session/trajectory.test.ts
@@ -67,6 +67,9 @@ describe('buildTrajectory — durations by callId pairing', () => {
     expect(label('cd apps/cli && cat f | grep x')).toBe('cat f | grep x');
     // A command that is nothing but `cd` is left as-is, never emptied.
     expect(label('cd /home/u/src/agents-cli')).toBe('cd /home/u/src/agents-cli');
+    // A separator INSIDE a quoted arg would cut mid-quote — keep the whole command
+    // rather than show a dangling-quote fragment.
+    expect(label('cd "/path/with; semicolon" && git push')).toBe('cd "/path/with; semicolon" && git push');
     // A non-noise command is untouched, and the label now agrees with the badge.
     const t = buildTrajectory(cmd('cd apps/cli && bun test'), meta(), { redact: false });
     expect(t.steps[0].label).toBe('bun test');

--- a/apps/cli/src/lib/session/trajectory.test.ts
+++ b/apps/cli/src/lib/session/trajectory.test.ts
@@ -48,6 +48,31 @@ describe('buildTrajectory — durations by callId pairing', () => {
     expect(prog('cat f | grep x')).toBe('cat'); // pipeline: leftmost effective program
   });
 
+  it('labels a shell step by what it DID, stripping the leading cd/export/assignment noise', () => {
+    const cmd = (command: string): SessionEvent[] => [
+      { type: 'tool_use', agent: 'claude', timestamp: '2026-08-01T00:00:00Z', tool: 'Bash', callId: 'x', command },
+      { type: 'tool_result', agent: 'claude', timestamp: '2026-08-01T00:00:01Z', tool: 'Bash', callId: 'x', outcome: 'ok' },
+    ];
+    // redact:false isolates the noise-stripping from the home-path masking.
+    const label = (command: string) => buildTrajectory(cmd(command), meta(), { redact: false }).steps[0].label;
+    // The dominant real shape: a `cd <repo> &&` prefix that made every row read identically.
+    expect(label('cd /home/u/src/agents-cli && git fetch origin')).toBe('git fetch origin');
+    // A multi-line script whose first line is the `cd` — firstLine used to keep only that.
+    expect(label('cd /home/u/src/agents-cli\ngit status')).toBe('git status');
+    // Assignments as a statement and as a prefix, and `set -e`, are all skipped.
+    expect(label('export FOO=bar; gh pr create')).toBe('gh pr create');
+    expect(label('set -e; bun test')).toBe('bun test');
+    expect(label('FOO=bar git push')).toBe('git push');
+    // A pipeline stays intact (only leading noise is removed).
+    expect(label('cd apps/cli && cat f | grep x')).toBe('cat f | grep x');
+    // A command that is nothing but `cd` is left as-is, never emptied.
+    expect(label('cd /home/u/src/agents-cli')).toBe('cd /home/u/src/agents-cli');
+    // A non-noise command is untouched, and the label now agrees with the badge.
+    const t = buildTrajectory(cmd('cd apps/cli && bun test'), meta(), { redact: false });
+    expect(t.steps[0].label).toBe('bun test');
+    expect(t.steps[0].program).toBe('bun');
+  });
+
   it('resolves program for every harness shell tool, not just Bash (Codex exec_command)', () => {
     const shellStep = (tool: string): SessionEvent[] => [
       { type: 'tool_use', agent: 'codex', timestamp: '2026-08-01T00:00:00Z', tool, callId: 'c', command: 'npm test' },

--- a/apps/cli/src/lib/session/trajectory.ts
+++ b/apps/cli/src/lib/session/trajectory.ts
@@ -188,6 +188,39 @@ function stringArg(args: Record<string, any> | undefined, ...keys: string[]): st
 }
 
 /**
+ * Strip a shell command's leading throwaway statements so its label reads by what
+ * it DID, not by its setup. Real agent commands overwhelmingly open with a
+ * `cd <repo> &&` (or a multi-line script whose first line is `cd <repo>`), plus the
+ * occasional `export X=Y;`, `set -e`, `source …`, or bare `VAR=val` assignment —
+ * exactly the {@link SHELL_NOISE_PROGRAMS} the badge already skips when resolving
+ * the effective program. Without this, every `cd /long/path && git …` row renders
+ * an identical `cd /long/path` and the trajectory is unreadable; here we drop that
+ * prefix so the label agrees with the badge (`git …`, `gh …`, `bun …`).
+ *
+ * Conservative on purpose: only a LEADING run of noise statements separated by
+ * `&&`, `;`, or a newline is removed (an assignment PREFIX like `VAR=val cmd` too),
+ * pipelines (`|`) are left intact, and a command that is nothing but noise (a lone
+ * `cd dir`) is returned unchanged rather than emptied. Display-only — the value is
+ * still clipped and secret-redacted downstream.
+ */
+function stripLeadingShellNoise(command: string): string {
+  // A leading `cd`/`export`/`set`/`source`/`unset`/`local`/`eval` statement, or an
+  // assignment, terminated by a statement separator (`&&`, `;`, or newline).
+  const noiseStatement = /^\s*(?:cd|export|set|source|unset|local|eval)\b[^\n&;|]*(?:&&|;|\n)+/i;
+  // A bare `VAR=val` — either a full statement (with a separator) or a prefix
+  // (followed by whitespace before the real program: `FOO=bar git push`).
+  const assignment = /^\s*[A-Za-z_][A-Za-z0-9_]*=[^\s&;|]*(?:\s*(?:&&|;|\n)+|\s+)/;
+  let cmd = command;
+  let prev = '';
+  while (cmd !== prev) {
+    prev = cmd;
+    cmd = cmd.replace(noiseStatement, '').replace(assignment, '');
+  }
+  const trimmed = cmd.trim();
+  return trimmed.length > 0 ? trimmed : command.trim();
+}
+
+/**
  * A redacted one-line label for a tool call, derived from the raw arguments.
  *
  * This is the single place unredacted command/argument text enters the model, so
@@ -204,7 +237,8 @@ function toolLabel(
   let raw: string | undefined;
   const lower = tool.toLowerCase();
   if (lower === 'bash' || lower === 'shell' || lower === 'run_command' || lower.includes('exec')) {
-    raw = command ?? stringArg(args, 'command', 'cmd', 'script');
+    const cmd = command ?? stringArg(args, 'command', 'cmd', 'script');
+    raw = cmd ? stripLeadingShellNoise(cmd) : cmd;
   } else if (lower === 'read' || lower === 'edit' || lower === 'write' || lower === 'notebookedit' || lower === 'multiedit') {
     raw = stringArg(args, 'file_path', 'path', 'notebook_path', 'filePath');
   } else if (lower === 'grep' || lower === 'glob' || lower === 'search' || lower === 'codebase_search') {

--- a/apps/cli/src/lib/session/trajectory.ts
+++ b/apps/cli/src/lib/session/trajectory.ts
@@ -200,9 +200,18 @@ function stringArg(args: Record<string, any> | undefined, ...keys: string[]): st
  * Conservative on purpose: only a LEADING run of noise statements separated by
  * `&&`, `;`, or a newline is removed (an assignment PREFIX like `VAR=val cmd` too),
  * pipelines (`|`) are left intact, and a command that is nothing but noise (a lone
- * `cd dir`) is returned unchanged rather than emptied. Display-only — the value is
- * still clipped and secret-redacted downstream.
+ * `cd dir`) is returned unchanged rather than emptied. The separator match is a
+ * plain negated class, not a shell tokenizer, so a separator INSIDE a quoted arg
+ * (`cd "a; b" && x`) would cut mid-quote — guarded by refusing any strip that
+ * leaves the label with unbalanced quotes and falling back to the whole command.
+ * Display-only — the value is still clipped and secret-redacted downstream.
  */
+function quotesBalanced(text: string): boolean {
+  const dq = (text.match(/(?<!\\)"/g) ?? []).length;
+  const sq = (text.match(/(?<!\\)'/g) ?? []).length;
+  return dq % 2 === 0 && sq % 2 === 0;
+}
+
 function stripLeadingShellNoise(command: string): string {
   // A leading `cd`/`export`/`set`/`source`/`unset`/`local`/`eval` statement, or an
   // assignment, terminated by a statement separator (`&&`, `;`, or newline).
@@ -217,7 +226,11 @@ function stripLeadingShellNoise(command: string): string {
     cmd = cmd.replace(noiseStatement, '').replace(assignment, '');
   }
   const trimmed = cmd.trim();
-  return trimmed.length > 0 ? trimmed : command.trim();
+  if (trimmed.length === 0) return command.trim();
+  // A strip that severed a quoted argument (a separator lived inside quotes) leaves
+  // a dangling quote — keep the whole command rather than show a mangled fragment.
+  if (!quotesBalanced(trimmed) && quotesBalanced(command)) return command.trim();
+  return trimmed;
 }
 
 /**


### PR DESCRIPTION
## The problem

`agents sessions trace` renders a per-step label from the shell command's **first line/segment**. In real coding sessions that is almost always a `cd <repo> &&` prefix (or a multi-line script whose first line is a bare `cd <repo>`), so the label showed the setup, not the action. The program **badge** already resolved the effective program (`git`/`gh`/`sed`) — but the label next to it was an identical `cd [HOME]/…/<repo>` on row after row. A 498-step trajectory was a wall of the same string.

Real labels from a live session's `--json`, before this change:

```
program | label
'git'   | 'cd [HOME]/src/github.com/muqsitnawaz/agents-cli'
'sed'   | 'cd [HOME]/src/github.com/muqsitnawaz/agents-cli'
'echo'  | 'cd [HOME]/src/github.com/muqsitnawaz/agents-cli'
'git'   | 'cd [HOME]/src/github.com/muqsitnawaz/agents-cli'
```

## The fix

Strip the leading throwaway statements — `cd`, `export`, `set`, `source`, `unset`, `eval`, and bare `VAR=val` assignments — from the shell label in `buildTrajectory` (the model), so it reads by what the command **did** and agrees with the badge. This mirrors the `SHELL_NOISE_PROGRAMS` set the badge already skips. Pipelines are left intact; a command that is nothing but `cd` is shown as-is (never emptied). Because it is fixed at the model, the HTML, text, and `--json` renderings all benefit.

The same rendered rows, after (screenshot of the trajectory list):

```
1  git   git fetch origin -q && git rev-list --count HEAD..origin/main …   5.1s
3  echo  echo "=== files touching 'view' command ==="; grep -rln "agen…    324ms
8  git   git show origin/main:apps/cli/src/lib/accounting/usage.ts 2>/de…  324ms
10 sed   sed -n '620,760p' /tmp/usage-main.ts                              1.7s
```

Every row is now distinct and legible.

**Also:** durations roll into hours past 60 minutes. An overnight idle gap read `1441m18s`; it now reads `24h01m`, in both the HTML and compact text renderers.

## Verification

- `bun test src/lib/session/trajectory*.test.ts src/lib/session/shell-programs.test.ts` — **77 pass, 0 fail**. New cases: leading `cd`/`export`/`set`/assignment stripping, pipeline-intact, lone-`cd` untouched, label agrees with badge; multi-hour idle stall renders in hours.
- `bunx tsc --noEmit` — clean.
- Rendered a real 27-step archived session with the new code and eyeballed the trajectory on the interactive host (screenshot above) — the `cd [HOME]/…` rows are gone; each shows its real command.

## Scope

Rendering-quality only. No change to `SessionEvent`, the parsers, the tool-call index, the `--json` envelope shape, or any flag/command surface. `docs/sessions.md` and CHANGELOG updated.