### PR TITLE
fix(teams): clear stale failure on resume

### DIFF
--- a/cli/.changelog/next/PHNX-3251.md
+++ b/cli/.changelog/next/PHNX-3251.md
@@ -1,3 +1,6 @@
 ### Fixed
 
 - **Teams now persist observed teammate failure evidence and keep independent DAG branches moving.** Placement, local/remote launch, cloud dispatch, dependency, and process-exit failures carry a stable code, sanitized message, exit code, retryability, and observation time in `teams status` text/JSON. A runnable node with a durable placement failure fails independently; a node blocked only by pool capacity or load stays pending with retryable evidence so a later wave can launch it. Descendants name failed or missing `--after` blockers instead of spinning until `--max-waves`. `teams start` (no `--watch`) reports teammates that failed during the wave in a `Failed this wave` section (JSON: `failed[]` with evidence) and exits non-zero when a wave produced only failures. Because a failed launch now keeps its record (evidence) instead of deleting it, re-running the identical `teams add --name <name>` after a failure requires `teams remove <team> <name>` first.
+  Successfully resuming a failed teammate clears the prior attempt's evidence as
+  the replacement enters `running`; a replacement that fails to launch restores
+  the original terminal state and evidence intact.

--- a/cli/src/lib/teams/agents.resume.test.ts
+++ b/cli/src/lib/teams/agents.resume.test.ts
@@ -190,6 +190,14 @@ describe.skipIf(IS_WINDOWS)('resumeTeammate — launch failure', () => {
       id, 'failure-team', 'claude', 'do a thing',
       null, 'edit', null, AgentStatus.COMPLETED, startedAt, completedAt, base,
     );
+    agent.failure = {
+      stage: 'execution',
+      code: 'process-exit-nonzero',
+      message: 'prior attempt exited 1',
+      exit_code: 1,
+      retryable: true,
+      observed_at: new Date().toISOString(),
+    };
     await agent.saveMeta();
     fs.writeFileSync(path.join(dir, 'prior-turn.log'), 'preserve me');
     const stdoutPath = path.join(dir, 'stdout.log');
@@ -240,6 +248,7 @@ describe.skipIf(IS_WINDOWS)('resumeTeammate — launch failure', () => {
       expect(retained!.startedAt.toISOString()).toBe(startedAt.toISOString());
       expect(retained!.pid).toBeNull();
       expect(retained!.startTime).toBeNull();
+      expect(retained!.failure).toEqual(agent.failure);
       expect(fs.readFileSync(path.join(dir, 'prior-turn.log'), 'utf-8')).toBe('preserve me');
       expect(fs.readFileSync(stdoutPath, 'utf-8')).toBe('prior stdout');
       // Neither the launch nor the restore write ever reached the filesystem
@@ -249,6 +258,7 @@ describe.skipIf(IS_WINDOWS)('resumeTeammate — launch failure', () => {
       expect(restored).not.toBeNull();
       expect(restored!.status).toBe(AgentStatus.COMPLETED);
       expect(restored!.completedAt?.toISOString()).toBe(completedAt.toISOString());
+      expect(restored!.failure).toEqual(agent.failure);
       expect(() => execFileSync('pgrep', ['-f', marker], { stdio: 'ignore' })).toThrow();
     } finally {
       fs.rmSync(base, { recursive: true, force: true });

--- a/cli/src/lib/teams/agents.resume.test.ts
+++ b/cli/src/lib/teams/agents.resume.test.ts
@@ -170,6 +170,46 @@ describe('resumeTeammate — resume-id guard', () => {
   });
 });
 
+describe.skipIf(IS_WINDOWS)('resumeTeammate — successful launch state', () => {
+  it('persists RUNNING without the prior attempt failure after a real local resume launch', async () => {
+    const base = tmpBase();
+    const id = `claude-agent-resume-success-${Date.now()}`;
+    fs.mkdirSync(path.join(base, id), { recursive: true });
+
+    const agent = new AgentProcess(
+      id, 'resume-success-team', 'claude', 'do a thing',
+      null, 'edit', null, AgentStatus.FAILED, new Date(), new Date(), base,
+    );
+    agent.failure = {
+      stage: 'execution',
+      code: 'process-exit-nonzero',
+      message: 'prior attempt exited 1',
+      exit_code: 1,
+      retryable: true,
+      observed_at: new Date().toISOString(),
+    };
+    await agent.saveMeta();
+
+    const mgr = new AgentManager(50, base);
+    try {
+      // Exercise the production resume + local spawn path. The harness may
+      // reject this synthetic session after launch; the invariant under test is
+      // the durable state written atomically when the replacement process has
+      // successfully spawned.
+      const resumed = await mgr.resumeTeammate(id, 'Continue the task');
+      expect(resumed.status).toBe(AgentStatus.RUNNING);
+      expect(resumed.failure).toBeNull();
+
+      const persisted = await AgentProcess.loadFromDisk(id, base);
+      expect(persisted?.status).toBe(AgentStatus.RUNNING);
+      expect(persisted?.failure).toBeNull();
+    } finally {
+      await mgr.stop(id).catch(() => false);
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
 describe.skipIf(IS_WINDOWS)('resumeTeammate — launch failure', () => {
   it('terminates the replacement and restores all prior state when persistence fails after spawn', async () => {
     const base = tmpBase();

--- a/cli/src/lib/teams/agents.ts
+++ b/cli/src/lib/teams/agents.ts
@@ -2328,6 +2328,7 @@ export class AgentManager {
     const resume = { id: agent.remoteSessionId ?? agent.agentId, message };
     const priorRuntime = {
       status: agent.status,
+      failure: agent.failure,
       completedAt: agent.completedAt,
       pid: agent.pid,
       startTime: agent.startTime,
@@ -2344,6 +2345,13 @@ export class AgentManager {
     // that happens, restore the stopped lifecycle state and keep its existing
     // metadata/log directory intact so the user can retry.
     agent.status = AgentStatus.RUNNING;
+    // Failure evidence describes the CURRENT attempt. Once a resume has
+    // successfully launched, retaining the prior terminal attempt's failure on
+    // a RUNNING (and eventually COMPLETED) teammate is false state. Clear it
+    // before either launcher persists RUNNING; priorRuntime restores it if the
+    // replacement launch fails, so a failed resume never erases the evidence
+    // needed to diagnose and retry the original attempt.
+    agent.failure = null;
     agent.completedAt = null;
 
     try {


### PR DESCRIPTION
## What

Clear prior-attempt failure evidence when a resumed teammate successfully enters `running`, while restoring that evidence if replacement launch fails. Follow-up to #3080 / PHNX-3251.

## Verification

- `bun x vitest run src/lib/teams/agents.resume.test.ts src/lib/teams/agents.failure.test.ts src/lib/teams/__tests__/api-summary.test.ts` — 25 passed
- `bun run build` — pass
- `git diff --check` — pass

## Review trigger

A late non-author review on #3080 identified the stale evidence state transition before publication. The release attestation was stopped; this PR must merge before release resumes.