### PR TITLE
feat(release): --with-helpers, so an ordinary release publishes the CLI and nothing else

### DIFF
--- a/cli/.changelog/next/RUSH-3216.md
+++ b/cli/.changelog/next/RUSH-3216.md
@@ -1,6 +1,4 @@
-### Added
-
-- **`scripts/release.sh --with-helpers`** — an ordinary CLI release now publishes the CLI
+- **``scripts/release.sh --with-helpers` (RUSH-3216)`** — an ordinary CLI release now publishes the CLI
   and nothing else. Two couplings remained after helpers moved to their own tags, and both
   are now behind this opt-in (default **off**):
   - staging `ComputerHelper.app.zip` onto the CLI's `v<version>` tag, which publishes an
@@ -14,3 +12,4 @@
   `origin/<default>` and re-runs the script from there, so the second parse is the merged
   copy and an unmerged flag dies as `unknown flag` even though the local parser handles it.
   Pass `--orchestration-phase` to skip the re-exec when exercising a new flag pre-merge.
+  Source: `cli/scripts/release.sh`.

--- a/cli/.changelog/next/RUSH-3216.md
+++ b/cli/.changelog/next/RUSH-3216.md
@@ -1,15 +1,12 @@
-- **``scripts/release.sh --with-helpers` (RUSH-3216)`** — an ordinary CLI release now publishes the CLI
-  and nothing else. Two couplings remained after helpers moved to their own tags, and both
-  are now behind this opt-in (default **off**):
-  - staging `ComputerHelper.app.zip` onto the CLI's `v<version>` tag, which publishes an
-    asset no client requests — every helper resolves from its own tag now; and
-  - `release-manifest.sh require`, which re-derives every helper's input digest and
-    **aborts** when one moved without a rebuild. That failed a perfectly good CLI release
-    because someone edited Swift the CLI does not ship.
-
-  Also documents a trap found while building this: a **new `release.sh` flag is inert
-  until it is merged**. `release.sh` execs `release-worktree.sh`, which checks out
-  `origin/<default>` and re-runs the script from there, so the second parse is the merged
-  copy and an unmerged flag dies as `unknown flag` even though the local parser handles it.
-  Pass `--orchestration-phase` to skip the re-exec when exercising a new flag pre-merge.
-  Source: `cli/scripts/release.sh`.
+- **`release.sh --with-helpers` — an ordinary release publishes the CLI and nothing else
+  (RUSH-3216).** Two couplings survived helpers moving to their own tags, and both are now
+  behind this opt-in (default off): staging `ComputerHelper.app.zip` onto the CLI's
+  `v<version>` tag, which publishes an asset no client requests; and
+  `release-manifest.sh require`, which re-derives every helper's input digest and aborts
+  when one moved without a rebuild — failing a good CLI release over Swift the CLI does not
+  ship. Source: `cli/scripts/release.sh`.
+- **A new `release.sh` flag is inert until it is merged (RUSH-3216).** `release.sh` execs
+  `release-worktree.sh`, which checks out `origin/<default>` and re-runs the script from
+  there, so the second parse is the merged copy and an unmerged flag dies as `unknown
+  flag` even though the local parser handles it. Pass `--orchestration-phase` to skip the
+  re-exec when exercising a new flag pre-merge. Source: `cli/scripts/release.sh`.

--- a/cli/.changelog/next/RUSH-3216.md
+++ b/cli/.changelog/next/RUSH-3216.md
@@ -8,3 +8,9 @@
   - `release-manifest.sh require`, which re-derives every helper's input digest and
     **aborts** when one moved without a rebuild. That failed a perfectly good CLI release
     because someone edited Swift the CLI does not ship.
+
+  Also documents a trap found while building this: a **new `release.sh` flag is inert
+  until it is merged**. `release.sh` execs `release-worktree.sh`, which checks out
+  `origin/<default>` and re-runs the script from there, so the second parse is the merged
+  copy and an unmerged flag dies as `unknown flag` even though the local parser handles it.
+  Pass `--orchestration-phase` to skip the re-exec when exercising a new flag pre-merge.

--- a/cli/.changelog/next/RUSH-3216.md
+++ b/cli/.changelog/next/RUSH-3216.md
@@ -1,0 +1,10 @@
+### Added
+
+- **`scripts/release.sh --with-helpers`** — an ordinary CLI release now publishes the CLI
+  and nothing else. Two couplings remained after helpers moved to their own tags, and both
+  are now behind this opt-in (default **off**):
+  - staging `ComputerHelper.app.zip` onto the CLI's `v<version>` tag, which publishes an
+    asset no client requests — every helper resolves from its own tag now; and
+  - `release-manifest.sh require`, which re-derives every helper's input digest and
+    **aborts** when one moved without a rebuild. That failed a perfectly good CLI release
+    because someone edited Swift the CLI does not ship.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -735,14 +735,18 @@ each phase labeled with the box it runs on and a ✓/✗ result:
 |---|---|---|
 | Orchestrate: bump, changelog, PR, tag | a detached worktree on the box you invoked it on | fresh `origin/<default>` under `.agents/worktrees/release-v<version>-<pid>` |
 | CI / tests (Linux) | an **auto-picked fleet worker** | [`scripts/test.sh`](scripts/test.sh) resolves it through `agents devices pick` — the least-loaded reachable POSIX box in the same auto pool `agents run --device auto` uses, so `role=worker`/`role=personal` marks govern it. `--test-device <box>` pins one; `--crabbox` still routes to a disposable [`sandbox.sh`](scripts/sandbox.sh) workspace. **Dynamic either way, never a hardcoded or release-exclusive instance** |
-| Promote attested tgz + npm publish + computer-helper re-attach | the **home base** (any OS — promote-only, RUSH-3026) | `--device <name>` in `release.sh`, defaulting to `mac-mini`; the script detects if it's already there (`scutil --get LocalHostName` / `hostname -s`), else reaches it over `ssh` |
+| Promote attested tgz + npm publish (+ computer-helper re-attach **only with `--with-helpers`**) | the **home base** (any OS — promote-only, RUSH-3026) | `--device <name>` in `release.sh`, defaulting to `mac-mini`; the script detects if it's already there (`scutil --get LocalHostName` / `hostname -s`), else reaches it over `ssh` |
 
 The home base holds the npm publish token + gh auth. It defaults to `mac-mini`
 and is overridable with **`--device <name>`**. Not an env var: a flag with a
 default. Since RUSH-3026 the home-base phase is **promote-only** (download the
-attested tarball, verify, install-smoke, `npm publish`, re-attach the reused
-helper zip) — nothing on it signs or notarizes, so **any OS works as the home
-base**, Linux included. `assert_promote_home_base` preflights it (tools + gh
+attested tarball, verify, install-smoke, `npm publish`) — nothing on it signs or
+notarizes, so **any OS works as the home base**, Linux included. Re-attaching the
+reused helper zip and verifying the helper input-digest manifest are **opt-in**
+(`--with-helpers`): an ordinary release publishes the CLI and nothing else, since
+helpers resolve from their own tags
+([`src/lib/helper-versions.ts`](src/lib/helper-versions.ts)) and a manifest check
+would otherwise abort a good CLI release whenever a helper's sources moved. `assert_promote_home_base` preflights it (tools + gh
 auth + a headlessly readable `npmjs.com` `NPM_TOKEN`) before the release's
 first mutation. Helper signing is a separate, source-change-only path and still
 needs a provisioned Mac. The test worker is **not** hardcoded.

--- a/cli/scripts/release.sh
+++ b/cli/scripts/release.sh
@@ -141,6 +141,16 @@ TARGET=""
 # build + sign + notarize + npm publish phase; defaults to mac-mini. A for-loop
 # with a pending flag (not `shift`) preserves "$@" intact, so the release-worktree
 # re-exec (RELEASE_ARGS=("$@")) forwards every arg including --device.
+#
+# A NEW FLAG DOES NOT WORK UNTIL IT IS ON origin/<default>. `:190` execs
+# release-worktree.sh, which checks out a worktree at `origin/$DEFAULT_BRANCH`
+# and re-runs THIS script from there — so the second parse is the merged copy,
+# not your working tree, and an unmerged flag dies as `unknown flag`. Verified on
+# 2026-08-25 while adding --with-helpers: the local parser accepted it and the
+# re-exec rejected it. To exercise a new flag pre-merge, pass
+# `--orchestration-phase` (the internal marker that means "already in the
+# worktree") to skip the re-exec. Content-assertion tests cannot catch this class:
+# they read the working-tree file, while the failure is in a different copy.
 DEVICE=""
 expect_device=false
 for arg in "$@"; do
@@ -160,7 +170,7 @@ for arg in "$@"; do
     --orchestration-phase) ORCHESTRATION_PHASE=true ;;
     --device|--host) expect_device=true ;;
     --device=*|--host=*) DEVICE="${arg#*=}" ;;
-    -h|--help) printf '%s\n' "usage: scripts/release.sh <version> [--apply] [--device <name>] [--skip-tests] [--yes]"; exit 0 ;;
+    -h|--help) printf '%s\n' "usage: scripts/release.sh <version> [--apply] [--with-helpers] [--device <name>] [--skip-tests] [--yes]"; exit 0 ;;
     --*) die "unknown flag: $arg" ;;
     *)
       [[ -z "$TARGET" ]] || die "unexpected argument: $arg"

--- a/cli/scripts/release.sh
+++ b/cli/scripts/release.sh
@@ -23,7 +23,13 @@
 # attested candidate; tag; promote the exact .tgz. Ordinary release P99 is
 # <=180 seconds. A retry still demands the same exact-tree key.
 #
-# Usage: scripts/release.sh <version> [--apply] [--device <name>]
+# Usage: scripts/release.sh <version> [--apply] [--with-helpers] [--device <name>]
+#
+# --with-helpers (default OFF) opts the release into helper work: staging the
+# computer-mac asset onto v<version> and verifying the helper input-digest
+# manifest. An ordinary release publishes the CLI and NOTHING else -- helpers
+# live on their own tags (cli/src/lib/helper-versions.ts) and are downloaded on
+# demand, so a CLI release neither ships nor gates on them.
 #
 # --device <name> (alias --host) picks the Mac that builds/signs/publishes;
 # defaults to mac-mini. Everything else is unchanged and zero-config.
@@ -119,6 +125,7 @@ phase_fail() {
 
 # ----- Parse args -----
 APPLY=false
+WITH_HELPERS=false
 SKIP_TESTS=false
 YES=false
 # --home-base-phase is an INTERNAL entrypoint, not a user knob: the trigger box
@@ -141,6 +148,13 @@ for arg in "$@"; do
   case "$arg" in
     --apply) APPLY=true ;;
     --skip-tests) SKIP_TESTS=true ;;
+    # Default OFF. An ordinary release publishes the CLI and NOTHING else: helpers
+    # live on their own tags now (cli/src/lib/helper-versions.ts), so staging a
+    # helper asset onto v$TARGET produces something no client requests, and
+    # requiring the helper manifest fails a perfectly good CLI release whenever a
+    # helper's sources moved without a rebuild. That coupling is the thing this
+    # flag exists to remove; pass it to opt a release back into helper work.
+    --with-helpers) WITH_HELPERS=true ;;
     --yes|-y) YES=true ;;
     --home-base-phase) HOME_BASE_PHASE=true ;;
     --orchestration-phase) ORCHESTRATION_PHASE=true ;;
@@ -239,11 +253,15 @@ run_home_base_phase() {
   # The tagged worktree is throwaway and has no store. Pull the files the
   # trigger uploaded to v$TARGET (stable names) into a temp dir.
   attest_dir="$(mktemp -d "${TMPDIR:-/tmp}/agents-cli-release-attest.XXXXXX")"
-  gh release download "v$TARGET" --dir "$attest_dir" \
-    --pattern 'release-attestation.json' \
-    --pattern 'release-manifest.json' \
-    --pattern 'phnx-labs-agents-cli-*.tgz' \
-    --pattern 'ComputerHelper.app.zip*' \
+  # Build the pattern list as an ARRAY. A `$( ... )` splice here would be
+  # word-split by the shell, which is the same class of bug that silently dropped
+  # vitest args in test.sh -- and an empty splice under `set -u` is its own trap.
+  dl_patterns=(--pattern 'release-attestation.json'
+               --pattern 'phnx-labs-agents-cli-*.tgz')
+  if [[ "$WITH_HELPERS" == true ]]; then
+    dl_patterns+=(--pattern 'release-manifest.json' --pattern 'ComputerHelper.app.zip*')
+  fi
+  gh release download "v$TARGET" --dir "$attest_dir" "${dl_patterns[@]}" \
     || die "could not download attested artifacts from GitHub release v$TARGET -- the trigger must upload them before this phase"
   bold "Requiring exact-tree attestation for ${tree:0:12} (no parent/nearby fallback)..."
   attest="$(scripts/release-attestation.sh require --dir "$attest_dir" --tree "$tree" --repo-root "$repo_root")" \
@@ -253,10 +271,19 @@ run_home_base_phase() {
   scripts/release-attestation.sh promote --file "$attest" --tarball "$tgz" >/dev/null \
     || die "pretested tarball failed digest bind -- refusing to rebuild"
 
-  manifest="$attest_dir/release-manifest.json"
-  [[ -f "$manifest" ]] || die "release manifest missing at $manifest -- no fallback rebuild"
-  scripts/release-manifest.sh require --file "$manifest" --repo-root "$repo_root" \
-    || die "helper manifest failed -- rebuild/notarization is outside the ordinary release path"
+  # Helper-manifest verification is opt-in (--with-helpers). It re-derives every
+  # helper's input digest and FAILS when one moved without a rebuild -- correct
+  # when the release is publishing helpers, and pure obstruction when it is not:
+  # a CLI-only release would abort because someone edited Swift the CLI does not
+  # ship. Helpers resolve from their own tags, so nothing here gates what users get.
+  if [[ "$WITH_HELPERS" == true ]]; then
+    manifest="$attest_dir/release-manifest.json"
+    [[ -f "$manifest" ]] || die "release manifest missing at $manifest -- no fallback rebuild"
+    scripts/release-manifest.sh require --file "$manifest" --repo-root "$repo_root" \
+      || die "helper manifest failed -- rebuild/notarization is outside the ordinary release path"
+  else
+    gray "CLI-only release: skipping helper-manifest verification (pass --with-helpers to include it)"
+  fi
 
   bold "Install-smoke of the exact pretested tarball..."
   scripts/release-install-smoke.sh "$tgz" "$TARGET" \
@@ -1040,19 +1067,30 @@ upload_release_proof() {
   tgz="$(jq -r .path <<<"$tgz_json")"
   [[ -n "$tgz" && -f "$tgz" ]] || die "pretested tarball missing -- refusing to rebuild"
   cp "$tgz" "$dest/$(basename "$tgz")"
-  [[ -f "$store/release-manifest.json" ]] \
-    || die "release manifest missing at $store/release-manifest.json -- no fallback rebuild"
-  cp "$store/release-manifest.json" "$dest/release-manifest.json"
-  if ! scripts/release-manifest.sh copy-asset --file "$store/release-manifest.json" --helper computer-mac --asset-path "$dest"; then
-    gh release download "v$PHNX_LATEST" --dir "$dest" --pattern 'ComputerHelper.app.zip*' \
-      || die "could not reuse ComputerHelper.app.zip from v$PHNX_LATEST -- no fallback rebuild"
+  # Helper assets and the manifest ride the release ONLY with --with-helpers.
+  #
+  # By default a CLI release publishes the CLI and nothing else. Helpers resolve
+  # from their OWN tags (`menubar/v<x.y.z>`, `keychain/v<x.y.z>`,
+  # `computer-mac/v<x.y.z>`, `computer-win/v<x.y.z>` -- see
+  # cli/src/lib/helper-versions.ts), so an asset staged onto v$TARGET is one no
+  # client ever requests: dead weight on every release, and previously a filename
+  # proven to 404 (the keychain staging wrote `Agents CLI.app.zip`, which GitHub
+  # rewrites to a dot).
+  #
+  # The comment that used to sit here claimed no helper assets were staged at all,
+  # which was false three lines below its own text -- computer-mac was still being
+  # copied. Flagged in the review of #3056; the flag is what makes the claim true.
+  if [[ "$WITH_HELPERS" == true ]]; then
+    [[ -f "$store/release-manifest.json" ]] \
+      || die "release manifest missing at $store/release-manifest.json -- no fallback rebuild"
+    cp "$store/release-manifest.json" "$dest/release-manifest.json"
+    if ! scripts/release-manifest.sh copy-asset --file "$store/release-manifest.json" --helper computer-mac --asset-path "$dest"; then
+      gh release download "v$PHNX_LATEST" --dir "$dest" --pattern 'ComputerHelper.app.zip*' \
+        || die "could not reuse ComputerHelper.app.zip from v$PHNX_LATEST -- no fallback rebuild"
+    fi
+  else
+    gray "CLI-only release: no helper assets staged onto v$TARGET (pass --with-helpers to include them)"
   fi
-  # No helper assets are staged onto v$TARGET any more. Helpers resolve from their
-  # OWN tags (`menubar/v<x.y.z>`, `keychain/v<x.y.z>`, `computer-mac/v<x.y.z>`,
-  # `computer-win/v<x.y.z>` -- see cli/src/lib/helper-versions.ts), so anything
-  # published here would be an asset no client ever requests. Worse, the keychain
-  # staging wrote it as `Agents CLI.app.zip`, and GitHub rewrites that space to a
-  # dot on upload -- so every release was republishing a filename proven to 404.
   if gh release view "v$TARGET" >/dev/null 2>&1; then
     gh release upload "v$TARGET" "$dest"/* --clobber \
       || die "failed to upload attested artifacts to v$TARGET"

--- a/cli/scripts/release.test.ts
+++ b/cli/scripts/release.test.ts
@@ -115,11 +115,35 @@ describeRelease('release.sh: an ordinary release is CLI-only', () => {
     expect(RELEASE_SH).toMatch(/^WITH_HELPERS=false$/m);
   });
 
-  it('advertises the flag in --help, so it is discoverable without reading the source', () => {
-    // Caught by running the script, not by reading it: --help listed every other
-    // flag and silently omitted this one.
-    const help = RELEASE_SH.slice(RELEASE_SH.indexOf('-h|--help)'));
-    expect(help.slice(0, 300)).toContain('--with-helpers');
+  it('lists EVERY flag its parser accepts in --help (executed, not grepped)', () => {
+    // Runs the real script. The content-assertion version of this test passed
+    // while --help silently omitted --with-helpers, because it only checked that
+    // one known string appeared. This derives the flag set from the parser and
+    // compares it against actual --help OUTPUT, so the next flag someone adds is
+    // covered without anyone remembering to extend the test.
+    const help = spawnSync('bash', [RELEASE_SH_PATH, '--help'], { encoding: 'utf-8' });
+    expect(help.status, help.stderr).toBe(0);
+
+    // Flags the `case` arms accept, minus the internal phase markers (deliberately
+    // undocumented) and --help itself.
+    const INTERNAL = new Set(['--home-base-phase', '--orchestration-phase', '-h', '--help']);
+    // Aliases are satisfied by their primary being documented — `--help` should
+    // teach one spelling, not every accepted synonym.
+    const ALIAS_OF: Record<string, string> = { '--host': '--device', '-y': '--yes' };
+    const parsed = new Set<string>();
+    for (const arm of RELEASE_SH.matchAll(/^\s{4}(-[^)]+)\)/gm)) {
+      for (const flag of arm[1].split('|')) {
+        const name = flag.trim().replace(/=\*$/, '');
+        // `--*)` is the unknown-flag catch-all, not a flag.
+        if (name === '--*' || !name.startsWith('-')) continue;
+        if (INTERNAL.has(name)) continue;
+        parsed.add(ALIAS_OF[name] ?? name);
+      }
+    }
+    expect(parsed.size, 'no flags parsed out of the case arms').toBeGreaterThan(3);
+
+    const missing = [...parsed].filter((f) => !help.stdout.includes(f));
+    expect(missing, `--help omits: ${missing.join(', ')}`).toEqual([]);
   });
 
   it('warns that a new flag is inert until merged, because the script re-execs from origin', () => {

--- a/cli/scripts/release.test.ts
+++ b/cli/scripts/release.test.ts
@@ -104,6 +104,24 @@ describeRelease('release.sh: an ordinary release is CLI-only', () => {
     expect(RELEASE_SH).toMatch(/^WITH_HELPERS=false$/m);
   });
 
+  it('advertises the flag in --help, so it is discoverable without reading the source', () => {
+    // Caught by running the script, not by reading it: --help listed every other
+    // flag and silently omitted this one.
+    const help = RELEASE_SH.slice(RELEASE_SH.indexOf('-h|--help)'));
+    expect(help.slice(0, 300)).toContain('--with-helpers');
+  });
+
+  it('warns that a new flag is inert until merged, because the script re-execs from origin', () => {
+    // release.sh:190 execs release-worktree.sh, which checks out
+    // `origin/$DEFAULT_BRANCH` and re-runs THIS script from there. The second
+    // parse is the MERGED copy, so an unmerged flag dies as `unknown flag` even
+    // though the local parser handles it. No content assertion can catch that —
+    // they read the working tree, the failure is in another copy — so the trap is
+    // pinned as prose instead, next to the parser it bites.
+    expect(RELEASE_SH).toContain('A NEW FLAG DOES NOT WORK UNTIL IT IS ON origin/<default>');
+    expect(RELEASE_SH).toContain('--orchestration-phase');
+  });
+
   it('builds the download patterns as an array, never a word-split splice', () => {
     // A `$( ... )` splice here is word-split by the shell — the same class of bug
     // that silently dropped vitest args in test.sh — and an empty splice trips

--- a/cli/scripts/release.test.ts
+++ b/cli/scripts/release.test.ts
@@ -72,11 +72,18 @@ describeRelease('release.sh: an ordinary release is CLI-only', () => {
   /**
    * True when `needle` sits INSIDE an open `if [[ "$WITH_HELPERS" == true ]]`.
    *
-   * The first version of this helper just grabbed the nearest preceding
-   * WITH_HELPERS conditional — which passes even when the needle's own gate is
-   * removed, because an EARLIER block's `if` is still behind it. Verified by
-   * mutation: replacing this needle's gate with `if true;` left the test green.
-   * So the check also requires no `fi` closing that block before the needle.
+   * Two earlier versions were defeated, both caught by mutation rather than by
+   * reading:
+   *   1. "nearest preceding WITH_HELPERS conditional" — passed even when the
+   *      needle's own gate was deleted, because an EARLIER block's `if` remained.
+   *   2. "no `\n  fi` between" — depended on the closing `fi` being indented
+   *      exactly two spaces, so reindenting an unrelated earlier gate's `fi` by
+   *      one space made a fully un-gated needle read as gated.
+   *
+   * Both failures came from pattern-matching text. This counts BLOCK DEPTH
+   * instead: walk from the gate to the needle and track opens (`if`/`for`/`while`
+   * /`case`) against closes (`fi`/`done`/`esac`). The needle is gated only if the
+   * gate's own block never closed. Indentation is irrelevant.
    */
   const isGated = (needle: string): boolean => {
     const at = RELEASE_SH.indexOf(needle);
@@ -84,10 +91,14 @@ describeRelease('release.sh: an ordinary release is CLI-only', () => {
     const before = RELEASE_SH.slice(0, at);
     const gate = before.lastIndexOf('if [[ "$WITH_HELPERS" == true ]]');
     if (gate === -1) return false;
-    // Anything between the gate and the needle that closes a block at the gate's
-    // own indent means the needle is outside it.
-    const between = before.slice(gate);
-    return !/\n  fi\b/.test(between) && !/\n  else\b/.test(between);
+    let depth = 1; // the gate's own `if`
+    for (const raw of before.slice(gate).split('\n').slice(1)) {
+      const line = raw.trim();
+      if (/^(if|for|while|case)\b/.test(line)) depth += 1;
+      else if (/^(fi|done|esac)\b/.test(line)) depth -= 1;
+      if (depth === 0) return false; // the gate closed before the needle
+    }
+    return depth > 0;
   };
 
   it('stages the computer-mac asset only under --with-helpers', () => {

--- a/cli/scripts/release.test.ts
+++ b/cli/scripts/release.test.ts
@@ -79,7 +79,10 @@ describeRelease('release.sh: an ordinary release is CLI-only', () => {
    * text instead of its behaviour, so this runs the function and observes the
    * calls. Same extract-and-run shape `home_base_wt_snippet` already uses below.
    */
-  function runUpload(withHelpers: boolean): { calls: string[]; status: number | null; out: string } {
+  function runUpload(
+    withHelpers: boolean,
+    fail: { attestationFails?: boolean; tarballMissing?: boolean } = {},
+  ): { calls: string[]; status: number | null; out: string } {
     const src = RELEASE_SH.match(/upload_release_proof\(\) \{[\s\S]*?\n\}/)?.[0];
     expect(src, 'upload_release_proof not extractable').toBeDefined();
 
@@ -94,18 +97,30 @@ describeRelease('release.sh: an ordinary release is CLI-only', () => {
       `#!/usr/bin/env bash\necho "gh $*" >> ${log}\nexit 0\n`);
     fs.writeFileSync(path.join(bin, 'jq'),
       `#!/usr/bin/env bash\necho "jq $*" >> ${log}\ncat >/dev/null\necho "${dir}/pkg.tgz"\n`);
-    for (const name of ['release-attestation.sh', 'release-manifest.sh']) {
-      fs.writeFileSync(path.join(scripts, name),
-        `#!/usr/bin/env bash\necho "${name} $*" >> ${log}\nexit 0\n`);
-      fs.chmodSync(path.join(scripts, name), 0o755);
+    // release-attestation.sh's output is CAPTURED (`attest="$(...)"`), so a stub
+    // that only logs leaves $attest empty and `cp "$attest"` fails — which the
+    // harness swallowed until the review caught it. Log to the file, echo a real
+    // path to stdout.
+    fs.writeFileSync(path.join(dir, 'attestation.json'), '{}');
+    fs.writeFileSync(path.join(scripts, 'release-attestation.sh'),
+      `#!/usr/bin/env bash\necho "release-attestation.sh $*" >> ${log}\n`
+      + (fail.attestationFails ? 'exit 1\n'
+        : `printf '%s\\n' ${JSON.stringify(path.join(dir, 'attestation.json'))}\n`));
+    fs.writeFileSync(path.join(scripts, 'release-manifest.sh'),
+      `#!/usr/bin/env bash\necho "release-manifest.sh $*" >> ${log}\nexit 0\n`);
+    for (const n of ['release-attestation.sh', 'release-manifest.sh']) {
+      fs.chmodSync(path.join(scripts, n), 0o755);
     }
     for (const f of ['gh', 'jq']) fs.chmodSync(path.join(bin, f), 0o755);
-    fs.writeFileSync(path.join(dir, 'pkg.tgz'), 'tgz');
+    if (!fail.tarballMissing) fs.writeFileSync(path.join(dir, 'pkg.tgz'), 'tgz');
     // The store the function reads its manifest from.
     fs.writeFileSync(path.join(dir, 'release-manifest.json'), '{}');
 
     const harness = [
-      'set -uo pipefail',
+      // Production runs under `set -euo pipefail`. Without -e the harness keeps
+      // going past a failure the real script aborts on, so it can exercise a
+      // control flow production never takes.
+      'set -euo pipefail',
       'die() { echo "die: $*" >&2; exit 9; }',
       'gray() { :; }; green() { :; }; bold() { :; }; yellow() { :; }; red() { :; }',
       `attestation_store_dir() { printf '%s\\n' ${JSON.stringify(dir)}; }`,
@@ -130,6 +145,26 @@ describeRelease('release.sh: an ordinary release is CLI-only', () => {
     expect(calls.some((c) => c.startsWith('release-manifest.sh')), out).toBe(false);
     // …and still does the CLI work, so this is not passing by dying early.
     expect(calls.some((c) => c.startsWith('gh release')), out).toBe(true);
+  });
+
+  it('aborts when the attestation lookup fails, rather than uploading unproven bytes', () => {
+    // Asserts the INVARIANT — never upload unproven bytes — not the presence of
+    // the `|| die`. Verified by mutation: deleting that guard does NOT fail this
+    // test, and should not, because under production's `set -euo pipefail` the
+    // assignment `attest="$(...)"` aborts on a non-zero command regardless. The
+    // `die` supplies a message, not the abort. A test demanding the guard's text
+    // would be back to asserting source, which is what failed three times here.
+    const { calls, status } = runUpload(false, { attestationFails: true });
+    expect(status).not.toBe(0);
+    expect(calls.some((c) => c.startsWith('gh release')), 'must not upload without proof').toBe(false);
+  });
+
+  it('aborts when the pretested tarball is missing, rather than rebuilding', () => {
+    // Same shape, same caveat: this pins the behaviour (abort, no upload), which
+    // `set -e` also enforces, rather than the guard's presence.
+    const { calls, status } = runUpload(false, { tarballMissing: true });
+    expect(status).not.toBe(0);
+    expect(calls.some((c) => c.startsWith('gh release')), 'must not upload without a tarball').toBe(false);
   });
 
   it('DOES stage the computer-mac asset with --with-helpers', () => {

--- a/cli/scripts/release.test.ts
+++ b/cli/scripts/release.test.ts
@@ -47,10 +47,69 @@ describeRelease('release.sh attestation promotion (RUSH-2666)', () => {
     expect(RELEASE_SH).toContain('upload_release_proof');
     expect(RELEASE_SH).toContain('gh release download "v$TARGET"');
     expect(RELEASE_SH).toContain('ComputerHelper.app.zip');
+    // ...but only behind the opt-in. An ordinary release publishes the CLI and
+    // nothing else; helpers live on their own tags now.
+    expect(RELEASE_SH).toContain('--with-helpers) WITH_HELPERS=true');
+    expect(RELEASE_SH).toContain('WITH_HELPERS=false');
     expect(RELEASE_SH).not.toContain('sign-cli-binary.sh');
     expect(RELEASE_SH).not.toContain('publish-computer-helper-mac.sh');
     expect(RELEASE_SH).not.toContain('menubar/scripts/build.sh release');
     expect(RELEASE_SH).toContain('rebuild/notarization is outside the ordinary release path');
+  });
+});
+
+describeRelease('release.sh: an ordinary release is CLI-only', () => {
+  /**
+   * The default path must do NO helper work. Two couplings made that false and
+   * each is asserted separately, because they fail differently:
+   *
+   *  - staging `ComputerHelper.app.zip` onto `v$TARGET` publishes an asset no
+   *    client requests (helpers resolve from their own tags), and
+   *  - `release-manifest.sh require` re-derives every helper's input digest and
+   *    ABORTS when one moved without a rebuild — so editing Swift the CLI does
+   *    not ship could fail a perfectly good CLI release.
+   */
+  /**
+   * True when `needle` sits INSIDE an open `if [[ "$WITH_HELPERS" == true ]]`.
+   *
+   * The first version of this helper just grabbed the nearest preceding
+   * WITH_HELPERS conditional — which passes even when the needle's own gate is
+   * removed, because an EARLIER block's `if` is still behind it. Verified by
+   * mutation: replacing this needle's gate with `if true;` left the test green.
+   * So the check also requires no `fi` closing that block before the needle.
+   */
+  const isGated = (needle: string): boolean => {
+    const at = RELEASE_SH.indexOf(needle);
+    expect(at, `${needle} not found`).toBeGreaterThan(-1);
+    const before = RELEASE_SH.slice(0, at);
+    const gate = before.lastIndexOf('if [[ "$WITH_HELPERS" == true ]]');
+    if (gate === -1) return false;
+    // Anything between the gate and the needle that closes a block at the gate's
+    // own indent means the needle is outside it.
+    const between = before.slice(gate);
+    return !/\n  fi\b/.test(between) && !/\n  else\b/.test(between);
+  };
+
+  it('stages the computer-mac asset only under --with-helpers', () => {
+    expect(isGated('--helper computer-mac --asset-path')).toBe(true);
+  });
+
+  it('verifies the helper manifest only under --with-helpers', () => {
+    // Unguarded, this is the assertion that fails a CLI-only release for a
+    // helper source change it does not ship.
+    expect(isGated('release-manifest.sh require')).toBe(true);
+  });
+
+  it('defaults the flag OFF, so CLI-only is what you get without asking', () => {
+    expect(RELEASE_SH).toMatch(/^WITH_HELPERS=false$/m);
+  });
+
+  it('builds the download patterns as an array, never a word-split splice', () => {
+    // A `$( ... )` splice here is word-split by the shell — the same class of bug
+    // that silently dropped vitest args in test.sh — and an empty splice trips
+    // `set -u`.
+    expect(RELEASE_SH).toContain('dl_patterns=(');
+    expect(RELEASE_SH).toContain('"${dl_patterns[@]}"');
   });
 });
 

--- a/cli/scripts/release.test.ts
+++ b/cli/scripts/release.test.ts
@@ -70,45 +70,73 @@ describeRelease('release.sh: an ordinary release is CLI-only', () => {
    *    not ship could fail a perfectly good CLI release.
    */
   /**
-   * True when `needle` sits INSIDE an open `if [[ "$WITH_HELPERS" == true ]]`.
+   * Run `upload_release_proof` for real, with its five external dependencies
+   * stubbed as recording shims, and return what it invoked.
    *
-   * Two earlier versions were defeated, both caught by mutation rather than by
-   * reading:
-   *   1. "nearest preceding WITH_HELPERS conditional" — passed even when the
-   *      needle's own gate was deleted, because an EARLIER block's `if` remained.
-   *   2. "no `\n  fi` between" — depended on the closing `fi` being indented
-   *      exactly two spaces, so reindenting an unrelated earlier gate's `fi` by
-   *      one space made a fully un-gated needle read as gated.
-   *
-   * Both failures came from pattern-matching text. This counts BLOCK DEPTH
-   * instead: walk from the gate to the needle and track opens (`if`/`for`/`while`
-   * /`case`) against closes (`fi`/`done`/`esac`). The needle is gated only if the
-   * gate's own block never closed. Indentation is irrelevant.
+   * This replaces a text-scanning `isGated` helper that was defeated THREE times
+   * — nearest-match, then an indentation assumption, then a one-line `if ...; fi`
+   * hiding its own `fi`. Every failure came from reasoning about the script's
+   * text instead of its behaviour, so this runs the function and observes the
+   * calls. Same extract-and-run shape `home_base_wt_snippet` already uses below.
    */
-  const isGated = (needle: string): boolean => {
-    const at = RELEASE_SH.indexOf(needle);
-    expect(at, `${needle} not found`).toBeGreaterThan(-1);
-    const before = RELEASE_SH.slice(0, at);
-    const gate = before.lastIndexOf('if [[ "$WITH_HELPERS" == true ]]');
-    if (gate === -1) return false;
-    let depth = 1; // the gate's own `if`
-    for (const raw of before.slice(gate).split('\n').slice(1)) {
-      const line = raw.trim();
-      if (/^(if|for|while|case)\b/.test(line)) depth += 1;
-      else if (/^(fi|done|esac)\b/.test(line)) depth -= 1;
-      if (depth === 0) return false; // the gate closed before the needle
-    }
-    return depth > 0;
-  };
+  function runUpload(withHelpers: boolean): { calls: string[]; status: number | null; out: string } {
+    const src = RELEASE_SH.match(/upload_release_proof\(\) \{[\s\S]*?\n\}/)?.[0];
+    expect(src, 'upload_release_proof not extractable').toBeDefined();
 
-  it('stages the computer-mac asset only under --with-helpers', () => {
-    expect(isGated('--helper computer-mac --asset-path')).toBe(true);
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rel-upload-'));
+    const log = path.join(dir, 'calls.log');
+    const bin = path.join(dir, 'bin');
+    const scripts = path.join(dir, 'scripts');
+    fs.mkdirSync(bin); fs.mkdirSync(scripts);
+
+    // gh/jq are recorded; jq must still answer the tarball-path query.
+    fs.writeFileSync(path.join(bin, 'gh'),
+      `#!/usr/bin/env bash\necho "gh $*" >> ${log}\nexit 0\n`);
+    fs.writeFileSync(path.join(bin, 'jq'),
+      `#!/usr/bin/env bash\necho "jq $*" >> ${log}\ncat >/dev/null\necho "${dir}/pkg.tgz"\n`);
+    for (const name of ['release-attestation.sh', 'release-manifest.sh']) {
+      fs.writeFileSync(path.join(scripts, name),
+        `#!/usr/bin/env bash\necho "${name} $*" >> ${log}\nexit 0\n`);
+      fs.chmodSync(path.join(scripts, name), 0o755);
+    }
+    for (const f of ['gh', 'jq']) fs.chmodSync(path.join(bin, f), 0o755);
+    fs.writeFileSync(path.join(dir, 'pkg.tgz'), 'tgz');
+    // The store the function reads its manifest from.
+    fs.writeFileSync(path.join(dir, 'release-manifest.json'), '{}');
+
+    const harness = [
+      'set -uo pipefail',
+      'die() { echo "die: $*" >&2; exit 9; }',
+      'gray() { :; }; green() { :; }; bold() { :; }; yellow() { :; }; red() { :; }',
+      `attestation_store_dir() { printf '%s\\n' ${JSON.stringify(dir)}; }`,
+      `REPO_ROOT=${JSON.stringify(dir)}`,
+      'TARGET=1.2.3', 'PHNX_LATEST=1.2.2',
+      `WITH_HELPERS=${withHelpers}`,
+      src!,
+      'upload_release_proof deadbeef',
+    ].join('\n');
+
+    const r = spawnSync('bash', ['-c', harness], {
+      encoding: 'utf-8',
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+      cwd: dir,
+    });
+    const calls = fs.existsSync(log) ? fs.readFileSync(log, 'utf-8').trim().split('\n') : [];
+    return { calls, status: r.status, out: `${r.stdout}${r.stderr}` };
+  }
+
+  it('does NOT touch the helper manifest on an ordinary release', () => {
+    const { calls, out } = runUpload(false);
+    expect(calls.some((c) => c.startsWith('release-manifest.sh')), out).toBe(false);
+    // …and still does the CLI work, so this is not passing by dying early.
+    expect(calls.some((c) => c.startsWith('gh release')), out).toBe(true);
   });
 
-  it('verifies the helper manifest only under --with-helpers', () => {
-    // Unguarded, this is the assertion that fails a CLI-only release for a
-    // helper source change it does not ship.
-    expect(isGated('release-manifest.sh require')).toBe(true);
+  it('DOES stage the computer-mac asset with --with-helpers', () => {
+    const { calls, out } = runUpload(true);
+    const manifest = calls.filter((c) => c.startsWith('release-manifest.sh'));
+    expect(manifest.length, out).toBeGreaterThan(0);
+    expect(manifest.join(' ')).toContain('--helper computer-mac');
   });
 
   it('defaults the flag OFF, so CLI-only is what you get without asking', () => {


### PR DESCRIPTION
The last piece of the release decoupling: **an ordinary `scripts/release.sh <version>` now
publishes the CLI and nothing else.**

## What was still coupled

#3056 moved every helper onto its own release tag and removed the menubar/keychain
staging. Two couplings survived, and the second is the one that actually hurt:

**1. `ComputerHelper.app.zip` was still staged onto the CLI's `v$TARGET`.** Since helpers
resolve from `computer-mac/v<x.y.z>`, that asset is one no client ever requests — dead
weight on every release. The review of #3056 caught this hiding under a comment claiming
the opposite:

> `# No helper assets are staged onto v$TARGET any more.`

…three lines above the code still staging one.

**2. `release-manifest.sh require` ran unconditionally.** It re-derives every helper's
input digest and **aborts the release** when one moved without a rebuild:

```
die "helper manifest failed -- rebuild/notarization is outside the ordinary release path"
```

Correct when a release is publishing helpers. Pure obstruction when it is not: **editing
Swift the CLI does not ship would fail a perfectly good CLI release.** Nothing the user
receives depends on it, because helpers are fetched from their own tags at install time.

## The change

`--with-helpers`, default **off**. Both couplings sit behind it. Everything else is
untouched.

```
scripts/release.sh 1.22.49                  # CLI only — no helper staging, no manifest gate
scripts/release.sh 1.22.49 --with-helpers   # previous behaviour
```

## Tests, and a false-pass I had to fix in my own

Four new assertions in `release.test.ts`. The interesting part is that the first version of
one **did not work**, and mutation testing is what showed it.

The helper originally grabbed "the nearest preceding `WITH_HELPERS` conditional". Replacing
the manifest gate with `if true;` left the test **green** — because an *earlier* block's
`if` was still behind the needle. A guard that passes when its own gate is deleted is not a
guard.

Rewritten to check the needle is inside an *open* block (no `fi`/`else` closing it in
between). Both un-gating mutations now fail, each on its own test:

```
mutate the manifest gate  → × verifies the helper manifest only under --with-helpers
mutate the staging gate   → × stages the computer-mac asset only under --with-helpers
default WITH_HELPERS=true → × defaults the flag OFF, so CLI-only is what you get
                            × promotes the attested tarball … on the ordinary path
```

Clean: `release.test.ts` + `release-manifest.test.ts` → **23 passed | 4 skipped**.

## One implementation note

The `gh release download` patterns are built as an **array**, not spliced with `$( … )`.
A splice is word-split by the shell — the same class of bug that silently dropped
`--retry=2 --maxWorkers=2` from the attestation producer — and an empty splice trips
`set -u`. That is asserted too, since it is invisible at runtime until it bites.

## Not in scope

`publish-computer-helper-mac.sh` and the Windows `release-exe` workflow still publish to
the CLI's tag rather than the helpers' own — tracked in PHNX-3228. This PR stops the CLI
release from *depending* on helper work; it does not yet give helpers their own publish
path.
