### PR TITLE
test(computer-win): pin tag immutability without origin tags

### DIFF
--- a/cli/scripts/publish-computer-win.test.ts
+++ b/cli/scripts/publish-computer-win.test.ts
@@ -35,9 +35,26 @@ describe('publish-computer-win.sh', () => {
   it('refuses an existing tag — a helper release is immutable', () => {
     // The asset upload uses --clobber, so re-tagging would silently replace a
     // binary an installed CLI already pins to that exact version.
-    const r = run('1.0.0');
-    expect(r.status).not.toBe(0);
-    expect(r.stderr).toMatch(/already exists/);
+    //
+    // Create the tag in THIS repo rather than assuming origin has
+    // computer-win/v1.0.0. `test.sh --device` and the attestation producer
+    // git-init a blank tree with no tags and no origin, so pinning 1.0.0
+    // made the suite red on every isolated run (dry-run exit 0).
+    const repoRoot = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf-8',
+    }).stdout.trim();
+    expect(repoRoot).not.toBe('');
+    const version = `0.0.${process.pid}`;
+    const tag = `computer-win/v${version}`;
+    const created = spawnSync('git', ['-C', repoRoot, 'tag', tag], { encoding: 'utf-8' });
+    expect(created.status).toBe(0);
+    try {
+      const r = run(version);
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(/already exists/);
+    } finally {
+      spawnSync('git', ['-C', repoRoot, 'tag', '-d', tag]);
+    }
   });
 
   it('refuses an unknown flag rather than ignoring it', () => {


### PR DESCRIPTION
## Why

Attesting `origin/main` for the 1.22.50 cut failed on an isolated tree:

```
FAIL  scripts/publish-computer-win.test.ts > refuses an existing tag — a helper release is immutable
AssertionError: expected +0 not to be +0
  const r = run('1.0.0');
  expect(r.status).not.toBe(0);
```

`publish-computer-win.sh` must refuse an existing `computer-win/v*` tag because the asset upload uses `--clobber`. The test pinned that against `1.0.0` on origin. `test.sh --device` and `release-attestation-produce.sh` git-init a blank tree with **no tags and no origin**, so `run('1.0.0')` dry-runs as a new version and exits 0.

Full-suite evidence (yosemite-m1, isolated tree at `2288bf636`): 947 files passed, 1 failed; 13383 passed / 1 failed / 105 skipped.

## Change

The immutability test now creates and deletes a unique local tag (`computer-win/v0.0.<pid>`) in the repo under test. It no longer depends on fetched origin tags.

Test-only. No user-visible behavior; no CHANGELOG fragment.

## Evidence

Worktree run after the change:

```
✓ scripts/publish-computer-win.test.ts (6 tests) 1162ms
Test Files  1 passed (1)
     Tests  6 passed (6)
```

## Merge

Rebase-merge when CI is green and a non-author review is posted (`prix/code-reviewer` is paused; a subagent review will land as a comment).