### PR TITLE
feat(release): stop shipping native .app bundles in the npm tarball (RUSH-3100)

### DIFF
--- a/cli/.changelog/next/RUSH-3100.md
+++ b/cli/.changelog/next/RUSH-3100.md
@@ -18,3 +18,9 @@
   `.app`s to be physically present at pack time, which is why the attestation could only
   be produced on macOS. Both scripts are retained — they are still the right gate for a
   *helper* release — they simply no longer block the CLI tarball.
+
+- **`release-attestation-produce.sh` no longer seeds the signed `.app`s into its worktree.**
+  That seeding existed only because `prepack` refused to pack without them, so it was the
+  workaround for the coupling this change removes. Its comments claimed "the prepack gates
+  still decide … fails the pack exactly as before", which stopped being true the moment
+  those gates were removed — a stale comment guarding nothing.

--- a/cli/.changelog/next/RUSH-3100.md
+++ b/cli/.changelog/next/RUSH-3100.md
@@ -1,26 +1,17 @@
-### Removed
-
-- **No native binaries ship in the npm tarball.** `Agents CLI.app` (2.6 MB) and
-  `MenubarHelper.app` (3.3 MB) were copied into `dist/` by the `build` script, listed in
-  `files`, and hard-gated by two `prepack` checks — so every Linux and Windows user
-  downloaded 5.9 MB of signed macOS bundles, and the tarball could only be packed on a
-  Mac holding those signed bundles. All three are gone; the helpers are fetched on demand
-  from their own release tags and verified exactly as before (sha256 + Developer ID team +
-  notarization + designated-requirement pin).
-
-  Unpacked tarball: **21,337,724 → 15,629,419 bytes**.
-
-  `build` still removes any stale bundle from `dist/` so an upgrade over an older install
-  cannot leave one behind.
-
-  This is what lets an ordinary release be produced without a signing Mac: the `prepack`
-  gates (`verify-keychain-helper.sh`, `verify-menubar-helper.sh`) required the signed
-  `.app`s to be physically present at pack time, which is why the attestation could only
-  be produced on macOS. Both scripts are retained — they are still the right gate for a
-  *helper* release — they simply no longer block the CLI tarball.
-
-- **`release-attestation-produce.sh` no longer seeds the signed `.app`s into its worktree.**
-  That seeding existed only because `prepack` refused to pack without them, so it was the
-  workaround for the coupling this change removes. Its comments claimed "the prepack gates
+- **No native binary ships in the npm tarball (RUSH-3100).** `Agents CLI.app` (2.6 MB) and
+  `MenubarHelper.app` (3.3 MB) were copied into `dist/` by `build`, listed in `files`, and
+  hard-gated by two `prepack` checks — so every Linux and Windows user downloaded 5.9 MB of
+  signed macOS bundles, and the tarball could only be packed on a Mac holding them. All
+  three are gone; helpers are fetched on demand from their own release tags and verified
+  exactly as before (sha256 + Developer ID team + notarization + designated-requirement
+  pin). Unpacked tarball: 21,337,724 → 15,629,419 bytes. `build` still clears any stale
+  bundle from `dist/` so an upgrade cannot leave one behind. This is what lets an ordinary
+  release be produced without a signing Mac: the prepack gates required the signed `.app`s
+  to be present at pack time, which is why the attestation was macOS-only. Both gate
+  scripts are retained — they remain the right check for cutting a *helper* release.
+  Source: `cli/package.json`.
+- **The attestation producer no longer seeds signed helper apps into its worktree
+  (RUSH-3100).** That seeding existed only because `prepack` refused to pack without them,
+  so it was the workaround for the coupling above; its comments claimed "the prepack gates
   still decide … fails the pack exactly as before", which stopped being true the moment
-  those gates were removed — a stale comment guarding nothing.
+  those gates were removed. Source: `cli/scripts/release-attestation-produce.sh`.

--- a/cli/.changelog/next/RUSH-3100.md
+++ b/cli/.changelog/next/RUSH-3100.md
@@ -1,0 +1,20 @@
+### Removed
+
+- **No native binaries ship in the npm tarball.** `Agents CLI.app` (2.6 MB) and
+  `MenubarHelper.app` (3.3 MB) were copied into `dist/` by the `build` script, listed in
+  `files`, and hard-gated by two `prepack` checks — so every Linux and Windows user
+  downloaded 5.9 MB of signed macOS bundles, and the tarball could only be packed on a
+  Mac holding those signed bundles. All three are gone; the helpers are fetched on demand
+  from their own release tags and verified exactly as before (sha256 + Developer ID team +
+  notarization + designated-requirement pin).
+
+  Unpacked tarball: **21,337,724 → 15,629,419 bytes**.
+
+  `build` still removes any stale bundle from `dist/` so an upgrade over an older install
+  cannot leave one behind.
+
+  This is what lets an ordinary release be produced without a signing Mac: the `prepack`
+  gates (`verify-keychain-helper.sh`, `verify-menubar-helper.sh`) required the signed
+  `.app`s to be physically present at pack time, which is why the attestation could only
+  be produced on macOS. Both scripts are retained — they are still the right gate for a
+  *helper* release — they simply no longer block the CLI tarball.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -651,18 +651,20 @@ stamped by [`src/lib/hosts/session-index.ts`](src/lib/hosts/session-index.ts) fr
 the dispatch host. Any new writer of an `agents run --device`-shaped row must set it,
 or the index will claim the dispatching box.
 
-## Bundled native helpers (where the tarball's `.app`s come from)
+## Native helpers (downloaded on demand, never bundled)
 
-Two native helpers plus the standalone signed CLI binary ship **inside** this
-package's npm tarball; two more helpers are dev-only and live at repo-root `native/`.
+**No native binary ships inside this package's npm tarball** (RUSH-3100). Every helper
+is a signed + notarized GitHub release asset on its OWN tag, downloaded and verified on
+demand — see `src/lib/helper-versions.ts` for the per-helper version floors. That is what
+lets an ordinary CLI release be produced without a signing Mac.
 
 | Helper | Source | Ships in tarball? | Resolver |
 |---|---|---|---|
-| Keychain broker | `src/lib/secrets/keychain-helper.swift` → `bin/Agents CLI.app` | **Yes** (signed + notarized) — **AND** an `Agents_CLI.app.zip` GitHub **release asset** on the helper's own `keychain/v<x.y.z>` tag, fetched on demand when the tarball's copy is absent. The asset name is **underscored, not spaced**: GitHub rewrites a space to a dot at upload, so `Agents CLI.app.zip` was served as `Agents.CLI.app.zip` and every client 404'd. No DR pin (Team + notarization only, unlike the menu-bar helper): keychain items are gated by the access-group entitlement + biometry, not a DR-keyed grant. | `src/lib/secrets/install-helper.ts`, `src/lib/secrets/download-keychain.ts` (shared machinery in `src/lib/helper-download.ts`) |
-| Menu-bar helper | [`menubar/`](menubar) (SwiftPM) → `bin/MenubarHelper.app` | **Yes** (signed + notarized) — **AND** a `MenubarHelper.app.zip` GitHub **release asset** on the helper's own `menubar/v<x.y.z>` tag, fetched on demand when the tarball's copy is absent | `src/lib/menubar/install-menubar.ts`, `src/lib/menubar/download-menubar.ts` (shared machinery in `src/lib/helper-download.ts`) |
+| Keychain broker | `src/lib/secrets/keychain-helper.swift` → `bin/Agents CLI.app` | **No** (RUSH-3100) — signed + notarized `Agents_CLI.app.zip` GitHub **release asset** on the helper's own `keychain/v<x.y.z>` tag, downloaded on demand. The asset name is **underscored, not spaced**: GitHub rewrites a space to a dot at upload, so `Agents CLI.app.zip` was served as `Agents.CLI.app.zip` and every client 404'd. No DR pin (Team + notarization only, unlike the menu-bar helper): keychain items are gated by the access-group entitlement + biometry, not a DR-keyed grant. | `src/lib/secrets/install-helper.ts`, `src/lib/secrets/download-keychain.ts` (shared machinery in `src/lib/helper-download.ts`) |
+| Menu-bar helper | [`menubar/`](menubar) (SwiftPM) → `bin/MenubarHelper.app` | **No** (RUSH-3100) — signed + notarized `MenubarHelper.app.zip` GitHub **release asset** on the helper's own `menubar/v<x.y.z>` tag, downloaded on demand | `src/lib/menubar/install-menubar.ts`, `src/lib/menubar/download-menubar.ts` (shared machinery in `src/lib/helper-download.ts`) |
 | Standalone CLI binary | `src/` → `bun build --compile` → `bin/agents-macos` | **No** — dropped from the tarball (RUSH-3026); macOS installs fall back to the JS entrypoint until it returns as a per-release GitHub asset | `scripts/postinstall.js` |
 | computer-mac | [`../../native/computer-mac`](../../native/computer-mac) | No — signed + notarized GitHub **release asset** on its own `computer-mac/v<x.y.z>` tag, downloaded on demand | `src/lib/computer/computer-rpc.ts`, `src/lib/computer/download.ts` (shared machinery in `src/lib/helper-download.ts`) |
-| computer-win | [`../../native/computer-win`](../../native/computer-win) | No (staged at release) | `src/lib/computer/ssh-tunnel.ts` |
+| computer-win | [`../../native/computer-win`](../../native/computer-win) | No — `computer-helper-win.exe` GitHub **release asset** on its own `computer-win/v<x.y.z>` tag, downloaded on demand | `src/lib/computer/ssh-tunnel.ts` |
 
 Path math: compiled resolvers run from `cli/dist/lib/…`. Files still in `dist/lib/`
 reach repo-root `native/` in **4 hops** (`../../../../native/…`); files in
@@ -713,7 +715,8 @@ every `package.json#bin` entry after `tsc` emits. Newer npm preserves tarball fi
 mode and does NOT auto-chmod — 644 surfaces as `zsh: permission denied: agents`.
 
 The `files` allowlist in [`package.json`](package.json) is a **whitelist** — only
-`dist/**`, the two signed `.app`s, and the postinstall scripts + README/LICENSE ship.
+`dist/**` (JS/d.ts/JSON/sh) and the postinstall scripts + README/LICENSE ship. No native
+binary is in it (RUSH-3100).
 Nothing from `apps/`, `native/`, or sibling `packages/` can leak into the tarball.
 
 ## Releasing
@@ -919,15 +922,21 @@ read-back-verifies a keychain push and fails loudly if it didn't persist, pointi
 at this fix). `--device` / `-D` is the fleet routing flag (legacy `--host` is stripped but not registered) on the secrets remote
 commands. See [`docs/secrets.md`](docs/secrets.md) → *Pushing to a headless sign host*.
 
-**Why not CI?** The tarball bundles `dist/lib/secrets/Agents CLI.app` — a native
-keychain helper compiled with `swiftc`, codesigned (Developer ID), and notarized
-(`xcrun notarytool`). `prepack` ([`scripts/verify-keychain-helper.sh`](scripts/verify-keychain-helper.sh))
-refuses to pack unless that signed binary matches the sha pinned in
-`scripts/Agents CLI.app.sha256`. CI runners are Linux and cannot produce it. Rebuild
-the helper only when `src/lib/secrets/keychain-helper.swift` changes.
+**Why the tarball no longer needs a Mac (RUSH-3100).** It used to bundle
+`dist/lib/secrets/Agents CLI.app` — a `swiftc`-compiled keychain helper, Developer-ID
+codesigned and notarized — and `prepack`
+([`scripts/verify-keychain-helper.sh`](scripts/verify-keychain-helper.sh)) refused to pack
+unless that signed binary matched a pinned sha. Since CI runners are Linux and cannot
+produce it, **that gate, not the code, is what chained an ordinary release to a signing
+Mac.** The bundles are gone from the tarball; the helper is a release asset on its own
+tag, downloaded and verified on demand. Both `verify-*-helper.sh` scripts are retained —
+they are still the right gate for a *helper* release — they just no longer block the CLI
+tarball. Rebuild a helper only when its own sources change; the input digest in
+[`scripts/release-manifest.sh`](scripts/release-manifest.sh) is what decides that.
 
-**Menu-bar helper** ([`menubar/`](menubar) → `bin/MenubarHelper.app`) ships the same
-way — built into `bin/`, copied to `dist/lib/menubar/` by `build`, gated in `prepack`
+**Menu-bar helper** ([`menubar/`](menubar) → `bin/MenubarHelper.app`) is built and
+verified the same way — built into `bin/`, published as a release asset on its own
+`menubar/v<x.y.z>` tag, gated when that asset is cut by
 by [`scripts/verify-menubar-helper.sh`](scripts/verify-menubar-helper.sh) (presence +
 `codesign --verify` + a **stapled notarization ticket** + a **designated-requirement
 pin**). The DR pin is what keeps the Accessibility grant alive across upgrades:

--- a/cli/package.json
+++ b/cli/package.json
@@ -25,8 +25,6 @@
     "dist/**/*.d.ts",
     "dist/**/*.json",
     "dist/**/*.sh",
-    "dist/lib/secrets/Agents CLI.app/**",
-    "dist/lib/menubar/MenubarHelper.app/**",
     "scripts/postinstall.js",
     "scripts/install-helper.js",
     "CHANGELOG.md",
@@ -45,10 +43,10 @@
     "url": "https://github.com/phnx-labs/agents-cli/issues"
   },
   "scripts": {
-    "build": "tsc && rm -rf 'dist/lib/secrets/AgentsKeychain.app' 'dist/lib/secrets/Agents CLI.app' 'dist/lib/menubar/MenubarHelper.app' && ([ -d 'bin/Agents CLI.app' ] && cp -R 'bin/Agents CLI.app' 'dist/lib/secrets/Agents CLI.app' || true) && ([ -d 'bin/MenubarHelper.app' ] && mkdir -p 'dist/lib/menubar' && cp -R 'bin/MenubarHelper.app' 'dist/lib/menubar/MenubarHelper.app' || true) && ([ -f 'bin/agents-macos' ] && mkdir -p dist/bin && cp -f 'bin/agents-macos' 'dist/bin/agents' && chmod 755 'dist/bin/agents' || true)",
+    "build": "tsc && rm -rf 'dist/lib/secrets/AgentsKeychain.app' 'dist/lib/secrets/Agents CLI.app' 'dist/lib/menubar/MenubarHelper.app' && ([ -f 'bin/agents-macos' ] && mkdir -p dist/bin && cp -f 'bin/agents-macos' 'dist/bin/agents' && chmod 755 'dist/bin/agents' || true)",
     "build:bin": "scripts/build-bin.sh",
     "prepare": "npm run build",
-    "prepack": "cp ../README.md README.md && scripts/verify-keychain-helper.sh && scripts/verify-menubar-helper.sh",
+    "prepack": "cp ../README.md README.md",
     "postinstall": "node scripts/postinstall.js",
     "dev": "tsx src/index.ts",
     "changelog": "bun scripts/gen-changelog.ts",

--- a/cli/scripts/release-attestation-produce.sh
+++ b/cli/scripts/release-attestation-produce.sh
@@ -183,8 +183,10 @@ rm -f "$SUITE_LOG"
 
 # Sign + notarize headlessly, matching what release.sh's privileged phase did
 # before RUSH-2666 moved build/sign to attestation time. Skipped off a macOS
-# signing box; npm pack's own prepack gates fail closed in that case (no
-# unsigned tarball is ever attested).
+# signing box -- and since RUSH-3100 that skip costs nothing, because the tarball
+# no longer carries a helper bundle for `npm pack` to gate on. The claim that
+# "prepack gates fail closed in that case" was the old contract and is no longer
+# what stops an unsigned helper shipping; nothing ships one, from anywhere.
 if [[ "$(uname)" == "Darwin" ]] && command -v agents >/dev/null 2>&1 \
   && [[ -x scripts/sign-cli-binary.sh ]]; then
   bold "Signing + notarizing the CLI binary and helper apps..."
@@ -208,27 +210,17 @@ if [[ "$(uname)" == "Darwin" ]] && command -v agents >/dev/null 2>&1 \
     shasum -a 256 "bin/Agents CLI.app/Contents/MacOS/Agents CLI" > "scripts/Agents CLI.app.sha256"
   ' || die "signed helper build failed"
 else
-  gray "Not on a macOS signing box -- skipping helper sign/build; npm pack's prepack gates decide."
-  # Seed the already-signed helper .apps from the caller checkout (RUSH-3026).
-  # The ordinary release never rebuilds an unchanged helper, and this fresh
-  # worktree has an empty bin/ -- without seeding, every non-Mac producer died
-  # at prepack, which chained attestation production (and therefore releases)
-  # to a Mac. The prepack gates still decide: the keychain app must match the
-  # tree's committed sha pin and the menubar app must be present, so a wrong or
-  # tampered seed fails the pack exactly as before. Seeding is copy-if-absent
-  # only -- a Darwin producer's freshly signed apps are never overwritten.
-  for app in "Agents CLI.app" "MenubarHelper.app"; do
-    # Seed source is the caller checkout ($REPO_ROOT); accept the cli/ layout and
-    # the pre-flatten apps/cli/ layout so a stale caller checkout still seeds.
-    seed=""
-    [[ -d "$REPO_ROOT/cli/bin/$app" ]] && seed="$REPO_ROOT/cli/bin/$app"
-    [[ -z "$seed" && -d "$REPO_ROOT/apps/cli/bin/$app" ]] && seed="$REPO_ROOT/apps/cli/bin/$app"
-    if [[ ! -d "bin/$app" && -n "$seed" ]]; then
-      mkdir -p bin
-      cp -R "$seed" "bin/$app"
-      gray "seeded bin/$app from the caller checkout (already-signed; prepack gates verify it)"
-    fi
-  done
+  # Nothing to do off a signing box: the tarball carries no helper bundle
+  # (RUSH-3100), so `npm pack` neither wants nor gates on one.
+  #
+  # This branch used to SEED the already-signed .apps from the caller checkout,
+  # because `prepack` refused to pack without them and a fresh worktree has an
+  # empty bin/ -- that seeding was the workaround for the very coupling RUSH-3100
+  # removed. With the gates gone the seed copies signed bundles into a tree that
+  # will not ship them, and its own comment ("the prepack gates still decide ...
+  # fails the pack exactly as before") became false the moment they were removed.
+  # A stale comment guarding nothing is worse than no comment, so both are gone.
+  gray "Not a macOS signing box -- nothing to do: the tarball ships no helper bundle."
 fi
 
 bold "Building (bun run build)..."

--- a/cli/scripts/release-attestation-produce.sh
+++ b/cli/scripts/release-attestation-produce.sh
@@ -17,12 +17,14 @@
 #   2. On a macOS box with `agents` + the apple.com secrets bundle, signs and
 #      notarizes the CLI binary and the two helper .apps headlessly (the same
 #      steps release.sh's privileged phase ran before RUSH-2666 relocated
-#      build/sign to attestation time). Off that box, this step is skipped and
-#      `npm pack`'s own prepack gates (verify-keychain-helper.sh,
-#      verify-menubar-helper.sh) fail closed instead -- there is no unsigned
-#      fallback tarball. (The CLI binary left the tarball in RUSH-3026, so its
-#      gate left prepack; the sign step below still builds it on a Mac for the
-#      per-release GitHub-asset path.)
+#      build/sign to attestation time). Off that box the step is simply skipped,
+#      and since RUSH-3100 that costs nothing: the tarball carries no helper
+#      bundle, so there is nothing for `npm pack` to gate on and no unsigned
+#      bundle can ship from anywhere. The old prepack gates
+#      (verify-keychain-helper.sh, verify-menubar-helper.sh) are retained for
+#      cutting a HELPER release, not for packing the CLI. (The CLI binary left
+#      the tarball in RUSH-3026; the sign step below still builds it on a Mac for
+#      the per-release GitHub-asset path.)
 #   3. Packs the tarball (`npm pack`) and binds its sha256 into the record.
 #   4. Writes the attestation via release-attestation.sh write, then copies
 #      the tarball alongside it so release-attestation.sh tarball/promote can

--- a/cli/scripts/release-attestation-produce.test.ts
+++ b/cli/scripts/release-attestation-produce.test.ts
@@ -166,15 +166,23 @@ function runProduce(
 
 
 describe('release-attestation-produce.sh', () => {
-  it('seeds the already-signed helper apps from the caller checkout on a non-Mac producer (RUSH-3026)', () => {
-    // The producer's fresh worktree has an empty bin/ (the .apps are untracked),
-    // so before this fix every non-Mac producer died at prepack — chaining
-    // attestation production, and therefore releases, to a Mac. The caller
-    // checkout's already-signed apps must be seeded copy-if-absent; the prepack
-    // gates still verify them.
-    const root = tmp('attest-produce-seed-');
+  it('does NOT seed helper apps on a non-Mac producer — the tarball ships none (RUSH-3100)', () => {
+    // This replaces the RUSH-3026 seeding test, and the reversal is the point.
+    //
+    // Seeding existed ONLY because `prepack` refused to pack without the signed
+    // .apps, and the producer's fresh worktree has an empty bin/. That was the
+    // workaround for the very coupling RUSH-3100 removed. With the gates gone,
+    // copying signed bundles into a tree that will not ship them is pure motion —
+    // and the seed's own comment ("the prepack gates still decide … fails the pack
+    // exactly as before") became false the moment they were removed.
+    //
+    // The assertion that matters is the NEGATIVE one: a non-Mac producer must
+    // still succeed. Asserting only "no seeding" would pass on a producer that
+    // broke outright.
+    const root = tmp('attest-produce-noseed-');
     const fx = buildFixture(root);
-    // Untracked, already-signed apps exist only in the CALLER checkout.
+    // Already-signed apps present in the CALLER checkout — the exact condition
+    // that used to trigger seeding.
     for (const [app, binName] of [
       ['Agents CLI.app', 'Agents CLI'],
       ['MenubarHelper.app', 'AGI Menu'],
@@ -184,17 +192,20 @@ describe('release-attestation-produce.sh', () => {
       fs.writeFileSync(path.join(dir, binName), 'signed-bytes\n');
     }
     const result = runProduce(fx, ['--keep']);
-    // Strip ANSI color codes so the path capture below is not polluted by the
-    // gray() escape sequences the producer wraps its lines in.
-    const out = (result.stdout + result.stderr).replace(/\[[0-9;]*m/g, '');
+    const out = (result.stdout + result.stderr).replace(/\[[0-9;]*m/g, '');
+
+    // It still produces an attestation.
     expect(result.status, out).toBe(0);
-    expect(out).toContain('seeded bin/Agents CLI.app');
-    expect(out).toContain('seeded bin/MenubarHelper.app');
-    // The kept worktree genuinely carries the seeded apps where prepack looks.
+    // …without copying either bundle anywhere.
+    expect(out).not.toContain('seeded bin/');
     const kept = out.match(/kept worktree for inspection: (\S+)/);
     expect(kept, out).toBeTruthy();
-    expect(fs.existsSync(path.join(kept![1], 'cli/bin/Agents CLI.app/Contents/MacOS/Agents CLI'))).toBe(true);
-    expect(fs.existsSync(path.join(kept![1], 'cli/bin/MenubarHelper.app/Contents/MacOS/AGI Menu'))).toBe(true);
+    for (const app of ['Agents CLI.app', 'MenubarHelper.app']) {
+      expect(
+        fs.existsSync(path.join(kept![1], 'cli/bin', app)),
+        `${app} must not be copied into the producer worktree`,
+      ).toBe(false);
+    }
   });
 
   it('routes --test-crabbox to test.sh\'s crabbox lane (surface parity, RUSH-3211)', () => {


### PR DESCRIPTION
The headline of RUSH-3100: **no native binaries in the npm tarball.**

## What shipped before

`cli/package.json` copied two signed macOS bundles into `dist/`, listed them in `files`,
and hard-gated `prepack` on both being present and correctly signed:

```
build:   … cp -R 'bin/Agents CLI.app' 'dist/lib/secrets/Agents CLI.app' …
             cp -R 'bin/MenubarHelper.app' 'dist/lib/menubar/MenubarHelper.app' …
files:   dist/lib/secrets/Agents CLI.app/**
         dist/lib/menubar/MenubarHelper.app/**
prepack: … scripts/verify-keychain-helper.sh && scripts/verify-menubar-helper.sh
```

So every Linux and Windows user downloaded 5.9 MB of signed macOS bundles they can never
execute — and, more consequentially, **the tarball could only be packed on a Mac holding
those signed bundles**, which is exactly why the release attestation could not be produced
in CI.

## Why this is safe to do now, and was not before

The download fallback these bundles masked **was dead**. `MenubarHelper.app.zip` and
`Agents CLI.app.zip` had zero assets across the last 25 tags, and the keychain asset name
could never have resolved at all (GitHub rewrites the space to a dot). Evicting the
bundles before fixing that would have bricked `agents menubar install` and the keychain
broker on every fresh install.

That is fixed and shipped: all four helpers now publish to their own tags and resolve
through the existing verification path (#3056, merged).

## Evidence

**The tarball, packed for real:**

```
$ npm pack
phnx-labs-agents-cli-1.22.48.tgz

$ tar -tzf *.tgz | grep -c '\.app/'
0
```

Platform-binary scan of the packed archive — `.app/`, `.exe`, `bin/agents`: **NONE**.
Unpacked size **21,337,724 → 15,629,419 bytes**.

**Installed clean into an isolated prefix, then asked for its helpers:**

```
$ npm install ./phnx-labs-agents-cli-1.22.48.tgz
added 156 packages

$ python -c "walk dist/ for *.app"
app bundles in installed tree: NONE

$ node -e "downloadMenubarHelperApp(...) / downloadKeychainHelperApp(...)"
Downloading MenubarHelper.app.zip menubar/v1.0.0 from GitHub releases...
OK   menubar  -> ~/.agents/.cache/menubar/mac-helper/v1.0.0/MenubarHelper.app
Downloading Agents_CLI.app.zip keychain/v1.0.0 from GitHub releases...
OK   keychain -> ~/.agents/.cache/secrets/mac-helper/v1.0.0/Agents CLI.app
```

The helper cache was **moved aside first**, so those are real fetches, not cache hits.
Both land `source=Notarized Developer ID` under `spctl --assess`.

## Deliberate non-changes

- **`build` still `rm -rf`s the bundle paths.** Dropping the copy-in is not enough — an
  upgrade over an older install would otherwise leave a stale bundle in `dist/`, and a
  stale signed bundle is worse than none.
- **`verify-keychain-helper.sh` and `verify-menubar-helper.sh` are retained.** They are
  still the correct gate for a *helper* release; they simply no longer block the CLI
  tarball. Deleting them would remove the check that stops an un-notarized bundle being
  published as a helper asset.
- **The bundle directory names are unchanged** (`Agents CLI.app`, with its space) — that
  is the on-disk name macOS and the TCC/keychain grant key on.

## Follow-ups, not in scope here

`release.sh` still has a `--with-helpers`-shaped gap: there is no flag to opt a helper
release in or out of an ordinary CLI release. And PHNX-3228 tracks the publishers
(`publish-computer-helper-mac.sh`, the Windows workflow) still targeting the CLI tag.
