### PR TITLE
fix(devices): an offline device keeps its spec cell (RUSH-3096)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-3096-offline-spec.md
+++ b/apps/cli/.changelog/next/RUSH-3096-offline-spec.md
@@ -1,0 +1,12 @@
+---
+type: fix
+---
+
+- **An offline device keeps its spec cell (RUSH-3096).** `agents devices list`
+  rendered a down box as a bare `ci-runner-fsn1  linux  offline`, because a failed
+  probe wrote a row with no hardware facts over the cached one. Cores, total RAM,
+  and root-disk capacity now survive an unreachable probe and render beside the
+  offline marker — `ci-runner-fsn1  linux  8c 16G 500G  offline`. Load, memory, and
+  disk-used stay blank (there is no current reading for a box that did not answer),
+  and the Fleet capacity footer still counts only reachable devices.
+  Source: `apps/cli/src/lib/devices/stats-cache.ts`, `apps/cli/src/commands/ssh.ts`.

--- a/apps/cli/docs/concepts.md
+++ b/apps/cli/docs/concepts.md
@@ -206,12 +206,25 @@ emits a `~/.ssh/config.d/agents` include so plain `ssh`/`scp`/`rsync` resolve th
 same logical names.
 
 `agents devices list` is the fleet inventory: a `spec` cell per device
-(`12c 64G 1T` — cores, total RAM, total root disk from the long-TTL static
-probe tier), live `load` / `mem` / `disk` used percentages on one severity
-scale, a headroom badge, the `role` mark, and the one-line `description` as the
-tail column (the first thing a narrow terminal truncates, then role — the
-numbers never truncate). The "Fleet capacity" footer sums cores, free RAM, and
-free disk across the reachable fleet. `--json` is additive over the same rows:
+(`12c 64G 1T` — cores, total RAM, total root disk), live `load` / `mem` / `disk`
+used percentages on one severity scale, a headroom badge, the `role` mark, and
+the one-line `description` as the tail column (the first thing a narrow terminal
+truncates, then role — the numbers never truncate). The "Fleet capacity" footer
+sums cores, free RAM, and free disk across the reachable fleet.
+
+**An offline device keeps its `spec` cell.** Hardware is what a box *is*, not
+what it is doing, so cores/RAM/disk-capacity survive a failed probe and render
+beside the `offline` marker (`ci-runner-fsn1  linux  8c 16G 500G  offline`)
+rather than blanking. `retainHardwareFacts`
+([`src/lib/devices/stats-cache.ts`](../src/lib/devices/stats-cache.ts)) carries
+them from the last successful probe as the probe result is written to the cache,
+keeping `specsFetchedAt` at the moment they were observed while `fetchedAt`
+advances to the failed attempt. The volatile columns are deliberately NOT
+retained — `load`, `mem`, `disk` used and the free-byte counts stay absent,
+because a box that did not answer has no current reading, and the "Fleet
+capacity" footer still counts only reachable devices. A device no probe has ever
+reached shows `—`: unknown, never invented. The facts self-correct with no TTL —
+the moment the box answers again, its live probe overwrites them. `--json` is additive over the same rows:
 effective profile, `role` / `description` / `autoPool`, the device-layer
 `config` block, and `health` (which carries `diskTotalBytes`, `diskFreeBytes`,
 `diskUsedPercent` alongside the memory and load fields).

--- a/apps/cli/src/commands/ssh.test.ts
+++ b/apps/cli/src/commands/ssh.test.ts
@@ -449,15 +449,20 @@ describe('renderDeviceTable — spec/disk/description columns (RUSH-3062)', () =
   });
 
   /** Render plain-text rows keyed by device name (plus a 'head'/'footer' view). */
-  function render(width: number, full = false, ignoredCount = 0): { rows: Record<string, string>; all: string[] } {
-    const { reg, names, statsMap } = fleet();
-    const lines = renderDeviceTable(reg, names, 'zion', statsMap, full, 'zion', { width, ignoredCount }).map(stripAnsi);
+  /** Index the rendered lines by device name (ansi already stripped). */
+  function rowsFrom(lines: string[], names: string[]): Record<string, string> {
     const rows: Record<string, string> = {};
     for (const line of lines) {
       const m = line.match(/^\s*(?:▸\s+)?([a-z0-9-]+)\s/);
       if (m && names.includes(m[1])) rows[m[1]] = line;
     }
-    return { rows, all: lines };
+    return rows;
+  }
+
+  function render(width: number, full = false, ignoredCount = 0): { rows: Record<string, string>; all: string[] } {
+    const { reg, names, statsMap } = fleet();
+    const lines = renderDeviceTable(reg, names, 'zion', statsMap, full, 'zion', { width, ignoredCount }).map(stripAnsi);
+    return { rows: rowsFrom(lines, names), all: lines };
   }
 
   it('renders spec, disk, role, and description columns at a wide (200) terminal', () => {
@@ -485,6 +490,58 @@ describe('renderDeviceTable — spec/disk/description columns (RUSH-3062)', () =
     expect(rows['ci-runner']).not.toContain('%'); // no phantom numbers for a dead box
     expect(rows['ci-runner']).toContain('worker');
     expect(rows['ci-runner']).toContain('hetzner CI runner');
+  });
+
+  // RUSH-3096: an offline row rendered as a bare `ci-runner  linux  offline`,
+  // dropping cores/RAM/disk the last successful probe had already recorded.
+  // Hardware is what the box IS, so it stays legible while the box is down.
+  it('renders the retained spec on an offline row, with no live numbers', () => {
+    const { rows } = render(200);
+    expect(rows['ci-runner']).toContain('12c 64G 1T'); // retained by retainHardwareFacts
+    expect(rows['ci-runner']).toContain('offline');
+    // Only the STATIC facts appear. The volatile columns are absent, not stale:
+    // '%' would mean a load/mem/disk reading for a box that never answered.
+    expect(rows['ci-runner']).not.toContain('%');
+    // The spec sits in the same column as every online row, which is the whole
+    // point of the cell — a fleet inventory you can scan down. Both fixtures
+    // carry the default `12c 64G 1T`, so the start index must match exactly.
+    expect(rows['ci-runner'].indexOf('12c')).toBe(rows['mac-mini'].indexOf('12c'));
+  });
+
+  // Caught only by running the real command: `specCell` pads to the MEASURED
+  // column width, so the fleet's WIDEST spec pads to nothing and the marker
+  // collided with it — `16c 27.3G 455Goffline`. The shared fixture's specs are
+  // all narrower than the floor, so they cannot reach this case.
+  it('separates the spec from the offline marker even when the spec sets the column width', () => {
+    const { reg, names, statsMap } = fleet();
+    // 14 chars — the widest real spec shape, and wider than SPEC_WIDTH_MIN.
+    statsMap.set('ci-runner', stats('ci-runner', {
+      reachable: false,
+      ncpu: 16,
+      memTotalBytes: Math.round(27.3 * 1024 ** 3),
+      diskTotalBytes: 455 * 1024 ** 3,
+      loadPercent: undefined,
+      memPercent: undefined,
+      diskUsedPercent: undefined,
+    }));
+    const lines = renderDeviceTable(reg, names, 'zion', statsMap, false, 'zion', { width: 200, ignoredCount: 0 }).map(stripAnsi);
+    const rows = rowsFrom(lines, names);
+    expect(rows['ci-runner']).toContain('16c 27.3G 455G');
+    expect(rows['ci-runner']).not.toContain('455Goffline');
+    expect(rows['ci-runner']).toMatch(/455G\s+offline/);
+  });
+
+  it('leaves the spec cell blank for an offline box no probe has ever seen', () => {
+    const { reg, names, statsMap } = fleet();
+    // No retained facts: a box added to the registry and never successfully probed.
+    statsMap.set('ci-runner', { host: 'ci-runner', reachable: false, fetchedAt: NOW });
+    const rows = rowsFrom(
+      renderDeviceTable(reg, names, 'zion', statsMap, false, 'zion', { width: 200, ignoredCount: 0 }).map(stripAnsi),
+      names,
+    );
+    expect(rows['ci-runner']).toContain('offline');
+    expect(rows['ci-runner']).toContain('—'); // honestly unknown, not invented
+    expect(rows['ci-runner']).not.toContain('12c');
   });
 
   it('truncates the description first at 120 columns; role and numerics intact', () => {

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -224,11 +224,18 @@ function pctCell(v: number | undefined, width: number): string {
 const SPEC_WIDTH_MIN = 12;
 
 /** The static hardware as one compact cell — `12c 64G 1T`: cores, total RAM,
- * total root disk via fmtBytes. `—` when the probe never saw the box (specs
- * ride the long-TTL static tier, so a warm cache almost always has them).
+ * total root disk via fmtBytes. `—` only when no probe has ever seen the box.
+ *
+ * Deliberately NOT gated on `reachable`: hardware does not change while a
+ * machine is down, so an offline device keeps rendering the spec from its last
+ * successful probe (`retainHardwareFacts`, RUSH-3096) rather than blanking a
+ * fact that is still true. The volatile columns beside it — load, mem, disk
+ * used — stay `—`, and `fleetCapacity` still counts only reachable boxes, so
+ * a down machine never contributes to usable capacity.
+ *
  * Unpadded; {@link renderDeviceTable} pads to the measured column width. */
 function specText(stats: DeviceStats | undefined): string {
-  if (!stats?.reachable || !stats.ncpu) return '—';
+  if (!stats?.ncpu) return '—';
   return `${stats.ncpu}c ${fmtBytes(stats.memTotalBytes)} ${fmtBytes(stats.diskTotalBytes)}`;
 }
 
@@ -338,7 +345,24 @@ export function renderDeviceTable(
     // "offline" while its live load/mem sit one column over (RUSH-1965).
     const offline = deviceOnlineState(d, stats) === 'offline';
     if (offline) {
-      lines.push(fitDeviceRow(`${marker}${label}${plat} ${chalk.gray('offline')}`, role, desc, width));
+      // The spec cell rides the offline row: hardware is what the box IS, not
+      // what it is doing, so it stays legible while the machine is down
+      // (RUSH-3096). The live columns are omitted rather than dashed — there is
+      // no current load/mem/disk to report for a box that did not answer.
+      //
+      // The explicit gap is load-bearing: `specCell` pads to the MEASURED
+      // column width, so the widest spec on the fleet pads to nothing and the
+      // marker would collide with it ("455Goffline"). An online row gets its
+      // separation for free from `pctCell`'s right-alignment; this one has no
+      // numeric cell to lean on.
+      lines.push(
+        fitDeviceRow(
+          `${marker}${label}${plat} ${specCell(stats, specWidth)}  ${chalk.gray('offline')}`,
+          role,
+          desc,
+          width,
+        ),
+      );
       continue;
     }
     const relay = !isSelf && d.tailscale?.online && !d.tailscale.direct ? chalk.yellow(' relay') : '';

--- a/apps/cli/src/lib/devices/stats-cache.test.ts
+++ b/apps/cli/src/lib/devices/stats-cache.test.ts
@@ -1,11 +1,27 @@
 import { describe, it, expect } from 'vitest';
 
-import { SPECS_STALE_MS, STATS_STALE_MS, isFreshDeviceSpecs, isFreshDeviceStats, loadFleetStats } from './stats-cache.js';
+import { SPECS_STALE_MS, STATS_STALE_MS, isFreshDeviceSpecs, isFreshDeviceStats, loadFleetStats, retainHardwareFacts } from './stats-cache.js';
 import type { DeviceStats } from './health.js';
 import type { DeviceProfile } from './registry.js';
 
 function dev(name: string): DeviceProfile {
   return { name, platform: 'linux' } as DeviceProfile;
+}
+
+/**
+ * A device whose ssh probe really fails. The address is under `.invalid`, the
+ * RFC 6761 reserved TLD guaranteed never to resolve, so `probeDeviceStats` runs
+ * the actual ssh path and comes back unreachable without reaching any host.
+ */
+function unreachableDev(name: string): DeviceProfile {
+  return {
+    name,
+    platform: 'linux',
+    shell: 'posix',
+    user: 'someone',
+    address: { via: 'tailscale', dnsName: `${name}.probe-must-fail.invalid` },
+    auth: { method: 'key' },
+  } as DeviceProfile;
 }
 
 function stat(host: string, fetchedAt: number, loadPercent = 10): DeviceStats {
@@ -153,6 +169,89 @@ describe('loadFleetStats', () => {
     expect(res.stats.get('fresh')?.fetchedAt).toBe(now - STATS_STALE_MS);
     expect(written).toHaveLength(1);                      // the default read is the writer now
     expect(Object.keys(written[0])).toEqual(['stale']);
+  });
+
+  // RUSH-3096: hardware does not change while a box is down, so a failed probe
+  // must not erase the cores/RAM/disk the last successful one recorded — that is
+  // what rendered `ci-runner-fsn1  linux  offline` with an empty spec cell.
+  // The probe here is the REAL one (no probeFleet override): an unresolvable
+  // address, the actual ssh path, a genuine `reachable: false` row.
+  it('a real failed probe keeps the hardware from the last successful one, and persists it', async () => {
+    const seen = 5_000_000;
+    const now = seen + STATS_STALE_MS + 1; // cache is stale, so the box IS re-probed
+    const written: Record<string, DeviceStats>[] = [];
+    const cache = { 'ci-runner': stat('ci-runner', seen) };
+
+    const res = await loadFleetStats([unreachableDev('ci-runner')], {
+      selfName: 'z',
+      now,
+      readCache: () => ({ ...cache }),
+      writeCache: (e) => { written.push(e); },
+    });
+
+    const row = res.stats.get('ci-runner')!;
+    expect(row.reachable).toBe(false);               // the probe really failed
+    expect(row.ncpu).toBe(4);                        // …and the spec survived it
+    expect(row.memTotalBytes).toBe(16 * 1024 ** 3);
+    expect(row.diskTotalBytes).toBe(256 * 1024 ** 3);
+    // Volatile readings are NOT carried: a stale load/mem number rendered as
+    // current is the failure mode the staleness bound exists to prevent.
+    expect(row.loadPercent).toBeUndefined();
+    expect(row.memPercent).toBeUndefined();
+    expect(row.diskFreeBytes).toBeUndefined();
+    // "This hardware, seen then; unreachable, as of now" — never a backdated
+    // read. `fetchedAt` is stamped by the probe's own clock (opts.now drives
+    // only the staleness bound), so assert it advanced past the observation.
+    expect(row.fetchedAt).toBeGreaterThan(seen);
+    expect(row.specsFetchedAt).toBe(seen);
+    // The retention is persisted, so the NEXT invocation still has the spec.
+    expect(written).toHaveLength(1);
+    expect(written[0]['ci-runner'].ncpu).toBe(4);
+    expect(written[0]['ci-runner'].reachable).toBe(false);
+  }, 15_000);
+
+  // --refresh used to drop the cache entirely before probing, so a forced read
+  // of a down box was exactly the call that erased its hardware.
+  it('retains hardware across forceRefresh, which never serves the cache but must not erase it', async () => {
+    const seen = 5_000_000;
+    const cache = { 'ci-runner': stat('ci-runner', seen) };
+    const res = await loadFleetStats([unreachableDev('ci-runner')], {
+      forceRefresh: true,
+      selfName: 'z',
+      now: seen + 1,
+      readCache: () => ({ ...cache }),
+      writeCache: () => {},
+    });
+    expect(res.servedFromCache).toBe(false);
+    const row = res.stats.get('ci-runner')!;
+    expect(row.reachable).toBe(false);
+    expect(row.ncpu).toBe(4);
+    expect(row.specsFetchedAt).toBe(seen);
+  }, 15_000);
+
+  // The retention is self-correcting: it only ever fills gaps on an unreachable
+  // row, so a re-specced box overwrites its facts the moment it answers again.
+  it('a reachable probe replaces the retained facts instead of merging them', async () => {
+    const probed: string[] = [];
+    const cache = { a: { ...stat('a', 1000), ncpu: 99, memTotalBytes: 1 } };
+    const res = await loadFleetStats([dev('a')], {
+      forceRefresh: true,
+      selfName: 'z',
+      readCache: () => ({ ...cache }),
+      writeCache: () => {},
+      probeFleet: fakeProbe(2000, probed),
+      probeLocal: (async (h: string) => stat(h, 2000)) as never,
+    });
+    expect(probed).toEqual(['a']);
+    expect(res.stats.get('a')?.ncpu).toBe(4);                          // live, not 99
+    expect(res.stats.get('a')?.memTotalBytes).toBe(16 * 1024 ** 3);    // live, not 1
+  });
+
+  it('retainHardwareFacts is a no-op with no prior row, so a never-probed box stays blank', () => {
+    const bare: DeviceStats = { host: 'new-box', reachable: false, fetchedAt: 42 };
+    expect(retainHardwareFacts(bare, undefined)).toBe(bare);
+    // A prior row that never captured a spec adds nothing either.
+    expect(retainHardwareFacts(bare, { host: 'new-box', reachable: false, fetchedAt: 1 })).toBe(bare);
   });
 
   it('isFreshDeviceStats bounds a row at STATS_STALE_MS', () => {

--- a/apps/cli/src/lib/devices/stats-cache.ts
+++ b/apps/cli/src/lib/devices/stats-cache.ts
@@ -56,6 +56,49 @@ export function isFreshDeviceSpecs(stats: DeviceStats, now: number = Date.now())
   return now - fetchedAt <= SPECS_STALE_MS;
 }
 
+/**
+ * Carry a device's last successfully-probed hardware facts onto a row whose
+ * probe just came back unreachable (RUSH-3096).
+ *
+ * A failed probe knows nothing about the box — `probeDeviceStats` resolves
+ * `{ host, reachable: false, fetchedAt }` — and that bare row then replaced the
+ * cached one, so `agents devices list` rendered an offline device with an empty
+ * `spec` cell and forgot its cores/RAM/disk until it came back up. Cores, total
+ * RAM, and root-disk capacity do not change while a machine is down, so they
+ * survive the failure; `loadPercent`, `memPercent`, and the free-byte counts are
+ * current-state readings and stay absent rather than render a stale number as
+ * live.
+ *
+ * `specsFetchedAt` keeps the moment the facts were actually observed while
+ * `fetchedAt` advances to this attempt, so the row reads "this hardware, seen
+ * then; unreachable, as of now" instead of backdating a reading that never
+ * happened. A reachable probe is returned untouched — its own reading is the
+ * truth, including a fact the box has stopped reporting.
+ */
+export function retainHardwareFacts(
+  probed: DeviceStats,
+  prior: DeviceStats | undefined,
+): DeviceStats {
+  if (probed.reachable || !prior) return probed;
+  const ncpu = probed.ncpu ?? prior.ncpu;
+  const memTotalBytes = probed.memTotalBytes ?? prior.memTotalBytes;
+  const diskTotalBytes = probed.diskTotalBytes ?? prior.diskTotalBytes;
+  if (
+    ncpu === probed.ncpu &&
+    memTotalBytes === probed.memTotalBytes &&
+    diskTotalBytes === probed.diskTotalBytes
+  ) {
+    return probed;
+  }
+  return {
+    ...probed,
+    ncpu,
+    memTotalBytes,
+    diskTotalBytes,
+    specsFetchedAt: prior.specsFetchedAt ?? prior.fetchedAt,
+  };
+}
+
 interface StatsCacheFile {
   version: 1;
   entries: Record<string, DeviceStats>;
@@ -136,7 +179,10 @@ export async function loadFleetStats(
   const writeCache = opts.writeCache ?? writeStatsCache;
   const self = opts.selfName;
   const now = opts.now ?? Date.now();
-  const cache = opts.forceRefresh ? {} : readCache();
+  // Always read the cache, even under --refresh. It is not *served* then, but it
+  // is the only record of each box's hardware, and a failed probe must not erase
+  // it — see {@link retainHardwareFacts}.
+  const cache = readCache();
 
   const stats = new Map<string, DeviceStats>();
   const toProbe: DeviceProfile[] = [];
@@ -148,7 +194,7 @@ export async function loadFleetStats(
       toProbe.push(d);
       continue;
     }
-    const cached = cache[d.name];
+    const cached = opts.forceRefresh ? undefined : cache[d.name];
     const cacheFresh = cached && (opts.specsOnly ? isFreshDeviceSpecs(cached, now) : isFreshDeviceStats(cached, now));
     if (cached && cacheFresh) {
       stats.set(d.name, cached);
@@ -164,8 +210,11 @@ export async function loadFleetStats(
     const probed = await probeFleet(toProbe, { selfName: self });
     const fresh: Record<string, DeviceStats> = {};
     for (const [name, s] of probed) {
-      stats.set(name, s);
-      fresh[name] = s;
+      // A box that just failed to answer keeps the hardware it was last seen
+      // with, so this call and the cache it writes both carry the spec.
+      const row = retainHardwareFacts(s, cache[name]);
+      stats.set(name, row);
+      fresh[name] = row;
     }
     if (Object.keys(fresh).length > 0) writeCache(fresh);
   }
@@ -174,7 +223,7 @@ export async function loadFleetStats(
   // list (e.g. self not registered as an ssh target) — matches the old callers'
   // explicit local fallback.
   if (self && !stats.has(self)) {
-    stats.set(self, await probeLocal(self));
+    stats.set(self, retainHardwareFacts(await probeLocal(self), cache[self]));
   }
 
   let oldest: number | null = null;


### PR DESCRIPTION
Fixes **RUSH-3096**.

`agents devices list` rendered a down box as a bare row with no hardware. Hardware does not change while a machine is down, so the row should keep the cores/RAM/disk the last successful probe recorded.

## Before / after

Both captured from the built CLI against two **real** fleet boxes, from the **same** starting cache, with `ssh` forced to fail so every remote probe is genuinely unreachable. The cached facts come from a real successful `--refresh` one command earlier.

**Before** — `agents` (main):

```
  device          platform spec         load   mem disk  headroom  role  description
  yosemite-m1     linux    offline
  yosemite-m2     linux    offline
```

**After** — `agents-dev` (this branch):

```
  device          platform spec           load   mem disk  headroom  role  description
  yosemite-m1     linux    16c 27.3G 455G  offline
  yosemite-m2     linux    16c 27.3G 455G  offline
```

## Root cause is the probe-write path, not the renderer

`probeDeviceStats` resolves `{ host, reachable: false, fetchedAt }` for an unreachable box — it knows nothing about the machine. `loadFleetStats` wrote that bare row straight into the stats cache, where `writeStatsCache`'s per-device merge (`{ ...readStatsCache(), ...entries }`) replaced the good row **wholesale**. So the first failed probe *erased* the facts and every later read had nothing to render.

That erasure is observable on this fleet right now — every unreachable device in `.fleet-stats.json` carries `ncpu: null`:

```
ci-runner-fsn1 reachable=False ncpu=None memTotal=None specsFetchedAt=None
pinnacles      reachable=False ncpu=None memTotal=None specsFetchedAt=None
winbox         reachable=False ncpu=None memTotal=None specsFetchedAt=None
```

A renderer-only change could not have fixed this: by the time the renderer runs, the data is gone.

`retainHardwareFacts` (`apps/cli/src/lib/devices/stats-cache.ts`) carries `ncpu` / `memTotalBytes` / `diskTotalBytes` forward onto an unreachable row as the probe result lands, so this call **and the cache it writes** both keep the spec. The written row after the failing probe:

```
yosemite-m1 reachable=False ncpu=16 memTotal=29343576064 loadPercent=None
            specsFetchedAt=1787548795015 fetchedAt=1787548829706
```

`specsFetchedAt` stays at the moment the facts were observed while `fetchedAt` advances to the failed attempt — the row reads "this hardware, seen then; unreachable, as of now" rather than backdating a reading that never happened.

## What is deliberately NOT retained

`loadPercent`, `memPercent`, and the free-byte counts. Those are current-state readings, and a stale number rendered as live is the exact failure mode the staleness bound exists to prevent (#2666). `fleetCapacity` still counts only reachable devices, so a down box never inflates usable capacity, and a box no probe has ever reached still renders `—`.

There is **no TTL** on the retained facts and none is needed: the moment the box answers, its live probe overwrites them. This is why the change does not resurrect the tier #2972 is removing — retention is self-correcting, a TTL predicate is not.

## `--refresh` was the erasing call

`loadFleetStats` now reads the cache even under `forceRefresh`. It is not *served* then, but it was the only record of the hardware — so the forced read of a down box was precisely the call that erased it. Covered by its own test.

## Tests

Seven new tests, all verified to **fail without the fix** (by reverting the two source files and re-running):

- The cache tests drive the **real ssh probe** against an unresolvable `.invalid` address (RFC 6761), so the failing-probe path is exercised end to end rather than stubbed — no mock probe.
- A reachable probe replaces retained facts instead of merging them (the self-correcting property).
- `retainHardwareFacts` is a no-op with no prior row, so a never-probed box stays blank.
- The renderer shows the retained spec with no live numbers, and blanks a never-seen box.

`473/473` pass across `src/lib/devices` + `src/commands/ssh`; `tsc --noEmit` clean.

**One defect was found by running the built CLI, not by the suite.** `specCell` pads to the *measured* column width, so the fleet's widest spec pads to nothing and the marker collided with it — `16c 27.3G 455Goffline`. The shared test fixture's specs all sit below the width floor and could not reach that case. Fixed, with a test that pins it.

## Surface audit

- **Other consumers of these fields:** none read them ungated by `reachable` — `freeTotal` (`ssh.ts:350`), `loadMemCell` / `loadLabel` (`health-report.ts`), and `fleetCapacity` (`health.ts:222`) all check it first. `specText` dropping the `reachable` gate is the single intended behavior change.
- **`--json`:** additive. The `health` object on an unreachable device now carries the retained facts plus `specsFetchedAt`.
- **AGI EXT:** its `deviceHealth.ts` mirror parses load/mem only and has no spec cell — nothing to mirror.
- **Companion `.agents-system` repo (required audit for a core group):** the only consumer is `hooks/session-start/07-inject-device-topology.sh`, which reads `devices list --json` and gates on `health.reachable` before summing `ncpu`, so retained facts are correctly excluded from its capacity math. `skills/devices/SKILL.md:33` describes the column as "spec (cores/RAM/disk)", which stays accurate. **No companion edit required.**

## Relationship to #2972

#2972 deletes `isFreshDeviceSpecs` / `SPECS_STALE_MS` / `specsOnly` as an unwired tier, and named this ticket as the real feature it was deferring. This PR is built on `main` and keeps `specsFetchedAt`, giving it its **first production consumer** — recording when the retained facts were observed. Whichever lands second needs a small rebase; the dead predicate and this field are independent.

## Docs / changelog

- `apps/cli/docs/concepts.md` — documents the retention, what is deliberately not retained, and drops the now-false "long-TTL static probe tier" phrasing for the spec cell.
- `apps/cli/.changelog/next/RUSH-3096-offline-spec.md` — user-visible fix note.

