### PR TITLE
docs(changelog): --visibility me|org identity-gated pages (PHNX-3260)

### DIFF
--- a/cli/.changelog/next/PHNX-3260.md
+++ b/cli/.changelog/next/PHNX-3260.md
@@ -1,0 +1,22 @@
+- **`agents artifacts share --visibility me|org` — identity-gated share pages (PHNX-3260).**
+  Extends the P1 `public|unlisted` tiers (RUSH-3135) with two Phoenix-gated GET
+  visibilities. `me` is visible only to the signed-in owner (the viewer's Phoenix
+  `userId` must equal the stamped `owner`); `org` is visible to any signed-in
+  Phoenix user whose **verified email domain** matches the owner's company domain
+  (`org_domain`, stamped from the owner's verified email on PUT). A mismatch on
+  either returns **404** — the same body as a missing object — so a wrong viewer
+  cannot even learn the page exists. Both are hidden from the public gallery and
+  `share list`, like `unlisted`. Publishing `org` from a public inbox
+  (gmail/googlemail/outlook/hotmail/live/icloud/me) is refused with **400**, and
+  `me`/`org` PUT without a Phoenix identity is a loud 400 (a BYO `WRITE_TOKEN`
+  alone cannot publish them). Browser GET of an unauthenticated `me`/`org` URL
+  **302**s to `${PHOENIX_ID_BASE}/login?return=<url>` (the same Google OAuth as
+  `/device`, no new IdP); the returned one-time `phoenix_ticket` is redeemed once
+  via `POST /api/v1/auth/ticket` and exchanged for an HttpOnly, HMAC-signed
+  `__Host-phoenix_share` cookie on the share host. An existing CLI
+  `Authorization: Bearer` still works with no redirect. `me`/`org` responses send
+  `Cache-Control: private, no-store` and `X-Robots-Tag: noindex`;
+  `public`/`unlisted` GET is unchanged (anonymous 200). Because the Worker template
+  changed, **already-provisioned BYO endpoints need `agents artifacts share update`**
+  to serve the new gate. Source: `apps/cli/src/lib/share/worker-template.ts`,
+  `apps/cli/src/lib/share/{backend,publish}.ts`, `apps/cli/src/commands/share.ts`.

--- a/cli/.changelog/next/PHNX-3260.md
+++ b/cli/.changelog/next/PHNX-3260.md
@@ -18,5 +18,5 @@
   `Cache-Control: private, no-store` and `X-Robots-Tag: noindex`;
   `public`/`unlisted` GET is unchanged (anonymous 200). Because the Worker template
   changed, **already-provisioned BYO endpoints need `agents artifacts share update`**
-  to serve the new gate. Source: `apps/cli/src/lib/share/worker-template.ts`,
-  `apps/cli/src/lib/share/{backend,publish}.ts`, `apps/cli/src/commands/share.ts`.
+  to serve the new gate. Source: `cli/src/lib/share/worker-template.ts`,
+  `cli/src/lib/share/{backend,publish}.ts`, `cli/src/commands/share.ts`.


### PR DESCRIPTION
## Why

The share visibility **P2** (me/org) shipped code-only. Both tracks are already on `main`:

- **#3092** `feat(share): extend --visibility to public|unlisted|me|org` (CLI)
- **#3093** `feat(share): gate me/org GET with Phoenix identity` (Worker)

Docs (command-index + command-reference) landed with them, but the **`.changelog/next` fragment never did** — the `docs` teammate on the "share-vis-land" team stalled before writing it. `CHANGELOG.md` is generated from `.changelog/next/*`, so without a fragment the next release would omit a user-visible feature.

## What

Adds `cli/.changelog/next/PHNX-3260.md` describing the `me`/`org` tiers: Phoenix-gated GET, the email-domain `org` rule, gmail-inbox 400, the browser `/login` → ticket → `__Host-phoenix_share` cookie bounce, `noindex`/`no-store` headers, and the required `agents artifacts share update` for already-provisioned BYO endpoints.

Docs-only. `CHANGELOG.md` is unchanged (fragments fold in at release).

## Verification

- `bun run changelog` leaves `CHANGELOG.md` byte-identical (fragment only surfaces at release).
- `bun test scripts/gen-changelog.test.ts` → 5 pass.

## Remaining PHNX-3260 tail (not in this PR)

- `agents artifacts share update` to deploy the new Worker to the live `share.agents-cli.sh` endpoint (its template currently reads `outdated`) — being handled separately.
- Close PHNX-3260 once the deploy + acceptance curls pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)