### PR TITLE
test(docs): scope the severity guard to the sentence, closing the reworded bypass

### DIFF
--- a/cli/src/lib/devices/doctor-findings.test.ts
+++ b/cli/src/lib/devices/doctor-findings.test.ts
@@ -667,18 +667,34 @@ describe('the severity rubric matches the code (docs cannot drift from behavior)
     // while its own restored `docs/observability.md` correctly listed it under
     // WARNING, in the same commit. Two doc sections contradicting each other on
     // one finding's severity is worse than either being silently absent.
+    // Scoped to the SENTENCE, not to adjacency. An adjacency-only match (severity
+    // word and backticked kind separated by whitespace alone) missed the review's
+    // mutation `is reported as CRITICAL when \`env-secret-export\` fires` — the
+    // same wrong claim, reworded. A sentence is the unit a reader actually binds
+    // a severity to.
+    //
+    // Flags only when the sentence carries the WRONG severity word and NOT the
+    // right one, so a sentence legitimately naming both ("criticals and warnings
+    // both appear in ...") does not fire, and neither does observability.md's own
+    // rubric, where each bucket sits in its own sentence with only its own word.
     const docsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'docs');
     const wrong: string[] = [];
     for (const file of fs.readdirSync(docsDir).filter((f) => f.endsWith('.md'))) {
       const text = fs.readFileSync(path.join(docsDir, file), 'utf-8');
-      for (const kind of ALL_FINDING_KINDS) {
-        const actual = FINDING_SEVERITY[kind];
-        const other = actual === 'critical' ? 'warning' : 'critical';
-        // Both orders occur naturally: "a critical `kind`" and "an `kind` warning".
-        const before = new RegExp(`\\b${other}\\s+\`${kind}\``, 'i');
-        const after = new RegExp(`\`${kind}\`\\s+${other}\\b`, 'i');
-        if (before.test(text) || after.test(text)) {
-          wrong.push(`${file}: ${kind} called ${other}, is ${actual}`);
+      for (const sentence of text.split(/(?<=[.!?])\s+|\n{2,}/)) {
+        const hasCritical = /\bcritical\b/i.test(sentence);
+        const hasWarning = /\bwarning\b/i.test(sentence);
+        if (!hasCritical && !hasWarning) continue;
+        for (const kind of ALL_FINDING_KINDS) {
+          // Backtick-delimited so a kind is never credited to a longer one that
+          // contains it (`cli-missing` inside `host-cli-missing`, and two more).
+          if (!sentence.includes(`\`${kind}\``)) continue;
+          const actual = FINDING_SEVERITY[kind];
+          const saysRight = actual === 'critical' ? hasCritical : hasWarning;
+          const saysOther = actual === 'critical' ? hasWarning : hasCritical;
+          if (saysOther && !saysRight) {
+            wrong.push(`${file}: ${kind} called ${actual === 'critical' ? 'warning' : 'critical'}, is ${actual}`);
+          }
         }
       }
     }

--- a/cli/src/lib/devices/doctor-findings.test.ts
+++ b/cli/src/lib/devices/doctor-findings.test.ts
@@ -681,9 +681,21 @@ describe('the severity rubric matches the code (docs cannot drift from behavior)
     const wrong: string[] = [];
     for (const file of fs.readdirSync(docsDir).filter((f) => f.endsWith('.md'))) {
       const text = fs.readFileSync(path.join(docsDir, file), 'utf-8');
-      for (const sentence of text.split(/(?<=[.!?])\s+|\n{2,}/)) {
-        const hasCritical = /\bcritical\b/i.test(sentence);
-        const hasWarning = /\bwarning\b/i.test(sentence);
+      // Do NOT split on a period that ends an abbreviation: `e.g.` / `i.e.` /
+      // `cf.` cut a clause in half, and the review defeated the guard that way —
+      // "the `env-secret-export` case, i.e. ... is treated as critical." became
+      // two fragments, neither holding both the kind and the wrong word.
+      // Version numbers (`1.22.48`) are safe already: the split needs whitespace
+      // after the period.
+      const sentences = text
+        .replace(/\b(e\.g|i\.e|cf|etc|vs)\./gi, '$1\u0000')
+        .split(/(?<=[.!?])\s+|\n{2,}/)
+        .map((x) => x.replace(/\u0000/g, '.'));
+      for (const sentence of sentences) {
+        // `criticals` / `warnings` must count: \b...\b missed the plural, which
+        // is ordinary prose ("the criticals are listed first").
+        const hasCritical = /\bcriticals?\b/i.test(sentence);
+        const hasWarning = /\bwarnings?\b/i.test(sentence);
         if (!hasCritical && !hasWarning) continue;
         for (const kind of ALL_FINDING_KINDS) {
           // Backtick-delimited so a kind is never credited to a longer one that


### PR DESCRIPTION
Follow-up to #3070, which merged while this was being written — so it is a separate PR
rather than a push onto that branch.

## What #3070 shipped, and where it was weak

#3070 added `no doc calls a finding by the wrong severity in prose`, a guard against the
bug it was fixing: `docs/secrets.md` calling `env-secret-export` **critical** when
`FINDING_SEVERITY` says **warning**.

Its review then broke that guard by mutation. The regexes required the severity word and
the backticked kind to be separated by whitespace alone, so a reworded form of the exact
same wrong claim passed silently:

```
is reported as CRITICAL when `env-secret-export` fires     →  guard PASSES
```

A guard that misses the reworded form of the one bug it exists for is close to no guard,
and worse than none because it looks like coverage. The review judged it non-blocking and
recommended a follow-up; this is that follow-up, filed immediately rather than left to be
forgotten.

## The fix

Adjacency → **sentence scope**. A sentence is the unit a reader actually binds a severity
to. Both forms now fail:

```
mutation A (the review's):  "is reported as CRITICAL when `env-secret-export` fires"
  × no doc calls a finding by the wrong severity in prose
  +   "secrets.md: env-secret-export called critical, is warning"

mutation B (the original):  "reports it as a critical `env-secret-export`"
  × no doc calls a finding by the wrong severity in prose
  +   "secrets.md: env-secret-export called critical, is warning"
```

Clean corpus: **80 passed**, `tsc --noEmit` clean.

## Why it does not now false-positive

Widening the window is exactly where this class of guard starts crying wolf, so two
properties are kept deliberately:

- **Fires only when the sentence carries the WRONG severity word and NOT the right one.**
  A sentence legitimately naming both does not fire — and neither does
  `observability.md`'s own rubric, where each bucket sits in its own sentence with only
  its own word. A naive proximity window would have broken precisely that.
- **Kinds stay backtick-delimited**, so the substring traps cannot cross-credit:
  `cli-missing` inside `host-cli-missing`, `stale` inside `stale-cli`, `duplicate-hook`
  inside `duplicate-hook-drift`.

## Known boundary, stated rather than implied

The guard scans `cli/docs/*.md` only. `cli/AGENTS.md` carries its own severity prose,
covered by a narrower bucket-slice test; the review checked it and found no live bug. I am
not widening twice in one change, but the boundary is real and recorded here so it is not
mistaken for full coverage.
