### PR TITLE
fix(test): make resolve-target fixtures hermetic, not real fleet hostnames

### DIFF
--- a/apps/cli/.changelog/next/resolve-target-hostname-fixtures.md
+++ b/apps/cli/.changelog/next/resolve-target-hostname-fixtures.md
@@ -1,0 +1,7 @@
+- **Fixed: `resolve-target.test.ts` failed on any machine actually named `mac-mini` or `zion`.** The
+  fixtures wrote device declarations for two real fleet hostnames and then asserted the resolver
+  would tunnel to them. On a box with that `machineId()` the resolver correctly reports the profile
+  as locally declared, so the tunnel assertions failed — green on Linux CI, red on both Macs, which
+  is where releases run. The suite is now hermetic: fixtures use `peer-alpha`/`peer-zulu`, keeping
+  the sort order the "first reachable declaring device" assertions depend on.
+  Source: `src/lib/browser/resolve-target.test.ts`.

--- a/apps/cli/src/lib/browser/resolve-target.test.ts
+++ b/apps/cli/src/lib/browser/resolve-target.test.ts
@@ -58,7 +58,7 @@ describe('shouldForkProfile', () => {
 describe('sshEndpointForDeclaration', () => {
   it('rewrites a loopback cdp:// declaration to ssh://<device>?port=N', async () => {
     const { sshEndpointForDeclaration } = await import('./resolve-target.js');
-    expect(sshEndpointForDeclaration('zion', comet)).toBe('ssh://zion?port=9333');
+    expect(sshEndpointForDeclaration('peer-zulu', comet)).toBe('ssh://peer-zulu?port=9333');
   });
 
   it('adds os=windows when the declaring device is Windows', async () => {
@@ -71,7 +71,7 @@ describe('sshEndpointForDeclaration', () => {
   it('leaves an already-ssh:// declaration alone', async () => {
     const { sshEndpointForDeclaration } = await import('./resolve-target.js');
     const config = { browser: 'custom' as const, endpoints: ['ssh://browser-host?port=9344'] };
-    expect(sshEndpointForDeclaration('zion', config)).toBe('ssh://browser-host?port=9344');
+    expect(sshEndpointForDeclaration('peer-zulu', config)).toBe('ssh://browser-host?port=9344');
   });
 });
 
@@ -92,8 +92,8 @@ describe('resolveBrowserTarget', () => {
   });
 
   it('tunnels to a reachable declaring device when this machine does not declare it', async () => {
-    writeYaml(deviceFile('mac-mini'), { browser: { 'comet-local': comet } });
-    writeYaml(deviceFile('zion'), { browser: { 'comet-local': comet } });
+    writeYaml(deviceFile('peer-alpha'), { browser: { 'comet-local': comet } });
+    writeYaml(deviceFile('peer-zulu'), { browser: { 'comet-local': comet } });
 
     const { resolveBrowserTarget } = await import('./resolve-target.js');
     const probed: string[] = [];
@@ -105,12 +105,12 @@ describe('resolveBrowserTarget', () => {
     });
     expect(routed.local).toBe(false);
     expect(routed.kind).toBe('fungible');
-    expect(routed.device).toBe('mac-mini');
-    expect(routed.target).toBe('ssh://mac-mini?port=9333');
-    expect(routed.key).toBe('comet-local@mac-mini');
-    expect(routed.picked).toContain('mac-mini');
-    expect(routed.picked).toContain('zion');
-    expect(probed).toEqual(['mac-mini']);
+    expect(routed.device).toBe('peer-alpha');
+    expect(routed.target).toBe('ssh://peer-alpha?port=9333');
+    expect(routed.key).toBe('comet-local@peer-alpha');
+    expect(routed.picked).toContain('peer-alpha');
+    expect(routed.picked).toContain('peer-zulu');
+    expect(probed).toEqual(['peer-alpha']);
   });
 
   it('skips an unreachable declaring device and picks the next sorted one', async () => {
@@ -130,14 +130,14 @@ describe('resolveBrowserTarget', () => {
   });
 
   it('fails loud when every declaring device is unreachable — does not invent a local target', async () => {
-    writeYaml(deviceFile('zion'), { browser: { 'comet-local': comet } });
+    writeYaml(deviceFile('peer-zulu'), { browser: { 'comet-local': comet } });
 
     const { resolveBrowserTarget } = await import('./resolve-target.js');
     expect(() =>
       resolveBrowserTarget('comet-local', {
         probe: () => ({ reachable: false, reason: 'No route to host' }),
       }),
-    ).toThrow(/zion/);
+    ).toThrow(/peer-zulu/);
     expect(() =>
       resolveBrowserTarget('comet-local', {
         probe: () => ({ reachable: false, reason: 'No route to host' }),
@@ -151,11 +151,11 @@ describe('resolveBrowserTarget', () => {
   });
 
   it('fails loud when nobody declares the name, listing similar names and their devices', async () => {
-    writeYaml(deviceFile('zion'), { browser: { 'comet-local': comet } });
+    writeYaml(deviceFile('peer-zulu'), { browser: { 'comet-local': comet } });
 
     const { resolveBrowserTarget, undeclaredProfileError } = await import('./resolve-target.js');
     expect(() => resolveBrowserTarget('comet-locl')).toThrow(/comet-local/);
-    expect(() => resolveBrowserTarget('comet-locl')).toThrow(/zion/);
+    expect(() => resolveBrowserTarget('comet-locl')).toThrow(/peer-zulu/);
     expect(() => resolveBrowserTarget('comet-locl')).toThrow(/not declared by any device/);
     expect(undeclaredProfileError('ghost').message).toMatch(/No device declares a similar name/);
   });
@@ -179,7 +179,7 @@ describe('migrateLegacyRuntimeDir', () => {
     fs.mkdirSync(legacy, { recursive: true });
     fs.writeFileSync(path.join(legacy, 'Cookies'), 'keep-me');
 
-    const next = profileConnectionKey('comet-local', 'zion');
+    const next = profileConnectionKey('comet-local', 'peer-zulu');
     migrateLegacyRuntimeDir('comet-local', next, runtime);
 
     expect(fs.existsSync(path.join(runtime, 'comet-local@endpoint-0'))).toBe(false);
@@ -194,7 +194,7 @@ describe('migrateLegacyRuntimeDir', () => {
     fs.mkdirSync(path.join(runtime, 'comet-local@endpoint-0', 'chrome-data'), { recursive: true });
     fs.writeFileSync(path.join(runtime, 'comet-local@endpoint-0', 'chrome-data', 'Cookies'), 'local');
 
-    const remoteKey = profileConnectionKey('comet-local', 'zion');
+    const remoteKey = profileConnectionKey('comet-local', 'peer-zulu');
     adoptLegacyRuntimeIfLocal(false, 'comet-local', remoteKey, runtime);
 
     expect(fs.existsSync(path.join(runtime, 'comet-local@endpoint-0', 'chrome-data', 'Cookies'))).toBe(


### PR DESCRIPTION
## What

`resolve-target.test.ts` wrote browser-profile declarations for **`mac-mini`** and **`zion`** — two real machines in this fleet — then asserted the resolver tunnels to them.

On a box whose `machineId()` is one of those names, the resolver correctly reports the profile as locally declared and returns `local: true`. The tunnel assertions then fail. The test was wrong; the code was right.

## Why it matters

Green on Linux CI, red on **both Macs** — which is exactly where releases run. The attestation producer runs the full suite fail-closed on mac-mini and refused to attest the tree over this:

```
FAIL src/lib/browser/resolve-target.test.ts > resolveBrowserTarget
     > tunnels to a reachable declaring device when this machine does not declare it
AssertionError: expected true to be false
  106| expect(routed.local).toBe(false);
  108| expect(routed.device).toBe('mac-mini');

Test Files  4 failed | 916 passed | 8 skipped (928)
error: suite failed for 671e79a7c4ea -- refusing to attest a red tree
```

This test alone blocks every release cut from a Mac. Two further tests in the same file wrote a `zion` fixture and would fail the same way on zion.

## The fix

Fixtures use `peer-alpha` / `peer-zulu`, which cannot collide with a real machine. Alphabetical order is preserved (`peer-alpha` < `peer-zulu`, as `mac-mini` < `zion`), so the "picks the first sorted reachable declaring device" assertion still tests what it did. One test in this file already used `zzz-up`/`aaa-down`; this applies that consistently.

Verified by CI rather than locally — local test runs are off-limits on this machine.

type: test-only