### PR TITLE
ci(computer-win): release on the helper's own tag, so a CLI release stops rebuilding a 165MB exe

### DIFF
--- a/.github/workflows/computer-helper-win.test.ts
+++ b/.github/workflows/computer-helper-win.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Pin the Windows helper's release trigger to its OWN tag.
+ *
+ * `release-exe` used to fire on the CLI's `v*` tags, which had two costs:
+ *
+ *   - every ordinary CLI release rebuilt and re-uploaded a ~165MB self-contained
+ *     exe that nobody had changed — the macOS helpers avoid this via
+ *     `release-manifest.sh`'s input digest, the Windows one had no gate at all;
+ *   - and it uploaded onto the CLI tag, which since the helper-tag split is an
+ *     address no client requests: `ssh-tunnel.ts` resolves
+ *     `computer-win/v<x.y.z>` from the CLI's pinned floor.
+ *
+ * Cutting `computer-win/v<x.y.z>` is a deliberate act, so the trigger itself is
+ * the rebuild gate. This is a test rather than a comment because GitHub does not
+ * evaluate the `paths:` filter for tag pushes — the tag pattern is the ONLY
+ * thing standing between a CLI release and a pointless 165MB rebuild, and a
+ * one-word edit silently restores the old behaviour.
+ */
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const YML = fs.readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), 'computer-helper-win.yml'),
+  'utf-8',
+);
+
+describe('computer-helper-win: the helper tag is the rebuild gate', () => {
+  it('releases on its own tag, never on the CLI version tag', () => {
+    expect(YML).toContain("tags: ['computer-win/v*']");
+    // The regression: `tags: ['v*']` matches every CLI release.
+    expect(YML).not.toContain("tags: ['v*']");
+    expect(YML).not.toContain('tags: ["v*"]');
+  });
+
+  it('still gates the release job on a tag push, not a branch push', () => {
+    // Without this the exe would be rebuilt on every push to main too.
+    expect(YML).toContain("if: github.ref_type == 'tag'");
+  });
+
+  it('uploads to the tag that triggered it', () => {
+    // GITHUB_REF_NAME is the helper tag now; hardcoding a `v$VERSION` anywhere
+    // here would publish to the CLI's tag again.
+    expect(YML).toContain('gh release upload $env:GITHUB_REF_NAME');
+    expect(YML).not.toMatch(/gh release upload\s+"?v\$/);
+  });
+});

--- a/.github/workflows/computer-helper-win.yml
+++ b/.github/workflows/computer-helper-win.yml
@@ -7,15 +7,22 @@ name: computer-helper-win
 # Required check: the verb set is at parity with the macOS helper and the smoke
 # is green on windows-latest, so a failure blocks the merge.
 #
-# On v* tags (pushed by cli/scripts/release.sh) the release-exe job builds
-# the shipped single-file exe, smokes it, and uploads it + a .sha256 as release
-# assets — the download source for npm-installed CLIs (GitHub #547). The paths
-# filter does not gate tag runs: GitHub does not evaluate `paths` for tag pushes.
+# On `computer-win/v*` tags the release-exe job builds the shipped single-file
+# exe, smokes it, and uploads it + a .sha256 as release assets — the download
+# source for npm-installed CLIs (GitHub #547). The paths filter does not gate tag
+# runs: GitHub does not evaluate `paths` for tag pushes, which is why the tag
+# pattern itself has to be the gate.
 
 on:
   push:
     branches: ['win-computer-use', 'main']
-    tags: ['v*']
+    # The helper's OWN tag, not the CLI's `v*`. Cutting `computer-win/v<x.y.z>`
+    # is a deliberate act, so the trigger IS the rebuild gate: an ordinary CLI
+    # release no longer rebuilds and re-uploads a ~165MB exe that nobody changed.
+    # It also puts the asset where the client actually looks — `ssh-tunnel.ts`
+    # resolves `computer-win/v<x.y.z>` since the helper-tag split, so uploading
+    # onto the CLI tag was publishing to an address no client requests.
+    tags: ['computer-win/v*']
     paths:
       - 'native/computer-win/**'
       - '.github/workflows/computer-helper-win.yml'
@@ -92,10 +99,13 @@ jobs:
           Write-Host "exe: $full"
           node smoke/smoke.mjs --exe "$full" --port 8772
 
-  # On v* tags: build the SAME self-contained single-file exe, smoke it, and
-  # upload it + its sha256 as release assets. `ssh-tunnel.ts` downloads exactly
-  # `releases/download/v<cli-version>/computer-helper-win.exe` when no local
-  # build exists (npm global installs), verifying against the .sha256 asset.
+  # On `computer-win/v*` tags: build the SAME self-contained single-file exe,
+  # smoke it, and upload it + its sha256 as release assets. `ssh-tunnel.ts`
+  # downloads `releases/download/computer-win/v<x.y.z>/computer-helper-win.exe`
+  # when no local build exists (npm global installs), verifying against the
+  # .sha256 asset. The version comes from the CLI's pinned helper floor
+  # (cli/src/lib/helper-versions.ts), NOT from the CLI's own version — that
+  # coupling is what this tag split removed.
   release-exe:
     if: github.ref_type == 'tag'
     runs-on: windows-latest
@@ -143,7 +153,7 @@ jobs:
         run: |
           gh release view $env:GITHUB_REF_NAME --repo $env:GITHUB_REPOSITORY 2>$null
           if ($LASTEXITCODE -ne 0) {
-            gh release create $env:GITHUB_REF_NAME --repo $env:GITHUB_REPOSITORY --verify-tag --title $env:GITHUB_REF_NAME --notes "agents-cli $env:GITHUB_REF_NAME. Assets: the Windows computer-helper daemon exe (downloaded on demand by 'agents computer setup --host')."
+            gh release create $env:GITHUB_REF_NAME --repo $env:GITHUB_REPOSITORY --verify-tag --title $env:GITHUB_REF_NAME --notes "Windows computer-helper daemon, $env:GITHUB_REF_NAME. Downloaded on demand by ``agents computer setup --host``; the CLI resolves this tag from its pinned helper floor (cli/src/lib/helper-versions.ts), not from its own version."
             if ($LASTEXITCODE -ne 0) { throw "gh release create failed" }
           }
           gh release upload $env:GITHUB_REF_NAME dist/computer-helper-win.exe dist/computer-helper-win.exe.sha256 --clobber --repo $env:GITHUB_REPOSITORY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,7 @@ one-off command in a PR.
 | CLI release | [`cli/scripts/release.sh`](cli/scripts/release.sh) `<version> [--apply]` | zero-config self-routing publish of `@phnx-labs/agents-cli` to npm: runnable from any fleet box with an empty environment — requires an exact-tree attestation (it runs **no** tests itself; `release-attestation-produce.sh` does, offloaded via `test.sh`), PR + CI, then a promote-only publish on the home base — any OS, `mac-mini` by default, overridable with `--device <name>` (RUSH-3026: the tarball no longer needs per-release signing); prints a `[n/6]` phase tracker. Legacy `@swarmify` shim built for reference, not published |
 | ext / agents-dbg build + release | in [phnx-labs/agi-ext](https://github.com/phnx-labs/agi-ext) `scripts/` | AGI EXT and the agents-dbg app moved with the extension repo (RUSH-3189) |
 | computer-mac build | [`native/computer-mac/scripts/build.sh`](native/computer-mac/scripts/build.sh) | Swift daemon |
+| computer-win release | [`cli/scripts/publish-computer-win.sh`](cli/scripts/publish-computer-win.sh) `<x.y.z> [--apply]` | cuts `computer-win/v<x.y.z>`, which is what triggers the exe build + upload. Dry-run by default; refuses an existing tag (helper releases are immutable — the upload uses `--clobber`). Symmetric with `publish-computer-helper-mac.sh`. Bump the `computer-win` floor in [`cli/src/lib/helper-versions.ts`](cli/src/lib/helper-versions.ts) afterwards — the tag makes the build downloadable, the floor makes a CLI ask for it |
 
 ### Never install a dev build over the user's `agents`
 

--- a/cli/.changelog/next/RUSH-3228-win.md
+++ b/cli/.changelog/next/RUSH-3228-win.md
@@ -1,0 +1,9 @@
+- **`scripts/publish-computer-win.sh` — a publish path for the Windows helper (RUSH-3228).**
+  Its release now triggers on `computer-win/v<x.y.z>` rather than the CLI's `v*` tag, but
+  nothing in the repo cut such a tag, so the trigger would have been dead — trading a
+  wasteful 165 MB rebuild on every CLI release for no rebuild at all. The tag *is* the
+  publish action (`release-exe` builds, smokes on a real windows-latest runner, and
+  uploads the exe + sha256), so a mis-shaped tag is a silent no-op: the script refuses a
+  `v`-prefixed or non-semver version, refuses an existing tag because the upload uses
+  `--clobber` and an installed CLI may already pin it, and is dry-run by default.
+  Symmetric with `publish-computer-helper-mac.sh`. Source: `cli/scripts/publish-computer-win.sh`.

--- a/cli/scripts/publish-computer-win.sh
+++ b/cli/scripts/publish-computer-win.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Cut a Windows computer-helper release by pushing its own tag.
+#
+# WHY A SCRIPT AND NOT JUST `git tag`: the tag IS the publish action. The
+# `release-exe` job in .github/workflows/computer-helper-win.yml fires on
+# `computer-win/v*`, builds the self-contained single-file exe, smoke-tests it on
+# a real windows-latest runner, and uploads it + its .sha256 as release assets.
+# Nothing else publishes that exe, so a mistyped or mis-shaped tag is a silent
+# no-op rather than an error -- exactly the failure this script exists to stop.
+#
+# It is deliberately the SYMMETRIC counterpart of publish-computer-helper-mac.sh:
+# one script per helper, each cutting that helper's own tag. Before the tag split
+# both helpers rode the CLI's `v*` tag, which meant every CLI release rebuilt a
+# ~165MB exe nobody had changed AND published it to an address no client
+# requests (`ssh-tunnel.ts` resolves `computer-win/v<x.y.z>` from the pinned
+# floor in cli/src/lib/helper-versions.ts).
+#
+# Usage:
+#   scripts/publish-computer-win.sh <x.y.z> [--apply]
+#
+# Default is DRY-RUN: it validates and prints what it would push. --apply pushes.
+#
+# After pushing, bump `computer-win`'s floor in cli/src/lib/helper-versions.ts in
+# a normal PR -- the tag makes the build downloadable, the floor is what makes a
+# CLI ask for it.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+red()   { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+gray()  { printf '\033[2m%s\033[0m\n'  "$*"; }
+die()   { red "error: $*"; exit 1; }
+
+VERSION=""
+APPLY=false
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=true ;;
+    -h|--help) sed -n '3,26p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    --*) die "unknown flag: $arg" ;;
+    *) [[ -z "$VERSION" ]] || die "unexpected argument: $arg"; VERSION="$arg" ;;
+  esac
+done
+
+[[ -n "$VERSION" ]] || die "usage: scripts/publish-computer-win.sh <x.y.z> [--apply]"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+  || die "version must be bare X.Y.Z (the tag prefix is added for you), got: $VERSION"
+
+TAG="computer-win/v$VERSION"
+
+# Fail loud on an existing tag rather than letting --force cross anyone's mind:
+# the asset upload uses --clobber, so re-tagging would silently replace a
+# published binary that some installed CLI already pinned.
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1 \
+  || git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+  die "$TAG already exists. Helper releases are immutable -- cut the next patch instead."
+fi
+
+# The tag must point at a commit whose native/computer-win/ is what you mean to
+# ship: the workflow checks out the TAG and builds from it.
+SHA="$(git rev-parse HEAD)"
+gray "  tag:    $TAG"
+gray "  commit: ${SHA:0:12} ($(git log -1 --format=%s | cut -c1-60))"
+gray "  builds: native/computer-win/ at that commit, on windows-latest"
+
+if [[ "$APPLY" != true ]]; then
+  green "DRY-RUN. Re-run with --apply to push $TAG and trigger the release build."
+  exit 0
+fi
+
+git tag -a "$TAG" -m "Windows computer-helper $VERSION" "$SHA"
+git push origin "$TAG"
+green "Pushed $TAG."
+gray  "  Watch: gh run list --workflow computer-helper-win.yml"
+gray  "  Then bump computer-win's floor in cli/src/lib/helper-versions.ts."

--- a/cli/scripts/publish-computer-win.test.ts
+++ b/cli/scripts/publish-computer-win.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const SH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'publish-computer-win.sh');
+const run = (...args: string[]) => spawnSync('bash', [SH, ...args], { encoding: 'utf-8' });
+
+/**
+ * The tag IS the publish action for the Windows helper — `release-exe` in
+ * computer-helper-win.yml fires on `computer-win/v*` and nothing else uploads
+ * that exe. So a mis-shaped tag is a silent no-op, not an error, which is
+ * precisely why the argument guards are worth pinning.
+ */
+describe('publish-computer-win.sh', () => {
+  it('defaults to dry-run — cutting a release is never accidental', () => {
+    const r = run('9.9.9');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('DRY-RUN');
+    expect(`${r.stdout}${r.stderr}`).toContain('computer-win/v9.9.9');
+  });
+
+  it('refuses a v-prefixed version rather than cutting computer-win/vv1.0.1', () => {
+    const r = run('v1.0.1');
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/bare X\.Y\.Z/);
+  });
+
+  it('refuses a non-semver version', () => {
+    expect(run('1.0').status).not.toBe(0);
+    expect(run('latest').status).not.toBe(0);
+  });
+
+  it('refuses an existing tag — a helper release is immutable', () => {
+    // The asset upload uses --clobber, so re-tagging would silently replace a
+    // binary an installed CLI already pins to that exact version.
+    const r = run('1.0.0');
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/already exists/);
+  });
+
+  it('refuses an unknown flag rather than ignoring it', () => {
+    const r = run('1.0.1', '--force');
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/unknown flag/);
+  });
+
+  it('is the symmetric counterpart of the macOS helper publisher', () => {
+    // One script per helper, each cutting that helper's own tag. If this file
+    // exists but its macOS sibling does not, the pair has drifted.
+    expect(fs.existsSync(path.join(path.dirname(SH), 'publish-computer-helper-mac.sh'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes the last rebuild-on-every-release gap, and it turns out the fix is simpler than
the digest gate I originally planned.

## The problem

`release-exe` fired on the CLI's `v*` tags:

```yaml
tags: ['v*']
```

Two costs, and the second is the one that made a digest gate unnecessary:

1. **Every ordinary CLI release rebuilt and re-uploaded a ~165 MB self-contained exe that
   nobody had changed.** The macOS helpers avoid this through `release-manifest.sh`'s
   input digest; the Windows one had no gate at all — the only condition on the job is
   `if: github.ref_type == 'tag'`.
2. **It uploaded onto the CLI's tag, which is now an address no client requests.** Since
   #3056, `ssh-tunnel.ts` resolves `computer-win/v<x.y.z>` from the CLI's pinned helper
   floor. So the rebuild was not just wasteful, it was publishing to the wrong place.

## The fix

```yaml
tags: ['computer-win/v*']
```

Cutting `computer-win/v<x.y.z>` is a deliberate act, so **the trigger is the rebuild
gate**. No input-digest machinery needed: a CLI release simply never triggers this
workflow, and the asset lands where the client actually looks. `GITHUB_REF_NAME` carries
through to the upload, so the create/upload steps needed no change.

## Why this is a test, not a comment

GitHub does **not** evaluate the `paths:` filter for tag pushes — the job's own comment
already says so. That means the tag pattern is the *only* thing between a CLI release and
a pointless 165 MB rebuild, and a one-word edit silently restores the old behaviour with
no other signal. So `computer-helper-win.test.ts` pins it:

```
revert to tags: ['v*']
  (fail) releases on its own tag, never on the CLI version tag
```

`bun test ./.github/workflows/` — 14 tests across 4 files, 0 fail. (These run under bun,
not vitest — the CI step is `bun test ./.github/workflows/`.)

## Stale claims fixed while here

The `release-exe` docblock still described the old contract — "On v* tags" and
`releases/download/v<cli-version>/computer-helper-win.exe`. Both now name the helper tag
and point at `helper-versions.ts` as the source of the version. The release-notes string
also read "agents-cli computer-win/v1.0.1", which is not what this release is.

## Not in scope

The exe is still **unsigned** — `certificate table: rva=0 size=0`, no Authenticode
signature, and no signing step anywhere in this workflow. macOS helpers are Developer-ID
signed + notarized + DR-pinned; Windows gets a sha256 and nothing else. That is a separate
piece of work needing a code-signing certificate, and worth doing: an unsigned exe trips
SmartScreen on every user's first run.
