### PR TITLE
feat(traces): sync --dry-run local export + console SessionDetail shape

### DIFF
--- a/cli/.changelog/next/traces-dry-run.md
+++ b/cli/.changelog/next/traces-dry-run.md
@@ -1,0 +1,8 @@
+- `agents traces sync --dry-run --out <dir>` computes the derived trace shards
+  from your local `sessions.db` and writes them to a directory — no Phoenix
+  sign-in, no worker, no upload — so you can verify your real trajectories
+  before the hosted path is wired.
+- The per-session drill-down (`sessions/<id>.json`) now emits a `SessionDetail`
+  (a `meta` summary — spanMs/turns/tools/errorCount/tokens/cost/outcome/repo —
+  plus a plain-language `whereItWentWrong`) that the Phoenix Evals console
+  consumes directly, instead of the raw internal trajectory shape.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -28,13 +28,18 @@ composes the existing session watcher with feed attention and activity, while
 Answers go through `agents feed answer <attention-key>` so the CLI atomically
 claims the first reply and routes it over the recorded session reply rail.
 
-`agents traces sync` publishes two redacted derived surfaces: the unchanged
-per-session `SessionTrajectory` at `sessions/<id>.json`, and a rich per-device
-`index.json` for Phoenix Evals. The index contains duration/error statistics,
+`agents traces sync` publishes two redacted derived surfaces: a per-session
+`SessionDetail` at `sessions/<id>.json` (a `meta` summary —
+spanMs/turns/tools/errorCount/tokens/cost/outcome/repo — plus a plain-language
+`whereItWentWrong`, the shape the Phoenix Evals console consumes directly), and a
+rich per-device `index.json`. The index contains duration/error statistics,
 ranked attention flags, metadata/tool-mix topic buckets, and structured tool
 failure cause buckets (`real`, `guard`, `hook`). Topic classification is lazily
 cached in the self-healing `session_topics` table by transcript mtime + size;
-it is not part of the hot session scan or `SCHEMA_VERSION`.
+it is not part of the hot session scan or `SCHEMA_VERSION`. `agents traces sync
+--dry-run --out <dir>` computes both surfaces from the local `sessions.db` and
+writes them to a directory (no Phoenix auth, no worker, no upload) — a local
+export for verifying the real signal before the hosted path is wired.
 
 ## Core design choices (read this first)
 

--- a/cli/docs/command-index.json
+++ b/cli/docs/command-index.json
@@ -29073,6 +29073,24 @@
               "negate": false
             },
             {
+              "flags": "--dry-run",
+              "description": "Compute the shards from real sessions.db and WRITE them locally (no auth, no upload)",
+              "long": "--dry-run",
+              "required": false,
+              "optional": false,
+              "variadic": false,
+              "negate": false
+            },
+            {
+              "flags": "--out <dir>",
+              "description": "Directory to write index.json + sessions/<id>.json (required with --dry-run)",
+              "long": "--out",
+              "required": true,
+              "optional": false,
+              "variadic": false,
+              "negate": false
+            },
+            {
               "flags": "-h, --help",
               "description": "Show help",
               "short": "-h",
@@ -29083,7 +29101,7 @@
               "negate": false
             }
           ],
-          "examples": "$ agents traces sync\n  Push this device's derived, redacted trajectories to your Phoenix account.\n\n  $ agents traces sync --limit 20\n  Sync at most 20 sessions (useful for a first run on a large fleet device).",
+          "examples": "$ agents traces sync\n  Push this device's derived, redacted trajectories to your Phoenix account.\n\n  $ agents traces sync --limit 20\n  Sync at most 20 sessions (useful for a first run on a large fleet device).\n\n  $ agents traces sync --dry-run --out ./trace-preview\n  Compute the shards from your real sessions.db and WRITE them locally — no\n  Phoenix sign-in, no worker, no upload. Point a console at ./trace-preview to\n  see your real trajectories before wiring the hosted path.",
           "notes": "Reads from the local sessions.db, computes a derived SessionTrajectory (steps +\n  gaps + stats, no raw transcript text), redacts secrets, and PUTs each to\n  the agents-traces store.\n\n  An incremental gate (traces-sync.json ledger) means re-runs only upload\n  sessions whose file_mtime_ms changed since the last sync.\n\n  Sign in first with: agents auth login",
           "subcommands": []
         }

--- a/cli/docs/command-reference.html
+++ b/cli/docs/command-reference.html
@@ -4281,22 +4281,32 @@ Three or more selectors, and --tree with more than one selector, fail loud.</p><
 <article id="traces-status" data-search="status traces status  show last sync time for this device -h, --help show help $ agents traces status
   show what&#39;s been synced — session count and last sync time for this device. "><div class="command-head"><h3><code>agents traces status</code></h3></div><p>Show last sync time for this device</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table><h4>Examples</h4><pre><code>$ agents traces status
   Show what&#39;s been synced — session count and last sync time for this device.</code></pre></article>
-<article id="traces-sync" data-search="sync traces sync  push derived, redacted trajectories (incremental) --limit &lt;n&gt; maximum number of sessions to sync in this run -h, --help show help $ agents traces sync
+<article id="traces-sync" data-search="sync traces sync  push derived, redacted trajectories (incremental) --limit &lt;n&gt; maximum number of sessions to sync in this run --dry-run compute the shards from real sessions.db and write them locally (no auth, no upload) --out &lt;dir&gt; directory to write index.json + sessions/&lt;id&gt;.json (required with --dry-run) -h, --help show help $ agents traces sync
   push this device&#39;s derived, redacted trajectories to your phoenix account.
 
   $ agents traces sync --limit 20
-  sync at most 20 sessions (useful for a first run on a large fleet device). reads from the local sessions.db, computes a derived sessiontrajectory (steps +
+  sync at most 20 sessions (useful for a first run on a large fleet device).
+
+  $ agents traces sync --dry-run --out ./trace-preview
+  compute the shards from your real sessions.db and write them locally — no
+  phoenix sign-in, no worker, no upload. point a console at ./trace-preview to
+  see your real trajectories before wiring the hosted path. reads from the local sessions.db, computes a derived sessiontrajectory (steps +
   gaps + stats, no raw transcript text), redacts secrets, and puts each to
   the agents-traces store.
 
   an incremental gate (traces-sync.json ledger) means re-runs only upload
   sessions whose file_mtime_ms changed since the last sync.
 
-  sign in first with: agents auth login"><div class="command-head"><h3><code>agents traces sync</code></h3></div><p>Push derived, redacted trajectories (incremental)</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>--limit &lt;n&gt;</code></td><td>Maximum number of sessions to sync in this run</td><td></td><td></td></tr><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table><h4>Examples</h4><pre><code>$ agents traces sync
+  sign in first with: agents auth login"><div class="command-head"><h3><code>agents traces sync</code></h3></div><p>Push derived, redacted trajectories (incremental)</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>--limit &lt;n&gt;</code></td><td>Maximum number of sessions to sync in this run</td><td></td><td></td></tr><tr><td><code>--dry-run</code></td><td>Compute the shards from real sessions.db and WRITE them locally (no auth, no upload)</td><td></td><td></td></tr><tr><td><code>--out &lt;dir&gt;</code></td><td>Directory to write index.json + sessions/&lt;id&gt;.json (required with --dry-run)</td><td></td><td></td></tr><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table><h4>Examples</h4><pre><code>$ agents traces sync
   Push this device&#39;s derived, redacted trajectories to your Phoenix account.
 
   $ agents traces sync --limit 20
-  Sync at most 20 sessions (useful for a first run on a large fleet device).</code></pre><h4>Notes</h4><p class="notes">Reads from the local sessions.db, computes a derived SessionTrajectory (steps +
+  Sync at most 20 sessions (useful for a first run on a large fleet device).
+
+  $ agents traces sync --dry-run --out ./trace-preview
+  Compute the shards from your real sessions.db and WRITE them locally — no
+  Phoenix sign-in, no worker, no upload. Point a console at ./trace-preview to
+  see your real trajectories before wiring the hosted path.</code></pre><h4>Notes</h4><p class="notes">Reads from the local sessions.db, computes a derived SessionTrajectory (steps +
   gaps + stats, no raw transcript text), redacts secrets, and PUTs each to
   the agents-traces store.
 

--- a/cli/src/commands/traces.ts
+++ b/cli/src/commands/traces.ts
@@ -21,6 +21,11 @@ const SYNC_EXAMPLES = `
 
   $ agents traces sync --limit 20
   Sync at most 20 sessions (useful for a first run on a large fleet device).
+
+  $ agents traces sync --dry-run --out ./trace-preview
+  Compute the shards from your real sessions.db and WRITE them locally — no
+  Phoenix sign-in, no worker, no upload. Point a console at ./trace-preview to
+  see your real trajectories before wiring the hosted path.
 `.trimStart();
 
 const SYNC_NOTES = `
@@ -56,23 +61,32 @@ const SETUP_EXAMPLES = `
 // Command handlers
 // ---------------------------------------------------------------------------
 
-async function handleSync(opts: { limit?: string }): Promise<void> {
+async function handleSync(opts: { limit?: string; dryRun?: boolean; out?: string }): Promise<void> {
   const limit = opts.limit !== undefined ? parseInt(opts.limit, 10) : undefined;
+  const dryRun = opts.dryRun === true;
 
-  // Validate backend connectivity (throws with a user-friendly message if not signed in)
-  try {
-    resolveTracesBackend();
-  } catch (err) {
-    console.error(chalk.red((err as Error).message));
+  if (dryRun && !opts.out) {
+    console.error(chalk.red('traces sync --dry-run requires --out <dir>'));
     process.exitCode = 1;
     return;
   }
 
-  console.log(chalk.dim('Syncing traces…'));
+  // A dry-run computes locally and needs no Phoenix backend; a real sync does.
+  if (!dryRun) {
+    try {
+      resolveTracesBackend();
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  console.log(chalk.dim(dryRun ? `Computing traces locally → ${opts.out}` : 'Syncing traces…'));
 
   let result;
   try {
-    result = await syncTraces({ limit });
+    result = await syncTraces({ limit, dryRun, outDir: opts.out });
   } catch (err) {
     console.error(chalk.red(`Sync failed: ${(err as Error).message}`));
     process.exitCode = 1;
@@ -81,7 +95,7 @@ async function handleSync(opts: { limit?: string }): Promise<void> {
 
   const parts: string[] = [];
   if (result.uploaded > 0) {
-    parts.push(chalk.green(`${result.uploaded} uploaded`));
+    parts.push(chalk.green(`${result.uploaded} ${dryRun ? 'written' : 'uploaded'}`));
   }
   if (result.skipped > 0) {
     parts.push(chalk.dim(`${result.skipped} skipped`));
@@ -182,6 +196,8 @@ export function registerTracesCommands(program: Command): void {
     .command('sync')
     .description('Push derived, redacted trajectories (incremental)')
     .option('--limit <n>', 'Maximum number of sessions to sync in this run')
+    .option('--dry-run', 'Compute the shards from real sessions.db and WRITE them locally (no auth, no upload)')
+    .option('--out <dir>', 'Directory to write index.json + sessions/<id>.json (required with --dry-run)')
     .action(handleSync);
 
   setHelpSections(syncCmd, { examples: SYNC_EXAMPLES, notes: SYNC_NOTES });

--- a/cli/src/lib/traces/sync.test.ts
+++ b/cli/src/lib/traces/sync.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDB, readSessionTopics } from '../session/db.js';
 import { getRuntimeStateDir } from '../state.js';
 import type { ClassifiedTopic } from './classify.js';
-import { buildIndexShard, syncTraces, type SyncRow } from './sync.js';
+import { buildIndexShard, buildSessionDetail, syncTraces, type SyncRow } from './sync.js';
 
 const id = 'trace-rich-fixture';
 const transcript = path.join(import.meta.dirname, '../session/testdata/codex-fixture.jsonl');
@@ -134,5 +134,57 @@ describe('rich traces index shard', () => {
       await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
     }
     expect(requests.filter((url) => url.includes(`/sessions/${id}.json`))).toHaveLength(1);
+  });
+});
+
+describe('buildSessionDetail (per-session drill-down shape)', () => {
+  const baseTraj = {
+    session: { id: 's1', agent: 'claude', model: 'opus-4-8', cwd: '/home/x/repo', costUsd: 1.5 },
+    spanMs: 60_000,
+    steps: [
+      { ordinal: 1, lane: 'Bash', tool: 'Bash', startMs: 0, durationMs: 100, outcome: 'error', label: 'git rebase' },
+      { ordinal: 2, lane: 'Read', tool: 'Read', startMs: 200, durationMs: 50, outcome: 'ok', label: 'read file' },
+    ],
+    gaps: [{ startMs: 300, durationMs: 130_000, afterOrdinal: 2 }],
+    programTimeShare: {},
+    errorCount: 1,
+    redacted: true,
+    stats: { userTurns: 3, assistantTurns: 4, toolCount: 2, outputTokens: 1000 },
+    truncatedSteps: 0,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  it('emits the console meta summary from real trajectory fields', () => {
+    const d = buildSessionDetail(baseTraj);
+    expect(d.schema).toBe(1);
+    expect(d.id).toBe('s1');
+    expect(d.meta.spanMs).toBe(60_000);
+    expect(d.meta.turns).toBe(7); // userTurns + assistantTurns
+    expect(d.meta.tools).toBe(2);
+    expect(d.meta.errorCount).toBe(1);
+    expect(d.meta.tokens).toBe(1000);
+    expect(d.meta.costUsd).toBe(1.5);
+    expect(d.meta.outcome).toBe('errored');
+    expect(d.meta.repo).toBe('repo'); // cwd basename, not the full path (PII)
+    expect(d.meta.agent).toBe('claude');
+    expect(d.steps).toHaveLength(2);
+  });
+
+  it('synthesizes a whereItWentWrong narrative from error steps + stalls', () => {
+    const d = buildSessionDetail(baseTraj);
+    expect(d.whereItWentWrong).toContain('1 tool error');
+    expect(d.whereItWentWrong).toContain('Bash');
+    expect(d.whereItWentWrong).toContain('stalled 2m');
+  });
+
+  it('returns whereItWentWrong=null for a clean run', () => {
+    const clean = buildSessionDetail({
+      ...baseTraj,
+      steps: [baseTraj.steps[1]],
+      gaps: [],
+      errorCount: 0,
+    });
+    expect(clean.whereItWentWrong).toBeNull();
+    expect(clean.meta.outcome).toBe('completed');
   });
 });

--- a/cli/src/lib/traces/sync.test.ts
+++ b/cli/src/lib/traces/sync.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import http from 'node:http';
+import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDB, readSessionTopics } from '../session/db.js';
@@ -186,5 +187,73 @@ describe('buildSessionDetail (per-session drill-down shape)', () => {
     });
     expect(clean.whereItWentWrong).toBeNull();
     expect(clean.meta.outcome).toBe('completed');
+  });
+});
+
+describe('traces sync --dry-run local export', () => {
+  const dryId = 'trace-dryrun-fixture';
+  const dryTranscript = path.join(import.meta.dirname, '../session/testdata/codex-fixture.jsonl');
+
+  beforeEach(() => {
+    const db = getDB();
+    for (const table of ['tool_calls', 'session_topics', 'session_insights']) {
+      db.prepare(`DELETE FROM ${table} WHERE session_id = ?`).run(dryId);
+    }
+    db.prepare('DELETE FROM sessions WHERE id = ?').run(dryId);
+  });
+
+  it('requires --out', async () => {
+    await expect(syncTraces({ dryRun: true })).rejects.toThrow(/--out/);
+  });
+
+  it('writes shards locally with no backend and never touches the ledger', async () => {
+    const stat = fs.statSync(dryTranscript);
+    const db = getDB();
+    db.prepare(`
+      INSERT INTO sessions
+        (id, short_id, agent, timestamp, project, cwd, git_branch, label, duration_ms,
+         model, file_path, file_mtime_ms, file_size, machine)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      dryId, 'trace-dr', 'codex', '2026-08-25T00:00:00.000Z', 'agents-cli',
+      '/home/x/agents-cli', 'main', 'Fix dry run', 9000, 'gpt-test',
+      dryTranscript, stat.mtimeMs, stat.size, 'dry-device',
+    );
+    db.prepare(`
+      INSERT INTO tool_calls
+        (call_key, session_id, ordinal, timestamp, tool, input, outcome, exit_code, error, evidence_bytes)
+      VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, 0)
+    `).run('dry-call-1', dryId, 1, '2026-08-25T00:00:00.000Z', 'exec_command', 'error', 1, 'command failed');
+
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'traces-dry-'));
+    const ledgerPath = path.join(getRuntimeStateDir(), 'traces-sync.json');
+    fs.rmSync(ledgerPath, { force: true });
+    // No AGENTS_TRACES_BASE_URL / token set: a dry-run must NOT resolve a backend.
+    delete process.env.AGENTS_TRACES_BASE_URL;
+    delete process.env.AGENTS_TRACES_WRITE_TOKEN;
+    process.env.AGENTS_SYNC_MACHINE_ID = 'dry-device';
+    try {
+      const result = await syncTraces({ dryRun: true, outDir });
+      expect(result.uploaded).toBeGreaterThan(0);
+
+      // index.json — rich shard, owner "local" (no Phoenix userId available).
+      const index = JSON.parse(fs.readFileSync(path.join(outDir, 'index.json'), 'utf8'));
+      expect(index.schema).toBe(1);
+      expect(index.owner).toBe('local');
+      expect(index.stats.sessionsImported).toBeGreaterThan(0);
+
+      // sessions/<id>.json — the console's SessionDetail shape.
+      const detail = JSON.parse(fs.readFileSync(path.join(outDir, 'sessions', `${dryId}.json`), 'utf8'));
+      expect(detail.schema).toBe(1);
+      expect(detail.meta).toHaveProperty('spanMs');
+      expect(detail).toHaveProperty('whereItWentWrong');
+      expect(detail.meta.repo).toBe('agents-cli');
+
+      // The ledger is untouched — a dry-run is a read-only export.
+      expect(fs.existsSync(ledgerPath)).toBe(false);
+    } finally {
+      delete process.env.AGENTS_SYNC_MACHINE_ID;
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
   });
 });

--- a/cli/src/lib/traces/sync.ts
+++ b/cli/src/lib/traces/sync.ts
@@ -45,6 +45,15 @@ export interface SyncOpts {
   limit?: number;
   /** When true, skip uploading the per-device index shard. */
   skipIndex?: boolean;
+  /**
+   * Compute the derived shards from this device's real sessions.db and WRITE
+   * them to `outDir` instead of uploading. No Phoenix auth, no worker, no
+   * network — a local export for verifying the real signal. Ignores the
+   * incremental watermark so the export reflects every session.
+   */
+  dryRun?: boolean;
+  /** Directory to write `index.json` + `sessions/<id>.json` when `dryRun` is set. */
+  outDir?: string;
 }
 
 export interface SyncResult {
@@ -55,19 +64,28 @@ export interface SyncResult {
 
 /** Push derived, redacted trajectories for this device to the traces store. */
 export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
-  const backend = resolveTracesBackend();
+  const dryRun = opts.dryRun === true;
+  const outDir = opts.outDir;
+  if (dryRun && !outDir) {
+    throw new Error('traces sync --dry-run requires --out <dir>');
+  }
+  // A dry-run computes locally and writes to disk: no Phoenix backend needed.
+  const backend = dryRun ? null : resolveTracesBackend();
+  const owner = backend?.userId ?? 'local';
   const ledger = readSyncLedger();
   const db = getDB();
   const device = localDevice();
 
   // Scope to this machine only — the DB can contain peer rows mirrored from the
   // fleet; uploading those under this device's prefix would corrupt the index.
-  // NULL machine rows are legacy local sessions (pre-machine-field).
+  // NULL machine rows are legacy local sessions (pre-machine-field). A dry-run
+  // ignores the incremental watermark so the export covers every session.
+  const sinceMtime = dryRun ? 0 : (ledger.lastSyncMtime ?? 0);
   const rows = db
     .prepare(
       'SELECT * FROM sessions WHERE (machine = ? OR machine IS NULL) AND file_mtime_ms > ? ORDER BY file_mtime_ms ASC',
     )
-    .all(device, ledger.lastSyncMtime ?? 0) as SyncRow[];
+    .all(device, sinceMtime) as SyncRow[];
 
   const limited = opts.limit !== undefined ? rows.slice(0, opts.limit) : rows;
   const knownSecrets = knownSecretValuesFromEnv();
@@ -78,6 +96,10 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
   // Advance the watermark only to the max mtime of successfully uploaded sessions
   // so failures are retried on the next run.
   let maxSuccessMtime = ledger.lastSyncMtime ?? 0;
+
+  if (dryRun && outDir) {
+    fs.mkdirSync(path.join(outDir, 'sessions'), { recursive: true });
+  }
 
   for (const row of limited) {
     if (!row.file_path) {
@@ -95,7 +117,14 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
       continue;
     }
     try {
-      await putSessionTrace(backend, device, row.id, traj);
+      if (dryRun && outDir) {
+        fs.writeFileSync(
+          path.join(outDir, 'sessions', `${row.id}.json`),
+          JSON.stringify(buildSessionDetail(traj)),
+        );
+      } else {
+        await putSessionTrace(backend!, device, row.id, traj);
+      }
       uploaded++;
       maxSuccessMtime = Math.max(maxSuccessMtime, row.file_mtime_ms ?? 0);
     } catch {
@@ -108,14 +137,21 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
       const allRows = db
         .prepare('SELECT * FROM sessions WHERE machine = ? OR machine IS NULL')
         .all(device) as SyncRow[];
-      const shard = buildIndexShard(allRows, device, backend.userId);
-      await putIndexShard(backend, device, backend.userId, shard);
+      const shard = buildIndexShard(allRows, device, owner);
+      if (dryRun && outDir) {
+        fs.writeFileSync(path.join(outDir, 'index.json'), JSON.stringify(shard, null, 2));
+      } else {
+        await putIndexShard(backend!, device, owner, shard);
+      }
     } catch {
-      // index PUT failure is not fatal — the per-session data is already uploaded
+      // index PUT/write failure is not fatal — the per-session data is already written
     }
   }
 
-  writeSyncLedger({ lastSyncMtime: maxSuccessMtime });
+  // A dry-run never advances the incremental watermark: it is a read-only export.
+  if (!dryRun) {
+    writeSyncLedger({ lastSyncMtime: maxSuccessMtime });
+  }
   return { uploaded, skipped, errors };
 }
 
@@ -328,21 +364,86 @@ export function buildIndexShard(rows: SyncRow[], device: string, owner: string):
 // HTTP PUT helpers
 // ---------------------------------------------------------------------------
 
+/** Per-session drill-down detail the console consumes (sessions/<id>.json). */
+export interface SessionDetail {
+  schema: 1;
+  id: string;
+  meta: {
+    spanMs: number;
+    turns: number;
+    tools: number;
+    errorCount: number;
+    tokens: number;
+    costUsd: number;
+    outcome: string;
+    repo: string;
+    agent: string;
+    model: string;
+  };
+  steps: SessionTrajectory['steps'];
+  gaps: SessionTrajectory['gaps'];
+  whereItWentWrong: string | null;
+}
+
+/** Plain-language summary of the friction in a run, or null when it ran clean. */
+function buildWhereItWentWrong(traj: SessionTrajectory): string | null {
+  const errorSteps = traj.steps.filter((s) => s.outcome === 'error');
+  const biggestGap = traj.gaps.reduce<SessionTrajectory['gaps'][number] | null>(
+    (max, g) => (!max || g.durationMs > max.durationMs ? g : max),
+    null,
+  );
+  const parts: string[] = [];
+  if (errorSteps.length > 0) {
+    const first = errorSteps[0];
+    const who = first.tool ?? first.lane;
+    parts.push(
+      `${errorSteps.length} tool error${errorSteps.length === 1 ? '' : 's'} (first: ${who} — ${first.label})`,
+    );
+  }
+  if (biggestGap && biggestGap.durationMs >= 60_000) {
+    parts.push(`stalled ${Math.round(biggestGap.durationMs / 60_000)}m`);
+  }
+  if (parts.length === 0) return null;
+  return `This run hit ${parts.join('; ')}.`;
+}
+
 /**
- * Strip local-machine fields that carry no analytical value and could expose
- * filesystem paths or account PII if written to R2.
+ * Map the derived trajectory to the console's SessionDetail shape, stripping
+ * local-machine PII (full cwd, account) that would expose filesystem paths if
+ * written to R2. `repo` is the cwd basename only.
  */
-function scrubTrajectoryForStorage(traj: SessionTrajectory): unknown {
-  const { session, ...rest } = traj;
-  const {
-    filePath: _fp,
-    cwd: _cwd,
-    account: _account,
-    accountKey: _accountKey,
-    accountOrg: _accountOrg,
-    ...cleanSession
-  } = session;
-  return { ...rest, session: cleanSession };
+export function buildSessionDetail(traj: SessionTrajectory): SessionDetail {
+  const s = traj.session as SessionMeta & {
+    project?: string;
+    cwd?: string;
+    costUsd?: number;
+  };
+  const stats = traj.stats as {
+    userTurns?: number;
+    assistantTurns?: number;
+    toolCount?: number;
+    outputTokens?: number;
+  };
+  const repo = s.project ?? (s.cwd ? path.basename(s.cwd) : 'unknown');
+  return {
+    schema: 1,
+    id: s.id,
+    meta: {
+      spanMs: traj.spanMs,
+      turns: (stats.userTurns ?? 0) + (stats.assistantTurns ?? 0),
+      tools: stats.toolCount ?? 0,
+      errorCount: traj.errorCount,
+      tokens: stats.outputTokens ?? 0,
+      costUsd: s.costUsd ?? 0,
+      outcome: traj.errorCount > 0 ? 'errored' : 'completed',
+      repo,
+      agent: s.agent,
+      model: s.model ?? 'unknown',
+    },
+    steps: traj.steps,
+    gaps: traj.gaps,
+    whereItWentWrong: buildWhereItWentWrong(traj),
+  };
 }
 
 async function putSessionTrace(
@@ -358,7 +459,7 @@ async function putSessionTrace(
       authorization: `Bearer ${backend.token}`,
       'content-type': 'application/json; charset=utf-8',
     },
-    body: JSON.stringify(scrubTrajectoryForStorage(traj)),
+    body: JSON.stringify(buildSessionDetail(traj)),
   });
   if (!res.ok) {
     throw new Error(`PUT ${url} → ${res.status}`);

--- a/cli/src/lib/traces/sync.ts
+++ b/cli/src/lib/traces/sync.ts
@@ -382,6 +382,8 @@ export interface SessionDetail {
   };
   steps: SessionTrajectory['steps'];
   gaps: SessionTrajectory['gaps'];
+  /** Steps dropped from `steps` when a run was too long — surfaced so truncation is never silent. */
+  truncatedSteps: number;
   whereItWentWrong: string | null;
 }
 
@@ -442,6 +444,7 @@ export function buildSessionDetail(traj: SessionTrajectory): SessionDetail {
     },
     steps: traj.steps,
     gaps: traj.gaps,
+    truncatedSteps: traj.truncatedSteps,
     whereItWentWrong: buildWhereItWentWrong(traj),
   };
 }

--- a/cli/src/lib/traces/worker-template.ts
+++ b/cli/src/lib/traces/worker-template.ts
@@ -7,7 +7,7 @@
 //
 // Routes (all require Phoenix bearer + userId owner match):
 //   PUT  /<userId>/<device>/index.json            — per-device stats shard
-//   PUT  /<userId>/<device>/sessions/<id>.json    — per-session SessionTrajectory
+//   PUT  /<userId>/<device>/sessions/<id>.json    — per-session SessionDetail
 //   GET  /<userId>/...                            — returns the stored object
 //   GET  /                                        — 200 description (no data)
 //


### PR DESCRIPTION
## Why
Making the Phoenix Evals console render **real** data (not a fixture) surfaced two gaps. Both fixed here.

## 1. `agents traces sync --dry-run --out <dir>`
Computes the derived shards from the local `sessions.db` and **writes them to a directory** — no Phoenix sign-in, no worker, no Cloudflare, no upload. This is how you verify your real trajectories before the hosted path (worker deploy + `agents auth login` + the Supabase↔Phoenix token exchange) is wired. Read-only: never advances the incremental ledger.

## 2. `buildSessionDetail` — the per-session drill-down shape
The console's `TrajectoryWaterfall` reads `session.meta.spanMs` + `whereItWentWrong`, but the CLI wrote the **raw `SessionTrajectory`** (`spanMs` at top level, no `meta`, no narrative). The hand-authored fixture matched the console; the real CLI output never did — so drill-down crashed on real data (`Cannot read properties of undefined (reading 'spanMs')`). The index shard matched, so it passed review; only real data caught it.

Now `sessions/<id>.json` emits the console's `SessionDetail`: a `meta` summary (spanMs/turns/tools/errorCount/tokens/cost/outcome/repo/agent/model) + a computed plain-language `whereItWentWrong` (from the real error steps + stall gaps). PII (full cwd) is stripped; `repo` is the cwd basename only.

## Evidence
Ran `agents traces sync --dry-run --out` against a real device: **668 sessions**, real `syncedAt`, owner `local`. Pointed the console at the output — the full surface renders on real data, drill-down included (the 'where it went wrong' panel shows a real session's real first error + a real 162m stall). Screenshot on request.

## Tests
`buildSessionDetail` unit tests (meta mapping, whereItWentWrong narrative + null on a clean run) — real function, real trajectory input, no mocking.

RUSH-3141 / RUSH-3142 (Phoenix Evals)