### PR TITLE
fix(test): ad-hoc menubar fixture declares CFBundleExecutable after the rename

### DIFF
--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -14,6 +14,7 @@ import {
   menubarHealReplacedBundle,
   menubarPlistNeedsRepoint,
   mayInstallMenubarHelper,
+  MENUBAR_HELPER_EXECUTABLE_NAME,
   processesToEnd,
   resetMenubarAccessibilityTcc,
   restartMenubarHelperAfterSwap,
@@ -466,10 +467,45 @@ darwinOnly('menubar launch guard requires notarization (real codesign/spctl)', (
     const app = path.join(dir, 'MenubarHelper.app');
     fs.mkdirSync(path.join(app, 'Contents', 'MacOS'), { recursive: true });
     // A real Mach-O so codesign has something to sign; /bin/echo is stable.
-    fs.copyFileSync('/bin/echo', path.join(app, 'Contents', 'MacOS', 'AGI Menu'));
+    // Read the basename from the shipped constant, never a literal: RUSH-3101
+    // renamed it and this fixture's hardcoded copy silently went stale.
+    fs.copyFileSync('/bin/echo', path.join(app, 'Contents', 'MacOS', MENUBAR_HELPER_EXECUTABLE_NAME));
+    // The real bundle declares CFBundleExecutable (menubar/scripts/build.sh:122).
+    // Without an Info.plist codesign INFERS the main executable from the bundle
+    // name -- MenubarHelper.app -> Contents/MacOS/MenubarHelper -- which stopped
+    // existing at the rename, so codesign rejected the whole bundle with
+    // "bundle format unrecognized, invalid, or unsuitable" and this fixture
+    // handed the assertions an UNSIGNED bundle. Declare it like the real build.
+    fs.writeFileSync(
+      path.join(app, 'Contents', 'Info.plist'),
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+        '<plist version="1.0">',
+        '<dict>',
+        '    <key>CFBundleExecutable</key>',
+        `    <string>${MENUBAR_HELPER_EXECUTABLE_NAME}</string>`,
+        '    <key>CFBundleIdentifier</key>',
+        '    <string>com.phnx-labs.agents-menubar</string>',
+        '    <key>CFBundlePackageType</key>',
+        '    <string>APPL</string>',
+        '</dict>',
+        '</plist>',
+        '',
+      ].join('\n'),
+    );
     // Ad-hoc sign it: the signature is valid, but it is NOT notarized — the exact
     // state a non-Developer-ID / un-notarized cut leaves the bundle in.
-    spawnSync('codesign', ['--force', '--sign', '-', '--identifier', 'com.phnx-labs.agents-menubar', app], { stdio: 'ignore' });
+    const signed = spawnSync(
+      'codesign',
+      ['--force', '--sign', '-', '--identifier', 'com.phnx-labs.agents-menubar', app],
+      { encoding: 'utf8' },
+    );
+    // Fail loud. The previous `stdio: 'ignore'` swallowed the packaging error and
+    // turned it into a confusing "expected false to be true" three lines later.
+    if (signed.status !== 0) {
+      throw new Error(`ad-hoc codesign failed (status ${signed.status}): ${(signed.stderr || '').trim()}`);
+    }
     return app;
   }
 


### PR DESCRIPTION
## Problem

`install-menubar.test.ts` has been red on macOS since `94405fa36` (RUSH-3101), which
renamed the shipped menubar executable to `AGI Menu`. This is one of the failures
blocking the attestation producer, and therefore blocking releases.

The failure reads as a signing regression but is not one:

```
FAIL  menubar launch guard requires notarization (real codesign/spctl)
      > an ad-hoc-signed (un-notarized) bundle passes codesign but FAILS Gatekeeper
AssertionError: expected false to be true
 ❯ src/lib/menubar/install-menubar.test.ts:479:35
```

## Root cause — the fixture, not the product

`makeAdHocBundle()` builds a bundle with **no `Info.plist`**. Without one, codesign
infers the main executable from the bundle name: `MenubarHelper.app` →
`Contents/MacOS/MenubarHelper`. The rename made that path stop existing, so codesign
rejects the whole bundle. Reproduced directly on macOS:

```
--- exec named "AGI Menu", no Info.plist ---
/tmp/mbtest-a/MenubarHelper.app: bundle format unrecognized, invalid, or unsuitable
SIGN FAILED

--- control: exec named MenubarHelper (pre-rename) ---
/tmp/mbtest-b/MenubarHelper.app: replacing existing signature
verify OK
```

`spawnSync(..., { stdio: 'ignore' })` swallowed that error, so the fixture handed the
assertions an **unsigned** bundle and `codesignVerifies` returned false at line 479 —
meaning the Gatekeeper assertion at line 481, the actual point of the guard, has not
executed since the rename.

**The shipped bundle is unaffected**: `menubar/scripts/build.sh:122-123` writes
`CFBundleExecutable = AGI Menu`, so codesign resolves it correctly. Only the fixture
relied on filename inference.

## Fix

- Declare `CFBundleExecutable` in the fixture's `Info.plist`, exactly as the real build does.
- Read the basename from the exported `MENUBAR_HELPER_EXECUTABLE_NAME` constant instead of
  a hardcoded literal, so the next rename cannot silently re-stale this fixture.
- Fail loud if `codesign` exits non-zero, instead of `stdio: 'ignore'` turning a packaging
  fault into a confusing assertion error three lines later.

## Verification (real codesign/spctl on macOS, no mocking)

Before: `Tests 1 failed | 66 passed (67)`
After:

```
✓ src/lib/menubar/install-menubar.test.ts (67 tests) 89ms
  Test Files  1 passed (1)
       Tests  67 passed (67)
```

`tsc --noEmit` clean.

## Scope

Test-only; no product code changes, so no CHANGELOG entry (per the docs/CHANGELOG
exemption for test-only changes). Does **not** address the other two RUSH-3113
failures (`self-heal.integration`, `drift-sync`) — those are unrelated and the
producer already retries them.
