### PR TITLE
chore: gitignore the local .release-attestations proof store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,13 @@ coverage/
 .agents/scratch/
 .plans/
 
+# Local release-proof store: release-attestation-produce.sh (the interim
+# attestation producer, RUSH-2749) writes the exact-tree attestation JSON +
+# pretested tarball here, and release.sh reads it from the same dir. It is a
+# machine-local build cache, never committed — without this it surfaces in
+# `git status` after every release and gets deleted by hand.
+/.release-attestations/
+
 # Scrub script lists personal data strings — must not be committed to public repo
 scripts/scrub-history.sh
 


### PR DESCRIPTION
## What

Adds `/.release-attestations/` to the root `.gitignore`.

## Why

`release-attestation-produce.sh` (the interim attestation producer, RUSH-2749) writes the exact-tree attestation JSON + pretested tarball into a repo-root `.release-attestations/` dir, and `release.sh` reads it from the same place (`attestation_store_dir()` / `release-worktree.sh:44`). It's a machine-local build cache that was never ignored, so it surfaced in `git status` after every release and had to be deleted by hand.

No behavior change — the dir keeps working exactly as before; it just stops dirtying the tree (which also matters because `release.sh` refuses to build from a dirty tree).

Related: PHNX-3237 (attestation producer has no clean-env path from a standard fleet box).