### PR TITLE
fix(docs): restore the secrets-custody and severity-rubric sections their guards pin

### DIFF
--- a/cli/.changelog/next/RUSH-3215.md
+++ b/cli/.changelog/next/RUSH-3215.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **Restored operator-facing master-key custody guidance to `docs/secrets.md`.** The
+  docs reset (`2d96d05d6`) rewrote the page from a manual into an architecture summary and
+  dropped the section that names the machine-local key path
+  (`~/.agents/.secrets-key/passphrase`), states that resolution is non-interactive, points
+  headless sync at `AGENTS_SYNC_PASSPHRASE` rather than the master key, and **forbids
+  exporting the master key from a shell rc file** — the exact advice that caused RUSH-1968
+  on seven machines. Four `docs-hygiene` guards had been failing ever since, which is the
+  alarm working as designed rather than test staleness.
+- **Restored the `**Severity rubric**` section to `docs/observability.md`**, removed by the
+  same reset. `doctor-findings.test.ts` pins this prose copy against `FINDING_SEVERITY`, so
+  its absence meant the docs-cannot-drift guard was simply not running.
+- **`add-targets-user-repo.test.ts` no longer enumerates the `state.js` surface.** Its
+  partial mock hand-listed every export, so adding `getCliVersionCachePath` to `state.ts`
+  took the whole file down with `No "getCliVersionCachePath" export is defined on the mock`.
+  It now spreads `importActual` and overrides only the directory resolvers it redirects, so
+  a new export cannot break it again.

--- a/cli/docs/observability.md
+++ b/cli/docs/observability.md
@@ -50,3 +50,21 @@ second activity timestamp.
 Health findings use one severity registry and one remediation vocabulary. A finding must
 name a command that fixes the full scope represented by its row. Unavailable evidence is
 reported as unknown or degraded, never healthy by default.
+
+**Severity rubric** — `FINDING_SEVERITY` in `src/lib/devices/doctor-findings.ts` is the
+single source of truth; this prose copy is pinned to it by a test, so the two cannot
+drift.
+
+**CRITICAL** — needs you now: `logged-out`, `missing-hook`, `missing-plugin`,
+`unwired-hook`, `hook-runtime-broken`, `cli-missing`, `owner-sink-unreachable`,
+`ssh-key-enrollment`.
+
+**WARNING** — worth fixing, not urgent: `logout-unprovable`,
+`hook-runtime-visibility-unavailable`, `missing-resource`, `content-drift`,
+`never-synced`, `stale`, `repo-behind`, `repo-drift`, `fleet-resource-gap`,
+`version-skew`, `orphan`, `duplicate-hook`, `duplicate-hook-drift`, `host-cli-missing`,
+`host-cli-invalid`, `rc-secret-export`, `env-secret-export`, `exec-policy`, `stale-cli`,
+`binary-shadow`.
+
+The split is provability and blast radius: a critical is something the operator can act
+on right now with a known fix, while a warning is drift that one sweep resolves.

--- a/cli/docs/secrets.md
+++ b/cli/docs/secrets.md
@@ -49,7 +49,7 @@ a different lifetime. Headless sync is configured with that transport variable.
 **Never place the master key in a shell startup file.** `AGENTS_SECRETS_PASSPHRASE`
 overrides the key file, so exporting it from `~/.zshenv`, `~/.bashrc`, or any other rc
 file leaves the plaintext key readable by every process the account starts — including
-agents — and `agents doctor` reports it as a critical `env-secret-export`. This is not
+agents — and `agents doctor` reports it as an `env-secret-export` warning. This is not
 hypothetical: it is what RUSH-1968 was, on seven machines at once, because an earlier
 revision of this page recommended it.
 <!-- /docs-hygiene:allow-master-key-discussion -->

--- a/cli/docs/secrets.md
+++ b/cli/docs/secrets.md
@@ -31,3 +31,31 @@ them into synced plaintext.
 
 Actors, audit events, and usage counters contain metadata only. Redaction is defense in
 depth, not permission to publish raw transcripts.
+
+## Linux: headless servers and the encrypted-file fallback
+
+Off macOS there is no platform keychain, so the encrypted-file store is the backend. Its
+data key is unwrapped from a machine-local key file at `~/.agents/.secrets-key/passphrase`
+— mode 0600, generated on first use, never synced and never a DotAgents resource. That
+file *is* the store: a machine that has it can read every bundle on it.
+
+Resolution is entirely non-interactive: the daemon-hosted broker reads the key file
+directly, and there is **no TTY step anywhere in this list**. A command that appears to
+wait for a passphrase is waiting for the *transport* passphrase of `secrets push` /
+`secrets pull` / `--to-file`, which is `AGENTS_SYNC_PASSPHRASE` — a different secret with
+a different lifetime. Headless sync is configured with that transport variable.
+
+<!-- docs-hygiene:allow-master-key-discussion -->
+**Never place the master key in a shell startup file.** `AGENTS_SECRETS_PASSPHRASE`
+overrides the key file, so exporting it from `~/.zshenv`, `~/.bashrc`, or any other rc
+file leaves the plaintext key readable by every process the account starts — including
+agents — and `agents doctor` reports it as a critical `env-secret-export`. This is not
+hypothetical: it is what RUSH-1968 was, on seven machines at once, because an earlier
+revision of this page recommended it.
+<!-- /docs-hygiene:allow-master-key-discussion -->
+
+<!-- docs-hygiene:allow-master-key-discussion -->
+The one legitimate use is `agents secrets export --device`, which forwards
+`AGENTS_SECRETS_PASSPHRASE` over ssh stdin so the remote can key its own store. It is
+opt-in, never written to disk on either side, and never persisted in an environment.
+<!-- /docs-hygiene:allow-master-key-discussion -->

--- a/cli/src/lib/__tests__/add-targets-user-repo.test.ts
+++ b/cli/src/lib/__tests__/add-targets-user-repo.test.ts
@@ -14,7 +14,14 @@ let TEST_ROOT: string;
 let SYSTEM_DIR: string;
 let USER_DIR: string;
 
-vi.mock('../state.js', () => ({
+// Spread the REAL module and override only the directory resolvers this test
+// needs redirected. The previous form hand-listed every export, so adding one to
+// state.ts broke this file with `No "<name>" export is defined on the mock` --
+// which is how `getCliVersionCachePath` took the whole file down on main. A
+// partial mock that enumerates its surface is a maintenance trap; this one
+// tracks the module automatically.
+vi.mock('../state.js', async (importActual) => ({
+  ...(await importActual<typeof import('../state.js')>()),
   get getAgentsDir() { return () => SYSTEM_DIR; },
   get getSystemAgentsDir() { return () => SYSTEM_DIR; },
   get getUserAgentsDir() { return () => USER_DIR; },

--- a/cli/src/lib/devices/doctor-findings.test.ts
+++ b/cli/src/lib/devices/doctor-findings.test.ts
@@ -15,6 +15,7 @@ import {
 } from './doctor-findings.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { ALL_AGENT_IDS, supportsAccountInspection } from '../agents.js';
 import type { VersionResourceReport } from '../doctor-diff.js';
 import type { FleetHookRuntimeState, FleetVersionSignIn, FleetDivergence } from './fleet-divergence.js';
@@ -657,6 +658,31 @@ describe('the severity rubric matches the code (docs cannot drift from behavior)
     const rubric = doc.slice(start, start + 1400);
     const { critical, warning } = buckets(rubric, '**CRITICAL**', '**WARNING**');
     expect(misplaced(critical, warning)).toEqual([]);
+  });
+
+  it('no doc calls a finding by the wrong severity in prose', () => {
+    // The rubric tests above pin the LISTS. They do not pin prose elsewhere that
+    // names a kind and a severity in the same breath — which is how this branch
+    // originally shipped `docs/secrets.md` calling `env-secret-export` "critical"
+    // while its own restored `docs/observability.md` correctly listed it under
+    // WARNING, in the same commit. Two doc sections contradicting each other on
+    // one finding's severity is worse than either being silently absent.
+    const docsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'docs');
+    const wrong: string[] = [];
+    for (const file of fs.readdirSync(docsDir).filter((f) => f.endsWith('.md'))) {
+      const text = fs.readFileSync(path.join(docsDir, file), 'utf-8');
+      for (const kind of ALL_FINDING_KINDS) {
+        const actual = FINDING_SEVERITY[kind];
+        const other = actual === 'critical' ? 'warning' : 'critical';
+        // Both orders occur naturally: "a critical `kind`" and "an `kind` warning".
+        const before = new RegExp(`\\b${other}\\s+\`${kind}\``, 'i');
+        const after = new RegExp(`\`${kind}\`\\s+${other}\\b`, 'i');
+        if (before.test(text) || after.test(text)) {
+          wrong.push(`${file}: ${kind} called ${other}, is ${actual}`);
+        }
+      }
+    }
+    expect(wrong).toEqual([]);
   });
 
   it('the AGENTS.md rubric puts every kind in the right bucket', () => {


### PR DESCRIPTION
Second half of making `main`'s full suite green. #3066 removes the top-level `await` that
accounted for 44 of the 49 failures; this PR is the other 5, which are three unrelated
root causes.

**Together the two PRs take the seven affected files from 49 failures to 0** — verified by
applying both and running them:

```
Test Files  7 passed (7)
     Tests  162 passed (162)
```

## 1. `docs/secrets.md` lost its master-key custody section (4 failures)

`2d96d05d6 docs: replace manuals with architecture decisions` rewrote the page from a
manual into an architecture summary. It dropped the section that:

- names the machine-local key path `~/.agents/.secrets-key/passphrase`,
- states resolution is non-interactive ("no TTY step anywhere in this list"),
- points headless sync at `AGENTS_SYNC_PASSPHRASE`, not the master key,
- and **forbids exporting the master key from a shell rc file**.

That last one is not decoration. `docs-hygiene.test.ts`'s docblock records why it exists:

> RUSH-1968 happened partly because the docs *recommended* the thing `agents doctor`
> flags … An operator who followed the docs put a master key into `~/.zshenv` on seven
> boxes.

**These four tests were not stale — they were the alarm.** Worth being precise about which
guards failed and which didn't: the three *anti-leak* guards (`never mentions a shell rc
file`, `never recommends … for shared or CI machines`, `never equates the 0600 key file
with an rc export`) all still **passed**, trivially, because a page with no operational
content cannot teach a leak. The four that failed are the ones asserting the page
*positively documents* custody. So the guard suite correctly distinguished "safe" from
"complete", and only the completeness half fired.

I checked whether the content had merely moved before restoring it. It had not:

```
docs-hygiene:allow-master-key-discussion   specifications.md=0  secrets.md=0
secrets-key/passphrase                     specifications.md=0  secrets.md=0
zshenv                                     specifications.md=0  secrets.md=0
AGENTS_SYNC_PASSPHRASE                     specifications.md=1  secrets.md=0
```

Only the env-var names survived, in `specifications.md`. The custody guidance was gone
from the corpus.

Restored as a focused section, which fits the page's new architecture-doc framing —
*where the key lives and what must never happen to it* is an architecture decision, not a
how-to. The two passages that must discuss the master key (the prohibition itself, and
`export --device`, which genuinely forwards it over ssh stdin) are wrapped in the
`docs-hygiene:allow-master-key-discussion` markers the guard requires, and stay inside its
pinned count/size budget.

## 2. `docs/observability.md` lost its `**Severity rubric**` (1 failure)

Same reset. `doctor-findings.test.ts` pins that prose copy against `FINDING_SEVERITY`
("A THIRD rubric — missed by the previous version of this test, and stale for the same
three days"). With the section gone the guard was not running at all.

Restored, with the buckets generated by reading `FINDING_SEVERITY` directly rather than
retyped — 8 critical kinds, 20 warning kinds.

## 3. `add-targets-user-repo.test.ts` enumerated the `state.js` surface

Its `vi.mock` hand-listed every export, so adding `getCliVersionCachePath` to `state.ts`
took the whole file down at collection:

```
Error: [vitest] No "getCliVersionCachePath" export is defined on the "../state.js" mock.
```

Now spreads `importActual` and overrides only the directory resolvers it needs redirected,
so a new export cannot break it again. This is the recurrence fix, not just the instance
fix.

## Why this class of failure survived

`tests.yml` runs only the tests `ci-scope.ts` selects for a diff. A docs commit that
removes a section pinned by a test in `src/lib/secrets/` does not select that test. So the
guard went dark, `main` went red, and every PR stayed green — for as long as nobody ran the
full suite, which happens only inside the release attestation.
