### PR TITLE
fix(monitors): early-exit fleet duplicate guard on clash (PHNX-3299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **`agents monitors add` refuses immediately when a reachable peer already has the same watcher (PHNX-3299).** The fleet duplicate guard used to collect every peer before reporting a clash, so a single slow box forced the full 12-second timeout even when another peer had already answered with the same fingerprint. The fan-out now aborts remaining SSH captures the moment a peer reports a matching monitor, while the no-match path still waits for the whole fleet so uniqueness can be proved. Source: `cli/src/commands/monitors.ts`, `cli/src/lib/monitors/remote.ts`.
+
 - **A fleet browser hub lets every box drive one shared logged-in browser with no `--device` (PHNX-2010).**
   New `browser.device` config key (user scope, so a single value in the central
   `agents.yaml` syncs fleet-wide). When set, a bare `agents browser start` forwards to

--- a/cli/src/commands/monitors.ts
+++ b/cli/src/commands/monitors.ts
@@ -370,8 +370,8 @@ async function guardAgainstDuplicateMonitor(config: MonitorConfig, force: boolea
   // triggers. Identity is the arguments, so the claim has to be fleet-wide —
   // different arguments (another PR) are not a clash and still pass.
   if (process.env[NO_MONITOR_FANOUT_ENV]) return;
-  const fleet = await gatherFleetMonitors();
   const mine = monitorFingerprint(config);
+  const fleet = await gatherFleetMonitors({ againstFingerprint: mine });
   const clash = fleet.monitors.find((r) => monitorFingerprint(r.monitor) === mine);
   if (clash) {
     stderrLine(chalk.red(`Monitor '${clash.monitor.name}' on ${chalk.bold(clash.machine)} already watches this exact source and fires the same action.`));

--- a/cli/src/lib/monitors/remote.test.ts
+++ b/cli/src/lib/monitors/remote.test.ts
@@ -12,8 +12,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseRemoteMonitors } from './remote.js';
+import { parseRemoteMonitors, gatherFleetMonitors } from './remote.js';
 import { monitorFingerprint } from './fingerprint.js';
+import type { SshCaptureFn } from '../remote-agents-json.js';
 import type { MonitorConfig } from './config.js';
 
 const watcher = (over: Record<string, unknown> = {}) => ({
@@ -130,5 +131,96 @@ describe('against the real `monitors list --json` projection', () => {
     const remote = parseRemoteMonitors(asListJson(runMonitor({ name: 'foo' })), 'zion');
     const mine = runMonitor({ name: 'zion:foo' }) as unknown as Ident;
     expect(remote.find((r) => monitorFingerprint(r.monitor) === monitorFingerprint(mine))?.machine).toBe('zion');
+  });
+});
+
+describe('gatherFleetMonitors', () => {
+  type Ident = Pick<MonitorConfig, 'name' | 'source' | 'condition' | 'action'>;
+
+  const runMonitor = (over: Record<string, unknown> = {}) => ({
+    name: 'land-2517',
+    source: { type: 'poll', command: 'gh pr view 2517', interval: '2m' },
+    condition: { mode: 'on-change' },
+    action: { type: 'run', agent: 'claude', prompt: 'merge it' },
+    ...over,
+  });
+
+  const asListJson = (m: any) =>
+    JSON.stringify([
+      {
+        name: m.name,
+        enabled: true,
+        source: m.source,
+        condition: m.condition,
+        action: m.action,
+        owner: 'all',
+        runsHere: true,
+        lastSeenAt: null,
+        lastFiredAt: null,
+      },
+    ]);
+
+  const FAST = 'tester@fast.example.com';
+  const SLOW = 'tester@slow.example.com';
+
+  it('aborts remaining peers as soon as a clash fingerprint is reported', async () => {
+    const mine = runMonitor({ name: 'mine' }) as unknown as Ident;
+    const targetFp = monitorFingerprint(mine);
+    const aborted: string[] = [];
+
+    const capture: SshCaptureFn = (target, _cmd, { signal }) =>
+      new Promise((resolve) => {
+        if (target === FAST) {
+          resolve({ code: 0, stdout: asListJson(runMonitor()) });
+          return;
+        }
+        if (signal?.aborted) {
+          aborted.push(target);
+          resolve({ code: null, stdout: '' });
+          return;
+        }
+        signal?.addEventListener(
+          'abort',
+          () => {
+            aborted.push(target);
+            resolve({ code: null, stdout: '' });
+          },
+          { once: true },
+        );
+      });
+
+    const result = await gatherFleetMonitors({
+      againstFingerprint: targetFp,
+      hosts: [FAST, SLOW],
+      deps: { capture },
+    });
+
+    const clash = result.monitors.find((r) => monitorFingerprint(r.monitor) === targetFp);
+    expect(clash?.machine).toBe('fast');
+    expect(result.skipped).toEqual([]);
+    expect(aborted).toEqual([SLOW]);
+  });
+
+  it('waits for every peer when no monitor matches the fingerprint', async () => {
+    const mine = runMonitor({
+      name: 'mine',
+      source: { type: 'poll', command: 'gh pr view 2600', interval: '2m' },
+    }) as unknown as Ident;
+    const targetFp = monitorFingerprint(mine);
+
+    const capture: SshCaptureFn = (target) =>
+      new Promise((resolve) => {
+        if (target === FAST) resolve({ code: 0, stdout: asListJson(runMonitor()) });
+        else setTimeout(() => resolve({ code: 0, stdout: asListJson(runMonitor({ name: 'other' })) }), 25);
+      });
+
+    const result = await gatherFleetMonitors({
+      againstFingerprint: targetFp,
+      hosts: [FAST, SLOW],
+      deps: { capture },
+    });
+
+    expect(result.monitors).toHaveLength(2);
+    expect(result.skipped).toEqual([]);
   });
 });

--- a/cli/src/lib/monitors/remote.ts
+++ b/cli/src/lib/monitors/remote.ts
@@ -17,8 +17,9 @@
  * every one of them onto every box — the accumulation this guard exists to stop.
  */
 
-import { gatherRemoteAgentsJson } from '../remote-agents-json.js';
+import { gatherRemoteAgentsJson, type GatherRemoteAgentsJsonDeps } from '../remote-agents-json.js';
 import type { MonitorConfig } from './config.js';
+import { monitorFingerprint } from './fingerprint.js';
 
 /** Recursion guard: a peer answering the fan-out must not fan out again. */
 export const NO_MONITOR_FANOUT_ENV = 'AGENTS_MONITORS_LOCAL';
@@ -71,19 +72,44 @@ export interface FleetMonitorsResult {
   skipped: string[];
 }
 
+export interface GatherFleetMonitorsOptions {
+  /** When supplied, the fan-out aborts as soon as any peer returns a monitor with
+   *  this behavioral fingerprint. The miss path still waits for every peer so the
+   *  guard can prove absence fleet-wide. */
+  againstFingerprint?: string;
+  /** Optional test seam for the SSH boundary; production uses the real capture. */
+  deps?: GatherRemoteAgentsJsonDeps;
+  /** Optional explicit host list; production omits it and asks the device registry. */
+  hosts?: string[];
+}
+
 /**
  * Every monitor on every other registered device. Never throws: an unreachable
  * fleet degrades to an empty list plus the names we could not consult, and the
  * caller decides what to say about them.
+ *
+ * When {@link GatherFleetMonitorsOptions.againstFingerprint} is provided, a peer
+ * returning that fingerprint is a definitive clash: the remaining peers are
+ * SIGTERM'd immediately rather than burning the rest of the timeout budget.
+ * Absence of a clash still waits for the full fleet, because uniqueness is only
+ * knowable once every peer has answered.
  */
-export async function gatherFleetMonitors(): Promise<FleetMonitorsResult> {
+export async function gatherFleetMonitors(
+  options: GatherFleetMonitorsOptions = {},
+): Promise<FleetMonitorsResult> {
   try {
     const result = await gatherRemoteAgentsJson<RemoteMonitor>({
       args: ['monitors', 'list', '--json'],
       noFanoutEnv: NO_MONITOR_FANOUT_ENV,
+      hosts: options.hosts,
       parse: parseRemoteMonitors,
       quiet: true,
-    });
+      earlyExit: options.againstFingerprint
+        ? {
+            isDefinitive: (item) => monitorFingerprint(item.monitor) === options.againstFingerprint,
+          }
+        : undefined,
+    }, options.deps);
     return {
       monitors: result.items,
       skipped: [...result.skipped, ...result.parseFailed],


### PR DESCRIPTION
## What changed\n\n- **`cli/src/lib/monitors/remote.ts`** — `gatherFleetMonitors` now accepts an optional `againstFingerprint`. When supplied, it threads `earlyExit` into `gatherRemoteAgentsJson` with `isDefinitive` matching the fingerprint of the monitor being added. A clash on any peer aborts the remaining SSH captures immediately; the miss path stays all-settle so absence can be proved fleet-wide.\n- **`cli/src/commands/monitors.ts`** — `guardAgainstDuplicateMonitor` computes the fingerprint before the fan-out and passes it to `gatherFleetMonitors`.\n- **`cli/src/lib/monitors/remote.test.ts`** — covers the clash abort (remaining peer cancelled, not listed as skipped) and the no-clash all-settle behavior.\n- **`CHANGELOG.md`** — Unreleased entry.\n\n## Verification\n\n```bash\ncd cli\nbun run test src/lib/monitors/remote.test.ts src/commands/monitors.test.ts\nbun run build\n```\n\nAll 17 tests pass; `tsc` is clean.\n\nCloses PHNX-3299.