### PR TITLE
chore(test): drop unused imports from the split device-config tests

### DIFF
--- a/cli/src/commands/ssh.device-config.fleet.test.ts
+++ b/cli/src/commands/ssh.device-config.fleet.test.ts
@@ -8,12 +8,7 @@
  * `device-config-test-harness.ts`.
  */
 import { describe, expect, it } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
 import {
-  HOME,
-  REPO_ROOT,
-  INDEX,
   guardedHome,
   run,
   centralDoc,

--- a/cli/src/commands/ssh.device-config.test.ts
+++ b/cli/src/commands/ssh.device-config.test.ts
@@ -8,12 +8,7 @@
  * `device-config-test-harness.ts`.
  */
 import { describe, expect, it } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
 import {
-  HOME,
-  REPO_ROOT,
-  INDEX,
   guardedHome,
   run,
   centralDoc,

--- a/cli/src/commands/ssh.device-config.tombstones.test.ts
+++ b/cli/src/commands/ssh.device-config.tombstones.test.ts
@@ -8,12 +8,7 @@
  * `device-config-test-harness.ts`.
  */
 import { describe, expect, it } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
 import {
-  HOME,
-  REPO_ROOT,
-  INDEX,
   guardedHome,
   run,
   centralDoc,


### PR DESCRIPTION
## What changed

Removes five unused imports from each of the three files PR #3086 split out of `ssh.device-config.test.ts`: `HOME`, `REPO_ROOT`, `INDEX`, `fs`, `path`.

## Why

Follow-up on the non-author review of #3086, which flagged this as a non-blocking SHOULD. One of the five is worse than dead weight:

**`HOME` is not exported by `device-config-test-harness.ts` at all.** The harness exports exactly `REPO_ROOT`, `INDEX`, `guardedHome`, `run`, `centralDoc`, `deviceDoc`, `addDevice` (`cli/src/commands/device-config-test-harness.ts:15-66`). All three files import a binding that does not exist; it resolves to `undefined` under vite's ESM interop instead of throwing, and `tsc` never sees it because test files are excluded from the type-check. So nothing catches it today — it just sits there looking like real API.

Usage counts across the three file bodies confirm the rest are genuinely dead:

| symbol | `.test.ts` | `.fleet.test.ts` | `.tombstones.test.ts` |
|---|---|---|---|
| `HOME` / `REPO_ROOT` / `INDEX` / `fs` | 0 | 0 | 0 |
| `path` | 0 | 1 — **inside a comment** (`// The human-readable path names it too.`) | 0 |
| `guardedHome` / `run` / `centralDoc` / `deviceDoc` / `addDevice` | used | used | used |

The `path` hit in the fleet file is the kind of thing a naive grep keeps, so it's called out explicitly: it is not code.

## Evidence

All three files still pass, at the same 18/18 the #3086 review verified by brace-matching against `origin/main`'s pre-split file:

```
Test Files  3 passed (3)
     Tests  18 passed (18)
```

Test-only change, so no CHANGELOG entry per the repo's stated exemption.
