### PR TITLE
fix(installs): preserve self-updating account slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Self-updating Cursor and Grok installs keep account slots separate from vendor releases (PHNX-3250).** A concrete `agents add <agent>@<label>` now preserves that label as the stable version-home identity while recording the current self-updated binary in `installation.json.releaseVersion`. Multiple homes can therefore carry the same current release without sharing credentials, and `remove --isolated` can no longer target a normal install merely because both report the same vendor version.
+
 - **`agents sync <agent> system` now reconciles system-layer plugins (RUSH-3207).**
   `resourceSourceMap` hardcoded every plugin's source layer to `'user'`, so a
   `system:*` selection expanded to zero plugins and a `system`-scoped sync silently

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -200,6 +200,15 @@ stale dirs into the survivor, `agents view` shows the live `--version`, and
 grok is self-updating but stores a real per-version binary under each version-home, so
 it is NOT a global-binary agent and is left uncollapsed. (RUSH-1321)
 
+For a concrete self-updating spec, the requested token is the stable installation
+label/account slot even when the vendor installer can only fetch today's release.
+`installation.json.releaseVersion` records the probed vendor release separately.
+This identity/release split is load-bearing: two Cursor or Grok homes may carry the
+same current release while retaining different native credentials, and removing an
+isolated label must never target a normal installation merely because their releases
+match. `@latest` keeps the probed release as its convenient label; concrete labels stay
+exactly addressable.
+
 ### 10. Diagnostic command taxonomy — `doctor` is the umbrella (RUSH-2027)
 
 Three diagnostics, distinct scopes. Don't blur them — each answers a different

--- a/cli/src/lib/installations/store.ts
+++ b/cli/src/lib/installations/store.ts
@@ -280,15 +280,18 @@ export function getBinaryPath(agent: AgentId, version: string): string {
   const agentConfig = AGENTS[agent];
   if (agent === 'grok') {
     const grokDownloads = path.join(getVersionHomePath(agent, version), '.grok', 'downloads');
-    // Best effort: first matching file for this version
+    // The directory token is the stable installation/account label. A
+    // self-updating slot may carry a newer vendor release, whose binary keeps
+    // the release in its filename; resolve through the frozen install record.
+    const releaseVersion = readInstallation(agent, version)?.releaseVersion ?? version;
     try {
       const entries = fs.readdirSync(grokDownloads);
-      const match = entries.find((e: string) => e.includes(version) && e.startsWith('grok-'));
+      const match = entries.find((e: string) => e.includes(releaseVersion) && e.startsWith('grok-'));
       if (match) return path.join(grokDownloads, match);
     } catch {}
     const fallback = resolveGrokFallbackBinary(grokDownloads);
     if (fallback) return fallback;
-    return path.join(grokDownloads, `grok-${version}`);
+    return path.join(grokDownloads, `grok-${releaseVersion}`);
   }
   if (agent === 'droid') {
     // Factory.ai's installer drops a standalone native binary (no npm package,

--- a/cli/src/lib/installations/versions.test.ts
+++ b/cli/src/lib/installations/versions.test.ts
@@ -1036,6 +1036,42 @@ describe('installVersion Grok binary relocation', () => {
     expect(result).toContain('0.2.77');
   });
 
+  it.skipIf(process.platform === 'win32')('copies a current Grok binary whose filename omits the release', () => {
+    const home = makeTempHome();
+    const oldDownloads = path.join(home, '.agents', '.history', 'versions', 'grok', '1.0.5', 'home', '.grok', 'downloads');
+    fs.mkdirSync(oldDownloads, { recursive: true });
+    fs.symlinkSync(path.dirname(oldDownloads), path.join(home, '.grok'));
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.agents', 'meta.json'), JSON.stringify({ defaults: { grok: '1.0.5' } }));
+
+    const genericBinary = path.join(oldDownloads, 'grok-linux-x86_64');
+    fs.writeFileSync(genericBinary, Buffer.alloc(1_000_001));
+    fs.chmodSync(genericBinary, 0o755);
+
+    const binDir = path.join(home, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const stub = path.join(binDir, 'grok');
+    fs.writeFileSync(stub, '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "grok 1.0.5"; exit 0; fi\nexit 0\n', 'utf-8');
+    fs.chmodSync(stub, 0o755);
+
+    const outcome = runInstallVersionWithScript(home, 'grok', '0.2.101', 'exit 0', binDir);
+    expect(outcome.result?.success).toBe(true);
+    expect(outcome.result?.installedVersion).toBe('0.2.101');
+    expect(fs.existsSync(genericBinary)).toBe(true);
+    expect(fs.existsSync(path.join(
+      home,
+      '.agents',
+      '.history',
+      'versions',
+      'grok',
+      '0.2.101',
+      'home',
+      '.grok',
+      'downloads',
+      'grok-linux-x86_64',
+    ))).toBe(true);
+  });
+
   it.skipIf(process.platform === 'win32')('fails loudly instead of creating a literal "latest" version dir when the post-install version probe never resolves (regression)', () => {
     const home = makeTempHome();
     const oldConfigDir = path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.106', 'home', '.grok');

--- a/cli/src/lib/installations/versions.test.ts
+++ b/cli/src/lib/installations/versions.test.ts
@@ -914,7 +914,7 @@ describe('installVersion version validation', () => {
     expect(fs.existsSync(path.join(home, '.agents', '.history', 'versions', 'gemini'))).toBe(false);
   });
 
-  it.skipIf(process.platform === 'win32')('gracefully redirects a pinned self-updating install to the current release (RUSH-1321)', () => {
+  it.skipIf(process.platform === 'win32')('keeps a pinned self-updating install as a stable label while recording the current release', () => {
     const home = makeTempHome();
     // A valid version passes VERSION_RE. `kiro` is self-updating (brew, no
     // VERSION token). A `kiro-cli` on PATH makes the single binary read as
@@ -931,7 +931,13 @@ describe('installVersion version validation', () => {
     expect(outcome.ok).toBe(true);
     const result = outcome.result;
     expect(result?.success).toBe(true);
-    expect(result?.installedVersion).toBe('2.12.1'); // the live version, not the ignored pin
+    expect(result?.installedVersion).toBe('0.0.0-rc.1');
+    const record = JSON.parse(fs.readFileSync(
+      path.join(home, '.agents', '.history', 'versions', 'kiro', '0.0.0-rc.1', 'installation.json'),
+      'utf-8',
+    ));
+    expect(record.label).toBe('0.0.0-rc.1');
+    expect(record.releaseVersion).toBe('2.12.1');
     expect(result?.error ?? '').not.toContain('Invalid version');
     expect(result?.error ?? '').not.toContain('does not support version-pinned installs');
   });
@@ -979,7 +985,7 @@ function runInstallVersionWithScript(
 }
 
 describe('installVersion Grok binary relocation', () => {
-  it.skipIf(process.platform === 'win32')('moves the installer-dropped binary from the previous default home into the target version home', () => {
+  it.skipIf(process.platform === 'win32')('moves the current binary into the requested account-slot label and records its release', () => {
     const home = makeTempHome();
     const oldConfigDir = path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.32', 'home', '.grok');
     const hostGrok = path.join(home, '.grok');
@@ -994,6 +1000,14 @@ describe('installVersion Grok binary relocation', () => {
     fs.writeFileSync(stub, '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "grok 0.2.101"; exit 0; fi\nexit 0\n', 'utf-8');
     fs.chmodSync(stub, 0o755);
 
+    // A concrete self-updating slot reuses the already-installed live release
+    // instead of rerunning the vendor installer. Seed the previous active
+    // home's real download exactly as that live installation would.
+    const existingVersioned = path.join(oldConfigDir, 'downloads', 'grok-0.2.101-macos-aarch64');
+    fs.writeFileSync(existingVersioned, '#!/bin/sh\nexit 0\n', 'utf-8');
+    fs.chmodSync(existingVersioned, 0o755);
+    fs.copyFileSync(existingVersioned, path.join(oldConfigDir, 'downloads', 'grok-macos-aarch64'));
+
     const script = [
       'mkdir -p ~/.grok/downloads',
       'printf \'#!/bin/sh\\nif [ "$1" = "--version" ]; then echo "grok 0.2.101"; exit 0; fi\\nexit 0\\n\' > ~/.grok/downloads/grok-0.2.101-macos-aarch64',
@@ -1001,17 +1015,25 @@ describe('installVersion Grok binary relocation', () => {
       'cp ~/.grok/downloads/grok-0.2.101-macos-aarch64 ~/.grok/downloads/grok-macos-aarch64',
     ].join(' && ');
 
-    const outcome = runInstallVersionWithScript(home, 'grok', 'latest', script, binDir);
+    const outcome = runInstallVersionWithScript(home, 'grok', '0.2.77', script, binDir);
     expect(outcome.ok).toBe(true);
     expect(outcome.result?.success).toBe(true);
-    expect(outcome.result?.installedVersion).toBe('0.2.101');
+    expect(outcome.result?.installedVersion).toBe('0.2.77');
 
-    const targetDownloads = path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.101', 'home', '.grok', 'downloads');
+    const targetDownloads = path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.77', 'home', '.grok', 'downloads');
     expect(fs.existsSync(path.join(targetDownloads, 'grok-0.2.101-macos-aarch64'))).toBe(true);
     expect(fs.existsSync(path.join(targetDownloads, 'grok-macos-aarch64'))).toBe(true);
+    expect(fs.existsSync(existingVersioned)).toBe(true);
+
+    const record = JSON.parse(fs.readFileSync(
+      path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.77', 'installation.json'),
+      'utf-8',
+    ));
+    expect(record.label).toBe('0.2.77');
+    expect(record.releaseVersion).toBe('0.2.101');
 
     const result = runVersionSync(home, "listInstalledVersions('grok')") as string[];
-    expect(result).toContain('0.2.101');
+    expect(result).toContain('0.2.77');
   });
 
   it.skipIf(process.platform === 'win32')('fails loudly instead of creating a literal "latest" version dir when the post-install version probe never resolves (regression)', () => {

--- a/cli/src/lib/installations/versions.test.ts
+++ b/cli/src/lib/installations/versions.test.ts
@@ -1004,7 +1004,7 @@ describe('installVersion Grok binary relocation', () => {
     // instead of rerunning the vendor installer. Seed the previous active
     // home's real download exactly as that live installation would.
     const existingVersioned = path.join(oldConfigDir, 'downloads', 'grok-0.2.101-macos-aarch64');
-    fs.writeFileSync(existingVersioned, '#!/bin/sh\nexit 0\n', 'utf-8');
+    fs.writeFileSync(existingVersioned, Buffer.alloc(1_000_001));
     fs.chmodSync(existingVersioned, 0o755);
     fs.copyFileSync(existingVersioned, path.join(oldConfigDir, 'downloads', 'grok-macos-aarch64'));
 
@@ -1070,6 +1070,31 @@ describe('installVersion Grok binary relocation', () => {
       'downloads',
       'grok-linux-x86_64',
     ))).toBe(true);
+  });
+
+  it.skipIf(process.platform === 'win32')('ignores a release-named wrapper and copies the real versionless Grok binary', () => {
+    const home = makeTempHome();
+    const oldDownloads = path.join(home, '.agents', '.history', 'versions', 'grok', '1.0.5', 'home', '.grok', 'downloads');
+    fs.mkdirSync(oldDownloads, { recursive: true });
+    fs.symlinkSync(path.dirname(oldDownloads), path.join(home, '.grok'));
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.agents', 'meta.json'), JSON.stringify({ defaults: { grok: '1.0.5' } }));
+    fs.writeFileSync(path.join(oldDownloads, 'grok-1.0.5-linux-x86_64'), '#!/bin/sh\nexit 1\n');
+    const realBinary = path.join(oldDownloads, 'grok-linux-x86_64');
+    fs.writeFileSync(realBinary, Buffer.alloc(1_000_001));
+    fs.chmodSync(realBinary, 0o755);
+
+    const binDir = path.join(home, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const stub = path.join(binDir, 'grok');
+    fs.writeFileSync(stub, '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "grok 1.0.5"; exit 0; fi\nexit 0\n', 'utf-8');
+    fs.chmodSync(stub, 0o755);
+
+    const outcome = runInstallVersionWithScript(home, 'grok', '0.2.101', 'exit 0', binDir);
+    const targetDownloads = path.join(home, '.agents', '.history', 'versions', 'grok', '0.2.101', 'home', '.grok', 'downloads');
+    expect(outcome.result?.success).toBe(true);
+    expect(fs.statSync(path.join(targetDownloads, 'grok-linux-x86_64')).size).toBe(1_000_001);
+    expect(fs.existsSync(path.join(targetDownloads, 'grok-1.0.5-linux-x86_64'))).toBe(false);
   });
 
   it.skipIf(process.platform === 'win32')('fails loudly instead of creating a literal "latest" version dir when the post-install version probe never resolves (regression)', () => {

--- a/cli/src/lib/installations/versions.ts
+++ b/cli/src/lib/installations/versions.ts
@@ -1173,7 +1173,6 @@ export function setIsolatedDefault(agent: AgentId, version: string | undefined):
 function transferGrokDownloads(
   sourceDownloads: string,
   targetDownloads: string,
-  installedVersion: string,
   copy: boolean,
 ): boolean {
   if (!fs.existsSync(sourceDownloads)) return false;
@@ -1182,46 +1181,22 @@ function transferGrokDownloads(
   const entries = fs.readdirSync(sourceDownloads).filter((e) => e.startsWith('grok-'));
   if (entries.length === 0) return false;
 
-  const escapedVersion = installedVersion.replace(/\./g, '\\.');
-  const versionedPattern = new RegExp(`^grok-${escapedVersion}-`);
-  const movedPaths: string[] = [];
-
-  // Move the versioned binary first — only create the target dir once we
-  // know there is something to move into it.
-  for (const entry of entries) {
-    if (!versionedPattern.test(entry)) continue;
-    const src = path.join(sourceDownloads, entry);
-    const dst = path.join(targetDownloads, entry);
-    if (fs.existsSync(dst)) continue;
-    try {
-      fs.mkdirSync(targetDownloads, { recursive: true });
-      if (copy) fs.copyFileSync(src, dst);
-      else fs.renameSync(src, dst);
-      movedPaths.push(dst);
-    } catch {
-      /* ignore per-file failures */
-    }
-  }
-
-  if (movedPaths.length === 0) {
-    const fallback = resolveGrokFallbackBinary(sourceDownloads);
-    if (!fallback) return false;
-    const dst = path.join(targetDownloads, path.basename(fallback));
-    try {
-      fs.mkdirSync(targetDownloads, { recursive: true });
-      if (copy) fs.copyFileSync(fallback, dst);
-      else fs.renameSync(fallback, dst);
-      return true;
-    } catch {
-      return false;
-    }
+  const realBinary = resolveGrokFallbackBinary(sourceDownloads);
+  if (!realBinary) return false;
+  const transferred = path.join(targetDownloads, path.basename(realBinary));
+  try {
+    fs.mkdirSync(targetDownloads, { recursive: true });
+    if (copy) fs.copyFileSync(realBinary, transferred);
+    else fs.renameSync(realBinary, transferred);
+  } catch {
+    return false;
   }
 
   // The installer also creates a generic platform binary (e.g. grok-macos-aarch64)
   // that is a copy of the versioned binary. Move it too if its size matches.
-  const movedSize = fs.statSync(movedPaths[0]).size;
+  const movedSize = fs.statSync(transferred).size;
   for (const entry of entries) {
-    if (versionedPattern.test(entry)) continue; // already handled
+    if (entry === path.basename(realBinary)) continue;
     const src = path.join(sourceDownloads, entry);
     const dst = path.join(targetDownloads, entry);
     if (fs.existsSync(dst)) continue;
@@ -1253,7 +1228,6 @@ function transferGrokDownloads(
  */
 function relocateGrokBinaryToVersionHome(
   installationLabel: string,
-  releaseVersion: string,
   copyExisting: boolean,
 ): void {
   const hostGrokLink = path.join(getHomeDir(), agentConfigDirName('grok'));
@@ -1269,13 +1243,13 @@ function relocateGrokBinaryToVersionHome(
     'downloads'
   );
 
-  if (transferGrokDownloads(sourceDownloads, targetDownloads, releaseVersion, copyExisting)) return;
+  if (transferGrokDownloads(sourceDownloads, targetDownloads, copyExisting)) return;
 
   for (const version of listInstalledVersions('grok')) {
     if (version === installationLabel) continue;
     const candidate = path.join(getVersionHomePath('grok', version), agentConfigDirName('grok'), 'downloads');
     if (path.resolve(candidate) === path.resolve(sourceDownloads)) continue; // already tried
-    if (transferGrokDownloads(candidate, targetDownloads, releaseVersion, copyExisting)) return;
+    if (transferGrokDownloads(candidate, targetDownloads, copyExisting)) return;
   }
 }
 
@@ -1423,7 +1397,7 @@ export async function installVersion(
     // resolves to the PREVIOUS default home. Move it into the target version home
     // so version isolation is correct.
     if (agent === 'grok') {
-      relocateGrokBinaryToVersionHome(installationLabel, releaseVersion, !runInstaller);
+      relocateGrokBinaryToVersionHome(installationLabel, !runInstaller);
     }
 
     // Symlink the installed binary into the version's node_modules/.bin so

--- a/cli/src/lib/installations/versions.ts
+++ b/cli/src/lib/installations/versions.ts
@@ -1167,9 +1167,14 @@ export function setIsolatedDefault(agent: AgentId, version: string | undefined):
 /**
  * Move any `grok-<installedVersion>-...` binary (and its generic platform
  * copy) found directly under `sourceDownloads` into `targetDownloads`.
- * Returns true if the versioned binary was moved.
+ * Returns true if the versioned binary was transferred.
  */
-function tryMoveGrokDownloads(sourceDownloads: string, targetDownloads: string, installedVersion: string): boolean {
+function transferGrokDownloads(
+  sourceDownloads: string,
+  targetDownloads: string,
+  installedVersion: string,
+  copy: boolean,
+): boolean {
   if (!fs.existsSync(sourceDownloads)) return false;
   if (path.resolve(sourceDownloads) === path.resolve(targetDownloads)) return false;
 
@@ -1189,7 +1194,8 @@ function tryMoveGrokDownloads(sourceDownloads: string, targetDownloads: string, 
     if (fs.existsSync(dst)) continue;
     try {
       fs.mkdirSync(targetDownloads, { recursive: true });
-      fs.renameSync(src, dst);
+      if (copy) fs.copyFileSync(src, dst);
+      else fs.renameSync(src, dst);
       movedPaths.push(dst);
     } catch {
       /* ignore per-file failures */
@@ -1208,7 +1214,8 @@ function tryMoveGrokDownloads(sourceDownloads: string, targetDownloads: string, 
     if (fs.existsSync(dst)) continue;
     try {
       if (fs.statSync(src).size === movedSize) {
-        fs.renameSync(src, dst);
+        if (copy) fs.copyFileSync(src, dst);
+        else fs.renameSync(src, dst);
       }
     } catch {
       /* ignore per-file failures */
@@ -1231,7 +1238,11 @@ function tryMoveGrokDownloads(sourceDownloads: string, targetDownloads: string, 
  * whatever version was default at the time), sweep every other installed
  * grok version home for the missing file before giving up.
  */
-function relocateGrokBinaryToVersionHome(installedVersion: string): void {
+function relocateGrokBinaryToVersionHome(
+  installationLabel: string,
+  releaseVersion: string,
+  copyExisting: boolean,
+): void {
   const hostGrokLink = path.join(getHomeDir(), agentConfigDirName('grok'));
   let sourceDownloads: string;
   try {
@@ -1240,18 +1251,18 @@ function relocateGrokBinaryToVersionHome(installedVersion: string): void {
     sourceDownloads = path.join(hostGrokLink, 'downloads');
   }
   const targetDownloads = path.join(
-    getVersionHomePath('grok', installedVersion),
+    getVersionHomePath('grok', installationLabel),
     agentConfigDirName('grok'),
     'downloads'
   );
 
-  if (tryMoveGrokDownloads(sourceDownloads, targetDownloads, installedVersion)) return;
+  if (transferGrokDownloads(sourceDownloads, targetDownloads, releaseVersion, copyExisting)) return;
 
   for (const version of listInstalledVersions('grok')) {
-    if (version === installedVersion) continue;
+    if (version === installationLabel) continue;
     const candidate = path.join(getVersionHomePath('grok', version), agentConfigDirName('grok'), 'downloads');
     if (path.resolve(candidate) === path.resolve(sourceDownloads)) continue; // already tried
-    if (tryMoveGrokDownloads(candidate, targetDownloads, installedVersion)) return;
+    if (transferGrokDownloads(candidate, targetDownloads, releaseVersion, copyExisting)) return;
   }
 }
 
@@ -1300,6 +1311,7 @@ export async function installVersion(
   opts?: { clean?: boolean }
 ): Promise<{ success: boolean; installedVersion: string; error?: string }> {
   const agentConfig = AGENTS[agent];
+  const requestedLabel = version;
 
   if (isAgentHardDeprecated(agent)) {
     return { success: false, installedVersion: version, error: hardDeprecationError(agent) };
@@ -1335,7 +1347,7 @@ export async function installVersion(
       version = 'latest';
     }
 
-    let installedVersion = version;
+    let releaseVersion = version;
     try {
       if (runInstaller) {
         const script = agentConfig.installScript.replaceAll('VERSION', version);
@@ -1365,14 +1377,21 @@ export async function installVersion(
             error: `${agentConfig.name} installed but its version could not be determined after several attempts.`,
           };
         }
-        installedVersion = probed;
+        releaseVersion = probed;
         // Fold any stale literal `latest` dir from an earlier probe-failed
         // install into the real version so it stops shadowing `agents view`.
-        await reconcileStaleLatestDir(agent, installedVersion);
+        await reconcileStaleLatestDir(agent, releaseVersion);
       }
 
+      // Self-updating installers always fetch the current vendor release, but a
+      // concrete requested token is still the stable installation/account slot.
+      // Keeping the two strings separate lets several homes carry the same
+      // release without sharing credentials. `latest` remains the convenient
+      // release-named slot; concrete tokens remain exactly addressable.
+      const installationLabel = requestedLabel === 'latest' ? releaseVersion : requestedLabel;
+
       if (agent === 'grok') {
-        await checkGrokAccountCollision(installedVersion);
+        await checkGrokAccountCollision(installationLabel);
       }
 
       onProgress?.(`${agentConfig.name} installed. Setting up agents-cli version home for isolation...`);
@@ -1382,7 +1401,8 @@ export async function installVersion(
     }
 
     ensureAgentsDir();
-    const versionDir = getVersionDir(agent, installedVersion);
+    const installationLabel = requestedLabel === 'latest' ? releaseVersion : requestedLabel;
+    const versionDir = getVersionDir(agent, installationLabel);
     fs.mkdirSync(versionDir, { recursive: true });
     fs.mkdirSync(path.join(versionDir, 'home'), { recursive: true });
 
@@ -1390,7 +1410,7 @@ export async function installVersion(
     // resolves to the PREVIOUS default home. Move it into the target version home
     // so version isolation is correct.
     if (agent === 'grok') {
-      relocateGrokBinaryToVersionHome(installedVersion);
+      relocateGrokBinaryToVersionHome(installationLabel, releaseVersion, !runInstaller);
     }
 
     // Symlink the installed binary into the version's node_modules/.bin so
@@ -1418,7 +1438,7 @@ export async function installVersion(
       if (installedBinary) {
         importInstallScriptBinary(
           { agentId: agent, npmPackage: agentConfig.npmPackage, cliCommand: agentConfig.cliCommand },
-          installedVersion,
+          installationLabel,
           installedBinary,
           versionDir
         );
@@ -1428,20 +1448,20 @@ export async function installVersion(
          correctly reports it uninstalled. */
     }
 
-    createVersionedAlias(agent, installedVersion);
+    createVersionedAlias(agent, installationLabel);
     // Freeze this installation's identity. The dir name is its stable label from
     // here on; the release it carries is recorded separately so `agents update`
     // can move the release without invalidating any reference to the label.
-    createInstallation(agent, installedVersion, installedVersion);
-    const trackerInstall = await installSessionTrackerHook(agent, installedVersion);
+    createInstallation(agent, installationLabel, releaseVersion);
+    const trackerInstall = await installSessionTrackerHook(agent, installationLabel);
     if (!trackerInstall.installed && trackerInstall.error) {
-      console.warn(`agents: SessionStart hook not installed for ${agent}@${installedVersion}: ${trackerInstall.error}`);
+      console.warn(`agents: SessionStart hook not installed for ${agent}@${installationLabel}: ${trackerInstall.error}`);
     }
     // The self-updating binary just changed on disk — drop the cached
     // `--version` so `agents view` reflects the freshly-installed release.
     invalidateLiveVersionCache(agent);
-    emit('version.install', { agent, version: installedVersion });
-    return { success: true, installedVersion };
+    emit('version.install', { agent, version: installationLabel });
+    return { success: true, installedVersion: installationLabel };
   }
 
   // Resolve the `latest`/`oldest` aliases to a concrete npm version up front so

--- a/cli/src/lib/installations/versions.ts
+++ b/cli/src/lib/installations/versions.ts
@@ -62,6 +62,7 @@ import {
   isVersionIsolated,
   listInstalledVersions,
   pickCanonicalGlobalBinaryVersion,
+  resolveGrokFallbackBinary,
   resolveVersion,
 } from './store.js';
 export * from './store.js';
@@ -1202,7 +1203,19 @@ function transferGrokDownloads(
     }
   }
 
-  if (movedPaths.length === 0) return false;
+  if (movedPaths.length === 0) {
+    const fallback = resolveGrokFallbackBinary(sourceDownloads);
+    if (!fallback) return false;
+    const dst = path.join(targetDownloads, path.basename(fallback));
+    try {
+      fs.mkdirSync(targetDownloads, { recursive: true });
+      if (copy) fs.copyFileSync(fallback, dst);
+      else fs.renameSync(fallback, dst);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
   // The installer also creates a generic platform binary (e.g. grok-macos-aarch64)
   // that is a copy of the versioned binary. Move it too if its size matches.

--- a/cli/tests/versions.test.ts
+++ b/cli/tests/versions.test.ts
@@ -1239,7 +1239,7 @@ describe('installVersion', () => {
     }
   });
 
-  it.skipIf(IS_WINDOWS)('gracefully redirects a version-pinned external install to the current release (RUSH-1321)', async () => {
+  it.skipIf(IS_WINDOWS)('keeps a concrete self-updating install label while recording the current release', async () => {
     // A self-updating agent (no VERSION token in the installer) can't pin. A
     // network-free `true` installer stands in for the real curl/brew script.
     // A stub `agy` (antigravity's actual cliCommand — NOT the agent id) on
@@ -1262,13 +1262,15 @@ describe('installVersion', () => {
     try {
       const result = await installVersion('antigravity', '1.2.3');
 
-      // No longer a hard `does not support version-pinned installs` error — the
-      // pin is redirected to installing the current release.
       expect(result.success).toBe(true);
-      expect(result.installedVersion).toBe('1.9.9'); // the live version, not the ignored pin
+      expect(result.installedVersion).toBe('1.2.3');
       expect(result.error ?? '').not.toContain('does not support version-pinned installs');
-      // The ignored `1.2.3` pin did NOT create a fictional `1.2.3` version dir.
-      expect(fs.existsSync(path.join(AGENTS_DIR, 'versions', 'antigravity', '1.2.3'))).toBe(false);
+      const record = JSON.parse(fs.readFileSync(
+        path.join(AGENTS_DIR, 'versions', 'antigravity', '1.2.3', 'installation.json'),
+        'utf-8',
+      ));
+      expect(record.label).toBe('1.2.3');
+      expect(record.releaseVersion).toBe('1.9.9');
     } finally {
       AGENTS.antigravity.installScript = original;
       process.env.PATH = originalPath;


### PR DESCRIPTION
## Summary
- preserve concrete Cursor/Grok install tokens as stable credential-slot labels
- record the vendor self-updated binary version separately as `releaseVersion`
- copy an existing Grok release into a second home instead of moving it out of the first account
- resolve Grok binaries through the recorded release while keeping slot addressing stable

Tracking: PHNX-3250

## Verification
- `bunx vitest run src/lib/installations/versions.test.ts src/lib/installations/store.test.ts` — 76 passed
- `scripts/build.sh --skip-tests` — canonical build completed (1584 files)
- `scripts/install.sh --skip-tests` — installed side-by-side `agents-dev`; production `agents` untouched

## Fleet reproduction
Before this fix, requesting historical Cursor/Grok versions on Yosemite workers produced the vendor current version as the directory label. Two account slots therefore collapsed onto one home, and `remove --isolated` could remove the normal install sharing that directory. The regression test now proves a requested Grok label remains addressable while its current release is separately recorded and the source account binary remains present.