### PR TITLE
fix(attest): honour --with-helpers in the producer, not just release.sh

### DIFF
--- a/cli/.changelog/next/RUSH-3216-producer.md
+++ b/cli/.changelog/next/RUSH-3216-producer.md
@@ -1,0 +1,9 @@
+- **The attestation producer skips the helper manifest by default too (RUSH-3216).**
+  `release.sh` gained `--with-helpers` so an ordinary release does no helper work, but
+  `release-attestation-produce.sh` kept the same unconditional
+  `release-manifest.sh` verification — so the coupling survived one step upstream. Found
+  live: a one-line **comment** fix in `native/computer-mac/scripts/build.sh` (an
+  `apps/cli/` → `cli/` path in prose) changed that helper's input digest and aborted an
+  otherwise-clean 1.22.49 attestation, for a helper the tarball no longer ships and the
+  CLI resolves from its own tag. The producer now takes the same `--with-helpers` flag,
+  default off. Source: `cli/scripts/release-attestation-produce.sh`.

--- a/cli/scripts/release-attestation-produce.sh
+++ b/cli/scripts/release-attestation-produce.sh
@@ -35,6 +35,13 @@
 #   scripts/release-attestation-produce.sh <commit-ish> [--dir DIR]
 #                                           [--repo-root DIR] [--keep]
 #                                           [--with-helpers]
+#                                           [--test-device <box> | --test-here
+#                                            | --test-crabbox]
+#
+# Where the suite runs. Default auto-picks a fleet worker via `agents devices
+# pick`; --test-device <box> names one; --test-here pins THIS machine (loud);
+# --test-crabbox uses a disposable crabbox. All three forward to scripts/test.sh,
+# which owns the routing.
 #
 # --with-helpers (default OFF) additionally verifies the helper input-digest
 # manifest. Off by default for the same reason release.sh's flag is: the check
@@ -83,7 +90,12 @@ while [[ $# -gt 0 ]]; do
     --test-crabbox) TEST_TARGET=(--crabbox); shift ;;
     --with-helpers) WITH_HELPERS=true; shift ;;
     -h|--help)
-      sed -n '3,32p' "$0" | sed 's/^# \?//'
+      # Print the WHOLE docblock, not a hardcoded line range. `sed -n '3,32p'`
+      # silently truncated: --with-helpers was documented at ~line 40 and never
+      # appeared in --help at all. A magic number drifts every time the header
+      # grows, and it fails silently — the help just gets quieter. Stop at the
+      # first non-comment line instead, so the range maintains itself.
+      awk 'NR>2 { if (/^#/) { sub(/^# ?/, ""); print } else { exit } }' "$0"
       exit 0
       ;;
     --*) die "unknown flag: $1" ;;

--- a/cli/scripts/release-attestation-produce.sh
+++ b/cli/scripts/release-attestation-produce.sh
@@ -34,6 +34,11 @@
 # Usage:
 #   scripts/release-attestation-produce.sh <commit-ish> [--dir DIR]
 #                                           [--repo-root DIR] [--keep]
+#                                           [--with-helpers]
+#
+# --with-helpers (default OFF) additionally verifies the helper input-digest
+# manifest. Off by default for the same reason release.sh's flag is: the check
+# aborts on any helper source change, including ones the tarball does not ship.
 #
 # --dir defaults to $RELEASE_ATTESTATION_DIR or <repo-root>/.release-attestations
 # -- the same resolution release.sh uses, so producing and requiring agree
@@ -57,6 +62,14 @@ STORE=""
 KEEP=false
 # Where the suite runs. Empty = scripts/test.sh's default (auto-pick a fleet worker).
 TEST_TARGET=()
+# Default OFF, matching release.sh's flag of the same name. The helper manifest
+# re-derives every helper's INPUT DIGEST and fails when one moved without a
+# rebuild — correct when a release is publishing helpers, and pure obstruction
+# when it is not. Proven on 2026-08-25: a one-line COMMENT fix in
+# native/computer-mac/scripts/build.sh (an `apps/cli/` -> `cli/` path in prose)
+# changed the digest and blocked an otherwise-perfect 1.22.49 attestation, for a
+# helper the tarball no longer ships and the CLI resolves from its own tag.
+WITH_HELPERS=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dir) STORE="$2"; shift 2 ;;
@@ -68,6 +81,7 @@ while [[ $# -gt 0 ]]; do
     # two of the three lanes, and a release on a box with no fleet worker in
     # reach had no way to ask for the disposable crabbox it can still use.
     --test-crabbox) TEST_TARGET=(--crabbox); shift ;;
+    --with-helpers) WITH_HELPERS=true; shift ;;
     -h|--help)
       sed -n '3,32p' "$0" | sed 's/^# \?//'
       exit 0
@@ -313,7 +327,7 @@ newest_release_with_manifest() {
   printf '%s\n' "$newest"
 }
 
-if [[ -x scripts/release-manifest.sh ]]; then
+if [[ "$WITH_HELPERS" == true && -x scripts/release-manifest.sh ]]; then
   bold "Updating the helper manifest..."
   MANIFEST_FILE="$STORE/release-manifest.json"
   CLI_VERSION_MANIFEST="$(jq -r .version package.json)"
@@ -388,5 +402,9 @@ if [[ -x scripts/release-manifest.sh ]]; then
   done
   green "Manifest at $MANIFEST_FILE"
 else
-  gray "No scripts/release-manifest.sh in this tree -- skipping helper manifest production."
+  if [[ "$WITH_HELPERS" != true ]]; then
+    gray "CLI-only attestation: skipping the helper manifest (pass --with-helpers to include it)."
+  else
+    gray "No scripts/release-manifest.sh in this tree -- skipping helper manifest production."
+  fi
 fi

--- a/cli/scripts/release-attestation-produce.test.ts
+++ b/cli/scripts/release-attestation-produce.test.ts
@@ -165,6 +165,32 @@ function runProduce(
 
 
 
+describe('release-attestation-produce.sh --help', () => {
+  it('lists every flag its parser accepts (executed, not grepped)', () => {
+    // `--help` printed a hardcoded `sed -n '3,32p'` slice, so --with-helpers —
+    // documented around line 40 — never appeared. A magic line range drifts
+    // every time the header grows and fails SILENTLY: the help just gets
+    // quieter. This derives the flag set from the parser's own case arms and
+    // compares against real --help output, so the next flag is covered without
+    // anyone remembering to extend the test.
+    const help = spawnSync('bash', [PRODUCE_SCRIPT, '--help'], { encoding: 'utf-8' });
+    expect(help.status, help.stderr).toBe(0);
+
+    const parsed = new Set<string>();
+    for (const arm of fs.readFileSync(PRODUCE_SCRIPT, 'utf-8').matchAll(/^\s{4}(--[^)]+)\)/gm)) {
+      for (const flag of arm[1].split('|')) {
+        const name = flag.trim();
+        if (name === '--*' || name === '--help') continue;
+        parsed.add(name);
+      }
+    }
+    expect(parsed.size, 'no flags parsed out of the case arms').toBeGreaterThan(3);
+
+    const missing = [...parsed].filter((f) => !help.stdout.includes(f));
+    expect(missing, `--help omits: ${missing.join(', ')}`).toEqual([]);
+  });
+});
+
 describe('release-attestation-produce.sh', () => {
   it('skips the helper manifest by default, so a helper source change cannot block a CLI attestation', () => {
     // The live failure this prevents: a one-line COMMENT fix in

--- a/cli/scripts/release-attestation-produce.test.ts
+++ b/cli/scripts/release-attestation-produce.test.ts
@@ -166,6 +166,22 @@ function runProduce(
 
 
 describe('release-attestation-produce.sh', () => {
+  it('skips the helper manifest by default, so a helper source change cannot block a CLI attestation', () => {
+    // The live failure this prevents: a one-line COMMENT fix in
+    // native/computer-mac/scripts/build.sh (an `apps/cli/` -> `cli/` path in
+    // prose) changed computer-mac's input digest and aborted an otherwise-clean
+    // 1.22.49 attestation — for a helper the tarball no longer ships and the CLI
+    // resolves from its own tag. release.sh gained --with-helpers for exactly
+    // this; the producer had the same unconditional check and was missed.
+    const fx = buildFixture(tmp('attest-produce-nomanifest-'));
+    const result = runProduce(fx);
+    const out = (result.stdout + result.stderr).replace(/\[[0-9;]*m/g, '');
+    expect(result.status, out).toBe(0);
+    expect(out).toContain('CLI-only attestation: skipping the helper manifest');
+    // The attestation itself is still produced — this is a skip, not a bail.
+    expect(out).toMatch(/Wrote .*\.json/);
+  });
+
   it('does NOT seed helper apps on a non-Mac producer — the tarball ships none (RUSH-3100)', () => {
     // This replaces the RUSH-3026 seeding test, and the reversal is the point.
     //
@@ -515,6 +531,17 @@ function seedManifest(store: string, helpers: Record<string, { inputDigest: stri
 }
 
 describe('release-attestation-produce.sh -- helper manifest (RUSH-2766)', () => {
+  // The manifest step is opt-in since --with-helpers (a CLI-only attestation must
+  // not abort because a helper's SOURCE moved — a one-line comment fix in
+  // native/computer-mac/scripts/build.sh blocked a real 1.22.49 attestation that
+  // way). Every test in this block is ABOUT the manifest, so they all pass the
+  // flag; a separate test below pins that the DEFAULT skips it.
+  const runProduceWithHelpers = (
+    fx: ReturnType<typeof buildFixture>,
+    extra: string[] = [],
+    env: NodeJS.ProcessEnv = {},
+  ) => runProduce(fx, ['--with-helpers', ...extra], env);
+
   it('carries forward an unchanged helper and records fresh digests for changed ones', () => {
     const root = tmp('attest-produce-manifest-');
     const fx = buildManifestFixture(root);
@@ -524,7 +551,7 @@ describe('release-attestation-produce.sh -- helper manifest (RUSH-2766)', () => 
     // the "signed" assets committed into the fixture.
     seedManifest(fx.store, { 'computer-mac': { inputDigest: fx.manifestDigests['computer-mac'] } });
 
-    const result = runProduce(fx);
+    const result = runProduceWithHelpers(fx);
     expect(result.status, result.stdout + result.stderr).toBe(0);
     expect(result.stdout + result.stderr).toContain('helper computer-mac unchanged');
 
@@ -590,7 +617,7 @@ describe('release-attestation-produce.sh -- helper manifest (RUSH-2766)', () => 
     );
     fs.chmodSync(path.join(fx.fakebin, 'gh'), 0o755);
 
-    const result = runProduce(fx);
+    const result = runProduceWithHelpers(fx);
 
     expect(result.status, result.stdout + result.stderr).toBe(0);
     expect(result.stdout + result.stderr).toContain('Seeded the helper manifest from v9.9.8');
@@ -647,7 +674,7 @@ describe('release-attestation-produce.sh -- helper manifest (RUSH-2766)', () => 
     fs.chmodSync(ghPath, 0o755);
 
     const output = (() => {
-      const r = runProduce(fx);
+      const r = runProduceWithHelpers(fx);
       return r.stdout + r.stderr;
     })();
 
@@ -689,7 +716,7 @@ describe('release-attestation-produce.sh -- helper manifest (RUSH-2766)', () => 
     );
     fs.chmodSync(path.join(fx.fakebin, 'gh'), 0o755);
 
-    const result = runProduce(fx);
+    const result = runProduceWithHelpers(fx);
     const out = result.stdout + result.stderr;
 
     expect(out, out).toContain('Seeded the helper manifest from v9.9.8');
@@ -715,7 +742,7 @@ describe('release-attestation-produce.sh -- helper manifest (RUSH-2766)', () => 
     );
     fs.chmodSync(path.join(fx.fakebin, 'gh'), 0o755);
 
-    const result = runProduce(fx);
+    const result = runProduceWithHelpers(fx);
 
     expect(result.status).not.toBe(0);
     expect(result.stdout + result.stderr).toContain('helper computer-mac input changed');
@@ -727,7 +754,7 @@ describe('release-attestation-produce.sh -- helper manifest (RUSH-2766)', () => 
     // No seeded manifest at all: computer-mac has no recorded digest, and this
     // producer never rebuilds it, so it must refuse rather than ship a stale
     // or missing helper record.
-    const result = runProduce(fx);
+    const result = runProduceWithHelpers(fx);
     expect(result.status).not.toBe(0);
     expect(result.stdout + result.stderr).toContain('helper computer-mac input changed');
     expect(result.stdout + result.stderr).toContain('publish-computer-helper-mac.sh');


### PR DESCRIPTION
Completes #3073, which only covered half the surface.

## The bug, found by a real release attempt

`release.sh` gained `--with-helpers` so an ordinary CLI release does no helper work. But
`release-attestation-produce.sh` kept the **same unconditional**
`release-manifest.sh require` verification, so the coupling simply moved one step
upstream — into the phase that runs *before* `release.sh` is ever invoked.

Found while attesting 1.22.49. This diff, already on `main`:

```diff
-# before install (apps/cli/src/lib/computer/download.ts).
+# before install (cli/src/lib/computer/download.ts).
```

A one-line **path correction in a comment** changed `computer-mac`'s input digest, so:

```
Test Files  940 passed | 6 skipped (946)
Tests       13350 passed | 105 skipped
Suite passed.
Packed phnx-labs-agents-cli-1.22.48.tgz
Wrote .../a29e31ed....json
error: helper computer-mac input changed but this producer never rebuilds it
PRODUCER EXIT=1
```

A green 13,350-test suite, a packed tarball, a written attestation — then a non-zero exit
because prose in a Swift build script moved. For a helper the tarball no longer ships and
the CLI resolves from its own tag.

## The fix

`--with-helpers` on the producer too, default off, matching `release.sh`'s flag exactly.

```sh
if [[ "$WITH_HELPERS" == true && -x scripts/release-manifest.sh ]]; then
```

## Tests

The 8 existing manifest tests are all *about* the manifest, so they route through one
`runProduceWithHelpers` helper scoped to that `describe` block rather than sprinkling the
flag across call sites.

One new test pins the half that was missing — that the **default** skips it — so the two
halves cannot drift apart again:

```ts
expect(result.status).toBe(0);
expect(out).toContain('CLI-only attestation: skipping the helper manifest');
expect(out).toMatch(/Wrote .*\.json/);   // a skip, not a bail
```

That last assertion is deliberate: without it the test would pass on a producer that
skipped the manifest by dying earlier.

19 passed.

## Why this class keeps happening

Both halves of this were written by me, in the same session, from the same premise — and
I still missed the second one. The tell was that I reasoned about `release.sh` because
that is the file named "release", when the actual gate ran a phase earlier. Worth a
moment's suspicion next time a flag is added to one script in a pipeline: the sibling that
feeds it usually has the same check.
