### PR TITLE
chore(agents): ignore .agents/artifacts/private/ for personal-data output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,12 @@ coverage/
 
 # Durable agent artifacts (plans, reports, visuals) are committed under
 # .agents/artifacts/<yyyy-mm-dd>/; worktrees and scratch stay local.
+# .agents/artifacts/private/ is the one artifacts subtree that never lands: it
+# holds personal data (contact lists, message-derived context) that the
+# "everything committed here is public" rule in AGENTS.md forbids checking in.
 .agents/worktrees/
 .agents/scratch/
+.agents/artifacts/private/
 .plans/
 
 # Local release-proof store: release-attestation-produce.sh (the interim

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,7 @@ or the repo root so the tree stays clean. What's committed vs gitignored is deli
 | `.agents/worktrees/<slug>/` | ignored | PR-bound worktrees, one per change (see [§Conventions](#conventions-repo-wide)) |
 | `.agents/scratch/` | ignored | throwaway working files |
 | `.agents/artifacts/<yyyy-mm-dd>/` | committed | every durable output — plans, reports, rendered visuals — filed under the day it was authored |
+| `.agents/artifacts/private/` | **ignored** | durable output that must never land — personal data (contact lists, message-derived context, anything naming real people) |
 
 Rule of thumb: **ephemeral → the gitignored dirs; durable → `.agents/artifacts/<yyyy-mm-dd>/`.**
 One dated layout, no kind-based subdirs: a plan, a report, and a rendered visual authored on
@@ -298,6 +299,11 @@ is (`plan-<slug>.html`, `<topic>-audit.md`) and render HTML next to its Markdown
 Everything committed here is public, so anonymize people, account handles, emails, device
 names, session identifiers, local paths, tailnet addresses, and
 absolute home paths before it lands. Never scatter scratch in `/tmp` or the repo root.
+
+When the output *is* the personal data — a contact list, an outreach roster, anything
+built from messages or an address book — anonymizing it would destroy it. Put that under
+`.agents/artifacts/private/`, which `.gitignore` excludes, and keep it in the repo so the
+work stays with the project instead of drifting into `/tmp` or a home directory.
 
 ## Conventions (repo-wide)
 


### PR DESCRIPTION
## Why

`.agents/artifacts/` is committed and therefore public, and AGENTS.md tells agents to
"anonymize people, account handles, emails … before it lands."

That rule has no answer for output whose entire content *is* personal data. A launch
outreach roster built from an address book, iMessage history, and LinkedIn connections
cannot be anonymized without destroying the thing. Today that output has nowhere to go,
so it lands in `/tmp` or a home directory and drifts away from the project that produced it.

## What

One ignored subtree — `.agents/artifacts/private/` — with the split documented in the
workspace table, so the work stays in the repo without ever being committed.

No code paths touched; `.gitignore` + `AGENTS.md` only.