### PR TITLE
fix(reconnect): warn when dead pane silently starts a fresh copy (RUSH-3139)

### DIFF
--- a/apps/cli/src/commands/focus.ts
+++ b/apps/cli/src/commands/focus.ts
@@ -102,6 +102,7 @@ export interface FocusOptions {
   abandoned?: boolean;
   queued?: boolean;
   unknown?: boolean;
+  reconnectReattach?: boolean;
 }
 
 const INHERITED_FOCUS_OPTIONS: Array<keyof FocusOptions> = [
@@ -158,6 +159,7 @@ export function registerFocusCommand(program: Command): void {
     .option('--launch-id <id>', 'Target the run by its launcher AGENT_LAUNCH_ID instead of a session id (resolved from this machine\'s hook records)')
     .option('--local', 'Only this machine (skip the cross-host sweep)')
     .option('--attach-only', 'Attach only — never open a new tab / resume a copy (the old `go` behavior)')
+    .option('--reconnect-reattach', '(internal) Set by the reconnect loop — warns when the expected pane is dead and a fresh copy starts instead', false)
     .option('-D, --device <target...>', 'Scope the picker to live sessions on these devices (device alias from `agents devices`, user@host; repeatable)')
     .option('--active', 'Only sessions present in the live roster')
     .option('-a, --agent <agent>', 'Filter by harness and recorded version (for example claude@latest)')
@@ -321,7 +323,7 @@ export async function focusAction(id: string | undefined, opts: FocusOptions): P
         // still joined instead of resumed as a copy; a crashed session has no live
         // row and recovers in place.
         const { activeById } = await gatherLiveTargets(true, { statuses: [] });
-        await focusResolvedSession(localMatch[0], activeById, self, fallback, opts.attachOnly === true);
+        await focusResolvedSession(localMatch[0], activeById, self, fallback, opts.attachOnly === true, opts.reconnectReattach === true);
         return;
       }
     }
@@ -417,7 +419,7 @@ export async function focusAction(id: string | undefined, opts: FocusOptions): P
       exact = [focusTargetForResolved(filteredMatch, outcome.session)];
     }
     if (exact.length === 1) {
-      await focusResolvedSession(exact[0], liveById, self, fallback, opts.attachOnly === true);
+      await focusResolvedSession(exact[0], liveById, self, fallback, opts.attachOnly === true, opts.reconnectReattach === true);
       return;
     }
     if (exact.length > 1) {
@@ -693,6 +695,7 @@ async function focusResolvedSession(
   self: string,
   fallback: UnreachableFallback,
   attachOnly: boolean,
+  reconnectReattach: boolean = false,
 ): Promise<void> {
   const active = liveById.get(meta.id);
   if (active && isAttachableLiveSession(active)) {
@@ -713,6 +716,19 @@ async function focusResolvedSession(
       process.exitCode = 1;
     }
     return;
+  }
+  if (reconnectReattach) {
+    // The reconnect loop expected this pane to be alive. It isn't — the peer
+    // rebooted, tmux crashed, or the agent exited while the link was down.
+    // Starting a fresh copy preserves continuity, but the user deserves to know
+    // the original context was not recovered.
+    console.error(chalk.yellow(
+      `\nWarning: ${meta.shortId}'s pane died on this host (reboot, tmux crash, or agent exited).`
+    ));
+    console.error(chalk.gray(
+      `  Your prior context is in the transcript — starting a fresh copy.\n` +
+      `  To see what happened: agents sessions preview ${meta.shortId}`
+    ));
   }
   await resumeSessionInPlace(meta);
 }

--- a/apps/cli/src/commands/focus.ts
+++ b/apps/cli/src/commands/focus.ts
@@ -707,6 +707,19 @@ async function focusResolvedSession(
     process.exitCode = 1;
     return;
   }
+  if (reconnectReattach) {
+    // The reconnect loop expected this pane to be alive. It isn't — the peer
+    // rebooted, tmux crashed, or the agent exited while the link was down.
+    // Warn before any recovery attempt (local resume OR remote hop) so the
+    // user always knows their original context was not directly recovered.
+    console.error(chalk.yellow(
+      `\nWarning: ${meta.shortId}'s pane is gone (reboot, tmux crash, or agent exited).`
+    ));
+    console.error(chalk.gray(
+      `  Prior context is in the transcript — starting recovery.\n` +
+      `  To see what happened: agents sessions preview ${meta.shortId}`
+    ));
+  }
   const remote = sessionProcessHost(meta, self);
   if (remote) {
     console.log(chalk.gray(`Recovering ${meta.shortId} on ${remote}…`));
@@ -716,19 +729,6 @@ async function focusResolvedSession(
       process.exitCode = 1;
     }
     return;
-  }
-  if (reconnectReattach) {
-    // The reconnect loop expected this pane to be alive. It isn't — the peer
-    // rebooted, tmux crashed, or the agent exited while the link was down.
-    // Starting a fresh copy preserves continuity, but the user deserves to know
-    // the original context was not recovered.
-    console.error(chalk.yellow(
-      `\nWarning: ${meta.shortId}'s pane died on this host (reboot, tmux crash, or agent exited).`
-    ));
-    console.error(chalk.gray(
-      `  Your prior context is in the transcript — starting a fresh copy.\n` +
-      `  To see what happened: agents sessions preview ${meta.shortId}`
-    ));
   }
   await resumeSessionInPlace(meta);
 }

--- a/apps/cli/src/lib/hosts/reconnect.test.ts
+++ b/apps/cli/src/lib/hosts/reconnect.test.ts
@@ -219,7 +219,7 @@ describe('reattachRemoteCommand — the real remote invocation, exercised throug
     const res = execFileSync('bash', ['-c', argvShim + reattachRemoteCommand({ kind: 'session', id: INJECTION_SID })], { encoding: 'utf8' });
     // No --attach-only: the peer's focus attaches a live pane or RESUMES a dead
     // one (RUSH-2085), so a reattach after the pane died never dead-ends.
-    expect(res.trimEnd().split('\n')).toEqual(['sessions', 'focus', INJECTION_SID, '--local']);
+    expect(res.trimEnd().split('\n')).toEqual(['sessions', 'focus', INJECTION_SID, '--local', '--reconnect-reattach']);
   });
 
   test.skipIf(!runsBash)('a 255 from the wrapped `agents` command comes back as REMOTE_EXIT_255_REMAPPED (254) — exercised end-to-end through reattachRemoteCommand, not just the wrapRemoteExitCode primitive', () => {
@@ -246,7 +246,7 @@ describe('reattachRemoteCommand — the real remote invocation, exercised throug
 
   test("the plain string, no shell needed: wraps in bash -lc around the peer's own recovery verb (attach-else-resume, no --attach-only)", () => {
     expect(reattachRemoteCommand(SESSION_TARGET)).toBe(
-      `bash -lc 'agents sessions focus ${SID} --local; rc=$?; [ "$rc" = "255" ] && rc=254; exit "$rc"'`,
+      `bash -lc 'agents sessions focus ${SID} --local --reconnect-reattach; rc=$?; [ "$rc" = "255" ] && rc=254; exit "$rc"'`,
     );
   });
 });
@@ -291,13 +291,13 @@ describe('reattachRemoteCommand — a launch target resolves on the PEER, needin
   test.skipIf(!runsBash)('sends --launch-id, so the box holding the hook records does the lookup', () => {
     const cmd = reattachRemoteCommand({ kind: 'launch', id: LAUNCH_ID });
     const res = execFileSync('bash', ['-c', argvShim + cmd], { encoding: 'utf8' });
-    expect(res.trimEnd().split('\n')).toEqual(['sessions', 'focus', '--launch-id', LAUNCH_ID, '--local']);
+    expect(res.trimEnd().split('\n')).toEqual(['sessions', 'focus', '--launch-id', LAUNCH_ID, '--local', '--reconnect-reattach']);
   });
 
   test.skipIf(!runsBash)('a launch id needing shell quoting still round-trips intact — no injection', () => {
     const nasty = "a'b; touch /tmp/PWNED-launchid-test; #";
     const res = execFileSync('bash', ['-c', argvShim + reattachRemoteCommand({ kind: 'launch', id: nasty })], { encoding: 'utf8' });
-    expect(res.trimEnd().split('\n')).toEqual(['sessions', 'focus', '--launch-id', nasty, '--local']);
+    expect(res.trimEnd().split('\n')).toEqual(['sessions', 'focus', '--launch-id', nasty, '--local', '--reconnect-reattach']);
   });
 });
 

--- a/apps/cli/src/lib/hosts/reconnect.ts
+++ b/apps/cli/src/lib/hosts/reconnect.ts
@@ -398,7 +398,7 @@ export function reattachRemoteCommand(target: ReconnectTarget): string {
   const selector = target.kind === 'launch'
     ? ['--launch-id', target.id]
     : [target.id];
-  const inner = ['agents', 'sessions', 'focus', ...selector, '--local']
+  const inner = ['agents', 'sessions', 'focus', ...selector, '--local', '--reconnect-reattach']
     .map(shellQuote)
     .join(' ');
   return wrapRemoteExitCode(inner);


### PR DESCRIPTION
fix(reconnect) — RUSH-3139

## What changed

When an interactive `--device` run's link drops and the reconnect loop calls
`agents sessions focus <id> --local` on the peer, `focusResolvedSession` falls
through to `resumeSessionInPlace` if the tmux pane is dead (peer reboot, tmux
crash, or agent exit during the blink). Before this fix the user received a fresh
harness copy with no indication their original context was not recovered.

### Files changed

**`apps/cli/src/commands/focus.ts`**
- Add `reconnectReattach?: boolean` to `FocusOptions`
- Register hidden `--reconnect-reattach` CLI flag (internal — set by the reconnect loop only)
- Add `reconnectReattach: boolean = false` to `focusResolvedSession` signature
- Thread `opts.reconnectReattach === true` through both `focusAction` call sites
- In `focusResolvedSession`, print yellow warning + gray hint before `resumeSessionInPlace` when the flag is set and the pane is dead

**`apps/cli/src/lib/hosts/reconnect.ts`**
- Add `--reconnect-reattach` to `reattachRemoteCommand` so every reconnect attempt carries the flag

## Run

Dead pane path (flag set, pane exited) vs happy path (pane alive, no warning):

![RUSH-3139 warning demo](https://share.agents-cli.sh/muqsitnawaz/muqsit-rush-3139-demo-e5e5442bf21af125)

## Scope

RUSH-3125 durability (`AGENTS_REMOTE_INTERACTIVE=1`, `resolveTmuxWrap`, `multiplex: false`) was already landed. This adds the user-visible notice for the cases where the guarantee couldn't hold because the peer rebooted or tmux crashed while the link was down.

Closes RUSH-3139. No docs or CHANGELOG needed — internal flag, no user-facing command change.

Ticket: https://linear.app/phnxlabs/issue/RUSH-3139