### PR TITLE
fix(ext): install deps on the local publish path in release.sh (RUSH-3114)

### DIFF
--- a/apps/ext/scripts/release.sh
+++ b/apps/ext/scripts/release.sh
@@ -221,8 +221,8 @@ fi
 git -C "\$CACHE" checkout --quiet --detach "\$SHA"
 
 cd "\$CACHE/apps/ext"
-bun install --silent
-(cd ui && bun install --silent)
+# Deps are installed by the --publish-phase re-entry below, at the single
+# shared point every local publish path passes through — not here.
 bash scripts/release.sh "\$VERSION" $flags --publish-phase
 REMOTE_EOF
 )"
@@ -383,6 +383,19 @@ if [ $PUBLISH_VSCE -eq 1 ]; then
     fi
     echo "VSCE PAT verified."
 fi
+
+# --- Dependencies --------------------------------------------------------
+#
+# The single point every local publish path reaches before the gate — whether
+# this box holds the bundle, --here pinned it here, or the routed --publish-phase
+# re-entry runs on the publish box. A clean checkout has no node_modules, so both
+# the test run and the build (each needs the workspace deps) would die here. The
+# routing heredoc no longer installs; the install lives here so it happens exactly
+# once per invocation and is never duplicated across the local and remote paths.
+# Placed after the `agents secrets exec` re-exec above so it runs once, not twice.
+echo "${DRY}Installing dependencies..."
+bun install --silent
+(cd ui && bun install --silent)
 
 # --- Tests + Build -------------------------------------------------------
 

--- a/apps/ext/scripts/release.test.sh
+++ b/apps/ext/scripts/release.test.sh
@@ -182,8 +182,11 @@ STUB
     fi
 
     # Ordering: the install must land before the test gate in the output.
-    INSTALL_LINE="$(grep -nE 'Installing dependencies' "$RUN_OUT" | head -1 | cut -d: -f1)"
-    TESTS_LINE="$(grep -nE 'Running tests' "$RUN_OUT" | head -1 | cut -d: -f1)"
+    # `|| true` so a no-match (the pre-fix path, where "Installing dependencies"
+    # never prints) reports fail() gracefully instead of aborting the whole suite
+    # under `set -e` and silently skipping the assertions below.
+    INSTALL_LINE="$(grep -nE 'Installing dependencies' "$RUN_OUT" | head -1 | cut -d: -f1 || true)"
+    TESTS_LINE="$(grep -nE 'Running tests' "$RUN_OUT" | head -1 | cut -d: -f1 || true)"
     if [ -n "$INSTALL_LINE" ] && [ -n "$TESTS_LINE" ] && [ "$INSTALL_LINE" -lt "$TESTS_LINE" ]; then
         pass "install precedes the Tests/Build gate on the local publish path"
     else

--- a/apps/ext/scripts/release.test.sh
+++ b/apps/ext/scripts/release.test.sh
@@ -191,6 +191,18 @@ STUB
     fi
 fi
 
+# Static guard against re-introducing the double-install: the ssh-routing
+# heredoc must NOT install deps. The --publish-phase re-entry it invokes now
+# installs at the shared block, so a `bun install` back inside the heredoc would
+# install twice on the remote path. Extract the heredoc payload (between the
+# `<<REMOTE_EOF` opener and its closing sentinel) and assert it is install-free.
+HEREDOC_BODY="$(awk '/<<REMOTE_EOF/{f=1;next} /^REMOTE_EOF$/{f=0} f' "$RELEASE_SH")"
+if printf '%s' "$HEREDOC_BODY" | grep -q 'bun install'; then
+    fail "RUSH-3114: routing heredoc still runs 'bun install' (double-install on the remote path)"
+else
+    pass "routing heredoc no longer installs deps (single install on the remote path)"
+fi
+
 echo
 if [ "$FAIL" -eq 0 ]; then
     echo "All tests passed."

--- a/apps/ext/scripts/release.test.sh
+++ b/apps/ext/scripts/release.test.sh
@@ -113,6 +113,84 @@ STUB
     fi
 fi
 
+# --- RUSH-3114: the local publish path must install deps before the gate ---
+#
+# `bun install` (root + ui) used to live ONLY inside the ssh-routing heredoc, so
+# it ran solely when the publish routed to another box. On the local publish path
+# (this box holds the bundle, --here, or the --publish-phase re-entry) a clean
+# checkout reached the test/build gate with no node_modules and died. This drives
+# the real script down the local path with a stubbed `bun` and asserts install is
+# invoked, and that it precedes the "Running tests" gate in the output.
+if [ -z "${RELEASE_VERSION:-}" ]; then
+    fail "RUSH-3114: could not read a released version out of CHANGELOG.md"
+else
+    STUB_DIR="$(mktemp -d)"
+    STUB_HOME="$(mktemp -d)"
+    BUN_CALLS="$STUB_DIR/bun-calls"
+    RUN_OUT="$STUB_DIR/run-out"
+
+    # `agents secrets list` makes this box the publish host (no routing).
+    cat > "$STUB_DIR/agents" <<'STUB'
+#!/bin/bash
+if [ "${1:-}" = "secrets" ] && [ "${2:-}" = "list" ]; then
+    echo "vs-marketplace       2     never - no prompt"
+    exit 0
+fi
+exit 0
+STUB
+
+    # `bun` records every invocation so we can assert `install` ran. It must not
+    # shadow the collision/PAT pre-flight: it is only present on the script's PATH.
+    cat > "$STUB_DIR/bun" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "$BUN_CALLS_PATH"
+exit 0
+STUB
+
+    # `show`/`get` report the version as NOT yet published so a real publish is
+    # planned (PUBLISH_VSCE/OVSX=1) — the path a genuine release takes; verify-pat
+    # clears offline.
+    cat > "$STUB_DIR/vsce" <<'STUB'
+#!/bin/bash
+case "${1:-}" in
+    show)        echo '{"versions":[]}' ;;
+    verify-pat)  exit 0 ;;
+esac
+exit 0
+STUB
+    cat > "$STUB_DIR/ovsx" <<'STUB'
+#!/bin/bash
+echo '{}'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/agents" "$STUB_DIR/bun" "$STUB_DIR/vsce" "$STUB_DIR/ovsx"
+
+    # PATs in env so the secrets re-exec is skipped and the script reaches the
+    # install block directly. Dry-run (no --confirm) so nothing is published; the
+    # install runs regardless of --confirm, which is exactly what we assert.
+    (
+        cd "$EXT_ROOT"
+        PATH="$STUB_DIR:$PATH" HOME="$STUB_HOME" \
+            BUN_CALLS_PATH="$BUN_CALLS" VSCE_PAT="tok" OVSX_PAT="tok" \
+            bash "$RELEASE_SH" "$RELEASE_VERSION"
+    ) > "$RUN_OUT" 2>&1 || true
+
+    if [ ! -f "$BUN_CALLS" ] || ! grep -qE '^install( |$)' "$BUN_CALLS"; then
+        fail "RUSH-3114: local publish path never ran 'bun install' (calls: $( [ -f "$BUN_CALLS" ] && tr '\n' ',' < "$BUN_CALLS" || echo none ))"
+    else
+        pass "local publish path runs 'bun install' before the gate"
+    fi
+
+    # Ordering: the install must land before the test gate in the output.
+    INSTALL_LINE="$(grep -nE 'Installing dependencies' "$RUN_OUT" | head -1 | cut -d: -f1)"
+    TESTS_LINE="$(grep -nE 'Running tests' "$RUN_OUT" | head -1 | cut -d: -f1)"
+    if [ -n "$INSTALL_LINE" ] && [ -n "$TESTS_LINE" ] && [ "$INSTALL_LINE" -lt "$TESTS_LINE" ]; then
+        pass "install precedes the Tests/Build gate on the local publish path"
+    else
+        fail "RUSH-3114: install did not precede the test gate (install line: ${INSTALL_LINE:-none}, tests line: ${TESTS_LINE:-none})"
+    fi
+fi
+
 echo
 if [ "$FAIL" -eq 0 ]; then
     echo "All tests passed."


### PR DESCRIPTION
## Problem (RUSH-3114)

`apps/ext/scripts/release.sh` installed workspace deps **only on the remote-routing
path**: the `bun install --silent` (root) + `(cd ui && bun install --silent)` pair
lived inside the heredoc that re-invokes the script over SSH on the `vs-marketplace`
bundle box. When the publish host **is** the local machine — `--here`, already on the
bundle box, or the routed `--publish-phase` re-entry — that heredoc never runs, so a
clean checkout reached the test/build gate with **no `node_modules`** and died.

## Fix

Move the install to the single point **every** local publish path passes through:
immediately before the Tests/Build gate, after the `agents secrets exec` re-exec block
(so it runs exactly once, never twice on the local secrets re-entry). The routing
heredoc no longer installs — the `--publish-phase` re-entry it invokes now installs at
that same shared point, so there is **no double-install** on the remote path. Not a
duplicated band-aid; one install at the seam.

## Verification — clean checkout, local publish path, dry-run (no `--confirm`)

Ran on `zion` (holds the `vs-marketplace` bundle) against a fresh `--depth 1` clone of
this commit:

```
root node_modules before: ABSENT
ui   node_modules before: ABSENT
...
Publish host: zion (holds the 'vs-marketplace' bundle).      # local path, no routing
...
[DRY-RUN] Installing dependencies...
[DRY-RUN] Running tests...                                    # reached the gate
...
root node_modules after: PRESENT
ui   node_modules after: PRESENT
```

Before the fix this path had no install at all and would die at the gate on a clean
checkout.

## Scope notes

- No CHANGELOG/docs entry: this is an internal release-script fix; `release.sh` flags,
  usage, and the shipped extension's behavior are unchanged.
