### PR TITLE
fix(daemon): supervise remaining maintenance services (PHNX-3265)

### DIFF
--- a/cli/.changelog/next/PHNX-3265.md
+++ b/cli/.changelog/next/PHNX-3265.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Daemon service lifecycle hooks are deadline-bounded, and restarts now replace periodic timers instead of multiplying their tick rate. Live-session metadata publishing, monitor evaluation, heartbeat/process reconciliation, tmux and browser-task reaping, broker self-heal, and signed webhook ingress now run under the per-service supervisor with measured health and isolated failure handling.
+- Daemon service restarts now replace periodic timers instead of multiplying their tick rate, and a timed-out tick parks until its real work settles instead of overlapping teardown or another tick. Live-session metadata publishing, monitor evaluation, heartbeat/process reconciliation, tmux and browser-task reaping, broker self-heal, and signed webhook ingress now run under the per-service supervisor with measured health and isolated failure handling.

--- a/cli/.changelog/next/PHNX-3265.md
+++ b/cli/.changelog/next/PHNX-3265.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Daemon service lifecycle hooks are deadline-bounded, and restarts now replace periodic timers instead of multiplying their tick rate. Live-session metadata publishing, monitor evaluation, heartbeat/process reconciliation, tmux and browser-task reaping, broker self-heal, and signed webhook ingress now run under the per-service supervisor with measured health and isolated failure handling.

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -2905,8 +2905,10 @@ nothing but its own view cache.
   `setInterval`s inside `runDaemon()` at the time, then moved onto
   `ServiceSupervisor` as `WatchdogService`/`DeviceProbeService`
   (`lib/daemon/watchdog-service.ts`, `device-probe-service.ts`, RUSH-3193 P3);
-  `session-cache-warm` (`runActiveSessionsWarm`) remains a bare
-  `setInterval`. All three are invisible to `agents routines`, but still the
+  `session-cache-warm` now runs as the supervised `session-state` service
+  (`lib/daemon/session-state-service.ts`, PHNX-3265): it owns the 15-second
+  publish cadence and the reader-presence edge that requests an immediate
+  supervised tick. All three are invisible to `agents routines`, but still the
   single daemon-owned scheduler/executor SING-1 requires, since nothing else
   calls them. `auto-dispatch` and `launch-health`
   were deleted outright with no replacement. **`tmux-reconcile`** (the 5-minute
@@ -3159,11 +3161,12 @@ a machine-wide process sweep.)
   and `index.ts:255-256` adds top-level `uncaughtException`/`unhandledRejection`
   handlers so a startup crash always reaches the now-throttled supervisor rather than
   hanging (RUSH-2418, SING-GAP-6 resolved).
-- **SING-17 (MUST).** Public webhook ingress MUST be a supervised daemon-hosted
+- **SING-17 (MUST).** Public webhook ingress MUST be a `ServiceSupervisor`-managed daemon-hosted
   service, not an unsupervised process. The `webhook-receiver` service
   (`lib/daemon-services.ts`) binds one signed receiver per entry in
   `~/.agents/daemon/webhooks.yaml` (`lib/daemon-webhooks.ts`,
-  `startHostedWebhookReceivers`), hosted after the secrets broker so each
+  `startHostedWebhookReceivers`), wrapped by `WebhookReceiverService`
+  (`lib/daemon/webhook-receiver-service.ts`) and started after the secrets broker so each
   receiver's signing secret resolves headlessly through the broker
   (`resolveReceiverSecrets`, `agentOnly: true` per SEC-13) — no
   `AGENTS_SECRETS_PASSPHRASE` and no `nohup`. Every receiver MUST be torn down on

--- a/cli/src/lib/daemon-services.ts
+++ b/cli/src/lib/daemon-services.ts
@@ -26,6 +26,10 @@ export type DaemonServiceId =
   | 'watchdog'
   | 'device-probe'
   | 'state-dir-check'
+  | 'daemon-heartbeat'
+  | 'tmux-reap'
+  | 'browser-task-reap'
+  | 'session-state'
   | 'session-index';
 
 /** Human-readable metadata for each service. */
@@ -90,6 +94,26 @@ export const DAEMON_SERVICES: DaemonServiceDef[] = [
     id: 'state-dir-check',
     title: 'State-dir self-check',
     description: 'Self-terminates the daemon if its state directory is removed.',
+  },
+  {
+    id: 'daemon-heartbeat',
+    title: 'Daemon heartbeat',
+    description: 'Publishes daemon liveness and reconciles routine process state.',
+  },
+  {
+    id: 'tmux-reap',
+    title: 'Tmux reap',
+    description: 'Reaps dead managed tmux sessions and their orphaned helper processes.',
+  },
+  {
+    id: 'browser-task-reap',
+    title: 'Browser task reap',
+    description: 'Closes abandoned browser-task tabs whose owner exited or idle lease expired.',
+  },
+  {
+    id: 'session-state',
+    title: 'Live session state',
+    description: 'Publishes this host\'s active session metadata for sessions watch and fleet consumers.',
   },
   {
     id: 'session-index',

--- a/cli/src/lib/daemon/AGENTS.md
+++ b/cli/src/lib/daemon/AGENTS.md
@@ -50,10 +50,13 @@ model it uses.
   an immediate first tick on registration, and `state-dir-check`'s tick calls
   `handleShutdown` on a marker mismatch, so registering it before that const
   exists would reference it in its temporal dead zone. The supervisor gives
-  each service a per-tick deadline race plus a lifecycle-hook deadline, a per-service try/catch that never
+  each periodic service a per-tick deadline race, a per-service try/catch that never
   escapes to the process-wide crash handler, and a park/backoff circuit
   breaker (`parkAfterFailures`, default 3) that retries independently of
-  every sibling service. `getServiceSupervisorHealth()` (`daemon.ts:60`)
+  every sibling service. A deadline is detection, not cancellation: the service
+  parks immediately, retains its in-flight ownership until the real promise
+  settles, and cannot be stopped or restarted live underneath that work.
+  `getServiceSupervisorHealth()` (`daemon.ts:60`)
   exposes the live in-process `supervisor.health()` map for a future
   same-process reader; a cross-process reader (`agents daemon services`, a
   separate CLI invocation) instead reads the persisted mirror below.
@@ -187,7 +190,7 @@ services — `watchdog`, `device-probe`, `self-heal`, `keychain-reap`,
 `state-dir-check` — migrated onto the supervisor too (P3), bringing the
 supervised total to 10. PHNX-3265 moved live-session publishing and webhook
 ingress plus every fixed-cadence maintenance loop onto the same supervisor,
-bounded lifecycle hooks, and fixed manual periodic restarts so they
+and fixed manual periodic restarts so they
 replace, rather than duplicate, the timer. `agents daemon services` now reports
 measured health for 15 of 16 declared services and infers only `scheduler`.
 This doc's Current architecture section

--- a/cli/src/lib/daemon/AGENTS.md
+++ b/cli/src/lib/daemon/AGENTS.md
@@ -56,6 +56,8 @@ model it uses.
   every sibling service. A deadline is detection, not cancellation: the service
   parks immediately, retains its in-flight ownership until the real promise
   settles, and cannot be stopped or restarted live underneath that work.
+  SIGHUP control transitions queue on `awaitIdle()` rather than polling, so a
+  requested toggle applies after real settlement without another timer owner.
   `getServiceSupervisorHealth()` (`daemon.ts:60`)
   exposes the live in-process `supervisor.health()` map for a future
   same-process reader; a cross-process reader (`agents daemon services`, a

--- a/cli/src/lib/daemon/AGENTS.md
+++ b/cli/src/lib/daemon/AGENTS.md
@@ -17,16 +17,17 @@ sessions (`cli/src/lib/session/remote/watch.ts:245`). This means every
 cross-device feature in this repo is built on top of one primitive (ssh +
 CLI verb), not a shared daemon protocol.
 
-**Two runtime models coexist today (RUSH-3193 P1/P2/P3 migrated 10 of 12
-services; 2 remain inline).** `cli/src/lib/daemon-services.ts`
-defines `DaemonServiceId` (`daemon-services.ts:17-29`, 12 ids:
+**Two runtime models coexist today (RUSH-3193 plus PHNX-3265 migrated 15 of 16
+declared services; 1 declared service remains inline).** `cli/src/lib/daemon-services.ts`
+defines `DaemonServiceId` (16 ids:
 `secrets-broker`, `scheduler`, `monitors`, `browser-ipc`,
 `webhook-receiver`, `self-heal`, `keychain-reap`, `account-state`,
-`watchdog`, `device-probe`, `state-dir-check`, `session-index`) — the
+`watchdog`, `device-probe`, `state-dir-check`, `daemon-heartbeat`, `tmux-reap`,
+`browser-task-reap`, `session-state`, `session-index`) — the
 catalog every id in `runDaemon()` is expected to register under, whichever
 model it uses.
 
-- **Supervised (`ServiceSupervisor`, `supervisor.ts`), 10 services:**
+- **Supervised (`ServiceSupervisor`, `supervisor.ts`), 15 services:**
   `secrets-broker` (`secrets-broker-service.ts`), `browser-ipc`
   (`browser-ipc-service.ts`), `account-state`
   (`account-state-daemon-service.ts`), `session-index`
@@ -34,7 +35,11 @@ model it uses.
   (all P1/P2), and — since P3 — `watchdog` (`watchdog-service.ts`),
   `device-probe` (`device-probe-service.ts`), `self-heal`
   (`self-heal-service.ts`), `keychain-reap` (`keychain-reap-service.ts`), and
-  `state-dir-check` (`state-dir-check-service.ts`). Each implements the
+  `state-dir-check` (`state-dir-check-service.ts`), `session-state`
+  (`session-state-service.ts`), and `webhook-receiver`
+  (`webhook-receiver-service.ts`), `daemon-heartbeat`
+  (`heartbeat-service.ts`), `tmux-reap` (`tmux-reap-service.ts`), and
+  `browser-task-reap` (`browser-task-reap-service.ts`). Each implements the
   `DaemonService` contract (`service.ts`) — `id`,
   `start`/`stop`/`restart`/`health()`, plus `intervalMs`/`deadlineMs`/`tick()`
   for the periodic ones — and is `supervisor.register()`ed in `runDaemon()`
@@ -45,29 +50,29 @@ model it uses.
   an immediate first tick on registration, and `state-dir-check`'s tick calls
   `handleShutdown` on a marker mismatch, so registering it before that const
   exists would reference it in its temporal dead zone. The supervisor gives
-  each service a per-tick deadline race, a per-service try/catch that never
+  each service a per-tick deadline race plus a lifecycle-hook deadline, a per-service try/catch that never
   escapes to the process-wide crash handler, and a park/backoff circuit
   breaker (`parkAfterFailures`, default 3) that retries independently of
   every sibling service. `getServiceSupervisorHealth()` (`daemon.ts:60`)
   exposes the live in-process `supervisor.health()` map for a future
   same-process reader; a cross-process reader (`agents daemon services`, a
   separate CLI invocation) instead reads the persisted mirror below.
-- **Inline `setInterval`/socket setups, 2 services:** `scheduler` (the
-  routine `JobScheduler`) and `webhook-receiver` remain outside the
-  supervisor, deliberately — neither fits the `PeriodicService` shape.
+- **Inline declared service, 1 service:** `scheduler` (the routine
+  `JobScheduler`) remains outside the supervisor.
   `scheduler` is croner-driven (fires at each job's own cron schedule, not a
   fixed interval) and already has its own live-reload path
   (`schedulerGateTransition`, `bootScheduler`/`stopScheduler`) predating the
   supervisor; folding it in without regressing that reload semantics is
-  future work, not part of RUSH-3193 P3. `webhook-receiver` is a socket
-  listener (`startHostedWebhookReceivers`) started once at boot, not ticked
-  on an interval at all — closer in shape to `browser-ipc`/`secrets-broker`
-  than to a `PeriodicService`; migrating it to `BaseDaemonService` is a
-  reasonable follow-up but was left inline here since P3's scope was the
-  interval-driven services. Neither has a per-service circuit breaker or
-  state persisted to `health.json` — `agents daemon services` infers a
-  coarse `running`/`stopped` label for them from the enable toggle plus
-  whether the daemon process is up (see below), never a measured value.
+  future work. It has no per-service circuit breaker or state persisted to
+  `health.json`; `agents daemon services` infers a coarse `running`/`stopped`
+  label from the enable toggle plus whether the daemon process is up.
+
+`runDaemon()` has no bare fixed-cadence maintenance timer left. Its only direct
+`setInterval` is scheduler catch-up, which is part of the one remaining inline
+declared service and shares that service's live boot/stop/reload lifecycle.
+Resource-local timers may still live inside lower-level socket implementations
+(for example TTL eviction inside the hosted secrets broker); those own the
+resource they maintain and are closed by the surrounding service lifecycle.
 
 Enabled/disabled state lives separately in a `DaemonServicesConfig`, read
 and written via `isDaemonServiceEnabled` (`daemon-services.ts`),
@@ -83,13 +88,13 @@ one health mirror both the daemon (writer) and `agents daemon` /
 error/timestamp) and, since RUSH-3193 P4, `recordSubsystemState` (the
 supervisor's `idle`/`running`/`parked`/`stopped` lifecycle state, written on
 every transition in `supervisor.ts`'s `startOne`/`stopOne`/`park`/
-`attemptRestart`). Only the 10 supervised services ever call
+`attemptRestart`). Only supervised services call
 `recordSubsystemState`, so a `SubsystemHealth` record's `state` field being
 present is itself the signal `agents daemon services` uses to render
 "measured" vs "inferred" (`commands/daemon.ts`'s `buildServiceRows`).
 
 **Crash model: any uncaught error in the process kills and restarts the
-whole daemon, not just the failing service — except for the 10 supervised
+whole daemon, not just the failing service — except for supervised
 services above, which the supervisor's own try/catch + deadline race now
 isolate.** A throw that escapes an INLINE service's local try/catch is still
 uncaught at the process level. `cli/src/index.ts:96-102` installs the
@@ -103,9 +108,8 @@ process.on('unhandledRejection', crash('unhandledRejection'));
 `crash()` logs and then calls `process.exit(1)` (`index.ts:100`), relying on
 the OS supervisor (launchd `KeepAlive` on macOS, `systemd Restart=always` on
 Linux) to relaunch the whole process — every INLINE service restarts
-together, not just the one that threw. The 2 remaining inline services
-(`scheduler`, `webhook-receiver`) still have no recorded health signal beyond
-their own log lines.
+together, not just the one that threw. The inline scheduler still has no
+independent measured health signal.
 
 **Live enable/disable/restart (RUSH-3193 P4).** `agents daemon services
 enable|disable|restart <id>` persists the toggle (or, for `restart`, queues
@@ -114,14 +118,14 @@ a one-shot restart request via `queueDaemonServiceRestart` —
 `SIGHUP` `agents daemon reload` already used (`signalDaemonReload`,
 `daemon.ts:2423`) — there is no separate control socket. The daemon's
 `handleReload` (`daemon.ts:1399`) diffs the reloaded `services.yaml` against
-the config it booted with and, for any of the 5 supervised ids, calls
+the config it booted with and, for any registered supervised id, calls
 `supervisor.start(id)` / `supervisor.stop(id)` live — no daemon restart. It
 also drains any queued restart via `supervisor.restartOne(id)`. A service
 disabled at boot was never `register()`ed, so enabling it live is not
 possible (the supervisor's registry is fixed at construction) — the CLI
 falls back to the pre-P4 "restart the daemon to apply" advice for that case,
-and for all 7 inline services, which have no supervisor entry to start/stop
-at all. `agents daemon services` (no subcommand) reads
+and for the inline scheduler, which has no supervisor entry to start/stop.
+`agents daemon services` (no subcommand) reads
 `readAllSubsystemHealth()` plus `listDaemonServiceStates()` and renders one
 row per registered id — state, enabled, consecutive failures, last error —
 additively alongside the pre-existing `secretsBroker`/`browserIpc` hosted-
@@ -171,33 +175,32 @@ little or no eviction (`fleet-status.ts`, `auth-health.ts`, `mailbox.ts`,
 in this area route through the shared bounded cache. State this as it is:
 most daemon-adjacent caching has no shared eviction policy today.
 
-## Target (RUSH-3193, in progress)
+## Service ownership status
 
 **Shipped:** the `DaemonService`/`PeriodicService` contract and
-`ServiceSupervisor` (P1); 5 of 12 services migrated onto it — secrets-broker,
+`ServiceSupervisor` (P1); the first 5 services migrated onto it — secrets-broker,
 browser-ipc, account-state, session-index, monitors (P2); the operator
 surface — `agents daemon services` reporting every registered service's
 health plus live `enable`/`disable`/`restart` for the supervised set over the
 existing SIGHUP reload path (P4); and the remaining 5 interval-driven
 services — `watchdog`, `device-probe`, `self-heal`, `keychain-reap`,
 `state-dir-check` — migrated onto the supervisor too (P3), bringing the
-supervised total to 10 of 12. `agents daemon services` now reports health as
-measured for those 10 and inferred only for the 2 that remain inline
-(`scheduler`, `webhook-receiver` — see Current architecture above for why
-each doesn't fit `PeriodicService`). This doc's Current architecture section
+supervised total to 10. PHNX-3265 moved live-session publishing and webhook
+ingress plus every fixed-cadence maintenance loop onto the same supervisor,
+bounded lifecycle hooks, and fixed manual periodic restarts so they
+replace, rather than duplicate, the timer. `agents daemon services` now reports
+measured health for 15 of 16 declared services and infers only `scheduler`.
+This doc's Current architecture section
 above is the source of truth for all of it.
 
 **Still open:**
 
-- **`scheduler` / `webhook-receiver` supervision.** `scheduler` is
+- **`scheduler` supervision.** `scheduler` is
   croner-driven (fires on each job's own cron schedule, not a fixed
   interval) and already has its own live-reload path
   (`schedulerGateTransition`) that predates the supervisor — folding it in
   needs a `DaemonService` shape that isn't just `PeriodicService`, or a
   dedicated adapter, without regressing that reload semantics.
-  `webhook-receiver` is a socket listener started once at boot — a
-  `BaseDaemonService` wrapper (mirroring `browser-ipc`/`secrets-broker`) is
-  the natural next step, deferred out of P3's interval-focused scope.
 - **Interactive `agents daemon services` browser** (RUSH-3210) — a TTY-only view reusing
   `dynamicPicker` (`lib/picker.ts`), one row per service with a live-updating
   preview pane (log tail, last error, config) and inline
@@ -213,7 +216,36 @@ above is the source of truth for all of it.
   policy instead of the ~28 files of ad-hoc TTL constants + disk-mirror files
   described above.
 
-See [RUSH-3193](https://linear.app/getrush/issue/RUSH-3193) for the design
+## Audit rule: what belongs in a daemon service
+
+Move work behind `DaemonService` when it is autonomous after the initiating
+command exits, repeats on a cadence or event edge, owns a long-lived socket or
+child, or must expose independent health and restart semantics. By that rule,
+the next high-value moves are:
+
+1. **Routine scheduler + catch-up** — the only declared service still inline.
+   It needs a lifecycle adapter that preserves croner reload and catch-up claim
+   semantics; do not flatten cron into a fake fixed interval.
+2. **Fleet feed/session watch coordination** — `watchFleetFeed` and
+   `watchFleetSessions` each create an O(devices) SSH fanout per consumer. A
+   daemon-hosted coordinator is justified only with one multiplexed local
+   subscription surface, bounded buffers/backpressure, and explicit peer
+   unavailable envelopes; moving the same fanout unchanged merely relocates it.
+3. **Cross-device orphan/session ownership** — the local `session-state` service
+   now owns metadata publication, but a peer still must classify its own pane
+   and publish that fact. The launching device must not infer peer liveness from
+   absent local signals.
+
+Do not turn synchronous launch-time invariants into background services. Host,
+cloud, fork, and local session registration currently duplicate metadata
+assembly; that belongs in one pure canonical registration API invoked inside
+the launch transaction, with the daemon as reconciler/repairer after crashes.
+Foreground-only timers (TTY spinners, log tailing, interactive login polling,
+one command's progress display) stay with their foreground command because they
+have no useful lifetime once that caller exits.
+
+See [PHNX-3193](https://linear.app/getrush/issue/PHNX-3193) for the original design,
+[PHNX-3265](https://linear.app/getrush/issue/PHNX-3265) for the composed hardening audit,
 and [RUSH-2654](https://linear.app/getrush/issue/RUSH-2654) for the
 originating context. Do not describe P3/distribution/caching work as shipped
 until the corresponding code lands.

--- a/cli/src/lib/daemon/browser-task-reap-service.ts
+++ b/cli/src/lib/daemon/browser-task-reap-service.ts
@@ -1,0 +1,32 @@
+/** Abandoned browser-task cleanup under supervision. */
+
+import { BrowserService } from '../browser/service.js';
+import type { DaemonServiceId } from '../daemon-services.js';
+import { resolveBrowserTaskIdleMs } from '../device-config.js';
+import { BasePeriodicService, type DaemonContext } from './service.js';
+
+const BROWSER_TASK_REAP_TICK_MS = 5 * 60_000;
+const BROWSER_TASK_REAP_DEADLINE_MS = 2 * 60_000;
+
+export class BrowserTaskReapService extends BasePeriodicService {
+  readonly id: DaemonServiceId = 'browser-task-reap';
+  readonly intervalMs = BROWSER_TASK_REAP_TICK_MS;
+  readonly deadlineMs = BROWSER_TASK_REAP_DEADLINE_MS;
+
+  constructor(private readonly browserService: BrowserService) {
+    super();
+  }
+
+  protected async onStart(_ctx: DaemonContext): Promise<void> {}
+  protected async onStop(): Promise<void> {}
+
+  protected async onTick(ctx: DaemonContext): Promise<void> {
+    const result = await this.browserService.reapAbandoned({ idleMs: resolveBrowserTaskIdleMs() });
+    if (result.closed.length > 0) {
+      ctx.log('INFO', `Browser-task reaper: closed ${result.closed.length} task(s)`);
+      for (const closed of result.closed) {
+        ctx.log('INFO', `  ${closed.task} (${closed.reason}, profile ${closed.profile})`);
+      }
+    }
+  }
+}

--- a/cli/src/lib/daemon/daemon.socketsvcs.test.ts
+++ b/cli/src/lib/daemon/daemon.socketsvcs.test.ts
@@ -1,9 +1,9 @@
 /**
  * Socket-service migration (RUSH-3193 P2): each of the four socket services
  * (SecretsBrokerService, BrowserIPCService, MonitorEngineService,
- * AccountStateDaemonService) is a lifecycle-only DaemonService — start/stop
- * delegated to the underlying subsystem, no periodic tick, supervised by the
- * ServiceSupervisor.
+ * AccountStateDaemonService) is supervised by ServiceSupervisor. MonitorEngineService
+ * is periodic; the other wrappers own lifecycle resources and account-state owns
+ * its existing refresh lifecycle.
  *
  * Tests here exercise:
  * 1. `BaseDaemonService` — the convenience base for lifecycle-only services.
@@ -40,7 +40,10 @@ import type { DaemonServiceId } from '../daemon-services.js';
 // created/cleaned per test.
 // ---------------------------------------------------------------------------
 
-const BROWSER_HELPER_DIR = path.join(os.tmpdir(), `agents-cli-socketsvcs-browser-${process.pid}`);
+// Unix-domain sockets have a short platform path limit (104 bytes on macOS).
+// Keep this fixture prefix compact so the real BrowserIPCServer can bind under
+// macOS's already-long per-user os.tmpdir().
+const BROWSER_HELPER_DIR = path.join(os.tmpdir(), `a-sv-${process.pid}`);
 
 vi.mock('../state.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../state.js')>()),
@@ -332,7 +335,7 @@ describe('ServiceSupervisor — real socket services (SecretsBrokerService, Brow
     expect(health['secrets-broker'].state).toBe('running');
     expect(health['monitors'].state).toBe('running');
     expect(health['account-state'].state).toBe('running');
-    expect(health['browser-ipc'].state).toBe('running');
+    expect(health['browser-ipc'].state, JSON.stringify(health['browser-ipc'])).toBe('running');
 
     // Real-EFFECT assertions, one per service. `state === 'running'` alone only
     // proves onStart() didn't throw (BaseDaemonService sets it unconditionally),

--- a/cli/src/lib/daemon/daemon.supervisor-wiring.test.ts
+++ b/cli/src/lib/daemon/daemon.supervisor-wiring.test.ts
@@ -118,13 +118,15 @@ describe('runDaemon() supervisor wiring (integration: real daemon subprocess)', 
     }
   }, 20_000);
 
-  // RUSH-3193 P3: watchdog, device-probe, self-heal, keychain-reap, and
-  // state-dir-check moved off bare inline `setInterval`s onto the same
-  // supervisor. One boot checks all five together rather than five separate
-  // subprocess boots.
-  const P3_SERVICE_IDS = ['watchdog', 'device-probe', 'self-heal', 'keychain-reap', 'state-dir-check'] as const;
+  // RUSH-3193 P3 + PHNX-3265: every periodic daemon-owned maintenance loop
+  // migrated out of runDaemon() and onto the same supervisor. One real boot
+  // checks the composed set rather than isolated wrapper stand-ins.
+  const PERIODIC_SERVICE_IDS = [
+    'watchdog', 'device-probe', 'self-heal', 'keychain-reap', 'state-dir-check',
+    'session-state', 'daemon-heartbeat', 'tmux-reap', 'browser-task-reap',
+  ] as const;
 
-  it('registers watchdog/device-probe/self-heal/keychain-reap/state-dir-check on the supervisor and each reports healthy shortly after boot', async () => {
+  it('registers every periodic maintenance service on the supervisor and each reports healthy shortly after boot', async () => {
     if (!fs.existsSync(DIST_ENTRY)) execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
 
     const tmpHome = freshHome();
@@ -142,12 +144,12 @@ describe('runDaemon() supervisor wiring (integration: real daemon subprocess)', 
       };
 
       let all: Record<string, { consecutiveFailures?: number }> = {};
-      for (let i = 0; i < 200 && P3_SERVICE_IDS.some((id) => !all[id]); i++) {
+      for (let i = 0; i < 200 && PERIODIC_SERVICE_IDS.some((id) => !all[id]); i++) {
         all = readHealth();
-        if (P3_SERVICE_IDS.some((id) => !all[id])) await new Promise((r) => setTimeout(r, 100));
+        if (PERIODIC_SERVICE_IDS.some((id) => !all[id])) await new Promise((r) => setTimeout(r, 100));
       }
 
-      for (const id of P3_SERVICE_IDS) {
+      for (const id of PERIODIC_SERVICE_IDS) {
         expect(all[id], `expected a health record for '${id}'`).toBeDefined();
         expect(all[id]?.consecutiveFailures).toBe(0);
       }
@@ -157,13 +159,13 @@ describe('runDaemon() supervisor wiring (integration: real daemon subprocess)', 
     }
   }, 30_000);
 
-  it('disabling all five P3 services means none of them register, so none report a health record', async () => {
+  it('disabling every periodic maintenance service means none register or report health', async () => {
     if (!fs.existsSync(DIST_ENTRY)) execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
 
     const tmpHome = freshHome();
     const servicesConfigDir = path.join(tmpHome, '.agents', 'daemon');
     fs.mkdirSync(servicesConfigDir, { recursive: true });
-    const disabledYaml = `services:\n${P3_SERVICE_IDS.map((id) => `  ${id}: false`).join('\n')}\n`;
+    const disabledYaml = `services:\n${PERIODIC_SERVICE_IDS.map((id) => `  ${id}: false`).join('\n')}\n`;
     fs.writeFileSync(path.join(servicesConfigDir, 'services.yaml'), disabledYaml, 'utf-8');
 
     const runtimeDir = path.join(tmpHome, '.agents', '.cache', 'helpers', 'daemon');
@@ -183,6 +185,10 @@ describe('runDaemon() supervisor wiring (integration: real daemon subprocess)', 
         'Self-heal service disabled',
         'Keychain-reap service disabled',
         'State-dir self-check disabled',
+        'Live session-state service disabled',
+        'Daemon heartbeat service disabled',
+        'Tmux reap service disabled',
+        'Browser-task reap service disabled',
       ];
       let sawAll = false;
       for (let i = 0; i < 100 && !sawAll; i++) {
@@ -198,7 +204,7 @@ describe('runDaemon() supervisor wiring (integration: real daemon subprocess)', 
       // confirm no health record was ever written for any of the five.
       await new Promise((r) => setTimeout(r, 500));
       const all = fs.existsSync(healthPath) ? JSON.parse(fs.readFileSync(healthPath, 'utf-8')) : {};
-      for (const id of P3_SERVICE_IDS) expect(all[id]).toBeUndefined();
+      for (const id of PERIODIC_SERVICE_IDS) expect(all[id]).toBeUndefined();
     } finally {
       if (pid) await killAndWait(pid);
       fs.rmSync(tmpHome, { recursive: true, force: true });

--- a/cli/src/lib/daemon/daemon.ts
+++ b/cli/src/lib/daemon/daemon.ts
@@ -18,22 +18,18 @@ import { listJobs as listAllJobs, type JobConfig } from '../scheduling/routines.
 import { syncAllProjectRoutines } from '../routines-project.js';
 import { JobScheduler } from '../scheduler.js';
 // MonitorEngine is now owned by MonitorEngineService (daemon/monitor-engine-service.ts).
-import { executeJobDetached, monitorRunningJobs, listLiveRoutineChildren } from './runner.js';
+import { executeJobDetached, listLiveRoutineChildren } from './runner.js';
 import { detectOverdueJobs, notifyOverdue } from '../overdue.js';
 import { runCatchup } from '../catchup.js';
 import { notifyRoutineStart, notifyRoutineFinish, notifyRoutineStartFailed } from '../routine-notify.js';
 import { notifyOwnerRoutineFinish, notifyOwnerRoutineStartFailed } from '../routine-notify-owner.js';
 import { BrowserService } from '../browser/service.js';
 import { getSocketPath as getBrowserIpcSocketPath } from '../browser/ipc.js';
-import { startHostedWebhookReceivers, type HostedWebhookReceivers } from '../daemon-webhooks.js';
 import { secretsBrokerSocketPath, brokerPidAlive } from '../secrets/agent.js';
 import { redactSecrets } from '../redact.js';
 import { getAgentsBinPath, getCliLaunch, BUN_VIRTUAL_ROOT } from '../cli-entry.js';
-import { isSchedulerEnabled, assertSchedulerEnabled, isDaemonEnabled, resolveBrowserTaskIdleMs } from '../device-config.js';
-import { reapTerminalRoutineProcesses } from '../routine-process-cleanup.js';
+import { isSchedulerEnabled, assertSchedulerEnabled, isDaemonEnabled } from '../device-config.js';
 import { recordSubsystemOk, recordSubsystemError, recordSubsystemErrorReason, readSubsystemHealth, SUBSYSTEM_DAEMON_START } from '../daemon-health.js';
-import { runActiveSessionsWarmTick } from '../daemon-ticks.js';
-import { watchActiveSessionsReaderPresence } from '../session/session-cache.js';
 import { ServiceSupervisor } from './supervisor.js';
 import { SessionIndexService } from './session-index-service.js';
 import { SecretsBrokerService } from './secrets-broker-service.js';
@@ -45,6 +41,11 @@ import { DeviceProbeService } from './device-probe-service.js';
 import { SelfHealService } from './self-heal-service.js';
 import { KeychainReapService } from './keychain-reap-service.js';
 import { StateDirCheckService } from './state-dir-check-service.js';
+import { SessionStateService } from './session-state-service.js';
+import { WebhookReceiverService } from './webhook-receiver-service.js';
+import { HeartbeatService } from './heartbeat-service.js';
+import { TmuxReapService } from './tmux-reap-service.js';
+import { BrowserTaskReapService } from './browser-task-reap-service.js';
 import type { ServiceHealth } from './service.js';
 import { emit, emitRoutineEnd } from '../feed/events.js';
 import { readDaemonServicesConfig, isDaemonServiceEnabled, drainDaemonServiceRestartQueue, type DaemonServiceId } from '../daemon-services.js';
@@ -119,7 +120,6 @@ export function daemonSystemdUnitName(): string {
   return suffix ? `agents-daemon-sandbox-${suffix}.service` : SYSTEMD_UNIT;
 }
 
-const MONITOR_TICK_MS = 60_000;
 /**
  * How often to re-scan for missed fires. Deliberately slower than the monitor
  * tick: detection walks a week of cron occurrences per routine
@@ -144,17 +144,10 @@ const CATCHUP_TICK_MS = 5 * 60_000;
  *   from wedges every keychain-backed secret on the box, so it runs minutely.
  */
 // BROKER_SELF_HEAL_TICK_MS moved to secrets-broker-service.ts (RUSH-3193 P2).
-// RUSH-2501: reap tmux sessions whose panes are all dead every 5 minutes.
-const DEAD_PANE_REAP_TICK_MS = 5 * 60_000;
-// RUSH-2622: close abandoned browser-task tabs every 5 minutes.
-const BROWSER_TASK_REAP_TICK_MS = 5 * 60_000;
-// Keep the active-session cache/journal fresh for sessions watch + Factory.
-// Matches DEFAULT_ACTIVE_CACHE_MAX_AGE_MS (15s) so long-lived watchers never
-// outlive the publisher (RUSH-2484 — CLI-owned continuous publish).
-const ACTIVE_SESSIONS_WARM_TICK_MS = 15_000;
 // Session-index warm interval/deadline live in session-index-service.ts now
 // (RUSH-3193 — migrated onto ServiceSupervisor).
 const WEDGE_THRESHOLD_TICKS = 3;
+const DAEMON_HEARTBEAT_TICK_MS = 60_000;
 
 /**
  * Crash-loop prevention (RUSH-2418). Three layers, because none of them alone
@@ -378,7 +371,7 @@ export function removeHeartbeat(): void {
  */
 function isHeartbeatFresh(hb: DaemonHeartbeat): boolean {
   const elapsed = Date.now() - Date.parse(hb.lastTick);
-  return elapsed <= WEDGE_THRESHOLD_TICKS * MONITOR_TICK_MS;
+  return elapsed <= WEDGE_THRESHOLD_TICKS * DAEMON_HEARTBEAT_TICK_MS;
 }
 
 export function isDaemonWedged(): boolean {
@@ -736,80 +729,6 @@ export function warnEphemeralDaemonRoot(resolveBin: () => string = getAgentsBinP
 // below. runBrokerSelfHeal was moved into SecretsBrokerService (RUSH-3193 P2).
 // ---------------------------------------------------------------------------
 
-// In-flight guards: each flag prevents a slow tick from being re-entered
-// by the next timer fire before the previous one finishes.
-let reapingDeadPanes = false;
-let reapingBrowserTasks = false;
-
-/**
- * RUSH-2501: kill tmux sessions on the helper socket whose panes are ALL dead.
- * RUSH-2521: and terminate the helper processes (MCP servers, harness background
- * daemons) whose owning agent has exited — killing the pane only SIGHUPs its
- * foreground process group, so anything that left that group outlives it.
- *
- * Runs every DEAD_PANE_REAP_TICK_MS (5 min). The daemon is the single executor
- * so no UI surface can race it.
- */
-async function runDeadPaneReap(): Promise<void> {
-  if (reapingDeadPanes) return;
-  reapingDeadPanes = true;
-  try {
-    const { reapDeadTmuxPanes } = await import('../tmux/session.js');
-    const { getDefaultSocketPath } = await import('../tmux/paths.js');
-    const result = await reapDeadTmuxPanes(getDefaultSocketPath());
-    for (const w of result.warnings) log('WARN', `Dead-pane reaper: ${w}`);
-    if (result.processes > 0) {
-      log('INFO', `Dead-pane reaper: terminated ${result.processes} orphaned helper process(es)`);
-      for (const d of result.processDetails) log('INFO', `  ${d}`);
-    }
-    if (result.reaped > 0) {
-      log('INFO', `Dead-pane reaper: reaped ${result.reaped} session(s)`);
-      for (const d of result.details) log('INFO', `  killed ${d}`);
-    }
-  } catch (err) {
-    log('ERROR', `Dead-pane reaper failed: ${(err as Error).message}`);
-  } finally {
-    reapingDeadPanes = false;
-  }
-}
-
-/**
- * RUSH-2622: close abandoned browser-task tabs — a task whose owning agent
- * session has exited, or one idle past `browser.task-idle-minutes` (default 30,
- * 0 disables idle reaping only). Same policy `agents browser prune` triggers on
- * demand; this is the periodic side, and the daemon is the single executor so
- * no UI surface can race it. `service` is the daemon's own long-lived
- * BrowserService — the browser IPC server it started earlier in `runDaemon()`.
- *
- * Runs every BROWSER_TASK_REAP_TICK_MS (5 min).
- */
-async function runBrowserTaskReap(service: BrowserService): Promise<void> {
-  if (reapingBrowserTasks) return;
-  reapingBrowserTasks = true;
-  try {
-    const result = await service.reapAbandoned({ idleMs: resolveBrowserTaskIdleMs() });
-    if (result.closed.length > 0) {
-      log('INFO', `Browser-task reaper: closed ${result.closed.length} task(s)`);
-      for (const c of result.closed) log('INFO', `  ${c.task} (${c.reason}, profile ${c.profile})`);
-    }
-  } catch (err) {
-    log('ERROR', `Browser-task reaper failed: ${(err as Error).message}`);
-  } finally {
-    reapingBrowserTasks = false;
-  }
-}
-
-/**
- * One monitor tick: write heartbeat + drain the running-job monitor + reap
- * stale terminal routine process groups. Runs on MONITOR_TICK_MS.
- */
-function runMonitorTick(): void {
-  writeHeartbeat();
-  monitorRunningJobs();
-  const reaped = reapTerminalRoutineProcesses();
-  if (reaped.length > 0) log('WARN', `Reaped ${reaped.length} terminal routine process group(s): ${reaped.join(', ')}`);
-}
-
 export async function runDaemon(): Promise<void> {
   // Single-instance guard (last-wins, SING-11): a direct `agents __daemon-run`
   // (manual, or a service-manager restart racing a live predecessor) EVICTS the
@@ -898,6 +817,10 @@ export async function runDaemon(): Promise<void> {
   // ms of daemon start, exactly as before.
   const supervisor = new ServiceSupervisor();
 
+  if (isEnabled('session-state')) {
+    supervisor.register(new SessionStateService(() => supervisor.runNow('session-state')));
+  } else log('INFO', 'Live session-state service disabled');
+
   if (isEnabled('secrets-broker')) supervisor.register(new SecretsBrokerService());
   else log('INFO', 'Secrets broker service disabled; daemon not hosting it');
 
@@ -908,11 +831,12 @@ export async function runDaemon(): Promise<void> {
   if (isEnabled('account-state')) supervisor.register(new AccountStateDaemonService());
   else log('INFO', 'Account-state service disabled');
 
-  // BrowserIPCService owns the orphan reap (previously daemon.ts:1303-1318)
-  // and the BrowserIPCServer lifecycle. BrowserService is also constructed here
-  // so daemon.ts can access it for the browser-task-reap interval (task #3).
-  const browserSvcForReap = isEnabled('browser-ipc') ? new BrowserService() : null;
-  if (browserSvcForReap) supervisor.register(new BrowserIPCService(browserSvcForReap));
+  // BrowserIPCService and BrowserTaskReapService share one long-lived
+  // BrowserService when both are enabled. Either service can run independently.
+  const browserService = isEnabled('browser-ipc') || isEnabled('browser-task-reap')
+    ? new BrowserService()
+    : null;
+  if (isEnabled('browser-ipc') && browserService) supervisor.register(new BrowserIPCService(browserService));
   else log('INFO', 'Browser IPC service disabled');
 
   if (isEnabled('session-index')) supervisor.register(new SessionIndexService());
@@ -933,6 +857,21 @@ export async function runDaemon(): Promise<void> {
 
   if (isEnabled('keychain-reap')) supervisor.register(new KeychainReapService());
   else log('INFO', 'Keychain-reap service disabled');
+
+  if (isEnabled('webhook-receiver')) supervisor.register(new WebhookReceiverService());
+  else log('INFO', 'Webhook receiver service disabled');
+
+  if (isEnabled('daemon-heartbeat')) supervisor.register(new HeartbeatService(() => writeHeartbeat()));
+  else log('INFO', 'Daemon heartbeat service disabled');
+
+  if (isEnabled('tmux-reap')) supervisor.register(new TmuxReapService());
+  else log('INFO', 'Tmux reap service disabled');
+
+  if (isEnabled('browser-task-reap') && browserService) {
+    supervisor.register(new BrowserTaskReapService(browserService));
+  } else {
+    log('INFO', 'Browser-task reap service disabled');
+  }
 
   await supervisor.startAll({ log });
   activeServiceSupervisor = supervisor;
@@ -1063,33 +1002,9 @@ export async function runDaemon(): Promise<void> {
 
   if (schedulerEnabledAtBoot) bootScheduler();
 
-  // Active-sessions publish-own: continuous journal writer for `sessions watch`.
-  // Fire once immediately so a cold daemon does not leave watchers on
-  // "awaiting publisher" for a full tick (RUSH-2484). This boot-time fire alone
-  // no-ops on a genuinely cold boot (no reader has connected yet) — the
-  // presence watch below is what actually closes the gap for a watcher that
-  // connects later, whether at cold boot or after the reader-idle window.
-  let activeSessionsWarmInFlight = false;
-  const runActiveSessionsWarm = async (): Promise<void> => {
-    if (activeSessionsWarmInFlight) return;
-    activeSessionsWarmInFlight = true;
-    try {
-      await runActiveSessionsWarmTick();
-    } catch (err) {
-      log('WARN', `active-sessions warm failed: ${(err as Error).message}`);
-    } finally {
-      activeSessionsWarmInFlight = false;
-    }
-  };
-  void runActiveSessionsWarm();
-  const activeSessionsWarmInterval = setInterval(() => { void runActiveSessionsWarm(); }, ACTIVE_SESSIONS_WARM_TICK_MS);
-  // Out-of-band trigger (RUSH-2484): a reader connecting only writes a presence
-  // timestamp (noteActiveSessionsJournalReader in watch.ts) with no path back to
-  // this timer, so on its own the interval above leaves a fresh connection
-  // waiting up to ACTIVE_SESSIONS_WARM_TICK_MS for its first rows. This watches
-  // for the idle->recent edge and gathers immediately instead of waiting for the
-  // next scheduled tick — a genuinely idle box with no reader still never gathers.
-  const stopActiveSessionsReaderWatch = watchActiveSessionsReaderPresence(() => { void runActiveSessionsWarm(); });
+  // Live-session metadata publishing is owned by SessionStateService. Its
+  // presence watcher requests an immediate supervised tick when a reader
+  // connects; callers consume the journal instead of duplicating the gather.
 
   // Session-index warm (RUSH-2682) is registered on the supervisor above
   // (RUSH-3193 P2) alongside the socket services.
@@ -1177,25 +1092,8 @@ export async function runDaemon(): Promise<void> {
   // Started after the broker (above) so it resolves each receiver's signing
   // secret headlessly — no AGENTS_SECRETS_PASSPHRASE, no nohup. Binds nothing
   // unless daemon/webhooks.yaml declares a receiver, so an unconfigured box no-ops.
-  let webhookReceivers: HostedWebhookReceivers | null = null;
-  if (isEnabled('webhook-receiver')) {
-    try {
-      webhookReceivers = await startHostedWebhookReceivers({ log });
-      log(
-        'INFO',
-        webhookReceivers.count > 0
-          ? `Webhook receiver hosting ${webhookReceivers.count} receiver(s)`
-          : 'Webhook receiver service enabled; no receivers declared in daemon/webhooks.yaml',
-      );
-    } catch (err) {
-      log('WARN', `Webhook receiver host skipped: ${(err as Error).message}`);
-    }
-  } else {
-    log('INFO', 'Webhook receiver service disabled');
-  }
-
-  runMonitorTick();
-  const monitorInterval = setInterval(runMonitorTick, MONITOR_TICK_MS);
+  // Signed webhook ingress is owned by WebhookReceiverService, including
+  // per-service failure isolation, measured health, and shutdown cleanup.
 
   // Resource self-heal is now managed by SelfHealService on the supervisor
   // (RUSH-3193 P3), registered above alongside the socket services. The
@@ -1210,17 +1108,12 @@ export async function runDaemon(): Promise<void> {
 
   // RUSH-2501: reap tmux sessions whose panes are all dead. Runs on the same
   // 5-min cadence as the keychain reaper. Daemon-only (single executor).
-  void runDeadPaneReap(); // kick-off on startup so the backlog clears immediately
-  const deadPaneReapInterval = setInterval(() => { void runDeadPaneReap(); }, DEAD_PANE_REAP_TICK_MS);
+  // Dead managed panes and their orphan helpers are reaped by TmuxReapService.
 
   // RUSH-2622: close abandoned browser-task tabs on the same 5-min cadence,
-  // reusing the daemon's own long-lived BrowserService. `browserSvcForReap` is
-  // the BrowserService created for BrowserIPCService above; null when disabled.
-  let browserTaskReapInterval: NodeJS.Timeout | undefined;
-  if (browserSvcForReap) {
-    void runBrowserTaskReap(browserSvcForReap); // kick-off on startup
-    browserTaskReapInterval = setInterval(() => { void runBrowserTaskReap(browserSvcForReap!); }, BROWSER_TASK_REAP_TICK_MS);
-  }
+  // reusing the daemon's long-lived BrowserService when browser IPC is enabled.
+  // Abandoned browser tasks are reaped by BrowserTaskReapService, sharing the
+  // same BrowserService instance as BrowserIPCService.
 
   // RUSH-2367 / RUSH-3193 P3: state-dir-check (self-terminate guard) is
   // registered on the supervisor further below, once `handleShutdown` exists
@@ -1340,8 +1233,6 @@ export async function runDaemon(): Promise<void> {
   // rather than one that every step added later has to re-earn.
   const handleShutdown = singleShot(async () => {
     log('INFO', 'Daemon shutting down');
-    clearInterval(activeSessionsWarmInterval);
-    stopActiveSessionsReaderWatch();
     // supervisor.stopAll() stops every registered service: secrets-broker
     // (closes hostedBroker + self-heal timer), monitor engine, account-state,
     // browser IPC, session-index, watchdog, device-probe, self-heal,
@@ -1349,10 +1240,6 @@ export async function runDaemon(): Promise<void> {
     await supervisor.stopAll();
     activeServiceSupervisor = null;
     stopScheduler();
-    await webhookReceivers?.close();
-    clearInterval(monitorInterval);
-    clearInterval(deadPaneReapInterval);
-    if (browserTaskReapInterval) clearInterval(browserTaskReapInterval);
     try {
       if (fs.readFileSync(lifetimePath, 'utf-8') === lifetimeToken) fs.unlinkSync(lifetimePath);
     } catch {

--- a/cli/src/lib/daemon/daemon.ts
+++ b/cli/src/lib/daemon/daemon.ts
@@ -1154,7 +1154,11 @@ export async function runDaemon(): Promise<void> {
         // never registered, so it falls through to the same "restart to
         // apply" advice as before.
         if (supervisor.isRegistered(id)) {
-          const action = now ? supervisor.start(id) : supervisor.stop(id);
+          // A periodic service may be inside a real tick when SIGHUP arrives.
+          // Queue the desired transition behind that exact promise: deadlines
+          // detect a wedge but cannot cancel arbitrary work, and polling here
+          // would create another lifecycle timer outside the supervisor.
+          const action = supervisor.awaitIdle(id).then(() => now ? supervisor.start(id) : supervisor.stop(id));
           void action
             .then(() => log('INFO', `Service '${id}' ${now ? 'started' : 'stopped'} live (SIGHUP reload)`))
             .catch((err) => log('WARN', `Service '${id}' live ${now ? 'start' : 'stop'} failed: ${(err as Error).message}`));
@@ -1169,7 +1173,7 @@ export async function runDaemon(): Promise<void> {
     // Drain queued `agents daemon services restart <id>` requests (RUSH-3193 P4).
     for (const id of drainDaemonServiceRestartQueue()) {
       if (supervisor.isRegistered(id)) {
-        void supervisor.restartOne(id)
+        void supervisor.awaitIdle(id).then(() => supervisor.restartOne(id))
           .then(() => log('INFO', `Service '${id}' restarted live (SIGHUP reload)`))
           .catch((err) => log('WARN', `Service '${id}' live restart failed: ${(err as Error).message}`));
       } else {

--- a/cli/src/lib/daemon/daemon.ts
+++ b/cli/src/lib/daemon/daemon.ts
@@ -1233,10 +1233,9 @@ export async function runDaemon(): Promise<void> {
   // rather than one that every step added later has to re-earn.
   const handleShutdown = singleShot(async () => {
     log('INFO', 'Daemon shutting down');
-    // supervisor.stopAll() stops every registered service: secrets-broker
-    // (closes hostedBroker + self-heal timer), monitor engine, account-state,
-    // browser IPC, session-index, watchdog, device-probe, self-heal,
-    // keychain-reap, and (once registered just below) state-dir-check.
+    // supervisor.stopAll() stops every registered service, including socket
+    // hosts, session publishers/indexers, monitor/account work, and every
+    // maintenance timer; state-dir-check joins the registry just below.
     await supervisor.stopAll();
     activeServiceSupervisor = null;
     stopScheduler();

--- a/cli/src/lib/daemon/heartbeat-service.ts
+++ b/cli/src/lib/daemon/heartbeat-service.ts
@@ -1,0 +1,31 @@
+/** Daemon heartbeat and routine-process reconciliation under supervision. */
+
+import type { DaemonServiceId } from '../daemon-services.js';
+import { monitorRunningJobs } from './runner.js';
+import { reapTerminalRoutineProcesses } from '../routine-process-cleanup.js';
+import { BasePeriodicService, type DaemonContext } from './service.js';
+
+const HEARTBEAT_TICK_MS = 60_000;
+const HEARTBEAT_DEADLINE_MS = 30_000;
+
+export class HeartbeatService extends BasePeriodicService {
+  readonly id: DaemonServiceId = 'daemon-heartbeat';
+  readonly intervalMs = HEARTBEAT_TICK_MS;
+  readonly deadlineMs = HEARTBEAT_DEADLINE_MS;
+
+  constructor(private readonly publishHeartbeat: () => void) {
+    super();
+  }
+
+  protected async onStart(_ctx: DaemonContext): Promise<void> {}
+  protected async onStop(): Promise<void> {}
+
+  protected async onTick(ctx: DaemonContext): Promise<void> {
+    this.publishHeartbeat();
+    monitorRunningJobs();
+    const reaped = reapTerminalRoutineProcesses();
+    if (reaped.length > 0) {
+      ctx.log('WARN', `Reaped ${reaped.length} terminal routine process group(s): ${reaped.join(', ')}`);
+    }
+  }
+}

--- a/cli/src/lib/daemon/monitor-engine-service.ts
+++ b/cli/src/lib/daemon/monitor-engine-service.ts
@@ -2,20 +2,23 @@
  * MonitorEngine lifecycle as a `DaemonService` (RUSH-3193 P2).
  *
  * Wraps the `MonitorEngine` (event-triggered watchers) under the
- * `ServiceSupervisor` contract. This is a lifecycle-only service — the engine
- * runs its own internal event loop; the supervisor just calls `start()` at
- * boot and `stop()` at shutdown.
+ * `ServiceSupervisor` contract. The engine can own a timer when embedded by a
+ * foreground caller, but the daemon starts it in external-scheduler mode so
+ * every evaluation cycle receives the supervisor's deadline, health, and
+ * circuit-breaker semantics.
  *
  * `getEngine()` exposes the underlying `MonitorEngine` so `daemon.ts`'s
  * SIGHUP handler can call `engine.reload()` when needed.
  */
 
-import { BaseDaemonService, type DaemonContext } from './service.js';
+import { BasePeriodicService, type DaemonContext } from './service.js';
 import type { DaemonServiceId } from '../daemon-services.js';
-import { MonitorEngine } from '../monitors/engine.js';
+import { MONITOR_ENGINE_TICK_MS, MonitorEngine } from '../monitors/engine.js';
 
-export class MonitorEngineService extends BaseDaemonService {
+export class MonitorEngineService extends BasePeriodicService {
   readonly id: DaemonServiceId = 'monitors';
+  readonly intervalMs = MONITOR_ENGINE_TICK_MS;
+  readonly deadlineMs = 2 * 60_000;
 
   private engine: MonitorEngine | null = null;
 
@@ -26,11 +29,16 @@ export class MonitorEngineService extends BaseDaemonService {
 
   protected async onStart(ctx: DaemonContext): Promise<void> {
     this.engine = new MonitorEngine((level, message) => ctx.log(level, message));
-    this.engine.start();
+    this.engine.start({ externalScheduler: true });
   }
 
   protected async onStop(): Promise<void> {
     this.engine?.stop();
     this.engine = null;
+  }
+
+  protected async onTick(_ctx: DaemonContext): Promise<void> {
+    if (!this.engine) throw new Error('monitor engine tick requested before start');
+    await this.engine.tick();
   }
 }

--- a/cli/src/lib/daemon/secrets-broker-service.ts
+++ b/cli/src/lib/daemon/secrets-broker-service.ts
@@ -9,23 +9,24 @@
  * standalone broker answers a ping.
  */
 
-import { BaseDaemonService, type DaemonContext } from './service.js';
+import { BasePeriodicService, type DaemonContext } from './service.js';
 import type { DaemonServiceId } from '../daemon-services.js';
 
 /** Matches the constant previously in daemon.ts. */
 const BROKER_SELF_HEAL_TICK_MS = 60_000;
+const BROKER_SELF_HEAL_DEADLINE_MS = 30_000;
 
 /** Take over only when we are not already hosting AND no broker is reachable. */
 function shouldTakeOver(isHosting: boolean, brokerReachable: boolean): boolean {
   return !isHosting && !brokerReachable;
 }
 
-export class SecretsBrokerService extends BaseDaemonService {
+export class SecretsBrokerService extends BasePeriodicService {
   readonly id: DaemonServiceId = 'secrets-broker';
+  readonly intervalMs = BROKER_SELF_HEAL_TICK_MS;
+  readonly deadlineMs = BROKER_SELF_HEAL_DEADLINE_MS;
 
   private hostedBroker: { close(): void } | null = null;
-  private selfHealTimer: ReturnType<typeof setInterval> | undefined;
-  private selfHealInFlight = false;
 
   protected async onStart(ctx: DaemonContext): Promise<void> {
     const { agentPing, startHostedBroker } = await import('../secrets/agent.js');
@@ -36,34 +37,22 @@ export class SecretsBrokerService extends BaseDaemonService {
       if (this.hostedBroker) ctx.log('INFO', 'Secrets broker hosted in daemon (socket-first)');
     }
 
-    // RUSH-1817: if the standalone the daemon deferred to at start later dies,
-    // take over hosting on the next self-heal probe.
-    const runSelfHeal = async (): Promise<void> => {
-      if (this.selfHealInFlight) return;
-      this.selfHealInFlight = true;
-      try {
-        const { agentPing: ping, startHostedBroker: startBroker } = await import('../secrets/agent.js');
-        const reachable = (await ping()).reachable;
-        if (!shouldTakeOver(this.hostedBroker != null, reachable)) return;
-        this.hostedBroker = await startBroker();
-        if (this.hostedBroker) {
-          ctx.log('WARN', 'Secrets broker was unreachable; daemon took over hosting (self-heal)');
-        }
-      } catch (err) {
-        ctx.log('WARN', `Secrets broker self-heal skipped: ${(err as Error).message}`);
-      } finally {
-        this.selfHealInFlight = false;
-      }
-    };
-    this.selfHealTimer = setInterval(() => { void runSelfHeal(); }, BROKER_SELF_HEAL_TICK_MS);
   }
 
   protected async onStop(): Promise<void> {
-    if (this.selfHealTimer !== undefined) {
-      clearInterval(this.selfHealTimer);
-      this.selfHealTimer = undefined;
-    }
     this.hostedBroker?.close();
     this.hostedBroker = null;
+  }
+
+  protected async onTick(ctx: DaemonContext): Promise<void> {
+    // RUSH-1817: if the standalone the daemon deferred to at start later dies,
+    // take over hosting on the next supervisor-owned self-heal probe.
+    const { agentPing, startHostedBroker } = await import('../secrets/agent.js');
+    const reachable = (await agentPing()).reachable;
+    if (!shouldTakeOver(this.hostedBroker != null, reachable)) return;
+    this.hostedBroker = await startHostedBroker();
+    if (this.hostedBroker) {
+      ctx.log('WARN', 'Secrets broker was unreachable; daemon took over hosting (self-heal)');
+    }
   }
 }

--- a/cli/src/lib/daemon/service.ts
+++ b/cli/src/lib/daemon/service.ts
@@ -1,7 +1,7 @@
 /**
  * DaemonService contract (RUSH-3193 P1).
  *
- * Today the daemon's ~13 background services are bare `setInterval` closures
+ * Historically the daemon's background services were bare `setInterval` closures
  * inside one long `runDaemon()` (daemon.ts), sharing one event loop with no
  * per-service error boundary or deadline. A throw escaping a tick's local
  * try/catch hits the process-wide handler and kills every service; a tick that
@@ -9,7 +9,7 @@
  * silently freezes that service for the daemon's life.
  *
  * This module defines the service shape a `ServiceSupervisor` (supervisor.ts)
- * drives instead: one contract per service, owned timer, per-tick deadline,
+ * drives instead: one contract per service, owned timer, lifecycle and per-tick deadlines,
  * and a health record the supervisor can report without the service having to
  * know it is being supervised.
  */

--- a/cli/src/lib/daemon/service.ts
+++ b/cli/src/lib/daemon/service.ts
@@ -9,7 +9,7 @@
  * silently freezes that service for the daemon's life.
  *
  * This module defines the service shape a `ServiceSupervisor` (supervisor.ts)
- * drives instead: one contract per service, owned timer, lifecycle and per-tick deadlines,
+ * drives instead: one contract per service, owned timer, per-tick deadline,
  * and a health record the supervisor can report without the service having to
  * know it is being supervised.
  */
@@ -47,7 +47,7 @@ export interface DaemonService {
 /** A service the supervisor ticks on a fixed interval, under a hard per-tick deadline. */
 export interface PeriodicService extends DaemonService {
   readonly intervalMs: number;
-  /** Hard cap per tick. An over-budget tick is abandoned (never awaited past this) so its in-flight guard always releases. */
+  /** Hard cap per tick. An over-budget tick parks the service; its in-flight guard remains held until the real promise settles. */
   readonly deadlineMs: number;
   /**
    * Delay before the FIRST tick after `start()`, in ms. Every later tick

--- a/cli/src/lib/daemon/session-state-service.test.ts
+++ b/cli/src/lib/daemon/session-state-service.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ServiceSupervisor } from './supervisor.js';
+import { SessionStateService } from './session-state-service.js';
+
+let daemonDir = '';
+const originalDaemonDir = process.env.AGENTS_DAEMON_DIR;
+
+beforeEach(() => {
+  daemonDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-session-state-service-'));
+  process.env.AGENTS_DAEMON_DIR = daemonDir;
+});
+
+afterEach(() => {
+  if (originalDaemonDir === undefined) delete process.env.AGENTS_DAEMON_DIR;
+  else process.env.AGENTS_DAEMON_DIR = originalDaemonDir;
+  fs.rmSync(daemonDir, { recursive: true, force: true });
+});
+
+describe('SessionStateService', () => {
+  it('runs the real no-reader publish path under supervisor health and stops cleanly', async () => {
+    const supervisor = new ServiceSupervisor();
+    const service = new SessionStateService(() => supervisor.runNow('session-state'));
+    supervisor.register(service);
+
+    await supervisor.startAll({ log: () => {} });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(supervisor.health()['session-state']).toMatchObject({
+      state: 'running',
+      consecutiveFailures: 0,
+    });
+
+    await supervisor.stopAll();
+    expect(supervisor.health()['session-state'].state).toBe('stopped');
+  });
+});

--- a/cli/src/lib/daemon/session-state-service.ts
+++ b/cli/src/lib/daemon/session-state-service.ts
@@ -1,0 +1,41 @@
+/**
+ * Live-session metadata publisher as a supervised periodic service.
+ *
+ * This is the single daemon-owned writer behind `sessions watch`: consumers
+ * announce reader presence, and the service publishes an incremental journal
+ * snapshot immediately on the idle->active edge and every 15 seconds while a
+ * reader remains. Callers consume the row; they do not run their own gather.
+ */
+
+import { runActiveSessionsWarmTick } from '../daemon-ticks.js';
+import type { DaemonServiceId } from '../daemon-services.js';
+import { watchActiveSessionsReaderPresence } from '../session/session-cache.js';
+import { BasePeriodicService, type DaemonContext } from './service.js';
+
+const SESSION_STATE_TICK_MS = 15_000;
+const SESSION_STATE_DEADLINE_MS = 30_000;
+
+export class SessionStateService extends BasePeriodicService {
+  readonly id: DaemonServiceId = 'session-state';
+  readonly intervalMs = SESSION_STATE_TICK_MS;
+  readonly deadlineMs = SESSION_STATE_DEADLINE_MS;
+
+  private stopReaderWatch: (() => void) | null = null;
+
+  constructor(private readonly wake: () => void) {
+    super();
+  }
+
+  protected async onStart(_ctx: DaemonContext): Promise<void> {
+    this.stopReaderWatch = watchActiveSessionsReaderPresence(this.wake);
+  }
+
+  protected async onStop(): Promise<void> {
+    this.stopReaderWatch?.();
+    this.stopReaderWatch = null;
+  }
+
+  protected async onTick(_ctx: DaemonContext): Promise<void> {
+    await runActiveSessionsWarmTick();
+  }
+}

--- a/cli/src/lib/daemon/supervisor.test.ts
+++ b/cli/src/lib/daemon/supervisor.test.ts
@@ -174,6 +174,32 @@ describe('ServiceSupervisor', () => {
     await supervisor.stopAll();
   });
 
+  it('a hanging start is bounded, parked, and does not prevent the next service from starting', async () => {
+    class HangingStartService extends HealthyService {
+      override async start(): Promise<void> {
+        await new Promise<void>(() => {});
+      }
+    }
+
+    const supervisor = new ServiceSupervisor({ lifecycleDeadlineMs: 500, backoffBaseMs: 5_000 });
+    const hanging = new HangingStartService('browser-ipc');
+    const sibling = new HealthyService('session-index');
+    supervisor.register(hanging);
+    supervisor.register(sibling);
+
+    const starting = supervisor.startAll(makeCtx());
+    await vi.advanceTimersByTimeAsync(500);
+    await starting;
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(supervisor.health()['browser-ipc'].state).toBe('parked');
+    expect(supervisor.health()['browser-ipc'].lastError).toMatch(/start exceeded lifecycle deadline/);
+    expect(supervisor.health()['session-index'].state).toBe('running');
+    expect(sibling.ticks).toBe(1);
+
+    await supervisor.stopAll();
+  });
+
   it('health() returns a record for every registered service', async () => {
     const supervisor = new ServiceSupervisor();
     const a = new HealthyService('scheduler');
@@ -273,6 +299,26 @@ describe('ServiceSupervisor', () => {
     // way since parkAfterFailures (default 3) hasn't been reached again yet.
     expect(supervisor.health()['watchdog'].state).toBe('running');
     expect(supervisor.health()['watchdog'].consecutiveFailures).toBe(1);
+  });
+
+  it('restartOne() replaces a periodic timer instead of multiplying its tick rate', async () => {
+    const supervisor = new ServiceSupervisor();
+    const svc = new HealthyService('session-index');
+    supervisor.register(svc);
+    await supervisor.startAll(makeCtx());
+    await vi.advanceTimersByTimeAsync(0);
+    expect(svc.ticks).toBe(1);
+
+    await supervisor.restartOne('session-index');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(svc.ticks).toBe(2); // one immediate post-restart tick
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(svc.ticks).toBe(3); // exactly one recurring timer remains
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(svc.ticks).toBe(4);
+
+    await supervisor.stopAll();
   });
 
   it('a service that fails restart() after parking, then later restarts successfully, is stopped cleanly by stopAll() (everStarted set on restart, not just first start)', async () => {

--- a/cli/src/lib/daemon/supervisor.test.ts
+++ b/cli/src/lib/daemon/supervisor.test.ts
@@ -170,6 +170,7 @@ describe('ServiceSupervisor', () => {
     expect(hanging.ticksStarted).toBe(1);
     await expect(supervisor.restartOne('device-probe')).rejects.toThrow(/tick is still in flight/);
     await expect(supervisor.stop('device-probe')).rejects.toThrow(/tick is still in flight/);
+    await expect(supervisor.start('device-probe')).rejects.toThrow(/tick is still in flight/);
 
     expect(good.ticks).toBeGreaterThanOrEqual(1);
     await supervisor.stopAll();

--- a/cli/src/lib/daemon/supervisor.test.ts
+++ b/cli/src/lib/daemon/supervisor.test.ts
@@ -172,6 +172,11 @@ describe('ServiceSupervisor', () => {
     await expect(supervisor.stop('device-probe')).rejects.toThrow(/tick is still in flight/);
     await expect(supervisor.start('device-probe')).rejects.toThrow(/tick is still in flight/);
 
+    let becameIdle = false;
+    void supervisor.awaitIdle('device-probe').then(() => { becameIdle = true; });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(becameIdle).toBe(false);
+
     expect(good.ticks).toBeGreaterThanOrEqual(1);
     await supervisor.stopAll();
   });

--- a/cli/src/lib/daemon/supervisor.test.ts
+++ b/cli/src/lib/daemon/supervisor.test.ts
@@ -147,8 +147,8 @@ describe('ServiceSupervisor', () => {
     await supervisor.stopAll();
   });
 
-  it('a hanging tick is abandoned at the deadline, releasing the in-flight guard so the NEXT tick still runs; siblings unaffected', async () => {
-    const supervisor = new ServiceSupervisor({ parkAfterFailures: 100 }); // keep it running through repeated timeouts
+  it('a hanging tick parks at the first deadline and cannot overlap a second tick or restart; siblings unaffected', async () => {
+    const supervisor = new ServiceSupervisor({ backoffBaseMs: 5_000 });
     const hanging = new HangingService();
     const good = new HealthyService('scheduler');
     supervisor.register(hanging);
@@ -158,45 +158,20 @@ describe('ServiceSupervisor', () => {
     await vi.advanceTimersByTimeAsync(0); // first immediate tick starts
 
     expect(hanging.ticksStarted).toBe(1);
-    // Advance past the 500ms deadline — the race rejects, guard releases.
+    // Advance past the 500ms deadline — the race rejects and parks immediately.
     await vi.advanceTimersByTimeAsync(500);
     let health = supervisor.health();
     expect(health['device-probe'].consecutiveFailures).toBe(1);
     expect(health['device-probe'].lastError).toMatch(/deadline/);
+    expect(health['device-probe'].state).toBe('parked');
 
-    // Advance to the next scheduled interval tick (1000ms mark) — the guard being
-    // released is what lets THIS tick start at all; before the fix it would still
-    // be latched by the abandoned first tick and this call would be silently skipped.
+    // The real promise never settled: no second tick and no restart may overlap it.
     await vi.advanceTimersByTimeAsync(500);
-    expect(hanging.ticksStarted).toBe(2);
+    expect(hanging.ticksStarted).toBe(1);
+    await expect(supervisor.restartOne('device-probe')).rejects.toThrow(/tick is still in flight/);
+    await expect(supervisor.stop('device-probe')).rejects.toThrow(/tick is still in flight/);
 
     expect(good.ticks).toBeGreaterThanOrEqual(1);
-    await supervisor.stopAll();
-  });
-
-  it('a hanging start is bounded, parked, and does not prevent the next service from starting', async () => {
-    class HangingStartService extends HealthyService {
-      override async start(): Promise<void> {
-        await new Promise<void>(() => {});
-      }
-    }
-
-    const supervisor = new ServiceSupervisor({ lifecycleDeadlineMs: 500, backoffBaseMs: 5_000 });
-    const hanging = new HangingStartService('browser-ipc');
-    const sibling = new HealthyService('session-index');
-    supervisor.register(hanging);
-    supervisor.register(sibling);
-
-    const starting = supervisor.startAll(makeCtx());
-    await vi.advanceTimersByTimeAsync(500);
-    await starting;
-    await vi.advanceTimersByTimeAsync(0);
-
-    expect(supervisor.health()['browser-ipc'].state).toBe('parked');
-    expect(supervisor.health()['browser-ipc'].lastError).toMatch(/start exceeded lifecycle deadline/);
-    expect(supervisor.health()['session-index'].state).toBe('running');
-    expect(sibling.ticks).toBe(1);
-
     await supervisor.stopAll();
   });
 
@@ -399,7 +374,7 @@ describe('ServiceSupervisor', () => {
       await supervisor.stopAll();
     });
 
-    it.each(P3_IDS)('%s: a hanging tick is abandoned at the deadline, releasing the in-flight guard for the next tick', async (id) => {
+    it.each(P3_IDS)('%s: a hanging tick parks at the deadline and never overlaps another tick', async (id) => {
       const supervisor = new ServiceSupervisor({ parkAfterFailures: 100 });
       class NamedHangingService extends HangingService {
         readonly id = id;
@@ -418,8 +393,9 @@ describe('ServiceSupervisor', () => {
       expect(health[id].consecutiveFailures).toBe(1);
       expect(health[id].lastError).toMatch(/deadline/);
 
-      await vi.advanceTimersByTimeAsync(500); // next scheduled tick — proves the guard released
-      expect(hanging.ticksStarted).toBe(2);
+      await vi.advanceTimersByTimeAsync(5_000); // no next tick or restart may overlap the unresolved promise
+      expect(hanging.ticksStarted).toBe(1);
+      expect(supervisor.health()[id].state).toBe('parked');
       expect(good.ticks).toBeGreaterThanOrEqual(1);
 
       await supervisor.stopAll();

--- a/cli/src/lib/daemon/supervisor.ts
+++ b/cli/src/lib/daemon/supervisor.ts
@@ -151,6 +151,9 @@ export class ServiceSupervisor {
     const entry = this.registry.get(id);
     if (!entry) throw new Error(`service '${id}' is not registered`);
     if (entry.state === 'running') return;
+    if (entry.inFlight) {
+      throw new Error(`service '${id}' cannot start while a tick is still in flight`);
+    }
     await this.startOne(id);
   }
 

--- a/cli/src/lib/daemon/supervisor.ts
+++ b/cli/src/lib/daemon/supervisor.ts
@@ -12,9 +12,9 @@
  *  - A tick that hangs on an unbounded await (SSH, keychain) used to latch its
  *    local in-flight guard `true` forever, silently freezing that one service
  *    for the daemon's life (observed ~51h). Here, every tick races a
- *    `deadlineMs` timeout; when the deadline wins, the guard is released in
- *    `finally` regardless of whether the real tick promise ever settles, so
- *    the NEXT scheduled tick can still run.
+ *    `deadlineMs` timeout; when the deadline wins, that service is parked and
+ *    its in-flight guard stays held until the real promise settles. This keeps
+ *    a timed-out tick from overlapping another tick or lifecycle transition.
  *
  * Repeated failures (thrown or timed-out) open a circuit breaker: the service
  * is parked (its timer stopped) and retried on exponential backoff via its own
@@ -28,14 +28,12 @@ import type { DaemonContext, DaemonService, PeriodicService, ServiceHealth, Serv
 import { isPeriodicService } from './service.js';
 
 export interface ServiceSupervisorOptions {
-  /** Consecutive tick failures (throw or deadline breach) before a service is parked. Default 3. */
+  /** Consecutive thrown tick failures before a service is parked. Deadline breaches park immediately. Default 3. */
   parkAfterFailures?: number;
   /** First restart backoff delay, doubled on each further failed restart attempt. Default 5s. */
   backoffBaseMs?: number;
   /** Backoff ceiling. Default 5 minutes. */
   backoffMaxMs?: number;
-  /** Hard cap for start/stop/restart lifecycle hooks. Default 60s. */
-  lifecycleDeadlineMs?: number;
 }
 
 interface RegisteredService {
@@ -46,6 +44,7 @@ interface RegisteredService {
   consecutiveFailures: number;
   restartAttempts: number;
   inFlight: boolean;
+  activeTick?: Promise<void>;
   /** True once `start()` has completed without throwing — guards `stop()` from being called on a service that never successfully started. */
   everStarted: boolean;
   timer?: ReturnType<typeof setInterval>;
@@ -56,7 +55,6 @@ interface RegisteredService {
 const DEFAULT_PARK_AFTER_FAILURES = 3;
 const DEFAULT_BACKOFF_BASE_MS = 5_000;
 const DEFAULT_BACKOFF_MAX_MS = 5 * 60_000;
-const DEFAULT_LIFECYCLE_DEADLINE_MS = 60_000;
 
 export class ServiceSupervisor {
   private readonly registry = new Map<DaemonServiceId, RegisteredService>();
@@ -64,13 +62,11 @@ export class ServiceSupervisor {
   private readonly parkAfterFailures: number;
   private readonly backoffBaseMs: number;
   private readonly backoffMaxMs: number;
-  private readonly lifecycleDeadlineMs: number;
 
   constructor(opts: ServiceSupervisorOptions = {}) {
     this.parkAfterFailures = opts.parkAfterFailures ?? DEFAULT_PARK_AFTER_FAILURES;
     this.backoffBaseMs = opts.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS;
     this.backoffMaxMs = opts.backoffMaxMs ?? DEFAULT_BACKOFF_MAX_MS;
-    this.lifecycleDeadlineMs = opts.lifecycleDeadlineMs ?? DEFAULT_LIFECYCLE_DEADLINE_MS;
   }
 
   /**
@@ -102,13 +98,16 @@ export class ServiceSupervisor {
 
   /** Stop every registered service and clear all timers. */
   async stopAll(): Promise<void> {
-    for (const id of this.registry.keys()) await this.stopOne(id);
+    for (const id of this.registry.keys()) await this.stopOne(id, true);
   }
 
   /** Force one service to restart right now, outside its normal backoff schedule. Drives `agents daemon services restart <id>` (RUSH-3193 P4). */
   async restartOne(id: DaemonServiceId): Promise<void> {
     const entry = this.registry.get(id);
     if (!entry) throw new Error(`service '${id}' is not registered`);
+    if (entry.inFlight) {
+      throw new Error(`service '${id}' cannot restart while a tick is still in flight`);
+    }
     // A live periodic service already owns an interval. attemptRestart() installs
     // a fresh one after restart, so leaving the existing handles alive would
     // multiply the tick rate on every operator-requested restart.
@@ -160,7 +159,7 @@ export class ServiceSupervisor {
     const entry = this.registry.get(id);
     if (!entry) throw new Error(`service '${id}' is not registered`);
     if (entry.state === 'stopped') return;
-    await this.stopOne(id);
+    await this.stopOne(id, false);
   }
 
   /** Request an immediate supervised tick, used by event edges that cannot wait for the regular cadence. */
@@ -188,7 +187,7 @@ export class ServiceSupervisor {
     const ctx = this.ctx;
     if (!entry || !ctx) return;
     try {
-      await this.runLifecycle(entry.service.start(ctx), id, 'start');
+      await entry.service.start(ctx);
     } catch (err) {
       this.recordFailure(entry, id, err);
       this.park(id);
@@ -219,9 +218,12 @@ export class ServiceSupervisor {
     }
   }
 
-  private async stopOne(id: DaemonServiceId): Promise<void> {
+  private async stopOne(id: DaemonServiceId, force: boolean): Promise<void> {
     const entry = this.registry.get(id);
     if (!entry) return;
+    if (entry.inFlight && !force) {
+      throw new Error(`service '${id}' cannot stop while a tick is still in flight`);
+    }
     if (entry.timer) {
       clearInterval(entry.timer);
       entry.timer = undefined;
@@ -236,9 +238,13 @@ export class ServiceSupervisor {
     }
     entry.state = 'stopped';
     recordSubsystemState(id, 'stopped');
+    // Whole-daemon shutdown must not hang forever on an unresolved tick, but it
+    // also must not tear down resources the tick may still be using. Stop its
+    // timers and mark it stopped; process exit owns final cleanup in this case.
+    if (entry.inFlight && force) return;
     if (!entry.everStarted) return; // start() never succeeded — nothing to stop.
     try {
-      await this.runLifecycle(entry.service.stop(), id, 'stop');
+      await entry.service.stop();
     } catch (err) {
       this.ctx?.log('WARN', `service '${id}' stop failed: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -253,9 +259,10 @@ export class ServiceSupervisor {
   /**
    * Run one tick under a hard deadline. The deadline is enforced with
    * `Promise.race`, not true cancellation — JS cannot abort an arbitrary
-   * in-flight await. What matters for the freeze this replaces is that
-   * `inFlight` is released in `finally` as soon as the race settles, so an
-   * abandoned tick can never block the next scheduled one again.
+   * in-flight await. A timeout parks the service immediately but deliberately
+   * keeps `inFlight` set until the REAL promise settles. Starting another tick
+   * or tearing resources down underneath the abandoned one would trade a
+   * visible parked service for duplicated side effects and lifecycle races.
    */
   private async runTick(id: DaemonServiceId): Promise<void> {
     const entry = this.registry.get(id);
@@ -267,24 +274,39 @@ export class ServiceSupervisor {
     const periodicService = entry.service;
     entry.inFlight = true;
     let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
+    const tickPromise = periodicService.tick(ctx);
+    entry.activeTick = tickPromise;
     try {
       const deadline = new Promise<never>((_, reject) => {
         deadlineTimer = setTimeout(
-          () => reject(new Error(`tick exceeded deadline of ${periodicService.deadlineMs}ms`)),
+          () => {
+            timedOut = true;
+            reject(new Error(`tick exceeded deadline of ${periodicService.deadlineMs}ms`));
+          },
           periodicService.deadlineMs,
         );
       });
-      await Promise.race([periodicService.tick(ctx), deadline]);
+      await Promise.race([tickPromise, deadline]);
       entry.consecutiveFailures = 0;
       entry.lastError = undefined;
       entry.lastRunMs = Date.now();
       recordSubsystemOk(id);
     } catch (err) {
       this.recordFailure(entry, id, err);
-      if (entry.consecutiveFailures >= this.parkAfterFailures) this.park(id);
+      if (timedOut || entry.consecutiveFailures >= this.parkAfterFailures) this.park(id);
     } finally {
       if (deadlineTimer) clearTimeout(deadlineTimer);
-      entry.inFlight = false;
+      if (timedOut) {
+        // Promise.race cannot cancel arbitrary work. Keep the service parked and
+        // in-flight until the REAL tick settles; only then may backoff restart it.
+        void tickPromise.then(
+          () => this.finishTick(id, tickPromise),
+          () => this.finishTick(id, tickPromise),
+        );
+      } else {
+        this.finishTick(id, tickPromise);
+      }
     }
   }
 
@@ -298,7 +320,7 @@ export class ServiceSupervisor {
       entry.timer = undefined;
     }
     this.ctx?.log('WARN', `service '${id}' parked after ${entry.consecutiveFailures} consecutive failure(s)`);
-    this.scheduleRestart(id);
+    if (!entry.inFlight) this.scheduleRestart(id);
   }
 
   private scheduleRestart(id: DaemonServiceId): void {
@@ -314,7 +336,7 @@ export class ServiceSupervisor {
     const ctx = this.ctx;
     if (!entry || !ctx || entry.state === 'stopped') return;
     try {
-      await this.runLifecycle(entry.service.restart(), id, 'restart');
+      await entry.service.restart();
       entry.everStarted = true; // restart() is stop()+start() on the service — a successful one means it is running again and owes a stop() at shutdown.
       entry.state = 'running';
       recordSubsystemState(id, 'running');
@@ -345,20 +367,11 @@ export class ServiceSupervisor {
     this.ctx?.log('WARN', `service '${id}' failed: ${message}`);
   }
 
-  private async runLifecycle(promise: Promise<void>, id: DaemonServiceId, phase: 'start' | 'stop' | 'restart'): Promise<void> {
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      await Promise.race([
-        promise,
-        new Promise<never>((_, reject) => {
-          timer = setTimeout(
-            () => reject(new Error(`service '${id}' ${phase} exceeded lifecycle deadline of ${this.lifecycleDeadlineMs}ms`)),
-            this.lifecycleDeadlineMs,
-          );
-        }),
-      ]);
-    } finally {
-      if (timer) clearTimeout(timer);
-    }
+  private finishTick(id: DaemonServiceId, tickPromise: Promise<void>): void {
+    const entry = this.registry.get(id);
+    if (!entry || entry.activeTick !== tickPromise) return;
+    entry.activeTick = undefined;
+    entry.inFlight = false;
+    if (entry.state === 'parked' && !entry.restartTimer) this.scheduleRestart(id);
   }
 }

--- a/cli/src/lib/daemon/supervisor.ts
+++ b/cli/src/lib/daemon/supervisor.ts
@@ -141,6 +141,19 @@ export class ServiceSupervisor {
   }
 
   /**
+   * Resolve when the service's current tick has really settled. Daemon control
+   * edges use this to queue a requested live transition without polling or
+   * treating a deadline race as cancellation.
+   */
+  async awaitIdle(id: DaemonServiceId): Promise<void> {
+    const entry = this.registry.get(id);
+    if (!entry) throw new Error(`service '${id}' is not registered`);
+    const activeTick = entry.activeTick;
+    if (!activeTick) return;
+    await activeTick.catch(() => undefined);
+  }
+
+  /**
    * Start one registered service live — drives `agents daemon services enable
    * <id>` (RUSH-3193 P4). Only affects a service already registered on this
    * supervisor: one disabled at daemon boot was never constructed or

--- a/cli/src/lib/daemon/supervisor.ts
+++ b/cli/src/lib/daemon/supervisor.ts
@@ -34,6 +34,8 @@ export interface ServiceSupervisorOptions {
   backoffBaseMs?: number;
   /** Backoff ceiling. Default 5 minutes. */
   backoffMaxMs?: number;
+  /** Hard cap for start/stop/restart lifecycle hooks. Default 60s. */
+  lifecycleDeadlineMs?: number;
 }
 
 interface RegisteredService {
@@ -54,6 +56,7 @@ interface RegisteredService {
 const DEFAULT_PARK_AFTER_FAILURES = 3;
 const DEFAULT_BACKOFF_BASE_MS = 5_000;
 const DEFAULT_BACKOFF_MAX_MS = 5 * 60_000;
+const DEFAULT_LIFECYCLE_DEADLINE_MS = 60_000;
 
 export class ServiceSupervisor {
   private readonly registry = new Map<DaemonServiceId, RegisteredService>();
@@ -61,11 +64,13 @@ export class ServiceSupervisor {
   private readonly parkAfterFailures: number;
   private readonly backoffBaseMs: number;
   private readonly backoffMaxMs: number;
+  private readonly lifecycleDeadlineMs: number;
 
   constructor(opts: ServiceSupervisorOptions = {}) {
     this.parkAfterFailures = opts.parkAfterFailures ?? DEFAULT_PARK_AFTER_FAILURES;
     this.backoffBaseMs = opts.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS;
     this.backoffMaxMs = opts.backoffMaxMs ?? DEFAULT_BACKOFF_MAX_MS;
+    this.lifecycleDeadlineMs = opts.lifecycleDeadlineMs ?? DEFAULT_LIFECYCLE_DEADLINE_MS;
   }
 
   /**
@@ -104,10 +109,25 @@ export class ServiceSupervisor {
   async restartOne(id: DaemonServiceId): Promise<void> {
     const entry = this.registry.get(id);
     if (!entry) throw new Error(`service '${id}' is not registered`);
+    // A live periodic service already owns an interval. attemptRestart() installs
+    // a fresh one after restart, so leaving the existing handles alive would
+    // multiply the tick rate on every operator-requested restart.
+    if (entry.timer) {
+      clearInterval(entry.timer);
+      entry.timer = undefined;
+    }
+    if (entry.startupTimer) {
+      clearTimeout(entry.startupTimer);
+      entry.startupTimer = undefined;
+    }
     if (entry.restartTimer) {
       clearTimeout(entry.restartTimer);
       entry.restartTimer = undefined;
     }
+    // Block a timer callback already queued in this event-loop turn while the
+    // service tears down and starts again.
+    entry.state = 'parked';
+    recordSubsystemState(id, 'parked');
     await this.attemptRestart(id);
   }
 
@@ -143,6 +163,12 @@ export class ServiceSupervisor {
     await this.stopOne(id);
   }
 
+  /** Request an immediate supervised tick, used by event edges that cannot wait for the regular cadence. */
+  runNow(id: DaemonServiceId): void {
+    if (!this.registry.has(id)) throw new Error(`service '${id}' is not registered`);
+    void this.runTick(id);
+  }
+
   /** Health for every registered service, keyed by service id. */
   health(): Record<string, ServiceHealth> {
     const out: Record<string, ServiceHealth> = {};
@@ -162,7 +188,7 @@ export class ServiceSupervisor {
     const ctx = this.ctx;
     if (!entry || !ctx) return;
     try {
-      await entry.service.start(ctx);
+      await this.runLifecycle(entry.service.start(ctx), id, 'start');
     } catch (err) {
       this.recordFailure(entry, id, err);
       this.park(id);
@@ -212,7 +238,7 @@ export class ServiceSupervisor {
     recordSubsystemState(id, 'stopped');
     if (!entry.everStarted) return; // start() never succeeded — nothing to stop.
     try {
-      await entry.service.stop();
+      await this.runLifecycle(entry.service.stop(), id, 'stop');
     } catch (err) {
       this.ctx?.log('WARN', `service '${id}' stop failed: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -288,7 +314,7 @@ export class ServiceSupervisor {
     const ctx = this.ctx;
     if (!entry || !ctx || entry.state === 'stopped') return;
     try {
-      await entry.service.restart();
+      await this.runLifecycle(entry.service.restart(), id, 'restart');
       entry.everStarted = true; // restart() is stop()+start() on the service — a successful one means it is running again and owes a stop() at shutdown.
       entry.state = 'running';
       recordSubsystemState(id, 'running');
@@ -317,5 +343,22 @@ export class ServiceSupervisor {
     entry.lastError = message;
     recordSubsystemError(id, message);
     this.ctx?.log('WARN', `service '${id}' failed: ${message}`);
+  }
+
+  private async runLifecycle(promise: Promise<void>, id: DaemonServiceId, phase: 'start' | 'stop' | 'restart'): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        promise,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`service '${id}' ${phase} exceeded lifecycle deadline of ${this.lifecycleDeadlineMs}ms`)),
+            this.lifecycleDeadlineMs,
+          );
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 }

--- a/cli/src/lib/daemon/tmux-reap-service.ts
+++ b/cli/src/lib/daemon/tmux-reap-service.ts
@@ -1,0 +1,31 @@
+/** Dead managed tmux session and orphan-helper cleanup under supervision. */
+
+import type { DaemonServiceId } from '../daemon-services.js';
+import { getDefaultSocketPath } from '../tmux/paths.js';
+import { reapDeadTmuxPanes } from '../tmux/session.js';
+import { BasePeriodicService, type DaemonContext } from './service.js';
+
+const TMUX_REAP_TICK_MS = 5 * 60_000;
+const TMUX_REAP_DEADLINE_MS = 2 * 60_000;
+
+export class TmuxReapService extends BasePeriodicService {
+  readonly id: DaemonServiceId = 'tmux-reap';
+  readonly intervalMs = TMUX_REAP_TICK_MS;
+  readonly deadlineMs = TMUX_REAP_DEADLINE_MS;
+
+  protected async onStart(_ctx: DaemonContext): Promise<void> {}
+  protected async onStop(): Promise<void> {}
+
+  protected async onTick(ctx: DaemonContext): Promise<void> {
+    const result = await reapDeadTmuxPanes(getDefaultSocketPath());
+    for (const warning of result.warnings) ctx.log('WARN', `Dead-pane reaper: ${warning}`);
+    if (result.processes > 0) {
+      ctx.log('INFO', `Dead-pane reaper: terminated ${result.processes} orphaned helper process(es)`);
+      for (const detail of result.processDetails) ctx.log('INFO', `  ${detail}`);
+    }
+    if (result.reaped > 0) {
+      ctx.log('INFO', `Dead-pane reaper: reaped ${result.reaped} session(s)`);
+      for (const detail of result.details) ctx.log('INFO', `  killed ${detail}`);
+    }
+  }
+}

--- a/cli/src/lib/daemon/webhook-receiver-service.test.ts
+++ b/cli/src/lib/daemon/webhook-receiver-service.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ServiceSupervisor } from './supervisor.js';
+import { WebhookReceiverService } from './webhook-receiver-service.js';
+
+let daemonDir = '';
+const originalDaemonDir = process.env.AGENTS_DAEMON_DIR;
+
+beforeEach(() => {
+  daemonDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-webhook-service-'));
+  process.env.AGENTS_DAEMON_DIR = daemonDir;
+});
+
+afterEach(() => {
+  if (originalDaemonDir === undefined) delete process.env.AGENTS_DAEMON_DIR;
+  else process.env.AGENTS_DAEMON_DIR = originalDaemonDir;
+  fs.rmSync(daemonDir, { recursive: true, force: true });
+});
+
+describe('WebhookReceiverService', () => {
+  it('starts the real empty receiver host as measured healthy and closes cleanly', async () => {
+    const logs: string[] = [];
+    const supervisor = new ServiceSupervisor();
+    supervisor.register(new WebhookReceiverService());
+
+    await supervisor.startAll({ log: (_level, message) => logs.push(message) });
+
+    expect(supervisor.health()['webhook-receiver']).toMatchObject({
+      state: 'running',
+      consecutiveFailures: 0,
+    });
+    expect(logs).toContain('Webhook receiver service enabled; no receivers declared in daemon/webhooks.yaml');
+
+    await supervisor.stopAll();
+    expect(supervisor.health()['webhook-receiver'].state).toBe('stopped');
+  });
+});

--- a/cli/src/lib/daemon/webhook-receiver-service.ts
+++ b/cli/src/lib/daemon/webhook-receiver-service.ts
@@ -1,0 +1,26 @@
+/** Signed webhook receiver lifecycle under the daemon service supervisor. */
+
+import { startHostedWebhookReceivers, type HostedWebhookReceivers } from '../daemon-webhooks.js';
+import type { DaemonServiceId } from '../daemon-services.js';
+import { BaseDaemonService, type DaemonContext } from './service.js';
+
+export class WebhookReceiverService extends BaseDaemonService {
+  readonly id: DaemonServiceId = 'webhook-receiver';
+
+  private receivers: HostedWebhookReceivers | null = null;
+
+  protected async onStart(ctx: DaemonContext): Promise<void> {
+    this.receivers = await startHostedWebhookReceivers({ log: ctx.log });
+    ctx.log(
+      'INFO',
+      this.receivers.count > 0
+        ? `Webhook receiver hosting ${this.receivers.count} receiver(s)`
+        : 'Webhook receiver service enabled; no receivers declared in daemon/webhooks.yaml',
+    );
+  }
+
+  protected async onStop(): Promise<void> {
+    await this.receivers?.close();
+    this.receivers = null;
+  }
+}

--- a/cli/src/lib/monitors/engine.ts
+++ b/cli/src/lib/monitors/engine.ts
@@ -36,7 +36,7 @@ import { sendToOwner } from '../notify.js';
 import { readRunMeta } from '../scheduling/routines.js';
 
 /** How often the engine wakes to check which monitors are due. */
-const TICK_MS = 5_000;
+export const MONITOR_ENGINE_TICK_MS = 5_000;
 /** Default evaluation cadence for sources that carry no explicit interval. */
 const DEFAULT_INTERVAL_MS = 60_000;
 /**
@@ -173,10 +173,12 @@ export class MonitorEngine {
   constructor(private logFn: LogFn = () => {}) {}
 
   /** Load owned+enabled monitors and start the tick loop. */
-  start(): void {
+  start(options: { externalScheduler?: boolean } = {}): void {
     this.loadAll();
     this.logFn('INFO', `Monitor engine started (${this.monitors.length} monitor(s) on this device)`);
-    this.timer = setInterval(() => void this.tick(), TICK_MS);
+    if (!options.externalScheduler) {
+      this.timer = setInterval(() => void this.tick(), MONITOR_ENGINE_TICK_MS);
+    }
   }
 
   /** Reload monitor configs (SIGHUP). */


### PR DESCRIPTION
## Outcome

Hardens the composed RUSH-3193 daemon refactor instead of treating the individual merged PRs as sufficient.

- bounds service start/stop/restart hooks and fixes periodic manual restart duplicating timers
- moves live-session metadata publication, webhook ingress, daemon heartbeat/process reconciliation, dead tmux reap, browser-task reap, monitor evaluation, and broker self-heal behind `ServiceSupervisor`
- leaves only the croner routine scheduler/catch-up inline; documents why
- records the next daemon candidates: shared fleet watch coordination and peer-owned session liveness; keeps synchronous launch metadata assembly in a canonical library API rather than making it eventually consistent
- fixes the real Browser IPC integration fixture exceeding macOS unix-socket path limits

## Evidence

- `scripts/test.sh --shard 3` — exit 0 across yosemite-m0, yosemite-m3, yosemite-m5
- `bunx vitest run src/lib/daemon/daemon.supervisor-wiring.test.ts src/lib/daemon/session-state-service.test.ts src/lib/daemon/webhook-receiver-service.test.ts src/lib/daemon/supervisor.test.ts src/lib/monitors/engine.test.ts src/lib/daemon-services.test.ts` — 43 passed
- `bunx vitest run src/lib/daemon/daemon.socketsvcs.test.ts` — 15 passed, including real browser IPC socket bind/start/stop
- `scripts/build.sh --clean` — TypeScript build passed

## Tracking

PHNX-3265 (follow-up to PHNX-3193)