### PR TITLE
fix(computer-win): name the real helper tag when an asset is missing

### DIFF
--- a/cli/.changelog/next/RUSH-3230-wintag.md
+++ b/cli/.changelog/next/RUSH-3230-wintag.md
@@ -1,0 +1,8 @@
+- **The Windows helper's "asset missing" error names a tag that exists (RUSH-3230).**
+  `downloadWinHelperExe` built its error message from `` `v${version}` `` — the CLI's tag
+  shape — while the URL it had just tried came from `helperTag('computer-win', version)`.
+  So a genuine 404 sent the reader looking for `v1.0.0`, which does not exist, instead of
+  `computer-win/v1.0.0`, which does. The mac path was corrected when helpers moved to their
+  own tags; the Windows path was left behind. Also drops a `getCliVersion` import that had
+  no call site — the last trace of the old CLI-version coupling in that file.
+  Source: `cli/src/lib/computer/ssh-tunnel.ts`.

--- a/cli/src/lib/computer/ssh-tunnel.test.ts
+++ b/cli/src/lib/computer/ssh-tunnel.test.ts
@@ -256,8 +256,19 @@ describe('win helper release-asset download', () => {
 
   it('fails naming the exact tag checked when the release asset does not exist', async () => {
     // Real GitHub 404 — no fallback to any other tag is attempted.
+    //
+    // The assertion is anchored on the HELPER tag, not just the version. It used
+    // to match /v0\.0\.0-.../, which passes whether the message names
+    // `v<version>` (the CLI's tag shape, which is wrong and does not exist) or
+    // `computer-win/v<version>` — the second contains the first as a substring,
+    // so the test could not tell the bug from the fix.
+    // Anchored on the "for tag " PHRASE, not just the tag text. The message also
+    // embeds the asset URL, which contains `computer-win/v<version>` no matter
+    // what the tag variable holds — so a bare tag-text match reads the URL and
+    // passes whether the tag is right or wrong. Verified by mutation: reverting
+    // the tag to `v${version}` must fail this.
     await expect(downloadWinHelperExe('0.0.0-ssh-tunnel-no-such-tag')).rejects.toThrow(
-      /v0\.0\.0-ssh-tunnel-no-such-tag/,
+      /for tag computer-win\/v0\.0\.0-ssh-tunnel-no-such-tag/,
     );
   }, 30_000);
 });

--- a/cli/src/lib/computer/ssh-tunnel.ts
+++ b/cli/src/lib/computer/ssh-tunnel.ts
@@ -165,7 +165,7 @@ export function resolveWinHelperExe(): string | null {
   return null;
 }
 
-/** GitHub repo whose `v<version>` releases carry the exe as an asset. */
+/** GitHub repo whose `computer-win/v<version>` releases carry the exe as an asset. */
 export const WIN_HELPER_RELEASE_REPO = 'phnx-labs/agi-cli';
 
 /** Cache dir for downloaded helper exes, one subdir per release tag. */
@@ -173,7 +173,7 @@ export function winHelperCacheDir(version: string): string {
   return path.join(getCacheDir(), 'computer', 'win-helper', `v${version}`);
 }
 
-/** Release-asset URLs for the exe + its checksum at one exact `v<version>` tag. */
+/** Release-asset URLs for the exe + its checksum at one exact `computer-win/v<version>` tag. */
 export function winHelperAssetUrls(version: string): { exe: string; sha256: string } {
   // The helper's OWN tag, not the CLI's. This exe is not an .app bundle so it
   // cannot share helper-download.ts's zip/codesign machinery, but it had the
@@ -190,7 +190,7 @@ export function winHelperAssetUrls(version: string): { exe: string; sha256: stri
  */
 
 /**
- * Download the exe release asset for this CLI version, verify its sha256
+ * Download the exe release asset for this HELPER version, verify its sha256
  * against the published `.sha256` asset, and cache it under the agents cache
  * dir. Only the exact `computer-win/v<version>` tag is consulted — a missing
  * asset is a hard error naming that tag, never a silent fallback to another

--- a/cli/src/lib/computer/ssh-tunnel.ts
+++ b/cli/src/lib/computer/ssh-tunnel.ts
@@ -33,7 +33,6 @@ import { getDevice, type DeviceProfile } from '../devices/registry.js';
 import { deviceIdentityArgs, sshTargetFor } from '../devices/connect.js';
 import { hostNameFor } from '../devices/ssh-config.js';
 import { getCacheDir } from '../state.js';
-import { getCliVersion } from '../version.js';
 import { openComputerClient, resolveTcpEndpoint, type ComputerClient } from './computer-rpc.js';
 import { helperFloor, helperTag } from '../helper-versions.js';
 
@@ -193,19 +192,24 @@ export function winHelperAssetUrls(version: string): { exe: string; sha256: stri
 /**
  * Download the exe release asset for this CLI version, verify its sha256
  * against the published `.sha256` asset, and cache it under the agents cache
- * dir. Only the exact `v<version>` tag is consulted — a missing asset is a
- * hard error naming that tag, never a silent fallback to another release.
+ * dir. Only the exact `computer-win/v<version>` tag is consulted — a missing
+ * asset is a hard error naming that tag, never a silent fallback to another
+ * release. The version is the HELPER's own, not the CLI's.
  */
 export async function downloadWinHelperExe(version: string): Promise<string> {
   const cached = path.join(winHelperCacheDir(version), WIN_HELPER_EXE);
   if (fs.existsSync(cached)) return cached;
 
-  const tag = `v${version}`;
+  // The SAME tag the URL is built from. This said `v${version}` — the CLI's tag
+  // shape — while winHelperAssetUrls uses helperTag('computer-win', ...), so a
+  // missing asset sent you looking for a tag that does not exist. The mac path
+  // had this fixed already; the Windows path was left behind by the tag split.
+  const tag = helperTag('computer-win', version);
   const { exe: exeUrl, sha256: shaUrl } = winHelperAssetUrls(version);
   const missing = (status: number, url: string) =>
     new Error(
       `no ${WIN_HELPER_EXE} release asset for tag ${tag} (HTTP ${status} on ${url}). ` +
-        `The Windows helper ships as a GitHub release asset per tagged CLI version; ` +
+        `The Windows helper ships as a GitHub release asset on its own helper tag; ` +
         `from a repo checkout you can build it locally instead: bash scripts/build-win.sh`,
     );
 


### PR DESCRIPTION
The two `ssh-tunnel.ts` items deliberately deferred from #3101, now that it has merged.

## The error named a tag that does not exist

`downloadWinHelperExe` built its failure message from `` `v${version}` `` — the CLI's tag shape — while the URL it had just requested came from `helperTag('computer-win', version)`:

```
no computer-helper-win.exe release asset for tag v1.0.0 (HTTP 404 on
  https://github.com/.../releases/download/computer-win/v1.0.0/computer-helper-win.exe)
```

So a real 404 sent the reader hunting for `v1.0.0`, which does not exist, while the thing they wanted was `computer-win/v1.0.0` — visible in the same sentence, from the URL. The mac path was corrected when helpers moved to their own tags; the Windows path was missed.

Also removes `import { getCliVersion }` — referenced exactly once (the import) and called zero times. The last trace of the old CLI-version coupling in that file.

## The existing test could not tell the bug from the fix

`ssh-tunnel.test.ts` already had `fails naming the exact tag checked`, asserting `/v0\.0\.0-ssh-tunnel-no-such-tag/`. That passes either way, because `computer-win/v0.0.0-…` contains `v0.0.0-…` as a substring.

I tightened it to `/computer-win\/v0\.0\.0-…/` — **and mutation-testing showed that still passed.** The message embeds the asset URL, which contains the correct tag no matter what the `tag` variable holds, so the regex was reading the URL rather than the tag.

Anchored on the phrase instead:

```js
/for tag computer-win\/v0\.0\.0-ssh-tunnel-no-such-tag/
```

Now the mutation dies:

```
× fails naming the exact tag checked when the release asset does not exist
Tests  1 failed | 23 passed (24)
```

Worth stating plainly since it happened twice in five minutes: the first assertion matched incidental content, and so did my first fix for it. A test that cannot distinguish the bug from the fix is not coverage, and the only thing that surfaced it was mutating the source and watching the test survive.

24 tests, `tsc --noEmit` clean.
