### PR TITLE
feat(traces): register Phoenix session with Prix after sync (PHNX-3257)

### DIFF
--- a/cli/.changelog/next/PHNX-3257.md
+++ b/cli/.changelog/next/PHNX-3257.md
@@ -1,0 +1,6 @@
+- **Register the Phoenix session with Prix after sync (PHNX-3257).** A successful
+  (non-dry-run) `agents traces sync` now fire-and-forget POSTs the Phoenix bearer
+  to `api.prix.dev/api/v1/traces/link`, so the Prix web console can mint a token
+  and serve live trajectories instead of fixtures. Scoped to the managed Phoenix
+  backend only — a BYO/self-hosted `AGENTS_TRACES_WRITE_TOKEN` is never sent to
+  Prix. Source: `cli/src/lib/traces/sync.ts`.

--- a/cli/docs/command-index.json
+++ b/cli/docs/command-index.json
@@ -29168,7 +29168,7 @@
             }
           ],
           "examples": "$ agents traces sync\n  Push this device's derived, redacted trajectories to your Phoenix account.\n\n  $ agents traces sync --limit 20\n  Sync at most 20 sessions (useful for a first run on a large fleet device).\n\n  $ agents traces sync --dry-run --out ./trace-preview\n  Compute the shards from your real sessions.db and WRITE them locally — no\n  Phoenix sign-in, no worker, no upload. Point a console at ./trace-preview to\n  see your real trajectories before wiring the hosted path.",
-          "notes": "Reads from the local sessions.db, computes a derived SessionTrajectory (steps +\n  gaps + stats, no raw transcript text), redacts secrets, and PUTs each to\n  the agents-traces store.\n\n  An incremental gate (traces-sync.json ledger) means re-runs only upload\n  sessions whose file_mtime_ms changed since the last sync.\n\n  Sign in first with: agents auth login",
+          "notes": "Reads from the local sessions.db, computes a derived SessionTrajectory (steps +\n  gaps + stats, no raw transcript text), redacts secrets, and PUTs each to\n  the agents-traces store.\n\n  An incremental gate (traces-sync.json ledger) means re-runs only upload\n  sessions whose file_mtime_ms changed since the last sync.\n\n  On a real (non-dry-run) sync with the managed Phoenix backend, also\n  fire-and-forget registers this session with Prix (api.prix.dev) so the\n  console can serve live trajectories — a link failure never blocks sync.\n\n  Sign in first with: agents auth login",
           "subcommands": []
         }
       ]

--- a/cli/docs/command-reference.html
+++ b/cli/docs/command-reference.html
@@ -4373,6 +4373,10 @@ Three or more selectors, and --tree with more than one selector, fail loud.</p><
   an incremental gate (traces-sync.json ledger) means re-runs only upload
   sessions whose file_mtime_ms changed since the last sync.
 
+  on a real (non-dry-run) sync with the managed phoenix backend, also
+  fire-and-forget registers this session with prix (api.prix.dev) so the
+  console can serve live trajectories — a link failure never blocks sync.
+
   sign in first with: agents auth login"><div class="command-head"><h3><code>agents traces sync</code></h3></div><p>Push derived, redacted trajectories (incremental)</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>--limit &lt;n&gt;</code></td><td>Maximum number of sessions to sync in this run</td><td></td><td></td></tr><tr><td><code>--dry-run</code></td><td>Compute the shards from real sessions.db and WRITE them locally (no auth, no upload)</td><td></td><td></td></tr><tr><td><code>--out &lt;dir&gt;</code></td><td>Directory to write index.json + sessions/&lt;id&gt;.json (required with --dry-run)</td><td></td><td></td></tr><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table><h4>Examples</h4><pre><code>$ agents traces sync
   Push this device&#39;s derived, redacted trajectories to your Phoenix account.
 
@@ -4388,6 +4392,10 @@ Three or more selectors, and --tree with more than one selector, fail loud.</p><
 
   An incremental gate (traces-sync.json ledger) means re-runs only upload
   sessions whose file_mtime_ms changed since the last sync.
+
+  On a real (non-dry-run) sync with the managed Phoenix backend, also
+  fire-and-forget registers this session with Prix (api.prix.dev) so the
+  console can serve live trajectories — a link failure never blocks sync.
 
   Sign in first with: agents auth login</p></article>
 <article id="trash" data-search="trash trash  inspect and restore soft-deleted agent version directories -h, --help show help  "><div class="command-head"><h3><code>agents trash</code></h3></div><p>Inspect and restore soft-deleted agent version directories</p><h4>Options</h4><table><thead><tr><th>Flags</th><th>Description</th><th>Choices</th><th>Default</th></tr></thead><tbody><tr><td><code>-h, --help</code></td><td>Show help</td><td></td><td></td></tr></tbody></table></article>

--- a/cli/src/commands/traces.ts
+++ b/cli/src/commands/traces.ts
@@ -36,6 +36,10 @@ const SYNC_NOTES = `
   An incremental gate (traces-sync.json ledger) means re-runs only upload
   sessions whose file_mtime_ms changed since the last sync.
 
+  On a real (non-dry-run) sync with the managed Phoenix backend, also
+  fire-and-forget registers this session with Prix (api.prix.dev) so the
+  console can serve live trajectories — a link failure never blocks sync.
+
   Sign in first with: agents auth login
 `.trimStart();
 

--- a/cli/src/lib/traces/sync.test.ts
+++ b/cli/src/lib/traces/sync.test.ts
@@ -150,15 +150,26 @@ describe('rich traces index shard', () => {
     process.env.AGENTS_TRACES_WRITE_TOKEN = 'test-token';
     process.env.AGENTS_SYNC_MACHINE_ID = 'test-device';
     fs.rmSync(path.join(getRuntimeStateDir(), 'traces-sync.json'), { force: true });
+    // The BYO write token bypasses Phoenix auth (backend.userId === 'byo') and must
+    // never be sent to the Prix link endpoint. Pass real calls through to the local
+    // test server; only intercept to prove no request ever targets prix.dev.
+    const realFetch = globalThis.fetch;
+    const outboundUrls: string[] = [];
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      outboundUrls.push(typeof input === 'string' ? input : input.toString());
+      return realFetch(input, init);
+    }) as typeof fetch;
     try {
       expect(await syncTraces()).toMatchObject({ uploaded: 1, errors: 0 });
       expect(await syncTraces()).toMatchObject({ uploaded: 0, errors: 0 });
     } finally {
+      globalThis.fetch = realFetch;
       delete process.env.AGENTS_TRACES_BASE_URL;
       delete process.env.AGENTS_TRACES_WRITE_TOKEN;
       delete process.env.AGENTS_SYNC_MACHINE_ID;
       await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
     }
+    expect(outboundUrls.some((u) => u.includes('api.prix.dev'))).toBe(false);
     expect(requests.filter((url) => url.includes(`/sessions/${id}.json`))).toHaveLength(1);
     // Verify the GET was issued for the prior shard on each live-sync run.
     expect(reqLog.filter((r) => r.startsWith('GET') && r.includes('/index.json'))).toHaveLength(2);

--- a/cli/src/lib/traces/sync.ts
+++ b/cli/src/lib/traces/sync.ts
@@ -164,6 +164,15 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
   // A dry-run never advances the incremental watermark: it is a read-only export.
   if (!dryRun) {
     writeSyncLedger({ lastSyncMtime: maxSuccessMtime });
+    // Register the Phoenix session with Prix so the console can fetch live data
+    // (PHNX-3257). Fire-and-forget — a link failure must not block sync.
+    if (backend) {
+      fetch('https://api.prix.dev/api/v1/traces/link', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${backend.token}` },
+        signal: AbortSignal.timeout(8_000),
+      }).catch(() => {});
+    }
   }
   return { uploaded, skipped, errors };
 }

--- a/cli/src/lib/traces/sync.ts
+++ b/cli/src/lib/traces/sync.ts
@@ -166,7 +166,10 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
     writeSyncLedger({ lastSyncMtime: maxSuccessMtime });
     // Register the Phoenix session with Prix so the console can fetch live data
     // (PHNX-3257). Fire-and-forget — a link failure must not block sync.
-    if (backend) {
+    // Managed backend only: the BYO path's token is a static write token that
+    // bypasses Phoenix auth (resolveTracesBackend's userId: 'byo' sentinel) —
+    // it is not a Phoenix identity credential and must never be sent to Prix.
+    if (backend && backend.userId !== 'byo') {
       fetch('https://api.prix.dev/api/v1/traces/link', {
         method: 'POST',
         headers: { Authorization: `Bearer ${backend.token}` },


### PR DESCRIPTION
## Summary

- After a successful non-dry-run `agents traces sync`, POST `https://api.prix.dev/api/v1/traces/link` with the Phoenix bearer token
- Prix API validates the token via Phoenix ID, finds the matching Supabase user by email, and stores the `phoenix_identity_links` row
- The Prix web console's `mintPhoenixBearer` can then exchange the Supabase JWT for the stored Phoenix token and serve live trajectories instead of fixtures
- Fire-and-forget call — a link failure never blocks or degrades sync output

## Part of PHNX-3257

This is the CLI half of the token exchange. The Prix API + web half ships in a companion PR in the agents/prix repo (adds migration 129, `POST /api/v1/traces/link`, `GET /api/v1/traces/console-token`, and implements `mintPhoenixBearer`).

**Exchange flow:**
1. CLI syncs → calls `POST /link` with Phoenix bearer (this PR)
2. Prix validates Phoenix token, finds Supabase user by email, stores link
3. Console calls `GET /console-token` with Supabase JWT → gets back Phoenix `{accessToken, userId}`
4. Console fetches live trajectories from the traces worker

## Test plan

- [ ] `agents traces sync` completes; verify `POST https://api.prix.dev/api/v1/traces/link` fires (network log or Prix API logs)
- [ ] Sign into Prix console at `/console/trajectories` → source should flip from `"fixture"` to `"worker"` after linking
- [ ] `agents traces sync --dry-run --out /tmp/out` — confirm no link call is made (dry-run gate)