### PR TITLE
fix(daemon): out-of-band gather on reader connect, closing RUSH-2484 regression (#3034)

### DIFF
--- a/cli/src/lib/daemon-ticks.ts
+++ b/cli/src/lib/daemon-ticks.ts
@@ -176,10 +176,12 @@ export async function runUsageRefreshTick(): Promise<void> {
  *
  * Gated on reader presence (RUSH-3193): when no `sessions watch` / `feed watch`
  * consumer has checked in within {@link ACTIVE_SESSIONS_READER_IDLE_WINDOW_MS} the
- * expensive `ps`+`lsof` gather is skipped entirely. The moment a watcher
- * connects it calls {@link noteActiveSessionsJournalReader}; the following tick
- * immediately gathers, so consumers always receive fresh rows within one normal
- * tick interval.
+ * expensive `ps`+`lsof` gather is skipped entirely on this scheduled tick. A
+ * watcher connecting to a cold/idle daemon is NOT served by this tick alone —
+ * {@link noteActiveSessionsJournalReader} only writes a presence timestamp, with
+ * no path back to this timer — so the daemon separately runs
+ * {@link watchActiveSessionsReaderPresence} to detect that idle→recent edge and
+ * fire an out-of-band call into this same function immediately (RUSH-2484).
  */
 export async function runActiveSessionsWarmTick(
   opts: { gather?: () => Promise<import('./session/active.js').ActiveSession[]>; nowMs?: number } = {},

--- a/cli/src/lib/daemon/daemon.ts
+++ b/cli/src/lib/daemon/daemon.ts
@@ -34,6 +34,7 @@ import { reapTerminalRoutineProcesses } from '../routine-process-cleanup.js';
 import { recordSubsystemOk, recordSubsystemError, recordSubsystemErrorReason, readSubsystemHealth, SUBSYSTEM_SECRETS_BROKER, SUBSYSTEM_BROWSER_IPC, SUBSYSTEM_DAEMON_START } from '../daemon-health.js';
 import { startAccountStateService } from '../account-state-service.js';
 import { runActiveSessionsWarmTick, runFleetCacheWarmTick, runUsageRefreshTick } from '../daemon-ticks.js';
+import { watchActiveSessionsReaderPresence } from '../session/session-cache.js';
 import { ServiceSupervisor } from './supervisor.js';
 import { SessionIndexService } from './session-index-service.js';
 import type { ServiceHealth } from './service.js';
@@ -1113,7 +1114,10 @@ export async function runDaemon(): Promise<void> {
 
   // Active-sessions publish-own: continuous journal writer for `sessions watch`.
   // Fire once immediately so a cold daemon does not leave watchers on
-  // "awaiting publisher" for a full tick (RUSH-2484).
+  // "awaiting publisher" for a full tick (RUSH-2484). This boot-time fire alone
+  // no-ops on a genuinely cold boot (no reader has connected yet) — the
+  // presence watch below is what actually closes the gap for a watcher that
+  // connects later, whether at cold boot or after the reader-idle window.
   let activeSessionsWarmInFlight = false;
   const runActiveSessionsWarm = async (): Promise<void> => {
     if (activeSessionsWarmInFlight) return;
@@ -1128,6 +1132,13 @@ export async function runDaemon(): Promise<void> {
   };
   void runActiveSessionsWarm();
   const activeSessionsWarmInterval = setInterval(() => { void runActiveSessionsWarm(); }, ACTIVE_SESSIONS_WARM_TICK_MS);
+  // Out-of-band trigger (RUSH-2484): a reader connecting only writes a presence
+  // timestamp (noteActiveSessionsJournalReader in watch.ts) with no path back to
+  // this timer, so on its own the interval above leaves a fresh connection
+  // waiting up to ACTIVE_SESSIONS_WARM_TICK_MS for its first rows. This watches
+  // for the idle->recent edge and gathers immediately instead of waiting for the
+  // next scheduled tick — a genuinely idle box with no reader still never gathers.
+  const stopActiveSessionsReaderWatch = watchActiveSessionsReaderPresence(() => { void runActiveSessionsWarm(); });
 
   // Session-index warm (RUSH-2682): keep THIS host's transcript index current so
   // a locally-started session is discoverable within seconds. Migrated onto
@@ -1555,6 +1566,7 @@ export async function runDaemon(): Promise<void> {
     log('INFO', 'Daemon shutting down');
     accountStateService?.stop();
     clearInterval(activeSessionsWarmInterval);
+    stopActiveSessionsReaderWatch();
     await supervisor.stopAll();
     activeServiceSupervisor = null;
     if (watchdogInterval) clearInterval(watchdogInterval);

--- a/cli/src/lib/session/remote/watch.ts
+++ b/cli/src/lib/session/remote/watch.ts
@@ -159,6 +159,10 @@ export async function watchLocalSessions(options: WatchLocalOptions): Promise<vo
   try { offset = fs.statSync(journal).size; } catch { /* first publication */ }
   const initial = readCache('local');
   options.emit(state.reset(options.scope, initial?.sessions ?? []));
+  // Known gap (out of scope for RUSH-2484): a present cache alone marks
+  // 'available' with no staleness/age check, so a reconnect can briefly render
+  // a stale snapshot as live before the out-of-band gather this file triggers
+  // (see watchActiveSessionsReaderPresence in session-cache.ts) replaces it.
   options.emit(state.scope(options.scope, initial ? 'available' : 'unavailable', initial ? undefined : 'awaiting publisher'));
   if (options.signal.aborted) return;
   // Signal the daemon that a consumer is live so it does not skip the gather.

--- a/cli/src/lib/session/session-cache.test.ts
+++ b/cli/src/lib/session/session-cache.test.ts
@@ -6,7 +6,7 @@
  * without SSH / process-table cost; the critical path under test is the
  * freshness/staleness + immutable-memo contract.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -21,15 +21,18 @@ import {
   isActiveSnapshotFresh,
   loadFleetActiveSessions,
   loadLocalActiveSessions,
+  noteActiveSessionsJournalReader,
   pickImmutableFields,
   publishLocalActiveSessions,
   readActiveSessionsCache,
   readImmutableMemo,
+  setActiveSessionsReaderPresencePathForTest,
   setActiveSessionsSnapshotPathForTest,
   setImmutableMemoPathForTest,
   stripLiveStatusKeys,
   transcriptMtimeMs,
   updateImmutableMemos,
+  watchActiveSessionsReaderPresence,
   writeActiveSessionsCache,
   writeImmutableMemo,
 } from './session-cache.js';
@@ -371,5 +374,94 @@ describe('immutable memo — mtime-keyed, never carries live status', () => {
     expect(transcriptMtimeMs(session({ sessionId: 'x', lastActivityMs: 9, startedAtMs: 1 }))).toBe(9);
     expect(transcriptMtimeMs(session({ sessionId: 'x', startedAtMs: 3 }))).toBe(3);
     expect(transcriptMtimeMs(session({ sessionId: 'x' }))).toBeNull();
+  });
+});
+
+describe('watchActiveSessionsReaderPresence — out-of-band trigger on reader connect (RUSH-2484)', () => {
+  // Real defect this closes: noteActiveSessionsJournalReader() (called by
+  // watchLocalSessions on connect) ONLY writes a timestamp file — it has no
+  // path back into the daemon process that owns the 15s warm-tick
+  // setInterval. A watcher connecting to a cold/idle daemon used to sit on
+  // "awaiting publisher" for up to a full ACTIVE_SESSIONS_WARM_TICK_MS (15s).
+  // These tests drive real setInterval-based scheduling via fake timers and
+  // assert the callback fires from the poll noticing the presence-file edge —
+  // never from a second, manually-invoked call to the tick function.
+  const ACTIVE_SESSIONS_WARM_TICK_MS = 15_000;
+  let dir: string;
+  let prevPresence: string | null;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'reader-presence-'));
+    prevPresence = setActiveSessionsReaderPresencePathForTest(path.join(dir, 'reader.presence'));
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setActiveSessionsReaderPresencePathForTest(prevPresence);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('never fires while idle, then fires on the very next poll after a reader connects', () => {
+    let connects = 0;
+    const stop = watchActiveSessionsReaderPresence(() => { connects++; }, { pollMs: 100 });
+
+    // Cold daemon, no reader: several polls pass with zero connects — proves
+    // the poll itself is not what triggers a gather.
+    vi.advanceTimersByTime(2_000);
+    expect(connects).toBe(0);
+
+    // A watcher connects. This mirrors watch.ts:165 exactly: it only writes
+    // a presence timestamp, nothing more.
+    noteActiveSessionsJournalReader();
+
+    // The idle->recent edge is caught on the very next 100ms poll — far
+    // short of the 15s scheduled warm-tick a watcher used to wait on.
+    vi.advanceTimersByTime(100);
+    expect(connects).toBe(1);
+    expect(100).toBeLessThan(ACTIVE_SESSIONS_WARM_TICK_MS);
+
+    stop();
+  });
+
+  it('does not re-fire on repeated heartbeats from an already-connected reader', () => {
+    let connects = 0;
+    const stop = watchActiveSessionsReaderPresence(() => { connects++; }, { pollMs: 100 });
+
+    noteActiveSessionsJournalReader();
+    vi.advanceTimersByTime(100);
+    expect(connects).toBe(1);
+
+    // Simulate the watcher's periodic heartbeat re-noting presence (watch.ts's
+    // heartbeatTimer) — must not trigger a second out-of-band gather per beat.
+    for (let i = 0; i < 5; i++) {
+      noteActiveSessionsJournalReader();
+      vi.advanceTimersByTime(100);
+    }
+    expect(connects).toBe(1);
+
+    stop();
+  });
+
+  it('re-fires after the reader goes idle and a fresh watcher reconnects', () => {
+    let connects = 0;
+    const stop = watchActiveSessionsReaderPresence(() => { connects++; }, { pollMs: 100, idleWindowMs: 500 });
+
+    noteActiveSessionsJournalReader();
+    vi.advanceTimersByTime(100);
+    expect(connects).toBe(1);
+
+    // Reader disconnects — no further presence writes — and ages past the
+    // idle window with no reconnect yet.
+    vi.advanceTimersByTime(600);
+    expect(connects).toBe(1);
+
+    // A new watcher connects to what is now, from the daemon's view, an idle
+    // box — exactly the reconnect-after-idle case the fix targets.
+    noteActiveSessionsJournalReader();
+    vi.advanceTimersByTime(100);
+    expect(connects).toBe(2);
+
+    stop();
   });
 });

--- a/cli/src/lib/session/session-cache.ts
+++ b/cli/src/lib/session/session-cache.ts
@@ -276,6 +276,41 @@ export function isActiveSessionsJournalReaderRecent(
   }
 }
 
+/** Default poll cadence for {@link watchActiveSessionsReaderPresence}. */
+export const ACTIVE_SESSIONS_READER_TRANSITION_POLL_MS = 1_000;
+
+/**
+ * Watch for a reader going from absent/idle to present and fire `onConnect`
+ * out of band, instead of waiting for the next scheduled warm tick (RUSH-2484).
+ *
+ * {@link noteActiveSessionsJournalReader} only writes a timestamp — it has no
+ * path back to the daemon process that owns the warm tick's `setInterval`. A
+ * watcher connecting to a cold or long-idle daemon therefore used to wait up
+ * to one full {@link ACTIVE_SESSIONS_WARM_TICK_MS} tick for its first fresh
+ * rows. This polls the tiny presence file (not the expensive `ps`+`lsof`
+ * gather) at {@link ACTIVE_SESSIONS_READER_TRANSITION_POLL_MS} and calls
+ * `onConnect` only on the idle→recent edge, so a steadily-connected reader's
+ * repeated heartbeats never re-trigger it and an idle box with no reader never
+ * gathers — the CPU win from RUSH-3193 is preserved.
+ *
+ * Returns a disposer that stops the poll.
+ */
+export function watchActiveSessionsReaderPresence(
+  onConnect: () => void,
+  opts: { pollMs?: number; idleWindowMs?: number; nowMs?: () => number } = {},
+): () => void {
+  const pollMs = opts.pollMs ?? ACTIVE_SESSIONS_READER_TRANSITION_POLL_MS;
+  const now = opts.nowMs ?? Date.now;
+  let lastRecent = isActiveSessionsJournalReaderRecent(now(), opts.idleWindowMs);
+  const timer = setInterval(() => {
+    const recent = isActiveSessionsJournalReaderRecent(now(), opts.idleWindowMs);
+    if (recent && !lastRecent) onConnect();
+    lastRecent = recent;
+  }, pollMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
+
 // ── snapshot read / write ──────────────────────────────────────────────────
 
 /** Read one scope from the snapshot file (best-effort; missing/corrupt → null). */


### PR DESCRIPTION
## Summary

#3034 (RUSH-3193 quick win) gated the active-sessions warm tick on journal-reader presence so an idle box skips the expensive `ps`+`lsof` gather — the CPU win. But it reintroduced the RUSH-2484 latency bug: `noteActiveSessionsJournalReader()` ([`watch.ts:165`](cli/src/lib/session/remote/watch.ts)) only ever writes a presence timestamp, with **no path back** to the daemon's `ACTIVE_SESSIONS_WARM_TICK_MS = 15_000` `setInterval` ([`daemon.ts:157`](cli/src/lib/daemon/daemon.ts)). So a watcher connecting to a cold or long-idle daemon silently waited up to a full 15s tick for its first rows — exactly what the boot-time immediate fire (`daemon.ts:~1116`) exists to prevent, but that fire itself no-ops on a genuinely cold boot since no presence file exists yet.

## Fix

- `watchActiveSessionsReaderPresence` (new, `cli/src/lib/session/session-cache.ts`) polls the tiny presence file at 1s and fires an immediate out-of-band gather **only** on the idle→recent edge — a reader's repeated heartbeats don't re-trigger it, and a genuinely idle box with no reader never gathers (the RUSH-3193 CPU win stays intact).
- `daemon.ts` wires this alongside the existing warm-tick `setInterval`, and stops it on shutdown.
- Corrected the stale doc comment in `daemon-ticks.ts` that claimed "the following tick immediately gathers" — that was never true; there was no mechanism connecting presence writes to the timer until this PR.
- Left a code comment at `watch.ts:161` noting the known (out-of-scope) gap flagged in review: `watchLocalSessions` marks `'available'` on cache presence alone, with no staleness/age check on a stale reconnect snapshot.

## Test plan

- [x] New test in `cli/src/lib/session/session-cache.test.ts` — `watchActiveSessionsReaderPresence — out-of-band trigger on reader connect (RUSH-2484)` — drives real `setInterval`-based scheduling via `vi.useFakeTimers()` and proves the callback fires **from the poll itself noticing the presence-file edge**, not from a second manually-invoked tick call (the prior fix's test did the latter and didn't actually prove the fix, per the re-review). Key assertion:
  ```ts
  vi.advanceTimersByTime(2_000);          // idle, no reader — proves the poll alone never fires
  expect(connects).toBe(0);
  noteActiveSessionsJournalReader();       // watcher connects — only writes a timestamp
  vi.advanceTimersByTime(100);             // next 100ms poll picks it up out of band
  expect(connects).toBe(1);
  expect(100).toBeLessThan(ACTIVE_SESSIONS_WARM_TICK_MS); // far short of the old 15s wait
  ```
  Also covers: no re-fire on repeated heartbeats from an already-connected reader, and re-fire after the reader goes idle and a fresh watcher reconnects.
- [x] `bun run test -- session-cache daemon-ticks` — 40/40 passed locally.
- [x] `bun run test -- daemon.supervisor-wiring` — 2/2 passed locally.
- [x] `npx tsc --noEmit` — clean.
- [x] Offloaded full suite via `scripts/test.sh --device mark-1` (per repo convention — never run the full ~13k-test suite on an interactive box).

Closes the regression from #3034; references RUSH-2484.