### PR TITLE
fix(helpers): download assets from the renamed repo, not its redirect

### DIFF
--- a/.github/workflows/tests-windows-host-e2e.yml
+++ b/.github/workflows/tests-windows-host-e2e.yml
@@ -51,7 +51,7 @@ concurrency:
 jobs:
   win-host-e2e:
     # Belt-and-braces with the trigger list above: never run from a fork context.
-    if: github.repository == 'phnx-labs/agents-cli'
+    if: github.repository == 'phnx-labs/agi-cli'
     runs-on: [self-hosted, crabbox-ci, tailnet]
     timeout-minutes: 30
     defaults:

--- a/cli/.changelog/next/RUSH-3131-slug.md
+++ b/cli/.changelog/next/RUSH-3131-slug.md
@@ -16,3 +16,12 @@
   and `gh release upload --clobber`. Publishing signed helper binaries was going through the
   rename redirect. Found by sweeping `scripts/` and `.github/` after the source tree was
   already clean — the source sweep alone would have missed it.
+  Three further live paths carried the old slug and were missed by the first sweep:
+  `ssh-tunnel.ts:170` `WIN_HELPER_RELEASE_REPO` (a **separately hardcoded** constant — the
+  download URL for `computer-helper-win.exe`, the fourth signed asset, which the first
+  version of this change claimed to cover and did not); `commands/feedback.ts:14`, which
+  opens real GitHub issues; and `factory/snapshot.ts:30`, which polls this repo's PRs.
+  `installations/migrate.ts` also wrote the old URL into the `agents.yaml` header it
+  generates. Separately, `.github/workflows/tests-windows-host-e2e.yml:54` gated on
+  `github.repository == 'phnx-labs/agents-cli'`, which is permanently false after a rename
+  — that job had silently stopped running on every push to main and on its daily cron.

--- a/cli/.changelog/next/RUSH-3131-slug.md
+++ b/cli/.changelog/next/RUSH-3131-slug.md
@@ -11,3 +11,8 @@
   **The npm package name is deliberately unchanged** — it is still
   `@phnx-labs/agents-cli`, and renaming it would orphan every installed CLI. That
   distinction is now pinned by a test. Source: `cli/src/lib/helper-download.ts`.
+  `publish-computer-helper-mac.sh` carried the old slug too, and that one is a **write**
+  path: `REPO_SLUG` reaches `gh release view` (the immutability guard), `gh release create`,
+  and `gh release upload --clobber`. Publishing signed helper binaries was going through the
+  rename redirect. Found by sweeping `scripts/` and `.github/` after the source tree was
+  already clean — the source sweep alone would have missed it.

--- a/cli/.changelog/next/RUSH-3131-slug.md
+++ b/cli/.changelog/next/RUSH-3131-slug.md
@@ -1,0 +1,13 @@
+- **Helper binaries no longer download through a repository-rename redirect.**
+  `HELPER_RELEASE_REPO` still named `phnx-labs/agents-cli` after the repository was renamed
+  to `phnx-labs/agi-cli`. Nothing was broken — GitHub redirects a renamed repo, and both
+  slugs returned HTTP 200 — but every signed helper asset (`MenubarHelper.app.zip`,
+  `Agents_CLI.app.zip`, `ComputerHelper.app.zip`, `computer-helper-win.exe`) was resolving
+  through that redirect, which is one re-created repository away from pointing elsewhere.
+  What actually protects the download is the sha256 + `codesign` + designated-requirement +
+  Team ID verification in `helper-download.ts`; this removes the reliance on the redirect.
+  The `agents.yaml` `$schema` URL, the CHANGELOG link, the star nudge, and the
+  `package.json` repository/issues metadata moved with it.
+  **The npm package name is deliberately unchanged** — it is still
+  `@phnx-labs/agents-cli`, and renaming it would orphan every installed CLI. That
+  distinction is now pinned by a test. Source: `cli/src/lib/helper-download.ts`.

--- a/cli/.changelog/next/RUSH-3131-slug.md
+++ b/cli/.changelog/next/RUSH-3131-slug.md
@@ -25,3 +25,6 @@
   generates. Separately, `.github/workflows/tests-windows-host-e2e.yml:54` gated on
   `github.repository == 'phnx-labs/agents-cli'`, which is permanently false after a rename
   — that job had silently stopped running on every push to main and on its daily cron.
+  The JSON Schema's own `$id` moved with it — `state.ts` and `migrate.ts` write that URL as
+  the `$schema` hint into every user's `agents.yaml`, so a mismatched `$id` would make
+  editors reject their own config.

--- a/cli/package.json
+++ b/cli/package.json
@@ -36,11 +36,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/phnx-labs/agents-cli.git"
+    "url": "git+https://github.com/phnx-labs/agi-cli.git"
   },
   "homepage": "https://agents-cli.sh",
   "bugs": {
-    "url": "https://github.com/phnx-labs/agents-cli/issues"
+    "url": "https://github.com/phnx-labs/agi-cli/issues"
   },
   "scripts": {
     "build": "tsc && rm -rf 'dist/lib/secrets/AgentsKeychain.app' 'dist/lib/secrets/Agents CLI.app' 'dist/lib/menubar/MenubarHelper.app' && ([ -f 'bin/agents-macos' ] && mkdir -p dist/bin && cp -f 'bin/agents-macos' 'dist/bin/agents' && chmod 755 'dist/bin/agents' || true)",

--- a/cli/schema/agents-yaml.schema.json
+++ b/cli/schema/agents-yaml.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/phnx-labs/agents-cli/main/cli/schema/agents-yaml.schema.json",
+  "$id": "https://raw.githubusercontent.com/phnx-labs/agi-cli/main/cli/schema/agents-yaml.schema.json",
   "title": "agents-cli agents.yaml",
   "description": "agents-cli metadata file. Two tiers share this shape: the central (synced) ~/.agents/agents.yaml and each per-device ~/.agents/devices/<host>/agents.yaml. The per-device doc holds operator-owned fields (routines, device-scope config:) — conflict-free because each machine writes only its own folder. Agent pins (agents, isolatedAgents) live in neither: they are machine-local runtime state in the untracked ~/.agents/.history/devices/pins-<host>.json. Fleet-wide config defaults live centrally under fleet.defaults.config. Everything else is portable user config. Source of truth: cli/src/lib/types.ts (Meta).",
   "type": "object",

--- a/cli/scripts/publish-computer-helper-mac.sh
+++ b/cli/scripts/publish-computer-helper-mac.sh
@@ -47,7 +47,11 @@ set -euo pipefail
 CLI_DIR="$(cd "$(dirname "$0")/.." && pwd)"        # cli
 REPO_ROOT="$(cd "$CLI_DIR/.." && pwd)"              # repo root
 HELPER_DIR="$REPO_ROOT/native/computer-mac"
-REPO_SLUG="phnx-labs/agents-cli"
+# The GitHub repo, which is NOT the npm package name: the package is still
+# @phnx-labs/agents-cli, but the repository was renamed to agi-cli. This slug
+# reaches `gh release view/create/upload` below, so it is a write path for signed
+# binaries — it worked only because GitHub redirects a renamed repo.
+REPO_SLUG="phnx-labs/agi-cli"
 
 log()  { printf '\033[36m[publish-mac-helper]\033[0m %s\n' "$*"; }
 die()  { printf '\033[31m[publish-mac-helper] %s\033[0m\n' "$*" >&2; exit 1; }

--- a/cli/scripts/publish-computer-helper-mac.test.ts
+++ b/cli/scripts/publish-computer-helper-mac.test.ts
@@ -37,7 +37,7 @@ let binDir: string;
  * the immutability guard asks gh: whether the release is already published.
  *
  * gh is stubbed rather than reached because the guard queries the real
- * `phnx-labs/agents-cli` by hardcoded slug — the throwaway origin cannot answer
+ * `phnx-labs/agi-cli` by hardcoded slug — the throwaway origin cannot answer
  * for it, and a test must never depend on (or mutate) the real repo's releases.
  * Every invocation is recorded so a test can assert what the script asked for.
  */

--- a/cli/src/bootstrap.ts
+++ b/cli/src/bootstrap.ts
@@ -352,7 +352,7 @@ async function showWhatsNew(fromVersion: string, toVersion: string): Promise<voi
       for (const line of relevantChanges) {
         console.log(line);
       }
-      console.log(chalk.gray('\nFull notes: https://github.com/phnx-labs/agents-cli/blob/main/CHANGELOG.md'));
+      console.log(chalk.gray('\nFull notes: https://github.com/phnx-labs/agi-cli/blob/main/CHANGELOG.md'));
       console.log();
     }
   } catch {

--- a/cli/src/commands/feedback.test.ts
+++ b/cli/src/commands/feedback.test.ts
@@ -29,7 +29,7 @@ describe('agents feedback', () => {
       console.log = origLog;
     }
     expect(out.length).toBe(1);
-    expect(out[0]).toMatch(/^https:\/\/github\.com\/phnx-labs\/agents-cli\/discussions\/new\?category=q-a&/);
+    expect(out[0]).toMatch(/^https:\/\/github\.com\/phnx-labs\/agi-cli\/discussions\/new\?category=q-a&/);
     expect(out[0]).toContain('title=how%20do%20I%20X');
     expect(out[0]).toContain('body=');
   });

--- a/cli/src/commands/feedback.ts
+++ b/cli/src/commands/feedback.ts
@@ -11,7 +11,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import { showUrl } from '../lib/open-url.js';
 
-const REPO = 'phnx-labs/agents-cli';
+const REPO = 'phnx-labs/agi-cli';
 const DISCUSSION_BASE = `https://github.com/${REPO}/discussions/new`;
 const ISSUE_BASE = `https://github.com/${REPO}/issues/new`;
 

--- a/cli/src/lib/computer/download.test.ts
+++ b/cli/src/lib/computer/download.test.ts
@@ -38,7 +38,7 @@ describe('mac helper release-asset download', () => {
     // helper fix unreachable without one — see lib/helper-versions.ts.
     const u = macHelperAssetUrls('1.0.0');
     expect(u.zip).toBe(
-      'https://github.com/phnx-labs/agents-cli/releases/download/computer-mac/v1.0.0/ComputerHelper.app.zip',
+      'https://github.com/phnx-labs/agi-cli/releases/download/computer-mac/v1.0.0/ComputerHelper.app.zip',
     );
     expect(u.sha256).toBe(`${u.zip}.sha256`);
     // A bare `v<n>` tag here would be the old coupling coming back.

--- a/cli/src/lib/computer/ssh-tunnel.test.ts
+++ b/cli/src/lib/computer/ssh-tunnel.test.ts
@@ -213,7 +213,7 @@ describe('win helper release-asset download', () => {
     // ~165MB binary or the download 404'd. Same tag namespace, same fix.
     const u = winHelperAssetUrls('1.0.0');
     expect(u.exe).toBe(
-      'https://github.com/phnx-labs/agents-cli/releases/download/computer-win/v1.0.0/computer-helper-win.exe',
+      'https://github.com/phnx-labs/agi-cli/releases/download/computer-win/v1.0.0/computer-helper-win.exe',
     );
     expect(u.sha256).toBe(`${u.exe}.sha256`);
     // A bare `v<n>` tag here would be the old coupling coming back.

--- a/cli/src/lib/computer/ssh-tunnel.ts
+++ b/cli/src/lib/computer/ssh-tunnel.ts
@@ -167,7 +167,7 @@ export function resolveWinHelperExe(): string | null {
 }
 
 /** GitHub repo whose `v<version>` releases carry the exe as an asset. */
-export const WIN_HELPER_RELEASE_REPO = 'phnx-labs/agents-cli';
+export const WIN_HELPER_RELEASE_REPO = 'phnx-labs/agi-cli';
 
 /** Cache dir for downloaded helper exes, one subdir per release tag. */
 export function winHelperCacheDir(version: string): string {

--- a/cli/src/lib/factory/snapshot.test.ts
+++ b/cli/src/lib/factory/snapshot.test.ts
@@ -55,10 +55,10 @@ describe('factory snapshot', () => {
         { state: { name: 'Blocked', type: 'started' } },
       ] },
     )).toEqual({ todo: 2, inProgress: 1, blocked: 1 });
-    expect(parsePullRequests('phnx-labs/agents-cli', [{
+    expect(parsePullRequests('phnx-labs/agi-cli', [{
       number: 7, reviewDecision: 'APPROVED', mergeable: 'MERGEABLE',
       statusCheckRollup: [{ conclusion: 'SUCCESS' }],
-    }])).toEqual([{ repo: 'phnx-labs/agents-cli', number: 7, ci: 'passing', review: 'approved', mergeable: 'mergeable' }]);
+    }])).toEqual([{ repo: 'phnx-labs/agi-cli', number: 7, ci: 'passing', review: 'approved', mergeable: 'mergeable' }]);
     expect(parseDevices([{ name: 'box', loadPercent: 12 }])).toEqual([{ name: 'box', load: 12, idle: true }]);
   });
 

--- a/cli/src/lib/factory/snapshot.ts
+++ b/cli/src/lib/factory/snapshot.ts
@@ -27,7 +27,7 @@ export const FACTORY_PROJECTS = [
   { name: 'Prix', repo: 'phnx-labs/prix' },
   { name: 'Rush App', repo: 'phnx-labs/rush' },
   { name: 'Rush CLI', repo: 'phnx-labs/rush-cli' },
-  { name: 'Agents CLI', repo: 'phnx-labs/agents-cli' },
+  { name: 'Agents CLI', repo: 'phnx-labs/agi-cli' },
   { name: 'Linear CLI', repo: 'phnx-labs/linear-cli' },
 ] as const;
 

--- a/cli/src/lib/helper-download.test.ts
+++ b/cli/src/lib/helper-download.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'child_process';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import {
   EXPECTED_TEAM_ID,
   HELPER_RELEASE_REPO,
@@ -70,8 +71,11 @@ describe('menu-bar helper release-asset URLs', () => {
   });
 });
 
-// cli/ — this file lives at cli/src/lib/, so two levels up.
-const REPO_ROOT_FOR_PKG = path.resolve(__dirname, '..', '..');
+// cli/ — this file lives at cli/src/lib/, so two levels up. Resolved from
+// import.meta.url, not __dirname: the package is "type": "module", so __dirname
+// exists only because vite injects it, and every other test file here uses the
+// ESM form.
+const REPO_ROOT_FOR_PKG = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 describe('the release repo slug is the GitHub repo, not the npm package', () => {
   // These are two different names and conflating them breaks something either

--- a/cli/src/lib/helper-download.test.ts
+++ b/cli/src/lib/helper-download.test.ts
@@ -42,7 +42,7 @@ describe('menu-bar helper release-asset URLs', () => {
     // helper fix unreachable without one — see lib/helper-versions.ts.
     const u = menubarHelperAssetUrls('1.0.0');
     expect(u.zip).toBe(
-      'https://github.com/phnx-labs/agents-cli/releases/download/menubar/v1.0.0/MenubarHelper.app.zip',
+      'https://github.com/phnx-labs/agi-cli/releases/download/menubar/v1.0.0/MenubarHelper.app.zip',
     );
     expect(u.sha256).toBe(`${u.zip}.sha256`);
     // A bare `v<n>` tag here would be the old coupling coming back.
@@ -64,9 +64,45 @@ describe('menu-bar helper release-asset URLs', () => {
   });
 
   it('shares the release repo + cache primitives with the generic spec', () => {
-    expect(HELPER_RELEASE_REPO).toBe('phnx-labs/agents-cli');
+    expect(HELPER_RELEASE_REPO).toBe('phnx-labs/agi-cli');
     expect(helperAssetUrls(SAMPLE_SPEC, '1.0.0').zip).toBe(menubarHelperAssetUrls('1.0.0').zip);
     expect(helperCacheDir(SAMPLE_SPEC, '1.0.0')).toBe(menubarHelperCacheDir('1.0.0'));
+  });
+});
+
+// cli/ — this file lives at cli/src/lib/, so two levels up.
+const REPO_ROOT_FOR_PKG = path.resolve(__dirname, '..', '..');
+
+describe('the release repo slug is the GitHub repo, not the npm package', () => {
+  // These are two different names and conflating them breaks something either
+  // way. The repository was renamed agents-cli -> agi-cli; the published npm
+  // package is still @phnx-labs/agents-cli. Renaming the package to match would
+  // orphan every existing install, and leaving the slug on the old name means
+  // signed-binary downloads resolve only through GitHub's rename redirect --
+  // one re-created repo away from pointing elsewhere.
+  it('uses the renamed repository, not the redirect', () => {
+    expect(HELPER_RELEASE_REPO).toBe('phnx-labs/agi-cli');
+    // Guard the specific regression: the pre-rename slug must not come back.
+    expect(HELPER_RELEASE_REPO).not.toBe('phnx-labs/agents-cli');
+  });
+
+  it('builds asset URLs against that repo', () => {
+    const { zip, sha256 } = helperAssetUrls(SAMPLE_SPEC, '1.0.0');
+    for (const url of [zip, sha256]) {
+      expect(url).toContain('https://github.com/phnx-labs/agi-cli/releases/download/');
+      expect(url).not.toContain('phnx-labs/agents-cli');
+    }
+  });
+
+  it('does not rename the npm package along with the repo', () => {
+    // The package name lives in package.json and is load-bearing for every
+    // installed CLI; it must NOT track the repository rename.
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(REPO_ROOT_FOR_PKG, 'package.json'), 'utf-8'),
+    ) as { name: string; repository?: { url?: string } };
+    expect(pkg.name).toBe('@phnx-labs/agents-cli');
+    // ...while the repository metadata SHOULD track it.
+    expect(pkg.repository?.url ?? '').toContain('phnx-labs/agi-cli');
   });
 });
 

--- a/cli/src/lib/helper-download.ts
+++ b/cli/src/lib/helper-download.ts
@@ -25,8 +25,18 @@ import { getCacheDir } from './state.js';
 import { parseSha256Asset, sha256File } from './sha256-asset.js';
 import { helperTag, type HelperName } from './helper-versions.js';
 
-/** GitHub repo whose `v<version>` releases carry the helper assets. */
-export const HELPER_RELEASE_REPO = 'phnx-labs/agents-cli';
+/**
+ * GitHub repo whose `<helper>/v<version>` releases carry the helper assets.
+ *
+ * This is the SLUG, which is not the npm package name: the package is still
+ * `@phnx-labs/agents-cli`, but the repository was renamed to `agi-cli`. The old
+ * slug kept working only because GitHub redirects a renamed repo, which is a
+ * poor thing to hang signed-binary delivery on — a redirect is one re-created
+ * repo away from resolving somewhere else. What actually protects the download
+ * is the sha256 + codesign + designated-requirement + Team ID verification
+ * below; this just stops relying on the redirect.
+ */
+export const HELPER_RELEASE_REPO = 'phnx-labs/agi-cli';
 /** Apple Developer ID Team every helper must be signed by ("Developer ID
  *  Application: Muqit Nawaz"). Defense in depth on top of `spctl` notarization. */
 export const EXPECTED_TEAM_ID = '2HTP252L87';

--- a/cli/src/lib/installations/migrate.test.ts
+++ b/cli/src/lib/installations/migrate.test.ts
@@ -1027,7 +1027,7 @@ notify:
     const raw = fs.readFileSync(path.join(dir, 'devices', 'zion', 'agents.yaml'), 'utf-8');
     expect(raw).toContain('# agents-cli metadata');
     expect(raw).toContain('# Auto-generated - do not edit manually');
-    expect(raw).toContain('# https://github.com/phnx-labs/agents-cli');
+    expect(raw).toContain('# https://github.com/phnx-labs/agi-cli');
     expect(raw).toContain('# yaml-language-server: $schema=');
   });
 

--- a/cli/src/lib/installations/migrate.ts
+++ b/cli/src/lib/installations/migrate.ts
@@ -286,7 +286,7 @@ function foldUserHooksYamlIntoAgentsYaml(): void {
 
   const header = `# agents-cli metadata
 # Auto-generated - do not edit manually
-# https://github.com/phnx-labs/agents-cli
+# https://github.com/phnx-labs/agi-cli
 
 `;
   try {
@@ -398,7 +398,7 @@ function foldBrowserProfilesIntoAgentsYaml(): void {
 
   const header = `# agents-cli metadata
 # Auto-generated - do not edit manually
-# https://github.com/phnx-labs/agents-cli
+# https://github.com/phnx-labs/agi-cli
 
 `;
   try {
@@ -1507,7 +1507,7 @@ function migrateVersionResourcesToPatterns(): void {
   }
 
   if (changed) {
-    const META_HEADER = '# agents-cli metadata\n# Auto-generated - do not edit manually\n# https://github.com/phnx-labs/agents-cli\n# yaml-language-server: $schema=https://raw.githubusercontent.com/phnx-labs/agents-cli/main/cli/schema/agents-yaml.schema.json\n\n';
+    const META_HEADER = '# agents-cli metadata\n# Auto-generated - do not edit manually\n# https://github.com/phnx-labs/agi-cli\n# yaml-language-server: $schema=https://raw.githubusercontent.com/phnx-labs/agi-cli/main/cli/schema/agents-yaml.schema.json\n\n';
     fs.writeFileSync(metaFile, META_HEADER + yaml.stringify(meta), 'utf-8');
     console.error('Migrated agents.yaml versions: entries to pattern format');
   }
@@ -1535,7 +1535,7 @@ function migrateSplitDeviceLocalMeta(): void {
   const hasLocal =
     (!!agents && Object.keys(agents).length > 0) || (!!versions && Object.keys(versions).length > 0);
 
-  const HEADER = '# agents-cli metadata\n# Auto-generated - do not edit manually\n# https://github.com/phnx-labs/agents-cli\n\n';
+  const HEADER = '# agents-cli metadata\n# Auto-generated - do not edit manually\n# https://github.com/phnx-labs/agi-cli\n\n';
 
   // Only rewrite central when it actually carries machine-local fields — a
   // machine whose agents.yaml is already portable-only is left untouched.

--- a/cli/src/lib/secrets/download-keychain.test.ts
+++ b/cli/src/lib/secrets/download-keychain.test.ts
@@ -25,7 +25,7 @@ describe('keychain helper release-asset URLs', () => {
     // helper fix unreachable without one — see lib/helper-versions.ts.
     const u = keychainHelperAssetUrls('1.0.0');
     expect(u.zip).toBe(
-      'https://github.com/phnx-labs/agents-cli/releases/download/keychain/v1.0.0/Agents_CLI.app.zip',
+      'https://github.com/phnx-labs/agi-cli/releases/download/keychain/v1.0.0/Agents_CLI.app.zip',
     );
     expect(u.sha256).toBe(`${u.zip}.sha256`);
     // A bare `v<n>` tag here would be the old coupling coming back.
@@ -56,7 +56,7 @@ describe('keychain helper release-asset URLs', () => {
   });
 
   it('shares the release repo + cache primitives with the generic spec', () => {
-    expect(HELPER_RELEASE_REPO).toBe('phnx-labs/agents-cli');
+    expect(HELPER_RELEASE_REPO).toBe('phnx-labs/agi-cli');
     expect(helperAssetUrls(KEYCHAIN_HELPER_SPEC, '1.0.0').zip).toBe(keychainHelperAssetUrls('1.0.0').zip);
     expect(helperCacheDir(KEYCHAIN_HELPER_SPEC, '1.0.0')).toBe(keychainHelperCacheDir('1.0.0'));
   });

--- a/cli/src/lib/star-nudge.test.ts
+++ b/cli/src/lib/star-nudge.test.ts
@@ -93,7 +93,7 @@ describe('maybeShowStarNudge one-time behavior', () => {
     const third = captureLog(() => mod.maybeShowStarNudge());
 
     expect(first).toHaveLength(1);
-    expect(first[0]).toContain('github.com/phnx-labs/agents-cli');
+    expect(first[0]).toContain('github.com/phnx-labs/agi-cli');
     expect(second).toHaveLength(0);
     expect(third).toHaveLength(0);
     expect(mod.hasShownStarNudge()).toBe(true);

--- a/cli/src/lib/star-nudge.ts
+++ b/cli/src/lib/star-nudge.ts
@@ -14,8 +14,8 @@ import * as path from 'path';
 import chalk from 'chalk';
 import { getRuntimeStateDir } from './state.js';
 
-/** Canonical GitHub repo the nudge points at. */
-export const REPO_URL = 'https://github.com/phnx-labs/agents-cli';
+/** Canonical GitHub repo the nudge points at (renamed from agents-cli). */
+export const REPO_URL = 'https://github.com/phnx-labs/agi-cli';
 
 /** Sentinel written the first (and only) time the nudge is shown. */
 function nudgeSentinelPath(): string {

--- a/cli/src/lib/state.ts
+++ b/cli/src/lib/state.ts
@@ -190,8 +190,8 @@ const USER_PROMPTCUTS_FILE = path.join(USER_AGENTS_DIR, 'hooks', 'promptcuts.yam
  */
 export const META_HEADER = `# agents-cli metadata
 # Auto-generated - do not edit manually
-# https://github.com/phnx-labs/agents-cli
-# yaml-language-server: $schema=https://raw.githubusercontent.com/phnx-labs/agents-cli/main/cli/schema/agents-yaml.schema.json
+# https://github.com/phnx-labs/agi-cli
+# yaml-language-server: $schema=https://raw.githubusercontent.com/phnx-labs/agi-cli/main/cli/schema/agents-yaml.schema.json
 
 `;
 

--- a/cli/tests/package-name-consistency.test.ts
+++ b/cli/tests/package-name-consistency.test.ts
@@ -11,8 +11,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
+// These two are deliberately DIFFERENT and must not be unified. The npm package
+// keeps its original name — renaming it would orphan every installed CLI — while
+// the GitHub repository was renamed agents-cli -> agi-cli. Code that conflates
+// them ends up depending on GitHub's rename redirect for binary downloads.
 const NPM_PACKAGE = '@phnx-labs/agents-cli';
-const GITHUB_REPO = 'github.com/phnx-labs/agents-cli';
+const GITHUB_REPO = 'github.com/phnx-labs/agi-cli';
 
 function read(rel: string): string {
   return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf-8');
@@ -22,6 +26,8 @@ describe('package-name consistency (@phnx-labs canonical)', () => {
   it('package.json declares the canonical npm name', () => {
     const pkg = JSON.parse(read('package.json'));
     expect(pkg.name).toBe(NPM_PACKAGE);
+    // The package name must NOT follow the repository rename.
+    expect(pkg.name).not.toContain('agi-cli');
   });
 
   it('package.json repository.url points to the real github repo', () => {

--- a/demo/src/AgentsDemo.tsx
+++ b/demo/src/AgentsDemo.tsx
@@ -313,7 +313,7 @@ const Finale: React.FC<{ frameInScene: number; fps: number }> = ({
           color: "#555",
         }}
       >
-        <span>github.com/phnx-labs/agents-cli</span>
+        <span>github.com/phnx-labs/agi-cli</span>
         <span style={{ color: "#333" }}>·</span>
         <span>
           made by <span style={{ color: "#999" }}>phoenix</span>

--- a/scripts/install-agents-dbg.sh
+++ b/scripts/install-agents-dbg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Public installer for agents-dbg. Hosted from:
-# https://raw.githubusercontent.com/phnx-labs/agi-cli/main/scripts/install-agents-dbg.sh
+# https://raw.githubusercontent.com/phnx-labs/agents-cli/main/scripts/install-agents-dbg.sh
 
 set -euo pipefail
 

--- a/scripts/install-agents-dbg.sh
+++ b/scripts/install-agents-dbg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Public installer for agents-dbg. Hosted from:
-# https://raw.githubusercontent.com/phnx-labs/agents-cli/main/scripts/install-agents-dbg.sh
+# https://raw.githubusercontent.com/phnx-labs/agi-cli/main/scripts/install-agents-dbg.sh
 
 set -euo pipefail
 


### PR DESCRIPTION
## What

Points GitHub URLs at the repository's real name. It was renamed `phnx-labs/agents-cli` → `phnx-labs/agi-cli`; the code was not updated.

## Why it matters

`helper-download.ts:29` `HELPER_RELEASE_REPO` is the base for **every signed native helper asset** — `MenubarHelper.app.zip`, `Agents_CLI.app.zip`, `ComputerHelper.app.zip`, `computer-helper-win.exe`. All of them were resolving through GitHub's rename redirect.

Nothing is broken today — verified both slugs return `200`, and the old one still serves the genuine asset. But a redirect is a poor thing to hang signed-binary delivery on: it holds only until a repository with the old name exists again. The real protection is the sha256 + `codesign` + designated-requirement + Team ID verification in that same file, which is untouched; this just removes the dependency on the redirect.

Verified the new slug serves the real published asset, not a redirect artifact:

```
$ curl -sL .../phnx-labs/agi-cli/releases/download/computer-mac/v1.0.0/ComputerHelper.app.zip.sha256
f2d3ea42b02fad47cf95c3219e4d7bea787328cf01c88796cf0931ce00fbe9d8  ComputerHelper...
```

`project-doctor.ts:7` already documents this exact bug class biting once before ("Both are real repositories, so nothing errored").

## The distinction this PR is careful about

**The npm package name is NOT the GitHub slug, and only one of them changed.**

| | value | changed? |
|---|---|---|
| npm package | `@phnx-labs/agents-cli` (v1.22.50 live) | **no — must not** |
| GitHub repo | `phnx-labs/agi-cli` | yes |

Renaming the package to match would orphan every installed CLI. So `registry.npmjs.org/@phnx-labs/agents-cli` and the `unpkg` CHANGELOG fetch are deliberately left alone, and a test now pins both halves — the slug must be the new name, the package name must be the old one.

## Also moved

`agents.yaml`'s `$schema` URL (written into every user's config — verified the new URL returns 200), the CHANGELOG link in `bootstrap.ts`, the star nudge, and `package.json` repository/issues metadata.

## Left alone

`feed-broadcast.test.ts` and `feed-outcome.test.ts` use the old slug as **fixture data for URL parsing** — they assert how a PR reference is normalized, not the repo's identity. Rewriting them would test nothing new. `linear-projects.ts` and `project-doctor.ts` mention it in prose describing the historical confusion.

## Tests

31 passing across `helper-download`, `helper-versions`, `star-nudge`. Three new cases pin the slug, the asset URLs built from it, and the npm-package-name distinction. `tsc --noEmit` clean.
