### PR TITLE
fix(traces): retry failed sessions instead of stranding them behind the watermark (PHNX-3267)

### DIFF
--- a/cli/.changelog/next/PHNX-3267.md
+++ b/cli/.changelog/next/PHNX-3267.md
@@ -1,0 +1,15 @@
+- **`agents traces sync` retains and reports failed sessions instead of stranding them (PHNX-3267).**
+  The sync watermark advanced to the max mtime of *successful* uploads, so a later
+  success moved it past an earlier failed session and the next run's
+  `file_mtime_ms > watermark` filter skipped that session forever — the "failures are
+  retried" comment was false. A live 1.22.49 sync on a real device reported 11,073
+  uploaded and 6,050 errors with no way to tell a transcript cleaned off disk from a
+  genuine upload failure. Sync now records each failed session's identity and typed,
+  redacted evidence in the ledger and unions those retry-worthy ids back into the row
+  query regardless of the watermark, so a stranded session is re-attempted until it
+  succeeds. Failures are classified `transcript-unavailable` (the file is gone —
+  expected history, not re-read, aged out after 14 days), `parse-failed`, or
+  `upload-failed` (both retried); `agents traces sync` prints the breakdown
+  (`… errors (N transcripts no longer on disk · M parse/upload failures — will retry)`)
+  and `agents traces status` lists the outstanding retry set with example detail.
+  Source: `cli/src/lib/traces/sync.ts`, `cli/src/commands/traces.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -46,6 +46,17 @@ it is not part of the hot session scan or `SCHEMA_VERSION`. `agents traces sync
 writes them to a directory (no Phoenix auth, no worker, no upload) — a local
 export for verifying the real signal before the hosted path is wired.
 
+The sync gate is a per-device mtime **watermark** plus a **failure ledger**, both in
+`traces-sync.json` (PHNX-3267). The watermark alone cannot retry a failure — a
+later-mtime success advances it past an earlier failed row, which the next run then
+skips forever — so the ledger also records each failed session's identity + typed,
+redacted evidence and the row query unions those retry-worthy ids back in regardless
+of the watermark. Failures are typed `transcript-unavailable` (the file is gone;
+expected history, not re-read, aged out after 14 days), `parse-failed`, or
+`upload-failed` (both retried until they resolve); `SyncResult` carries the per-kind
+counts, `agents traces sync` prints the breakdown, and `agents traces status` lists
+the outstanding retry set. A `--dry-run` never touches the ledger.
+
 ## Core design choices (read this first)
 
 Break these and downstream code drifts silently.

--- a/cli/src/commands/traces.ts
+++ b/cli/src/commands/traces.ts
@@ -1,8 +1,7 @@
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { setHelpSections } from '../lib/help.js';
-import { syncTraces, type SyncFailure } from '../lib/traces/sync.js';
-import { readSyncLedger } from '../lib/traces/sync.js';
+import { readSyncLedger, syncTraces, type SyncFailure } from '../lib/traces/sync.js';
 import { managedTracesBaseUrl, resolveTracesBackend } from '../lib/traces/backend.js';
 import { showUrl } from '../lib/open-url.js';
 import { DEFAULT_CF_BUNDLE, readCloudflareCreds } from '../lib/share/config.js';

--- a/cli/src/commands/traces.ts
+++ b/cli/src/commands/traces.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { setHelpSections } from '../lib/help.js';
-import { syncTraces } from '../lib/traces/sync.js';
+import { syncTraces, type SyncFailure } from '../lib/traces/sync.js';
 import { readSyncLedger } from '../lib/traces/sync.js';
 import { managedTracesBaseUrl, resolveTracesBackend } from '../lib/traces/backend.js';
 import { showUrl } from '../lib/open-url.js';
@@ -105,7 +105,20 @@ async function handleSync(opts: { limit?: string; dryRun?: boolean; out?: string
     parts.push(chalk.dim(`${result.skipped} skipped`));
   }
   if (result.errors > 0) {
-    parts.push(chalk.yellow(`${result.errors} errors`));
+    // Distinguish expected history (transcripts cleaned off disk) from genuine
+    // failures that will be retried, so the operator knows which need attention.
+    const detail: string[] = [];
+    if (result.transcriptUnavailable > 0) {
+      detail.push(`${result.transcriptUnavailable} transcripts no longer on disk`);
+    }
+    const retryable = result.parseFailed + result.uploadFailed;
+    if (retryable > 0) {
+      detail.push(`${retryable} parse/upload failures — will retry`);
+    }
+    parts.push(
+      chalk.yellow(`${result.errors} errors`) +
+        (detail.length ? chalk.dim(` (${detail.join(' · ')})`) : ''),
+    );
   }
   if (parts.length === 0) {
     parts.push(chalk.dim('nothing new'));
@@ -124,7 +137,27 @@ async function handleStatus(): Promise<void> {
 
   const when = new Date(ledger.lastSyncMtime).toLocaleString();
   console.log(`Last sync: ${chalk.bold(when)}`);
-  console.log(chalk.dim('Run `agents traces sync` to push new sessions.'));
+
+  const failures = ledger.failures ?? [];
+  if (failures.length > 0) {
+    const byKind = new Map<string, SyncFailure[]>();
+    for (const f of failures) {
+      const list = byKind.get(f.kind) ?? [];
+      list.push(f);
+      byKind.set(f.kind, list);
+    }
+    console.log(chalk.yellow(`\n${failures.length} unresolved failure${failures.length === 1 ? '' : 's'}:`));
+    for (const [kind, list] of byKind) {
+      const retry = kind === 'transcript-unavailable' ? chalk.dim(' (not retried)') : chalk.dim(' (retried each sync)');
+      console.log(`  ${chalk.bold(list.length)} ${kind}${retry}`);
+      const example = list[0];
+      if (example?.detail) {
+        console.log(chalk.dim(`    e.g. ${example.id.slice(0, 8)} · ${example.detail}`));
+      }
+    }
+  }
+
+  console.log(chalk.dim('\nRun `agents traces sync` to push new sessions.'));
 }
 
 async function handleOpen(): Promise<void> {

--- a/cli/src/lib/traces/sync.test.ts
+++ b/cli/src/lib/traces/sync.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDB, readSessionTopics } from '../session/db.js';
 import { getRuntimeStateDir } from '../state.js';
 import type { ClassifiedTopic } from './classify.js';
-import { buildIndexShard, buildSessionDetail, syncTraces, type SyncRow } from './sync.js';
+import { buildIndexShard, buildSessionDetail, readSyncLedger, syncTraces, type SyncRow } from './sync.js';
 
 const id = 'trace-rich-fixture';
 const transcript = path.join(import.meta.dirname, '../session/testdata/codex-fixture.jsonl');
@@ -298,6 +298,137 @@ describe('traces sync --dry-run local export', () => {
     } finally {
       delete process.env.AGENTS_SYNC_MACHINE_ID;
       fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('traces sync failure retry ledger (PHNX-3267)', () => {
+  const realTranscript = path.join(import.meta.dirname, '../session/testdata/codex-fixture.jsonl');
+  const ids = ['retry-a', 'retry-b', 'retry-c-gone', 'retry-d-ok'];
+  const ledgerPath = path.join(getRuntimeStateDir(), 'traces-sync.json');
+
+  function insertSession(sessionId: string, mtimeMs: number, filePath: string): void {
+    const db = getDB();
+    db.prepare(`
+      INSERT INTO sessions
+        (id, short_id, agent, timestamp, project, cwd, git_branch, label, duration_ms,
+         model, file_path, file_mtime_ms, file_size, machine)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      sessionId, sessionId.slice(0, 8), 'codex', '2026-08-25T00:00:00.000Z', 'agents-cli',
+      '/home/x/agents-cli', 'main', 'Retry test', 9000, 'gpt-test',
+      filePath, mtimeMs, 100, 'retry-device',
+    );
+  }
+
+  beforeEach(() => {
+    const db = getDB();
+    for (const table of ['tool_calls', 'session_topics', 'session_insights']) {
+      for (const sessionId of ids) db.prepare(`DELETE FROM ${table} WHERE session_id = ?`).run(sessionId);
+    }
+    for (const sessionId of ids) db.prepare('DELETE FROM sessions WHERE id = ?').run(sessionId);
+    fs.rmSync(ledgerPath, { force: true });
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTS_TRACES_BASE_URL;
+    delete process.env.AGENTS_TRACES_WRITE_TOKEN;
+    delete process.env.AGENTS_SYNC_MACHINE_ID;
+  });
+
+  it('retries an upload-failed session stranded below the watermark, then a stable sync uploads zero', async () => {
+    // A (older) and B (newer). B's later success advances the watermark past A —
+    // the exact case the plain watermark loses. A must still come back via the ledger.
+    insertSession('retry-a', 1000, realTranscript);
+    insertSession('retry-b', 2000, realTranscript);
+
+    let failA = true;
+    const puts: string[] = [];
+    const server = http.createServer((req, res) => {
+      if (req.method === 'PUT') puts.push(req.url ?? '');
+      req.resume();
+      if (req.method === 'PUT' && failA && req.url?.includes('/sessions/retry-a.json')) {
+        res.writeHead(500).end('boom');
+      } else {
+        res.writeHead(200).end('ok');
+      }
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('no TCP address');
+    process.env.AGENTS_TRACES_BASE_URL = `http://127.0.0.1:${address.port}`;
+    process.env.AGENTS_TRACES_WRITE_TOKEN = 'test-token';
+    process.env.AGENTS_SYNC_MACHINE_ID = 'retry-device';
+    try {
+      // First sync: B uploads, A's PUT 500s → recorded as an upload-failed retry.
+      const first = await syncTraces({ skipIndex: true });
+      expect(first.uploaded).toBe(1);
+      expect(first.uploadFailed).toBe(1);
+      expect(first.errors).toBe(1);
+      const afterFirst = readSyncLedger();
+      expect(afterFirst.lastSyncMtime).toBe(2000); // watermark advanced PAST A (1000)
+      const stranded = (afterFirst.failures ?? []).find((f) => f.id === 'retry-a');
+      expect(stranded?.kind).toBe('upload-failed');
+      expect(stranded?.detail).toContain('500'); // actionable evidence, not an opaque count
+
+      // A is now below the watermark. Only the union-with-retry-ids re-selects it.
+      failA = false;
+      puts.length = 0;
+      const second = await syncTraces({ skipIndex: true });
+      expect(puts.some((u) => u.includes('/sessions/retry-a.json'))).toBe(true); // re-attempted
+      expect(second.uploaded).toBe(1); // A recovered
+      expect(second.uploadFailed).toBe(0);
+      expect((readSyncLedger().failures ?? [])).toHaveLength(0); // cleared on success
+
+      // Third sync of unchanged data uploads nothing (idempotent).
+      puts.length = 0;
+      const third = await syncTraces({ skipIndex: true });
+      expect(third.uploaded).toBe(0);
+      expect(third.errors).toBe(0);
+      expect(puts).toHaveLength(0);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+    }
+  });
+
+  it('classifies a missing transcript as unavailable and does not re-query it once past the watermark', async () => {
+    // C points at a file that does not exist; D is a real, uploadable session with a
+    // higher mtime so the watermark advances past C.
+    insertSession('retry-c-gone', 1000, '/nonexistent/path/gone.jsonl');
+    insertSession('retry-d-ok', 2000, realTranscript);
+
+    const puts: string[] = [];
+    const server = http.createServer((req, res) => {
+      if (req.method === 'PUT') puts.push(req.url ?? '');
+      req.resume();
+      res.writeHead(200).end('ok');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('no TCP address');
+    process.env.AGENTS_TRACES_BASE_URL = `http://127.0.0.1:${address.port}`;
+    process.env.AGENTS_TRACES_WRITE_TOKEN = 'test-token';
+    process.env.AGENTS_SYNC_MACHINE_ID = 'retry-device';
+    try {
+      const first = await syncTraces({ skipIndex: true });
+      expect(first.transcriptUnavailable).toBe(1);
+      expect(first.uploadFailed).toBe(0);
+      expect(first.parseFailed).toBe(0);
+      expect(first.uploaded).toBe(1); // D
+      const recorded = (readSyncLedger().failures ?? []).find((f) => f.id === 'retry-c-gone');
+      expect(recorded?.kind).toBe('transcript-unavailable');
+
+      // Second sync: C is below the advanced watermark and unavailable, so it is
+      // neither re-selected by the watermark nor by the retry union — no wasted work.
+      puts.length = 0;
+      const second = await syncTraces({ skipIndex: true });
+      expect(second.uploaded).toBe(0);
+      expect(second.transcriptUnavailable).toBe(0); // not re-queried, not re-counted
+      expect(puts).toHaveLength(0);
+      // The evidence is retained in the ledger for the operator even though it is not retried.
+      expect((readSyncLedger().failures ?? []).some((f) => f.id === 'retry-c-gone')).toBe(true);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
     }
   });
 });

--- a/cli/src/lib/traces/sync.ts
+++ b/cli/src/lib/traces/sync.ts
@@ -9,6 +9,15 @@
  * Sync gate: `sessions.db` `file_mtime_ms` is the source of truth.  A ledger
  * at `getRuntimeStateDir()/traces-sync.json` records the last sync timestamp
  * per device so re-runs skip unchanged sessions.
+ *
+ * Retry ledger: the mtime watermark alone cannot retry failures — a later-mtime
+ * success advances it past an earlier failed row, which the next run's
+ * `file_mtime_ms > watermark` filter then skips forever. So the same ledger also
+ * records the identity + typed evidence of each failed session (`failures`), and
+ * the row query unions those retry-worthy ids back in regardless of the watermark
+ * (PHNX-3267). Failures are typed so a gone transcript (`transcript-unavailable`,
+ * expected history, aged out after a TTL and never re-read) is distinguished from a
+ * real parse/upload failure (retried until it resolves).
  */
 
 import fs from 'node:fs';
@@ -62,7 +71,14 @@ export interface SyncOpts {
 export interface SyncResult {
   uploaded: number;
   skipped: number;
+  /** Total failures = transcriptUnavailable + parseFailed + uploadFailed. Kept for callers. */
   errors: number;
+  /** The transcript file the row points at is gone/unreadable — expected history, not retried each run. */
+  transcriptUnavailable: number;
+  /** The transcript exists but could not be parsed into a trajectory — retried until it parses. */
+  parseFailed: number;
+  /** Parsed fine but the upload PUT failed (network/5xx) — retried on the next sync. */
+  uploadFailed: number;
 }
 
 /** Push derived, redacted trajectories for this device to the traces store. */
@@ -84,21 +100,74 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
   // NULL machine rows are legacy local sessions (pre-machine-field). A dry-run
   // ignores the incremental watermark so the export covers every session.
   const sinceMtime = dryRun ? 0 : (ledger.lastSyncMtime ?? 0);
-  const rows = db
+  const watermarkRows = db
     .prepare(
       'SELECT * FROM sessions WHERE (machine = ? OR machine IS NULL) AND file_mtime_ms > ? ORDER BY file_mtime_ms ASC',
     )
     .all(device, sinceMtime) as SyncRow[];
+
+  // The watermark alone loses failures: a later-mtime success advances it past an
+  // earlier failed row, which the `file_mtime_ms > sinceMtime` filter then skips
+  // forever. So union in the sessions we explicitly recorded as retry-worthy
+  // failures (parse/upload — a `transcript-unavailable` file is gone, re-reading it
+  // wastes work) regardless of where the watermark sits. A dry-run ignores the
+  // ledger entirely and already selects every row.
+  const retryIds = dryRun
+    ? []
+    : (ledger.failures ?? [])
+        .filter((f) => f.kind !== 'transcript-unavailable')
+        .map((f) => f.id);
+  let rows = watermarkRows;
+  if (retryIds.length) {
+    const seen = new Set(watermarkRows.map((r) => r.id));
+    const retryRows: SyncRow[] = [];
+    for (let i = 0; i < retryIds.length; i += 400) {
+      const chunk = retryIds.slice(i, i + 400);
+      retryRows.push(
+        ...(db
+          .prepare(
+            `SELECT * FROM sessions WHERE (machine = ? OR machine IS NULL) AND id IN (${chunk.map(() => '?').join(',')})`,
+          )
+          .all(device, ...chunk) as SyncRow[]),
+      );
+    }
+    const stranded = retryRows.filter((r) => !seen.has(r.id));
+    rows = [...watermarkRows, ...stranded].sort(
+      (a, b) => (a.file_mtime_ms ?? 0) - (b.file_mtime_ms ?? 0),
+    );
+  }
 
   const limited = opts.limit !== undefined ? rows.slice(0, opts.limit) : rows;
   const knownSecrets = knownSecretValuesFromEnv();
 
   let uploaded = 0;
   let skipped = 0;
-  let errors = 0;
-  // Advance the watermark only to the max mtime of successfully uploaded sessions
-  // so failures are retried on the next run.
+  let transcriptUnavailable = 0;
+  let parseFailed = 0;
+  let uploadFailed = 0;
+  // Advance the watermark only to the max mtime of successfully uploaded sessions.
+  // On its own this does NOT retry failures (a later success strands earlier ones);
+  // the failure ledger below is what actually re-selects them next run.
   let maxSuccessMtime = ledger.lastSyncMtime ?? 0;
+
+  // Carry prior failures forward by id so a stranded row's identity + evidence
+  // survives across syncs. A success removes the id; a repeat failure updates it.
+  const now = Date.now();
+  const failures = new Map<string, SyncFailure>(
+    (ledger.failures ?? []).map((f) => [f.id, f]),
+  );
+  const recordFailure = (row: SyncRow, kind: SyncFailureKind, err: unknown): void => {
+    const raw = err instanceof Error ? err.message : String(err);
+    const prev = failures.get(row.id);
+    failures.set(row.id, {
+      id: row.id,
+      mtimeMs: row.file_mtime_ms ?? 0,
+      kind,
+      detail: redactSecrets(raw.split('\n')[0] ?? '', knownSecrets).slice(0, 200),
+      firstSeen: prev?.firstSeen ?? now,
+      attempts: (prev?.attempts ?? 0) + 1,
+    });
+  };
 
   if (dryRun && outDir) {
     fs.mkdirSync(path.join(outDir, 'sessions'), { recursive: true });
@@ -115,8 +184,16 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
       const session = rowToMeta(row);
       const events = parseSession(row.file_path, row.agent as SessionAgentId);
       traj = buildTrajectory(events, session, { redact: true, knownSecrets });
-    } catch {
-      errors++;
+    } catch (err) {
+      // A gone/unreadable transcript is expected history, not a retry-worthy error;
+      // a file that IS present but failed to parse is a real problem to retry.
+      if (!fs.existsSync(row.file_path)) {
+        transcriptUnavailable++;
+        recordFailure(row, 'transcript-unavailable', err);
+      } else {
+        parseFailed++;
+        recordFailure(row, 'parse-failed', err);
+      }
       continue;
     }
     try {
@@ -130,8 +207,10 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
       }
       uploaded++;
       maxSuccessMtime = Math.max(maxSuccessMtime, row.file_mtime_ms ?? 0);
-    } catch {
-      errors++;
+      failures.delete(row.id); // recovered — drop it from the retry set
+    } catch (err) {
+      uploadFailed++;
+      recordFailure(row, 'upload-failed', err);
     }
   }
 
@@ -163,7 +242,16 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
 
   // A dry-run never advances the incremental watermark: it is a read-only export.
   if (!dryRun) {
-    writeSyncLedger({ lastSyncMtime: maxSuccessMtime });
+    // Age out long-unavailable transcripts so a corpus of deleted files cannot grow
+    // the retry set without bound; parse/upload failures persist until they resolve.
+    const persistedFailures = [...failures.values()].filter(
+      (f) =>
+        !(
+          f.kind === 'transcript-unavailable' &&
+          now - f.firstSeen > TRANSCRIPT_UNAVAILABLE_TTL_MS
+        ),
+    );
+    writeSyncLedger({ lastSyncMtime: maxSuccessMtime, failures: persistedFailures });
     // Register the Phoenix session with Prix so the console can fetch live data
     // (PHNX-3257). Fire-and-forget — a link failure must not block sync.
     // Managed backend only: the BYO path's token is a static write token that
@@ -177,7 +265,14 @@ export async function syncTraces(opts: SyncOpts = {}): Promise<SyncResult> {
       }).catch(() => {});
     }
   }
-  return { uploaded, skipped, errors };
+  return {
+    uploaded,
+    skipped,
+    errors: transcriptUnavailable + parseFailed + uploadFailed,
+    transcriptUnavailable,
+    parseFailed,
+    uploadFailed,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -569,8 +664,32 @@ async function putIndexShard(
 // Sync ledger — per-device timestamp gate
 // ---------------------------------------------------------------------------
 
+/** How a session failed to sync. Only parse/upload failures are re-queried every run. */
+export type SyncFailureKind = 'transcript-unavailable' | 'parse-failed' | 'upload-failed';
+
+export interface SyncFailure {
+  id: string;
+  mtimeMs: number;
+  kind: SyncFailureKind;
+  /** Bounded, redacted first line of the underlying error — actionable evidence. */
+  detail: string;
+  /** Epoch ms first recorded, so a permanently-unavailable transcript can be aged out. */
+  firstSeen: number;
+  attempts: number;
+}
+
+/**
+ * A `transcript-unavailable` failure is kept (so its count stays reportable) but
+ * not retried, because re-reading a file that is gone wastes work. Age it out of
+ * the ledger after this window so a corpus of long-deleted transcripts cannot grow
+ * the failure set without bound.
+ */
+const TRANSCRIPT_UNAVAILABLE_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
 interface SyncLedger {
   lastSyncMtime?: number;
+  /** Failed session identities, keyed by id, that survive across syncs. */
+  failures?: SyncFailure[];
 }
 
 function ledgerPath(): string {


### PR DESCRIPTION
## Why

A live Phoenix Evals verification (`agents traces sync` on a real device, 1.22.49)
reported **11,073 uploaded and 6,050 errors**. Two defects in
`cli/src/lib/traces/sync.ts` made those errors both unrecoverable and un-triageable:

1. **The watermark loses failures.** Sync advanced `maxSuccessMtime` to the max
   `file_mtime_ms` of *successfully* uploaded sessions, then committed it to the
   ledger. Rows are queried `file_mtime_ms > watermark ORDER BY … ASC`, so once any
   later-mtime session succeeds, the watermark moves **past** an earlier failed row
   and the next run skips it forever. The source comment "failures are retried on the
   next run" was false — a single later success strands every earlier failure.
2. **Failures carried no evidence.** Two bare `catch {}` blocks collapsed every
   failure into one opaque `errors` integer — a transcript cleaned off disk (expected;
   ~6,505 of the device's historical rows) was indistinguishable from a real HTTP
   upload failure.

## What changed

A **failure ledger** alongside the mtime watermark, both in `traces-sync.json`:

- Each failed session's identity + typed, redacted, bounded evidence is recorded, and
  the row query **unions those retry-worthy ids back in regardless of the watermark**,
  so a stranded row is re-attempted until it succeeds (or its transcript is gone).
- Failures are typed: `transcript-unavailable` (the file is gone — expected history,
  not re-read, aged out after 14 days), `parse-failed`, `upload-failed` (both retried).
- `SyncResult` carries per-kind counts; `agents traces sync` prints the breakdown
  (`… errors (N transcripts no longer on disk · M parse/upload failures — will retry)`),
  and `agents traces status` lists the outstanding retry set with example detail.
- `--dry-run` still never touches the ledger.

## Evidence

Real-path tests (a real local HTTP server as the R2 backend + a real `sessions.db`,
no mocking — the same harness the existing live-sync test uses):

```
✓ retries an upload-failed session stranded below the watermark, then a stable sync uploads zero
✓ classifies a missing transcript as unavailable and does not re-query it once past the watermark
Test Files  1 passed (1)   Tests  8 passed (8)
```

The retry test seeds A (mtime 1000) and B (mtime 2000), fails A's PUT so the watermark
advances to 2000 (**past** A), then proves A is re-selected and uploaded on the next
sync — which only the retry union can do — and that a third unchanged sync uploads zero
(idempotent). The evidence assertion checks the recorded detail contains `500`, not an
opaque count.

## Tests

`cli/src/lib/traces/sync.test.ts` — the two scenarios above, real function + real
trajectory input + real HTTP backend, no mocking. Full suite running on a fleet worker.

RUSH-3141 / PHNX-3267 (Phoenix Evals follow-up)