### PR TITLE
chore(changelog): drop internal Crabbox cleanup note

### DIFF
--- a/apps/cli/.changelog/1.22.48.md
+++ b/apps/cli/.changelog/1.22.48.md
@@ -429,9 +429,3 @@ type: feat
 ---
 
 The watchdog decider is now an agent, not a heuristic script. Every idle session on the machine (its originating task + transcript tail) is handed to ONE `agents run --mode plan` call per tick, which judges each: idle-but-unfinished → nudge that drives it to finish; idle-and-done or genuinely-needs-human → skip. The deterministic pre-filter (`isLikelyTrulyBlocked`, completion/promise regex) and the per-session LLM spawn are gone — one bounded call per tick, only when something is actually idle. A nudge is booked in the cooldown ledger and logged `nudge` ONLY when delivery is confirmed; tmux/iterm/pty self-confirm, while vscodium's fire-and-forget `--open-url` is recorded `undelivered` until the swarm-ext extension acks the verb, ending the phantom-nudge ledger. `agents watchdog history` gains an `undelivered` row; the `--smart` flag is removed (the agent is always the decider). Defaults stay OFF.
-- **Test guidance no longer claims the Crabbox pool is down.** `scripts/test.sh`
-  remains Crabbox-first and now reports a failed offload without guessing that
-  the pool or provider is unavailable; its preceding command output is the
-  source of truth. The repository instructions and release-attestation comments
-  likewise describe the live default path instead of the resolved RUSH-3004
-  incident.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -433,12 +433,6 @@ type: feat
 ---
 
 The watchdog decider is now an agent, not a heuristic script. Every idle session on the machine (its originating task + transcript tail) is handed to ONE `agents run --mode plan` call per tick, which judges each: idle-but-unfinished → nudge that drives it to finish; idle-and-done or genuinely-needs-human → skip. The deterministic pre-filter (`isLikelyTrulyBlocked`, completion/promise regex) and the per-session LLM spawn are gone — one bounded call per tick, only when something is actually idle. A nudge is booked in the cooldown ledger and logged `nudge` ONLY when delivery is confirmed; tmux/iterm/pty self-confirm, while vscodium's fire-and-forget `--open-url` is recorded `undelivered` until the swarm-ext extension acks the verb, ending the phantom-nudge ledger. `agents watchdog history` gains an `undelivered` row; the `--smart` flag is removed (the agent is always the decider). Defaults stay OFF.
-- **Test guidance no longer claims the Crabbox pool is down.** `scripts/test.sh`
-  remains Crabbox-first and now reports a failed offload without guessing that
-  the pool or provider is unavailable; its preceding command output is the
-  source of truth. The repository instructions and release-attestation comments
-  likewise describe the live default path instead of the resolved RUSH-3004
-  incident.
 
 ## 1.22.47
 


### PR DESCRIPTION
## Summary

Removes the internal Crabbox guidance cleanup from both the canonical 1.22.48 changelog source and its generated CHANGELOG output. The actual correction from #3030 remains in the repository guidance and scripts.

## Verification

- `bun scripts/gen-changelog.ts`
- `rg -n "Test guidance no longer claims|resolved RUSH-3004" .changelog CHANGELOG.md` returns no matches
- `git diff --check`