### PR TITLE
fix(sqlite): drop the top-level await that made the full suite red on main

### DIFF
--- a/cli/.changelog/next/RUSH-3214.md
+++ b/cli/.changelog/next/RUSH-3214.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **The full test suite was red on `main`, and pull-request CI could not see it.** A
+  top-level `await import('bun:sqlite')` in `src/lib/sqlite.ts` made that module
+  un-lowerable to CJS, so every test that spawns a subprocess through `tsx` died at
+  transform time with `Top-level await is currently not supported with the "cjs" output
+  format` — 49 failures across 7 files, none of which touch SQLite. Both runtime arms now
+  load through `createRequire`, so there is no top-level await to lower. The specifier is
+  held in a variable rather than written inline, keeping the off-Bun collector from trying
+  to resolve a module that only exists under Bun (what the old `as string` cast did for
+  the dynamic import).
+
+  This mattered beyond the suite: `release-attestation-produce.sh` runs the **full** suite
+  fail-closed, while PR CI runs only the tests selected for a diff. A failure outside every
+  recent diff's selection is therefore invisible until release time, where it blocks the
+  attestation and with it any publish.

--- a/cli/src/lib/sqlite.ts
+++ b/cli/src/lib/sqlite.ts
@@ -43,10 +43,23 @@ function loadNodeSqlite(): unknown {
   }
 }
 
-// Keep Node on createRequire() so Vitest doesn't try to prebundle the built-in
-// sqlite module as a userland package during test collection.
+// Keep BOTH runtimes on createRequire() so Vitest doesn't try to prebundle the
+// built-in sqlite module as a userland package during test collection.
+//
+// The Bun arm used to be `await import('bun:sqlite' as string)`, which made this
+// a TOP-LEVEL AWAIT. esbuild cannot lower top-level await to CJS, so every test
+// that spawns a subprocess through `tsx` (CJS mode) died at transform time with
+// `Top-level await is currently not supported with the "cjs" output format` --
+// 49 failures across 7 files, none of which touch sqlite. `require` is
+// synchronous, so the await disappears and with it the whole failure class.
+//
+// The specifier is held in a variable, not written inline: a literal
+// `require('bun:sqlite')` is statically analyzable, so bundlers and Vitest's
+// collector try to resolve a module that does not exist off-Bun. That
+// indirection is what the old `as string` cast was doing for the dynamic import.
+const BUN_SQLITE = 'bun:sqlite';
 const sqliteMod = isBun
-  ? await import('bun:sqlite' as string)
+  ? (require as (id: string) => unknown)(BUN_SQLITE)
   : loadNodeSqlite();
 
 // bun:sqlite exports `Database`; node:sqlite exports `DatabaseSync`.


### PR DESCRIPTION
## The bug

`cli/src/lib/sqlite.ts:49` loaded the Bun arm with a **top-level await**:

```ts
const sqliteMod = isBun
  ? await import('bun:sqlite' as string)
  : loadNodeSqlite();
```

esbuild cannot lower top-level await to CJS. So every test that spawns a subprocess
through `tsx` (CJS mode) died at transform time:

```
ERROR: Top-level await is currently not supported with the "cjs" output format
  at cli/src/lib/sqlite.ts:49:4
```

**49 failures across 7 files, none of which touch SQLite** — `plugins/skills.test.ts` (18),
`commands.test.ts` (15), `installations/versions.heal-dangling.test.ts` (7),
`secrets/docs-hygiene.test.ts` (4), `memory.test.ts` (4),
`__tests__/add-targets-user-repo.test.ts` (2), `devices/doctor-findings.test.ts` (1).

## Why this was invisible

`.github/workflows/tests.yml` runs only the tests `ci-scope.ts` **selects for the diff**.
`release-attestation-produce.sh` runs the **full** suite, fail-closed. A failure outside
every recent diff's selection is therefore green on every PR and only surfaces at release
time — where it blocks the attestation and with it any publish.

Measured on `origin/main` just now, full suite offloaded to `yosemite-m3`:

```
Test Files  7 failed | 931 passed | 6 skipped (944)
     Tests  49 failed
```

So `main` has been unreleasable, with every PR green.

## The fix

Load both arms through `createRequire` — synchronous, so the await disappears:

```ts
const BUN_SQLITE = 'bun:sqlite';
const sqliteMod = isBun
  ? (require as (id: string) => unknown)(BUN_SQLITE)
  : loadNodeSqlite();
```

The specifier is held in a variable rather than inline on purpose. A literal
`require('bun:sqlite')` is statically analyzable, so bundlers and Vitest's collector try
to resolve a module that does not exist off-Bun — that indirection is what the old
`as string` cast was doing for the dynamic import. The Node arm is unchanged.

## Evidence

**Bun arm actually exercised**, not assumed — the standalone signed `dist/bin/agents`
embeds Bun, so this path is production:

```
$ bun bunreq.mjs        # exact pattern: createRequire(import.meta.url)(BUN_SQLITE)
createRequire(import.meta.url)("bun:sqlite") -> function
roundtrip -> { x: 42 }   # real CREATE / INSERT / SELECT against bun:sqlite
```

Node arm still resolves `node:sqlite` -> `DatabaseSync`.

**The seven files that were failing:**

```
before:  49 failed
after:    5 failed | 155 passed (160)
```

`tsc --noEmit` clean.

## Scope — the remaining 5 are a different bug

They are pre-existing on `main` and unrelated to SQLite; this PR deliberately does not
touch them:

- `secrets/docs-hygiene.test.ts` (4) — `docs/secrets.md` no longer contains strings the
  test requires (`~/.agents/.secrets-key/passphrase`, `AGENTS_SYNC_PASSPHRASE`, a
  file-store section). Doc content drift.
- `devices/doctor-findings.test.ts` (1) — the `docs/observability.md` severity rubric no
  longer matches `FINDING_SEVERITY`.
- `__tests__/add-targets-user-repo.test.ts` — a `vi.mock` of `../state.js` missing a
  `getCliVersionCachePath` export.

Follow-up PR, since each is its own root cause and mixing them would make this one
unreviewable. **`main` is still unreleasable until those land too** — this PR removes the
largest cause, not the last one.
