### PR TITLE
fix(menubar): compare the helper's version for staleness, not the CLI's

### DIFF
--- a/cli/.changelog/next/RUSH-3230-axis.md
+++ b/cli/.changelog/next/RUSH-3230-axis.md
@@ -1,0 +1,18 @@
+- **The menu-bar helper's staleness check compares the HELPER's version, not the CLI's
+  (RUSH-3230).** `installAndStartService` stamped `getCliVersion()` as the installed
+  helper's version, and `menubarSetupStale()` compared against `getCliVersion()` too. Once
+  helpers gained their own version line that was wrong in both directions: every CLI
+  release made an unchanged helper look stale and reinstalled it — recopying the bundle
+  under the running helper, which `KeepAlive` then restarts (the #2109 storm: a new pid
+  every 5-15s, 578 launches in one log) — while a genuinely newer helper at the same CLI
+  version never looked stale at all, so it could never install.
+  The stamp is now JSON recording what the helper actually IS: `release` with its helper
+  version, or `local` with the source path + mtime for a dev build (menubar's build.sh
+  hardcodes `CFBundleShortVersionString`, so a local build has no version to compare).
+  Staleness compares like with like, treats a kind change (local <-> release) as stale, and
+  never downgrades when the installed helper is ahead of the floor. A pre-JSON stamp is
+  stale exactly once and is re-stamped in the new format, so the migration cannot loop.
+  `agents menubar status` / `doctor` now print three labelled lines — helper installed,
+  helper available, CLI version — instead of conflating two axes into one, and the
+  permanent false "(mismatch — `agents menubar setup` updates it)" hint is gone.
+  Source: `cli/src/lib/menubar/install-menubar.ts`.

--- a/cli/src/commands/menubar.ts
+++ b/cli/src/commands/menubar.ts
@@ -40,8 +40,9 @@ function printStatus(s: MenubarStatus, opts: { brief?: boolean } = {}): void {
     return;
   }
   console.log(`  app installed      ${s.installedApp ? chalk.gray(s.installedApp) : chalk.gray('no')}`);
-  console.log(`  installed version  ${s.installedVersion ? chalk.gray(s.installedVersion) : chalk.gray('unknown')}`);
-  console.log(`  current version    ${chalk.gray(s.currentVersion)}`);
+  console.log(`  helper installed   ${s.installedVersion ? chalk.gray(s.installedVersion) : chalk.gray('unknown')}`);
+  console.log(`  helper available   ${chalk.gray(s.currentVersion)}`);
+  console.log(`  CLI version        ${chalk.gray(s.cliVersion)}`);
   console.log(`  bundle source      ${s.source ? chalk.gray(s.source) : chalk.red('missing (cannot enable)')}`);
   console.log(`  disabled by user   ${yn(s.disabledByUser)}`);
 
@@ -92,8 +93,9 @@ function printSetupResult(r: SetupResult): void {
 function printDoctorReport(r: MenubarDoctorReport): void {
   console.log(chalk.bold('AGI Menu doctor\n'));
   console.log(`  install path       ${r.installPath ? chalk.gray(r.installPath) : chalk.red('not installed')}`);
-  console.log(`  installed version  ${r.installedVersion ? chalk.gray(r.installedVersion) : chalk.gray('unknown')}`);
-  console.log(`  CLI version        ${chalk.gray(r.currentVersion)}${r.versionMatches ? '' : chalk.yellow('  (mismatch — `agents menubar setup` updates it)')}`);
+  console.log(`  helper installed   ${r.installedVersion ? chalk.gray(r.installedVersion) : chalk.gray('unknown')}`);
+  console.log(`  helper available   ${chalk.gray(r.currentVersion)}${r.versionMatches ? '' : chalk.yellow('  (newer helper available — `agents menubar setup` installs it)')}`);
+  console.log(`  CLI version        ${chalk.gray(r.cliVersion)}`);
 
   const identity = r.signingIdentity === 'developer-id'
     ? chalk.green('Developer ID (update-stable)')

--- a/cli/src/lib/menubar/install-menubar.test.ts
+++ b/cli/src/lib/menubar/install-menubar.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import {
   classifyMenubarProcesses,
   codesignVerifies,
@@ -141,20 +142,62 @@ describe('processesToEnd', () => {
 // running the previous release's binary. isMenubarStale is the decision that
 // must flag an upgraded/missing install for reinstall.
 describe('isMenubarStale', () => {
+  const REL = (v: string) => ({ source: 'release' as const, helperVersion: v });
+  const LOC = (stamp: string) => ({ source: 'local' as const, sourceStamp: stamp });
+
   it('is stale when the helper binary is gone (App Support cleared)', () => {
-    expect(isMenubarStale({ installedVersion: '1.20.24', currentVersion: '1.20.24', execExists: false })).toBe(true);
+    expect(isMenubarStale({ installed: REL('1.0.0'), available: REL('1.0.0'), execExists: false })).toBe(true);
   });
 
-  it('is stale after an upgrade (installed version != current)', () => {
-    expect(isMenubarStale({ installedVersion: '1.20.24', currentVersion: '1.20.25', execExists: true })).toBe(true);
+  it('is stale when a NEWER helper is available', () => {
+    expect(isMenubarStale({ installed: REL('1.0.0'), available: REL('1.0.1'), execExists: true })).toBe(true);
   });
 
-  it('is stale on a pre-stamp install (no version marker yet)', () => {
-    expect(isMenubarStale({ installedVersion: null, currentVersion: '1.20.25', execExists: true })).toBe(true);
+  it('is NOT stale when the installed helper is newer than the floor', () => {
+    // The resolver may legitimately have installed ahead of the floor; a lower
+    // available version must never trigger a downgrade-reinstall.
+    expect(isMenubarStale({ installed: REL('1.1.0'), available: REL('1.0.0'), execExists: true })).toBe(false);
   });
 
-  it('is NOT stale when version matches and the binary is present', () => {
-    expect(isMenubarStale({ installedVersion: '1.20.25', currentVersion: '1.20.25', execExists: true })).toBe(false);
+  it('is NOT stale when the helper version matches and the binary is present', () => {
+    expect(isMenubarStale({ installed: REL('1.0.0'), available: REL('1.0.0'), execExists: true })).toBe(false);
+  });
+
+  it('is stale on a pre-stamp install (no marker yet)', () => {
+    expect(isMenubarStale({ installed: null, available: REL('1.0.0'), execExists: true })).toBe(true);
+  });
+
+  it('is stale exactly once on a legacy bare-string stamp, then re-stamped', () => {
+    // Old installs wrote the CLI's version as a bare string. That cannot be
+    // compared on the helper axis at all, so it is stale once — the reinstall
+    // rewrites it as JSON and the next call compares normally.
+    expect(isMenubarStale({ installed: { source: 'legacy', raw: '1.22.49' }, available: REL('1.0.0'), execExists: true })).toBe(true);
+  });
+
+  it('is stale when the install KIND changes (local <-> release)', () => {
+    // A dev build and a release bundle are not interchangeable, whatever their
+    // version strings say.
+    expect(isMenubarStale({ installed: LOC('/src/MenubarHelper.app@111'), available: REL('1.0.0'), execExists: true })).toBe(true);
+    expect(isMenubarStale({ installed: REL('1.0.0'), available: LOC('/src/MenubarHelper.app@111'), execExists: true })).toBe(true);
+  });
+
+  it('tracks a local build by source path + mtime, since it carries no version', () => {
+    // menubar/scripts/build.sh hardcodes CFBundleShortVersionString, so a local
+    // rebuild is only detectable by its source stamp changing.
+    expect(isMenubarStale({ installed: LOC('/src/MenubarHelper.app@111'), available: LOC('/src/MenubarHelper.app@111'), execExists: true })).toBe(false);
+    expect(isMenubarStale({ installed: LOC('/src/MenubarHelper.app@111'), available: LOC('/src/MenubarHelper.app@222'), execExists: true })).toBe(true);
+  });
+
+  it('never compares against the CLI version', () => {
+    // The bug this replaces: an unchanged helper looked stale on every CLI
+    // release (the #2109 restart storm), and a newer helper at the same CLI
+    // version never looked stale at all.
+    const src = fs.readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), 'install-menubar.ts'),
+      'utf-8',
+    );
+    const fn = src.slice(src.indexOf('export function isMenubarStale'), src.indexOf('function menubarSetupStale'));
+    expect(fn).not.toContain('getCliVersion');
   });
 });
 

--- a/cli/src/lib/menubar/install-menubar.test.ts
+++ b/cli/src/lib/menubar/install-menubar.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { menubarHelperCacheDir } from './download-menubar.js';
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -11,6 +12,8 @@ import {
   generateServicePlist,
   hasDeveloperIdSignature,
   isMenubarStale,
+  releaseVersionOfCachedBundle,
+  stampFor,
   isMenubarProcessStaleAgainstBundle,
   menubarHealReplacedBundle,
   menubarPlistNeedsRepoint,
@@ -188,6 +191,59 @@ describe('isMenubarStale', () => {
     expect(isMenubarStale({ installed: LOC('/src/MenubarHelper.app@111'), available: LOC('/src/MenubarHelper.app@222'), execExists: true })).toBe(true);
   });
 
+  it('stamps from the SAME resolved source the installer uses', () => {
+    // The blocker this replaces: startMenubarServiceFromSource stamped
+    // `stampFor(opts.sourceAppPath)` — the UNRESOLVED parameter — while
+    // ensureMenubarAppInstalled resolved `opts.sourceAppPath ?? sourceAppPath()`
+    // itself. On the self-heal path (which passes nothing) that installed a
+    // LOCAL build while stamping a RELEASE version; the next invocation saw a
+    // kind mismatch and reinstalled, forever. Asserted on the source because the
+    // composition, not either function alone, is what was wrong.
+    const src = fs.readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), 'install-menubar.ts'),
+      'utf-8',
+    );
+    const start = src.indexOf('function startMenubarServiceFromSource');
+    expect(start).toBeGreaterThan(-1);
+    const fn = src.slice(start, src.indexOf('\nfunction ', start + 10));
+    expect(fn.length).toBeGreaterThan(200);
+    // One resolution, reused — never the raw option in either position.
+    expect(fn).toContain('const src = opts.sourceAppPath ?? sourceAppPath()');
+    expect(fn).toContain('sourceAppPath: src');
+    expect(fn).toContain('stampFor(src)');
+    expect(fn).not.toContain('stampFor(opts.sourceAppPath)');
+  });
+
+  it('classifies a release only when the bundle is really in its cache dir', () => {
+    // A path regex got this wrong both ways: a checkout under any directory with
+    // a version-shaped segment read as a release, and vice versa.
+    const cacheFor = (v: string) => `/cache/menubar/mac-helper/v${v}`;
+    expect(releaseVersionOfCachedBundle('/cache/menubar/mac-helper/v1.0.1/MenubarHelper.app', cacheFor)).toBe('1.0.1');
+    // Version-shaped, but not the cache — a checkout, not a release.
+    expect(releaseVersionOfCachedBundle('/Users/me/src/v1.0.1/menubar/MenubarHelper.app', cacheFor)).toBeNull();
+    // No version at all.
+    expect(releaseVersionOfCachedBundle('/Users/me/src/agents-cli/cli/menubar/MenubarHelper.app', cacheFor)).toBeNull();
+  });
+
+  it('stampFor uses the real cache dir, not a path pattern', () => {
+    // Mutation-driven: making stampFor always return `local` killed no test,
+    // because the classifier was only exercised through an injected cache
+    // function. This drives stampFor itself against the REAL cache path.
+    const inCache = path.join(menubarHelperCacheDir('1.0.1'), 'MenubarHelper.app');
+    expect(stampFor(inCache)).toEqual({ source: 'release', helperVersion: '1.0.1' });
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mb-v1.0.1-'));
+    const local = path.join(dir, 'MenubarHelper.app');
+    fs.mkdirSync(local);
+    try {
+      const st = stampFor(local);
+      expect(st.source).toBe('local');
+      if (st.source === 'local') expect(st.sourceStamp.startsWith(`${local}@`)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('never compares against the CLI version', () => {
     // The bug this replaces: an unchanged helper looked stale on every CLI
     // release (the #2109 restart storm), and a newer helper at the same CLI
@@ -196,7 +252,15 @@ describe('isMenubarStale', () => {
       path.join(path.dirname(fileURLToPath(import.meta.url)), 'install-menubar.ts'),
       'utf-8',
     );
-    const fn = src.slice(src.indexOf('export function isMenubarStale'), src.indexOf('function menubarSetupStale'));
+    const start = src.indexOf('export function isMenubarStale');
+    const end = src.indexOf('function menubarSetupStale');
+    // Guard the guard: if either marker is ever renamed the slice silently
+    // becomes empty or inverted, and `not.toContain` passes vacuously — the
+    // assertion would survive the very regression it exists to catch.
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const fn = src.slice(start, end);
+    expect(fn.length).toBeGreaterThan(200);
     expect(fn).not.toContain('getCliVersion');
   });
 });

--- a/cli/src/lib/menubar/install-menubar.test.ts
+++ b/cli/src/lib/menubar/install-menubar.test.ts
@@ -251,9 +251,18 @@ describe('isMenubarStale', () => {
     // never settled. Whatever the source, stamping it and then asking about the
     // same source must say "not stale", or the self-heal reinstalls forever.
     //
-    // This is the testable core of installMenubarLaunchAgentOnUpgrade. Driving
-    // that function end to end would need codesign/spctl/launchctl stubbed,
-    // which this repo forbids — so the invariant is asserted where it lives.
+    // Scope, stated honestly: this does NOT catch the original blocker. That bug
+    // lived in the CALLER's composition — install stamped one input while the
+    // check derived from another — and is caught by the source assertion in
+    // `stamps from the SAME resolved source the installer uses`. Verified by
+    // mutation: making stampFor return a constant leaves THIS test green,
+    // because both sides then agree on the same wrong value.
+    //
+    // What it does pin is that stampFor is deterministic for a given input —
+    // the other half of convergence. A stampFor that varied run to run (a
+    // timestamp, a random temp path) would storm even with the caller correct.
+    // Driving installMenubarLaunchAgentOnUpgrade end to end would need
+    // codesign/spctl/launchctl stubbed, which this repo forbids.
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mb-converge-'));
     const local = path.join(dir, 'MenubarHelper.app');
     fs.mkdirSync(local);

--- a/cli/src/lib/menubar/install-menubar.test.ts
+++ b/cli/src/lib/menubar/install-menubar.test.ts
@@ -244,6 +244,30 @@ describe('isMenubarStale', () => {
     }
   });
 
+  it('converges: what an install stamps is not stale on the next invocation', () => {
+    // THE property a reinstall storm violates, stated directly. #2109 was not
+    // "the wrong version was compared" — it was that the value written at
+    // install time and the value computed at check time disagreed, so the check
+    // never settled. Whatever the source, stamping it and then asking about the
+    // same source must say "not stale", or the self-heal reinstalls forever.
+    //
+    // This is the testable core of installMenubarLaunchAgentOnUpgrade. Driving
+    // that function end to end would need codesign/spctl/launchctl stubbed,
+    // which this repo forbids — so the invariant is asserted where it lives.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mb-converge-'));
+    const local = path.join(dir, 'MenubarHelper.app');
+    fs.mkdirSync(local);
+    try {
+      for (const source of [local, path.join(menubarHelperCacheDir('1.0.1'), 'MenubarHelper.app')]) {
+        const written = stampFor(source);        // what install persists
+        const computed = stampFor(source);       // what the next check derives
+        expect(isMenubarStale({ installed: written, available: computed, execExists: true })).toBe(false);
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('never compares against the CLI version', () => {
     // The bug this replaces: an unchanged helper looked stale on every CLI
     // release (the #2109 restart storm), and a newer helper at the same CLI

--- a/cli/src/lib/menubar/install-menubar.test.ts
+++ b/cli/src/lib/menubar/install-menubar.test.ts
@@ -14,6 +14,7 @@ import {
   hasDeveloperIdSignature,
   installMenubarLaunchAgentOnUpgrade,
   isMenubarStale,
+  stampVersionLabel,
   LOCAL_BUILD_LABEL,
   releaseVersionOfCachedBundle,
   stampFor,
@@ -305,6 +306,49 @@ describe('isMenubarStale', () => {
     };
     expect(mayInstallMenubarHelper({ ...base, installedVersion: '1.0.0', currentVersion: LOCAL_BUILD_LABEL })).toBe(false);
     expect(mayInstallMenubarHelper({ ...base, installedVersion: LOCAL_BUILD_LABEL, currentVersion: '1.0.0' })).toBe(false);
+  });
+
+  it('a local rebuild is a real change, not two equal `local` labels', () => {
+    // Reviewer-found, third instance of one bug class: stampVersionLabel
+    // collapses EVERY local build to the literal 'local', discarding the mtime.
+    // Any comparison done through the label therefore reports "unchanged" across
+    // a genuine dev rebuild. The stamps themselves distinguish them.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mb-rebuild-'));
+    const app = path.join(dir, 'MenubarHelper.app');
+    fs.mkdirSync(app);
+    try {
+      const before = stampFor(app);
+      fs.utimesSync(app, new Date(), new Date(Date.now() + 60_000)); // rebuild
+      const after = stampFor(app);
+
+      // Through the lossy label the two are indistinguishable...
+      expect(stampVersionLabel(before)).toBe(stampVersionLabel(after));
+      // ...but the stamps are not, which is what the comparison must use.
+      expect(JSON.stringify(before)).not.toBe(JSON.stringify(after));
+      expect(isMenubarStale({ installed: before, available: after, execExists: true })).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("the setup bundle step compares stamps, not the lossy label", () => {
+    // Mutation-driven: the behavioural test above stays green even when the step
+    // label is computed through `stampVersionLabel`, because it exercises
+    // stampFor/isMenubarStale rather than the step itself. That step lives inside
+    // runMenubarSetup, which needs a signed bundle to reach — so the comparison
+    // is asserted at source, the same way the install/stamp composition is.
+    const src = fs.readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), 'install-menubar.ts'),
+      'utf-8',
+    );
+    // Anchor on the unique symbol, not `step('bundle'` — there are three of
+    // those and indexOf finds an error path, not the comparison under test.
+    const i = src.indexOf('const bundleUnchanged');
+    expect(i).toBeGreaterThan(-1);
+    const around = src.slice(i, src.indexOf("step('bundle'", i) + 200);
+    expect(around).toContain('JSON.stringify(availableStamp())');
+    expect(around).not.toMatch(/bundleUnchanged[\s\S]{0,120}stampVersionLabel\(bundleStamp\) ===/);
+    expect(around).not.toContain('=== getCliVersion()');
   });
 
   it('never compares against the CLI version', () => {
@@ -951,11 +995,16 @@ describe('isMenubarProcessStaleAgainstBundle', () => {
  *    synthetic bundle can never reach `installAndStartService`, and a real
  *    Developer-ID-signed one is not available in CI.
  *
- * So this pins the contract that IS reachable: under a redirected HOME the
- * function completes, registers nothing with the real service manager, and
- * leaves no stamp behind. That last part is the documented "stamp only a heal
- * that actually happened" rule — stamping a no-op would spend the shared
- * cooldown and lock every other install out for an hour having fixed nothing.
+ * What this ACTUALLY verifies, stated narrowly because the first version of
+ * this comment claimed more than the assertions did: on a checkout where
+ * `sourceAppPath()` finds no bundle the function returns at its first guard, so
+ * what is pinned is that it completes without throwing, twice, and registers
+ * nothing with the real service manager under a sandbox HOME. The stamp-marker
+ * path is asserted below rather than merely claimed here.
+ *
+ * It does NOT exercise install, verification, or the stamp-on-heal rule — those
+ * need a signed bundle. The regression class itself is closed structurally (one
+ * resolved `src`, used for both install and stamp) rather than by this test.
  */
 describe('installMenubarLaunchAgentOnUpgrade (driven, sandboxed)', () => {
   const savedHome = process.env.HOME;
@@ -985,6 +1034,11 @@ describe('installMenubarLaunchAgentOnUpgrade (driven, sandboxed)', () => {
       const launchAgents = path.join(home, 'Library', 'LaunchAgents');
       const plists = fs.existsSync(launchAgents) ? fs.readdirSync(launchAgents) : [];
       expect(plists.filter((f) => f.includes('menubar'))).toEqual([]);
+      // And no stamp — claimed in the docblock above, so actually checked.
+      const stamps = fs.existsSync(path.join(home, '.agents'))
+        ? fs.readdirSync(path.join(home, '.agents'), { recursive: true }) as string[]
+        : [];
+      expect(stamps.filter((f) => String(f).includes('menubar-version'))).toEqual([]);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/cli/src/lib/menubar/install-menubar.test.ts
+++ b/cli/src/lib/menubar/install-menubar.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { menubarHelperCacheDir } from './download-menubar.js';
+import { serviceManagerRegistrationAllowed } from '../service-manifest.js';
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -11,7 +12,9 @@ import {
   gatekeeperAssesses,
   generateServicePlist,
   hasDeveloperIdSignature,
+  installMenubarLaunchAgentOnUpgrade,
   isMenubarStale,
+  LOCAL_BUILD_LABEL,
   releaseVersionOfCachedBundle,
   stampFor,
   isMenubarProcessStaleAgainstBundle,
@@ -275,6 +278,33 @@ describe('isMenubarStale', () => {
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it('finds the cache match even when an earlier path segment looks like a version', () => {
+    // Reviewer-found: the classifier took the LEFTMOST version-shaped match, so
+    // a genuinely cached bundle under e.g. an nvm dir (`.../v24.15.0/...`)
+    // matched that segment, failed the prefix check, and read as a local build.
+    const cacheFor = (v: string) => `/Users/me/.nvm/versions/node/v24.15.0/cache/menubar/mac-helper/v${v}`;
+    expect(releaseVersionOfCachedBundle(`${cacheFor('1.0.1')}/MenubarHelper.app`, cacheFor)).toBe('1.0.1');
+  });
+
+  it('does not let a local build win or lose a version contest', () => {
+    // Reviewer-found: excluding LOCAL_BUILD_LABEL from the compareVersions arm
+    // had zero coverage — mutating it away killed nothing. `local` is a KIND
+    // marker; ordering it against real semver would let a dev build seize a
+    // release helper, or be refused by one, on a meaningless comparison.
+    const base = {
+      ownerEntryExists: true,
+      sourceIsDeveloperId: true,
+      plistEntry: '/a',
+      activeEntry: '/b',            // not the owner, so only a version arm could grant
+      helperExecMissing: false,
+      needsDevIdHeal: false,
+      msSinceLastHeal: 0,
+      cooldownMs: 3_600_000,
+    };
+    expect(mayInstallMenubarHelper({ ...base, installedVersion: '1.0.0', currentVersion: LOCAL_BUILD_LABEL })).toBe(false);
+    expect(mayInstallMenubarHelper({ ...base, installedVersion: LOCAL_BUILD_LABEL, currentVersion: '1.0.0' })).toBe(false);
   });
 
   it('never compares against the CLI version', () => {
@@ -905,5 +935,58 @@ describe('isMenubarProcessStaleAgainstBundle', () => {
 
   it('is still stale when the pid predates the bundle by a full second', () => {
     expect(isMenubarProcessStaleAgainstBundle(1_787_441_352_000, 1_787_441_353_700)).toBe(true);
+  });
+});
+
+/**
+ * Drives `installMenubarLaunchAgentOnUpgrade` for real — the function the
+ * #2109 storm lived in, and which had no test that executed it at all.
+ *
+ * Honest scope. Two things make a full convergence drive unreachable rather
+ * than merely awkward, and both are properties of the code, not the harness:
+ *  - `sourceAppPath()` resolves candidates relative to the MODULE's own
+ *    location, so a fake source cannot be planted via HOME; planting one would
+ *    mean writing into the source tree.
+ *  - the install path refuses any bundle that fails `codesign` + `spctl`, so a
+ *    synthetic bundle can never reach `installAndStartService`, and a real
+ *    Developer-ID-signed one is not available in CI.
+ *
+ * So this pins the contract that IS reachable: under a redirected HOME the
+ * function completes, registers nothing with the real service manager, and
+ * leaves no stamp behind. That last part is the documented "stamp only a heal
+ * that actually happened" rule — stamping a no-op would spend the shared
+ * cooldown and lock every other install out for an hour having fixed nothing.
+ */
+describe('installMenubarLaunchAgentOnUpgrade (driven, sandboxed)', () => {
+  const savedHome = process.env.HOME;
+  const savedRealHome = process.env.AGENTS_REAL_HOME;
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+    if (savedRealHome === undefined) delete process.env.AGENTS_REAL_HOME; else process.env.AGENTS_REAL_HOME = savedRealHome;
+  });
+
+  it('is a safe no-op under a sandbox HOME, and never registers a service', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-menubar-home-'));
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+    process.env.HOME = home;
+    process.env.AGENTS_REAL_HOME = home;
+    try {
+      // The seam is deliberately NOT set, so registration is refused — this
+      // asserts the guard rather than opting out of it.
+      expect(serviceManagerRegistrationAllowed().allowed).toBe(false);
+
+      // Twice: a storm is non-convergence, so one call proving nothing is the
+      // point of running it again.
+      expect(() => installMenubarLaunchAgentOnUpgrade()).not.toThrow();
+      expect(() => installMenubarLaunchAgentOnUpgrade()).not.toThrow();
+
+      // Nothing was registered and nothing was stamped under the sandbox HOME.
+      const launchAgents = path.join(home, 'Library', 'LaunchAgents');
+      const plists = fs.existsSync(launchAgents) ? fs.readdirSync(launchAgents) : [];
+      expect(plists.filter((f) => f.includes('menubar'))).toEqual([]);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/cli/src/lib/menubar/install-menubar.test.ts
+++ b/cli/src/lib/menubar/install-menubar.test.ts
@@ -346,7 +346,9 @@ describe('isMenubarStale', () => {
     const i = src.indexOf('const bundleUnchanged');
     expect(i).toBeGreaterThan(-1);
     const around = src.slice(i, src.indexOf("step('bundle'", i) + 200);
-    expect(around).toContain('JSON.stringify(availableStamp())');
+    // Must go through the canonical comparator on the full stamps...
+    expect(around).toContain('isMenubarStale({');
+    expect(around).toContain('available: availableStamp()');
     expect(around).not.toMatch(/bundleUnchanged[\s\S]{0,120}stampVersionLabel\(bundleStamp\) ===/);
     expect(around).not.toContain('=== getCliVersion()');
   });
@@ -1034,11 +1036,13 @@ describe('installMenubarLaunchAgentOnUpgrade (driven, sandboxed)', () => {
       const launchAgents = path.join(home, 'Library', 'LaunchAgents');
       const plists = fs.existsSync(launchAgents) ? fs.readdirSync(launchAgents) : [];
       expect(plists.filter((f) => f.includes('menubar'))).toEqual([]);
-      // And no stamp — claimed in the docblock above, so actually checked.
-      const stamps = fs.existsSync(path.join(home, '.agents'))
-        ? fs.readdirSync(path.join(home, '.agents'), { recursive: true }) as string[]
-        : [];
-      expect(stamps.filter((f) => String(f).includes('menubar-version'))).toEqual([]);
+      // And no stamp. Reviewer-found: this checked `<HOME>/.agents/`, which is
+      // not where the stamp goes at all — `installedVersionMarkerPath()` writes
+      // `<HOME>/Library/Application Support/agents-cli/.menubar-version`. The
+      // assertion passed because nothing is stamped here either way, i.e. for
+      // the wrong reason. Point it at the real path.
+      const marker = path.join(home, 'Library', 'Application Support', 'agents-cli', '.menubar-version');
+      expect(fs.existsSync(marker)).toBe(false);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/cli/src/lib/menubar/install-menubar.ts
+++ b/cli/src/lib/menubar/install-menubar.ts
@@ -605,12 +605,16 @@ export function releaseVersionOfCachedBundle(
   appPath: string,
   cacheDirFor: (v: string) => string = menubarHelperCacheDir,
 ): string | null {
-  const m = /v(\d+\.\d+\.\d+)/.exec(appPath);
-  if (!m) return null;
-  const expected = path.resolve(cacheDirFor(m[1]));
-  return path.resolve(appPath).startsWith(expected + path.sep) || path.resolve(appPath) === expected
-    ? m[1]
-    : null;
+  // Try EVERY version-shaped segment, not just the leftmost. A cached bundle
+  // under a home or mount path that itself contains an unrelated `vX.Y.Z`
+  // (an nvm dir, a versioned volume) would otherwise match that first segment,
+  // fail the prefix check, and be misclassified as a local build.
+  const resolved = path.resolve(appPath);
+  for (const m of appPath.matchAll(/v(\d+\.\d+\.\d+)/g)) {
+    const expected = path.resolve(cacheDirFor(m[1]));
+    if (resolved === expected || resolved.startsWith(expected + path.sep)) return m[1];
+  }
+  return null;
 }
 
 /**
@@ -1115,8 +1119,12 @@ export async function runMenubarSetup(): Promise<SetupResult> {
     step('bundle', 'failed', 'could not install the helper bundle');
     return { steps, configured: false, status: getMenubarStatus() };
   }
-  step('bundle', before.installedVersion === getCliVersion() ? 'ok' : 'changed',
-    `${installedAppPath()} (${getCliVersion()})`);
+  // The helper axis here too: this label read "ok" only when the installed
+  // helper's stamp happened to equal the CLI's version, which after this change
+  // is never true on a release install.
+  const bundleStamp = stampVersionLabel(readInstalledMenubarStamp());
+  step('bundle', bundleStamp === availableHelperLabel() ? 'ok' : 'changed',
+    `${installedAppPath()} (${bundleStamp ?? 'unknown'})`);
 
   if (!(codesignVerifies(installedAppPath()) && gatekeeperAssesses(installedAppPath()))) {
     step('signature', 'failed',

--- a/cli/src/lib/menubar/install-menubar.ts
+++ b/cli/src/lib/menubar/install-menubar.ts
@@ -26,7 +26,7 @@ import { getCliVersion, resolveAgentsBin, resolveInstalledLayout } from '../vers
 import { copyAppBundle, withInstallLock } from '../app-bundle-install.js';
 import { compareVersions } from '../agent-spec/primitives.js';
 import { namespacedServiceLabel, serviceManifestHomeEnv, serviceManagerRegistrationAllowed } from '../service-manifest.js';
-import { downloadMenubarHelperApp } from './download-menubar.js';
+import { downloadMenubarHelperApp, menubarHelperCacheDir } from './download-menubar.js';
 import { helperFloor } from '../helper-versions.js';
 
 const APP_BUNDLE_NAME = 'MenubarHelper.app';
@@ -107,6 +107,9 @@ function installedVersionMarkerPath(): string {
  * dev build has none (menubar/scripts/build.sh hardcodes CFBundleShortVersionString),
  * so it is identified by the source path + mtime it was copied from.
  */
+/** Version label for a bundle that has none of its own (a local dev build). */
+export const LOCAL_BUILD_LABEL = 'local';
+
 export type MenubarStamp =
   | { source: 'release'; helperVersion: string }
   | { source: 'local'; sourceStamp: string }
@@ -471,7 +474,16 @@ export function restartMenubarHelperAfterSwap(
  */
 function startMenubarServiceFromSource(opts: { clearOptOut?: boolean; sourceAppPath?: string } = {}): boolean {
   if (!onDarwin()) return false;
-  const exec = ensureMenubarAppInstalled({ forceReinstall: true, sourceAppPath: opts.sourceAppPath });
+  // Resolve the source HERE, once, and hand the SAME value to the installer and
+  // the stamp. Passing `opts.sourceAppPath` to both let them disagree: the
+  // installer falls back to `sourceAppPath()` internally, so on the self-heal
+  // path (which passes nothing) it would install a LOCAL build while the stamp
+  // recorded a release version. The next invocation then computed `local`, saw a
+  // kind mismatch, and reinstalled — every time, forever. That is the #2109
+  // storm this whole change exists to stop, so the two must read one variable.
+  const src = opts.sourceAppPath ?? sourceAppPath();
+  if (!src) return false;
+  const exec = ensureMenubarAppInstalled({ forceReinstall: true, sourceAppPath: src });
   if (!exec) return false;
 
   // Never bootstrap a helper macOS will reject at launch: an invalid signature
@@ -489,7 +501,7 @@ function startMenubarServiceFromSource(opts: { clearOptOut?: boolean; sourceAppP
   }
 
   if (opts.clearOptOut) clearMenubarOptOut();
-  installAndStartService(exec, stampFor(opts.sourceAppPath));
+  installAndStartService(exec, stampFor(src));
   return true;
 }
 
@@ -549,24 +561,56 @@ function stampVersionLabel(stamp: MenubarStamp | null): string | null {
   if (!stamp) return null;
   if (stamp.source === 'release') return stamp.helperVersion;
   if (stamp.source === 'legacy') return null;
-  return 'local';
+  return LOCAL_BUILD_LABEL;
 }
 
-/** The helper version this install would put on disk right now. */
+/** What this install would put on disk right now, as a stamp. */
+function availableStamp(): MenubarStamp {
+  const src = sourceAppPath();
+  // No local bundle means the release path: what would be installed is the
+  // helper version the floor names.
+  return src ? stampFor(src) : { source: 'release', helperVersion: helperFloor('menubar') };
+}
+
+/** The helper version this install would put on disk right now, for display. */
 function availableHelperLabel(): string {
-  return stampVersionLabel(stampFor(sourceAppPath() ?? undefined)) ?? 'local';
+  return stampVersionLabel(availableStamp()) ?? LOCAL_BUILD_LABEL;
 }
 
-/** Identify the bundle about to be installed, for the stamp. */
-function stampFor(sourceAppPath: string | undefined): MenubarStamp {
-  if (!sourceAppPath) return { source: 'release', helperVersion: helperFloor('menubar') };
-  // A cache path under the helper cache dir IS a release bundle; anything else
-  // is a local build with no meaningful version of its own.
-  const m = /[/\\]v(\d+\.\d+\.\d+)[/\\]/.exec(sourceAppPath);
-  if (m) return { source: 'release', helperVersion: m[1] };
+/**
+ * Identify the bundle about to be installed, for the stamp.
+ *
+ * A bundle is a RELEASE iff it sits under the helper's own download cache —
+ * asked of `menubarHelperCacheDir`, not pattern-matched out of the path. A regex
+ * for `/v<x.y.z>/` gets this wrong in both directions: a checkout living under
+ * any directory that happens to contain a version-shaped segment reads as a
+ * release, and a release cache laid out differently reads as local. Either
+ * misclassification flips `source` between invocations, and a kind change is
+ * unconditionally stale — which is a reinstall loop.
+ */
+export function stampFor(resolvedSourceAppPath: string): MenubarStamp {
+  const version = releaseVersionOfCachedBundle(resolvedSourceAppPath);
+  if (version) return { source: 'release', helperVersion: version };
   let mtime = 0;
-  try { mtime = fs.statSync(sourceAppPath).mtimeMs; } catch { /* best effort */ }
-  return { source: 'local', sourceStamp: `${sourceAppPath}@${mtime}` };
+  try { mtime = fs.statSync(resolvedSourceAppPath).mtimeMs; } catch { /* best effort */ }
+  return { source: 'local', sourceStamp: `${resolvedSourceAppPath}@${mtime}` };
+}
+
+/**
+ * The helper version a path denotes, iff it is inside that version's cache dir.
+ * Returns null for anything else — including a version-shaped path that is not
+ * actually the cache.
+ */
+export function releaseVersionOfCachedBundle(
+  appPath: string,
+  cacheDirFor: (v: string) => string = menubarHelperCacheDir,
+): string | null {
+  const m = /v(\d+\.\d+\.\d+)/.exec(appPath);
+  if (!m) return null;
+  const expected = path.resolve(cacheDirFor(m[1]));
+  return path.resolve(appPath).startsWith(expected + path.sep) || path.resolve(appPath) === expected
+    ? m[1]
+    : null;
 }
 
 /**
@@ -606,7 +650,7 @@ export function isMenubarStale(opts: {
 function menubarSetupStale(): boolean {
   return isMenubarStale({
     installed: readInstalledMenubarStamp(),
-    available: stampFor(sourceAppPath() ?? undefined),
+    available: availableStamp(),
     execExists: fs.existsSync(installedExecutablePath()),
   });
 }
@@ -776,8 +820,16 @@ export function mayInstallMenubarHelper(opts: {
   // plist of a helper that is already present and working — the menu bar keeps
   // running, nothing deadlocks.
   if (!opts.ownerEntryExists) return opts.sourceIsDeveloperId;
-  if (opts.installedVersion && opts.currentVersion) {
-    const versionOrder = compareVersions(opts.currentVersion, opts.installedVersion);
+  // `local` is a KIND marker, not a version — a dev build has none. Comparing it
+  // with compareVersions would order it against real semver arbitrarily and let a
+  // dev build win (or lose) a contest it should not enter. When either side is a
+  // local build the version arm is skipped entirely and the owner arm decides,
+  // which is the correct outcome: ownership, not version, distinguishes them.
+  const comparableVersions =
+    opts.installedVersion && opts.currentVersion &&
+    opts.installedVersion !== LOCAL_BUILD_LABEL && opts.currentVersion !== LOCAL_BUILD_LABEL;
+  if (comparableVersions) {
+    const versionOrder = compareVersions(opts.currentVersion!, opts.installedVersion!);
     if (versionOrder > 0) return opts.sourceIsDeveloperId;
     if (versionOrder < 0) return false;
     return opts.plistEntry === opts.activeEntry;
@@ -1339,7 +1391,13 @@ export function buildMenubarDoctorReport(): MenubarDoctorReport {
     installedVersion: status.installedVersion,
     currentVersion: status.currentVersion,
     cliVersion: status.cliVersion,
-    versionMatches: status.installedVersion === status.currentVersion,
+    // Two local builds are not a version "mismatch" — neither carries a version.
+    // Reporting one told the user to run `setup` for a difference that does not
+    // exist, which is what made the old hint fire forever.
+    versionMatches:
+      status.installedVersion === LOCAL_BUILD_LABEL && status.currentVersion === LOCAL_BUILD_LABEL
+        ? true
+        : status.installedVersion === status.currentVersion,
     signingIdentity,
     running: status.running,
     staleRunningProcess,

--- a/cli/src/lib/menubar/install-menubar.ts
+++ b/cli/src/lib/menubar/install-menubar.ts
@@ -99,12 +99,41 @@ function installedVersionMarkerPath(): string {
   return path.join(installDir(), '.menubar-version');
 }
 
-function readInstalledMenubarVersion(): string | null {
+/**
+ * What the installed helper IS — deliberately not the CLI's version.
+ *
+ * `source` matters because the two install paths have different notions of
+ * "changed": a release bundle is identified by its helper version, while a local
+ * dev build has none (menubar/scripts/build.sh hardcodes CFBundleShortVersionString),
+ * so it is identified by the source path + mtime it was copied from.
+ */
+export type MenubarStamp =
+  | { source: 'release'; helperVersion: string }
+  | { source: 'local'; sourceStamp: string }
+  | { source: 'legacy'; raw: string };
+
+/**
+ * Read the stamp, tolerating the pre-JSON format.
+ *
+ * Older installs wrote a bare version string — and wrote the CLI's version into
+ * it, which is the bug this replaces. Such a stamp cannot be compared on the
+ * helper axis at all, so it reports `legacy` and is treated as stale exactly
+ * once, which re-stamps it in the new format. That mirrors the existing
+ * null-is-stale rule and is why the migration cannot loop.
+ */
+function readInstalledMenubarStamp(): MenubarStamp | null {
+  let raw: string;
   try {
-    return fs.readFileSync(installedVersionMarkerPath(), 'utf-8').trim() || null;
+    raw = fs.readFileSync(installedVersionMarkerPath(), 'utf-8').trim();
   } catch {
     return null;
   }
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as MenubarStamp;
+    if (parsed && (parsed.source === 'release' || parsed.source === 'local')) return parsed;
+  } catch { /* fall through to legacy */ }
+  return { source: 'legacy', raw };
 }
 
 /** Executable inside the installed bundle. */
@@ -460,7 +489,7 @@ function startMenubarServiceFromSource(opts: { clearOptOut?: boolean; sourceAppP
   }
 
   if (opts.clearOptOut) clearMenubarOptOut();
-  installAndStartService(exec);
+  installAndStartService(exec, stampFor(opts.sourceAppPath));
   return true;
 }
 
@@ -498,35 +527,86 @@ function clearMenubarOptOut(): void {
  * particular is what the upgrade self-heal reads to decide staleness, and a
  * path that skipped it would make every later `agents` invocation reinstall.
  */
-function installAndStartService(exec: string): void {
+function installAndStartService(exec: string, stamp: MenubarStamp): void {
   const plist = servicePlistPath();
   fs.mkdirSync(path.dirname(plist), { recursive: true });
   fs.writeFileSync(plist, generateServicePlist(exec));
   restartMenubarLaunchAgent(process.getuid?.() ?? 0, plist);
-  try { fs.writeFileSync(installedVersionMarkerPath(), getCliVersion()); } catch { /* best effort */ }
+  try {
+    fs.writeFileSync(installedVersionMarkerPath(), JSON.stringify(stamp));
+  } catch { /* best effort */ }
 }
 
 /**
- * Pure staleness decision (no I/O) so the truth table is unit-testable. The
- * installed service is stale when the helper binary is gone, or when it was
- * installed by a different CLI version than the one now running — a version
- * change is the signal that the plist's baked interpreter/entry/bundle paths
- * and the helper binary itself may have drifted. A null installedVersion
- * (pre-stamp install) counts as stale so old installs get re-stamped once.
+ * Render a stamp as a comparable/displayable version string.
+ *
+ * A local build has no version of its own, so it reports `local`; the ownership
+ * contest treats that as "not comparable" and falls through to its owner arm,
+ * which is the correct outcome — a dev build must never win a version contest
+ * against a release.
+ */
+function stampVersionLabel(stamp: MenubarStamp | null): string | null {
+  if (!stamp) return null;
+  if (stamp.source === 'release') return stamp.helperVersion;
+  if (stamp.source === 'legacy') return null;
+  return 'local';
+}
+
+/** The helper version this install would put on disk right now. */
+function availableHelperLabel(): string {
+  return stampVersionLabel(stampFor(sourceAppPath() ?? undefined)) ?? 'local';
+}
+
+/** Identify the bundle about to be installed, for the stamp. */
+function stampFor(sourceAppPath: string | undefined): MenubarStamp {
+  if (!sourceAppPath) return { source: 'release', helperVersion: helperFloor('menubar') };
+  // A cache path under the helper cache dir IS a release bundle; anything else
+  // is a local build with no meaningful version of its own.
+  const m = /[/\\]v(\d+\.\d+\.\d+)[/\\]/.exec(sourceAppPath);
+  if (m) return { source: 'release', helperVersion: m[1] };
+  let mtime = 0;
+  try { mtime = fs.statSync(sourceAppPath).mtimeMs; } catch { /* best effort */ }
+  return { source: 'local', sourceStamp: `${sourceAppPath}@${mtime}` };
+}
+
+/**
+ * Pure staleness decision (no I/O) so the truth table is unit-testable.
+ *
+ * This compares the HELPER axis, not the CLI's. It used to compare the installed
+ * stamp against `getCliVersion()`, which was wrong in both directions once the
+ * helpers gained their own version line: every CLI release made an unchanged
+ * helper look stale and reinstalled it (the #2109 restart storm), while a
+ * genuinely newer helper at the same CLI version never looked stale at all.
+ *
+ * Stale when: the executable is gone; nothing is stamped; the stamp predates the
+ * JSON format (`legacy` — re-stamped once); the install KIND changed
+ * (local <-> release), since a dev build and a release bundle are not
+ * interchangeable; a release install whose available helper version is newer;
+ * or a local install whose source path or mtime moved.
  */
 export function isMenubarStale(opts: {
-  installedVersion: string | null;
-  currentVersion: string;
+  installed: MenubarStamp | null;
+  available: MenubarStamp;
   execExists: boolean;
 }): boolean {
   if (!opts.execExists) return true;
-  return opts.installedVersion !== opts.currentVersion;
+  const { installed, available } = opts;
+  if (!installed) return true;
+  if (installed.source === 'legacy') return true;
+  if (installed.source !== available.source) return true;
+  if (installed.source === 'release' && available.source === 'release') {
+    return compareVersions(available.helperVersion, installed.helperVersion) > 0;
+  }
+  if (installed.source === 'local' && available.source === 'local') {
+    return installed.sourceStamp !== available.sourceStamp;
+  }
+  return true;
 }
 
 function menubarSetupStale(): boolean {
   return isMenubarStale({
-    installedVersion: readInstalledMenubarVersion(),
-    currentVersion: getCliVersion(),
+    installed: readInstalledMenubarStamp(),
+    available: stampFor(sourceAppPath() ?? undefined),
     execExists: fs.existsSync(installedExecutablePath()),
   });
 }
@@ -762,8 +842,8 @@ function mayHealMenubar(needsDevIdHeal: boolean): boolean {
     ownerEntryExists: Boolean(plistEntry) && fs.existsSync(plistEntry as string),
     helperExecMissing: !fs.existsSync(installedExecutablePath()),
     needsDevIdHeal,
-    installedVersion: readInstalledMenubarVersion(),
-    currentVersion: getCliVersion(),
+    installedVersion: stampVersionLabel(readInstalledMenubarStamp()),
+    currentVersion: availableHelperLabel(),
     msSinceLastHeal: msSinceLastMenubarHeal(),
     cooldownMs: MENUBAR_TAKEOVER_COOLDOWN_MS,
     sourceIsDeveloperId: Boolean(src) && hasDeveloperIdSignature(src as string),
@@ -998,7 +1078,7 @@ export async function runMenubarSetup(): Promise<SetupResult> {
   // menu bar, so a stale `menubar disable` must not silently win.
   clearMenubarOptOut();
 
-  installAndStartService(exec);
+  installAndStartService(exec, stampFor(src ?? undefined));
   step('login item', before.serviceInstalled ? 'ok' : 'changed',
     `${serviceLabel()} — starts at login, restarts if it dies`);
 
@@ -1096,8 +1176,12 @@ export interface MenubarStatus {
   platform: string;
   source: string | null;
   installedApp: string | null;
+  /** The installed HELPER's version — not the CLI's. `local` for a dev build. */
   installedVersion: string | null;
+  /** The helper version this install would put on disk right now. */
   currentVersion: string;
+  /** The CLI's own version, reported separately so the two are never conflated. */
+  cliVersion: string;
   stale: boolean;
   serviceInstalled: boolean;
   running: boolean;
@@ -1127,8 +1211,9 @@ export function getMenubarStatus(): MenubarStatus {
     platform: process.platform,
     source: sourceAppPath(),
     installedApp: fs.existsSync(dest) ? dest : null,
-    installedVersion: readInstalledMenubarVersion(),
-    currentVersion: getCliVersion(),
+    installedVersion: stampVersionLabel(readInstalledMenubarStamp()),
+    currentVersion: availableHelperLabel(),
+    cliVersion: getCliVersion(),
     stale: onDarwin() && serviceInstalled && menubarSetupStale(),
     serviceInstalled,
     running: own.length > 0,
@@ -1142,8 +1227,13 @@ export function getMenubarStatus(): MenubarStatus {
 export interface MenubarDoctorReport {
   platform: string;
   installPath: string | null;
+  /** The installed HELPER's version — not the CLI's. `local` for a dev build. */
   installedVersion: string | null;
+  /** The helper version this install would put on disk right now. */
   currentVersion: string;
+  /** The CLI's own version, reported separately so the two are never conflated. */
+  cliVersion: string;
+  /** installed helper vs available helper. Never compares the CLI's version. */
   versionMatches: boolean;
   /** `unknown` on non-darwin or when nothing is installed to inspect. */
   signingIdentity: 'developer-id' | 'ad-hoc' | 'unknown';
@@ -1214,6 +1304,7 @@ export function buildMenubarDoctorReport(): MenubarDoctorReport {
       installPath: null,
       installedVersion: null,
       currentVersion: getCliVersion(),
+      cliVersion: getCliVersion(),
       versionMatches: false,
       signingIdentity: 'unknown',
       running: false,
@@ -1247,6 +1338,7 @@ export function buildMenubarDoctorReport(): MenubarDoctorReport {
     installPath: appPath,
     installedVersion: status.installedVersion,
     currentVersion: status.currentVersion,
+    cliVersion: status.cliVersion,
     versionMatches: status.installedVersion === status.currentVersion,
     signingIdentity,
     running: status.running,

--- a/cli/src/lib/menubar/install-menubar.ts
+++ b/cli/src/lib/menubar/install-menubar.ts
@@ -557,7 +557,7 @@ function installAndStartService(exec: string, stamp: MenubarStamp): void {
  * which is the correct outcome — a dev build must never win a version contest
  * against a release.
  */
-function stampVersionLabel(stamp: MenubarStamp | null): string | null {
+export function stampVersionLabel(stamp: MenubarStamp | null): string | null {
   if (!stamp) return null;
   if (stamp.source === 'release') return stamp.helperVersion;
   if (stamp.source === 'legacy') return null;
@@ -1122,9 +1122,18 @@ export async function runMenubarSetup(): Promise<SetupResult> {
   // The helper axis here too: this label read "ok" only when the installed
   // helper's stamp happened to equal the CLI's version, which after this change
   // is never true on a release install.
-  const bundleStamp = stampVersionLabel(readInstalledMenubarStamp());
-  step('bundle', bundleStamp === availableHelperLabel() ? 'ok' : 'changed',
-    `${installedAppPath()} (${bundleStamp ?? 'unknown'})`);
+  //
+  // Compare the STAMPS, not their labels. `stampVersionLabel` collapses every
+  // local build to the literal 'local', discarding the mtime — so a real dev
+  // rebuild (which the surrounding logic does correctly reinstall) would print
+  // "ok" and hide that anything changed. That is the same collapse already
+  // excluded in `versionMatches` and `mayInstallMenubarHelper`; this was the
+  // third site and the only one still reading through the lossy label.
+  const bundleStamp = readInstalledMenubarStamp();
+  const bundleUnchanged =
+    bundleStamp !== null && JSON.stringify(bundleStamp) === JSON.stringify(availableStamp());
+  step('bundle', bundleUnchanged ? 'ok' : 'changed',
+    `${installedAppPath()} (${stampVersionLabel(bundleStamp) ?? 'unknown'})`);
 
   if (!(codesignVerifies(installedAppPath()) && gatekeeperAssesses(installedAppPath()))) {
     step('signature', 'failed',

--- a/cli/src/lib/menubar/install-menubar.ts
+++ b/cli/src/lib/menubar/install-menubar.ts
@@ -1130,8 +1130,13 @@ export async function runMenubarSetup(): Promise<SetupResult> {
   // excluded in `versionMatches` and `mayInstallMenubarHelper`; this was the
   // third site and the only one still reading through the lossy label.
   const bundleStamp = readInstalledMenubarStamp();
+  // Reuse the file's canonical comparator rather than a second, serialization
+  // -based one: `JSON.stringify` was sound only because both stamps come from
+  // `stampFor`, which is an implicit key-order dependency with no reason to
+  // exist when isMenubarStale already answers exactly this question.
   const bundleUnchanged =
-    bundleStamp !== null && JSON.stringify(bundleStamp) === JSON.stringify(availableStamp());
+    bundleStamp !== null &&
+    !isMenubarStale({ installed: bundleStamp, available: availableStamp(), execExists: true });
   step('bundle', bundleUnchanged ? 'ok' : 'changed',
     `${installedAppPath()} (${stampVersionLabel(bundleStamp) ?? 'unknown'})`);
 


### PR DESCRIPTION
Phase 1 of the helper auto-update work. **This must land before the version resolver**, not after — see below.

## The bug

`installAndStartService` stamped `getCliVersion()` as the installed *helper's* version (`install-menubar.ts:506`), and `menubarSetupStale()` compared against `getCliVersion()` too (`:529`). Once the helpers gained their own version line, that is wrong in both directions:

- **Every CLI release made an unchanged helper look stale**, so it was reinstalled — recopying the bundle out from under the running helper, which `KeepAlive` then restarts. That is the #2109 storm `cli/AGENTS.md` documents at length: a new pid every 5–15s, 578 launches in one helper log, a status item that never stayed visible.
- **A genuinely newer helper at the same CLI version never looked stale**, so it could never install. Which is exactly the capability this whole track is supposed to deliver.

## Why the ordering matters

This is why it cannot ship after the resolver. Change only the *resolve* side and the stamp becomes `1.0.0` (helper) while `currentVersion` stays `1.22.x` (CLI) — never equal — so the storm fires on **every darwin invocation**. Fixing the axis first makes the resolver a safe no-op change on top.

## What changed

The stamp records what the helper actually **is**, as JSON:

```ts
type MenubarStamp =
  | { source: 'release'; helperVersion: string }
  | { source: 'local'; sourceStamp: string }   // path@mtime
  | { source: 'legacy'; raw: string };
```

`local` exists because `menubar/scripts/build.sh:170` hardcodes `CFBundleShortVersionString` to `0.1.0` — a dev build has no version to compare, so it is tracked by the source path + mtime it was copied from.

Staleness now compares like with like: a newer available helper, a changed local source, a changed install **kind** (local ↔ release — a dev build and a release bundle are not interchangeable), or a missing executable. It will **not** downgrade when the installed helper is ahead of the floor.

A pre-JSON stamp reports `legacy` and is stale exactly once, which re-stamps it in the new format — mirroring the existing null-is-stale rule, which is why the migration cannot loop.

## Surfaces

`agents menubar status` / `doctor` printed two values and called one of them "CLI version" while it held a helper version. They now print three labelled lines — helper installed / helper available / CLI version — and the permanently-false `(mismatch — agents menubar setup updates it)` hint is gone. It fired forever on any npm install, telling users to run a command that fixed nothing.

## Tests

The old truth table asserted the CLI-axis shape. Three of its four cases would have kept "passing" against the new signature **for the wrong reason** — an old-shape object leaves `installed` undefined, which returns stale unconditionally. Test files are excluded from the type-check, so `tsc` did not catch it. Rewritten with real cases: newer-available, ahead-of-floor, kind change, local mtime, legacy migration.

Includes a guard asserting `isMenubarStale`'s body never mentions `getCliVersion`, so the axis cannot silently revert.

Mutation — restoring the CLI comparison — kills 3 cases:

```
× is NOT stale when the installed helper is newer than the floor
× is NOT stale when the helper version matches and the binary is present
× never compares against the CLI version
Tests  3 failed | 69 passed (72)
```

Consumers enumerated rather than hand-picked (the habit that cost four review rounds on #3098): every test file referencing the changed surfaces — **16 files, 465 tests, green.** `tsc --noEmit` clean.

## Not in this PR

`ssh-tunnel.ts:203` builds an "asset missing" error naming `v<version>` instead of `helperTag(...)`, and imports `getCliVersion` without ever calling it. Same axis, different file — deliberately separate so this diff stays reviewable.
