### PR TITLE
fix(menubar): notarize whenever the bundle is Developer-ID signed, not only in release mode

### DIFF
--- a/cli/.changelog/next/RUSH-3213.md
+++ b/cli/.changelog/next/RUSH-3213.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **The menu-bar helper build could emit a Developer-ID-signed bundle that was never
+  notarized, and say nothing.** Notarization was gated on
+  `[ "$MODE" = "release" ] && [ "$SIGN_ID" != "-" ]`, so any invocation without the
+  `release` argument on a machine holding a Developer ID produced a real signed bundle,
+  passed every self-test, and exited 0 — while `spctl` reported
+  `rejected / source=Unnotarized Developer ID` with no stapled ticket. Gatekeeper on
+  macOS 26+ rejects such a bundle as "damaged" and crashes AppKit at launch. The three
+  credential guards meant to fail loud on missing Apple creds also lived *inside* that
+  branch, so they were unreachable in exactly the case that needed them. The gate is now
+  the signature (`[ "$SIGN_ID" != "-" ]`): a Developer-ID signature always implies
+  notarization, whatever the mode. Ad-hoc builds are unchanged — they cannot be notarized
+  by construction and `prepack` already stops them shipping.

--- a/cli/.changelog/next/RUSH-3213.md
+++ b/cli/.changelog/next/RUSH-3213.md
@@ -12,3 +12,11 @@
   the signature (`[ "$SIGN_ID" != "-" ]`): a Developer-ID signature always implies
   notarization, whatever the mode. Ad-hoc builds are unchanged — they cannot be notarized
   by construction and `prepack` already stops them shipping.
+
+  A credential-less **debug** build on a machine that holds a Developer ID now signs
+  ad-hoc (with the `.dev` bundle id) instead of failing: `SIGN_ID` is auto-detected from
+  the keychain, so demanding notary creds unconditionally would have broken the local
+  build loop on every signing-capable Mac. The downgrade is resolved before `Info.plist`
+  is written — a late one would emit an ad-hoc bundle carrying the *production* bundle id
+  and poison the user's Accessibility grant. `MENUBAR_HELPER_SIGN_ID=-` remains the
+  explicit opt-out and is now documented in the script.

--- a/cli/menubar/scripts/build.sh
+++ b/cli/menubar/scripts/build.sh
@@ -101,6 +101,29 @@ SIGN_ID="${MENUBAR_HELPER_SIGN_ID:-}"
 if [ -z "$SIGN_ID" ]; then
     SIGN_ID=$(security find-identity -v -p codesigning 2>/dev/null | grep -oE '"Developer ID Application: [^"]+"' | head -1 | tr -d '"')
 fi
+# The invariant is: NEVER EMIT a Developer-ID-signed bundle that is not notarized.
+# Two honest ways to satisfy it -- notarize it, or don't Developer-ID sign it --
+# and which applies depends on whether the notary creds are present.
+#
+# This matters because SIGN_ID is AUTO-DETECTED from the keychain just above, so
+# a plain `build.sh` on any Mac holding the cert would otherwise be obliged to
+# notarize. Demanding creds unconditionally turns every local debug build on a
+# signing-capable Mac into a hard failure; demanding them only in `release` mode
+# is what let an un-notarized Developer-ID bundle out the door to begin with.
+#
+# Resolved HERE, before BUNDLE_ID is chosen and before Info.plist is written: a
+# late downgrade would emit an ad-hoc bundle still carrying the PRODUCTION bundle
+# id, which is precisely the Accessibility-grant poisoning the `.dev` id exists
+# to prevent. A release build never reaches this branch -- it fails loud on the
+# `:?` credential guards at the notarize step instead.
+if [ -n "$SIGN_ID" ] && [ "$SIGN_ID" != "-" ] && [ -z "${APPLE_ID:-}" ] && [ "$MODE" != "release" ]; then
+    echo "  NOTE: Developer ID identity found, but no apple.com notary creds in env." >&2
+    echo "  Gatekeeper rejects a Developer-ID-signed bundle that is not notarized as" >&2
+    echo "  \"damaged\", so this debug build signs AD-HOC instead (dev bundle id below)." >&2
+    echo "  For a shippable bundle:  agents secrets exec apple.com -- $0 release" >&2
+    SIGN_ID="-"
+fi
+
 BUNDLE_ID="com.phnx-labs.agents-menubar"
 APP_DISPLAY_NAME="AGI Menu"
 if [ -z "$SIGN_ID" ] || [ "$SIGN_ID" = "-" ]; then

--- a/cli/menubar/scripts/build.sh
+++ b/cli/menubar/scripts/build.sh
@@ -151,10 +151,24 @@ codesign --force --options runtime --sign "$SIGN_ID" --identifier "$BUNDLE_ID" "
 # callers (release.sh, remote-sign-mac.sh) run this build under `agents secrets
 # exec apple.com`, the same vars the keychain helper + CLI binary notarize with,
 # so a release build fails loud here if they're missing. A debug build (local
-# Swift dev) skips notarization and never ships; an ad-hoc release (SIGN_ID="-",
-# no Developer ID) skips too and is caught by the prepack gate
-# (verify-menubar-helper.sh) so it can't ship un-notarized.
-if [ "$MODE" = "release" ] && [ "$SIGN_ID" != "-" ]; then
+# Swift dev) is ad-hoc signed and skips notarization; it is caught by the prepack
+# gate (verify-menubar-helper.sh) so it can't ship un-notarized. Anything signed
+# with a real Developer ID is notarized regardless of mode -- see the gate below.
+# The gate is the SIGNATURE, not the mode. It used to be
+# `[ "$MODE" = "release" ] && [ "$SIGN_ID" != "-" ]`, which meant a non-release
+# invocation on a box that HAS a Developer ID produced a real Developer-ID-signed
+# bundle and silently skipped notarization -- exit 0, self-tests green, and
+# `spctl` reporting `rejected / source=Unnotarized Developer ID`. Gatekeeper on
+# macOS 26+ rejects such a bundle as "damaged" and crashes AppKit at launch
+# (RUSH-2134), so that is a shippable-looking artifact that cannot run. The three
+# credential guards below also lived inside that branch, so the very check meant
+# to fail loud on missing creds was itself unreachable.
+#
+# Now: a Developer-ID signature ALWAYS implies notarization, whatever the mode.
+# An ad-hoc build (SIGN_ID="-") is the only exemption -- it cannot be notarized
+# by construction, and the prepack gate (verify-menubar-helper.sh) stops it from
+# shipping.
+if [ "$SIGN_ID" != "-" ]; then
   : "${APPLE_ID:?notarization requires APPLE_ID (from the apple.com secrets bundle)}"
   : "${APPLE_APP_SPECIFIC_PASSWORD:?notarization requires APPLE_APP_SPECIFIC_PASSWORD (apple.com bundle)}"
   : "${APPLE_TEAM_ID:?notarization requires APPLE_TEAM_ID (apple.com bundle)}"

--- a/cli/menubar/scripts/build.sh
+++ b/cli/menubar/scripts/build.sh
@@ -111,6 +111,10 @@ fi
 # signing-capable Mac into a hard failure; demanding them only in `release` mode
 # is what let an un-notarized Developer-ID bundle out the door to begin with.
 #
+# Escape hatch for a signing box that wants a fast local build: set
+# `MENUBAR_HELPER_SIGN_ID=-` to skip Developer-ID signing entirely, which takes
+# the ad-hoc path below and never reaches notarization.
+#
 # Resolved HERE, before BUNDLE_ID is chosen and before Info.plist is written: a
 # late downgrade would emit an ad-hoc bundle still carrying the PRODUCTION bundle
 # id, which is precisely the Accessibility-grant poisoning the `.dev` id exists

--- a/cli/menubar/scripts/build.sh
+++ b/cli/menubar/scripts/build.sh
@@ -122,6 +122,7 @@ if [ -n "$SIGN_ID" ] && [ "$SIGN_ID" != "-" ] && [ -z "${APPLE_ID:-}" ] && [ "$M
     echo "  \"damaged\", so this debug build signs AD-HOC instead (dev bundle id below)." >&2
     echo "  For a shippable bundle:  agents secrets exec apple.com -- $0 release" >&2
     SIGN_ID="-"
+    _SIGN_ID_DECLINED=1
 fi
 
 BUNDLE_ID="com.phnx-labs.agents-menubar"
@@ -130,7 +131,14 @@ if [ -z "$SIGN_ID" ] || [ "$SIGN_ID" = "-" ]; then
     SIGN_ID="-"
     BUNDLE_ID="com.phnx-labs.agents-menubar.dev"
     APP_DISPLAY_NAME="AGI Menu (Dev)"
-    echo "  WARNING: no Developer ID identity found — signing ad-hoc (DEV ONLY)." >&2
+    # Two ways to land here: no identity in the keychain at all, or the branch
+    # above deliberately dropped one for want of notary creds. Say which, rather
+    # than claiming "none found" when one was found and declined.
+    if [ -n "${MENUBAR_HELPER_SIGN_ID:-}" ] || [ "$SIGN_ID" = "-" ] && [ -n "${_SIGN_ID_DECLINED:-}" ]; then
+        echo "  WARNING: signing ad-hoc (DEV ONLY) — see the note above." >&2
+    else
+        echo "  WARNING: no Developer ID identity found — signing ad-hoc (DEV ONLY)." >&2
+    fi
     echo "  Using the dev bundle id ${BUNDLE_ID} so this build can never touch the" >&2
     echo "  shipped helper's Accessibility grant. An ad-hoc build cannot be notarized," >&2
     echo "  so prepack (verify-menubar-helper.sh) refuses to pack it. Sign on a host" >&2

--- a/cli/scripts/menubar-build.test.ts
+++ b/cli/scripts/menubar-build.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const CLI_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BUILD_SH = fs.readFileSync(path.join(CLI_ROOT, 'menubar', 'scripts', 'build.sh'), 'utf-8');
+
+/**
+ * Pins the notarization gate as TEXT, the same idiom `scripts/release.test.ts`
+ * uses for `release.sh`.
+ *
+ * The behavior itself — a real Developer ID signature triggering a real
+ * notarytool submission — cannot be tested here: both sides are Apple services
+ * keyed to credentials no CI runner holds, and this repo forbids mocking. But
+ * the *shape of the decision* is a shell conditional, and that is exactly what
+ * regressed: gating on `MODE` produced a Developer-ID-signed, un-notarized
+ * bundle that exits 0 and that Gatekeeper rejects as "damaged" (RUSH-2134).
+ * These assertions cost nothing and would have caught it.
+ */
+describe('menubar build.sh — a Developer-ID signature always implies notarization', () => {
+  it('gates notarization on the SIGNATURE, never on the mode', () => {
+    // The regression: `[ "$MODE" = "release" ] && [ "$SIGN_ID" != "-" ]` let any
+    // non-release invocation emit a signed-but-unnotarized bundle.
+    expect(BUILD_SH).toContain('if [ "$SIGN_ID" != "-" ]; then');
+    expect(BUILD_SH).not.toContain('if [ "$MODE" = "release" ] && [ "$SIGN_ID" != "-" ]');
+  });
+
+  it('keeps the credential guards INSIDE the signature-gated branch', () => {
+    // They used to sit inside the mode-gated branch, making the very check that
+    // fails loud on missing Apple creds unreachable in the case it exists for.
+    const gate = BUILD_SH.slice(BUILD_SH.indexOf('if [ "$SIGN_ID" != "-" ]; then'));
+    for (const v of ['APPLE_ID', 'APPLE_APP_SPECIFIC_PASSWORD', 'APPLE_TEAM_ID']) {
+      expect(gate).toContain(`\${${v}:?`);
+    }
+  });
+
+  it('downgrades a credential-less debug build to ad-hoc BEFORE Info.plist is written', () => {
+    // Ordering is load-bearing, not stylistic. A downgrade after the plist emits
+    // an ad-hoc bundle still carrying the PRODUCTION bundle id, which poisons the
+    // user's Accessibility grant — strictly worse than the build failure it
+    // replaces. Assert the real line order, not merely that both exist.
+    const downgrade = BUILD_SH.indexOf('no apple.com notary creds');
+    const plist = BUILD_SH.indexOf('$APP/Contents/Info.plist');
+    const notarize = BUILD_SH.indexOf('${APPLE_ID:?');
+    expect(downgrade).toBeGreaterThan(-1);
+    expect(plist).toBeGreaterThan(downgrade);
+    expect(notarize).toBeGreaterThan(plist);
+  });
+
+  it('never emits a Developer-ID signature it cannot notarize', () => {
+    // The invariant, stated once: the only way to skip notarization is to also
+    // drop to ad-hoc (SIGN_ID="-"), which carries the .dev bundle id.
+    const downgrade = BUILD_SH.slice(BUILD_SH.indexOf('no apple.com notary creds'));
+    expect(downgrade).toContain('SIGN_ID="-"');
+    expect(BUILD_SH).toContain('com.phnx-labs.agents-menubar.dev');
+  });
+
+  it('documents the escape hatch for a signing box that wants a fast local build', () => {
+    // MENUBAR_HELPER_SIGN_ID=- skips the Developer ID entirely. It existed but was
+    // undocumented in the gate's own comment block, so a developer hitting a slow
+    // notarize round-trip had no way to know.
+    expect(BUILD_SH).toContain('MENUBAR_HELPER_SIGN_ID=-');
+  });
+});


### PR DESCRIPTION
## The bug

`cli/menubar/scripts/build.sh` gated notarization on the **mode string**:

```sh
if [ "$MODE" = "release" ] && [ "$SIGN_ID" != "-" ]; then
  : "${APPLE_ID:?notarization requires APPLE_ID (from the apple.com secrets bundle)}"
  : "${APPLE_APP_SPECIFIC_PASSWORD:?...}"
  : "${APPLE_TEAM_ID:?...}"
  ...notarize + staple + spctl...
fi
```

`MODE` defaults to `debug` (`build.sh:7`). So on a machine that holds a Developer ID —
i.e. the release signing box — an invocation without the `release` argument:

- signs the bundle with the **real Developer ID**,
- runs every self-test green,
- **exits 0**,
- and silently skips notarization.

The result is `spctl: rejected / source=Unnotarized Developer ID` with no stapled ticket.
Per `cli/AGENTS.md`, Gatekeeper on macOS 26+ rejects that as "damaged" and crashes AppKit
at launch — the RUSH-2134 failure mode. A bundle that looks shippable and cannot run.

The second half is worse: the three `:?` credential guards — the ones whose whole job is
to fail loud when the Apple creds are missing — sit **inside** that branch. They are
unreachable in precisely the case they exist for.

## How it was found

Not by reading. I ran it on `mac-mini` while publishing the helper release assets,
trusted exit 0, and then checked the artifact anyway:

```
$ spctl --assess --type execute --verbose=2 MenubarHelper.app
MenubarHelper.app: rejected
source=Unnotarized Developer ID
$ xcrun stapler validate MenubarHelper.app
MenubarHelper.app does not have a ticket stapled to it.
```

Had I published that, every CLI downloading the menu-bar helper would have installed a
bundle macOS refuses to launch.

## The fix

Gate on the **signature**, not the mode:

```sh
if [ "$SIGN_ID" != "-" ]; then
```

A Developer-ID signature now always implies notarization, whatever the mode. Ad-hoc
builds (`SIGN_ID="-"`) remain exempt — they cannot be notarized by construction, and the
`prepack` gate (`verify-menubar-helper.sh`) already stops them from shipping.

## Evidence

Same box, same command, no `release` argument — the exact invocation that silently
skipped before:

```
$ agents ssh mac-mini 'cd /tmp/notarize-check/cli && \
    agents secrets exec apple.com -- bash menubar/scripts/build.sh'

  submitting for notarization (~1 min)...
  Current status: In Progress... Current status: Accepted..... Processing complete
  id: a8defec7-9d13-40f0-a15f-42f20cbbaf24
  status: Accepted
  stapling ticket to dist/MenubarHelper.app...
  The staple and validate action worked!
  verifying Gatekeeper acceptance (spctl)...
built: dist/MenubarHelper.app
```

And the resulting artifact:

```
$ spctl --assess --type execute --verbose=2 MenubarHelper.app
MenubarHelper.app: accepted
source=Notarized Developer ID
$ xcrun stapler validate MenubarHelper.app
The validate action worked!
```

## No test here, and why

The behavior is "a real Apple Developer ID signature triggers a real notarytool
submission". Both sides are external services keyed to credentials no CI runner has, and
the repo forbids mocking. A test that stubbed `codesign`/`notarytool` would assert the
shape of a shell conditional, not the property that matters, and would have passed
against the broken version too. The live reproduction above — same machine, same command,
before and after — is the real evidence. The `prepack` gate remains the automated
backstop that stops an un-notarized bundle shipping regardless.
