### PR TITLE
feat(share): gate me/org GET with Phoenix identity (PHNX-3260)

### DIFF
--- a/cli/src/lib/share/worker-template.test.ts
+++ b/cli/src/lib/share/worker-template.test.ts
@@ -1089,6 +1089,38 @@ describe('me/org GET identity gate (PHNX-3260)', () => {
     expect(res.headers.get('location')).toContain('/login?return=');
   });
 
+  it('me ?revisions=json is identity-gated the same way as the page GET', async () => {
+    const worker = await loadWorker();
+    const { env } = makeEnv();
+    await putAsPhoenix(worker, env, 'alice/secret', '<h1>v1</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'me');
+    await putAsPhoenix(worker, env, 'alice/secret', '<h1>v2</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'me');
+    worker.hooks.verifyPhoenixToken = async () => null;
+
+    const anon = await worker.default.fetch(new Request('https://share.test/alice/secret?revisions=json'), env);
+    expect(anon.status).toBe(302);
+    expect(anon.headers.get('location')).toContain('/login?return=');
+    expect(anon.headers.get('location')).toContain(encodeURIComponent('https://share.test/alice/secret?revisions=json'));
+
+    worker.hooks.verifyPhoenixToken = async () => ({ userId: 'bob', email: 'bob@acme.com' });
+    const other = await worker.default.fetch(
+      new Request('https://share.test/alice/secret?revisions=json', { headers: { authorization: 'Bearer bob' } }),
+      env,
+    );
+    expect(other.status).toBe(404);
+    expect(await other.text()).toBe('not found');
+
+    worker.hooks.verifyPhoenixToken = async () => ({ userId: 'alice', email: 'alice@acme.com' });
+    const ok = await worker.default.fetch(
+      new Request('https://share.test/alice/secret?revisions=json', { headers: { authorization: 'Bearer alice' } }),
+      env,
+    );
+    expect(ok.status).toBe(200);
+    expect(ok.headers.get('cache-control')).toBe('private, no-store');
+    expect(ok.headers.get('X-Robots-Tag')).toBe('noindex');
+    const payload = await ok.json();
+    expect(payload.count).toBe(1);
+  });
+
   it('me PUT without PHOENIX_ID_BASE 400s even with a Phoenix hook', async () => {
     const worker = await loadWorker();
     const { env } = makeEnv();

--- a/cli/src/lib/share/worker-template.test.ts
+++ b/cli/src/lib/share/worker-template.test.ts
@@ -1,10 +1,14 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderWorkerScript } from './worker-template.js';
 
-// The Worker source is emitted as a string. Import it as an ES module via a
-// data: URI (same technique as publish.test.ts) and drive its `fetch` handler
-// against an in-memory BUCKET so the real route logic is exercised — no mocking
-// of the listing/format code under test.
+// The Worker source is emitted as a string. Import it as an ES module (temp
+// file — the script is past bun's data: URI NameTooLong limit) and drive its
+// `fetch` handler against an in-memory BUCKET so the real route logic is
+// exercised — no mocking of the listing/format code under test.
 
 interface StoredObject {
   body: Buffer;
@@ -68,8 +72,13 @@ function makeEnv() {
 }
 
 async function loadWorker() {
+  // The Worker source is an ES module. A data: URI used to work, but HMAC
+  // cookie helpers pushed it past bun's NameTooLong limit for data URLs.
   const src = renderWorkerScript();
-  return import(`data:text/javascript;base64,${Buffer.from(src).toString('base64')}#${Date.now()}`);
+  const dir = mkdtempSync(join(tmpdir(), 'share-worker-'));
+  const file = join(dir, `worker-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`);
+  writeFileSync(file, src);
+  return import(pathToFileURL(file).href);
 }
 
 async function put(worker: any, env: any, key: string, body: string, headers: Record<string, string> = {}) {
@@ -660,7 +669,7 @@ describe('Phoenix PUT auth + visibility (RUSH-3135)', () => {
     expect(store.has('7b28a4b7-1fb0-4abe-948d-32daf2ff7298/old')).toBe(false);
   });
 
-  it('400s org visibility on PUT (not supported in P1)', async () => {
+  it('400s org visibility on BYO WRITE_TOKEN PUT (Phoenix identity required)', async () => {
     const worker = await loadWorker();
     const { env } = makeEnv();
     const res = await worker.default.fetch(
@@ -676,7 +685,7 @@ describe('Phoenix PUT auth + visibility (RUSH-3135)', () => {
       env,
     );
     expect(res.status).toBe(400);
-    expect(await res.json()).toMatchObject({ error: 'visibility org is not supported yet' });
+    expect(await res.json()).toMatchObject({ error: 'visibility me/org requires Phoenix identity' });
   });
 
   it('BYO WRITE_TOKEN path still publishes and stamps owner from the path namespace', async () => {
@@ -821,5 +830,282 @@ describe('defaultVerifyPhoenixToken real fetch/parse (RUSH-3135)', () => {
     );
     expect(denied.status).toBe(401);
     expect(store.has('alice/other')).toBe(false);
+  });
+});
+
+describe('me/org GET identity gate (PHNX-3260)', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function stubFetch(handler: (req: Request) => Response | Promise<Response>): Array<{ url: string; method: string; body: string }> {
+    const seen: Array<{ url: string; method: string; body: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      seen.push({ url: req.url, method: req.method, body: await req.clone().text() });
+      return handler(req);
+    }) as typeof fetch;
+    return seen;
+  }
+
+  async function putAsPhoenix(
+    worker: any,
+    env: any,
+    key: string,
+    body: string,
+    identity: { userId: string; email: string },
+    visibility: 'me' | 'org' | 'public' | 'unlisted',
+  ) {
+    worker.hooks.verifyPhoenixToken = async () => identity;
+    (env as { PHOENIX_ID_BASE?: string }).PHOENIX_ID_BASE = env.PHOENIX_ID_BASE || 'https://phoenix.test';
+    const handle = identity.email.split('@')[0].split('+')[0];
+    const res = await worker.default.fetch(
+      new Request(`https://share.test/${key}`, {
+        method: 'PUT',
+        headers: {
+          authorization: 'Bearer phoenix-token',
+          'content-type': 'text/html; charset=utf-8',
+          'x-share-visibility': visibility,
+        },
+        body,
+      }),
+      env,
+    );
+    expect(res.status, `PUT ${key} as ${handle} vis=${visibility}`).toBe(200);
+    return res;
+  }
+
+  function setCookieHeader(res: Response): string {
+    const cookies = typeof res.headers.getSetCookie === 'function' ? res.headers.getSetCookie() : [];
+    if (cookies.length > 0) return cookies[0]!;
+    return res.headers.get('set-cookie') || '';
+  }
+
+  it('public and unlisted GET stay anonymous 200', async () => {
+    const worker = await loadWorker();
+    const { env } = makeEnv();
+    await put(worker, env, 'octocat/public-page', '<h1>public</h1>');
+    await put(worker, env, 'octocat/secret-report', '<h1>secret</h1>', {
+      'x-share-visibility': 'unlisted',
+    });
+
+    const listed = await worker.default.fetch(new Request('https://share.test/octocat/public-page'), env);
+    expect(listed.status).toBe(200);
+    expect(listed.headers.get('cache-control')).toBe('public, max-age=60');
+    expect(listed.headers.get('X-Robots-Tag')).toBeNull();
+
+    const unlisted = await worker.default.fetch(new Request('https://share.test/octocat/secret-report'), env);
+    expect(unlisted.status).toBe(200);
+    expect(unlisted.headers.get('X-Robots-Tag')).toBe('noindex');
+  });
+
+  it('me GET with no auth 302s to Phoenix login?return=<this url>', async () => {
+    const worker = await loadWorker();
+    const { env } = makeEnv();
+    await putAsPhoenix(worker, env, 'alice/secret', '<h1>mine</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'me');
+    worker.hooks.verifyPhoenixToken = async () => null;
+
+    const res = await worker.default.fetch(new Request('https://share.test/alice/secret'), env);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(
+      'https://phoenix.test/login?return=' + encodeURIComponent('https://share.test/alice/secret'),
+    );
+  });
+
+  it('me GET with no PHOENIX_ID_BASE 401s loud instead of bouncing', async () => {
+    const worker = await loadWorker();
+    const { env, store } = makeEnv();
+    store.set('alice/secret', {
+      body: Buffer.from('<h1>mine</h1>'),
+      httpMetadata: { contentType: 'text/html' },
+      customMetadata: { visibility: 'me', owner: 'alice' },
+      uploaded: new Date().toISOString(),
+      size: 12,
+    });
+    worker.hooks.verifyPhoenixToken = async () => null;
+
+    const res = await worker.default.fetch(new Request('https://share.test/alice/secret'), env);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'phoenix login is not configured' });
+  });
+
+  it('phoenix_ticket redeem sets HMAC cookie and 302s stripping the ticket (keeps other query)', async () => {
+    const worker = await loadWorker();
+    const { env } = makeEnv();
+    await putAsPhoenix(worker, env, 'alice/secret', '<h1>mine</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'me');
+    worker.hooks.verifyPhoenixToken = async () => null;
+    const seen = stubFetch(
+      () => new Response(JSON.stringify({ userId: 'alice', email: 'alice@acme.com' }), { status: 200 }),
+    );
+
+    const res = await worker.default.fetch(
+      new Request('https://share.test/alice/secret?ref=slack&phoenix_ticket=tix-1'),
+      env,
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://share.test/alice/secret?ref=slack');
+    expect(seen).toEqual([
+      { url: 'https://phoenix.test/api/v1/auth/ticket', method: 'POST', body: JSON.stringify({ ticket: 'tix-1' }) },
+    ]);
+
+    const setCookie = setCookieHeader(res);
+    expect(setCookie).toContain('__Host-phoenix_share=');
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('Secure');
+    expect(setCookie).toContain('Path=/');
+    expect(setCookie).toContain('SameSite=Lax');
+    expect(setCookie).toContain('Max-Age=604800');
+
+    const cookieValue = setCookie.split(';')[0]!;
+    const follow = await worker.default.fetch(
+      new Request('https://share.test/alice/secret', { headers: { cookie: cookieValue } }),
+      env,
+    );
+    expect(follow.status).toBe(200);
+    expect(await follow.text()).toContain('mine');
+    expect(follow.headers.get('cache-control')).toBe('private, no-store');
+    expect(follow.headers.get('X-Robots-Tag')).toBe('noindex');
+  });
+
+  it('me GET by a second identity 404s with the same body as a missing object', async () => {
+    const worker = await loadWorker();
+    const { env } = makeEnv();
+    await putAsPhoenix(worker, env, 'alice/secret', '<h1>mine</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'me');
+    worker.hooks.verifyPhoenixToken = async () => ({ userId: 'bob', email: 'bob@acme.com' });
+
+    const denied = await worker.default.fetch(
+      new Request('https://share.test/alice/secret', { headers: { authorization: 'Bearer bob' } }),
+      env,
+    );
+    expect(denied.status).toBe(404);
+    expect(denied.headers.get('content-type')).toBe('text/plain');
+    expect(await denied.text()).toBe('not found');
+
+    const missing = await worker.default.fetch(new Request('https://share.test/alice/does-not-exist'), env);
+    expect(missing.status).toBe(404);
+    expect(await missing.text()).toBe('not found');
+  });
+
+  it('org GET 200s same-domain and 404s a mismatched domain', async () => {
+    const worker = await loadWorker();
+    const { env, store } = makeEnv();
+    await putAsPhoenix(worker, env, 'alice/team', '<h1>org</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'org');
+    expect(store.get('alice/team')?.customMetadata.org_domain).toBe('acme.com');
+
+    worker.hooks.verifyPhoenixToken = async () => ({ userId: 'carol', email: 'carol@acme.com' });
+    const ok = await worker.default.fetch(
+      new Request('https://share.test/alice/team', { headers: { authorization: 'Bearer carol' } }),
+      env,
+    );
+    expect(ok.status).toBe(200);
+    expect(ok.headers.get('cache-control')).toBe('private, no-store');
+    expect(ok.headers.get('X-Robots-Tag')).toBe('noindex');
+
+    worker.hooks.verifyPhoenixToken = async () => ({ userId: 'dave', email: 'dave@other.com' });
+    const denied = await worker.default.fetch(
+      new Request('https://share.test/alice/team', { headers: { authorization: 'Bearer dave' } }),
+      env,
+    );
+    expect(denied.status).toBe(404);
+    expect(await denied.text()).toBe('not found');
+  });
+
+  it('org PUT from gmail 400s (public inbox)', async () => {
+    const worker = await loadWorker();
+    const { env } = makeEnv();
+    (env as { PHOENIX_ID_BASE?: string }).PHOENIX_ID_BASE = 'https://phoenix.test';
+    worker.hooks.verifyPhoenixToken = async () => ({ userId: 'alice', email: 'alice@gmail.com' });
+    const res = await worker.default.fetch(
+      new Request('https://share.test/alice/plan', {
+        method: 'PUT',
+        headers: {
+          authorization: 'Bearer phoenix-token',
+          'content-type': 'text/html; charset=utf-8',
+          'x-share-visibility': 'org',
+        },
+        body: '<h1>org</h1>',
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: 'org visibility cannot use a public email domain',
+      domain: 'gmail.com',
+    });
+  });
+
+  it('valid bearer skips the login redirect on me GET', async () => {
+    const worker = await loadWorker();
+    const { env } = makeEnv();
+    await putAsPhoenix(worker, env, 'alice/secret', '<h1>mine</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'me');
+    worker.hooks.verifyPhoenixToken = async () => ({ userId: 'alice', email: 'alice@acme.com' });
+
+    const res = await worker.default.fetch(
+      new Request('https://share.test/alice/secret', { headers: { authorization: 'Bearer phoenix-token' } }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('location')).toBeNull();
+    expect(await res.text()).toContain('mine');
+  });
+
+  it('gallery and JSON listing omit me and org pages', async () => {
+    const worker = await loadWorker();
+    const { env } = makeEnv();
+    await putAsPhoenix(worker, env, 'alice/public-page', '<h1>public</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'public');
+    await putAsPhoenix(worker, env, 'alice/only-me', '<h1>me</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'me');
+    await putAsPhoenix(worker, env, 'alice/team', '<h1>org</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'org');
+
+    const listing = await worker.default.fetch(new Request('https://share.test/alice?format=json'), env);
+    const payload = await listing.json();
+    expect(payload.objects.map((o: any) => o.slug)).toEqual(['public-page']);
+    expect(payload.count).toBe(1);
+
+    const gallery = await worker.default.fetch(new Request('https://share.test/alice'), env);
+    const html = await gallery.text();
+    expect(html).toContain('public-page');
+    expect(html).not.toContain('only-me');
+    expect(html).not.toContain('team');
+  });
+
+  it('unsigned cookie is not accepted as identity (HMAC required)', async () => {
+    const worker = await loadWorker();
+    const { env } = makeEnv();
+    await putAsPhoenix(worker, env, 'alice/secret', '<h1>mine</h1>', { userId: 'alice', email: 'alice@acme.com' }, 'me');
+    worker.hooks.verifyPhoenixToken = async () => null;
+
+    const exp = Math.floor(Date.now() / 1000) + 604800;
+    const payload = `alice|alice@acme.com|${exp}`;
+    const unsigned = Buffer.from(payload).toString('base64url');
+    const res = await worker.default.fetch(
+      new Request('https://share.test/alice/secret', {
+        headers: { cookie: `__Host-phoenix_share=${unsigned}.deadbeef` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('/login?return=');
+  });
+
+  it('me PUT without PHOENIX_ID_BASE 400s even with a Phoenix hook', async () => {
+    const worker = await loadWorker();
+    const { env } = makeEnv();
+    worker.hooks.verifyPhoenixToken = async () => ({ userId: 'alice', email: 'alice@acme.com' });
+    const res = await worker.default.fetch(
+      new Request('https://share.test/alice/secret', {
+        method: 'PUT',
+        headers: {
+          authorization: 'Bearer phoenix-token',
+          'content-type': 'text/html; charset=utf-8',
+          'x-share-visibility': 'me',
+        },
+        body: '<h1>mine</h1>',
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: 'visibility me/org requires Phoenix identity' });
   });
 });

--- a/cli/src/lib/share/worker-template.ts
+++ b/cli/src/lib/share/worker-template.ts
@@ -215,9 +215,22 @@ export default {
 
       // Revision history for one canonical <user>/<slug> key (RUSH-2683). Checked
       // before the plain object GET below so the query param routes even though
-      // the canonical key itself resolves to a real object.
+      // the canonical key itself resolves to a real object. me/org use the same
+      // identity gate as the page GET — listing session/host/repo on an unauthed
+      // ?revisions=json must not leak that the page exists.
       if (segments.length === 2 && url.searchParams.get('revisions') === 'json') {
-        return renderRevisions(env.BUCKET, url.origin, path, request.method);
+        const canonical = await env.BUCKET.get(path);
+        if (canonical) {
+          const denied = await gateRestrictedGet(request, env, url, canonical);
+          if (denied) return denied;
+        }
+        return renderRevisions(
+          env.BUCKET,
+          url.origin,
+          path,
+          request.method,
+          canonical && isIdentityGated((canonical.customMetadata && canonical.customMetadata.visibility) || 'public'),
+        );
       }
 
       const obj = await env.BUCKET.get(path);
@@ -227,16 +240,9 @@ export default {
         await env.BUCKET.delete(path);
         return new Response('gone — this link has expired', { status: 410, headers: { 'content-type': 'text/plain' } });
       }
+      const denied = await gateRestrictedGet(request, env, url, obj);
+      if (denied) return denied;
       const visibility = (obj.customMetadata && obj.customMetadata.visibility) || 'public';
-      if (visibility === 'me' || visibility === 'org') {
-        const viewer = await resolveViewer(request, env, url);
-        if (viewer.redirect) return viewer.redirect;
-        if (viewer.error) return viewer.error;
-        if (!viewer.identity) return bounceToLogin(url, env);
-        if (!viewerMayRead(visibility, obj.customMetadata, viewer.identity)) {
-          return new Response('not found', { status: 404, headers: { 'content-type': 'text/plain' } });
-        }
-      }
       const headers = new Headers();
       obj.writeHttpMetadata(headers);
       headers.set('etag', obj.httpEtag);
@@ -398,7 +404,7 @@ async function renderListing(bucket, origin, user, method) {
   });
 }
 
-async function renderRevisions(bucket, origin, key, method) {
+async function renderRevisions(bucket, origin, key, method, identityGated) {
   const objects = [];
   let cursor;
   do {
@@ -424,12 +430,15 @@ async function renderRevisions(bucket, origin, key, method) {
   // Newest first — the most recently replaced version leads.
   items.sort((a, b) => (a.uploadedAt < b.uploadedAt ? 1 : a.uploadedAt > b.uploadedAt ? -1 : 0));
 
+  const cacheHeaders = identityGated
+    ? { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'private, no-store', 'X-Robots-Tag': 'noindex' }
+    : { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'public, max-age=30' };
   if (method === 'HEAD') {
-    return new Response(null, { status: 200, headers: { 'content-type': 'application/json; charset=utf-8' } });
+    return new Response(null, { status: 200, headers: cacheHeaders });
   }
   return new Response(JSON.stringify({ key, count: items.length, revisions: items }), {
     status: 200,
-    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'public, max-age=30' },
+    headers: cacheHeaders,
   });
 }
 
@@ -548,6 +557,23 @@ function emailDomain(email) {
 
 function isHiddenFromGallery(visibility) {
   return visibility === 'unlisted' || visibility === 'me' || visibility === 'org';
+}
+
+function isIdentityGated(visibility) {
+  return visibility === 'me' || visibility === 'org';
+}
+
+async function gateRestrictedGet(request, env, url, obj) {
+  const visibility = (obj.customMetadata && obj.customMetadata.visibility) || 'public';
+  if (!isIdentityGated(visibility)) return null;
+  const viewer = await resolveViewer(request, env, url);
+  if (viewer.redirect) return viewer.redirect;
+  if (viewer.error) return viewer.error;
+  if (!viewer.identity) return bounceToLogin(url, env);
+  if (!viewerMayRead(visibility, obj.customMetadata, viewer.identity)) {
+    return new Response('not found', { status: 404, headers: { 'content-type': 'text/plain' } });
+  }
+  return null;
 }
 
 function viewerMayRead(visibility, meta, identity) {

--- a/cli/src/lib/share/worker-template.ts
+++ b/cli/src/lib/share/worker-template.ts
@@ -15,12 +15,17 @@
 //     A managed deployment sets PHOENIX_ID_BASE; BYO sets WRITE_TOKEN; the
 //     platform endpoint may set both. Fail loud (401) when neither authenticates.
 //     Writes the body to R2 via the BUCKET binding, storing visibility
-//     (public|unlisted; org → 400 in P1), owner, an optional expires-at, plus
-//     provenance (agent/session/host/repo/date), a label, and any `--meta`
-//     entries in object metadata. Overwriting an existing slug first copies the
-//     current object to <slug>/rev-<ts>-<rand> (revision history) unless
+//     (public|unlisted|me|org), owner, org_domain (org only), an optional
+//     expires-at, plus provenance (agent/session/host/repo/date), a label, and
+//     any `--meta` entries in object metadata. me/org require a Phoenix
+//     identity (BYO WRITE_TOKEN cannot publish them). org from a public inbox
+//     domain is 400. Overwriting an existing slug first copies the current
+//     object to <slug>/rev-<ts>-<rand> (revision history) unless
 //     x-share-no-revision is set.
-//   - GET  /<username>/<slug>  — public; streams the object from R2, 410s (and lazily
+//   - GET  /<username>/<slug>  — public|unlisted are anonymous; me requires the
+//     Phoenix owner, org requires a same-domain Phoenix identity (Bearer, then
+//     HMAC cookie, then phoenix_ticket). Unauthenticated me/org 302s to
+//     Phoenix login (or 401 JSON if PHOENIX_ID_BASE is unset). 410s (and lazily
 //     deletes) once its expiry has passed. A bucket lifecycle rule is the durable
 //     sweeper; this is the immediate gate.
 //   - GET  /<username>/<slug>?revisions=json — machine-readable history of the
@@ -79,6 +84,19 @@ export default {
       const vis = normalizeVisibility(request.headers.get('x-share-visibility'));
       if (vis.error) return vis.error;
       const visibility = vis.value;
+      if (visibility === 'me' || visibility === 'org') {
+        const phoenixBase = typeof env.PHOENIX_ID_BASE === 'string' ? env.PHOENIX_ID_BASE.replace(/\\/+$/, '') : '';
+        if (auth.kind !== 'phoenix' || !phoenixBase) {
+          return json({ error: 'visibility me/org requires Phoenix identity' }, 400);
+        }
+        if (visibility === 'org') {
+          const domain = emailDomain(auth.email);
+          if (!domain) return json({ error: 'org visibility requires a verified email domain' }, 400);
+          if (PUBLIC_INBOX_DOMAINS.indexOf(domain) !== -1) {
+            return json({ error: 'org visibility cannot use a public email domain', domain: domain }, 400);
+          }
+        }
+      }
       const segments = path.split('/').filter(Boolean);
       if (auth.kind === 'phoenix') {
         const expected = phoenixHandle(auth);
@@ -91,7 +109,8 @@ export default {
       const expiresAt = request.headers.get('x-share-expires-at') || '';
       // 'unlisted' hides the page from the public gallery + JSON listing while
       // keeping the direct URL world-readable (capability URL, not secret).
-      // GET also sends X-Robots-Tag: noindex for unlisted objects.
+      // me/org are also hidden from gallery/listing; GET is identity-gated
+      // and always sends X-Robots-Tag: noindex (same as unlisted).
       const contentType = request.headers.get('content-type') || 'text/html; charset=utf-8';
       // Provenance (RUSH-2683): captured client-side from the exec env/git/clock,
       // never invented here — a header is simply absent when the CLI had nothing
@@ -132,6 +151,7 @@ export default {
           ? auth.owner
           : (env.SHARE_NAMESPACE || segments[0] || 'byo');
       if (owner) customMetadata['owner'] = owner;
+      if (visibility === 'org') customMetadata['org_domain'] = emailDomain(auth.email);
       if (agent) customMetadata['agent'] = agent;
       if (session) customMetadata['session'] = session;
       if (host) customMetadata['host'] = host;
@@ -207,13 +227,26 @@ export default {
         await env.BUCKET.delete(path);
         return new Response('gone — this link has expired', { status: 410, headers: { 'content-type': 'text/plain' } });
       }
+      const visibility = (obj.customMetadata && obj.customMetadata.visibility) || 'public';
+      if (visibility === 'me' || visibility === 'org') {
+        const viewer = await resolveViewer(request, env, url);
+        if (viewer.redirect) return viewer.redirect;
+        if (viewer.error) return viewer.error;
+        if (!viewer.identity) return bounceToLogin(url, env);
+        if (!viewerMayRead(visibility, obj.customMetadata, viewer.identity)) {
+          return new Response('not found', { status: 404, headers: { 'content-type': 'text/plain' } });
+        }
+      }
       const headers = new Headers();
       obj.writeHttpMetadata(headers);
       headers.set('etag', obj.httpEtag);
       if (!headers.has('content-type')) headers.set('content-type', 'text/html; charset=utf-8');
-      headers.set('cache-control', 'public, max-age=60');
-      if (obj.customMetadata && obj.customMetadata.visibility === 'unlisted') {
+      if (visibility === 'me' || visibility === 'org') {
+        headers.set('cache-control', 'private, no-store');
         headers.set('X-Robots-Tag', 'noindex');
+      } else {
+        headers.set('cache-control', 'public, max-age=60');
+        if (visibility === 'unlisted') headers.set('X-Robots-Tag', 'noindex');
       }
       return new Response(request.method === 'HEAD' ? null : obj.body, { status: 200, headers });
     }
@@ -268,8 +301,8 @@ async function renderGallery(bucket, origin, user, method) {
   const activeObjects = objects.filter(o => {
     if (isRevisionKey(o.key)) return false;
     if (o.key.endsWith('.png')) return false;
-    // Unlisted pages are reachable by direct URL only — never on the gallery.
-    if (o.customMetadata && o.customMetadata.visibility === 'unlisted') return false;
+    // Unlisted / me / org pages are reachable by direct URL only — never on the gallery.
+    if (isHiddenFromGallery(o.customMetadata && o.customMetadata.visibility)) return false;
     const expiresAt = o.customMetadata && o.customMetadata['expires-at'];
     return !(expiresAt && Date.now() > Date.parse(expiresAt));
   });
@@ -331,10 +364,10 @@ async function renderListing(bucket, origin, user, method) {
   const items = objects
     .filter(o => {
       // Mirror the gallery: hide revisions, sibling .png OG covers, expired
-      // pages, and unlisted pages — the listing is the machine-readable public surface.
+      // pages, and unlisted/me/org pages — the listing is the machine-readable public surface.
       if (isRevisionKey(o.key)) return false;
       if (o.key.endsWith('.png')) return false;
-      if (o.customMetadata && o.customMetadata.visibility === 'unlisted') return false;
+      if (isHiddenFromGallery(o.customMetadata && o.customMetadata.visibility)) return false;
       const expiresAt = o.customMetadata && o.customMetadata['expires-at'];
       return !(expiresAt && now > Date.parse(expiresAt));
     })
@@ -405,7 +438,10 @@ async function renderRevisions(bucket, origin, key, method) {
 // before it ever reaches this Worker; see RESERVED_META_KEYS in publish.ts).
 // One list, reused both to strip a same-named --meta collision on write and
 // to split arbitrary --meta entries back out on read.
-var RESERVED_METADATA_KEYS = ['expires-at', 'visibility', 'owner', 'agent', 'session', 'host', 'repo', 'date', 'label', 'label-source'];
+var RESERVED_METADATA_KEYS = ['expires-at', 'visibility', 'owner', 'org_domain', 'agent', 'session', 'host', 'repo', 'date', 'label', 'label-source'];
+var PUBLIC_INBOX_DOMAINS = ['gmail.com', 'googlemail.com', 'outlook.com', 'hotmail.com', 'live.com', 'icloud.com', 'me.com'];
+var SHARE_COOKIE = '__Host-phoenix_share';
+var SHARE_COOKIE_MAX_AGE = 604800;
 
 // Everything in customMetadata that ISN'T one of the reserved provenance/label
 // keys above — i.e. the caller's own \`--meta key=value\` entries. Surfaced on
@@ -496,13 +532,168 @@ async function claimHandle(bucket, handle, userId) {
   return {};
 }
 
-// P1 visibility: public | unlisted. 'org' (and anything else) is 400 — org is Phase 2.
 function normalizeVisibility(raw) {
   const v = (raw || '').trim().toLowerCase();
   if (!v || v === 'public') return { value: 'public' };
-  if (v === 'unlisted') return { value: 'unlisted' };
-  if (v === 'org') return { error: json({ error: 'visibility org is not supported yet' }, 400) };
-  return { error: json({ error: 'visibility must be public or unlisted' }, 400) };
+  if (v === 'unlisted' || v === 'me' || v === 'org') return { value: v };
+  return { error: json({ error: 'visibility must be public, unlisted, me, or org' }, 400) };
+}
+
+function emailDomain(email) {
+  if (!email) return '';
+  const at = String(email).lastIndexOf('@');
+  if (at < 0) return '';
+  return String(email).slice(at + 1).toLowerCase();
+}
+
+function isHiddenFromGallery(visibility) {
+  return visibility === 'unlisted' || visibility === 'me' || visibility === 'org';
+}
+
+function viewerMayRead(visibility, meta, identity) {
+  if (visibility === 'me') {
+    const owner = meta && meta.owner;
+    return !!owner && owner === identity.userId;
+  }
+  if (visibility === 'org') {
+    const stamped = meta && meta.org_domain;
+    if (!stamped) return false;
+    return emailDomain(identity.email) === String(stamped).toLowerCase();
+  }
+  return true;
+}
+
+function bounceToLogin(url, env) {
+  const base = typeof env.PHOENIX_ID_BASE === 'string' ? env.PHOENIX_ID_BASE.replace(/\\/+$/, '') : '';
+  if (!base) return json({ error: 'phoenix login is not configured' }, 401);
+  return new Response(null, {
+    status: 302,
+    headers: { Location: base + '/login?return=' + encodeURIComponent(url.toString()) },
+  });
+}
+
+function readCookie(request, name) {
+  const header = request.headers.get('Cookie') || '';
+  const parts = header.split(';');
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i];
+    const eq = p.indexOf('=');
+    if (eq < 0) continue;
+    if (p.slice(0, eq).trim() === name) return p.slice(eq + 1).trim();
+  }
+  return '';
+}
+
+function toB64Url(s) {
+  const bytes = new TextEncoder().encode(s);
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=+$/, '');
+}
+
+function fromB64Url(s) {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/') + pad;
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+function bufToHex(buf) {
+  return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function hmacHex(secret, data) {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data));
+  return bufToHex(sig);
+}
+
+async function signShareCookie(identity, env) {
+  const secret = typeof env.WRITE_TOKEN === 'string' ? env.WRITE_TOKEN : '';
+  if (!secret) return '';
+  const exp = Math.floor(Date.now() / 1000) + SHARE_COOKIE_MAX_AGE;
+  const payload = identity.userId + '|' + (identity.email || '') + '|' + exp;
+  const sig = await hmacHex(secret, payload);
+  const value = toB64Url(payload) + '.' + sig;
+  return SHARE_COOKIE + '=' + value + '; HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=' + SHARE_COOKIE_MAX_AGE;
+}
+
+async function identityFromCookie(request, env) {
+  const secret = typeof env.WRITE_TOKEN === 'string' ? env.WRITE_TOKEN : '';
+  if (!secret) return null;
+  const raw = readCookie(request, SHARE_COOKIE);
+  if (!raw) return null;
+  const dot = raw.lastIndexOf('.');
+  if (dot < 1) return null;
+  let payload;
+  try {
+    payload = fromB64Url(raw.slice(0, dot));
+  } catch {
+    return null;
+  }
+  const sig = raw.slice(dot + 1);
+  const expected = await hmacHex(secret, payload);
+  if (!safeEqual(sig, expected)) return null;
+  const first = payload.indexOf('|');
+  const last = payload.lastIndexOf('|');
+  if (first < 0 || last <= first) return null;
+  const userId = payload.slice(0, first);
+  const email = payload.slice(first + 1, last);
+  const cookieExp = Number(payload.slice(last + 1));
+  if (!userId || !Number.isFinite(cookieExp) || Math.floor(Date.now() / 1000) > cookieExp) return null;
+  return { userId: userId, email: email };
+}
+
+async function redeemTicket(ticket, env) {
+  const base = typeof env.PHOENIX_ID_BASE === 'string' ? env.PHOENIX_ID_BASE.replace(/\\/+$/, '') : '';
+  if (!base || !ticket) return null;
+  let res;
+  try {
+    res = await fetch(base + '/api/v1/auth/ticket', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ticket: ticket }),
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  let body;
+  try {
+    body = await res.json();
+  } catch {
+    return null;
+  }
+  if (!body || typeof body.userId !== 'string' || !body.userId) return null;
+  return { userId: body.userId, email: typeof body.email === 'string' ? body.email : '' };
+}
+
+async function resolveViewer(request, env, url) {
+  const claims = await hooks.verifyPhoenixToken(request, env);
+  if (claims && typeof claims.userId === 'string' && claims.userId) {
+    return { identity: { userId: claims.userId, email: typeof claims.email === 'string' ? claims.email : '' } };
+  }
+  const cookieId = await identityFromCookie(request, env);
+  if (cookieId) return { identity: cookieId };
+  const ticket = url.searchParams.get('phoenix_ticket');
+  if (!ticket) return {};
+  const redeemed = await redeemTicket(ticket, env);
+  if (!redeemed) return { error: json({ error: 'invalid ticket' }, 401) };
+  const cookie = await signShareCookie(redeemed, env);
+  if (!cookie) return { error: json({ error: 'phoenix login is not configured' }, 401) };
+  url.searchParams.delete('phoenix_ticket');
+  const headers = new Headers();
+  headers.set('Location', url.toString());
+  headers.append('Set-Cookie', cookie);
+  return { redirect: new Response(null, { status: 302, headers: headers }) };
 }
 
 async function defaultVerifyPhoenixToken(request, env) {


### PR DESCRIPTION
## What changed

Share Worker GET/PUT identity gate for `--visibility me|org` so Chrome can open those URLs after Phoenix ID `/login` + ticket redeem.

- **GET me/org**, no bearer and no cookie → 302 `${PHOENIX_ID_BASE}/login?return=<absolute this URL>`. Missing `PHOENIX_ID_BASE` → 401 `{error:'phoenix login is not configured'}`.
- Query `phoenix_ticket` → POST `${PHOENIX_ID_BASE}/api/v1/auth/ticket` `{ticket}` once → HMAC-SHA256 cookie `__Host-phoenix_share` (`userId|email|exp` keyed by `WRITE_TOKEN`) via `Headers.append`, then 302 stripping `phoenix_ticket` (other query kept).
- `resolveViewer` order: Bearer (`hooks.verifyPhoenixToken`), then cookie HMAC, then ticket. Valid bearer never redirects.
- **me**: `owner === identity.userId` else 404 `not found` (same body as a missing object). **org**: email domain (after `@`, lowercased) === `org_domain` else 404.
- public/unlisted GET unchanged (anonymous 200). Gallery/listing hide me and org the same way as unlisted.
- **PUT** `normalizeVisibility` accepts `public|unlisted|me|org`. org from a public inbox (gmail/googlemail/outlook/hotmail/live/icloud/me) → 400. Stamp `org_domain`. `org_domain` is reserved metadata. BYO `WRITE_TOKEN` cannot publish me/org → 400.
- me/org GET: `Cache-Control: private, no-store` + `X-Robots-Tag: noindex`.

`templateHash` changes; orchestrator runs `agents artifacts share update` after merge. Do not run it from this PR.

## Boundary

Owns only `cli/src/lib/share/worker-template.ts` and `cli/src/lib/share/worker-template.test.ts`. CLI `--visibility` is PR #3092. Docs/CHANGELOG are the docs track.

## Verification

```
$ bun run test src/lib/share/worker-template.test.ts
 Test Files  1 passed (1)
      Tests  51 passed (51)
```

Cases: public/unlisted anonymous; me no auth 302 login; ticket redeem sets cookie + strip query; second identity 404; org domain match 200 mismatch 404; gmail org PUT 400; bearer skips redirect; gallery omits me/org.

Linear: [PHNX-3260](https://linear.app/getrush/issue/PHNX-3260/share-visibility-me-org-email-domain-public)