### PR TITLE
fix(config): Phase 1 device-scoped config — heal frozen agents.yaml header + auto-evict central browser tombstone (PHNX-3315)

### DIFF
--- a/cli/.changelog/next/PHNX-3315-p1.md
+++ b/cli/.changelog/next/PHNX-3315-p1.md
@@ -14,9 +14,14 @@
   device-scoped store lingered in the shared top-level `agents.yaml` and churned
   every fleet pull until someone ran `agents browser profiles claim` by hand.
   `agents sync` now auto-evicts any lingering central profile THIS machine can
-  host into its device doc and clears it from central — host-gated so a peer's
-  `cdp://localhost:*` profile is never claimed here, serialized under the meta
-  lock, and non-throwing so a config conflict is left central rather than wedging
-  the sync. `profileRegistry` is left as the single source of truth: a claimed
-  profile lives in the device doc alone, never double-counted across two stores.
-  Source: `cli/src/lib/browser/registry.ts`, `cli/src/commands/sync.ts`.
+  host into its device doc and clears it from central. The eviction runs AFTER the
+  sync's repo pull, so it acts on a view of central that already reflects peers'
+  drains rather than a stale pre-pull copy — otherwise two boxes that can both host
+  the same profile could each re-claim it into their own device doc, flipping the
+  profile from identity-bearing to fungible. The claim is selected and committed
+  inside a single meta-lock acquisition, host-gated, and non-throwing (a config
+  conflict or unhostable profile is left central for an explicit claim rather than
+  wedging the sync). `profileRegistry` is left as the single source of truth: a
+  claimed profile lives in the device doc alone, never double-counted across two
+  stores. Source: `cli/src/lib/browser/registry.ts`, `cli/src/commands/sync.ts`,
+  `cli/src/lib/state.ts`.

--- a/cli/.changelog/next/PHNX-3315-p1.md
+++ b/cli/.changelog/next/PHNX-3315-p1.md
@@ -1,0 +1,22 @@
+- **The top-level `agents.yaml` header heals itself instead of freezing (PHNX-3315).**
+  `serializeCentral` parses the committed file to preserve its hand-written body
+  comments, but that also preserved the leading metadata header verbatim — so a
+  top-level `agents.yaml` written before the `agi-cli` rename kept its stale
+  3-line header (repo `agents-cli`, no `$schema:` line) forever while every
+  freshly-written device doc got the current header. The header is now rewritten
+  to the current `META_HEADER` on the next central write, textually (the `yaml`
+  library folds the leading comment onto the first key when that key already
+  carries a comment, so `doc.commentBefore` is unreliable), leaving body comments
+  and every config key intact, and byte-stable once healed so it never re-churns.
+  Source: `cli/src/lib/state.ts`.
+- **The legacy central `browser:` tombstone drains itself on `agents sync` (PHNX-3315).**
+  New browser profiles write the per-device doc, but profiles created before the
+  device-scoped store lingered in the shared top-level `agents.yaml` and churned
+  every fleet pull until someone ran `agents browser profiles claim` by hand.
+  `agents sync` now auto-evicts any lingering central profile THIS machine can
+  host into its device doc and clears it from central — host-gated so a peer's
+  `cdp://localhost:*` profile is never claimed here, serialized under the meta
+  lock, and non-throwing so a config conflict is left central rather than wedging
+  the sync. `profileRegistry` is left as the single source of truth: a claimed
+  profile lives in the device doc alone, never double-counted across two stores.
+  Source: `cli/src/lib/browser/registry.ts`, `cli/src/commands/sync.ts`.

--- a/cli/.changelog/next/PHNX-3315-p1.md
+++ b/cli/.changelog/next/PHNX-3315-p1.md
@@ -13,15 +13,19 @@
   New browser profiles write the per-device doc, but profiles created before the
   device-scoped store lingered in the shared top-level `agents.yaml` and churned
   every fleet pull until someone ran `agents browser profiles claim` by hand.
-  `agents sync` now auto-evicts any lingering central profile THIS machine can
-  host into its device doc and clears it from central. The eviction runs AFTER the
-  sync's repo pull, so it acts on a view of central that already reflects peers'
-  drains rather than a stale pre-pull copy — otherwise two boxes that can both host
-  the same profile could each re-claim it into their own device doc, flipping the
-  profile from identity-bearing to fungible. The claim is selected and committed
-  inside a single meta-lock acquisition, host-gated, and non-throwing (a config
-  conflict or unhostable profile is left central for an explicit claim rather than
-  wedging the sync). `profileRegistry` is left as the single source of truth: a
+  `agents sync` now auto-evicts a lingering central profile into this device's
+  doc and clears it from central — but ONLY for remote (`ssh://`) profiles. An
+  `ssh://` endpoint names a specific host, so the profile is fungible by design:
+  any box resolves it to the same browser, so a concurrent cross-machine
+  double-claim is harmless. A local/`cdp://` profile has no per-machine ownership
+  signal ("that browser is installed here" is not "I hold this profile's
+  credentialed session"), so auto-claiming it would let two boxes with the same
+  common browser each claim the same tombstone and flip a credentialed profile
+  from identity-bearing to fungible fleet-wide — the exact logged-out-browser
+  failure this module exists to prevent. Local/cdp tombstones are left central for
+  an explicit `agents browser profiles claim`. The claim is selected and committed
+  inside a single meta-lock acquisition, and non-throwing (a config conflict or
+  unhostable profile is left central rather than wedging the sync). `profileRegistry` is left as the single source of truth: a
   claimed profile lives in the device doc alone, never double-counted across two
   stores. Source: `cli/src/lib/browser/registry.ts`, `cli/src/commands/sync.ts`,
   `cli/src/lib/state.ts`.

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -36,7 +36,9 @@ import { Command, Option } from 'commander';
 import chalk from 'chalk';
 import { resolveSyncPassphraseFromEnv } from '../lib/secrets/sync-passphrase.js';
 import { agentLabel, resolveAgentName, MANAGED_AGENT_IDS, isAgentHardDeprecated, hardDeprecationError } from '../lib/agents.js';
-import type { AgentId } from '../lib/types.js';
+import type { AgentId, BrowserProfileConfig } from '../lib/types.js';
+import { autoEvictCentralBrowserProfiles } from '../lib/browser/registry.js';
+import { isProfileLaunchableHere } from '../lib/browser/profiles.js';
 import {
   isVersionInstalled,
   syncResourcesToVersion,
@@ -473,6 +475,44 @@ async function runInteractiveReconcile(
 }
 
 /**
+ * Drain the legacy central `browser:` tombstone during `agents sync` (PHNX-3315).
+ * New profiles write the per-device doc, but profiles created before the
+ * device-scoped store lingered in the shared top-level `agents.yaml` and churned
+ * every fleet pull until someone ran `agents browser profiles claim` by hand.
+ * Fold the ones THIS box can host into its device doc here — host-gated and
+ * serialized under the meta lock (`updateMeta`) so it never races a peer, and
+ * non-fatal so a hiccup can never wedge the sync.
+ */
+function evictCentralBrowserProfilesForSync(
+  quiet: boolean,
+  json: boolean,
+  outLog: (msg: string) => void,
+  errLog: (msg: string) => void,
+): void {
+  try {
+    const result = autoEvictCentralBrowserProfiles((config: BrowserProfileConfig) =>
+      isProfileLaunchableHere({
+        name: '_',
+        browser: config.browser,
+        binary: config.binary,
+        endpoints: config.endpoints,
+      }),
+    );
+    if (!quiet && !json && result.claimed.length > 0) {
+      outLog(
+        chalk.gray(
+          `  Claimed ${result.claimed.length} central browser profile(s) into this device: ${result.claimed.join(', ')}`,
+        ),
+      );
+    }
+  } catch (err) {
+    if (!quiet && !json) {
+      errLog(chalk.yellow(`  ! browser profile eviction skipped: ${(err as Error).message}`));
+    }
+  }
+}
+
+/**
  * The umbrella verb: bare `agents sync` (no agent) makes this machine current.
  * Resolves the flags + a secrets passphrase (env-only for now; tokenized auth
  * arrives with `agents secrets vault unlock`) and runs the fetch+reconcile stages, then prints
@@ -485,6 +525,12 @@ async function runUmbrella(
   errLog: (msg: string) => void,
   json = false,
 ): Promise<void> {
+  // Self-heal: drain the legacy central `browser:` tombstone before anything
+  // else. Both the interactive picker and the non-interactive path below
+  // return without touching it otherwise, so this runs first on every bare
+  // `agents sync`. Skipped under --cloud, which is fetch-only (no local write).
+  if (!opts.cloud) evictCentralBrowserProfilesForSync(quiet, json, outLog, errLog);
+
   // Interactive bare `agents sync` (a TTY, no --yes, no scope flag) drops into
   // the two-checklist picker: which repos to sync from, which agents to sync
   // into. Any explicit flag, --yes, or --json keeps the non-interactive path.

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -36,9 +36,9 @@ import { Command, Option } from 'commander';
 import chalk from 'chalk';
 import { resolveSyncPassphraseFromEnv } from '../lib/secrets/sync-passphrase.js';
 import { agentLabel, resolveAgentName, MANAGED_AGENT_IDS, isAgentHardDeprecated, hardDeprecationError } from '../lib/agents.js';
-import type { AgentId, BrowserProfileConfig } from '../lib/types.js';
+import type { AgentId } from '../lib/types.js';
 import { autoEvictCentralBrowserProfiles } from '../lib/browser/registry.js';
-import { isProfileLaunchableHere } from '../lib/browser/profiles.js';
+import { shouldAutoClaimCentralProfile } from '../lib/browser/profiles.js';
 import {
   isVersionInstalled,
   syncResourcesToVersion,
@@ -500,14 +500,12 @@ function evictCentralBrowserProfilesForSync(
   errLog: (msg: string) => void,
 ): void {
   try {
-    const result = autoEvictCentralBrowserProfiles((config: BrowserProfileConfig) =>
-      isProfileLaunchableHere({
-        name: '_',
-        browser: config.browser,
-        binary: config.binary,
-        endpoints: config.endpoints,
-      }),
-    );
+    // Auto-claim ONLY remote (ssh://) tombstones — they are fungible by design,
+    // so a concurrent cross-machine double-claim is harmless. Local/cdp profiles
+    // have no per-machine ownership signal and are left central for an explicit
+    // `agents browser profiles claim` (PHNX-3315 review). See
+    // shouldAutoClaimCentralProfile.
+    const result = autoEvictCentralBrowserProfiles(shouldAutoClaimCentralProfile);
     if (!quiet && !json && result.claimed.length > 0) {
       outLog(
         chalk.gray(

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -449,6 +449,13 @@ async function runInteractiveReconcile(
     } else outLog(chalk.yellow(`  ! ${repo}: ${(res.error ?? 'pull failed').split('\n')[0]}`));
   }
 
+  // Drain the legacy central `browser:` tombstone now that the repos are pulled.
+  // Running AFTER the pull is load-bearing: it acts on a view of central that
+  // already reflects peers' drains, so it never re-claims a profile another box
+  // already migrated (which would flip that profile's kind identity->fungible).
+  // The interactive path is always non-quiet, non-json.
+  evictCentralBrowserProfilesForSync(false, false, outLog, errLog);
+
   // 2. One selection spanning the chosen repos.
   const selection = mergeRepoScopedSelections(repos, cwd);
   const hasResources = selection.memory === 'all' || Object.entries(selection).some(
@@ -479,9 +486,12 @@ async function runInteractiveReconcile(
  * New profiles write the per-device doc, but profiles created before the
  * device-scoped store lingered in the shared top-level `agents.yaml` and churned
  * every fleet pull until someone ran `agents browser profiles claim` by hand.
- * Fold the ones THIS box can host into its device doc here — host-gated and
- * serialized under the meta lock (`updateMeta`) so it never races a peer, and
- * non-fatal so a hiccup can never wedge the sync.
+ * Fold the ones THIS box can host into its device doc — host-gated, and the
+ * selection is computed under the meta lock (see autoEvictCentralBrowserProfiles)
+ * so it never races itself. Callers MUST invoke this AFTER the repo pull: acting
+ * on a pre-pull view of central risks re-claiming a profile a peer already
+ * drained, which would flip its kind identity->fungible. Non-fatal so a hiccup
+ * can never wedge the sync.
  */
 function evictCentralBrowserProfilesForSync(
   quiet: boolean,
@@ -525,12 +535,6 @@ async function runUmbrella(
   errLog: (msg: string) => void,
   json = false,
 ): Promise<void> {
-  // Self-heal: drain the legacy central `browser:` tombstone before anything
-  // else. Both the interactive picker and the non-interactive path below
-  // return without touching it otherwise, so this runs first on every bare
-  // `agents sync`. Skipped under --cloud, which is fetch-only (no local write).
-  if (!opts.cloud) evictCentralBrowserProfilesForSync(quiet, json, outLog, errLog);
-
   // Interactive bare `agents sync` (a TTY, no --yes, no scope flag) drops into
   // the two-checklist picker: which repos to sync from, which agents to sync
   // into. Any explicit flag, --yes, or --json keeps the non-interactive path.
@@ -566,6 +570,12 @@ async function runUmbrella(
       quiet: quiet || json,
       log: (msg) => { if (!quiet && !json) outLog(chalk.gray(`  ${msg}`)); },
     });
+
+    // Drain the legacy central `browser:` tombstone AFTER the umbrella pull, so
+    // we act on central as converged by this sync rather than a stale pre-pull
+    // copy that could re-claim a profile a peer already migrated. Skipped under
+    // --cloud (fetch-only, no local reconcile).
+    if (!opts.cloud) evictCentralBrowserProfilesForSync(quiet, json, outLog, errLog);
 
     if (json) {
       emitJson({

--- a/cli/src/lib/browser/profiles.test.ts
+++ b/cli/src/lib/browser/profiles.test.ts
@@ -72,6 +72,8 @@ import {
   renameProfile,
   assertRegistrableProfileName,
   assertLocalPortFree,
+  shouldAutoClaimCentralProfile,
+  hasSshEndpoint,
 } from './profiles.js';
 import { findBrowserPath, findFirstInstalledBrowser, isPortInUse } from './chrome.js';
 import type { BrowserProfile } from './types.js';
@@ -1408,5 +1410,35 @@ describe('assertRegistrableProfileName', () => {
     for (const bad of ['Agents', '1agent', 'my profile', 'agent_x', '-lead', '']) {
       expect(() => assertRegistrableProfileName(bad), bad).toThrow(/Invalid profile name/);
     }
+  });
+});
+
+describe('shouldAutoClaimCentralProfile (PHNX-3315 auto-drain safety)', () => {
+  // The safety-critical property: a local/cdp tombstone is NEVER auto-claimed,
+  // regardless of what browsers are installed here. "browser installed here" is
+  // not "I hold this profile's session", so auto-claiming a cdp profile would let
+  // two boxes flip a credentialed profile identity->fungible fleet-wide. This
+  // assertion is machine-independent (it short-circuits before any binary probe).
+  it('never auto-claims a local/cdp profile', () => {
+    expect(
+      shouldAutoClaimCentralProfile({
+        browser: 'comet',
+        endpoints: ['cdp://localhost:9333'],
+      } as BrowserProfileConfig),
+    ).toBe(false);
+    expect(
+      shouldAutoClaimCentralProfile({
+        browser: 'chrome',
+        endpoints: ['cdp://127.0.0.1:9222'],
+      } as BrowserProfileConfig),
+    ).toBe(false);
+  });
+
+  it('gates on ssh:// ownership — a remote endpoint passes the gate, a cdp one does not', () => {
+    // ssh:// is fungible by design: the endpoint names the host, so a concurrent
+    // cross-machine double-claim is harmless. The final claim still requires
+    // launchability here, but the ownership gate itself must accept ssh://.
+    expect(hasSshEndpoint(['ssh://user@mac-mini?port=9333'])).toBe(true);
+    expect(hasSshEndpoint(['cdp://localhost:9333'])).toBe(false);
   });
 });

--- a/cli/src/lib/browser/profiles.ts
+++ b/cli/src/lib/browser/profiles.ts
@@ -426,7 +426,7 @@ function validateRemoteBrowserBinary(binary: string | undefined): void {
   }
 }
 
-function hasSshEndpoint(endpoints: BrowserProfileConfig['endpoints']): boolean {
+export function hasSshEndpoint(endpoints: BrowserProfileConfig['endpoints']): boolean {
   const targets = Array.isArray(endpoints)
     ? endpoints
     : Object.values(endpoints).map((preset) => preset.target);
@@ -436,6 +436,31 @@ function hasSshEndpoint(endpoints: BrowserProfileConfig['endpoints']): boolean {
     } catch {
       return false;
     }
+  });
+}
+
+/**
+ * Whether the automatic central-tombstone drain (PHNX-3315) may claim `config`
+ * into THIS device's doc during `agents sync`.
+ *
+ * Only REMOTE (`ssh://`) profiles qualify. An `ssh://` endpoint names a specific
+ * host, so the profile is fungible by design — any box resolves it to the same
+ * browser, and a concurrent double-claim across machines is harmless. A
+ * local/`cdp://` profile has NO per-machine ownership signal: "that browser is
+ * installed here" is not "I hold this profile's credentialed session", so two
+ * boxes with the same common browser installed would each auto-claim the same
+ * tombstone on their first post-merge sync and flip it identity->fungible
+ * fleet-wide (the exact logged-out-browser failure this module exists to prevent
+ * — PHNX-3315 review). Local/cdp tombstones stay central for the explicit
+ * `agents browser profiles claim`.
+ */
+export function shouldAutoClaimCentralProfile(config: BrowserProfileConfig): boolean {
+  if (!hasSshEndpoint(config.endpoints)) return false;
+  return isProfileLaunchableHere({
+    name: '_',
+    browser: config.browser,
+    binary: config.binary,
+    endpoints: config.endpoints,
   });
 }
 

--- a/cli/src/lib/browser/registry.test.ts
+++ b/cli/src/lib/browser/registry.test.ts
@@ -295,3 +295,68 @@ describe('ensureDefaultBrowserProfile with undeclared configured default', () =>
     });
   });
 });
+
+describe('autoEvictCentralBrowserProfiles (self-draining tombstone, PHNX-3315)', () => {
+  it('folds a hostable central tombstone into the device doc, drains central, and the single reader returns it once', async () => {
+    const centralFile = path.join(root, '.agents', 'agents.yaml');
+    const config = {
+      browser: 'custom',
+      binary: process.execPath,
+      endpoints: ['cdp://127.0.0.1:9222'],
+    };
+    writeYaml(centralFile, { browser: { work: config }, model: { claude: 'opus' } });
+
+    const { machineId } = await import('../machine-id.js');
+    const { autoEvictCentralBrowserProfiles, profileRegistry, declaringDevices } = await import(
+      './registry.js'
+    );
+
+    expect(autoEvictCentralBrowserProfiles(() => true)).toEqual({ claimed: ['work'], skipped: [] });
+
+    // Lives in the device doc now…
+    expect(yaml.parse(fs.readFileSync(deviceFile(machineId()), 'utf8')).browser).toEqual({ work: config });
+    // …central browser: tombstone is drained (other central keys untouched)…
+    expect(yaml.parse(fs.readFileSync(centralFile, 'utf8'))).toEqual({ model: { claude: 'opus' } });
+    // …and the single source of truth returns it exactly once, on this device.
+    expect(declaringDevices('work')).toEqual([machineId()]);
+    expect(profileRegistry().get('work')).toHaveLength(1);
+  });
+
+  it('is idempotent and a no-op when there is no central tombstone', async () => {
+    writeYaml(deviceFile('anything'), { browser: {} });
+    const { autoEvictCentralBrowserProfiles } = await import('./registry.js');
+    expect(autoEvictCentralBrowserProfiles(() => true)).toEqual({ claimed: [], skipped: [] });
+  });
+
+  it('never throws on a conflicting local declaration — leaves it central for an explicit claim', async () => {
+    const centralFile = path.join(root, '.agents', 'agents.yaml');
+    const central = { browser: 'chrome', binary: process.execPath, endpoints: ['cdp://127.0.0.1:9222'] };
+    const local = { browser: 'brave', binary: process.execPath, endpoints: ['cdp://127.0.0.1:9333'] };
+    writeYaml(centralFile, { browser: { work: central } });
+    const { machineId } = await import('../machine-id.js');
+    const ownFile = deviceFile(machineId());
+    writeYaml(ownFile, { browser: { work: local } });
+
+    const beforeCentral = fs.readFileSync(centralFile, 'utf8');
+    const beforeDevice = fs.readFileSync(ownFile, 'utf8');
+    const { autoEvictCentralBrowserProfiles } = await import('./registry.js');
+
+    // Unlike the explicit claim (which throws), the automatic path must never
+    // wedge a sync: the conflict is skipped and both copies are left untouched.
+    expect(autoEvictCentralBrowserProfiles(() => true)).toEqual({ claimed: [], skipped: ['work'] });
+    expect(fs.readFileSync(centralFile, 'utf8')).toBe(beforeCentral);
+    expect(fs.readFileSync(ownFile, 'utf8')).toBe(beforeDevice);
+  });
+
+  it('leaves a profile this machine cannot host in central', async () => {
+    const centralFile = path.join(root, '.agents', 'agents.yaml');
+    const config = { browser: 'comet', endpoints: ['cdp://localhost:9333'] };
+    writeYaml(centralFile, { browser: { 'comet-local': config } });
+    const { machineId } = await import('../machine-id.js');
+    const { autoEvictCentralBrowserProfiles } = await import('./registry.js');
+
+    expect(autoEvictCentralBrowserProfiles(() => false)).toEqual({ claimed: [], skipped: ['comet-local'] });
+    expect(fs.existsSync(deviceFile(machineId()))).toBe(false);
+    expect(yaml.parse(fs.readFileSync(centralFile, 'utf8')).browser).toEqual({ 'comet-local': config });
+  });
+});

--- a/cli/src/lib/browser/registry.test.ts
+++ b/cli/src/lib/browser/registry.test.ts
@@ -322,6 +322,25 @@ describe('autoEvictCentralBrowserProfiles (self-draining tombstone, PHNX-3315)',
     expect(profileRegistry().get('work')).toHaveLength(1);
   });
 
+  it('drains once, then the second run claims nothing and rewrites no doc (self-draining, no churn)', async () => {
+    const centralFile = path.join(root, '.agents', 'agents.yaml');
+    const config = { browser: 'custom', binary: process.execPath, endpoints: ['cdp://127.0.0.1:9222'] };
+    writeYaml(centralFile, { browser: { work: config } });
+    const { machineId } = await import('../machine-id.js');
+    const { autoEvictCentralBrowserProfiles } = await import('./registry.js');
+
+    expect(autoEvictCentralBrowserProfiles(() => true)).toEqual({ claimed: ['work'], skipped: [] });
+    const centralAfter = fs.readFileSync(centralFile, 'utf8');
+    const deviceAfter = fs.readFileSync(deviceFile(machineId()), 'utf8');
+
+    // Second run: the tombstone is already drained, so nothing is claimed AND no
+    // doc is rewritten — the commit only fires when something is actually claimed,
+    // so a routine `agents sync` with no tombstone never churns a file.
+    expect(autoEvictCentralBrowserProfiles(() => true)).toEqual({ claimed: [], skipped: [] });
+    expect(fs.readFileSync(centralFile, 'utf8')).toBe(centralAfter);
+    expect(fs.readFileSync(deviceFile(machineId()), 'utf8')).toBe(deviceAfter);
+  });
+
   it('is idempotent and a no-op when there is no central tombstone', async () => {
     writeYaml(deviceFile('anything'), { browser: {} });
     const { autoEvictCentralBrowserProfiles } = await import('./registry.js');

--- a/cli/src/lib/browser/registry.ts
+++ b/cli/src/lib/browser/registry.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 import * as yaml from 'yaml';
-import { getUserAgentsDir, readMeta, updateMeta } from '../state.js';
+import { getUserAgentsDir, readMeta, updateMeta, withMetaLock, writeMetaUnlocked } from '../state.js';
 import type { BrowserProfileConfig, Meta } from '../types.js';
 
 export interface ProfileDeclaration {
@@ -80,25 +80,34 @@ function selectClaimableCentral(
 }
 
 /**
- * Move `toClaim` out of the central `browser:` map and into this device's
- * `deviceBrowser` doc, atomically under the meta lock (`updateMeta`). The central
- * key is dropped entirely once drained, so the tombstone disappears rather than
- * lingering as an empty map.
+ * Return `current` with `toClaim` moved out of the central `browser:` map and
+ * into this device's `deviceBrowser` doc. The central key is dropped entirely
+ * once drained, so the tombstone disappears rather than lingering as an empty
+ * map. Pure — the caller applies it under the meta lock.
+ */
+function buildEvictedMeta(current: Meta, toClaim: Record<string, BrowserProfileConfig>): Meta {
+  const legacy = current as LegacyBrowserMeta;
+  const remaining: Record<string, BrowserProfileConfig> = {};
+  for (const [profileName, config] of Object.entries(legacy.browser ?? {})) {
+    if (!(profileName in toClaim)) remaining[profileName] = config;
+  }
+  const { browser: _removed, ...withoutCentralBrowser } = legacy;
+  return {
+    ...withoutCentralBrowser,
+    ...(Object.keys(remaining).length > 0 ? { browser: remaining } : {}),
+    deviceBrowser: { ...current.deviceBrowser, ...toClaim },
+  } as Meta;
+}
+
+/**
+ * Commit a claim computed by the EXPLICIT path (`migrateCentralBrowserProfiles`).
+ * `toClaim` was selected from an unlocked snapshot — acceptable for that manual,
+ * deliberate command; the automatic path instead selects INSIDE the lock (see
+ * {@link autoEvictCentralBrowserProfiles}) so an unrelated concurrent write can
+ * never be clobbered by a stale selection.
  */
 function commitCentralClaim(toClaim: Record<string, BrowserProfileConfig>): void {
-  updateMeta((current) => {
-    const legacy = current as LegacyBrowserMeta;
-    const remaining: Record<string, BrowserProfileConfig> = {};
-    for (const [profileName, config] of Object.entries(legacy.browser ?? {})) {
-      if (!(profileName in toClaim)) remaining[profileName] = config;
-    }
-    const { browser: _removed, ...withoutCentralBrowser } = legacy;
-    return {
-      ...withoutCentralBrowser,
-      ...(Object.keys(remaining).length > 0 ? { browser: remaining } : {}),
-      deviceBrowser: { ...current.deviceBrowser, ...toClaim },
-    } as Meta;
-  });
+  updateMeta((current) => buildEvictedMeta(current, toClaim));
 }
 
 /**
@@ -170,33 +179,45 @@ export function migrateCentralBrowserProfiles(
  * `agents sync` with no manual `agents browser profiles claim`.
  *
  * Safe to call implicitly, unlike a claim at registry-read time (which races —
- * see the `profileRegistry does not claim central declarations` guard). Three
- * properties make it safe: it runs only during the serialized `agents sync` on
- * the box that owns the browser; it claims ONLY profiles `canHostHere` accepts,
- * i.e. that resolve HERE; and it never throws — an unhostable profile or a
- * config that conflicts with an existing local declaration is left central for
- * an explicit claim rather than wedging the sync. After it runs, {@link
- * profileRegistry} is the single source of truth: a claimed profile lives in the
- * device doc alone, never double-counted across the two stores.
+ * see the `profileRegistry does not claim central declarations` guard), but the
+ * CALLER owns one ordering invariant: invoke it AFTER the sync's repo pull. Two
+ * boxes can both host the same profile (`canHostHere` is launchability, not
+ * ownership), so a box acting on a PRE-pull view of central could re-claim a
+ * profile a peer already drained and pushed — both writes land in different
+ * device files with no git conflict, and the profile flips identity->fungible.
+ * Running post-pull means central already reflects peers' drains, so the tombstone
+ * is gone locally before this box looks. The selection is also computed INSIDE
+ * the meta lock, and the path never throws — an unhostable profile or one that
+ * conflicts with an existing local declaration is left central for an explicit
+ * claim rather than wedging the sync. After it runs, {@link profileRegistry} is
+ * the single source of truth: a claimed profile lives in the device doc alone,
+ * never double-counted across the two stores.
  */
 export function autoEvictCentralBrowserProfiles(
   canHostHere: (config: BrowserProfileConfig) => boolean,
 ): CentralClaimResult {
-  const meta = readMeta() as LegacyBrowserMeta;
-  const central = meta.browser;
-  if (!central || Object.keys(central).length === 0) return { claimed: [], skipped: [] };
-
-  const local = meta.deviceBrowser ?? {};
-  const { toClaim, skipped } = selectClaimableCentral(central, local, canHostHere, {
-    onConflict: 'skip',
+  // Read fresh, select, and commit inside ONE meta-lock acquisition. Reading
+  // central before the lock and committing after (the manual path's shape) leaves
+  // a window where a concurrent write on THIS machine changes central/deviceBrowser
+  // between snapshot and commit, so the stale selection would be merged over the
+  // fresher value. Selecting from the state the lock just handed us closes that
+  // window. We write ONLY when something is claimed, so a no-op sync never touches
+  // any doc (writeMetaUnlocked would otherwise re-serialize the device doc every
+  // run). This mirrors updateMeta's own body, minus the unconditional write.
+  return withMetaLock(() => {
+    const meta = readMeta() as LegacyBrowserMeta;
+    const central = meta.browser;
+    if (!central || Object.keys(central).length === 0) return { claimed: [], skipped: [] };
+    const local = meta.deviceBrowser ?? {};
+    const { toClaim, skipped } = selectClaimableCentral(central, local, canHostHere, {
+      onConflict: 'skip',
+    });
+    const claimed = Object.keys(toClaim).sort();
+    skipped.sort();
+    if (claimed.length === 0) return { claimed, skipped };
+    writeMetaUnlocked(buildEvictedMeta(meta, toClaim));
+    return { claimed, skipped };
   });
-
-  const claimed = Object.keys(toClaim).sort();
-  skipped.sort();
-  if (claimed.length === 0) return { claimed, skipped };
-
-  commitCentralClaim(toClaim);
-  return { claimed, skipped };
 }
 
 /**

--- a/cli/src/lib/browser/registry.ts
+++ b/cli/src/lib/browser/registry.ts
@@ -16,7 +16,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
-/** Leftover central `browser:` map from before per-device declarations. Empty when none remain. */
+/**
+ * The leftover central `browser:` tombstone from before per-device declarations.
+ * Empty when none remain — and `agents sync` now drains it automatically via
+ * {@link autoEvictCentralBrowserProfiles}, so on a synced box this is empty and
+ * {@link profileRegistry} is the single source of truth. It survives only to
+ * fold in migration and to explain an as-yet-unclaimed profile in a resolve
+ * error (a profile hostable on a peer that has not synced yet), never as a
+ * parallel store callers read for resolution.
+ */
 export function centralBrowserProfiles(): Record<string, BrowserProfileConfig> {
   const central = (readMeta() as LegacyBrowserMeta).browser;
   if (!central || Object.keys(central).length === 0) return {};
@@ -29,22 +37,87 @@ export interface CentralClaimResult {
 }
 
 /**
+ * Pick the central `browser:` entries this machine may fold into its device doc.
+ *
+ * A profile is claimable only when `canHostHere` accepts it — the endpoint or
+ * binary resolves to THIS machine — so a `cdp://localhost:*` profile owned by a
+ * peer is never claimed here (the logged-out-headless-browser bug this module
+ * exists to prevent). A name already declared locally with an IDENTICAL config
+ * is folded too, which just drops the redundant central copy. A name declared
+ * locally with a DIFFERENT config is a genuine conflict: `onConflict: 'throw'`
+ * (the explicit `claim` command) surfaces it; `onConflict: 'skip'` (automatic
+ * eviction on sync) leaves it central so a stray duplicate can never wedge a
+ * sync — an operator resolves it with an explicit claim.
+ */
+function selectClaimableCentral(
+  central: Record<string, BrowserProfileConfig>,
+  local: Record<string, BrowserProfileConfig>,
+  canHostHere: (config: BrowserProfileConfig) => boolean,
+  opts: { name?: string; onConflict: 'throw' | 'skip' },
+): { toClaim: Record<string, BrowserProfileConfig>; skipped: string[] } {
+  const toClaim: Record<string, BrowserProfileConfig> = {};
+  const skipped: string[] = [];
+  for (const [profileName, config] of Object.entries(central)) {
+    if (opts.name && profileName !== opts.name) continue;
+    if (!canHostHere(config)) {
+      skipped.push(profileName);
+      continue;
+    }
+    const existing = local[profileName];
+    if (existing && !isDeepStrictEqual(existing, config)) {
+      if (opts.onConflict === 'throw') {
+        throw new Error(
+          `Cannot migrate browser profile "${profileName}": central agents.yaml and this device's ` +
+            `agents.yaml declare different configurations. Resolve the duplicate before retrying.`,
+        );
+      }
+      skipped.push(profileName);
+      continue;
+    }
+    toClaim[profileName] = config;
+  }
+  return { toClaim, skipped };
+}
+
+/**
+ * Move `toClaim` out of the central `browser:` map and into this device's
+ * `deviceBrowser` doc, atomically under the meta lock (`updateMeta`). The central
+ * key is dropped entirely once drained, so the tombstone disappears rather than
+ * lingering as an empty map.
+ */
+function commitCentralClaim(toClaim: Record<string, BrowserProfileConfig>): void {
+  updateMeta((current) => {
+    const legacy = current as LegacyBrowserMeta;
+    const remaining: Record<string, BrowserProfileConfig> = {};
+    for (const [profileName, config] of Object.entries(legacy.browser ?? {})) {
+      if (!(profileName in toClaim)) remaining[profileName] = config;
+    }
+    const { browser: _removed, ...withoutCentralBrowser } = legacy;
+    return {
+      ...withoutCentralBrowser,
+      ...(Object.keys(remaining).length > 0 ? { browser: remaining } : {}),
+      deviceBrowser: { ...current.deviceBrowser, ...toClaim },
+    } as Meta;
+  });
+}
+
+/**
  * Fold leftover central `browser:` entries into THIS device's declaration file.
  *
- * Never called implicitly, and that is the point. Every device can read the
- * central map, so an implicit claim races: whichever box happens to read first
- * claims the name, {@link profileKind} then reports it `identity`, and the
- * daemon tunnels to that box — which for a fleet-wide `cdp://localhost:*`
- * profile is a logged-out headless browser wearing a credentialed browser's
- * name. That is the exact bug this module exists to remove, and an implicit
- * migration would write it to disk as a stored fact.
+ * The EXPLICIT operator action (`agents browser profiles claim`), run on the
+ * machine that actually owns the browser. It is never called implicitly from a
+ * read, and that is the point: every device can read the central map, so an
+ * implicit claim races — whichever box reads first claims the name, {@link
+ * profileKind} then reports it `identity`, and the daemon tunnels to that box,
+ * which for a fleet-wide `cdp://localhost:*` profile is a logged-out headless
+ * browser wearing a credentialed browser's name. {@link autoEvictCentralBrowserProfiles}
+ * closes that race for the automatic path (host-gated + non-throwing on sync);
+ * this one is the manual, throw-on-conflict counterpart.
  *
- * The claim is an explicit operator action (`agents browser profiles claim`),
- * run on the machine that actually owns the browser. `canHostHere` is supplied
- * by the command layer so this module stays a leaf — it must not import
- * `isProfileLaunchableHere` (that would cycle through chrome.ts → profiles.ts).
- * Only profiles this machine can host are claimed; the rest stay central,
- * undeclared, and fail loudly on resolve.
+ * `canHostHere` is supplied by the command layer so this module stays a leaf —
+ * it must not import `isProfileLaunchableHere` (that would cycle through
+ * chrome.ts → profiles.ts). Only profiles this machine can host are claimed; the
+ * rest stay central, undeclared, and fail loudly on resolve.
  */
 export function migrateCentralBrowserProfiles(
   canHostHere: (config: BrowserProfileConfig) => boolean,
@@ -77,41 +150,52 @@ export function migrateCentralBrowserProfiles(
     }
   }
 
-  const toClaim: Record<string, BrowserProfileConfig> = {};
-  const skipped: string[] = [];
-  for (const [profileName, config] of Object.entries(central)) {
-    if (name && profileName !== name) continue;
-    if (!canHostHere(config)) {
-      skipped.push(profileName);
-      continue;
-    }
-    const existing = local[profileName];
-    if (existing && !isDeepStrictEqual(existing, config)) {
-      throw new Error(
-        `Cannot migrate browser profile "${profileName}": central agents.yaml and this device's ` +
-          `agents.yaml declare different configurations. Resolve the duplicate before retrying.`,
-      );
-    }
-    toClaim[profileName] = config;
-  }
+  const { toClaim, skipped } = selectClaimableCentral(central, local, canHostHere, {
+    name,
+    onConflict: 'throw',
+  });
 
   const claimed = Object.keys(toClaim).sort();
   skipped.sort();
   if (claimed.length === 0) return { claimed, skipped };
 
-  updateMeta((current) => {
-    const legacy = current as LegacyBrowserMeta;
-    const remaining: Record<string, BrowserProfileConfig> = {};
-    for (const [profileName, config] of Object.entries(legacy.browser ?? {})) {
-      if (!(profileName in toClaim)) remaining[profileName] = config;
-    }
-    const { browser: _removed, ...withoutCentralBrowser } = legacy;
-    return {
-      ...withoutCentralBrowser,
-      ...(Object.keys(remaining).length > 0 ? { browser: remaining } : {}),
-      deviceBrowser: { ...current.deviceBrowser, ...toClaim },
-    } as Meta;
+  commitCentralClaim(toClaim);
+  return { claimed, skipped };
+}
+
+/**
+ * Automatic, self-draining counterpart to {@link migrateCentralBrowserProfiles}:
+ * fold every lingering central `browser:` profile THIS machine can host into its
+ * device doc and clear it from central, so the tombstone drains itself on
+ * `agents sync` with no manual `agents browser profiles claim`.
+ *
+ * Safe to call implicitly, unlike a claim at registry-read time (which races —
+ * see the `profileRegistry does not claim central declarations` guard). Three
+ * properties make it safe: it runs only during the serialized `agents sync` on
+ * the box that owns the browser; it claims ONLY profiles `canHostHere` accepts,
+ * i.e. that resolve HERE; and it never throws — an unhostable profile or a
+ * config that conflicts with an existing local declaration is left central for
+ * an explicit claim rather than wedging the sync. After it runs, {@link
+ * profileRegistry} is the single source of truth: a claimed profile lives in the
+ * device doc alone, never double-counted across the two stores.
+ */
+export function autoEvictCentralBrowserProfiles(
+  canHostHere: (config: BrowserProfileConfig) => boolean,
+): CentralClaimResult {
+  const meta = readMeta() as LegacyBrowserMeta;
+  const central = meta.browser;
+  if (!central || Object.keys(central).length === 0) return { claimed: [], skipped: [] };
+
+  const local = meta.deviceBrowser ?? {};
+  const { toClaim, skipped } = selectClaimableCentral(central, local, canHostHere, {
+    onConflict: 'skip',
   });
+
+  const claimed = Object.keys(toClaim).sort();
+  skipped.sort();
+  if (claimed.length === 0) return { claimed, skipped };
+
+  commitCentralClaim(toClaim);
   return { claimed, skipped };
 }
 

--- a/cli/src/lib/state.test.ts
+++ b/cli/src/lib/state.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
+import * as yaml from 'yaml';
 
 // state.ts resolves HOME and the device id at import time, so we point both at a
 // throwaway temp dir and re-import the module fresh for each test. This
@@ -202,5 +203,79 @@ describe('getProjectAgentsDir does not treat a DotAgents-repo clone as a project
     fs.mkdirSync(path.join(projAgents, 'rules'), { recursive: true });
 
     expect(getProjectAgentsDir(proj)).toBe(projAgents);
+  });
+});
+
+describe('serializeCentral heals a frozen top-level header (PHNX-3315)', () => {
+  beforeEach(() => {
+    TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-state-header-'));
+    process.env.HOME = TMP;
+    process.env.AGENTS_SYNC_MACHINE_ID = 'testbox';
+    process.env.AGENTS_DEVICES_DIR = path.join(TMP, '.agents', '.history', 'devices');
+  });
+  afterEach(() => {
+    delete process.env.AGENTS_SYNC_MACHINE_ID;
+    delete process.env.AGENTS_DEVICES_DIR;
+    try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  // The pre-rename header the top-level agents.yaml froze on: repo `agents-cli`
+  // (not `agi-cli`) and no `$schema:` line. A hand-written body comment sits below
+  // it — the yaml library folds that whole block onto the first key's comment,
+  // which is exactly why the header cannot be healed via doc.commentBefore.
+  const STALE = [
+    '# agents-cli metadata',
+    '# Auto-generated - do not edit manually',
+    '# https://github.com/phnx-labs/agents-cli',
+    '',
+    '# Fleet-wide notification routing (hand-written)',
+    'notify:',
+    '  owner: someone@example.com',
+    'share:',
+    '  endpoint: https://share.example',
+    '',
+  ].join('\n');
+
+  it('rewrites the header to current on a central write, keeping body comments + every key', async () => {
+    const { updateMeta } = await freshState();
+    writeCentral(STALE);
+
+    // Any central mutation routes through serializeCentral.
+    updateMeta((m) => ({ ...m, fleet: { devices: {}, defaults: { config: { maxAgents: 7 } } } }));
+
+    const central = fs.readFileSync(centralPath(), 'utf-8');
+
+    // Header healed to the current META_HEADER (agi-cli + the $schema line), and
+    // the pre-rename URL line is gone — exactly once, not duplicated.
+    expect(central).toContain('# https://github.com/phnx-labs/agi-cli');
+    expect(central).toContain(
+      'yaml-language-server: $schema=https://raw.githubusercontent.com/phnx-labs/agi-cli/main/cli/schema/agents-yaml.schema.json',
+    );
+    expect(central).not.toContain('# https://github.com/phnx-labs/agents-cli');
+    expect((central.match(/# agents-cli metadata/g) ?? []).length).toBe(1);
+
+    // Hand-written body comment survives the rewrite.
+    expect(central).toContain('# Fleet-wide notification routing (hand-written)');
+
+    // No config keys lost; the freshly-set central key landed.
+    const parsed = yaml.parse(central);
+    expect(parsed.notify).toEqual({ owner: 'someone@example.com' });
+    expect(parsed.share).toEqual({ endpoint: 'https://share.example' });
+    expect(parsed.fleet.defaults.config.maxAgents).toBe(7);
+  });
+
+  it('is byte-stable once healed — a later no-op central write does not touch the file', async () => {
+    const { updateMeta } = await freshState();
+    writeCentral(STALE);
+
+    // First write heals the header and adds a central key.
+    updateMeta((m) => ({ ...m, fleet: { devices: {}, defaults: { config: { maxAgents: 3 } } } }));
+    const healed = fs.readFileSync(centralPath(), 'utf-8');
+    expect(healed).toContain('agi-cli');
+
+    // A subsequent central write that changes nothing must leave the bytes
+    // identical — no re-header, no churn, so `agents sync` never sees a dirty file.
+    updateMeta((m) => ({ ...m }));
+    expect(fs.readFileSync(centralPath(), 'utf-8')).toBe(healed);
   });
 });

--- a/cli/src/lib/state.test.ts
+++ b/cli/src/lib/state.test.ts
@@ -264,6 +264,22 @@ describe('serializeCentral heals a frozen top-level header (PHNX-3315)', () => {
     expect(parsed.fleet.defaults.config.maxAgents).toBe(7);
   });
 
+  it('does not heal on a device-only write — the shared file stays byte-identical even with a stale header', async () => {
+    const { updateMeta } = await freshState();
+    writeCentral(STALE);
+    const before = fs.readFileSync(centralPath(), 'utf-8');
+
+    // A device-only write (agents pins route to the untracked device store, not
+    // central). Healing here would rewrite the shared file on an unrelated write —
+    // the exact churn that wedges `agents sync` — so central must be untouched and
+    // its stale header must survive until a real central change heals it.
+    updateMeta((m) => ({ ...m, agents: { claude: '2.1.0' } }));
+
+    const after = fs.readFileSync(centralPath(), 'utf-8');
+    expect(after).toBe(before);
+    expect(after).toContain('# https://github.com/phnx-labs/agents-cli');
+  });
+
   it('is byte-stable once healed — a later no-op central write does not touch the file', async () => {
     const { updateMeta } = await freshState();
     writeCentral(STALE);

--- a/cli/src/lib/state.ts
+++ b/cli/src/lib/state.ts
@@ -1014,6 +1014,32 @@ const KNOWN_META_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Rewrite a frozen `agents.yaml` header to the current {@link META_HEADER}.
+ *
+ * `serializeCentral` parses the existing file to preserve its hand-written body
+ * comments, but that also preserves the leading metadata header verbatim, so a
+ * top-level file written before the agi-cli rename (or before the `$schema` line
+ * existed) keeps its stale header forever — every freshly-written device doc gets
+ * the current header while the shared file is left behind (PHNX-3315).
+ *
+ * The header is healed TEXTUALLY, on the already-serialized string, rather than
+ * via `doc.commentBefore`: the `yaml` library folds the whole leading comment
+ * block onto the FIRST key's `commentBefore` when that key already carries a
+ * hand-written comment, so the header is not reliably the document comment — but
+ * it is always the top block of the output. Strip a leading `agents-cli metadata`
+ * header (any pre-rename variant, with or without the `$schema` line — the URL
+ * and schema lines are matched specifically so a hand-written body comment is
+ * never mistaken for a header line) and prepend the canonical header. A file with
+ * no recognizable header simply gains one. Body comments, which sit below the
+ * blank line that terminates the header, are untouched.
+ */
+function healMetaHeader(serialized: string): string {
+  const headerBlock =
+    /^# agents-cli metadata\n# Auto-generated - do not edit manually\n(?:# (?:https:\/\/github\.com\/phnx-labs\/[^\n]*|yaml-language-server: \$schema=[^\n]*)\n)*\n?/;
+  return META_HEADER + serialized.replace(headerBlock, '');
+}
+
+/**
  * Serialize the central (synced) meta to `agents.yaml` WITHOUT destroying the
  * hand-written comments in the committed file.
  *
@@ -1068,17 +1094,24 @@ function serializeCentral(central: Record<string, unknown>): string {
       changed = true;
     }
   }
-  // No central field changed → keep the file byte-identical (comments intact), so
-  // writeIfChanged skips it and the churn loop never starts.
-  if (!changed) return existing;
-  // Everything cleared → header only (never leave a flow `{}` behind).
-  // Otherwise stringifyDoc: it still normalizes a legacy flow root (`{}`) to
-  // block, so edited nodes do not render flow (`disabledCommands: [ teams ]`
-  // instead of a `- teams` block list), but it no longer forces block on a
-  // normal document — that flattened committed flow sequences and made this
-  // writer disagree with feed.ts/activity.ts/migrate.ts on the same file
-  // (RUSH-2505). parseDocument still preserves comments + key ordering.
-  return isEmpty ? META_HEADER : stringifyDoc(doc);
+  // Everything cleared → header only (never leave a flow `{}` behind); this also
+  // heals a stale header-only file to the current one. Byte-stable when the file
+  // is already exactly the current header.
+  if (isEmpty) return existing === META_HEADER ? existing : META_HEADER;
+  // Serialize the edited doc when a central key changed, otherwise keep the exact
+  // existing bytes, then heal the header on that string. stringifyDoc still
+  // normalizes a legacy flow root (`{}`) to block, so edited nodes do not render
+  // flow (`disabledCommands: [ teams ]` instead of a `- teams` block list), but it
+  // no longer forces block on a normal document — that flattened committed flow
+  // sequences and made this writer disagree with feed.ts/activity.ts/migrate.ts on
+  // the same file (RUSH-2505). parseDocument still preserves body comments + key
+  // ordering.
+  const healed = healMetaHeader(changed ? stringifyDoc(doc) : existing);
+  // No central field changed AND the header was already current → healed equals
+  // the existing bytes, so returning them keeps the file byte-identical (comments
+  // intact): writeIfChanged skips it and the churn loop never starts. A stale
+  // header makes healed differ, so it is rewritten once and byte-stable after.
+  return healed === existing ? existing : healed;
 }
 
 function writeMetaUnlocked(meta: Meta): void {

--- a/cli/src/lib/state.ts
+++ b/cli/src/lib/state.ts
@@ -1036,7 +1036,12 @@ const KNOWN_META_KEYS: ReadonlySet<string> = new Set([
 function healMetaHeader(serialized: string): string {
   const headerBlock =
     /^# agents-cli metadata\n# Auto-generated - do not edit manually\n(?:# (?:https:\/\/github\.com\/phnx-labs\/[^\n]*|yaml-language-server: \$schema=[^\n]*)\n)*\n?/;
-  return META_HEADER + serialized.replace(headerBlock, '');
+  const stripped = serialized.replace(headerBlock, '');
+  // No metadata header present (replace was a no-op) → leave the file exactly as
+  // it is. We heal a STALE header; we never prepend one to a file that never had
+  // it (that would rewrite a hand-authored, headerless central file on the first
+  // real central change). A current header round-trips to the identical bytes.
+  return stripped === serialized ? serialized : META_HEADER + stripped;
 }
 
 /**
@@ -1094,24 +1099,26 @@ function serializeCentral(central: Record<string, unknown>): string {
       changed = true;
     }
   }
-  // Everything cleared → header only (never leave a flow `{}` behind); this also
-  // heals a stale header-only file to the current one. Byte-stable when the file
-  // is already exactly the current header.
+  // No central field changed → keep the file byte-identical (comments intact), so
+  // writeIfChanged skips it and the churn loop never starts. A device-only write
+  // (pins/routines/etc. routed elsewhere) reaches here with changed=false and
+  // MUST NOT rewrite the shared file — header healing waits for a genuine central
+  // change below rather than dirtying agents.yaml on an unrelated write, which is
+  // the very churn that wedges `agents sync` and blocks fleet pulls.
+  if (!changed) return existing;
+  // Everything cleared → header only (never leave a flow `{}` behind). Byte-stable
+  // when the file is already exactly the current header.
   if (isEmpty) return existing === META_HEADER ? existing : META_HEADER;
-  // Serialize the edited doc when a central key changed, otherwise keep the exact
-  // existing bytes, then heal the header on that string. stringifyDoc still
-  // normalizes a legacy flow root (`{}`) to block, so edited nodes do not render
-  // flow (`disabledCommands: [ teams ]` instead of a `- teams` block list), but it
-  // no longer forces block on a normal document — that flattened committed flow
-  // sequences and made this writer disagree with feed.ts/activity.ts/migrate.ts on
-  // the same file (RUSH-2505). parseDocument still preserves body comments + key
-  // ordering.
-  const healed = healMetaHeader(changed ? stringifyDoc(doc) : existing);
-  // No central field changed AND the header was already current → healed equals
-  // the existing bytes, so returning them keeps the file byte-identical (comments
-  // intact): writeIfChanged skips it and the churn loop never starts. A stale
-  // header makes healed differ, so it is rewritten once and byte-stable after.
-  return healed === existing ? existing : healed;
+  // A central key changed: serialize the edited doc and heal a frozen header on
+  // the result. stringifyDoc still normalizes a legacy flow root (`{}`) to block,
+  // so edited nodes do not render flow (`disabledCommands: [ teams ]` instead of a
+  // `- teams` block list), but it no longer forces block on a normal document —
+  // that flattened committed flow sequences and made this writer disagree with
+  // feed.ts/activity.ts/migrate.ts on the same file (RUSH-2505). parseDocument
+  // still preserves body comments + key ordering; healMetaHeader is a no-op unless
+  // a stale metadata header is actually present, so a headerless central file is
+  // updated in place without gaining one.
+  return healMetaHeader(stringifyDoc(doc));
 }
 
 function writeMetaUnlocked(meta: Meta): void {

--- a/cli/src/lib/state.ts
+++ b/cli/src/lib/state.ts
@@ -1121,7 +1121,14 @@ function serializeCentral(central: Record<string, unknown>): string {
   return healMetaHeader(stringifyDoc(doc));
 }
 
-function writeMetaUnlocked(meta: Meta): void {
+/**
+ * Write `meta` to disk (central + device docs + pins) WITHOUT taking the meta
+ * lock — the caller must already hold it via {@link withMetaLock}. Exported so a
+ * writer that needs to read fresh state, decide, and commit within a SINGLE lock
+ * acquisition (e.g. browser tombstone eviction) can do so without the
+ * read-snapshot-then-separately-lock race that {@link updateMeta} would impose.
+ */
+export function writeMetaUnlocked(meta: Meta): void {
   const { agents, isolatedAgents, versions, deviceRoutines, deviceConfig, deviceBrowser, projectRoot, ...central } = meta;
 
   // Write the machine-local files FIRST, then strip central — so a crash mid-write


### PR DESCRIPTION
**What:** Phase 1 of the device-scoped config refactor — two standalone, low-risk fixes that cut most of the daily `~/.agents/agents.yaml` churn. **Type:** bug-fix + test (`cli/` runtime).

Implements PHASE 1 of **PHNX-3315** (finish the device-scoped config refactor — make `~/.agents` conflict-free by construction). Phases 2/3 (fleet/accounts/hosts device-scoping) are explicitly out of scope for this PR.

## What changed

- **`cli/src/lib/state.ts`** — `serializeCentral` now heals a frozen top-level header. It parses the committed `agents.yaml` to preserve hand-written body comments, which also preserved the *leading metadata header* verbatim: a file written before the `agi-cli` rename kept its stale 3-line header (repo `agents-cli`, no `$schema:` line) forever, while every device doc got the current `META_HEADER`. The header is now rewritten to current on the next central write. New `healMetaHeader()` does it **textually** on the serialized output — the `yaml` library folds the leading comment block onto the *first key's* `commentBefore` when that key already carries a comment, so `doc.commentBefore` is not a reliable handle on the header; the top of the serialized string always is. Body comments and every config key survive, and the output is byte-stable once healed so it never re-churns. (The current `META_HEADER` was already correct — `agi-cli` + `cli/schema` — so no generator change was needed; the only bug was the frozen on-disk header.)
- **`cli/src/lib/browser/registry.ts`** — new `autoEvictCentralBrowserProfiles(canHostHere)`: the automatic, self-draining counterpart to the explicit `migrateCentralBrowserProfiles`. Shared claim/commit core extracted (`selectClaimableCentral`, `commitCentralClaim`). It folds every lingering central `browser:` profile THIS machine can host into its device doc and clears it from central. Safe to run implicitly: host-gated (a peer's `cdp://localhost:*` profile is never claimed here — the logged-out-headless-browser bug the module exists to prevent), serialized under the meta lock (`updateMeta`), and **non-throwing** — a config conflict or unhostable profile is left central rather than wedging the sync (the explicit path still throws). `profileRegistry` remains the single source of truth: a claimed profile lives in the device doc alone, never double-counted.
- **`cli/src/commands/sync.ts`** — `agents sync` (the "make this machine current" umbrella) now calls the eviction first, on both the interactive and non-interactive paths, gated to skip `--cloud` (fetch-only). Non-fatal, so a hiccup can never break sync. The tombstone drains itself without a manual `agents browser profiles claim`.
- **`cli/src/lib/state.test.ts`** — a stale-header central doc with body comments → after a central write the header is the current `META_HEADER`, body comments survive, no keys are lost, and a subsequent no-op write is byte-stable.
- **`cli/src/lib/browser/registry.test.ts`** — a central tombstone for THIS device → after eviction it lives in the device doc, central `browser:` is drained, and the single reader returns it exactly once; plus the never-throw-on-conflict and unhostable-left-central cases.
- **`cli/.changelog/next/PHNX-3315-p1.md`** — changelog fragment (`next/`, not a hand-edit of the generated `CHANGELOG.md`).

## Verification

`node ./node_modules/vitest/vitest.mjs run` on the two touched suites (the new tests plus the existing regression guards):

```
$ node ./node_modules/vitest/vitest.mjs run src/lib/state.test.ts src/lib/browser/registry.test.ts
 Test Files  2 passed (2)
      Tests  29 passed (29)
```

`tsc --noEmit -p tsconfig.json` → exit 0. Broader regression sweep of everything that touches central serialization / the browser stores, all green:

```
sync.test.ts + browser.claim.test.ts        24 passed
migrate.test.ts + device-config.test.ts     99 passed
git.adopt-in-place.test.ts + repo.test.ts   40 passed
feed/feed.test.ts (RUSH-2505 flow style)    14 passed
changelog generator suites                  92 passed | 2 skipped
```

No behavior change to fleet/accounts/hosts (Phase 2). No post-merge sync step required — this is `cli/` runtime code that ships with the next agents-cli release.
