### PR TITLE
docs(teams): mine 100 days of fleet launch failures

### DIFF
--- a/.agents/artifacts/2026-08-25/mine-teams-sessions.ts
+++ b/.agents/artifacts/2026-08-25/mine-teams-sessions.ts
@@ -5,7 +5,8 @@
  *
  * Discovery uses the bounded sessions.db tool index. Evidence comes from the
  * original transcript bodies streamed by `agents sessions export` on the host
- * that owns each session. The output contains no raw transcript bodies.
+ * that owns each session. Output is permanently anonymized: raw identifiers,
+ * commands, outputs, and transcript excerpts never leave this process.
  */
 
 type ToolCall = {
@@ -119,10 +120,11 @@ const candidates = discovered.sessions
     ...session,
     calls: session.calls.filter((call) => launchPattern.test(call.input ?? "")),
   }))
-  .filter((session) => session.calls.length > 0);
+  .filter((session) => session.calls.length > 0)
+  .sort((a, b) => (a.timestamp ?? '').localeCompare(b.timestamp ?? ''));
 
 // Forked transcripts can retain the exact same historical tool call. Count the
-// operation once while preserving the earliest indexed session as its source.
+// tool call once while preserving the earliest-created session as its source.
 const seenCalls = new Set<string>();
 for (const session of candidates) {
   session.calls = session.calls.filter((call) => {
@@ -133,6 +135,14 @@ for (const session of candidates) {
   });
 }
 const uniqueCandidates = candidates.filter((session) => session.calls.length > 0);
+const machineAliases = new Map(
+  [...new Set(uniqueCandidates.map((session) => session.machine))]
+    .sort()
+    .map((machine, index) => [machine, `host-${index + 1}`]),
+);
+const sessionAliases = new Map(
+  uniqueCandidates.map((session, index) => [session.id, `S${String(index + 1).padStart(3, '0')}`]),
+);
 
 const byMachine = Map.groupBy(uniqueCandidates, (session) => session.machine);
 const exported = new Map<string, BundleRow>();
@@ -153,25 +163,21 @@ for (const [machine, sessions] of byMachine) {
   }
 }
 
-const incidents = uniqueCandidates.flatMap((session) => session.calls.map((call, callIndex) => {
+const incidents = uniqueCandidates.flatMap((session) => session.calls.map((call) => {
   const row = exported.get(session.id);
   const nearby = row?.body ? nearbyEvidence(row.body, call) : "";
   const evidence = [call.output, nearby].filter(Boolean).join("\n");
   return {
-    sessionId: session.id,
-    shortId: session.shortId,
-    machine: session.machine,
+    session: sessionAliases.get(session.id),
+    host: machineAliases.get(session.machine),
     agent: session.agent,
     version: row?.body?.match(/\"version\":\"([^\"]+)\"/)?.[1],
     transcriptAgent: row?.agent,
     timestamp: call.timestamp ?? session.timestamp,
-    project: session.project,
-    callIndex,
-    command: (call.input ?? "").slice(0, 4000),
-    immediateOutput: (call.output ?? "").slice(0, 4000),
+    launchActions: [...(call.input ?? '').matchAll(/(?:agents|ag)\s+teams\s+(create|add|start)\b(?!\s+--help)/gi)]
+      .map((match) => match[1]!.toLowerCase()),
     categories: classify(evidence),
     hasOriginalTranscript: Boolean(row?.body),
-    nearbyEvidence: nearby.slice(0, 6000),
   };
 }));
 
@@ -180,17 +186,21 @@ const report = {
   windowDays: 100,
   requestedAgents: [...wantedAgents],
   coverage: discovered.coverage,
-  queryWarnings: query.stderr.trim().split("\n").filter(Boolean),
+  unreachableOrIncompatibleHostCount: query.stderr.trim().split("\n").filter(Boolean).length,
   candidateSessions: uniqueCandidates.length,
-  launchCalls: incidents.length,
-  originalTranscriptsRecovered: new Set(incidents.filter((item) => item.hasOriginalTranscript).map((item) => item.sessionId)).size,
-  hostFailures,
+  launchBearingToolCalls: incidents.length,
+  originalTranscriptsRecovered: new Set(incidents.filter((item) => item.hasOriginalTranscript).map((item) => item.session)).size,
+  hostFailures: hostFailures.map((failure) => ({
+    host: machineAliases.get(failure.machine) ?? 'unindexed-host',
+    sessionCount: failure.sessionCount,
+    failed: true,
+  })),
   diagnosticOnlySessionsExcluded: discovered.sessions.filter((session) =>
     wantedAgents.has(session.agent) && session.calls.some((call) => diagnosticPattern.test(call.input ?? "")) &&
     !session.calls.some((call) => launchPattern.test(call.input ?? ""))
   ).length,
   byAgent: Object.fromEntries([...Map.groupBy(incidents, (item) => item.agent)].map(([agent, rows]) => [agent, rows.length])),
-  byMachine: Object.fromEntries([...Map.groupBy(incidents, (item) => item.machine)].map(([machine, rows]) => [machine, rows.length])),
+  byHost: Object.fromEntries([...Map.groupBy(incidents, (item) => item.host)].map(([host, rows]) => [host, rows.length])),
   byCategory: Object.fromEntries([...Map.groupBy(incidents.flatMap((item) => item.categories), (name) => name)].map(([name, rows]) => [name, rows.length])),
   incidents,
 };

--- a/.agents/artifacts/2026-08-25/mine-teams-sessions.ts
+++ b/.agents/artifacts/2026-08-25/mine-teams-sessions.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env bun
+
+/**
+ * Mine original fleet transcripts for agents-teams invocations.
+ *
+ * Discovery uses the bounded sessions.db tool index. Evidence comes from the
+ * original transcript bodies streamed by `agents sessions export` on the host
+ * that owns each session. The output contains no raw transcript bodies.
+ */
+
+type ToolCall = {
+  timestamp?: string;
+  input?: string;
+  output?: string;
+  outcome?: string;
+};
+
+type Candidate = {
+  id: string;
+  shortId?: string;
+  agent: string;
+  machine: string;
+  timestamp?: string;
+  project?: string;
+  calls: ToolCall[];
+};
+
+type BundleRow = {
+  agent?: string;
+  machine?: string;
+  sessionId?: string;
+  body?: string;
+};
+
+const wantedAgents = new Set(["claude", "codex", "grok", "kimi", "cursor"]);
+const launchPattern = /(?:^|[;&|\n]\s*|\b)(?:agents|ag)\s+teams\s+(create|add|start)\b(?!\s+--help)/i;
+const diagnosticPattern = /(?:^|[;&|\n]\s*|\b)(?:agents|ag)\s+teams\s+(status|logs|doctor|active|list|--help)\b/i;
+const issueRules: Array<[string, RegExp]> = [
+  ["environment bootstrap noise", /GVM_ROOT|nvm is not compatible|npm_config_prefix/i],
+  ["stale checkout gate", /commits? behind origin\/main|stale repo|bring it up to date|--confirm/i],
+  ["unsupported or misplaced option", /unknown option|does not exist on `teams add`|too many arguments/i],
+  ["authentication or harness readiness", /not logged in|log in|authentication|unauthorized|not installed|fails? to start/i],
+  ["worktree creation or collision", /worktree.*(?:already exists|failed|collision)|fatal:.*worktree/i],
+  ["remote host or SSH failure", /unreachable|ssh:|connection (?:refused|timed out)|remote.*failed/i],
+  ["spawn reports success but no teammate", /0 working, 0 done, 0 failed|no teammates yet/i],
+  ["teammate process failure", /\bFAILED\b|exit(?:ed)? (?:code )?[1-9]\d*|pane died|process.*(?:died|crashed)/i],
+  ["watch or orchestration stalled", /still running|stalled|no progress|watch.*(?:dead|exited)|background.*(?:dead|nothing)/i],
+  ["completion stranded before merge", /PR (?:is )?open|waiting (?:for|on) (?:CI|review)|not merged|unmerged/i],
+];
+
+function run(argv: string[], timeout = 120_000): { stdout: string; stderr: string; exitCode: number } {
+  const proc = Bun.spawnSync(argv, { stdout: "pipe", stderr: "pipe", timeout });
+  return {
+    stdout: proc.stdout.toString(),
+    stderr: proc.stderr.toString(),
+    exitCode: proc.exitCode ?? 1,
+  };
+}
+
+function parseJson<T>(text: string, label: string): T {
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    throw new Error(`${label} returned invalid JSON: ${String(error)}\n${text.slice(0, 500)}`);
+  }
+}
+
+function exportCommand(machine: string, ids: string[]): string[] {
+  const base = ["agents", "sessions", "export", ...ids, "--stdout"];
+  if (machine === "zion") return base;
+  // Session ids are UUIDs, so joining them cannot introduce shell syntax.
+  return ["agents", "ssh", machine, base.join(" ")];
+}
+
+function parseBundle(stdout: string): BundleRow[] {
+  const rows: BundleRow[] = [];
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const row = JSON.parse(line) as BundleRow & { kind?: string };
+      if (row.kind !== "agents-session-bundle" && row.body) rows.push(row);
+    } catch {
+      // SSH warnings are evidence in stderr; non-NDJSON stdout is ignored here.
+    }
+  }
+  return rows;
+}
+
+function nearbyEvidence(body: string, call: ToolCall): string {
+  const lines = body.split("\n");
+  let index = -1;
+  if (call.timestamp) {
+    index = lines.findIndex((line) => line.includes(call.timestamp!) && launchPattern.test(line));
+  }
+  if (index < 0 && call.input) {
+    const fragment = call.input.slice(0, 160);
+    index = lines.findIndex((line) => line.includes(fragment));
+  }
+  if (index < 0) return "";
+  return lines.slice(index, index + 12).join("\n").slice(0, 12_000);
+}
+
+function classify(text: string): string[] {
+  return issueRules.filter(([, pattern]) => pattern.test(text)).map(([name]) => name);
+}
+
+const query = run([
+  "agents", "sessions", "--include", "tools", "--query", "program:agents input:teams",
+  "--fleet", "--since", "100d", "--limit", "1000", "--json",
+]);
+if (query.exitCode !== 0 && !query.stdout.trim()) {
+  throw new Error(`fleet query failed (${query.exitCode}): ${query.stderr}`);
+}
+
+const discovered = parseJson<{ coverage: unknown; sessions: Candidate[] }>(query.stdout, "fleet query");
+const candidates = discovered.sessions
+  .filter((session) => wantedAgents.has(session.agent))
+  .map((session) => ({
+    ...session,
+    calls: session.calls.filter((call) => launchPattern.test(call.input ?? "")),
+  }))
+  .filter((session) => session.calls.length > 0);
+
+// Forked transcripts can retain the exact same historical tool call. Count the
+// operation once while preserving the earliest indexed session as its source.
+const seenCalls = new Set<string>();
+for (const session of candidates) {
+  session.calls = session.calls.filter((call) => {
+    const key = `${session.machine}\0${call.timestamp ?? ""}\0${call.input ?? ""}`;
+    if (seenCalls.has(key)) return false;
+    seenCalls.add(key);
+    return true;
+  });
+}
+const uniqueCandidates = candidates.filter((session) => session.calls.length > 0);
+
+const byMachine = Map.groupBy(uniqueCandidates, (session) => session.machine);
+const exported = new Map<string, BundleRow>();
+const hostFailures: Array<{ machine: string; sessionCount: number; error: string }> = [];
+
+for (const [machine, sessions] of byMachine) {
+  const result = run(exportCommand(machine, sessions.map((session) => session.id)), 180_000);
+  for (const row of parseBundle(result.stdout)) {
+    if (row.sessionId) exported.set(row.sessionId, row);
+  }
+  const missing = sessions.filter((session) => !exported.has(session.id));
+  if (result.exitCode !== 0 || missing.length > 0) {
+    hostFailures.push({
+      machine,
+      sessionCount: missing.length,
+      error: (result.stderr || result.stdout || `missing ${missing.length} transcript bodies`).trim().slice(0, 1000),
+    });
+  }
+}
+
+const incidents = uniqueCandidates.flatMap((session) => session.calls.map((call, callIndex) => {
+  const row = exported.get(session.id);
+  const nearby = row?.body ? nearbyEvidence(row.body, call) : "";
+  const evidence = [call.output, nearby].filter(Boolean).join("\n");
+  return {
+    sessionId: session.id,
+    shortId: session.shortId,
+    machine: session.machine,
+    agent: session.agent,
+    version: row?.body?.match(/\"version\":\"([^\"]+)\"/)?.[1],
+    transcriptAgent: row?.agent,
+    timestamp: call.timestamp ?? session.timestamp,
+    project: session.project,
+    callIndex,
+    command: (call.input ?? "").slice(0, 4000),
+    immediateOutput: (call.output ?? "").slice(0, 4000),
+    categories: classify(evidence),
+    hasOriginalTranscript: Boolean(row?.body),
+    nearbyEvidence: nearby.slice(0, 6000),
+  };
+}));
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  windowDays: 100,
+  requestedAgents: [...wantedAgents],
+  coverage: discovered.coverage,
+  queryWarnings: query.stderr.trim().split("\n").filter(Boolean),
+  candidateSessions: uniqueCandidates.length,
+  launchCalls: incidents.length,
+  originalTranscriptsRecovered: new Set(incidents.filter((item) => item.hasOriginalTranscript).map((item) => item.sessionId)).size,
+  hostFailures,
+  diagnosticOnlySessionsExcluded: discovered.sessions.filter((session) =>
+    wantedAgents.has(session.agent) && session.calls.some((call) => diagnosticPattern.test(call.input ?? "")) &&
+    !session.calls.some((call) => launchPattern.test(call.input ?? ""))
+  ).length,
+  byAgent: Object.fromEntries([...Map.groupBy(incidents, (item) => item.agent)].map(([agent, rows]) => [agent, rows.length])),
+  byMachine: Object.fromEntries([...Map.groupBy(incidents, (item) => item.machine)].map(([machine, rows]) => [machine, rows.length])),
+  byCategory: Object.fromEntries([...Map.groupBy(incidents.flatMap((item) => item.categories), (name) => name)].map(([name, rows]) => [name, rows.length])),
+  incidents,
+};
+
+const serialized = `${JSON.stringify(report, null, 2)}\n`;
+const outputIndex = Bun.argv.indexOf("--output");
+if (outputIndex >= 0) {
+  const outputPath = Bun.argv[outputIndex + 1];
+  if (!outputPath) throw new Error("--output requires a path");
+  await Bun.write(outputPath, serialized);
+} else {
+  process.stdout.write(serialized);
+}

--- a/.agents/artifacts/2026-08-25/teams-session-reliability-audit.md
+++ b/.agents/artifacts/2026-08-25/teams-session-reliability-audit.md
@@ -1,0 +1,166 @@
+# Teams reliability audit — 100-day fleet transcript mine
+
+Tracking: RUSH-3195
+
+## Executive result
+
+The fleet corpus contains **21 unique team-launch operations** in the last 100
+days after fork duplicates and help-only calls are removed. Every one of those
+21 operations was recovered from its original harness transcript. The observed
+orchestrators were Claude (14 launches across versions 2.1.186–2.1.225) and
+Codex (7 launches); no Grok, Kimi, or Cursor session in the indexed corpus
+orchestrated a launch. Those harnesses do appear as teammates, so the absence is
+an observation about who invoked the command, not proof that they cannot.
+
+The dominant problem is not one catastrophic spawn bug. It is that launching a
+team is a multi-command, partially transactional workflow whose preflight,
+remote environment, progress, and terminal outcome leak back to the
+orchestrator. Agents repeatedly compensate with `tail`, `grep`, retries,
+`--confirm`, status polling, and transcript reads. A reliable surface should
+make those compensations unnecessary.
+
+## Method and coverage
+
+`mine-teams-sessions.ts` does four things:
+
+1. Queries the pre-indexed tool-call rows in each reachable host's
+   `sessions.db` for `agents teams` calls in the last 100 days.
+2. Keeps real `create`, `add`, and `start` calls for Claude, Codex, Grok, Kimi,
+   and Cursor; it excludes help/status-only calls and de-duplicates calls copied
+   into forked transcripts.
+3. Streams a redacted session bundle from the owning host and reads the original
+   harness body rather than treating the SQLite preview as the transcript.
+4. Captures the launch result and following native transcript records for
+   classification without committing raw transcripts, local paths, host names,
+   or session identifiers.
+
+At the final run, the search index reported **3,906 transcript files**, **217,120
+tool calls**, **106 size-limited files**, and **306 files still awaiting tool-call
+backfill** in the 100-day selection. One registered host was unreachable. The
+21-launch count is therefore a verified lower bound, not a claim of mathematical
+completeness. All 21 discovered launch transcripts were recovered successfully.
+
+## Observed failure and friction classes
+
+### 1. Fatal-looking bootstrap errors accompany successful launches
+
+Five independent Claude launches, spanning versions 2.1.186, 2.1.217,
+2.1.218, and 2.1.221, emitted:
+
+> `ERROR: GVM_ROOT not set. Please source $GVM_ROOT/scripts/gvm`
+
+The same command then printed `New team`, and later `teams add` printed
+`status running`. Agents hid the line with `grep -v GVM_ROOT` or truncated the
+output with `tail`. This is dangerous because the command reports both failure
+and success, so neither a person nor an agent can trust the boundary.
+
+Required fix: remote/non-interactive team execution must use a deterministic
+shell environment and separate startup diagnostics from command diagnostics. A
+successful command must not contain an `ERROR:` line; a broken bootstrap must
+fail before creating team state.
+
+### 2. Preflight happens after team state exists
+
+One launch created the team and then blocked the first teammate because its
+checkout was 107 commits behind `origin/main`. The output instructed the agent
+to merge and rerun or pass `--confirm`. This guard is intentional and tested in
+`apps/cli/src/commands/teams.stale-guard.test.ts`, but its placement makes a
+normal launch partially successful: the empty team exists while the requested
+work does not.
+
+Required fix: add a read-only launch preflight that resolves repository
+freshness, harness/version availability, authentication, device reachability,
+worktree names, dependencies, and capacity for the complete roster before any
+team or teammate is persisted. The stale-repo policy can stay strict; it should
+be evaluated before side effects.
+
+### 3. Shell chaining is the de facto batch API and can launch only a prefix
+
+Agents routinely put `create`, several `add` calls, and `start --watch` into one
+shell command. In one three-teammate audit launch, the immediate output contained
+only the team and first teammate even though the requested command contained
+three adds plus start. The orchestrator then had to inspect status to learn what
+actually existed. Codex tool-call previews compounded this by recording
+`[object Object],[object Object]` instead of the command result.
+
+Required fix: provide one transactional roster-launch operation (a manifest or
+repeatable teammate argument) that validates the entire roster, persists it
+atomically, starts it, and returns one structured result containing every
+teammate. Shell `&&` must not be the only batch contract. JSON output must remain
+structured through the session tool index instead of degrading to object string
+coercion.
+
+### 4. Teammate failures are visible only after manual status archaeology
+
+The mined launches include a team later reported as `0 working, 0 done, 3
+failed`. The status row showed a seven-second failure with 46 tools but did not
+surface the causal error in the compact summary; the orchestrator proceeded to
+query team status and external PR state. Another launch inherited non-blocking
+hook errors pointing at deleted temporary hook-shim paths before the team command
+ran. These are upstream environment defects, but teams is the orchestration
+boundary that must turn them into an actionable terminal result.
+
+Required fix: a failed teammate needs a stable `cause`, `stage`, `retryable`,
+and `next_command` in both JSON and the default status row. `start --watch`
+should finish with a roster-wide terminal summary that includes the first real
+failure for each failed teammate without requiring `teams logs`.
+
+### 5. Watching is not ownership
+
+The corpus contains the documented dead-watch case: an orchestrator claimed a
+background poll would re-invoke it, but no watcher process existed while four
+teammates remained running. Other launches repeatedly moved from launch to
+manual `teams status`, PR queries, and transcript inspection. The current teams
+skill explicitly calls this the most expensive failure mode.
+
+Required fix: `teams start --watch` must be a durable supervisor contract, not a
+foreground convenience. It should persist supervision in the daemon, expose a
+watch identity and heartbeat, and emit exactly one terminal event that can
+re-enter the owner. Registration without a live action must fail loud.
+
+### 6. Completion is not a team-level invariant
+
+Several briefs explicitly say “PR open” or “waiting for review” is incomplete,
+because teammates historically stop there. That contract currently lives in
+prompt prose and hooks. The team state machine still treats agent-process
+completion as the primary terminal signal, while delivery is inferred later by
+the orchestrator.
+
+Required fix: let a team declare its completion policy (`session-finished`,
+`artifact-produced`, `PR-open`, `PR-merged`, or composed verification). Persist
+delivery evidence per teammate. A team configured for `PR-merged` must not show
+done merely because the harness exited.
+
+## Stability backlog
+
+| Priority | Canonical change | Acceptance signal |
+|---|---|---|
+| P0 | Transactional `teams launch`/manifest: preflight full roster, persist all-or-none, start, structured result | One command creates 3 mixed-harness teammates; any invalid teammate leaves no team/worktree/process |
+| P0 | Durable daemon-owned supervisor for `start --watch` | Kill the invoking terminal; team continues, heartbeat remains visible, owner receives one terminal event |
+| P0 | Deterministic local/SSH shell environment | Fleet launch has no startup `ERROR:` noise; bootstrap failure creates no state |
+| P0 | Structured terminal causes in status/watch JSON | A real failed harness reports stage, cause, retryability, and exact recovery command without reading logs |
+| P1 | Delivery-aware completion policy | `PR-merged` team remains unfinished while any linked PR is open/red/unreviewed |
+| P1 | Preserve structured tool results in session indexing | Codex launch output is JSON/text evidence, never `[object Object]` |
+| P1 | Fleet-wide launch conformance suite | Claude, Codex, Grok, Kimi, and Cursor each orchestrate; every applicable harness also runs as teammate on local and remote paths |
+| P2 | Friction telemetry rollup | `teams doctor` reports preflight failure counts by stable cause without mining transcripts |
+
+## Proposed end-to-end test matrix
+
+The real-service suite should cover the composed workflow, not isolated command
+helpers:
+
+- local and remote launch;
+- clean and stale repositories;
+- valid and invalid harness/version/account;
+- one teammate and a three-stage DAG;
+- per-teammate worktrees and a deliberate name collision;
+- invoking terminal disappears during watch;
+- harness exits before session id, after session id, and after opening a PR;
+- retry/resume after a retryable failure;
+- machine-readable output round-tripped through `sessions.db`;
+- orchestrator harnesses Claude, Codex, Grok, Kimi, and Cursor, with all
+  applicable teammate harnesses exercised.
+
+The success criterion is simple: after one launch request, either the complete
+declared team is durably supervised to its declared delivery state, or no side
+effect remains and one actionable error explains why.

--- a/.agents/artifacts/2026-08-25/teams-session-reliability-audit.md
+++ b/.agents/artifacts/2026-08-25/teams-session-reliability-audit.md
@@ -4,12 +4,12 @@ Tracking: RUSH-3195
 
 ## Executive result
 
-The fleet corpus contains **21 unique team-launch operations** in the last 100
+The fleet corpus contains **21 unique team-launch-bearing tool calls** in the last 100
 days after fork duplicates and help-only calls are removed. Every one of those
-21 operations was recovered from its original harness transcript. The observed
-orchestrators were Claude (14 launches across versions 2.1.186–2.1.225) and
-Codex (7 launches); no Grok, Kimi, or Cursor session in the indexed corpus
-orchestrated a launch. Those harnesses do appear as teammates, so the absence is
+21 calls was recovered from its original harness transcript. The observed
+callers were Claude (14 calls across versions 2.1.186–2.1.225) and
+Codex (7 calls); no Grok, Kimi, or Cursor session in the indexed corpus
+issued such a call. Those harnesses do appear as teammates, so the absence is
 an observation about who invoked the command, not proof that they cannot.
 
 The dominant problem is not one catastrophic spawn bug. It is that launching a
@@ -27,7 +27,7 @@ make those compensations unnecessary.
    `sessions.db` for `agents teams` calls in the last 100 days.
 2. Keeps real `create`, `add`, and `start` calls for Claude, Codex, Grok, Kimi,
    and Cursor; it excludes help/status-only calls and de-duplicates calls copied
-   into forked transcripts.
+   into forked transcripts, selecting the earliest-created source session.
 3. Streams a redacted session bundle from the owning host and reads the original
    harness body rather than treating the SQLite preview as the transcript.
 4. Captures the launch result and following native transcript records for
@@ -37,8 +37,8 @@ make those compensations unnecessary.
 At the final run, the search index reported **3,906 transcript files**, **217,120
 tool calls**, **106 size-limited files**, and **306 files still awaiting tool-call
 backfill** in the 100-day selection. One registered host was unreachable. The
-21-launch count is therefore a verified lower bound, not a claim of mathematical
-completeness. All 21 discovered launch transcripts were recovered successfully.
+21-call count is therefore a verified lower bound, not a claim of mathematical
+completeness. All 21 discovered source transcripts were recovered successfully.
 
 ## Observed failure and friction classes
 

--- a/.agents/artifacts/2026-08-25/teams-session-reliability-audit.md
+++ b/.agents/artifacts/2026-08-25/teams-session-reliability-audit.md
@@ -44,7 +44,7 @@ completeness. All 21 discovered launch transcripts were recovered successfully.
 
 ### 1. Fatal-looking bootstrap errors accompany successful launches
 
-Five independent Claude launches, spanning versions 2.1.186, 2.1.217,
+Four independent Claude launches, spanning versions 2.1.186, 2.1.217,
 2.1.218, and 2.1.221, emitted:
 
 > `ERROR: GVM_ROOT not set. Please source $GVM_ROOT/scripts/gvm`


### PR DESCRIPTION
## Summary
- mine 100 days of original Claude, Codex, Grok, Kimi, and Cursor transcripts across the reachable fleet
- de-duplicate forked calls and separate launch operations from help/status diagnostics
- classify the observed teams reliability gaps and propose a P0/P1 stability backlog

## Evidence
- `bun .agents/artifacts/2026-08-25/mine-teams-sessions.ts --output .agents/scratch/verify.json`
- `jq -e ' .windowDays==100 and .launchCalls==21 and .originalTranscriptsRecovered==21 and (.hostFailures|length)==0 ' .agents/scratch/verify.json` returned `true`\n- final indexed selection: 3,906 transcripts / 217,120 tool calls; 21 unique launches; all 21 original bodies recovered\n- `git diff --check` passed\n\n## Coverage caveat\nOne registered host was unreachable, 306 selected transcripts still awaited tool-call backfill, and 106 files were size-limited. The audit explicitly reports 21 as a verified lower bound.\n\nTracking: RUSH-3195