### PR TITLE
fix(view): align Claude usage windows

### DIFF
--- a/cli/.changelog/next/RUSH-2406.md
+++ b/cli/.changelog/next/RUSH-2406.md
@@ -1,0 +1,1 @@
+fix(view): keep Claude session/week quota slots aligned, render omitted windows as unavailable, and show only the unlabeled last-active timestamp

--- a/cli/docs/credential-management.md
+++ b/cli/docs/credential-management.md
@@ -76,6 +76,19 @@ Both come from the same mistake: **agents-cli touching the interactive login.**
    `agents view` reads those snapshots. A headless account that has not produced
    a native snapshot still renders `usage unavailable (headless)`.
 
+   **Claude is event-fed, not polled.** The managed Claude settings command is
+   `agents __claude-statusline`. Resource sync merges that command into each
+   version home's existing `settings.json`, preserving every other setting and
+   delegating a prior custom status-line command. Claude Code invokes it with
+   `rate_limits` only after a real inference response; launching Claude without
+   receiving a response can therefore show host/model while leaving quota
+   unchanged. The five-hour and seven-day fields may arrive independently, so
+   ingestion merges each window into the last snapshot instead of replacing the
+   other one. `agents view claude` always reserves both `S` and `W` slots: a
+   provider-omitted window is a filled red unavailable bar, distinct from a real
+   zero-percent window. Do not restore `/api/oauth/usage` polling or read/copy the
+   interactive OAuth credential to fill these bars.
+
 6. **Zero Touch ID** — `ag view`, agent launch, usage, any op — across **every
    harness**, including the hard ones (Droid, Kimi). Solution decided per credential
    *type*, not per agent name.
@@ -178,6 +191,10 @@ deliberately created with `agents accounts add` and explicitly pushed with
   named account bundle. Neither path reads the harness's ACL-bound keychain login.
   No no-ACL cache of the interactive token is needed because the interactive
   token is never read.
+  Claude's human row ends with one unlabeled last-active timestamp. Auth-health
+  remains available in `--json` for machine consumers; it is not rendered as a
+  second timestamp beside usage because that probe age is neither activity age
+  nor usage-capture age.
   When Anthropic returns 403 `user:profile` on that token, the probe sets
   `reason: 'usage_scope'` so auth-health stays `unverified` (not `revoked`) and
   the row shows `usage unavailable (headless)` (RUSH-2392).

--- a/cli/docs/credential-management.md
+++ b/cli/docs/credential-management.md
@@ -85,7 +85,7 @@ Both come from the same mistake: **agents-cli touching the interactive login.**
    unchanged. The five-hour and seven-day fields may arrive independently, so
    ingestion merges each window into the last snapshot instead of replacing the
    other one. `agents view claude` always reserves both `S` and `W` slots: a
-   provider-omitted window is a filled red unavailable bar, distinct from a real
+   provider-omitted window is a filled red `unavailable` slot, distinct from a real
    zero-percent window. Do not restore `/api/oauth/usage` polling or read/copy the
    interactive OAuth credential to fill these bars.
 

--- a/cli/docs/observability.md
+++ b/cli/docs/observability.md
@@ -1450,9 +1450,14 @@ a stable per-account key:
   is **local-only, no network**. It reads each agent's on-disk credential and
   surfaces an email when one is readable, else a stable account id, else a bare
   `signed in`.
-- **Usage bars** — a separate network pass ([`src/lib/accounting/usage.ts`](../src/lib/accounting/usage.ts))
-  fetches live quota and renders `S:`/`W:`/`M:` bars + plan, according to each
-  provider's reported window duration. It's **stale-while-revalidate**
+- **Usage bars** — provider collectors ([`src/lib/accounting/usage.ts`](../src/lib/accounting/usage.ts))
+  normalize quota and render `S:`/`W:`/`M:` bars + plan. Network-capable
+  providers use a separate live pass. Claude is the deliberate exception:
+  Claude Code sends native five-hour/seven-day `rate_limits` to the managed
+  `agents __claude-statusline` command after an inference response, and the
+  command merges whichever windows were present into the per-account cache.
+  No Claude interactive token, refresh token, Keychain item, or
+  `/api/oauth/usage` poll is involved. The cache is **stale-while-revalidate**
   (on-disk cache under `~/.agents/.cache/`, keyed per account: 2-min fresh, 24-h
   block) so `agents view` stays off the network on the hot path.
 - **Routing reads the same cache, CACHE-ONLY — never on the hot path's network
@@ -1509,7 +1514,7 @@ contains — this is a data-availability limit, not a policy choice:
 
 | Agent | Account column | Usage bars | How it's derived |
 |---|---|---|---|
-| Claude | email + plan | live (`api.anthropic.com`) | email/plan/quota from the local OAuth credential + usage API |
+| Claude | email + plan | event-fed (native status-line payload) | identity from the version home; quota from Claude Code's post-response `rate_limits`. Missing `S`/`W` fields merge with the last snapshot and render as fixed red unavailable slots when no value has ever arrived. |
 | Codex | email + plan | last-seen (session logs) | email/plan from the auth JWT; quota parsed from the newest session's rate-limit event |
 | Gemini | email | — | email read from the local auth file |
 | Grok | email + tier | last-seen (`~/.grok/logs/unified.jsonl`) | email from the local auth file; weekly window (`W`) + subscription tier parsed from the newest `billing: fetched credits config` log line, since Grok's network usage endpoints 404 |

--- a/cli/src/commands/view.account.test.ts
+++ b/cli/src/commands/view.account.test.ts
@@ -21,9 +21,7 @@ import {
 import { padToWidth, stringWidth } from '../lib/session/width.js';
 
 describe('joinViewColumns — fixed multi-agent layout', () => {
-  it('keeps the auth chip at the same column when status is empty', () => {
-    // The multi-agent misalignment bug: skipping empty status mid-row shifted
-    // lastActive/auth left. Fixed columns pad empties so gutters match.
+  it('keeps the unlabeled last-active timestamp aligned when status is empty', () => {
     const wVer = 18;
     const wModel = 8;
     const wEmail = 10;
@@ -38,7 +36,6 @@ describe('joinViewColumns — fixed multi-agent layout', () => {
       usage: string,
       status: string,
       active: string,
-      auth: string,
     ) =>
       joinViewColumns([
         padToWidth(ver, wVer),
@@ -47,7 +44,6 @@ describe('joinViewColumns — fixed multi-agent layout', () => {
         padToWidth(usage, wUsage),
         padToWidth(status, wStatus),
         padToWidth(active, wActive),
-        auth,
       ]);
 
     const rateLimited = row(
@@ -56,8 +52,7 @@ describe('joinViewColumns — fixed multi-agent layout', () => {
       'a@x.com',
       'Max  S: 100%',
       'rate-limited',
-      'active 8h ago',
-      '○ auth 1m ago',
+      '8h ago',
     );
     const healthy = row(
       '2.1.219',
@@ -65,16 +60,11 @@ describe('joinViewColumns — fixed multi-agent layout', () => {
       'b@y.com',
       'Max  S: 5%',
       '',
-      'active 2m ago',
-      '● auth 1m ago',
+      '2m ago',
     );
-
-    const authAt = (line: string): number => {
-      const m = line.match(/[●○◐]/);
-      return m?.index ?? -1;
-    };
-    expect(authAt(rateLimited)).toBeGreaterThan(0);
-    expect(authAt(healthy)).toBe(authAt(rateLimited));
+    expect(rateLimited.indexOf('8h ago')).toBe(healthy.indexOf('2m ago'));
+    expect(rateLimited).not.toContain('auth');
+    expect(healthy).not.toContain('auth');
     // Both rows stay within a sane terminal width after the overview meter cap.
     expect(stringWidth(rateLimited)).toBeLessThanOrEqual(120);
     expect(stringWidth(healthy)).toBe(stringWidth(rateLimited));

--- a/cli/src/commands/view.ts
+++ b/cli/src/commands/view.ts
@@ -31,7 +31,7 @@ import type { AccountInfo, CliState } from '../lib/agents.js';
 import { ambientClaudeToken, loginHint } from '../lib/signin-badge.js';
 import type { AgentId } from '../lib/types.js';
 import { machineId } from '../lib/machine-id.js';
-import { authCacheKey, formatCheckedAge, readAuthHealthCache, type AuthHealth } from '../lib/auth-health.js';
+import { authCacheKey, readAuthHealthCache } from '../lib/auth-health.js';
 import {
   agentReportsUsage,
   classifyUsageErrorKind,
@@ -104,6 +104,9 @@ export function viewUsageSummaryOptions(
     unverified: !headless && !!usageInfo?.snapshot && !!usageInfo.error,
     headless,
     maxWindows,
+    expectedWindows: agentId === 'claude'
+      ? [{ key: 'session', shortLabel: 'S' }, { key: 'week', shortLabel: 'W' }]
+      : undefined,
     errorKind: classifyUsageErrorKind(usageInfo?.error),
     errorDetail: usageInfo?.error ?? null,
     benignState,
@@ -166,9 +169,6 @@ export function compareAccountOrderedVersions(
  * views leave the cap unset and show every blocking window.
  */
 const OVERVIEW_MAX_USAGE_WINDOWS = 2;
-
-/** Fixed width for the last-active column ("active just now", "active 8h ago"). */
-const LAST_ACTIVE_COL_WIDTH = 18;
 
 /**
  * Join fixed view columns with a consistent two-space gutter. Empty trailing
@@ -413,22 +413,6 @@ function renderHostClisSection(cwd: string): void {
   }
 }
 
-/**
- * A compact live-auth chip for a version row, read from the fleet auth-health
- * cache (written by `agents fleet ping` / the daemon). Empty when the install
- * hasn't been probed — this is the local "signed in" flag's ground-truth
- * companion: ● live, ○ revoked (re-login), ◐ unverified/limited, plus its age.
- */
-function liveAuthChip(cache: Record<string, AuthHealth>, host: string, agentId: AgentId, version: string): string {
-  const h = cache[authCacheKey(host, agentId, version)];
-  if (!h) return '';
-  const glyph = h.verdict === 'live' ? chalk.green('●')
-    : h.verdict === 'revoked' ? chalk.red('○')
-    : h.verdict === 'expired' ? chalk.yellow('○')
-    : chalk.yellow('◐');
-  return `${glyph} ${chalk.gray(`auth ${formatCheckedAge(h.checkedAt)}`)}`;
-}
-
 async function showInstalledVersions(
   filterAgentId?: AgentId,
   viewOpts?: { forceRefresh?: boolean },
@@ -491,10 +475,6 @@ async function showInstalledVersions(
     }
   }
   // Shim healing is silent — users don't need to know about internal repairs
-
-  const selfHost = machineId();
-  // Read the auth-health cache once (not per version row — see the batching note above).
-  const authCache = readAuthHealthCache();
 
   // Pre-fetch account info for all versions in parallel. Spinner stays up through
   // account + usage so a multi-account cold path doesn't leave a blank terminal
@@ -753,7 +733,7 @@ async function showInstalledVersions(
         // Only show lastActive for versions with an actual logged-in account.
         // Otherwise it reflects install time (misleading "just now" for fresh installs).
         const lastActive = vInfo && hasEmail ? formatLastActive(vInfo.lastActive) : '';
-        const activeStr = lastActive ? `active ${lastActive}` : '';
+        const activeStr = lastActive;
         const hasActive = activeStr.length > 0;
         // The model now has its own column above; keep only the run mode here.
         const runDefaults = resolveRunDefaults(agentId, version);
@@ -790,15 +770,11 @@ async function showInstalledVersions(
             const statusStr = formatUsageStatusBadge(vInfo?.usageStatus);
             parts.push(padToWidth(statusStr, maxStatusWidth));
           }
-          // Fixed-width lastActive so the auth chip (●/○/◐) lines up even when
-          // some rows have no email-derived lastActive.
-          parts.push(hasActive ? padToWidth(activeStr, LAST_ACTIVE_COL_WIDTH) : ' '.repeat(LAST_ACTIVE_COL_WIDTH));
+          if (hasActive) parts.push(activeStr);
         }
         if (runDefaultBits.length > 0) {
           parts.push(chalk.gray(`run ${runDefaultBits.join(' ')}`));
         }
-        const authChip = liveAuthChip(authCache, selfHost, agentId, version);
-        if (authChip) parts.push(authChip);
 
         console.log(joinViewColumns(parts));
         if (showPaths) {
@@ -898,7 +874,7 @@ async function showInstalledVersions(
         viewUsageSummaryOptions(agentId, !!gInfo?.signedIn, gUsage, usageWindowCap),
       );
       const gLastActive = gInfo ? formatLastActive(gInfo.lastActive) : '';
-      const gActiveStr = gLastActive ? `active ${gLastActive}` : '';
+      const gActiveStr = gLastActive;
       if (gInfo?.email || gUsageStr || gActiveStr || gInfo?.signedIn) {
         const gDisplay = accountColumnLabel(gInfo);
         parts.push(gDisplay ? chalk.cyan(padToWidth(gDisplay, gMaxEmail)) : ' '.repeat(gMaxEmail));
@@ -907,7 +883,7 @@ async function showInstalledVersions(
       if (gMaxStatusWidth > 0) {
         parts.push(padToWidth(formatUsageStatusBadge(gInfo?.usageStatus), gMaxStatusWidth));
       }
-      if (gActiveStr) parts.push(padToWidth(gActiveStr, LAST_ACTIVE_COL_WIDTH));
+      if (gActiveStr) parts.push(gActiveStr);
       console.log(joinViewColumns(parts));
       if (showPaths && cliState?.path) {
         console.log(chalk.gray(`      ${cliState.path}`));

--- a/cli/src/lib/accounting/usage.test.ts
+++ b/cli/src/lib/accounting/usage.test.ts
@@ -750,6 +750,44 @@ describe('formatUsageSummary marks bars the live read could not confirm', () => 
   });
 });
 
+describe('formatUsageSummary expected window slots', () => {
+  const expectedWindows = [
+    { key: 'session', shortLabel: 'S' },
+    { key: 'week', shortLabel: 'W' },
+  ];
+  const base = {
+    source: 'cache' as const,
+    sourceLabel: 'cached',
+    capturedAt: new Date(NOW),
+  };
+
+  it('renders a red missing session slot and keeps the week column aligned', () => {
+    const weekOnly = formatUsageSummary(null, {
+      ...base,
+      windows: [{ key: 'week' as const, label: 'Week', shortLabel: 'W', usedPercent: 81, resetsAt: null, windowMinutes: 10080 }],
+    }, 3, { expectedWindows });
+    const both = formatUsageSummary(null, {
+      ...base,
+      windows: [
+        { key: 'session' as const, label: 'Session', shortLabel: 'S', usedPercent: 12, resetsAt: null, windowMinutes: 300 },
+        { key: 'week' as const, label: 'Week', shortLabel: 'W', usedPercent: 38, resetsAt: null, windowMinutes: 10080 },
+      ],
+    }, 3, { expectedWindows });
+
+    expect(weekOnly).toContain('S: █████ --');
+    expect(weekOnly.indexOf('W:')).toBe(both.indexOf('W:'));
+  });
+
+  it('distinguishes a real zero-percent window from a missing window', () => {
+    const rendered = formatUsageSummary(null, {
+      ...base,
+      windows: [{ key: 'session' as const, label: 'Session', shortLabel: 'S', usedPercent: 0, resetsAt: null, windowMinutes: 300 }],
+    }, 3, { expectedWindows });
+    expect(rendered).toContain('S: ░░░░░ 0%');
+    expect(rendered).toContain('W: █████ --');
+  });
+});
+
 describe('shared network usage failure classification', () => {
   let dir: string;
   let prevPath: string | null;

--- a/cli/src/lib/accounting/usage.test.ts
+++ b/cli/src/lib/accounting/usage.test.ts
@@ -774,7 +774,7 @@ describe('formatUsageSummary expected window slots', () => {
       ],
     }, 3, { expectedWindows });
 
-    expect(weekOnly).toContain('S: █████ --');
+    expect(weekOnly).toContain('S: █████ unavailable');
     expect(weekOnly.indexOf('W:')).toBe(both.indexOf('W:'));
   });
 
@@ -784,7 +784,7 @@ describe('formatUsageSummary expected window slots', () => {
       windows: [{ key: 'session' as const, label: 'Session', shortLabel: 'S', usedPercent: 0, resetsAt: null, windowMinutes: 300 }],
     }, 3, { expectedWindows });
     expect(rendered).toContain('S: ░░░░░ 0%');
-    expect(rendered).toContain('W: █████ --');
+    expect(rendered).toContain('W: █████ unavailable');
   });
 });
 

--- a/cli/src/lib/accounting/usage.ts
+++ b/cli/src/lib/accounting/usage.ts
@@ -829,7 +829,7 @@ export function formatUsageSummary(
       : selected.map((window) => ({ window, shortLabel: window.shortLabel }));
     const windowParts = windowsToRender.map(({ window, shortLabel }, index) => {
       if (!window) {
-        const missing = chalk.red(`${shortLabel}: ${FULL.repeat(COMPACT_BAR_LEN)} --`);
+        const missing = chalk.red(`${shortLabel}: ${FULL.repeat(COMPACT_BAR_LEN)} unavailable`);
         return index < windowsToRender.length - 1 ? padToWidth(missing, 20) : missing;
       }
       const bar = renderCompactUsageBar(window.usedPercent);

--- a/cli/src/lib/accounting/usage.ts
+++ b/cli/src/lib/accounting/usage.ts
@@ -37,6 +37,7 @@ import type { AgentId } from '../types.js';
 import { mapBounded } from '../concurrency.js';
 import { atomicWriteFileSync, ensureLockTarget, withFileLock } from '../fs-atomic.js';
 import { withRefreshLease } from '../refresh-coordinator.js';
+import { padToWidth } from '../session/width.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -740,6 +741,8 @@ export interface FormatUsageSummaryOpts {
    * column width; single-agent and detail views leave this unset.
    */
   maxWindows?: number;
+  /** Windows that must keep a visible slot even when the provider omits one. */
+  expectedWindows?: Array<{ key: string; shortLabel: string }>;
   /**
    * The classified cause of `usageInfo.error` (RUSH-3040), from
    * {@link classifyUsageErrorKind}. Lets the no-bars branch below name the
@@ -820,11 +823,20 @@ export function formatUsageSummary(
       0,
       snapshot.windows.filter((w) => w.key !== 'sonnet_week').length - selected.length,
     );
-    const windowParts = selected.map((window) => {
+    const expected = opts?.expectedWindows;
+    const windowsToRender = expected
+      ? expected.map(({ key, shortLabel }) => ({ window: selected.find((item) => item.key === key), shortLabel }))
+      : selected.map((window) => ({ window, shortLabel: window.shortLabel }));
+    const windowParts = windowsToRender.map(({ window, shortLabel }, index) => {
+      if (!window) {
+        const missing = chalk.red(`${shortLabel}: ${FULL.repeat(COMPACT_BAR_LEN)} --`);
+        return index < windowsToRender.length - 1 ? padToWidth(missing, 20) : missing;
+      }
       const bar = renderCompactUsageBar(window.usedPercent);
       const pct = colorUsage(`${Math.round(window.usedPercent)}%`, window.usedPercent);
       const reset = window.resetsAt ? chalk.dim(` (${formatResetHint(window.resetsAt)})`) : '';
-      return `${chalk.gray(`${window.shortLabel}:`)} ${bar} ${pct}${reset}`;
+      const rendered = `${chalk.gray(`${shortLabel}:`)} ${bar} ${pct}${reset}`;
+      return index < windowsToRender.length - 1 ? padToWidth(rendered, 20) : rendered;
     });
     if (hidden > 0) {
       windowParts.push(chalk.dim(`+${hidden}`));


### PR DESCRIPTION
## Outcome
- reserves fixed S/W slots for Claude usage and renders omitted native windows as a solid red `unavailable` slot
- removes the redundant human auth-probe column and leaves one unlabeled last-active timestamp
- documents the native post-response status-line mechanism and forbids reverting to interactive-token or `/api/oauth/usage` polling

## Verification
- `scripts/test.sh --device yosemite-m1 -- src/commands/view.account.test.ts src/lib/accounting/usage.test.ts` — 112 passed
- installed with `scripts/install.sh --skip-tests`
- live `agents-dev view claude` shows red `S: █████ unavailable`, aligned W columns, and one bare activity timestamp across all nine installed Claude versions

Tracking: RUSH-2406