### PR TITLE
fix(sync): reconcile system-layer plugins on a system-scoped sync (RUSH-3207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **`agents sync <agent> system` now reconciles system-layer plugins (RUSH-3207).**
+  `resourceSourceMap` hardcoded every plugin's source layer to `'user'`, so a
+  `system:*` selection expanded to zero plugins and a `system`-scoped sync silently
+  skipped system-layer plugins (like the `swarm` plugin). A merged plugin change never
+  reached installed agents via `agents sync <agent> system`, and `agents plugins list`
+  still reported "Synced: everywhere" because the synced-status check is existence-only.
+  Plugins are now attributed to the layer they actually resolve from (system / user /
+  project / extra), the same first-wins resolution the plugins staleness checker uses,
+  so a `system` sync includes system-layer plugins and the existing content fingerprint
+  reinstalls them when their content changed even if the manifest version did not.
+
 - **Balanced rotation no longer pins every launch to one account when the usage
   refresher is throttled (RUSH-2858).** `preferVerified` narrowed the candidate
   pool to accounts with a <5-minute usage snapshot before the weighted-random

--- a/cli/src/lib/installations/versions.test.ts
+++ b/cli/src/lib/installations/versions.test.ts
@@ -1657,3 +1657,26 @@ describe('removeVersion — default reassignment when removing the pinned defaul
     expect(defaultAfter).toBe(null);
   });
 });
+
+describe('system-scoped selection includes system-layer plugins (RUSH-3207)', () => {
+  it('a `system` repo scope selects a system-layer plugin and excludes a user-layer one', () => {
+    const home = makeTempHome();
+    // One plugin in the system layer (~/.agents/.system/plugins), like `swarm`, and one
+    // in the user layer (~/.agents/plugins). A valid name+version manifest is all
+    // discoverPlugins needs to see them.
+    for (const [rel, name] of [['.system/plugins', 'swarm'], ['plugins', 'mine']] as const) {
+      const dir = path.join(home, '.agents', ...rel.split('/'), name, '.claude-plugin');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'plugin.json'), JSON.stringify({ name, version: '0.0.0' }));
+    }
+    const result = runVersionSync(
+      home,
+      `buildRepoScopedSelection('system', ${JSON.stringify(home)})`,
+    ) as { plugins?: string[] };
+    // Before the fix, resourceSourceMap hardcoded every plugin to the 'user' layer, so
+    // `system:*` expanded to zero plugins and `agents sync <agent> system` silently
+    // skipped system-layer plugins — the swarm-plugin bug.
+    expect(result.plugins ?? []).toContain('swarm');
+    expect(result.plugins ?? []).not.toContain('mine');
+  });
+});

--- a/cli/src/lib/installations/versions.ts
+++ b/cli/src/lib/installations/versions.ts
@@ -218,6 +218,22 @@ function sourceMapFromWorkflows(cwd: string): Map<string, string> {
   );
 }
 
+// A plugin is a directory whose marker is `.claude-plugin/plugin.json`. Attribute
+// each to the layer it actually resolves from (system / user / project / extra) —
+// the same first-wins resolution the plugins staleness checker uses. Hardcoding
+// 'user' here made a `system:*` selection expand to zero plugins, so
+// `agents sync <agent> system` silently skipped system-layer plugins like `swarm`
+// (RUSH-3207).
+function sourceMapFromPlugins(cwd: string): Map<string, string> {
+  return sourceMapFromLayeredDirectory(
+    cwd,
+    ['plugins'],
+    (dir) => fs.readdirSync(dir, { withFileTypes: true })
+      .filter(d => d.isDirectory() && fs.existsSync(path.join(dir, d.name, '.claude-plugin', 'plugin.json')))
+      .map(d => d.name),
+  );
+}
+
 function sourceMapFromPluginSkills(plugins: DiscoveredPlugin[], activePluginNames: Set<string>, cwd: string): Map<string, string> {
   const sourceRank = new Map<string, number>([
     ['user', 0],
@@ -2449,8 +2465,13 @@ function resourceSourceMap(kind: SelectableKind, cwd: string, available: Availab
     }
     case 'mcp':
       return new Map(getScopedMcpResources(cwd).map(r => [r.name, r.scope]));
-    case 'plugins':
-      return new Map(available.plugins.map(n => [n, 'user']));
+    case 'plugins': {
+      const sources = sourceMapFromPlugins(cwd);
+      return new Map(available.plugins.flatMap((n) => {
+        const source = sources.get(n);
+        return source ? [[n, source] as [string, string]] : [];
+      }));
+    }
     case 'workflows': {
       const sources = sourceMapFromWorkflows(cwd);
       return new Map(available.workflows.flatMap((n) => {


### PR DESCRIPTION
**What + type:** bug fix in the sync resource-selection path. Closes RUSH-3207.

## The bug
`agents sync <agent> system` reconciles commands/skills/hooks/memory/permissions but **silently skips plugins**, so a merged change to a system-layer plugin (e.g. the `swarm` plugin's skills) never reaches installed agents. It hit live: a rewritten `plugins/swarm/skills/spec/SKILL.md` merged to the system layer and synced to 7 boxes with `agents sync claude@all system`, and every box kept serving the old skill. The plugin version was unchanged, and `agents plugins list` reported "Synced: everywhere", hiding it.

## Root cause
In `cli/src/lib/installations/versions.ts`, `resourceSourceMap` hardcoded every plugin's source layer to `'user'`:
```
case 'plugins':
  return new Map(available.plugins.map(n => [n, 'user']));
```
So a `system:*` selection pattern matched **zero** plugins (`resource-patterns.ts` keeps only names whose mapped source equals the pattern's source), `buildSelection` skipped the kind, and the plugin writer was gated off. The downstream machinery was fine — the plugins staleness checker fingerprints **content** (not version) and the writer overwrites unconditionally from the plugin source — but the plugin never entered the selection on a `system` scope.

## Fix
Attribute each plugin to the layer it actually resolves from (system / user / project / extra) with a `sourceMapFromPlugins` helper that mirrors the existing `sourceMapFromWorkflows` / `sourceMapFromPermissionGroups` and the plugins staleness checker's first-wins resolution. A `system` sync now includes system-layer plugins, and the existing content fingerprint reinstalls them when content changed even if the manifest version did not — no separate `agents plugins sync` step.

## Test
`versions.test.ts`: a `system` repo scope selects a system-layer plugin (`.agents/.system/plugins`) and excludes a user-layer one (`.agents/plugins`).

## Verification note
Local run not performed — this worktree has no `node_modules` (fresh checkout off `origin/main`), so the suite runs in **CI**. The fix is a surgical mirror of three sibling cases (`workflows` / `permissions` / `mcp`) in the same function.

## Follow-up (same root area, separate)
`isInstalledInMarketplace` reports a plugin as synced based on the marketplace copy **existing**, never its content/revision — which is why stale plugin content showed "Synced: everywhere". Worth a follow-up so the status reflects content.