### PR TITLE
fix(run)!: tmux.enabled gates remote --device wraps (PHNX-3316)

### DIFF
--- a/cli/.changelog/next/PHNX-3316.md
+++ b/cli/.changelog/next/PHNX-3316.md
@@ -6,11 +6,14 @@
   auto-reconnect in `cli/src/lib/hosts/reconnect.ts`, whose target
   (`agents sessions focus <id> --local`) already resumes the harness session in
   place when no pane exists — a dropped link costs the in-flight turn, not the
-  conversation. One case still wraps regardless: a remote run with no TTY
-  (`--device --no-follow`), whose detached pane is the run's only stdout.
+  conversation. One case still wraps regardless: a followed remote run whose
+  launcher has no TTY (CI, scripts, another agent driving the CLI), where the
+  detached pane is the run's only interface.
   `undurable` is now reached only when a wrap was actually wanted (opted-in
-  device, or no-follow) but the peer has no tmux; its refusal message names the
-  `agents config set devices.<host>.tmux off` alternative alongside `--raw`.
+  device, or the no-TTY case) but the peer has no tmux; its refusal message
+  names the `agents ssh <host> 'agents devices config <host> tmux.enabled off'`
+  alternative (the key is machine-local, so it must be set on the peer)
+  alongside `--raw`.
   RUSH-3125's forced wrap conflated durability with an ergonomics preference
   and wrapped boxes whose operator had explicitly left tmux off.
   `hosts/reconnect.ts`'s header premise, the `hosts/dispatch.ts`

--- a/cli/.changelog/next/PHNX-3316.md
+++ b/cli/.changelog/next/PHNX-3316.md
@@ -1,0 +1,19 @@
+- **`tmux.enabled` now gates remote `--device` runs too — no more forced tmux wrap (PHNX-3316).**
+  `resolveTmuxWrap` (`cli/src/lib/exec.ts`) no longer lets `remoteDispatch`
+  override the device's `tmux.enabled`: off (the default) means a followed
+  `agents run --device <host>` spawns the agent directly, with no tmux session
+  on the peer. Durability for a bare remote run comes from the existing
+  auto-reconnect in `cli/src/lib/hosts/reconnect.ts`, whose target
+  (`agents sessions focus <id> --local`) already resumes the harness session in
+  place when no pane exists — a dropped link costs the in-flight turn, not the
+  conversation. One case still wraps regardless: a remote run with no TTY
+  (`--device --no-follow`), whose detached pane is the run's only stdout.
+  `undurable` is now reached only when a wrap was actually wanted (opted-in
+  device, or no-follow) but the peer has no tmux; its refusal message names the
+  `agents config set devices.<host>.tmux off` alternative alongside `--raw`.
+  RUSH-3125's forced wrap conflated durability with an ergonomics preference
+  and wrapped boxes whose operator had explicitly left tmux off.
+  `hosts/reconnect.ts`'s header premise, the `hosts/dispatch.ts`
+  REMOTE_INTERACTIVE_ENV comments, and the `tmux.enabled` help text
+  (`device-config.ts`) are updated to match; wrap-matrix tests cover the new
+  gate.

--- a/cli/src/commands/exec.ts
+++ b/cli/src/commands/exec.ts
@@ -1889,15 +1889,19 @@ agents run auto --device yosemite-s0 "fix the flaky test"   # pin the device
                 });
               }
             }
-            // A network drop kills the local ssh client (exit 255) but the remote
-            // agent survives in its detached tmux session. With a known session id
-            // (Claude's forced id, a resumed run, or a non-Claude id we just
-            // resolved from the remote hook record) and a tmux-hosted run,
-            // re-attach the live pane automatically instead of exiting — the user
-            // never has to notice the drop and `agents sessions focus` by hand.
-            // `raw` runs aren't tmux wrapped, so there is nothing to reconnect to.
-            // For `run auto` prefer the join-resolved id (the harness the remote
-            // ACTUALLY picked) over the explicit --session-id only claude adopts.
+            // A network drop kills the local ssh client (exit 255). What the
+            // remote agent does next depends on the peer's tmux.enabled
+            // (PHNX-3316): wrapped, it survives in its detached pane and the
+            // reconnect rejoins it; bare (the default), the drop SIGHUPs it and
+            // the reconnect resumes the session in place from disk. Either way,
+            // with a known session id (Claude's forced id, a resumed run, or a
+            // non-Claude id we just resolved from the remote hook record) we
+            // reconnect automatically instead of exiting — the user never has
+            // to notice the drop and `agents sessions focus` by hand.
+            // `raw` runs opted out of all of this, so there is nothing to
+            // reconnect to. For `run auto` prefer the join-resolved id (the
+            // harness the remote ACTUALLY picked) over the explicit
+            // --session-id only claude adopts.
             const { pickReconnectTarget, reconnectInteractiveSession, afterInteractiveRemoteExit, SSH_CONN_FAILURE } = await import('../lib/hosts/reconnect.js');
             const reconnectTarget = pickReconnectTarget({
               agent: runAgent,

--- a/cli/src/lib/device-config.ts
+++ b/cli/src/lib/device-config.ts
@@ -236,8 +236,9 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     type: 'bool',
     defaultValue: false,
     description:
-      'Whether an interactive `agents run` on this device is wrapped in the shared-socket tmux session. ' +
-      'Off, the default, spawns the agent directly. Turn it on to give every agent an addressable pane for ' +
+      'Whether an interactive `agents run` on this device is wrapped in the shared-socket tmux session — local runs and ' +
+      'followed `--device` runs alike (PHNX-3316). Off, the default, spawns the agent directly; a remote run left bare ' +
+      'is protected by reconnect-and-resume, not a pane. Turn it on to give every agent an addressable pane for ' +
       '`agents message`, injection, and `agents focus` once the tmux mouse, clipboard, and scrollback behavior suits this device.',
   },
   {

--- a/cli/src/lib/exec.test.ts
+++ b/cli/src/lib/exec.test.ts
@@ -610,14 +610,19 @@ describePosix('resolveTmuxWrap (interactive spawn-wrap gate)', () => {
     expect(resolveTmuxWrap({ ...base, configEnabled: false, tmuxAvailable: true, raw: false }).kind).toBe('bare');
   });
 
-  // RUSH-3125: a run dispatched here over --device holds its TTY on an ssh link,
-  // so a blink SIGHUPs a bare spawn. Durability is not the local operator's
-  // mouse/scrollback preference, so it does not consult tmux.enabled.
-  it('wraps a REMOTE-dispatched run even when this device set tmux.enabled=false', () => {
-    expect(resolveTmuxWrap({ ...base, configEnabled: false, remoteDispatch: true }).kind).toBe('wrap');
+  // PHNX-3316: tmux.enabled=false means NO wrap, local or remote. A followed
+  // --device run left bare is protected by reconnect-and-resume (hosts/
+  // reconnect.ts), not by a pane. The RUSH-3125 forced wrap conflated
+  // durability with an ergonomics preference and wrapped boxes whose operator
+  // had explicitly left tmux off.
+  it('does NOT wrap a followed REMOTE-dispatched run when this device set tmux.enabled=false', () => {
+    expect(resolveTmuxWrap({ ...base, configEnabled: false, remoteDispatch: true }).kind).toBe('bare');
+    // …even when tmux is missing — nothing requested the wrap, so there is
+    // nothing to refuse.
+    expect(resolveTmuxWrap({ ...base, configEnabled: false, remoteDispatch: true, tmuxAvailable: false }).kind).toBe('bare');
   });
 
-  it('refuses a remote-dispatched run when tmux is missing, instead of spawning something a blink would kill', () => {
+  it('refuses a remote-dispatched run that WANTS the wrap when tmux is missing, instead of spawning something a blink would kill', () => {
     expect(resolveTmuxWrap({ ...base, remoteDispatch: true, tmuxAvailable: false }).kind).toBe('undurable');
     // A LOCAL run with no tmux is merely unwrapped — nothing about it needs to
     // outlive a network link, so it must not be refused.
@@ -628,8 +633,13 @@ describePosix('resolveTmuxWrap (interactive spawn-wrap gate)', () => {
     expect(resolveTmuxWrap({ ...base, hasTty: false }).kind).toBe('bare');
   });
 
-  it('still wraps a REMOTE-dispatched run with no TTY (--no-follow wants a detached pane)', () => {
+  it('still wraps a REMOTE-dispatched run with no TTY, even with tmux.enabled=false (--no-follow wants a detached pane)', () => {
+    // The pane is the run's only stdout — infrastructure, not ergonomics — so
+    // the config toggle does not reach this case.
     expect(resolveTmuxWrap({ ...base, hasTty: false, remoteDispatch: true }).kind).toBe('wrap');
+    expect(resolveTmuxWrap({ ...base, hasTty: false, remoteDispatch: true, configEnabled: false }).kind).toBe('wrap');
+    // …and with no tmux on the peer there is no pane to hold it: refuse.
+    expect(resolveTmuxWrap({ ...base, hasTty: false, remoteDispatch: true, configEnabled: false, tmuxAvailable: false }).kind).toBe('undurable');
   });
 
   it('lets the explicit per-run opt-outs beat the durability rule', () => {

--- a/cli/src/lib/exec.test.ts
+++ b/cli/src/lib/exec.test.ts
@@ -633,8 +633,9 @@ describePosix('resolveTmuxWrap (interactive spawn-wrap gate)', () => {
     expect(resolveTmuxWrap({ ...base, hasTty: false }).kind).toBe('bare');
   });
 
-  it('still wraps a REMOTE-dispatched run with no TTY, even with tmux.enabled=false (--no-follow wants a detached pane)', () => {
-    // The pane is the run's only stdout — infrastructure, not ergonomics — so
+  it('still wraps a followed REMOTE run whose launcher has no TTY, even with tmux.enabled=false (the pane is its only interface)', () => {
+    // A launcher without a TTY (CI, scripts, another agent) gives the peer
+    // nothing to attach to, so the pane is infrastructure, not ergonomics —
     // the config toggle does not reach this case.
     expect(resolveTmuxWrap({ ...base, hasTty: false, remoteDispatch: true }).kind).toBe('wrap');
     expect(resolveTmuxWrap({ ...base, hasTty: false, remoteDispatch: true, configEnabled: false }).kind).toBe('wrap');

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -1405,15 +1405,16 @@ export interface TmuxWrapContext {
    * True when this run was dispatched onto this box over SSH by `--device`
    * (the launcher exports {@link REMOTE_INTERACTIVE_ENV}).
    *
-   * A remote interactive agent is a child of the sshd session and holds its
-   * controlling TTY, so without the wrap a dropped link SIGHUPs it and the work
-   * in flight is gone. Durability is therefore NOT a preference the way
-   * `configEnabled` is — `tmux.enabled` is about whether this box's operator
-   * likes tmux's mouse/clipboard/scrollback at their own keyboard, which says
-   * nothing about whether a run arriving over the network must outlive it.
-   * Conflating the two is what left every `--device` agent unsurvivable
-   * (RUSH-3125), while lib/hosts/reconnect.ts reconnected on the premise that
-   * they were detached.
+   * Since PHNX-3316 this flag no longer forces the wrap: `tmux.enabled` gates
+   * local and remote runs alike, because the operator reading "tmux disabled"
+   * expects NO tmux anywhere. A followed remote run left bare is protected by
+   * reconnect-and-resume (lib/hosts/reconnect.ts): a dropped link costs the
+   * in-flight turn, and the harness session resumes from disk.
+   *
+   * The flag still matters for one case: a remote run with NO TTY
+   * (`--no-follow`) has no interface at all without a detached pane — the pane
+   * is the run's stdout, not an ergonomics choice — so it wraps regardless of
+   * `configEnabled` (and is refused as `undurable` when tmux is missing).
    */
   remoteDispatch: boolean;
   /** Whether a tmux binary is on PATH. */
@@ -1429,58 +1430,63 @@ export interface TmuxWrapContext {
 }
 
 /**
- * What to do with an interactive spawn. Three outcomes, not two: a run that
- * MUST be durable and cannot be is neither "wrap" nor "spawn bare" — it is a
- * launch that should not happen, because a bare remote spawn looks fine right
- * up until the link blinks and the agent dies with it.
+ * What to do with an interactive spawn. Three outcomes, not two: a remote run
+ * that WOULD wrap (the operator opted in, or a `--no-follow` run whose only
+ * interface is the detached pane) on a box with no tmux is neither "wrap" nor
+ * "spawn bare" — it is a launch that should not happen, because a bare remote
+ * spawn looks fine right up until the link blinks and the agent dies with it.
  */
 export type TmuxWrapDecision =
   /** Run the agent in a detached tmux session and attach this TTY. */
   | { kind: 'wrap' }
   /** Spawn directly — nothing about this run needs a pane. */
   | { kind: 'bare' }
-  /** Remote-dispatched and tmux is missing on this box: refuse, don't pretend. */
+  /** Remote-dispatched, wants the wrap, and tmux is missing: refuse, don't pretend. */
   | { kind: 'undurable' };
 
 /**
  * Decide whether to run an interactive agent INSIDE a detached tmux session on
  * the shared socket (then attach the current TTY) instead of a bare spawn.
  *
- * Wrapping serves two independent purposes, and they are gated differently:
+ * The wrap is opt-in via this device's `tmux.enabled` (`configEnabled`): a
+ * unique `%pane` handle so `agents sessions --active` can tell co-located
+ * agents apart and `agents focus` re-attaches without forking, plus scrollback
+ * and mouse at the operator's keyboard. Off means OFF, for local and remote
+ * runs alike (PHNX-3316) — a followed `--device` run left bare is protected by
+ * reconnect-and-resume (lib/hosts/reconnect.ts), which rejoins the live pane
+ * when one exists and resumes the harness session from disk when it does not.
+ * The RUSH-3125 forced remote wrap conflated durability with that preference
+ * and surprised every operator who had explicitly left tmux off.
  *
- *  - **Addressability** (`configEnabled`): a unique `%pane` handle so
- *    `agents sessions --active` can tell co-located agents apart and `agents
- *    focus` re-attaches without forking. That is a local preference — the
- *    operator turns it on once tmux's mouse/clipboard/scrollback suits them.
- *  - **Durability** (`remoteDispatch`): a run that arrived over SSH must outlive
- *    the SSH client, because a bare remote spawn dies of SIGHUP the moment the
- *    link blinks. That is not a preference, so it does not consult
- *    `configEnabled` (RUSH-3125 — see {@link TmuxWrapContext.remoteDispatch}).
+ * One case still wraps regardless: a remote run with NO TTY
+ * (`--device --no-follow`) has no interface at all without a detached pane —
+ * the pane is the run's stdout, not an ergonomics choice.
  *
- * The per-run opt-outs bind BOTH: `--raw` / `--no-tmux` / `AGENTS_NO_TMUX=1` are
- * explicit "I want the bare process" requests, and honouring them over the
- * durability rule keeps one escape hatch that always works.
+ * The per-run opt-outs bind everything: `--raw` / `--no-tmux` /
+ * `AGENTS_NO_TMUX=1` are explicit "I want the bare process" requests, and an
+ * escape hatch that silently stopped applying over `--device` would be worse
+ * than the bare run the user asked for.
  *
  * Pure, so the gate is unit-tested independently of the (side-effecting) spawn.
  */
 export function resolveTmuxWrap(ctx: TmuxWrapContext): TmuxWrapDecision {
   // A headless `-p` run has no TTY to attach, Windows has no tmux path, and
-  // nesting tmux-in-tmux is pointless — none of these can wrap, and none of them
-  // is a remote interactive agent whose life depends on it.
+  // nesting tmux-in-tmux is pointless.
   if (!ctx.interactive) return { kind: 'bare' };
   if (ctx.platform === 'win32') return { kind: 'bare' };
   if (ctx.inTmux) return { kind: 'bare' };
-  // Explicit opt-outs win over the durability rule: `--raw` exists precisely to
-  // get the unwrapped process, and a flag that silently stopped working on a
-  // remote box would be worse than an undurable run the user asked for.
+  // Explicit opt-outs win over every other rule: `--raw` exists precisely to
+  // get the unwrapped process.
   if (ctx.raw) return { kind: 'bare' };
   if (ctx.noTmuxEnv) return { kind: 'bare' };
   // Local interactive with no TTY cannot attach. Wrapping anyway creates a
   // detached pane, attach returns immediately, and resolveAfterAttach treats
   // the still-alive pane as Ctrl-b d — the session-tracker test leak.
-  // Remote dispatch is the exception: --no-follow *intends* a detached pane.
   if (!ctx.hasTty && !ctx.remoteDispatch) return { kind: 'bare' };
-  if (!ctx.configEnabled && !ctx.remoteDispatch) return { kind: 'bare' };
+  // tmux.enabled gates the wrap for local AND followed remote runs. A remote
+  // run with no TTY is the one exception: --no-follow *intends* a detached
+  // pane, which is the run's only stdout — infrastructure, not ergonomics.
+  if (!ctx.configEnabled && !(ctx.remoteDispatch && !ctx.hasTty)) return { kind: 'bare' };
   // Fail loud rather than launch a remote agent that a blink would kill: the
   // caller refuses the run instead of starting work that cannot be recovered.
   if (!ctx.tmuxAvailable) return ctx.remoteDispatch ? { kind: 'undurable' } : { kind: 'bare' };
@@ -1943,9 +1949,10 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
   });
 
   // Interactive spawn-wrap: run the agent INSIDE a shared-socket tmux session
-  // (then attach this TTY) so it gets a unique, addressable %pane — and, when
-  // the run arrived over `--device`, so it survives the SSH link that carries
-  // it. Every failed guard keeps the bare spawn below.
+  // (then attach this TTY) so it gets a unique, addressable %pane. Opt-in via
+  // this device's tmux.enabled, local and remote alike (PHNX-3316); a followed
+  // remote run left bare relies on reconnect-and-resume, not a pane. Every
+  // failed guard keeps the bare spawn below.
   const tmuxWrap = resolveTmuxWrap({
     interactive,
     platform: process.platform,
@@ -1964,9 +1971,11 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
     // there is no launcher-side probe ahead of this one. Failing here still
     // fails before the agent starts, which is what matters; a pre-dispatch
     // probe would only move the message earlier, at the cost of a round trip on
-    // every launch.
-    const msg = `agents: ${machineId()} has no tmux, so a --device run here could not survive a dropped connection.\n`
+    // every launch. Reached only when the wrap was wanted: the device opted in
+    // via tmux.enabled, or the run is --no-follow and the pane is its stdout.
+    const msg = `agents: ${machineId()} has no tmux, so this --device run cannot get its detached pane.\n`
       + `  install it:            (apt|dnf|brew) install tmux\n`
+      + `  or run without tmux:   agents config set devices.${machineId()}.tmux off   (link drops resume the session)\n`
       + `  or accept the risk:    agents run … --device ${machineId()} --raw\n`;
     process.stderr.write(`\x1b[31m${msg}\x1b[0m`);
     timer.end({ exitCode: 1, status: 'failed', error: 'remote interactive run has no tmux for durability' });

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -1411,10 +1411,12 @@ export interface TmuxWrapContext {
    * reconnect-and-resume (lib/hosts/reconnect.ts): a dropped link costs the
    * in-flight turn, and the harness session resumes from disk.
    *
-   * The flag still matters for one case: a remote run with NO TTY
-   * (`--no-follow`) has no interface at all without a detached pane — the pane
-   * is the run's stdout, not an ergonomics choice — so it wraps regardless of
-   * `configEnabled` (and is refused as `undurable` when tmux is missing).
+   * The flag still matters for one case: a followed remote run whose LAUNCHER
+   * has no TTY (CI, a script, another agent driving the CLI — `sshStream`
+   * allocates the peer's TTY from `process.stdin.isTTY`, dispatch.ts) gets no
+   * TTY on the peer either, so there is nothing to attach to and the detached
+   * pane is the run's only interface — it wraps regardless of `configEnabled`
+   * (and is refused as `undurable` when tmux is missing).
    */
   remoteDispatch: boolean;
   /** Whether a tmux binary is on PATH. */
@@ -1423,8 +1425,10 @@ export interface TmuxWrapContext {
    * True when this process has a real TTY to attach (`stdout.isTTY`).
    * A piped `agents run --interactive` (session-tracker tests, CI) has none:
    * wrapping then treating the failed attach as Ctrl-b d leaked live panes
-   * for a week on yosemite-s0 (PHNX-3293). Remote dispatch still wraps
-   * without a TTY — `--device --no-follow` *wants* a detached pane.
+   * for a week on yosemite-s0 (PHNX-3293). A remote dispatch still wraps
+   * without a TTY — a launcher that has none (CI, scripts, another agent)
+   * gives the peer nothing to attach to, so the detached pane is the run's
+   * only interface.
    */
   hasTty: boolean;
 }
@@ -1458,9 +1462,9 @@ export type TmuxWrapDecision =
  * The RUSH-3125 forced remote wrap conflated durability with that preference
  * and surprised every operator who had explicitly left tmux off.
  *
- * One case still wraps regardless: a remote run with NO TTY
- * (`--device --no-follow`) has no interface at all without a detached pane —
- * the pane is the run's stdout, not an ergonomics choice.
+ * One case still wraps regardless: a followed remote run whose launcher has
+ * no TTY (CI, scripts, another agent) gives the peer nothing to attach to —
+ * the detached pane is the run's only interface, not an ergonomics choice.
  *
  * The per-run opt-outs bind everything: `--raw` / `--no-tmux` /
  * `AGENTS_NO_TMUX=1` are explicit "I want the bare process" requests, and an
@@ -1483,9 +1487,10 @@ export function resolveTmuxWrap(ctx: TmuxWrapContext): TmuxWrapDecision {
   // detached pane, attach returns immediately, and resolveAfterAttach treats
   // the still-alive pane as Ctrl-b d — the session-tracker test leak.
   if (!ctx.hasTty && !ctx.remoteDispatch) return { kind: 'bare' };
-  // tmux.enabled gates the wrap for local AND followed remote runs. A remote
-  // run with no TTY is the one exception: --no-follow *intends* a detached
-  // pane, which is the run's only stdout — infrastructure, not ergonomics.
+  // tmux.enabled gates the wrap for local AND followed remote runs. The one
+  // exception: a followed remote run whose launcher has no TTY (CI, scripts)
+  // gives the peer nothing to attach to — the detached pane is its only
+  // interface, infrastructure rather than ergonomics.
   if (!ctx.configEnabled && !(ctx.remoteDispatch && !ctx.hasTty)) return { kind: 'bare' };
   // Fail loud rather than launch a remote agent that a blink would kill: the
   // caller refuses the run instead of starting work that cannot be recovered.
@@ -1972,11 +1977,14 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
     // fails before the agent starts, which is what matters; a pre-dispatch
     // probe would only move the message earlier, at the cost of a round trip on
     // every launch. Reached only when the wrap was wanted: the device opted in
-    // via tmux.enabled, or the run is --no-follow and the pane is its stdout.
-    const msg = `agents: ${machineId()} has no tmux, so this --device run cannot get its detached pane.\n`
-      + `  install it:            (apt|dnf|brew) install tmux\n`
-      + `  or run without tmux:   agents config set devices.${machineId()}.tmux off   (link drops resume the session)\n`
-      + `  or accept the risk:    agents run … --device ${machineId()} --raw\n`;
+    // via tmux.enabled, or a followed run whose launcher had no TTY (CI,
+    // scripts) left the peer nothing to attach to, so the pane is its stdout.
+    // The config tip uses the ssh form because tmux.enabled is machine-local:
+    // setting it from the launcher throws (assertLocalTarget).
+    const msg = `agents: ${machineId()} has no tmux, so this --device run cannot get the pane it needs.\n`
+      + `  install it:              (apt|dnf|brew) install tmux\n`
+      + `  or turn the wrap off:    agents ssh ${machineId()} 'agents devices config ${machineId()} tmux.enabled off'\n`
+      + `  or accept a bare run:    agents run … --device ${machineId()} --raw\n`;
     process.stderr.write(`\x1b[31m${msg}\x1b[0m`);
     timer.end({ exitCode: 1, status: 'failed', error: 'remote interactive run has no tmux for durability' });
     return { exitCode: 1, stdout: '', stderr: msg };

--- a/cli/src/lib/hosts/dispatch.test.ts
+++ b/cli/src/lib/hosts/dispatch.test.ts
@@ -657,12 +657,12 @@ describe('remoteRunShellPrelude — the run-auto chain-hop guard crosses the SSH
     expect(buildInteractiveRunForwardedArgs({ agent: 'auto' }).join(' ')).not.toContain('AGENTS_RUN_AUTO_HOST_RESOLVED');
   });
 
-  // RUSH-3125. The interactive dispatch hands the remote agent a TTY that IS an
-  // ssh link, so the remote CLI has to know to detach — otherwise a blink
-  // SIGHUPs the agent and the in-flight turn is lost, while reconnect.ts
-  // re-attaches on the premise that it survived. Like the run-auto guard, this
-  // MUST be a shell export: resolveTmuxWrap reads the remote CLI's own
-  // process.env, which a forwarded `--env` never reaches.
+  // RUSH-3125 / PHNX-3316. The interactive dispatch hands the remote agent a
+  // TTY that IS an ssh link, so the remote CLI has to know the run arrived
+  // over the network — resolveTmuxWrap reads it for the --no-follow pane
+  // requirement, and reconnect.ts keys the drop-recovery off it. Like the
+  // run-auto guard, this MUST be a shell export: resolveTmuxWrap reads the
+  // remote CLI's own process.env, which a forwarded `--env` never reaches.
   it('exports the remote-interactive marker when asked, and the remote shell really sees it', () => {
     const prelude = remoteRunShellPrelude('claude', { AGENTS_REMOTE_INTERACTIVE: '1' });
     expect(prelude).toContain('export AGENTS_REMOTE_INTERACTIVE=1');

--- a/cli/src/lib/hosts/dispatch.ts
+++ b/cli/src/lib/hosts/dispatch.ts
@@ -91,9 +91,10 @@ export function withActorEnv(env?: Record<string, string>): Record<string, strin
  *
  * `extra` carries the markers that are true of ONE path rather than both — the
  * interactive dispatch adds REMOTE_INTERACTIVE_ENV, which the remote CLI reads
- * to decide it must detach. It goes through this builder rather than being
- * concatenated on at the call site so every remote env marker is exported the
- * same way, in one place.
+ * to know its stdio is an ssh link (reconnect target, `--no-follow` pane
+ * requirement). It goes through this builder rather than being concatenated on
+ * at the call site so every remote env marker is exported the same way, in one
+ * place.
  */
 export function remoteRunShellPrelude(agent: string, extra: Record<string, string> = {}): string {
   const guard: Record<string, string> = agent === RUN_AUTO_KEYWORD ? { [RUN_AUTO_HOST_RESOLVED_ENV]: '1' } : {};
@@ -637,10 +638,12 @@ export async function runInteractiveOnHost(host: Host, opts: InteractiveDispatch
   // than re-resolving from this box's SSH_CONNECTION (RUSH-2028); a `run auto`
   // dispatch also gets the chain-hop guard (remoteRunShellPrelude).
   //
-  // REMOTE_INTERACTIVE_ENV rides the same prelude and is what makes the remote
-  // agent DETACHED: its stdio is this ssh link, so without the tmux wrap a
-  // blink SIGHUPs it and the in-flight turn is gone — while reconnect.ts is
-  // built to re-attach a pane it assumes survived (RUSH-3125). Set here, on the
+  // REMOTE_INTERACTIVE_ENV rides the same prelude and tells the remote CLI its
+  // stdio is this ssh link: it marks the run as reconnect-managed (a drop is
+  // answered by reconnect.ts, which rejoins the live pane or resumes the
+  // session in place) and, for --no-follow, requires the detached pane that is
+  // the run's only stdout. Since PHNX-3316 it no longer forces the tmux wrap
+  // on a followed run — the peer's tmux.enabled decides that. Set here, on the
   // interactive path only: `launchDetached` already setsids the headless one.
   const prelude = remoteRunShellPrelude(opts.agent, { [REMOTE_INTERACTIVE_ENV]: '1' });
   let remoteCmd = `${prelude}${cwd}${invocation}`;

--- a/cli/src/lib/hosts/dispatch.ts
+++ b/cli/src/lib/hosts/dispatch.ts
@@ -641,10 +641,11 @@ export async function runInteractiveOnHost(host: Host, opts: InteractiveDispatch
   // REMOTE_INTERACTIVE_ENV rides the same prelude and tells the remote CLI its
   // stdio is this ssh link: it marks the run as reconnect-managed (a drop is
   // answered by reconnect.ts, which rejoins the live pane or resumes the
-  // session in place) and, for --no-follow, requires the detached pane that is
-  // the run's only stdout. Since PHNX-3316 it no longer forces the tmux wrap
-  // on a followed run — the peer's tmux.enabled decides that. Set here, on the
-  // interactive path only: `launchDetached` already setsids the headless one.
+  // session in place) and, when the launcher has no TTY (CI, scripts), requires
+  // the detached pane that is the run's only interface. Since PHNX-3316 it no
+  // longer forces the tmux wrap on a TTY-followed run — the peer's
+  // tmux.enabled decides that. Set here, on the interactive path only:
+  // `launchDetached` already setsids the headless one.
   const prelude = remoteRunShellPrelude(opts.agent, { [REMOTE_INTERACTIVE_ENV]: '1' });
   let remoteCmd = `${prelude}${cwd}${invocation}`;
   if (opts.copyCreds) {

--- a/cli/src/lib/hosts/reconnect.ts
+++ b/cli/src/lib/hosts/reconnect.ts
@@ -389,10 +389,13 @@ export function startConnectionTarget(opts: {
 /**
  * Decide what happens after an interactive `--device` stream returns.
  *
- * Auto-reconnect only when the link dropped (255) AND the run is tmux-hosted
- * (`willReconnect`). `--raw` is not wrapped, so it never reconnects — but it
- * still prints the session id: the user is at a shell, and EXEC-55 does not
- * exempt raw (RUSH-3227). Bundling the notice behind `!isRaw` was the miss.
+ * Auto-reconnect fires whenever the link dropped (255) and the run did not opt
+ * out with `--raw` (`willReconnect`) — wrap or no wrap. A wrapped run's pane
+ * survived, so the reattach rejoins it; a bare run's agent died with the link,
+ * so the same verb resumes the session in place from disk (PHNX-3316). `--raw`
+ * never reconnects — but it still prints the session id: the user is at a
+ * shell, and EXEC-55 does not exempt raw (RUSH-3227). Bundling the notice
+ * behind `!isRaw` was the miss.
  */
 export function afterInteractiveRemoteExit(opts: {
   target?: ReconnectTarget;

--- a/cli/src/lib/hosts/reconnect.ts
+++ b/cli/src/lib/hosts/reconnect.ts
@@ -2,34 +2,35 @@
  * Auto-reconnect for an interactive `agents run --device` session whose
  * SSH link dropped.
  *
- * A remote interactive agent runs in a DETACHED tmux session on the peer (see
- * lib/exec.ts `runInTmux`), so a network blink kills only the local ssh client —
- * the agent keeps running.
- *
- * **That premise is a guarantee, not a hope, only since RUSH-3125.** It used to
- * rest on the peer's `tmux.enabled`, an ergonomics preference that defaults OFF
- * — so on a default box the agent was a child of the sshd session, a blink
- * SIGHUPed it, and this file reconnected to a corpse while telling the user it
- * was "still running there." The interactive dispatch now exports
- * REMOTE_INTERACTIVE_ENV and exec.ts `resolveTmuxWrap` wraps on it regardless of
- * that toggle, so what is written below actually holds. Anything that would let
- * a remote interactive run reach the peer unwrapped breaks this whole file.
+ * What the reconnect lands on depends on the peer's `tmux.enabled`
+ * (PHNX-3316). With the wrap opted in, the agent runs in a DETACHED tmux
+ * session on the peer (see lib/exec.ts `runInTmux`), so a network blink kills
+ * only the local ssh client and the reattach below rejoins the live pane.
+ * With the wrap off — the fleet default — the remote agent is a child of the
+ * sshd session and a blink SIGHUPs it: the in-flight turn is lost, and the
+ * reattach RESUMES the harness session from disk instead. Both outcomes go
+ * through the same verb below; what changed in PHNX-3316 is that "resumed"
+ * is once again an honest, expected result rather than a corpse this file
+ * pretended was alive (the pre-RUSH-3125 bug), and RUSH-3125's forced wrap —
+ * which made the pane a guarantee by overriding the operator's tmux.enabled —
+ * is gone with it.
  *
  * `sshStream` reports that drop as exit code 255 (ssh's
  * own connection-layer failure; see ssh-exec.ts). Without this, exec.ts would
  * `process.exit(255)` and the user would have to notice, find the session id, and
- * `agents sessions focus` by hand. Instead we re-attach the live remote pane over
- * SSH automatically, with bounded backoff, until the user detaches cleanly (the
- * remote returns 0), the agent exits (the tmux session is gone; a non-255 code),
- * or the user interrupts the wait with Ctrl-C ({@link waitOrInterrupt} → 130).
+ * `agents sessions focus` by hand. Instead we re-attach over SSH automatically,
+ * with bounded backoff, until the user detaches cleanly (the remote returns 0),
+ * the agent exits (a non-255 code), or the user interrupts the wait with
+ * Ctrl-C ({@link waitOrInterrupt} → 130).
  *
  * The re-attach reuses the peer's OWN recovery verb — `agents sessions focus <id>
  * --local` — which JOINS the live local tmux pane there (a second client, no fork)
- * when it still exists, and RESUMES the session in place when the pane is already
- * gone. Dropping `--attach-only` is deliberate: a reattach that lands after the
- * remote pane died must not dead-end at a bare shell (the RUSH-2085 bug), it must
- * fall through to resume so the user is put back into the agent. There is one
- * re-attach implementation (the peer's focus) to keep in sync.
+ * when it exists, and RESUMES the session in place when there is no pane — which
+ * is every drop on a default (wrap-off) box. Dropping `--attach-only` is
+ * deliberate: a reattach that finds no pane must not dead-end at a bare shell
+ * (the RUSH-2085 bug), it must fall through to resume so the user is put back
+ * into the agent. There is one re-attach implementation (the peer's focus) to
+ * keep in sync.
  *
  * **What it takes to refill the budget: reached the host AND held the pane.** ssh
  * returns 255 for BOTH "couldn't connect at all" and "connected, then the link


### PR DESCRIPTION
**Behavior change** — one gate in `resolveTmuxWrap`, plus the comment/docs/tests that described the old rule.

## What changed

- **`cli/src/lib/exec.ts`** — `resolveTmuxWrap`: `remoteDispatch` no longer overrides `tmux.enabled`. Off (the fleet default) means a followed `agents run --device <host>` spawns **bare** — no tmux session on the peer. The one exception: a remote run with no TTY (`--no-follow`) still wraps, because the detached pane is its only stdout. `undurable` is now reachable only when a wrap was actually *wanted* (opted-in device, or no-follow) but the peer has no tmux; the refusal message now names `agents config set devices.<host>.tmux off` alongside `--raw`.
- **`cli/src/lib/hosts/reconnect.ts`** — header premise rewritten: on a default (wrap-off) box a drop SIGHUPs the remote agent and the reconnect **resumes the harness session in place** via the existing `agents sessions focus <id> --local` fall-through, instead of rejoining a pane that RUSH-3125 had to guarantee.
- **`cli/src/lib/hosts/dispatch.ts`**, **`device-config.ts`** — REMOTE_INTERACTIVE_ENV comments and the `tmux.enabled` help text updated to the new contract.
- **`cli/src/lib/exec.test.ts`**, **`hosts/dispatch.test.ts`** — wrap matrix inverted for the followed-remote case; new coverage: config-off remote → bare (with and without tmux installed), no-TTY remote → wrap even with config off, no-TTY remote + no tmux → undurable.
- **`cli/.changelog/next/PHNX-3316.md`** — changelog entry.

BREAKING: followed remote interactive runs on default-config devices no longer get a tmux pane. A dropped link loses the in-flight turn (the session resumes from disk on reconnect). Opt back in per device: `agents config set devices.<host>.tmux on`.

## Why

RUSH-3125 made every remote run wrap regardless of `tmux.enabled`, conflating durability with an ergonomics preference — operators who explicitly left tmux off got a tmux bar anyway. The durability story no longer needs the wrap: reconnect.ts already falls through to an in-place resume when no pane exists, and the session registry (pid→session, actor, host) tracks identity for bare spawns.

## Verification

```
Test Files  4 passed (4)
     Tests  291 passed | 1 skipped (292)
```
(`exec.test.ts`, `hosts/reconnect.test.ts`, `hosts/dispatch.test.ts`, `device-config.test.ts` in the worktree.)

Live end-to-end (bare remote run zion → yosemite-m3, link drop → auto-resume) runs post-merge before release, per the plan: ~/.agents/.agents/artifacts/2026-08-27/plan-tmux-status-hostname.md

Companion PR (the tmux bar itself, for opted-in devices): muqsitnawaz/.agents#295