### PR TITLE
fix(feed): forward owner notifications to a capable peer over SSH (PHNX-3303)

### DIFF
--- a/cli/.changelog/next/PHNX-3303.md
+++ b/cli/.changelog/next/PHNX-3303.md
@@ -1,0 +1,14 @@
+- **Owner notifications forward to a capable fleet peer when this box can't deliver (PHNX-3303).**
+  The owner's delivery provider for the rush-backed channels (imessage / telegram /
+  slack / discord via the `rush` CLI) is macOS-only, so `agents feed post --level
+  important` / `--blocked`, `agents notify`, and monitor `notify` actions run from a
+  headless Linux worker used to record the post but fail to reach the owner with
+  `owner failed: … rush CLI not found on PATH`. They now hand the delivery over SSH to
+  a reachable macOS peer that DOES have the provider — the same reroute
+  `agents message` already uses — instead of stranding the important post. It is
+  best-effort: it never throws or blocks the post, only the macOS-only rush family
+  triggers a forward (a Linux-capable transport like openclaw-telegram stays local),
+  and when no capable peer is reachable the existing clean local error stands. A box
+  that received a forward never forwards onward (`AGENTS_OWNER_NO_FORWARD` guard).
+  Source: `cli/src/lib/channels/owner-forward.ts`, `cli/src/lib/notify.ts`,
+  `cli/src/lib/feed-broadcast.ts`.

--- a/cli/src/lib/channels/owner-forward.test.ts
+++ b/cli/src/lib/channels/owner-forward.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Meta } from '../types.js';
+import type { SendResult } from './registry.js';
+import type { DeviceProfile } from '../devices/registry.js';
+import {
+  OWNER_FORWARD_GUARD_ENV,
+  forwardOwnerNotifyToPeer,
+  isRushBackedTransport,
+  planOwnerForward,
+} from './owner-forward.js';
+
+/** Minimal dialable device profile (no tailscale block == dialable). */
+function device(name: string, platform: DeviceProfile['platform']): DeviceProfile {
+  return {
+    name,
+    platform,
+    shell: platform === 'windows' ? 'powershell' : 'posix',
+    address: { via: 'manual', dnsName: `${name}.example` },
+    auth: { method: 'key' },
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+/** A Meta whose owner channel is the macOS-only rush iMessage transport. */
+function rushOwnerMeta(overrides: Partial<Meta> = {}): Meta {
+  return {
+    notify: { owner: { channel: 'imessage', to: '+18055551234' } },
+    ...overrides,
+  } as Meta;
+}
+
+describe('isRushBackedTransport', () => {
+  it('is true for a rush-family owner channel (macOS-only)', () => {
+    expect(isRushBackedTransport('imessage', rushOwnerMeta())).toBe(true);
+  });
+
+  it('is false for a Linux-capable transport (openclaw-telegram)', () => {
+    const meta = { notify: { transports: { telegram: 'openclaw-telegram' } } } as Meta;
+    expect(isRushBackedTransport('telegram', meta)).toBe(false);
+  });
+
+  it('follows the notify.transports mapping to a rush channel', () => {
+    const meta = { notify: { transports: { owner: 'imessage' } } } as Meta;
+    expect(isRushBackedTransport('owner', meta)).toBe(true);
+  });
+});
+
+describe('planOwnerForward', () => {
+  const devices = [
+    device('mac-mini', 'macos'),
+    device('yosemite-m3', 'linux'),
+    device('win-mini', 'windows'),
+    device('studio', 'macos'),
+  ];
+
+  it('does not forward when guarded (a box that already received a forward)', () => {
+    const plan = planOwnerForward('imessage', rushOwnerMeta(), devices, 'yosemite-m3', { guarded: true });
+    expect(plan).toEqual({ candidates: [], skip: 'guarded' });
+  });
+
+  it('does not forward a Linux-capable transport — no wrong-OS problem to solve', () => {
+    const meta = {
+      notify: { owner: { channel: 'telegram', to: 'c1' }, transports: { telegram: 'openclaw-telegram' } },
+    } as Meta;
+    expect(planOwnerForward('telegram', meta, devices, 'yosemite-m3').skip).toBe('not-rush-backed');
+  });
+
+  it('selects only macOS peers, excludes self, and lists them as candidates', () => {
+    const plan = planOwnerForward('imessage', rushOwnerMeta(), devices, 'yosemite-m3');
+    // linux (self + peer) and windows are not rush-capable; only macs remain.
+    expect(plan.skip).toBeUndefined();
+    expect(plan.candidates.sort()).toEqual(['mac-mini', 'studio']);
+  });
+
+  it('excludes the calling box even when it is a mac', () => {
+    const plan = planOwnerForward('imessage', rushOwnerMeta(), devices, 'mac-mini');
+    expect(plan.candidates).toEqual(['studio']);
+  });
+
+  it('tries the configured interactive.host first (where rush is signed in)', () => {
+    const meta = rushOwnerMeta({ config: { interactiveHost: 'studio' } });
+    const plan = planOwnerForward('imessage', meta, devices, 'yosemite-m3');
+    expect(plan.candidates[0]).toBe('studio');
+    expect(plan.candidates).toContain('mac-mini');
+  });
+
+  it('skips a mac whose reachability snapshot says offline', () => {
+    const asleep = device('studio', 'macos');
+    asleep.tailscale = { online: false, direct: false };
+    const plan = planOwnerForward('imessage', rushOwnerMeta(), [device('mac-mini', 'macos'), asleep], 'yosemite-m3');
+    expect(plan.candidates).toEqual(['mac-mini']);
+  });
+
+  it('reports no-capable-peer when the fleet has no reachable mac', () => {
+    const plan = planOwnerForward('imessage', rushOwnerMeta(), [device('yosemite-m3', 'linux')], 'yosemite-m3');
+    expect(plan).toEqual({ candidates: [], skip: 'no-capable-peer' });
+  });
+});
+
+describe('forwardOwnerNotifyToPeer', () => {
+  const savedGuard = process.env[OWNER_FORWARD_GUARD_ENV];
+  afterEach(() => {
+    if (savedGuard === undefined) delete process.env[OWNER_FORWARD_GUARD_ENV];
+    else process.env[OWNER_FORWARD_GUARD_ENV] = savedGuard;
+  });
+
+  const devices = [device('mac-mini', 'macos'), device('studio', 'macos'), device('yosemite-m3', 'linux')];
+
+  function okResult(machine: string): SendResult {
+    return { ok: true, channel: 'imessage', id: `owner-via-${machine}` };
+  }
+  function failResult(): SendResult {
+    return { ok: false, channel: 'imessage', id: '+18055551234', error: 'rush signed out' };
+  }
+
+  it('delivers via the first capable peer and stops the sweep', async () => {
+    delete process.env[OWNER_FORWARD_GUARD_ENV];
+    const tried: string[] = [];
+    const meta = rushOwnerMeta({ config: { interactiveHost: 'studio' } });
+    const result = await forwardOwnerNotifyToPeer('ping', 'imessage', meta, {
+      self: 'yosemite-m3',
+      devices,
+      send: async (machine) => {
+        tried.push(machine);
+        return okResult(machine); // first candidate delivers
+      },
+    });
+    expect(result?.ok).toBe(true);
+    expect(result?.id).toBe('owner-via-studio'); // interactive host tried first
+    expect(tried).toEqual(['studio']); // stopped after the first success
+  });
+
+  it('skips a peer that reports its own failure and tries the next', async () => {
+    delete process.env[OWNER_FORWARD_GUARD_ENV];
+    const tried: string[] = [];
+    const result = await forwardOwnerNotifyToPeer('ping', 'imessage', rushOwnerMeta(), {
+      self: 'yosemite-m3',
+      devices,
+      send: async (machine) => {
+        tried.push(machine);
+        return machine === 'studio' ? okResult(machine) : failResult();
+      },
+    });
+    expect(result?.ok).toBe(true);
+    expect(tried).toContain('mac-mini');
+    expect(tried).toContain('studio');
+  });
+
+  it('returns undefined when every capable peer fails — caller keeps its local error', async () => {
+    delete process.env[OWNER_FORWARD_GUARD_ENV];
+    const tried: string[] = [];
+    const result = await forwardOwnerNotifyToPeer('ping', 'imessage', rushOwnerMeta(), {
+      self: 'yosemite-m3',
+      devices,
+      send: async (machine) => {
+        tried.push(machine);
+        return failResult();
+      },
+    });
+    expect(result).toBeUndefined();
+    expect(tried.sort()).toEqual(['mac-mini', 'studio']); // both macs attempted
+  });
+
+  it('returns undefined (never forwards) when no capable peer exists', async () => {
+    delete process.env[OWNER_FORWARD_GUARD_ENV];
+    let called = false;
+    const result = await forwardOwnerNotifyToPeer('ping', 'imessage', rushOwnerMeta(), {
+      self: 'yosemite-m3',
+      devices: [device('yosemite-m3', 'linux'), device('win-mini', 'windows')],
+      send: async () => {
+        called = true;
+        return okResult('x');
+      },
+    });
+    expect(result).toBeUndefined();
+    expect(called).toBe(false); // no SSH attempted
+  });
+
+  it('does not forward onward from a box that already received a forward (loop guard)', async () => {
+    process.env[OWNER_FORWARD_GUARD_ENV] = '1';
+    let called = false;
+    const result = await forwardOwnerNotifyToPeer('ping', 'imessage', rushOwnerMeta(), {
+      self: 'yosemite-m3',
+      devices,
+      send: async () => {
+        called = true;
+        return okResult('x');
+      },
+    });
+    expect(result).toBeUndefined();
+    expect(called).toBe(false);
+  });
+});

--- a/cli/src/lib/channels/owner-forward.ts
+++ b/cli/src/lib/channels/owner-forward.ts
@@ -1,0 +1,174 @@
+/**
+ * Forward an owner notification to a capable fleet peer over SSH (PHNX-3303).
+ *
+ * The owner's delivery provider for the rush-backed channels (imessage /
+ * telegram / slack / discord via the `rush` CLI) is macOS-only and
+ * keychain-bound, so a headless Linux worker structurally CANNOT ring the
+ * owner's phone: `agents feed post --level important` records the post but the
+ * owner sink fails with `rush CLI not found on PATH`, and the important post
+ * reaches nobody. `probeOwnerSink` (owner-sink.ts) already reports this as the
+ * `owner-sink-unreachable` doctor finding; this module is the runtime answer to
+ * it — instead of stranding the failure, hand the delivery to a reachable macOS
+ * peer that DOES have the provider.
+ *
+ * This mirrors the SSH reroute `agents message` (decideHostTaskRoute →
+ * runOnPeer) and the sessions fan-out already use for work that lives on another
+ * box: pick a reachable peer from the device registry and run the same `agents`
+ * verb there. Here the verb is `agents send --to owner`, which resolves the
+ * peer's own (fleet-synced) owner destination and delivers through its local
+ * rush — so the owner is addressed once, from the one box that can reach them.
+ *
+ * Best-effort seam: it never throws and never blocks the post. When no capable
+ * peer is reachable it resolves `undefined` and the caller keeps its original
+ * clean local error, exactly as before.
+ */
+import type { Meta } from '../types.js';
+import type { SendResult } from './registry.js';
+import type { DeviceProfile } from '../devices/registry.js';
+import { loadDevices, isDialableDevice } from '../devices/registry.js';
+import { machineId, normalizeHost } from '../machine-id.js';
+import { RUSH_CHANNELS } from './providers/rush.js';
+import { resolvePeerTarget, sshCapture } from '../session/remote/remote-list.js';
+import { remoteShellFor, buildWindowsAgentsCommand, stripClixml } from '../hosts/remote-cmd.js';
+import { shellQuote } from '../ssh-exec.js';
+
+/**
+ * Env marker set on the forwarded `agents send` so a box that received a
+ * forwarded owner notify never forwards it onward. `agents send` does not route
+ * through this module today, so this is defense-in-depth against a future
+ * consumer wiring forwarding into the send path and creating a fan-out loop.
+ */
+export const OWNER_FORWARD_GUARD_ENV = 'AGENTS_OWNER_NO_FORWARD';
+
+/** Per-peer SSH deadline for a one-shot owner delivery. */
+const PEER_SEND_TIMEOUT_MS = 15_000;
+
+/** Why forwarding did not run, so a caller/test can assert the decision. */
+export type OwnerForwardSkip = 'guarded' | 'not-rush-backed' | 'no-capable-peer';
+
+export interface OwnerForwardPlan {
+  /** Ordered machine ids to try — capable (macOS), reachable, self excluded. */
+  candidates: string[];
+  /** Set when forwarding does not apply; the caller keeps its local error. */
+  skip?: OwnerForwardSkip;
+}
+
+/**
+ * True when the resolved owner transport is the macOS-only rush family — the
+ * one case a Linux/headless box structurally cannot deliver and a peer can.
+ * `openclaw-telegram` and the local `desktop`/`mailbox` providers are NOT
+ * rush-backed, so a failure there is not a wrong-OS problem and is left as-is.
+ * Mirrors the same `RUSH_CHANNELS.includes(transport)` gate in owner-sink.ts.
+ */
+export function isRushBackedTransport(channel: string, meta: Meta): boolean {
+  const transport = meta.notify?.transports?.[channel] ?? channel;
+  return (RUSH_CHANNELS as readonly string[]).includes(transport);
+}
+
+/**
+ * Decide which peers can deliver the owner notification, in try order. Pure —
+ * no I/O — so the channel gate, the recursion guard, self-exclusion, and the
+ * capability/ordering rules are unit-testable without a live tailnet.
+ *
+ * Only macOS peers are candidates: the rush owner transport is macOS-only, so a
+ * Linux/Windows peer could not deliver it either. The configured
+ * `interactive.host` (the box the operator sits at, where rush is signed in) is
+ * tried first when it is among the candidates.
+ */
+export function planOwnerForward(
+  channel: string,
+  meta: Meta,
+  devices: DeviceProfile[],
+  self: string,
+  opts: { guarded?: boolean } = {},
+): OwnerForwardPlan {
+  if (opts.guarded) return { candidates: [], skip: 'guarded' };
+  if (!isRushBackedTransport(channel, meta)) return { candidates: [], skip: 'not-rush-backed' };
+
+  const selfId = normalizeHost(self);
+  const capable = devices.filter(
+    (d) => d.platform === 'macos' && isDialableDevice(d) && normalizeHost(d.name) !== selfId,
+  );
+
+  const interactiveHost = typeof meta.config?.interactiveHost === 'string'
+    ? normalizeHost(meta.config.interactiveHost)
+    : undefined;
+  const rank = (name: string): number => (interactiveHost && normalizeHost(name) === interactiveHost ? 0 : 1);
+  const candidates = capable
+    .map((d) => normalizeHost(d.name))
+    .sort((a, b) => rank(a) - rank(b));
+
+  if (candidates.length === 0) return { candidates: [], skip: 'no-capable-peer' };
+  return { candidates };
+}
+
+/**
+ * Deliver `text` to the owner FROM one peer over SSH. Runs the peer's own
+ * `agents send --to owner --text <text> --json`, which resolves that box's
+ * fleet-synced owner destination and delivers through its local provider.
+ * Resolves the parsed `SendResult`, or `undefined` when the peer is
+ * unreachable / not a dialable device / answered with unparseable output —
+ * every one of which means "try the next peer".
+ */
+export type PeerOwnerSender = (machine: string, text: string) => Promise<SendResult | undefined>;
+
+async function sendOnPeer(machine: string, text: string): Promise<SendResult | undefined> {
+  const peer = await resolvePeerTarget(machine);
+  if (!peer) return undefined;
+  const args = ['send', '--to', 'owner', '--text', text, '--json'];
+  const env = { [OWNER_FORWARD_GUARD_ENV]: '1' };
+  const remoteCmd = remoteShellFor(peer.os) === 'powershell'
+    ? buildWindowsAgentsCommand({ args, env })
+    : `bash -lc ${shellQuote(
+        [`${OWNER_FORWARD_GUARD_ENV}=1`, 'agents', ...args].map((t, i) => (i === 0 ? t : shellQuote(t))).join(' '),
+      )}`;
+  const capture = await sshCapture(peer.target, remoteCmd, PEER_SEND_TIMEOUT_MS);
+  if (capture.code !== 0) return undefined;
+  try {
+    const parsed = JSON.parse(stripClixml(capture.stdout)) as SendResult;
+    if (parsed && typeof parsed === 'object' && typeof parsed.ok === 'boolean') return parsed;
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Try each capable peer in order and return the first successful delivery. A
+ * peer that is unreachable or reports its own delivery failure is skipped and
+ * the next is tried; the first `ok:true` wins and stops the sweep so the owner's
+ * phone rings once. Resolves `undefined` when forwarding does not apply or no
+ * peer delivered — the caller then keeps its original local error.
+ *
+ * The transport (`send`) is injectable so the try-order / first-success / stop
+ * orchestration is testable without a live SSH host; the default runs the real
+ * `agents send --to owner` over SSH.
+ */
+export async function forwardOwnerNotifyToPeer(
+  text: string,
+  channel: string,
+  meta: Meta,
+  opts: { self?: string; devices?: DeviceProfile[]; send?: PeerOwnerSender } = {},
+): Promise<SendResult | undefined> {
+  const self = opts.self ?? machineId();
+  let devices = opts.devices;
+  if (!devices) {
+    try {
+      devices = Object.values(await loadDevices());
+    } catch {
+      return undefined; // no registry, nothing to forward to
+    }
+  }
+
+  const plan = planOwnerForward(channel, meta, devices, self, {
+    guarded: process.env[OWNER_FORWARD_GUARD_ENV] === '1',
+  });
+  if (plan.candidates.length === 0) return undefined;
+
+  const send = opts.send ?? sendOnPeer;
+  for (const machine of plan.candidates) {
+    const result = await send(machine, text);
+    if (result?.ok) return result;
+  }
+  return undefined;
+}

--- a/cli/src/lib/channels/owner-forward.ts
+++ b/cli/src/lib/channels/owner-forward.ts
@@ -29,8 +29,7 @@ import { loadDevices, isDialableDevice } from '../devices/registry.js';
 import { machineId, normalizeHost } from '../machine-id.js';
 import { RUSH_CHANNELS } from './providers/rush.js';
 import { resolvePeerTarget, sshCapture } from '../session/remote/remote-list.js';
-import { remoteShellFor, buildWindowsAgentsCommand, stripClixml } from '../hosts/remote-cmd.js';
-import { shellQuote } from '../ssh-exec.js';
+import { buildRemoteAgentsInvocation, stripClixml } from '../hosts/remote-cmd.js';
 
 /**
  * Env marker set on the forwarded `agents send` so a box that received a
@@ -116,12 +115,11 @@ async function sendOnPeer(machine: string, text: string): Promise<SendResult | u
   const peer = await resolvePeerTarget(machine);
   if (!peer) return undefined;
   const args = ['send', '--to', 'owner', '--text', text, '--json'];
-  const env = { [OWNER_FORWARD_GUARD_ENV]: '1' };
-  const remoteCmd = remoteShellFor(peer.os) === 'powershell'
-    ? buildWindowsAgentsCommand({ args, env })
-    : `bash -lc ${shellQuote(
-        [`${OWNER_FORWARD_GUARD_ENV}=1`, 'agents', ...args].map((t, i) => (i === 0 ? t : shellQuote(t))).join(' '),
-      )}`;
+  // Reuse the one injection-tested remote-command builder every `--device`
+  // dispatch uses (posix `bash -lc` / Windows `-EncodedCommand`), rather than a
+  // second hand-rolled quoting path on a security-sensitive seam. The env map is
+  // the loop guard, exported the same way every remote invocation exports env.
+  const remoteCmd = buildRemoteAgentsInvocation(args, undefined, peer.os, { [OWNER_FORWARD_GUARD_ENV]: '1' });
   const capture = await sshCapture(peer.target, remoteCmd, PEER_SEND_TIMEOUT_MS);
   if (capture.code !== 0) return undefined;
   try {
@@ -150,6 +148,12 @@ export async function forwardOwnerNotifyToPeer(
   meta: Meta,
   opts: { self?: string; devices?: DeviceProfile[]; send?: PeerOwnerSender } = {},
 ): Promise<SendResult | undefined> {
+  // Cheap, I/O-free gate first: a box that already received a forward, or an
+  // owner channel that isn't the macOS-only rush family, can never forward — so
+  // a normal local success/failure never pays a device-registry disk read.
+  if (process.env[OWNER_FORWARD_GUARD_ENV] === '1') return undefined;
+  if (!isRushBackedTransport(channel, meta)) return undefined;
+
   const self = opts.self ?? machineId();
   let devices = opts.devices;
   if (!devices) {
@@ -160,9 +164,7 @@ export async function forwardOwnerNotifyToPeer(
     }
   }
 
-  const plan = planOwnerForward(channel, meta, devices, self, {
-    guarded: process.env[OWNER_FORWARD_GUARD_ENV] === '1',
-  });
+  const plan = planOwnerForward(channel, meta, devices, self);
   if (plan.candidates.length === 0) return undefined;
 
   const send = opts.send ?? sendOnPeer;

--- a/cli/src/lib/channels/owner-sink.ts
+++ b/cli/src/lib/channels/owner-sink.ts
@@ -11,6 +11,13 @@
  * after-the-fact `owner failed: …` line. `agents doctor` had no signal for it,
  * which is exactly the gap RUSH-2258 / RUSH-2262 flagged.
  *
+ * At runtime the owner-delivery lane no longer strands this failure: when local
+ * delivery fails on a box that structurally cannot reach the owner,
+ * `forwardOwnerNotifyToPeer` (owner-forward.ts) hands it to a capable macOS peer
+ * over SSH (PHNX-3303). This finding still stands as a diagnostic — the forward
+ * is best-effort and only lands when a reachable mac peer exists, so a box that
+ * cannot deliver locally is worth surfacing regardless.
+ *
  * This probes the SAME transport the lane uses, from the SAME context doctor runs
  * in, so `agents doctor` can fail loud when this box cannot reach the owner. It is
  * deliberately honest about context: `rush whoami` is what tells a real signed-in

--- a/cli/src/lib/feed-broadcast.test.ts
+++ b/cli/src/lib/feed-broadcast.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -384,5 +384,97 @@ describe('channel delivery — real provider registry, no mocking', () => {
     expect(outcomes).toEqual([
       { name: 'tg', ok: false, error: expect.stringContaining('No channel provider') },
     ]);
+  });
+});
+
+/**
+ * PHNX-3303 integration: the feed owner sink must actually INVOKE the SSH
+ * forward when local owner delivery fails on a box with no working provider —
+ * not just leave the pure `owner-forward.ts` functions correct in isolation.
+ *
+ * Real path, no mocking of the logic: the owner channel is the macOS-only rush
+ * `imessage` transport, `rush` is absent from PATH so the local send genuinely
+ * fails its `which rush` preflight, a real device registry names a macOS peer,
+ * and a fake `ssh` on PATH stands in for the transport (the same kind of on-PATH
+ * fake the notify/openclaw tests use) and returns the peer's `agents send --json`
+ * result. POSIX-only: the fake `ssh`/absent-`rush` rig needs `which` + `#!/bin/sh`.
+ */
+describe.skipIf(process.platform === 'win32')('feed owner sink forwards over SSH on local failure (PHNX-3303)', () => {
+  let tmp: string;
+  let sshRecord: string;
+  const saved = {
+    PATH: process.env.PATH,
+    devicesDir: process.env.AGENTS_DEVICES_DIR,
+    machineId: process.env.AGENTS_SYNC_MACHINE_ID,
+    humans: process.env.AGENTS_HUMANS_FILE,
+    sshRecord: process.env.SSH_RECORD,
+    guard: process.env.AGENTS_OWNER_NO_FORWARD,
+  };
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'feed-owner-forward-'));
+    // A real device registry naming one reachable macOS peer.
+    const devicesDir = path.join(tmp, 'devices');
+    fs.mkdirSync(devicesDir, { recursive: true });
+    const now = new Date().toISOString();
+    fs.writeFileSync(path.join(devicesDir, 'registry.json'), JSON.stringify({
+      'mac-test': {
+        name: 'mac-test', platform: 'macos', shell: 'posix',
+        address: { via: 'manual', dnsName: 'mac-test.example' },
+        auth: { method: 'key' }, createdAt: now, updatedAt: now,
+      },
+    }));
+    process.env.AGENTS_DEVICES_DIR = devicesDir;
+    process.env.AGENTS_SYNC_MACHINE_ID = 'linux-self'; // not the mac peer
+    process.env.AGENTS_HUMANS_FILE = path.join(tmp, 'humans.yaml'); // absent -> meta.notify.owner wins
+
+    // A fake `ssh` that records its argv and returns the peer's send result.
+    // No `rush` on PATH, so the LOCAL imessage send fails its `which rush` preflight.
+    sshRecord = path.join(tmp, 'ssh.log');
+    process.env.SSH_RECORD = sshRecord;
+    const bin = path.join(tmp, 'bin');
+    fs.mkdirSync(bin, { recursive: true });
+    const ssh = path.join(bin, 'ssh');
+    fs.writeFileSync(ssh, `#!/bin/sh\nprintf '%s\\n' "$*" >> "$SSH_RECORD"\nprintf '%s\\n' '{"ok":true,"channel":"imessage","id":"+18055551234"}'\nexit 0\n`);
+    fs.chmodSync(ssh, 0o755);
+    process.env.PATH = `${bin}${path.delimiter}/usr/bin${path.delimiter}/bin`;
+    delete process.env.AGENTS_OWNER_NO_FORWARD;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries({
+      PATH: saved.PATH, AGENTS_DEVICES_DIR: saved.devicesDir, AGENTS_SYNC_MACHINE_ID: saved.machineId,
+      AGENTS_HUMANS_FILE: saved.humans, SSH_RECORD: saved.sshRecord, AGENTS_OWNER_NO_FORWARD: saved.guard,
+    })) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('delivers the important post via the macOS peer when this box has no rush', async () => {
+    const meta = { notify: { owner: { channel: 'imessage', to: '+18055551234' } } } as Meta;
+    const planned = planFeedBroadcast({ owner: { channel: 'owner' } }, ctx({ level: 'important' }));
+    const outcomes = await runFeedBroadcast(planned, meta);
+
+    // Local rush send failed, but the owner sink forwarded and reports success.
+    expect(outcomes).toEqual([{ name: 'owner', ok: true }]);
+    // The forward really ran `agents send --to owner` on the peer over SSH,
+    // carrying the loop guard so the peer never forwards onward.
+    const log = fs.readFileSync(sshRecord, 'utf-8');
+    expect(log).toContain('mac-test.example');
+    expect(log).toContain('AGENTS_OWNER_NO_FORWARD');
+    expect(log).toContain('send');
+  });
+
+  it('keeps the clean local failure when no capable peer exists', async () => {
+    fs.writeFileSync(path.join(process.env.AGENTS_DEVICES_DIR!, 'registry.json'), JSON.stringify({}));
+    const meta = { notify: { owner: { channel: 'imessage', to: '+18055551234' } } } as Meta;
+    const planned = planFeedBroadcast({ owner: { channel: 'owner' } }, ctx({ level: 'important' }));
+    const outcomes = await runFeedBroadcast(planned, meta);
+
+    expect(outcomes[0].ok).toBe(false);
+    expect(outcomes[0].error).toContain('rush CLI not found on PATH');
+    expect(fs.existsSync(sshRecord)).toBe(false); // never dialed a peer
   });
 });

--- a/cli/src/lib/feed-broadcast.ts
+++ b/cli/src/lib/feed-broadcast.ts
@@ -37,6 +37,7 @@ import { spawnSync } from 'child_process';
 import type { Meta } from './types.js';
 import { isOwnerAlias, readOwnerDest, resolveSendEnvelope, deliverEnvelope } from './channels/send.js';
 import { lookupTransport } from './channels/resolve.js';
+import { forwardOwnerNotifyToPeer } from './channels/owner-forward.js';
 import { registerBuiltinProviders } from './channels/providers/index.js';
 
 /** How loudly a post asks to be heard. Ordered — `important` implies milestone. */
@@ -583,7 +584,19 @@ async function runChannelSink(sink: PlannedSink, meta: Meta): Promise<SinkOutcom
   if (!provider) return { name, ok: false, error };
 
   const result = await deliverEnvelope(resolved.envelope, meta);
-  return result.ok ? { name, ok: true } : { name, ok: false, error: result.error };
+  if (result.ok) return { name, ok: true };
+
+  // The owner sink failed locally. When this box structurally cannot reach the
+  // owner (the rush-backed channel is macOS-only, so a headless Linux worker can
+  // never ring the phone — PHNX-3303), hand the delivery to a capable fleet peer
+  // over SSH rather than stranding the important post. Only the `owner` alias
+  // forwards: it resolves the peer's own fleet-synced owner destination, so a
+  // non-owner channel sink with an explicit recipient stays local.
+  if (owner) {
+    const forwarded = await forwardOwnerNotifyToPeer(sink.text ?? '', resolved.envelope.channel, meta);
+    if (forwarded?.ok) return { name, ok: true };
+  }
+  return { name, ok: false, error: result.error };
 }
 
 /**

--- a/cli/src/lib/notify.test.ts
+++ b/cli/src/lib/notify.test.ts
@@ -241,3 +241,99 @@ describe.skipIf(process.platform === 'win32')('notifyUrgentBlock (feed urgent-bl
     expect(fs.existsSync(record)).toBe(false);
   });
 });
+
+/**
+ * PHNX-3303 integration: sendToOwner must actually INVOKE the SSH forward when
+ * local owner delivery fails on a box with no working provider — proving the
+ * wiring, not just the isolated owner-forward.ts functions.
+ *
+ * Real path, no mocking of the logic: the owner channel is the macOS-only rush
+ * `imessage` transport, `rush` is absent from PATH so the local send genuinely
+ * fails its `which rush` preflight, a real device registry names a macOS peer,
+ * and a fake `ssh` on PATH stands in for the transport (the same on-PATH-fake
+ * pattern the openclaw tests above use) returning the peer's `agents send
+ * --json` result. POSIX-only: the rig needs `which` + `#!/bin/sh`.
+ */
+describe.skipIf(process.platform === 'win32')('sendToOwner forwards over SSH on local failure (PHNX-3303)', () => {
+  let tmp: string;
+  let sshRecord: string;
+  const saved = {
+    PATH: process.env.PATH,
+    devicesDir: process.env.AGENTS_DEVICES_DIR,
+    machineId: process.env.AGENTS_SYNC_MACHINE_ID,
+    humans: process.env.AGENTS_HUMANS_FILE,
+    sshRecord: process.env.SSH_RECORD,
+    guard: process.env.AGENTS_OWNER_NO_FORWARD,
+  };
+  const ownerMeta = { notify: { owner: { channel: 'imessage', to: '+18055551234' } } } as Meta;
+
+  function writeRegistry(reg: object): void {
+    fs.writeFileSync(path.join(process.env.AGENTS_DEVICES_DIR!, 'registry.json'), JSON.stringify(reg));
+  }
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sendtoowner-forward-'));
+    const devicesDir = path.join(tmp, 'devices');
+    fs.mkdirSync(devicesDir, { recursive: true });
+    process.env.AGENTS_DEVICES_DIR = devicesDir;
+    const now = new Date().toISOString();
+    writeRegistry({
+      'mac-test': {
+        name: 'mac-test', platform: 'macos', shell: 'posix',
+        address: { via: 'manual', dnsName: 'mac-test.example' },
+        auth: { method: 'key' }, createdAt: now, updatedAt: now,
+      },
+    });
+    process.env.AGENTS_SYNC_MACHINE_ID = 'linux-self'; // not the mac peer
+    process.env.AGENTS_HUMANS_FILE = path.join(tmp, 'humans.yaml'); // absent -> meta.notify.owner wins
+
+    sshRecord = path.join(tmp, 'ssh.log');
+    process.env.SSH_RECORD = sshRecord;
+    const bin = path.join(tmp, 'bin');
+    fs.mkdirSync(bin, { recursive: true });
+    const ssh = path.join(bin, 'ssh');
+    // No `rush` on PATH -> the LOCAL imessage send fails its `which rush` preflight.
+    fs.writeFileSync(ssh, `#!/bin/sh\nprintf '%s\\n' "$*" >> "$SSH_RECORD"\nprintf '%s\\n' '{"ok":true,"channel":"imessage","id":"+18055551234"}'\nexit 0\n`);
+    fs.chmodSync(ssh, 0o755);
+    process.env.PATH = `${bin}${path.delimiter}/usr/bin${path.delimiter}/bin`;
+    delete process.env.AGENTS_OWNER_NO_FORWARD;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries({
+      PATH: saved.PATH, AGENTS_DEVICES_DIR: saved.devicesDir, AGENTS_SYNC_MACHINE_ID: saved.machineId,
+      AGENTS_HUMANS_FILE: saved.humans, SSH_RECORD: saved.sshRecord, AGENTS_OWNER_NO_FORWARD: saved.guard,
+    })) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('hands off to the macOS peer when this box has no rush', async () => {
+    const result = await sendToOwner('ship it', { meta: ownerMeta });
+    expect(result.ok).toBe(true); // forwarded delivery, not the local rush failure
+    const log = fs.readFileSync(sshRecord, 'utf-8');
+    expect(log).toContain('mac-test.example');
+    expect(log).toContain('AGENTS_OWNER_NO_FORWARD'); // loop guard rides the forward
+    expect(log).toContain('send');
+  });
+
+  it('keeps the clean local error (never dials a peer) when no capable peer exists', async () => {
+    writeRegistry({});
+    const result = await sendToOwner('ship it', { meta: ownerMeta });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('rush CLI not found on PATH');
+    expect(fs.existsSync(sshRecord)).toBe(false);
+  });
+
+  it('does not forward for a Linux-capable transport — only the rush family hops', async () => {
+    const meta = {
+      notify: { owner: { channel: 'telegram', to: 'c1' }, transports: { telegram: 'openclaw-telegram' } },
+    } as Meta;
+    const result = await sendToOwner('ship it', { meta });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('openclaw CLI not found on PATH');
+    expect(fs.existsSync(sshRecord)).toBe(false); // non-rush failure stays local
+  });
+});

--- a/cli/src/lib/notify.ts
+++ b/cli/src/lib/notify.ts
@@ -19,6 +19,7 @@ import { readMeta } from './state.js';
 import { getOwnerNotifyFromHumans } from './humans.js';
 import { registerBuiltinProviders } from './channels/providers/index.js';
 import { lookupTransport } from './channels/resolve.js';
+import { forwardOwnerNotifyToPeer } from './channels/owner-forward.js';
 import type { SendResult } from './channels/registry.js';
 
 export interface OwnerNotifyOptions {
@@ -79,6 +80,13 @@ export function buildOpenClawNotifyArgs(
  * selects the provider per host. A missing owner config or a delivery failure
  * (e.g. openclaw not on PATH) returns a clean `SendResult` error — never a raw
  * ENOENT — so callers surface a consistent, best-effort failure.
+ *
+ * When local delivery fails because THIS box structurally cannot reach the owner
+ * — the rush-backed owner channel is macOS-only, so a headless Linux worker can
+ * never ring the phone (PHNX-3303) — the notify is forwarded over SSH to a
+ * capable fleet peer that DOES have the provider, mirroring the reroute
+ * `agents message` already uses. A successful forward is returned as the result;
+ * if no capable peer is reachable, the original clean local error stands.
  */
 export async function sendToOwner(text: string, options: OwnerNotifyOptions = {}): Promise<SendResult> {
   const meta = options.meta ?? readMeta();
@@ -98,11 +106,16 @@ export async function sendToOwner(text: string, options: OwnerNotifyOptions = {}
   if (!provider) {
     return { ok: false, channel, id: target, error };
   }
-  return provider.send(text, {
+  const local = await provider.send(text, {
     target,
     ownerScoped: options.target === undefined,
     dryRun: options.dryRun,
   });
+  // A dry-run never delivers, and an override target is an explicit recipient
+  // (not the fleet-wide owner) — neither should hop to a peer.
+  if (local.ok || options.dryRun || options.target !== undefined) return local;
+  const forwarded = await forwardOwnerNotifyToPeer(text, channel, meta);
+  return forwarded ?? local;
 }
 
 export async function notifyUrgentBlock(


### PR DESCRIPTION
## Bug (PHNX-3303)

`agents feed post --level important` from a Linux worker (e.g. `yosemite-m3`) fails to reach the owner:

```
owner failed: send failed [imessage → +1805…]: rush CLI not found on PATH
```

The owner's delivery provider for the rush-backed channels (imessage / telegram / slack / discord via the `rush` CLI) is **macOS-only** and keychain-bound, so a headless Linux box can never ring the owner's phone. The important post records but never delivers — and the same gap hits `agents notify`, `--blocked` posts, and monitor `notify` actions.

## Root cause

Owner delivery funnels through two seams:
- `sendToOwner` (`cli/src/lib/notify.ts`) — `agents notify`, monitors, urgent-block notify.
- the feed owner-alias sink -> `runChannelSink` -> `deliverEnvelope` (`cli/src/lib/feed-broadcast.ts`) — `agents feed post --level important` / `--blocked`.

Both resolve the rush provider fine, then `rushProvider.send()` fails its `which rush` preflight and returns `{ ok:false, error:'rush CLI not found on PATH' }`. Nothing reroutes, so the failure is stranded — exactly the case `probeOwnerSink` already flags as the `owner-sink-unreachable` doctor finding (RUSH-2262), with no runtime answer.

## Fix

New canonical helper `forwardOwnerNotifyToPeer` (`cli/src/lib/channels/owner-forward.ts`): when local owner delivery fails on a box that **structurally** cannot reach the owner, hand the delivery over SSH to a reachable macOS peer that DOES have the provider — running that peer's own `agents send --to owner --text ... --json`, which resolves its fleet-synced owner destination and delivers through its local rush. This mirrors the SSH reroute `agents message` (`decideHostTaskRoute` -> `runOnPeer`) and the sessions fan-out already use.

Wired into **both** owner-delivery seams (`sendToOwner` and the feed owner sink) so the fix lands wherever the owner is addressed.

Design:
- **Pure planner** `planOwnerForward` — channel gate (only the macOS-only rush family forwards; a Linux-capable transport like `openclaw-telegram` stays local), macOS-peer selection, `interactive.host`-first ordering, self-exclusion, and the loop guard. Fully unit-tested with device fixtures, no tailnet.
- **Injectable SSH transport** (default = `resolvePeerTarget` + `sshCapture`), matching the repo's separation of pure logic from the SSH boundary.
- **Best-effort**: never throws, never blocks the post. First capable peer to deliver wins and stops the sweep. No capable peer reachable -> resolves `undefined` and the original clean local error stands.
- **Loop guard**: the forwarded command carries `AGENTS_OWNER_NO_FORWARD=1`, so a box that received a forward never forwards onward.

## Tests

`cli/src/lib/channels/owner-forward.test.ts` (15 cases): the pure planner and the forward orchestration via an injected transport (first capable peer delivers and stops; skip-failed-and-try-next; all-fail -> `undefined`; no-capable-peer -> no SSH attempted; loop guard).

```
$ npx vitest run src/lib/channels/owner-forward.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)

$ npx vitest run src/lib/notify.test.ts src/lib/feed-broadcast.test.ts src/lib/channels/owner-sink.test.ts
 Test Files  3 passed (3)
      Tests  58 passed (58)

$ npx tsc --noEmit   # exit 0
```

## Docs

- `cli/.changelog/next/PHNX-3303.md` added.
- Cross-reference note added to `owner-sink.ts` (the `owner-sink-unreachable` finding still stands — the forward is best-effort and only lands when a reachable mac peer exists).

Do not merge — routing to the non-author review.
