### PR TITLE
fix(test): remove stale Crabbox outage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,7 @@ one-off command in a PR.
 |---|---|---|
 | CLI build | [`apps/cli/scripts/build.sh`](apps/cli/scripts/build.sh) `[<version>] [--clean]` | builds into `apps/cli/dist` |
 | CLI dev install | [`apps/cli/scripts/install.sh`](apps/cli/scripts/install.sh) `[--bounce-daemon]` | side-by-side dev build at `~/.local/agents-cli-dev`, invoked as **`agents-dev`** (and `ag-dev`); never creates or touches `~/.local/bin/{agents,ag,browser}` |
-| CLI tests | [`apps/cli/scripts/test.sh`](apps/cli/scripts/test.sh) `[--device <box>] [--here]` | the full vitest suite. **Offloads by default** — crabbox via [`sandbox.sh`](apps/cli/scripts/sandbox.sh), or `--device <box>` for any fleet Linux box. Never runs locally unless you pass `--here`, and fails loud (naming `--device`) rather than falling back. **While the crabbox pool is down (RUSH-3004, Hetzner `server_limit`), `--device <box>` is the working path** — the bare form will fail, by design, rather than quietly pinning your machine. `bun run test` is the raw in-place runner the offload targets invoke; do not call it directly on a machine someone is using |
+| CLI tests | [`apps/cli/scripts/test.sh`](apps/cli/scripts/test.sh) `[--device <box>] [--here]` | the full vitest suite. **Offloads by default** — crabbox via [`sandbox.sh`](apps/cli/scripts/sandbox.sh), or `--device <box>` for an explicit fleet Linux target. Never runs locally unless you pass `--here`, and fails loud rather than falling back. `bun run test` is the raw in-place runner the offload targets invoke; do not call it directly on a machine someone is using |
 | CLI release | [`apps/cli/scripts/release.sh`](apps/cli/scripts/release.sh) `<version> [--apply]` | zero-config self-routing publish of `@phnx-labs/agents-cli` to npm: runnable from any fleet box with an empty environment — requires an exact-tree attestation (it runs **no** tests itself; `release-attestation-produce.sh` does, offloaded via `test.sh`), PR + CI, then a promote-only publish on the home base — any OS, `mac-mini` by default, overridable with `--device <name>` (RUSH-3026: the tarball no longer needs per-release signing); prints a `[n/6]` phase tracker. Legacy `@swarmify` shim built for reference, not published |
 | ext / agents-dbg build + release | in [phnx-labs/agi-ext](https://github.com/phnx-labs/agi-ext) `scripts/` | AGI EXT and the agents-dbg app moved with the extension repo (RUSH-3189) |
 | computer-mac build | [`native/computer-mac/scripts/build.sh`](native/computer-mac/scripts/build.sh) | Swift daemon |
@@ -252,8 +252,8 @@ To run your changes:
 ```bash
 cd apps/cli
 bun run test                      # the suite, locally
-scripts/test.sh --device mark-1   # the suite, on a fleet Linux box  <- works today
-scripts/test.sh                   # the suite, offloaded to a crabbox (pool down: RUSH-3004)
+scripts/test.sh                   # the suite, offloaded to a crabbox (default)
+scripts/test.sh --device mark-1   # the suite, on an explicit fleet Linux box
 
 scripts/install.sh --skip-tests   # build + install this working tree
 agents-dev sessions --active      # drive YOUR build

--- a/apps/cli/.changelog/1.22.48.md
+++ b/apps/cli/.changelog/1.22.48.md
@@ -429,3 +429,9 @@ type: feat
 ---
 
 The watchdog decider is now an agent, not a heuristic script. Every idle session on the machine (its originating task + transcript tail) is handed to ONE `agents run --mode plan` call per tick, which judges each: idle-but-unfinished → nudge that drives it to finish; idle-and-done or genuinely-needs-human → skip. The deterministic pre-filter (`isLikelyTrulyBlocked`, completion/promise regex) and the per-session LLM spawn are gone — one bounded call per tick, only when something is actually idle. A nudge is booked in the cooldown ledger and logged `nudge` ONLY when delivery is confirmed; tmux/iterm/pty self-confirm, while vscodium's fire-and-forget `--open-url` is recorded `undelivered` until the swarm-ext extension acks the verb, ending the phantom-nudge ledger. `agents watchdog history` gains an `undelivered` row; the `--smart` flag is removed (the agent is always the decider). Defaults stay OFF.
+- **Test guidance no longer claims the Crabbox pool is down.** `scripts/test.sh`
+  remains Crabbox-first and now reports a failed offload without guessing that
+  the pool or provider is unavailable; its preceding command output is the
+  source of truth. The repository instructions and release-attestation comments
+  likewise describe the live default path instead of the resolved RUSH-3004
+  incident.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.22.48
 
+- **Test guidance no longer claims the Crabbox pool is down.** `scripts/test.sh`
+  remains Crabbox-first and now reports a failed offload without guessing that
+  the pool or provider is unavailable; its preceding command output is the
+  source of truth. The repository instructions and release-attestation comments
+  likewise describe the live default path instead of the resolved RUSH-3004
+  incident.
+
 - **On your own machine, every Claude run uses your normal login — not the
   worker setup-token (RUSH-2395).** The credential now follows **device role**,
   not run mode. A device marked `config.role: personal` (your interactive box —

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 ## 1.22.48
 
-- **Test guidance no longer claims the Crabbox pool is down.** `scripts/test.sh`
-  remains Crabbox-first and now reports a failed offload without guessing that
-  the pool or provider is unavailable; its preceding command output is the
-  source of truth. The repository instructions and release-attestation comments
-  likewise describe the live default path instead of the resolved RUSH-3004
-  incident.
-
 - **On your own machine, every Claude run uses your normal login — not the
   worker setup-token (RUSH-2395).** The credential now follows **device role**,
   not run mode. A device marked `config.role: personal` (your interactive box —
@@ -440,6 +433,12 @@ type: feat
 ---
 
 The watchdog decider is now an agent, not a heuristic script. Every idle session on the machine (its originating task + transcript tail) is handed to ONE `agents run --mode plan` call per tick, which judges each: idle-but-unfinished → nudge that drives it to finish; idle-and-done or genuinely-needs-human → skip. The deterministic pre-filter (`isLikelyTrulyBlocked`, completion/promise regex) and the per-session LLM spawn are gone — one bounded call per tick, only when something is actually idle. A nudge is booked in the cooldown ledger and logged `nudge` ONLY when delivery is confirmed; tmux/iterm/pty self-confirm, while vscodium's fire-and-forget `--open-url` is recorded `undelivered` until the swarm-ext extension acks the verb, ending the phantom-nudge ledger. `agents watchdog history` gains an `undelivered` row; the `--smart` flag is removed (the agent is always the decider). Defaults stay OFF.
+- **Test guidance no longer claims the Crabbox pool is down.** `scripts/test.sh`
+  remains Crabbox-first and now reports a failed offload without guessing that
+  the pool or provider is unavailable; its preceding command output is the
+  source of truth. The repository instructions and release-attestation comments
+  likewise describe the live default path instead of the resolved RUSH-3004
+  incident.
 
 ## 1.22.47
 

--- a/apps/cli/scripts/release-attestation-produce.sh
+++ b/apps/cli/scripts/release-attestation-produce.sh
@@ -157,8 +157,7 @@ SUITE_LOG="$(mktemp "${TMPDIR:-/tmp}/agents-cli-attest-suite.XXXXXX")"
 # whole ~13k-test suite there too -- welding "sign on a Mac" to "pin a Mac for
 # ten minutes". test.sh decides WHERE the suite runs; the Mac keeps only
 # sign/notarize/pack. Default is the crabbox pool; --test-device <box> targets a
-# fleet Linux box (use this while RUSH-3004 keeps the pool down); --test-here
-# restores the old in-place behavior explicitly.
+# fleet Linux box; --test-here restores the old in-place behavior explicitly.
 # bash 3.2 (what macOS ships, and the producer MUST run on a Mac when a helper
 # input changed) treats "${arr[@]}" on an EMPTY array as an unbound variable
 # under `set -u`. The ${arr[@]+"${arr[@]}"} guard is the portable form.

--- a/apps/cli/scripts/test.sh
+++ b/apps/cli/scripts/test.sh
@@ -173,17 +173,16 @@ case "$MODE" in
   Run it on a fleet Linux box instead:   scripts/test.sh --device yosemite-m1
   Or, if you accept pinning THIS machine: scripts/test.sh --here"
     fi
-    # Fail loud, never silently local. The crabbox pool has been down fleet-wide
-    # (RUSH-3004 Hetzner 403, RUSH-2773) and that outage is exactly when someone
-    # is tempted to "just run it here" -- so name the alternative in the error.
+    # Fail loud, never silently local. Name the explicit alternatives without
+    # guessing whether a credential, provider, network, or crabbox operation failed.
     # VITEST_ARGS must ride through here too. The producer passes
     # `-- --retry=2 --maxWorkers=2` and offload is its DEFAULT mode, so dropping
     # them silently removes the mitigation that keeps a good tree from
     # false-failing (see release-attestation-produce.sh's RUSH-3015 note).
     if ! scripts/sandbox.sh test ${VITEST_ARGS[@]+"${VITEST_ARGS[@]}"}; then
-      die "the crabbox run failed (pool outage? see RUSH-3004 / RUSH-2773).
-  Run it on a fleet Linux box instead:   scripts/test.sh --device yosemite-m1
-  Or, if you accept pinning THIS machine: scripts/test.sh --here"
+      die "the crabbox run failed; the command output above is the source of truth.
+  To target a fleet Linux box explicitly: scripts/test.sh --device yosemite-m1
+  To explicitly pin THIS machine:         scripts/test.sh --here"
     fi
     ;;
 esac

--- a/apps/cli/scripts/test.test.ts
+++ b/apps/cli/scripts/test.test.ts
@@ -30,8 +30,7 @@ describe('scripts/test.sh — the suite never runs locally by accident', () => {
   });
 
   it('fails loud and names --device when the offload target is unavailable', () => {
-    // A PATH with no `crabbox` is exactly the fleet-outage case (RUSH-3004),
-    // which is when someone is most tempted to "just run it here".
+    // A missing offload prerequisite must fail rather than silently run locally.
     const emptyBin = fs.mkdtempSync(path.join(os.tmpdir(), 'testsh-nopath-'));
     const r = run([], { PATH: `${emptyBin}:/usr/bin:/bin` });
     fs.rmSync(emptyBin, { recursive: true, force: true });


### PR DESCRIPTION
## What changed
- remove the false current-state claim that the Crabbox pool is down
- make the default Crabbox path the first documented test path again
- stop `test.sh` from guessing that an arbitrary failure is a pool outage
- remove stale RUSH-3004 outage comments from tests and release attestation

## Real verification

The default offload path provisioned and ran successfully on Hetzner:

```text
Using crabbox: brisk-barnacle
provider=hetzner target=linux type=cpx62
Test Files  1 passed (1)
Tests  8 passed (8)
command complete ... exit=0
```

Command: `apps/cli/scripts/test.sh -- scripts/test.test.ts`

RUSH-3004