### PR TITLE
fix(ci): map runtime readFileSync deps, not just static imports (RUSH-3097)

### DIFF
--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -26,6 +26,7 @@ import {
   planIsFailing,
   proofFromPlan,
   relatedTestFiles,
+  runtimeReadTestsBySource,
   selectImpact,
   validateOwnershipManifest,
 } from './ci-scope';
@@ -425,6 +426,59 @@ describe('selectImpact policy', () => {
     const result = validateOwnershipManifest(MANIFEST, REPO);
     expect(result.missingTests).toEqual([]);
     expect(result.unmapped).toEqual([]);
+  });
+
+  test('a runtime readFileSync of a literal script path selects the reading test (RUSH-3097)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agents-ci-runtime-read-'));
+    try {
+      writeFixture(dir, 'apps/cli/scripts/thing.sh', '#!/bin/sh\necho hi\n');
+      writeFixture(
+        dir,
+        'apps/cli/scripts/thing-var.test.ts',
+        "import * as fs from 'node:fs';\n"
+          + "import * as path from 'node:path';\n"
+          + "const SCRIPT = path.resolve(__dirname, 'thing.sh');\n"
+          + 'const body = fs.readFileSync(SCRIPT, \'utf-8\');\n'
+          + 'export const y = body;\n',
+      );
+      writeFixture(
+        dir,
+        'apps/cli/scripts/thing-inline.test.ts',
+        "import * as fs from 'node:fs';\n"
+          + "import * as path from 'node:path';\n"
+          + 'const body = fs.readFileSync(path.resolve(__dirname, \'thing.sh\'), \'utf-8\');\n'
+          + 'export const y = body;\n',
+      );
+      writeFixture(
+        dir,
+        'apps/cli/scripts/thing-unrelated.test.ts',
+        "export const y = 1;\n",
+      );
+      const files = [
+        'apps/cli/scripts/thing.sh',
+        'apps/cli/scripts/thing-var.test.ts',
+        'apps/cli/scripts/thing-inline.test.ts',
+        'apps/cli/scripts/thing-unrelated.test.ts',
+      ];
+      const related = runtimeReadTestsBySource(['apps/cli/scripts/thing.sh'], dir, files);
+      expect(related.get('apps/cli/scripts/thing.sh')).toEqual(expect.arrayContaining([
+        'apps/cli/scripts/thing-var.test.ts',
+        'apps/cli/scripts/thing-inline.test.ts',
+      ]));
+      expect(related.get('apps/cli/scripts/thing.sh')).not.toContain('apps/cli/scripts/thing-unrelated.test.ts');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('release.sh selects every scripts/*.test.ts that reads it via readFileSync at runtime, not just its companion (RUSH-3097)', () => {
+    const plan = selectImpact({ files: ['apps/cli/scripts/release.sh'], repoRoot: REPO, manifest: MANIFEST });
+    const byFile = new Map(plan.tests.map((t) => [t.file, t.reason]));
+    expect(byFile.get('apps/cli/scripts/release.test.ts')).toBe('companion');
+    expect(byFile.get('apps/cli/scripts/promote-home-base-probe.test.ts')).toBe('runtime-read');
+    expect(byFile.get('apps/cli/scripts/signing-home-base-probe.test.ts')).toBe('runtime-read');
+    expect(byFile.get('apps/cli/scripts/stuck-release.test.ts')).toBe('runtime-read');
+    expect(plan.unmapped).toEqual([]);
   });
 });
 

--- a/scripts/ci-scope.ts
+++ b/scripts/ci-scope.ts
@@ -386,14 +386,10 @@ export function relatedTestFiles(
   return [...new Set([...byFile.values()].flat())];
 }
 
-export function relatedTestsBySource(
-  changed: readonly string[],
-  repoRoot: string,
-  files?: readonly string[],
+function invertGraphOntoChanged(
+  graph: Map<string, string[]>,
+  changedSet: Set<string>,
 ): Map<string, string[]> {
-  const universe = files ?? trackedFiles(repoRoot).filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'));
-  const graph = buildImportGraph(repoRoot, universe);
-  const changedSet = new Set(changed.map(posix));
   const out = new Map<string, string[]>();
   for (const file of changedSet) out.set(file, []);
   for (const [from, tos] of graph) {
@@ -404,6 +400,79 @@ export function relatedTestsBySource(
     }
   }
   return out;
+}
+
+export function relatedTestsBySource(
+  changed: readonly string[],
+  repoRoot: string,
+  files?: readonly string[],
+): Map<string, string[]> {
+  const universe = files ?? trackedFiles(repoRoot).filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'));
+  const graph = buildImportGraph(repoRoot, universe);
+  return invertGraphOntoChanged(graph, new Set(changed.map(posix)));
+}
+
+// A test that reads its script-under-test with `readFileSync` at runtime (to
+// assert on its literal source, or via `path.resolve(__dirname, ...)`) has a
+// real dependency edge the static IMPORT_RE graph above can never see — there
+// is no `import "./release.sh"` to find (RUSH-3097). This resolves that one
+// runtime pattern the same way buildImportGraph resolves static imports: a
+// literal filename passed to readFileSync, either inline as
+// `path.resolve(__dirname, 'LIT')` / `path.join(__dirname, 'LIT')`, or via a
+// same-file `const NAME = path.resolve(__dirname, 'LIT')` the read then
+// references by name. It deliberately does not attempt general data-flow
+// analysis beyond that one indirection — a test that hides the path behind
+// anything more dynamic than a same-file constant needs a real import instead.
+const PATH_VARIABLE_RE = /\b(?:const|let|var)\s+(\w+)\s*=\s*(?:path\.)?(?:resolve|join)\(\s*__dirname\s*,\s*(['"])([^'"]+)\2\s*\)/g;
+const RUNTIME_READ_INLINE_RE = /readFileSync\s*\(\s*(?:path\.)?(?:resolve|join)\(\s*__dirname\s*,\s*(['"])([^'"]+)\1\s*\)/g;
+const RUNTIME_READ_VAR_RE = /readFileSync\s*\(\s*(\w+)\s*[,)]/g;
+
+export function extractRuntimeReadLiterals(text: string): string[] {
+  const vars = new Map<string, string>();
+  PATH_VARIABLE_RE.lastIndex = 0;
+  let vm: RegExpExecArray | null;
+  while ((vm = PATH_VARIABLE_RE.exec(text))) vars.set(vm[1], vm[3]);
+
+  const literals = new Set<string>();
+  RUNTIME_READ_INLINE_RE.lastIndex = 0;
+  let im: RegExpExecArray | null;
+  while ((im = RUNTIME_READ_INLINE_RE.exec(text))) literals.add(im[2]);
+
+  RUNTIME_READ_VAR_RE.lastIndex = 0;
+  let am: RegExpExecArray | null;
+  while ((am = RUNTIME_READ_VAR_RE.exec(text))) {
+    const literal = vars.get(am[1]);
+    if (literal) literals.add(literal);
+  }
+  return [...literals];
+}
+
+export function buildRuntimeReadGraph(repoRoot: string, files: readonly string[]): Map<string, string[]> {
+  const graph = new Map<string, string[]>();
+  for (const file of files) {
+    if (!file.endsWith('.ts') && !file.endsWith('.tsx')) continue;
+    const abs = join(repoRoot, file);
+    if (!existsSync(abs)) continue;
+    const text = readFileSync(abs, 'utf8');
+    if (!text.includes('readFileSync')) continue;
+    const targets: string[] = [];
+    for (const literal of extractRuntimeReadLiterals(text)) {
+      const resolved = resolve(repoRoot, dirname(file), literal);
+      if (existsSync(resolved)) targets.push(posix(relative(repoRoot, resolved)));
+    }
+    if (targets.length) graph.set(posix(file), targets);
+  }
+  return graph;
+}
+
+export function runtimeReadTestsBySource(
+  changed: readonly string[],
+  repoRoot: string,
+  files?: readonly string[],
+): Map<string, string[]> {
+  const universe = files ?? trackedFiles(repoRoot).filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'));
+  const graph = buildRuntimeReadGraph(repoRoot, universe);
+  return invertGraphOntoChanged(graph, new Set(changed.map(posix)));
 }
 
 function addTest(
@@ -453,6 +522,9 @@ export function selectImpact(input: SelectImpactInput): ImpactPlan {
   const relatedBySource = relatedByDefault
     ? relatedTestsBySource(input.files, repoRoot)
     : new Map<string, string[]>();
+  const runtimeReadBySource = relatedByDefault
+    ? runtimeReadTestsBySource(input.files, repoRoot)
+    : new Map<string, string[]>();
 
   for (const raw of input.files) {
     const file = posix(raw);
@@ -482,6 +554,10 @@ export function selectImpact(input: SelectImpactInput): ImpactPlan {
     if ((area?.related ?? file.startsWith('apps/cli/')) && relatedByDefault) {
       for (const test of relatedBySource.get(file) ?? []) {
         addTest(selected, mapping, file, test, 'static-import');
+        mark();
+      }
+      for (const test of runtimeReadBySource.get(file) ?? []) {
+        addTest(selected, mapping, file, test, 'runtime-read');
         mark();
       }
     }


### PR DESCRIPTION
## Summary
- CI impact selection (`scripts/ci-scope.ts`) only followed static `import`/`from` edges when deciding which tests a changed file affects. Several release-safety tests read their script under test at **runtime** via `fs.readFileSync` — `promote-home-base-probe.test.ts`, `signing-home-base-probe.test.ts`, `stuck-release.test.ts`, and `release.test.ts` all `readFileSync` `apps/cli/scripts/release.sh`, none via a static import. With no static edge to follow, a `release.sh` change previously selected only its filename-matched companion (`release.test.ts`) and silently skipped the other three.
- Adds `buildRuntimeReadGraph` / `runtimeReadTestsBySource`, which resolve the same class of literal-path patterns these tests actually use — `fs.readFileSync(path.resolve(__dirname, 'LITERAL'))` inline, or via a same-file `const NAME = path.resolve(__dirname, 'LITERAL')` the read then references — and fold the resulting edges into `selectImpact` under a new `runtime-read` reason, gated the same way `static-import` edges already are.
- Verified against the real repo: a change to `apps/cli/scripts/release.sh` now selects `release.test.ts` (companion), plus `promote-home-base-probe.test.ts`, `signing-home-base-probe.test.ts`, `stuck-release.test.ts`, and `create-annotated-release-tag.test.ts` — all `runtime-read`.

## Test plan
- [x] `bun test scripts/ci-scope.test.ts` — 61 pass (2 new tests added, one exercising the synthetic variable/inline readFileSync fixtures directly, one asserting the real `apps/cli/scripts/release.sh` → 4-test mapping end to end)
- [x] `bun scripts/ci-scope.ts --validate-manifest` — unaffected, still covers all 3176 tracked files
- [x] `bun test ./.github/workflows/ ./scripts/ci-bench/` — 40 pass
- [x] Manually ran `bun scripts/ci-scope.ts <<< "apps/cli/scripts/release.sh"` and confirmed the mapping table includes all 4 target tests with `reason=runtime-read` (or `companion` for the same-named one)

Fixes RUSH-3097.