### PR TITLE
fix(ext): a dropped --device tab reads as a recoverable reconnect (RUSH-3125 F6)

### DIFF
--- a/.agents/artifacts/2026-08-23/plan-ext-agent-reconnect.md
+++ b/.agents/artifacts/2026-08-23/plan-ext-agent-reconnect.md
@@ -486,19 +486,46 @@ Worth a timed look at the TUI before landing.
 - [x] F3 — per-tab connection for interactive streams
 - [x] F4 — patient, interruptible reconnect with countdown
 - [x] F5 — termios save/restore + stdin drain + DEC reset
-- [ ] F6 — ext renders `reconnecting`; no dead-end shell
+- [x] F6 — no dead-end shell: a lost `--device` tab frames the drop as a
+      recoverable reconnect (see the divergence note below); no auto-resume
 - [x] F7 — notices point at `agents sessions resume`
 - [x] Verified against real state: A/B on a box configured like the peers, a real
       pty for the termios restore, and a live launch-id resolution
 - [x] Docs: `specifications.md` EXEC-48..54, `apps/cli/AGENTS.md`, CHANGELOG fragments
 - [x] PR opened — [#3006](https://github.com/phnx-labs/agi-cli/pull/3006), CI green
 
-**Landed:** F1, F2, F3, F4, F5, F7. **Outstanding:** F6 (the ext-side rendering),
-which the scheduling-singularity rule keeps as pure presentation now that
-detection and action are fixed in the CLI.
+**Landed:** F1, F2, F3, F4, F5, F6, F7.
+
+### F6 divergence — frame, don't auto-resume (RUSH-3139 boundary)
+
+This plan (2026-08-23) said F6 would have `wrapNativeAgentCommand` *re-enter the
+CLI recovery verb* on a lost link. Two facts that surfaced after it was written
+make a literal auto-`agents sessions resume` the wrong build:
+
+1. **RUSH-3139 (split out of this ticket on 2026-08-24)** proved that when the
+   peer pane is dead, `agents sessions resume` silently resumes a **copy** — a
+   new session id `/continue`-ing the transcript — and loses the in-flight turn,
+   with no notice. Auto-running it on give-up would ship that known bug. RUSH-3139
+   owns the reconnect *loop's* reattach semantics (`reconnect.ts:235`); F6 owns
+   only the ext dead-end, which runs after `agents run` has fully exited.
+2. **The ext wrapper cannot know the id for a non-Claude harness** — the
+   resolved/launch id lives in the CLI (`recoveryHint`, `reconnect.ts:332`), and
+   only Claude carries `--session-id` in the ext-built command.
+
+So F6 as landed: the wrapper recognizes the reconnect-lost exit codes (255
+`SSH_CONN_FAILURE` / 254 `REMOTE_EXIT_255_REMAPPED`) and frames the tab as a
+recoverable reconnect pointing at `agents sessions --active` — never a bare
+"status 255" crash line, never a silent resume. The CLI's own give-up notice
+already printed the exact `agents sessions resume <id>` line above when one
+applies. The "tab shows reconnecting" half is covered by F4's in-terminal
+countdown, which the tab renders live; a Fleet-panel *transient*-reconnecting
+badge (distinct from the existing orphaned/crashed `reconnect` band) would need a
+CLI-side live-state emit and is deferred as polish, not a dead-end.
 
 ## Tracking
 
 - [RUSH-3125](https://linear.app/prix/issue/RUSH-3125) — Agent tabs die on a network blink: remote interactive runs are not detached on the peer
 - [PR #3006](https://github.com/phnx-labs/agi-cli/pull/3006) — F1, F2, F3, F4, F5, F7 (CI green)
-- Branch: `fix/ext-agent-reconnect`
+- PR (F6) — `fix/ext-reconnect-no-deadend`: the no-dead-end wrapper
+- [RUSH-3139](https://linear.app/prix/issue/RUSH-3139) — the reconnect-loop copy-resume, owns the auto-resume half F6 deliberately leaves alone
+- Branch: `fix/ext-agent-reconnect` (F1–F5, F7), `fix/ext-reconnect-no-deadend` (F6)

--- a/apps/ext/CHANGELOG.md
+++ b/apps/ext/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to AGI EXT (the VS Code extension) are documented here. Form
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
+## [0.9.335] - 2026-08-25
+
+- **A dropped `--device` agent tab no longer dead-ends at a cryptic crash line.**
+  When the SSH link to a peer dropped and the CLI's bounded reconnect loop then
+  gave up (exit 255), or the remote run ended unexpectedly (exit 254), the tab
+  printed `Agent exited with status 255 — …`, which reads like a crash and gives
+  no path back to the agent that is likely still running on the peer. Those two
+  exit codes now render `Lost the connection to the remote agent — it may still
+  be running on the peer. Reconnect from:  agents sessions --active`, and the
+  shell stays open so the CLI's own recovery hint above it remains readable. A
+  genuine launch failure (bad host, bad invocation, missing binary) keeps the
+  plain status line — there is no session to rejoin. The wrapper deliberately
+  does not auto-run `agents sessions resume`: a dead peer pane silently resumes a
+  copy and loses the in-flight turn (RUSH-3139), so recovery stays a deliberate
+  user action. Source: `src/core/agents.ts` (`wrapNativeAgentCommand`). RUSH-3125
+  F6.
+
 ## [0.9.334] - 2026-08-23
 
 - **A device reset no longer wipes every other device's Needs-You items.** The

--- a/apps/ext/src/core/agents.test.ts
+++ b/apps/ext/src/core/agents.test.ts
@@ -607,6 +607,33 @@ describe('wrapNativeAgentCommand (RUSH-2593)', () => {
     expect(out).toContain('Agent exited with status 7');
     expect(out).toContain('MARKER_REACHED');
   });
+
+  // RUSH-3125 F6: a lost `--device` connection whose reconnect gave up
+  // (SSH_CONN_FAILURE=255) or whose remote run ended unexpectedly
+  // (REMOTE_EXIT_255_REMAPPED=254) must read as a recoverable reconnect, not a
+  // bare "status 255" crash line — and must NOT auto-resume (RUSH-3139).
+  for (const code of [255, 254]) {
+    test(`real bash: a reconnect-lost exit (${code}) prints the reconnect line, not the crash line, and keeps the shell running`, () => {
+      const wrapped = wrapNativeAgentCommand(`bash -c 'exit ${code}'`, false);
+      const out = execFileSync('bash', ['-c', `${wrapped}; echo MARKER_REACHED`], { encoding: 'utf8' });
+      expect(out).toContain('Lost the connection to the remote agent');
+      expect(out).toContain('agents sessions --active');
+      // Framed as recoverable, never as a raw status code…
+      expect(out).not.toContain(`Agent exited with status ${code}`);
+      // …never silently resumed (that is RUSH-3139's copy-of-the-session bug)…
+      expect(out).not.toContain('agents sessions resume');
+      // …and the shell survives past the message.
+      expect(out).toContain('MARKER_REACHED');
+    });
+  }
+
+  test('real bash: a plain launch failure (1) still gets the generic line, not the reconnect line — there is no session to rejoin', () => {
+    const wrapped = wrapNativeAgentCommand(`bash -c 'exit 1'`, false);
+    const out = execFileSync('bash', ['-c', `${wrapped}; echo MARKER_REACHED`], { encoding: 'utf8' });
+    expect(out).toContain('Agent exited with status 1');
+    expect(out).not.toContain('Lost the connection to the remote agent');
+    expect(out).toContain('MARKER_REACHED');
+  });
 });
 
 describe('extension tmux removal — spawn command contract', () => {

--- a/apps/ext/src/core/agents.ts
+++ b/apps/ext/src/core/agents.ts
@@ -257,22 +257,52 @@ export function buildAgentLaunchCommand(
 
 /**
  * Wrap a native-mode agent launch command so the outcome decides whether the
- * tab closes. On a clean exit (status 0 — the agent ran and the user quit it,
- * or the runner otherwise finished normally) the wrapper `exit`s the shell,
- * which closes the VS Code tab automatically — mirroring the pane-died
- * behaviour tmux mode already has. On a nonzero exit (a launch failure: the
- * remote host is unreachable, the CLI rejects the invocation, the binary is
- * missing) the wrapper leaves the interactive shell running instead of
- * exiting, so the tab — and the error text already printed into it — stays on
- * screen for the user to read (RUSH-2593: an `exec`-replaced process died on a
- * bad remote launch and the terminal closed before anyone could see why).
+ * tab closes, and so a lost `--device` connection reads as recoverable rather
+ * than as a crash.
+ *
+ * The exit codes are set by `agents run --interactive --device` and mirrored
+ * from `apps/cli/src/lib/hosts/reconnect.ts` (the ext is a separate package
+ * with no cross-package import — root CLAUDE.md — so the values are duplicated
+ * here with the source cited; the CLI-side constants are authoritative):
+ *
+ * - **0** — a clean quit (the user exited the agent, or it finished). The
+ *   wrapper `exit`s the shell, which closes the VS Code tab automatically —
+ *   mirroring the pane-died behaviour tmux mode already has.
+ * - **255 / 254** — `SSH_CONN_FAILURE` / `REMOTE_EXIT_255_REMAPPED`: the SSH
+ *   link to the peer dropped and the CLI's bounded reconnect loop then gave up,
+ *   or the remote run ended unexpectedly. The agent may still be alive on the
+ *   peer, so the wrapper frames it as a recoverable reconnect and points at the
+ *   session list — not a bare "status 255" that reads like a crash (RUSH-3125,
+ *   F6). It deliberately does NOT auto-run `agents sessions resume`: a dead peer
+ *   pane silently resumes a COPY and loses the in-flight turn, which is a real
+ *   open bug (RUSH-3139), so recovery stays a deliberate user action until that
+ *   lands. `agents sessions --active` is used rather than a specific id because
+ *   only the CLI knows the resolved/launch id for a non-Claude harness, and its
+ *   own give-up notice already printed the exact `agents sessions resume <id>`
+ *   line above when one applies.
+ * - **any other nonzero** — a launch failure (the remote host is unreachable at
+ *   start, the CLI rejects the invocation, the binary is missing). There is no
+ *   session to rejoin, so the generic status line stays.
+ *
+ * In every nonzero case the interactive shell is LEFT RUNNING so the text above
+ * it stays on screen for the user to read (RUSH-2593: an `exec`-replaced process
+ * died on a bad remote launch and the terminal closed before anyone could see
+ * why).
  *
  * Shell tabs must NOT be wrapped: the user drives them interactively and
  * keeping the parent shell alive on any exit is the expected behaviour.
  */
 export function wrapNativeAgentCommand(command: string, isShell: boolean): string {
   if (!command || isShell) return command;
-  return `${command}; ec=$?; if [ "$ec" -eq 0 ]; then exit 0; else echo "Agent exited with status $ec — terminal kept open so you can read the error above."; fi`;
+  const reconnectMsg =
+    'Lost the connection to the remote agent — it may still be running on the peer. Reconnect from:  agents sessions --active';
+  const genericMsg = 'Agent exited with status $ec — terminal kept open so you can read the error above.';
+  return (
+    `${command}; ec=$?; ` +
+    `if [ "$ec" -eq 0 ]; then exit 0; ` +
+    `elif [ "$ec" -eq 255 ] || [ "$ec" -eq 254 ]; then echo "${reconnectMsg}"; ` +
+    `else echo "${genericMsg}"; fi`
+  );
 }
 
 // The launch contract (apps/ext/AGENTS.md § "Launch contract"): EVERY agent

--- a/apps/ext/src/vscode/extension.ts
+++ b/apps/ext/src/vscode/extension.ts
@@ -1989,9 +1989,10 @@ async function openSingleAgent(
   });
 
   if (command) {
-    // wrapNativeAgentCommand exits the shell (closing the tab) on a clean exit
-    // but leaves it open with a readable status line on a launch failure
-    // (RUSH-2593). No-op for shell tabs.
+    // wrapNativeAgentCommand exits the shell (closing the tab) on a clean exit,
+    // frames a dropped --device link as a recoverable reconnect (RUSH-3125 F6),
+    // and otherwise leaves the tab open with a readable status line on a launch
+    // failure (RUSH-2593). No-op for shell tabs.
     await sendCommandWhenReady(terminal, wrapNativeAgentCommand(command, agentKey === 'shell'));
     readiness.armAgentReady(terminal, agentKey && sessionId
       ? { agentKey, sessionId, cwd }
@@ -3417,8 +3418,10 @@ export async function openSingleAgentWithQueue(
 
   if (command) {
     // Always an agent-terminal here, never a shell tab (isShell is always
-    // false). wrapNativeAgentCommand closes the tab on a clean exit but keeps
-    // it open with a readable status line on a launch failure (RUSH-2593).
+    // false). wrapNativeAgentCommand closes the tab on a clean exit, frames a
+    // dropped --device link as a recoverable reconnect (RUSH-3125 F6), and
+    // otherwise keeps it open with a readable status line on a launch failure
+    // (RUSH-2593).
     await sendCommandWhenReady(terminal, wrapNativeAgentCommand(command, false));
   }
 


### PR DESCRIPTION
**What:** the last piece of RUSH-3125 (F6). A `--device` agent tab whose SSH link dropped no longer dead-ends at a cryptic `Agent exited with status 255` crash line — it frames the drop as a recoverable reconnect. `fix(ext)`, one function + tests + docs.

### Captured run (real bash, no mocking) — 80 pass, tsc clean, per-exit-code behavior
[Run evidence screenshot](https://share.agents-cli.sh/muqsitnawaz/muqsit-1787639138724-30bdbd440a41789d) — `bun test` (80 pass), `tsc` clean, and the live wrapped-command output for exits 0 / 254 / 255 / 1.

### Why
F1–F5 + F7 (PR #3006) made a `--device` run survive a blink and reconnect for ~15 min. What was left: when the reconnect loop *gives up* (exit 255 `SSH_CONN_FAILURE`) or the remote run ends unexpectedly (exit 254 `REMOTE_EXIT_255_REMAPPED`), `wrapNativeAgentCommand` (`apps/ext/src/core/agents.ts`) printed `Agent exited with status 255 — …` and left a bare shell. That reads like a crash and gives no path back to the agent that is likely still alive on the peer.

### Behavior (in the screenshot)
- exit 0 → wrapper `exit 0`s, the tab closes (clean quit)
- exit 254 / 255 → `Lost the connection to the remote agent — it may still be running on the peer. Reconnect from:  agents sessions --active`, shell stays open
- any other nonzero → the plain status line (there is no session to rejoin)

Before F6, exit 254/255 both printed the generic crash-looking line.

### Design note — frame, don't auto-resume (the RUSH-3139 boundary)
The 2026-08-23 plan said F6 would *re-enter the CLI recovery verb*. Two facts that surfaced after it was written make a literal auto-`agents sessions resume` wrong, so this deliberately does **not** auto-resume:
1. **RUSH-3139** (split out of this ticket on 2026-08-24) proved that when the peer pane is dead, `agents sessions resume` silently resumes a **copy** and loses the in-flight turn. RUSH-3139 owns the reconnect *loop's* reattach semantics (`reconnect.ts:235`); F6 owns only the ext dead-end, which runs after `agents run` has fully exited.
2. The ext wrapper can't know the id for a non-Claude harness — the resolved/launch id lives in the CLI (`recoveryHint`, `reconnect.ts:332`); only Claude carries `--session-id` in the ext-built command. `agents sessions --active` is id-free and always correct, and the CLI's own give-up notice already printed the exact `agents sessions resume <id>` line above when one applies.

Divergence documented in the plan (`.agents/artifacts/2026-08-23/plan-ext-agent-reconnect.md`, "F6 divergence" section).

### Scope
Near-mechanical single-function change in `apps/ext`. No CLI change, no scheduler added (detection/action stay in the CLI, per scheduling-singularity — the wrapper only renders + points at a CLI noun). Docs: `apps/ext/CHANGELOG.md` (0.9.335), the function docblock, and the plan checklist/divergence note.

Ticket: RUSH-3125 (F6 line). Remaining reconnect-loop copy-resume is RUSH-3139.