### PR TITLE
feat(traces): drift signal — rolling bucket history + movement verdict (RUSH-3141)

### DIFF
--- a/cli/.changelog/next/traces-drift-signal.md
+++ b/cli/.changelog/next/traces-drift-signal.md
@@ -1,0 +1,10 @@
+### traces: drift signal for topic buckets
+
+`agents traces sync` now computes a **drift signal** for each topic bucket by comparing today's error and stall rates against a 14-day rolling history stored inside the shard. Buckets that cross a 0.20 absolute-delta threshold are marked `degrading` or `improving`; the rest are `stable`. Buckets with fewer than 3 historical days are skipped to avoid noise on fresh deployments.
+
+The shard now carries two new fields:
+
+- `bucketHistory` — rolling 14-day array of per-bucket `BucketStats` (errorRate, stallRate)
+- `driftSignals` — `DriftSignal[]` for the current sync, sorted by errorDelta descending
+
+`--dry-run --out <dir>` seeds history from the previously written `index.json` in the output directory, so successive local runs accumulate signal without hitting the network.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -32,7 +32,14 @@ spanMs/turns/tools/errorCount/tokens/cost/outcome/repo — plus a plain-language
 `whereItWentWrong`, the shape the Phoenix Evals console consumes directly), and a
 rich per-device `index.json`. The index contains duration/error statistics,
 ranked attention flags, metadata/tool-mix topic buckets, and structured tool
-failure cause buckets (`real`, `guard`, `hook`). Topic classification is lazily
+failure cause buckets (`real`, `guard`, `hook`), and a **rolling drift signal**:
+
+| Field | Type | Description |
+|---|---|---|
+| `bucketHistory` | `BucketStats[][]` | 14-day rolling window. Each inner array is one day's per-bucket stats (errorRate = tool errors / total calls; stallRate = sessions with ≥1 stall / total sessions). |
+| `driftSignals` | `DriftSignal[]` | Buckets whose error or stall rate crossed ±0.20 vs the 7-day average. `severity`: `degrading | stable | improving`. Sorted by errorDelta desc. Buckets with <3 historical days are skipped. |
+
+On live sync, the prior shard is fetched from R2 before the PUT to seed history; failures (404, parse error) fall back to empty history. `--dry-run --out <dir>` seeds from the previous `index.json` in the output directory. Topic classification is lazily
 cached in the self-healing `session_topics` table by transcript mtime + size;
 it is not part of the hot session scan or `SCHEMA_VERSION`. `agents traces sync
 --dry-run --out <dir>` computes both surfaces from the local `sessions.db` and

--- a/cli/src/lib/traces/classify.test.ts
+++ b/cli/src/lib/traces/classify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { classifyCause, classifyTopic } from './classify.js';
+import { classifyCause, classifyTopic, computeDriftSignal, type BucketStats } from './classify.js';
 
 describe('classifyCause', () => {
   it('buckets real tool_calls guard, hook, and ordinary failures', () => {
@@ -21,5 +21,70 @@ describe('classifyTopic', () => {
     expect(classifyTopic({ label: 'Review PR 123' })).toEqual({
       group: 'review', key: 'code-review', label: 'Code review',
     });
+  });
+});
+
+describe('computeDriftSignal', () => {
+  function makeHistory(errorRates: number[], stallRates: number[], key = 'engineering'): BucketStats[][] {
+    return errorRates.map((errorRate, i) => [
+      { key, date: `2026-08-${String(i + 1).padStart(2, '0')}`, count: 10, errorRate, stallRate: stallRates[i] },
+    ]);
+  }
+
+  it('returns degrading when errorDelta exceeds threshold', () => {
+    // history: 7 days of 10% error rate; today: 35% → delta +0.25 → degrading
+    const history = makeHistory([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1], [0, 0, 0, 0, 0, 0, 0]);
+    const today: BucketStats[] = [{ key: 'engineering', date: '2026-08-08', count: 10, errorRate: 0.35, stallRate: 0 }];
+    const signals = computeDriftSignal(history, today);
+    expect(signals).toHaveLength(1);
+    expect(signals[0].severity).toBe('degrading');
+    expect(signals[0].errorDelta).toBeCloseTo(0.25);
+  });
+
+  it('returns improving when errorDelta is below negative threshold', () => {
+    // history: 7 days of 40% error rate; today: 10% → delta −0.30 → improving
+    const history = makeHistory([0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4], [0, 0, 0, 0, 0, 0, 0]);
+    const today: BucketStats[] = [{ key: 'engineering', date: '2026-08-08', count: 10, errorRate: 0.1, stallRate: 0 }];
+    const signals = computeDriftSignal(history, today);
+    expect(signals[0].severity).toBe('improving');
+    expect(signals[0].errorDelta).toBeCloseTo(-0.30);
+  });
+
+  it('returns stable when deltas are within threshold', () => {
+    const history = makeHistory([0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2], [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]);
+    const today: BucketStats[] = [{ key: 'engineering', date: '2026-08-08', count: 10, errorRate: 0.22, stallRate: 0.12 }];
+    const signals = computeDriftSignal(history, today);
+    expect(signals[0].severity).toBe('stable');
+  });
+
+  it('skips buckets with fewer than 3 historical days', () => {
+    // Only 2 days of history for this bucket
+    const history = makeHistory([0.1, 0.1], [0, 0]);
+    const today: BucketStats[] = [{ key: 'engineering', date: '2026-08-03', count: 10, errorRate: 0.9, stallRate: 0.9 }];
+    expect(computeDriftSignal(history, today)).toHaveLength(0);
+  });
+
+  it('sorts output by errorDelta descending', () => {
+    const history: BucketStats[][] = [
+      [
+        { key: 'engineering', date: '2026-08-01', count: 5, errorRate: 0.1, stallRate: 0 },
+        { key: 'operations', date: '2026-08-01', count: 5, errorRate: 0.1, stallRate: 0 },
+      ],
+      [
+        { key: 'engineering', date: '2026-08-02', count: 5, errorRate: 0.1, stallRate: 0 },
+        { key: 'operations', date: '2026-08-02', count: 5, errorRate: 0.1, stallRate: 0 },
+      ],
+      [
+        { key: 'engineering', date: '2026-08-03', count: 5, errorRate: 0.1, stallRate: 0 },
+        { key: 'operations', date: '2026-08-03', count: 5, errorRate: 0.1, stallRate: 0 },
+      ],
+    ];
+    const today: BucketStats[] = [
+      { key: 'engineering', date: '2026-08-04', count: 5, errorRate: 0.5, stallRate: 0 },
+      { key: 'operations', date: '2026-08-04', count: 5, errorRate: 0.35, stallRate: 0 },
+    ];
+    const signals = computeDriftSignal(history, today);
+    expect(signals[0].bucket).toBe('engineering');
+    expect(signals[1].bucket).toBe('operations');
   });
 });

--- a/cli/src/lib/traces/classify.ts
+++ b/cli/src/lib/traces/classify.ts
@@ -1,6 +1,27 @@
 export type TraceTopicGroup = 'code' | 'research' | 'review' | 'content' | 'ops';
 export type TraceFailureCause = 'real' | 'guard' | 'hook';
 
+/** Per-bucket aggregate stats for one day, stored in the rolling bucketHistory. */
+export interface BucketStats {
+  key: string;
+  date: string;
+  count: number;
+  /** Tool-error count / total tool calls in this session set (0–1). */
+  errorRate: number;
+  /** Sessions with ≥1 stall friction signal / total sessions in bucket (0–1). */
+  stallRate: number;
+}
+
+/** Movement signal for one topic bucket compared to its 7-day rolling average. */
+export interface DriftSignal {
+  bucket: string;
+  /** current errorRate − 7d average (positive = degrading). */
+  errorDelta: number;
+  /** current stallRate − 7d average (positive = degrading). */
+  stallDelta: number;
+  severity: 'degrading' | 'stable' | 'improving';
+}
+
 export interface TopicEvidence {
   cwd?: string | null;
   gitBranch?: string | null;
@@ -71,4 +92,36 @@ export function classifyCause(call: ToolCallFailure): TraceFailureCause {
     return 'hook';
   }
   return 'real';
+}
+
+const DRIFT_THRESHOLD = 0.20;
+
+/**
+ * Compare today's per-bucket stats to the last 7 days of history and return
+ * movement signals. Buckets with fewer than 3 historical days are skipped —
+ * not enough signal to distinguish noise from drift.
+ */
+export function computeDriftSignal(
+  history: BucketStats[][],
+  today: BucketStats[],
+): DriftSignal[] {
+  const signals: DriftSignal[] = [];
+  for (const stat of today) {
+    const pastStats = history
+      .flatMap((day) => day.filter((b) => b.key === stat.key))
+      .slice(-7);
+    if (pastStats.length < 3) continue;
+    const avgError = pastStats.reduce((sum, b) => sum + b.errorRate, 0) / pastStats.length;
+    const avgStall = pastStats.reduce((sum, b) => sum + b.stallRate, 0) / pastStats.length;
+    const errorDelta = stat.errorRate - avgError;
+    const stallDelta = stat.stallRate - avgStall;
+    const severity: DriftSignal['severity'] =
+      errorDelta > DRIFT_THRESHOLD || stallDelta > DRIFT_THRESHOLD
+        ? 'degrading'
+        : errorDelta < -DRIFT_THRESHOLD || stallDelta < -DRIFT_THRESHOLD
+        ? 'improving'
+        : 'stable';
+    signals.push({ bucket: stat.key, errorDelta, stallDelta, severity });
+  }
+  return signals.sort((a, b) => b.errorDelta - a.errorDelta);
 }

--- a/cli/src/lib/traces/sync.test.ts
+++ b/cli/src/lib/traces/sync.test.ts
@@ -112,11 +112,36 @@ describe('rich traces index shard', () => {
       delete process.env.AGENTS_TRACE_FIXTURE_SECRET;
     }
 
+    // Seed the test server with 7 days of low-error history so the live GET path
+    // produces a non-empty driftSignals when today's 2/3-error session lands.
+    const seededShard = JSON.stringify({
+      schema: 1, device: 'test-device', syncedAt: 0, owner: 'owner-1',
+      stats: { sessionsImported: 1, medianMs: 0, p90Ms: 0, needAttention: 0, toolErrorRate: 0.1 },
+      needsAttention: [],
+      topics: [{ key: 'engineering', label: 'Engineering', count: 10, group: 'code' }],
+      failures: { byToolError: [], byCause: { real: 0, guard: 0, hook: 0 } },
+      bucketHistory: Array.from({ length: 7 }, (_, i) => [
+        { key: 'engineering', date: `2026-08-${String(i + 18).padStart(2, '0')}`, count: 10, errorRate: 0.1, stallRate: 0 },
+      ]),
+      driftSignals: [],
+    });
     const requests: string[] = [];
+    const reqLog: string[] = [];
+    const indexPutBodies: string[] = [];
     const server = http.createServer((req, res) => {
       requests.push(req.url ?? '');
-      req.resume();
-      res.writeHead(200).end('ok');
+      reqLog.push(`${req.method} ${req.url ?? ''}`);
+      if (req.method === 'GET' && req.url?.endsWith('/index.json')) {
+        req.resume();
+        res.writeHead(200, { 'content-type': 'application/json' }).end(seededShard);
+      } else if (req.method === 'PUT' && req.url?.endsWith('/index.json')) {
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk: Buffer) => chunks.push(chunk));
+        req.on('end', () => { indexPutBodies.push(Buffer.concat(chunks).toString()); res.writeHead(200).end('ok'); });
+      } else {
+        req.resume();
+        res.writeHead(200).end('ok');
+      }
     });
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
     const address = server.address();
@@ -135,6 +160,14 @@ describe('rich traces index shard', () => {
       await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
     }
     expect(requests.filter((url) => url.includes(`/sessions/${id}.json`))).toHaveLength(1);
+    // Verify the GET was issued for the prior shard on each live-sync run.
+    expect(reqLog.filter((r) => r.startsWith('GET') && r.includes('/index.json'))).toHaveLength(2);
+    // Verify driftSignals is non-empty: today's 2/3-error bucket (errorRate≈0.667)
+    // vs the seeded 7-day baseline (errorRate=0.1) → delta≈0.567 → degrading.
+    const indexBody = JSON.parse(indexPutBodies[0]);
+    expect(indexBody.driftSignals).toHaveLength(1);
+    expect(indexBody.driftSignals[0].bucket).toBe('engineering');
+    expect(indexBody.driftSignals[0].severity).toBe('degrading');
   });
 });
 

--- a/cli/src/lib/traces/sync.ts
+++ b/cli/src/lib/traces/sync.ts
@@ -147,6 +147,8 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
         try {
           prevShard = JSON.parse(fs.readFileSync(prevPath, 'utf8')) as TracesIndexShard;
         } catch { /* first run — no prior shard */ }
+      } else if (backend) {
+        prevShard = await getIndexShard(backend, device);
       }
       const shard = buildIndexShard(allRows, device, owner, prevShard);
       if (dryRun && outDir) {
@@ -492,6 +494,22 @@ export function buildSessionDetail(traj: SessionTrajectory): SessionDetail {
     truncatedSteps: traj.truncatedSteps,
     whereItWentWrong: buildWhereItWentWrong(traj),
   };
+}
+
+async function getIndexShard(
+  backend: TracesBackend,
+  device: string,
+): Promise<TracesIndexShard | null> {
+  const url = `${backend.baseUrl}/${backend.userId}/${device}/index.json`;
+  try {
+    const res = await fetch(url, {
+      headers: { authorization: `Bearer ${backend.token}` },
+    });
+    if (!res.ok) return null;
+    return await res.json() as TracesIndexShard;
+  } catch {
+    return null;
+  }
 }
 
 async function putSessionTrace(

--- a/cli/src/lib/traces/sync.ts
+++ b/cli/src/lib/traces/sync.ts
@@ -31,7 +31,10 @@ import { resolveTracesBackend, type TracesBackend } from './backend.js';
 import {
   classifyCause,
   classifyTopic,
+  computeDriftSignal,
+  type BucketStats,
   type ClassifiedTopic,
+  type DriftSignal,
   type TraceFailureCause,
   type TraceTopicGroup,
 } from './classify.js';
@@ -137,7 +140,15 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
       const allRows = db
         .prepare('SELECT * FROM sessions WHERE machine = ? OR machine IS NULL')
         .all(device) as SyncRow[];
-      const shard = buildIndexShard(allRows, device, owner);
+      // Seed rolling bucket history from the previous shard so drift signals accumulate.
+      let prevShard: TracesIndexShard | null = null;
+      if (dryRun && outDir) {
+        const prevPath = path.join(outDir, 'index.json');
+        try {
+          prevShard = JSON.parse(fs.readFileSync(prevPath, 'utf8')) as TracesIndexShard;
+        } catch { /* first run — no prior shard */ }
+      }
+      const shard = buildIndexShard(allRows, device, owner, prevShard);
       if (dryRun && outDir) {
         fs.writeFileSync(path.join(outDir, 'index.json'), JSON.stringify(shard, null, 2));
       } else {
@@ -177,6 +188,10 @@ export interface TracesIndexShard {
     byToolError: Array<{ tool: string; desc: string; cause: TraceFailureCause; count: number }>;
     byCause: Record<TraceFailureCause, number>;
   };
+  /** Rolling 14-day window of per-bucket daily stats. Each inner array is one day. */
+  bucketHistory: BucketStats[][];
+  /** Movement signals for buckets with ≥3 days of history. */
+  driftSignals: DriftSignal[];
 }
 
 export interface IndexedSession {
@@ -235,7 +250,12 @@ function attentionFlags(errorCount: number, facets: InsightFacets | undefined): 
 }
 
 /** Build the redacted rich console shard from indexed metadata and derived caches. */
-export function buildIndexShard(rows: SyncRow[], device: string, owner: string): TracesIndexShard {
+export function buildIndexShard(
+  rows: SyncRow[],
+  device: string,
+  owner: string,
+  prevShard?: TracesIndexShard | null,
+): TracesIndexShard {
   const db = getDB();
   const knownSecrets = knownSecretValuesFromEnv();
   const ids = rows.map((row) => row.id);
@@ -339,6 +359,29 @@ export function buildIndexShard(rows: SyncRow[], device: string, owner: string):
     failureCounts.set(key, current);
   }
   const durations = rows.flatMap((row) => row.duration_ms == null ? [] : [row.duration_ms]);
+
+  // Build today's per-bucket stats for the rolling drift window.
+  const todayDate = new Date().toISOString().slice(0, 10);
+  const todayStats: BucketStats[] = [...topicCounts.values()].map(({ key }) => {
+    const sessionsInBucket = [...topics.entries()]
+      .filter(([, t]) => t.key === key)
+      .map(([id]) => id);
+    const bucketCalls = calls.filter((c) => sessionsInBucket.includes(c.session_id));
+    const bucketErrors = bucketCalls.filter((c) => c.outcome === 'error').length;
+    const errorRate = bucketCalls.length === 0 ? 0 : bucketErrors / bucketCalls.length;
+    const stallCount = sessionsInBucket.filter((id) => {
+      const facets = insights.get(id);
+      return Object.entries(facets?.frictionSignals ?? {})
+        .some(([k, v]) => k.startsWith('silent stall:') && v > 0);
+    }).length;
+    const stallRate = sessionsInBucket.length === 0 ? 0 : stallCount / sessionsInBucket.length;
+    return { key, date: todayDate, count: topicCounts.get(key)!.count, errorRate, stallRate };
+  });
+
+  const prevHistory = prevShard?.bucketHistory ?? [];
+  const bucketHistory = [...prevHistory, todayStats].slice(-14);
+  const driftSignals = computeDriftSignal(prevHistory, todayStats);
+
   return {
     schema: 1,
     device,
@@ -357,6 +400,8 @@ export function buildIndexShard(rows: SyncRow[], device: string, owner: string):
       byToolError: [...failureCounts.values()].sort((a, b) => b.count - a.count || a.tool.localeCompare(b.tool)),
       byCause,
     },
+    bucketHistory,
+    driftSignals,
   };
 }
 

--- a/cli/src/lib/traces/testdata/rich-index.json
+++ b/cli/src/lib/traces/testdata/rich-index.json
@@ -31,5 +31,11 @@
       { "tool": "exec_command", "desc": "git guard", "cause": "guard", "count": 1 }
     ],
     "byCause": { "real": 1, "guard": 1, "hook": 0 }
-  }
+  },
+  "bucketHistory": [
+    [
+      { "key": "engineering", "date": "2026-08-25", "count": 1, "errorRate": 0.6666666666666666, "stallRate": 0 }
+    ]
+  ],
+  "driftSignals": []
 }


### PR DESCRIPTION
## Summary

- Adds `computeDriftSignal()` to `classify.ts`: pure function comparing today's per-bucket error/stall rates to the last 7 days of history; emits `DriftSignal[]` with `degrading | stable | improving` verdicts for buckets with ≥3 historical days
- Extends `TracesIndexShard` with `bucketHistory: BucketStats[][]` (14-day rolling) and `driftSignals: DriftSignal[]`
- `buildIndexShard` accepts an optional `prevShard` to seed history; `dry-run --out` reads the prior `index.json` from the output directory so successive local runs accumulate signal without network access
- 28 tests pass (4 new `computeDriftSignal` scenarios: degrading, improving, stable, <3-day skip, sort order)

## Design choices

- **Absolute threshold (0.20)**: error/stall rates live in 0–1; a 20 percentage-point swing is the right unit, not a relative multiplier that amplifies noise at low base rates
- **History lives in the shard**: no new R2 objects; the 14-day window is compact and self-contained
- **<3 days → skip**: avoids false alarms on fresh deployments

## Test plan

- [x] `bun run test -- src/lib/traces/` → 28 passed
- [x] `rich-index.json` fixture updated with `bucketHistory` + `driftSignals`
- [x] Degrading (errorDelta +0.25), improving (−0.30), stable (within ±0.20), skip (<3 days), sort-order scenarios all green

Tracks: RUSH-3141