### PR TITLE
fix(statusline): stop a delegate fork bomb from the Claude status-line command

### DIFF
--- a/cli/.changelog/next/statusline-fork-bomb.md
+++ b/cli/.changelog/next/statusline-fork-bomb.md
@@ -1,0 +1,15 @@
+- **Claude status-line delegate no longer fork-bombs the machine.** The delegate
+  self-reference guard compared the saved command against the exact literal
+  `agents __claude-statusline`, so a delegate seeded with the same private
+  subcommand under a *different* binary name (e.g. `agents-dev __claude-statusline`
+  from a dev install, or an absolute path) was not recognized as us. Every
+  status-line render then `spawnSync`ed that command, which read the same delegate
+  and spawned another — unbounded recursion. Observed on a real box: ~4,900 live
+  `node __claude-statusline` processes accumulated over a 2-day uptime, exhausting
+  96 GB of swap and driving load past 300, so keystrokes lagged. The guard now
+  matches the `__claude-statusline` subcommand under any binary name or path
+  (`isStatusLineSelfReference`), `installClaudeStatusLine` refuses to persist such
+  a command as a delegate (and deletes an already-poisoned delegate on re-install),
+  a `AGENTS_CLAUDE_STATUSLINE_DELEGATED` env marker hard-caps delegation at one hop,
+  and the delegate `spawnSync` now carries a 5 s timeout. Source:
+  `apps/cli/src/lib/claude-statusline.ts`.

--- a/cli/.changelog/next/statusline-fork-bomb.md
+++ b/cli/.changelog/next/statusline-fork-bomb.md
@@ -12,4 +12,4 @@
   a command as a delegate (and deletes an already-poisoned delegate on re-install),
   a `AGENTS_CLAUDE_STATUSLINE_DELEGATED` env marker hard-caps delegation at one hop,
   and the delegate `spawnSync` now carries a 5 s timeout. Source:
-  `apps/cli/src/lib/claude-statusline.ts`.
+  `cli/src/lib/claude-statusline.ts`.

--- a/cli/src/lib/claude-statusline.test.ts
+++ b/cli/src/lib/claude-statusline.test.ts
@@ -9,6 +9,7 @@ import {
   installClaudeStatusLine,
   isStatusLineSelfReference,
   renderClaudeStatusLine,
+  renderDelegate,
 } from './claude-statusline.js';
 import {
   readClaudeUsageCache,
@@ -179,6 +180,45 @@ describe('Claude native status line', () => {
 
     expect(installClaudeStatusLine(home)).toEqual({ changed: true });
     expect(fs.existsSync(delegate)).toBe(false);
+  });
+
+  it('renderDelegate runs a genuine external delegate and returns its output', () => {
+    const home = tempHome();
+    const delegate = path.join(home, '.agents', 'claude-statusline-delegate');
+    fs.mkdirSync(path.dirname(delegate), { recursive: true });
+    fs.writeFileSync(delegate, 'printf custom-status\n');
+    expect(renderDelegate('', home)).toBe('custom-status');
+  });
+
+  it('renderDelegate never SPAWNS a self-referencing delegate — the read-side fork-bomb guard', () => {
+    const home = tempHome();
+    const delegate = path.join(home, '.agents', 'claude-statusline-delegate');
+    const sentinel = path.join(home, 'delegate-was-spawned');
+    fs.mkdirSync(path.dirname(delegate), { recursive: true });
+    // A command that (a) IS a self-reference — it ends in our private subcommand
+    // — and (b) would create a sentinel file if it were ever executed. With the
+    // pre-fix exact-string guard this `agents-dev`-shaped command was spawned and
+    // recursed; the fix must return '' WITHOUT running it.
+    fs.writeFileSync(delegate, `sh -c 'touch "${sentinel}"' __claude-statusline\n`);
+    expect(renderDelegate('', home)).toBe('');
+    expect(fs.existsSync(sentinel)).toBe(false);
+  });
+
+  it('renderDelegate refuses a second hop when already running as a delegate (one-hop backstop)', () => {
+    const home = tempHome();
+    const delegate = path.join(home, '.agents', 'claude-statusline-delegate');
+    fs.mkdirSync(path.dirname(delegate), { recursive: true });
+    // A perfectly valid external producer — but the env marker says we are
+    // ourselves a delegate, so it must NOT be spawned (hard depth-1 cap).
+    fs.writeFileSync(delegate, 'printf should-not-run\n');
+    const prior = process.env.AGENTS_CLAUDE_STATUSLINE_DELEGATED;
+    process.env.AGENTS_CLAUDE_STATUSLINE_DELEGATED = '1';
+    try {
+      expect(renderDelegate('', home)).toBe('');
+    } finally {
+      if (prior === undefined) delete process.env.AGENTS_CLAUDE_STATUSLINE_DELEGATED;
+      else process.env.AGENTS_CLAUDE_STATUSLINE_DELEGATED = prior;
+    }
   });
 
   it('does not resurrect a removed custom status-line command', () => {

--- a/cli/src/lib/claude-statusline.test.ts
+++ b/cli/src/lib/claude-statusline.test.ts
@@ -7,6 +7,7 @@ import {
   CLAUDE_STATUSLINE_COMMAND,
   ingestClaudeStatusLineUsage,
   installClaudeStatusLine,
+  isStatusLineSelfReference,
   renderClaudeStatusLine,
 } from './claude-statusline.js';
 import {
@@ -126,6 +127,58 @@ describe('Claude native status line', () => {
       '/home/me/statusline.sh\n',
     );
     expect(installClaudeStatusLine(home)).toEqual({ changed: false });
+  });
+
+  it('recognizes our own subcommand under any binary name as a self-reference', () => {
+    // The exact production command, and the fork-bomb seeds: the same private
+    // subcommand under a different binary name or an absolute path.
+    expect(isStatusLineSelfReference(CLAUDE_STATUSLINE_COMMAND)).toBe(true);
+    expect(isStatusLineSelfReference('agents-dev __claude-statusline')).toBe(true);
+    expect(isStatusLineSelfReference('ag __claude-statusline')).toBe(true);
+    expect(isStatusLineSelfReference('/Users/me/.local/bin/agents-dev __claude-statusline')).toBe(true);
+    expect(isStatusLineSelfReference('  agents   __claude-statusline  ')).toBe(true);
+    // A genuine third-party producer is NOT a self-reference.
+    expect(isStatusLineSelfReference('/home/me/statusline.sh')).toBe(false);
+    expect(isStatusLineSelfReference('starship prompt')).toBe(false);
+    expect(isStatusLineSelfReference('')).toBe(false);
+  });
+
+  it('never saves our own command (under a dev binary name) as a delegate — the fork bomb', () => {
+    // Reproduces the seed of the fork bomb: settings.json points the status line
+    // at `agents-dev __claude-statusline`. installClaudeStatusLine must NOT
+    // preserve that as a delegate, or every render would spawn a copy that reads
+    // the same delegate and spawns another, without bound.
+    const home = tempHome();
+    const delegate = path.join(home, '.agents', 'claude-statusline-delegate');
+    const settingsPath = path.join(home, '.claude', 'settings.json');
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      statusLine: { type: 'command', command: 'agents-dev __claude-statusline' },
+    }));
+
+    expect(installClaudeStatusLine(home)).toEqual({ changed: true });
+    // No recursive delegate was written.
+    expect(fs.existsSync(delegate)).toBe(false);
+    // The command was canonicalized to the production entrypoint.
+    expect(JSON.parse(fs.readFileSync(settingsPath, 'utf8')).statusLine.command)
+      .toBe(CLAUDE_STATUSLINE_COMMAND);
+  });
+
+  it('deletes a pre-existing recursive delegate on re-install', () => {
+    // A box already poisoned by the bomb: the delegate file itself holds our own
+    // subcommand. Re-installing must remove it, not leave it to keep recursing.
+    const home = tempHome();
+    const delegate = path.join(home, '.agents', 'claude-statusline-delegate');
+    const settingsPath = path.join(home, '.claude', 'settings.json');
+    fs.mkdirSync(path.dirname(delegate), { recursive: true });
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(delegate, 'agents-dev __claude-statusline\n');
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      statusLine: { type: 'command', command: 'agents-dev __claude-statusline' },
+    }));
+
+    expect(installClaudeStatusLine(home)).toEqual({ changed: true });
+    expect(fs.existsSync(delegate)).toBe(false);
   });
 
   it('does not resurrect a removed custom status-line command', () => {

--- a/cli/src/lib/claude-statusline.ts
+++ b/cli/src/lib/claude-statusline.ts
@@ -10,6 +10,41 @@ import { mergeClaudeUsageCacheWindows, type UsageWindow } from './accounting/usa
 export const CLAUDE_STATUSLINE_COMMAND = 'agents __claude-statusline';
 const DELEGATE_FILE = path.join('.agents', 'claude-statusline-delegate');
 
+// The private subcommand this feature runs. It is only ever invoked internally,
+// so ANY command that contains it — under any binary name or path (`agents`,
+// `agents-dev`, `ag`, an absolute path, a wrapper) — IS this status-line
+// producer, and delegating to it recurses without bound. Match the subcommand,
+// not the exact `agents __claude-statusline` string, or a delegate seeded with a
+// differently-named binary (e.g. `agents-dev __claude-statusline`) fork-bombs the
+// machine: each render spawns a copy that reads the same delegate and spawns
+// another, forever.
+const STATUSLINE_SUBCOMMAND = '__claude-statusline';
+
+// Set on the child env before spawning a delegate. If it is already present we
+// are ourselves running as someone's delegate, so we refuse to delegate again —
+// a hard depth-1 backstop that bounds the blast radius even if a self-reference
+// somehow slips past isStatusLineSelfReference(). One hop is the contract:
+// installClaudeStatusLine only ever preserves a single prior command.
+const DELEGATE_GUARD_ENV = 'AGENTS_CLAUDE_STATUSLINE_DELEGATED';
+
+// A hung or slow delegate must never pin a status-line render open — the render
+// is re-invoked on every refresh, so an unbounded delegate accumulates processes.
+const DELEGATE_TIMEOUT_MS = 5_000;
+
+/**
+ * True when `command` re-invokes THIS status-line producer (our private
+ * `__claude-statusline` subcommand) under any binary name or path. Delegating to
+ * such a command is the fork bomb, so both the read side (renderDelegate) and the
+ * write side (installClaudeStatusLine) treat it as "not a real external
+ * producer" and never chain to it.
+ */
+export function isStatusLineSelfReference(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) return false;
+  if (trimmed === CLAUDE_STATUSLINE_COMMAND) return true;
+  return new RegExp(`(^|\\s)${STATUSLINE_SUBCOMMAND}(\\s|$)`).test(trimmed);
+}
+
 interface ClaudeStatusLinePayload {
   cwd?: string;
   workspace?: { current_dir?: string };
@@ -70,14 +105,17 @@ function delegatePath(versionHome: string): string {
 }
 
 function renderDelegate(payload: string, versionHome: string): string {
+  // Already running as a delegate hop — never spawn another. Hard recursion stop.
+  if (process.env[DELEGATE_GUARD_ENV]) return '';
   let command = '';
   try { command = fs.readFileSync(delegatePath(versionHome), 'utf8').trim(); } catch { return ''; }
-  if (!command || command === CLAUDE_STATUSLINE_COMMAND) return '';
+  if (!command || isStatusLineSelfReference(command)) return '';
   const result = spawnSync(command, {
     shell: true,
     input: payload,
     encoding: 'utf8',
-    env: process.env,
+    env: { ...process.env, [DELEGATE_GUARD_ENV]: '1' },
+    timeout: DELEGATE_TIMEOUT_MS,
   });
   return result.status === 0 ? result.stdout.trim() : '';
 }
@@ -136,10 +174,14 @@ export function installClaudeStatusLine(versionHome: string): { changed: boolean
       ? priorStatusLine.command.trim()
       : '';
     if (existing === CLAUDE_STATUSLINE_COMMAND) return { changed: false };
-    if (existing) {
+    if (existing && !isStatusLineSelfReference(existing)) {
+      // A genuine third-party status-line command → preserve it as a delegate.
       fs.mkdirSync(path.dirname(delegatePath(versionHome)), { recursive: true });
       atomicWriteFileSync(delegatePath(versionHome), `${existing}\n`);
     } else {
+      // Empty, or our own subcommand under a different binary name
+      // (`agents-dev __claude-statusline`, an absolute path, …). Saving that as a
+      // delegate is the fork bomb — never persist it. Drop any prior delegate.
       fs.rmSync(delegatePath(versionHome), { force: true });
     }
     settings.statusLine = {

--- a/cli/src/lib/claude-statusline.ts
+++ b/cli/src/lib/claude-statusline.ts
@@ -104,7 +104,7 @@ function delegatePath(versionHome: string): string {
   return path.join(versionHome, DELEGATE_FILE);
 }
 
-function renderDelegate(payload: string, versionHome: string): string {
+export function renderDelegate(payload: string, versionHome: string): string {
   // Already running as a delegate hop — never spawn another. Hard recursion stop.
   if (process.env[DELEGATE_GUARD_ENV]) return '';
   let command = '';


### PR DESCRIPTION
## What

The Claude status-line delegate (`cli/src/lib/claude-statusline.ts`) can recurse without bound and fork-bomb the machine.

`renderDelegate`'s self-reference guard compared the saved delegate command against the **exact literal** `CLAUDE_STATUSLINE_COMMAND = 'agents __claude-statusline'` (line 10). When the delegate was seeded with the *same private subcommand under a different binary name* — `agents-dev __claude-statusline` (a dev install), or an absolute path — the guard didn't recognize it as us. Every status-line render then `spawnSync`ed that command, which read the same delegate file and spawned another `… __claude-statusline`, forever.

## Evidence (from a real box — `zion`)

Profiled a machine the operator reported as sluggish. Load 28 on 18 cores, but the real damage was memory:

```
node processes:                4309   (idle fleet peers run ~0–40)
grouped by command:            4327  node … agents-dev __claude-statusline
swap:                          used = 96,740 M / 98,304 M   (free 1,563 M)
each statusline proc PPID:     a DIFFERENT statusline pid   (a chain, not accumulation)
delegate file contents:        agents-dev __claude-statusline   (× every version home)
`agents-dev` on that box:      symlink → `agents`  (so it runs identical code, reads the same delegate → infinite)
```

`sample` of a stuck process showed it blocked in the libuv event loop on an unresolved stream read (`uv__io_poll` → `LibuvStreamWrap::ReadStart`), never exiting.

After the scoped mitigation (remove the 9 recursive delegate files + reap the chain), on the same box:

```
node processes:   4309 → 40
swap used:        96,740 M → 9,331 M   (macOS reclaimed the swap file: 98 G → 10 G total)
1-min load:       decaying 369 → 267 → 210 → 166  (toward the 5-min avg)
```

## Root cause

`claude-statusline.ts:75` (before): `if (!command || command === CLAUDE_STATUSLINE_COMMAND) return '';` — an exact-string guard that a differently-named binary defeats. And `installClaudeStatusLine` (line 138–141) *saved* `agents-dev __claude-statusline` as the delegate in the first place, seeding the loop.

This is the same "unbounded repeating spawn is a machine-killer" class the menubar helper already learned (`cli/CLAUDE.md` → *Every CLI child the helper spawns is bounded…*), here from the CLI side.

## Fix

- **`isStatusLineSelfReference(command)`** — matches the `__claude-statusline` subcommand under **any** binary name or path. Both the read side (`renderDelegate`) and the write side (`installClaudeStatusLine`) use it.
- **`installClaudeStatusLine`** no longer persists a self-referencing command as a delegate, and **deletes an already-poisoned delegate** on re-install (self-heals a box already hit).
- **`AGENTS_CLAUDE_STATUSLINE_DELEGATED`** env marker hard-caps delegation at **one hop** — a backstop even if a self-reference slips the string check.
- The delegate `spawnSync` now carries a **5 s timeout** so a hung delegate can't pin a render open.

## Tests

`cli/src/lib/claude-statusline.test.ts` — 8 pass (5 existing + 3 new):

- `isStatusLineSelfReference` recognizes the subcommand under `agents-dev`, `ag`, an absolute path, and with extra whitespace; rejects genuine third-party producers.
- `installClaudeStatusLine` given `agents-dev __claude-statusline` in settings writes **no** recursive delegate and canonicalizes the command.
- Re-install **deletes** a pre-existing recursive delegate file.

```
Test Files  1 passed (1)
     Tests  8 passed (8)
```

## Related issue

Fixes phnx-labs/agents-cli#3105.