### PR TITLE
fix(sessions): route Cursor auto-title through the shared label cleaner (PHNX-3123)

### DIFF
--- a/cli/.changelog/next/PHNX-3123.md
+++ b/cli/.changelog/next/PHNX-3123.md
@@ -1,0 +1,13 @@
+- **Cursor auto-titles go through the same skill-scaffolding cleaner as Claude (PHNX-3123).**
+  `readCursorMeta` took `chatMeta.title` verbatim, so a Cursor session whose
+  server-generated title echoed the injected `Base directory for this skill: …`
+  line kept that path as `SessionMeta.label` — the field that wins on every
+  surface for the session's whole life. Claude's `ai-title` was already collapsed
+  to `/<skill>` at label composition (PR #2995); that collapse now lives in one
+  shared helper (`cleanGeneratedSessionLabel`) and Cursor's title takes the same
+  path. An ordinary Cursor title, and one that merely names a `skills/…` path,
+  is unchanged. A Claude `/rename` (`custom-title`) is still never rewritten.
+  Codex / OpenCode / Kimi / Droid put auto-titles on `topic`, not `label`, so
+  they are out of this change. **Not retroactive:** already-indexed labels stay
+  until the transcript next changes (RUSH-3122). Source:
+  `cli/src/lib/session/prompt.ts`, `cli/src/lib/session/discover.ts`.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -94,6 +94,20 @@
 
 ## 1.22.51
 
+- **Cursor auto-titles go through the same skill-scaffolding cleaner as Claude (PHNX-3123).**
+  `readCursorMeta` took `chatMeta.title` verbatim, so a Cursor session whose
+  server-generated title echoed the injected `Base directory for this skill: …`
+  line kept that path as `SessionMeta.label` — the field that wins on every
+  surface for the session's whole life. Claude's `ai-title` was already collapsed
+  to `/<skill>` at label composition (PR #2995); that collapse now lives in one
+  shared helper (`cleanGeneratedSessionLabel`) and Cursor's title takes the same
+  path. An ordinary Cursor title, and one that merely names a `skills/…` path,
+  is unchanged. A Claude `/rename` (`custom-title`) is still never rewritten.
+  Codex / OpenCode / Kimi / Droid put auto-titles on `topic`, not `label`, so
+  they are out of this change. **Not retroactive:** already-indexed labels stay
+  until the transcript next changes (RUSH-3122). Source:
+  `cli/src/lib/session/prompt.ts`, `cli/src/lib/session/discover.ts`.
+
 - **`publish-computer-helper-mac.sh` cuts the helper's own tag (PHNX-3228).**
   It published `ComputerHelper.app.zip` to the CLI's `v<version>` release, but since the
   client was repointed at per-helper tags the resolver asks for `computer-mac/v<x.y.z>`

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -94,20 +94,6 @@
 
 ## 1.22.51
 
-- **Cursor auto-titles go through the same skill-scaffolding cleaner as Claude (PHNX-3123).**
-  `readCursorMeta` took `chatMeta.title` verbatim, so a Cursor session whose
-  server-generated title echoed the injected `Base directory for this skill: …`
-  line kept that path as `SessionMeta.label` — the field that wins on every
-  surface for the session's whole life. Claude's `ai-title` was already collapsed
-  to `/<skill>` at label composition (PR #2995); that collapse now lives in one
-  shared helper (`cleanGeneratedSessionLabel`) and Cursor's title takes the same
-  path. An ordinary Cursor title, and one that merely names a `skills/…` path,
-  is unchanged. A Claude `/rename` (`custom-title`) is still never rewritten.
-  Codex / OpenCode / Kimi / Droid put auto-titles on `topic`, not `label`, so
-  they are out of this change. **Not retroactive:** already-indexed labels stay
-  until the transcript next changes (RUSH-3122). Source:
-  `cli/src/lib/session/prompt.ts`, `cli/src/lib/session/discover.ts`.
-
 - **`publish-computer-helper-mac.sh` cuts the helper's own tag (PHNX-3228).**
   It published `ComputerHelper.app.zip` to the CLI's `v<version>` release, but since the
   client was repointed at per-helper tags the resolver asks for `computer-mac/v<x.y.z>`

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -344,6 +344,19 @@ SSH access (§7); rendering sessions that no harness produced.
   title / `/rename` > `agents run --name` handle > unset (listing then falls back
   to `topic`); an empty incoming label MUST NOT clobber a stored non-empty one
   (`lib/session/db.ts:800-803,1098-1100`; test `db.names.test.ts:50-128`).
+- **SES-14a (MUST).** A harness-generated session title MUST pass through
+  `cleanGeneratedSessionLabel` (`lib/session/prompt.ts`) at the point the
+  scanner composes `SessionMeta.label`, so injected skill scaffolding
+  (`Base directory for this skill: …`) collapses to `/<skill>`. Today that is
+  Claude `ai-title` (`finalizeClaudeScan` in `lib/session/discover.ts`) and
+  Cursor `chatMeta.title` (`readCursorMeta`). A user `/rename` (`custom-title`)
+  MUST NOT be rewritten. Codex / OpenCode / Kimi / Droid auto-titles land on
+  `topic`, not `label`, and are out of this requirement.
+
+  Given a Cursor `meta.json` whose `title` is the skill-basedir line, When
+  `readCursorMeta` runs, Then `meta.label` is `/<skill>`.
+  Tests: `lib/session/prompt.test.ts`, `lib/session/__tests__/parse-cursor.test.ts`,
+  `lib/session/__tests__/discover.test.ts`.
 - **SES-15 (MUST).** A timestamp-less source MUST fall back to file mtime and
   MUST NOT bind NULL into the `NOT NULL` timestamp column
   (`lib/session/discover.ts:4198-4202,1238-1243`).

--- a/cli/src/lib/session/__tests__/parse-cursor.test.ts
+++ b/cli/src/lib/session/__tests__/parse-cursor.test.ts
@@ -105,6 +105,39 @@ describe('Cursor session parsing and discovery metadata', () => {
     expect(result!.events).toEqual(parseCursor(transcriptPath));
   });
 
+  test('collapses a scaffolded chatMeta.title to the skill, matching Claude ai-title', () => {
+    // Cursor writes its own auto-title into chats/.../meta.json independently of
+    // the Claude JSONL ai-title path. The same skill-preamble echo that PR #2995
+    // cleaned for Claude must collapse here too — label wins on every surface.
+    const metaPath = path.join(root, '.cursor', 'chats', 'workspace-hash', SESSION_ID, 'meta.json');
+    fs.mkdirSync(path.dirname(metaPath), { recursive: true });
+    fs.writeFileSync(metaPath, JSON.stringify({
+      schemaVersion: 1,
+      createdAtMs: 1785654071336,
+      hasConversation: true,
+      title: 'Base directory for this skill: /home/u/.agents/.history/versions/claude/2.1.207/home/.claude/skills/continue',
+      updatedAtMs: 1785668144486,
+      cwd: '/tmp/public-project',
+    }));
+
+    const result = readCursorMeta(transcriptPath);
+    expect(result).not.toBeNull();
+    expect(result!.meta.label).toBe('/continue');
+  });
+
+  test('leaves a Cursor title that merely names a skills/ path unchanged', () => {
+    const metaPath = path.join(root, '.cursor', 'chats', 'workspace-hash', SESSION_ID, 'meta.json');
+    fs.mkdirSync(path.dirname(metaPath), { recursive: true });
+    fs.writeFileSync(metaPath, JSON.stringify({
+      title: 'rewrite the skills/continue docs',
+      cwd: '/tmp/public-project',
+    }));
+
+    const result = readCursorMeta(transcriptPath);
+    expect(result).not.toBeNull();
+    expect(result!.meta.label).toBe('rewrite the skills/continue docs');
+  });
+
   test('indexes transcript-only archives without inventing cwd or title', () => {
     const result = readCursorMeta(transcriptPath);
     expect(result).not.toBeNull();

--- a/cli/src/lib/session/discover.ts
+++ b/cli/src/lib/session/discover.ts
@@ -30,7 +30,7 @@ import { getConfigSymlinkVersion } from '../installations/shims.js';
 import { SESSION_AGENTS } from './types.js';
 import { deriveShortId } from './short-id.js';
 import { buildClaudeAccountIndex, resolveClaudeAccount, type ClaudeAccountIndex } from './claude-accounts.js';
-import { extractSessionTopic, extractSlashCommandName, extractSlashCommandFromToolInput, classifyUserPrompt } from './prompt.js';
+import { extractSessionTopic, extractSlashCommandName, extractSlashCommandFromToolInput, cleanGeneratedSessionLabel } from './prompt.js';
 import { isBackgroundShellStart, isSkillInvocation, extractSkills, extractSlashCommands, isSubAgentTool } from './highlights.js';
 import { parseAntigravity, parseCursor, splitSessionFilePath } from './parse.js';
 import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand, detectSpawnedTeam, isTicketCreateTool, extractCreatedTicket, extractRecentDirectoriesTouched, extractTodoProgressFromEvents } from './state.js';
@@ -3872,15 +3872,10 @@ export function finalizeClaudeScan(state: ClaudeParseState): ClaudeSessionScan {
   // A topic is the first meaningful prompt. Harness-owned names travel in the
   // separate label field so consumers can replace an early topic once Claude's
   // generated title (or a later `/rename`) arrives.
-  // Claude's generated `ai-title` is derived from the first turn, so a session
-  // opened with a skill gets named after the injected "Base directory for this
-  // skill: …" line instead of its task — and that name then wins on every
-  // surface for the session's whole life. `classifyUserPrompt` reports `skill`
-  // only for that injected line, so collapse it to `/<skill>`. A `/rename`
-  // (`custom-title`) is the user's own words and is never rewritten.
-  const generated = classifyUserPrompt(state.aiTitle ?? '');
-  const label = state.customTitle
-    || (generated.kind === 'skill' ? generated.clean : state.aiTitle);
+  // Generated titles (Claude `ai-title`, Cursor `chatMeta.title`) go through
+  // one shared cleaner so a skill-preamble echo collapses to `/<skill>`. A
+  // `/rename` (`custom-title`) is the user's own words and is never rewritten.
+  const label = state.customTitle || cleanGeneratedSessionLabel(state.aiTitle);
   const worktree = detectWorktree(state.cwd, state.gitBranch);
   const ticket = detectTicket(state.userTexts.join('\n') || undefined, state.gitBranch);
 
@@ -5234,8 +5229,8 @@ export function readCursorMeta(
     .filter((event) => event.type === 'message' && event.role === 'user' && event.content)
     .map((event) => event.content!);
   const firstUserText = userTexts[0];
-  const title = typeof chatMeta?.title === 'string' && chatMeta.title.trim()
-    ? chatMeta.title.trim()
+  const title = typeof chatMeta?.title === 'string'
+    ? cleanGeneratedSessionLabel(chatMeta.title)
     : undefined;
 
   const meta: SessionMeta = {

--- a/cli/src/lib/session/prompt.test.ts
+++ b/cli/src/lib/session/prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractSessionTopic, cleanSessionPrompt, classifyUserPrompt, isSyntheticUserMessage, HEADLESS_PLAN_MODE_PREFIX } from './prompt.js';
+import { extractSessionTopic, cleanSessionPrompt, classifyUserPrompt, cleanGeneratedSessionLabel, isSyntheticUserMessage, HEADLESS_PLAN_MODE_PREFIX } from './prompt.js';
 
 describe('classifyUserPrompt (a "You" line that drops path noise)', () => {
   it('folds a standalone screenshot path (with spaces) to [image]', () => {
@@ -52,6 +52,29 @@ describe('classifyUserPrompt (a "You" line that drops path noise)', () => {
     const r = classifyUserPrompt(long);
     expect(r.kind).toBe('text');
     expect(r.clean.length).toBeGreaterThan(300);
+  });
+});
+
+describe('cleanGeneratedSessionLabel (harness auto-title → SessionMeta.label)', () => {
+  it('collapses the injected skill-basedir line to /<skill>', () => {
+    expect(cleanGeneratedSessionLabel(
+      'Base directory for this skill: /home/u/.agents/.history/versions/claude/2.1.207/home/.claude/skills/continue',
+    )).toBe('/continue');
+  });
+
+  it('leaves an ordinary generated title unchanged', () => {
+    expect(cleanGeneratedSessionLabel('Session command audit')).toBe('Session command audit');
+  });
+
+  it('does not rewrite a title that merely names a skills/ path', () => {
+    expect(cleanGeneratedSessionLabel('rewrite the skills/continue docs'))
+      .toBe('rewrite the skills/continue docs');
+  });
+
+  it('returns undefined for empty or whitespace-only titles', () => {
+    expect(cleanGeneratedSessionLabel(undefined)).toBeUndefined();
+    expect(cleanGeneratedSessionLabel('')).toBeUndefined();
+    expect(cleanGeneratedSessionLabel('   ')).toBeUndefined();
   });
 });
 

--- a/cli/src/lib/session/prompt.ts
+++ b/cli/src/lib/session/prompt.ts
@@ -238,6 +238,27 @@ export function classifyUserPrompt(
   return { clean: display, kind: 'text' };
 }
 
+/**
+ * Collapse a harness-generated session title when it is injected skill
+ * scaffolding; otherwise leave the title as the harness wrote it.
+ *
+ * Claude's `ai-title` and Cursor's `chatMeta.title` are both derived from the
+ * first turn, so a session opened with a skill gets named after the injected
+ * "Base directory for this skill: …" line. {@link classifyUserPrompt} reports
+ * `kind: 'skill'` only for that line, so collapse it to `/<skill>`. Empty or
+ * whitespace-only input yields `undefined` so the caller falls through to the
+ * first-prompt topic.
+ *
+ * A user-authored title (Claude `/rename` / `custom-title`) is never passed
+ * here — the caller keeps it verbatim.
+ */
+export function cleanGeneratedSessionLabel(title: string | undefined): string | undefined {
+  const trimmed = title?.trim();
+  if (!trimmed) return undefined;
+  const classified = classifyUserPrompt(trimmed);
+  return classified.kind === 'skill' ? classified.clean : trimmed;
+}
+
 /** Extract a one-line topic from a raw user message, or undefined if the message is pure noise. */
 export function extractSessionTopic(raw: string): string | undefined {
   if (!raw.trim()) return undefined;


### PR DESCRIPTION
## Summary

Cursor's `chatMeta.title` was assigned straight onto `SessionMeta.label`, bypassing the skill-scaffolding collapse PR #2995 added for Claude's `ai-title`. A Cursor session whose auto-title echoed `Base directory for this skill: …` kept that path as the name that wins on every surface (picker, `--flat`/`--tree`, Fleet, feed).

The collapse now lives in one helper, `cleanGeneratedSessionLabel` next to `classifyUserPrompt`, and both scanners call it:

- Claude `ai-title` in `finalizeClaudeScan` (custom-title / `/rename` still never rewritten)
- Cursor `chatMeta.title` in `readCursorMeta`

An ordinary Cursor title, and one that merely names a `skills/…` path, is unchanged.

## Harness parity

This is the label-composition path. Codex / OpenCode / Kimi / Droid put auto-titles on `topic`, not `label`, so they are out of this change (stated here rather than silently skipped). The cleaner is shared so those scanners can adopt it if they ever start composing `label`.

Companion `phnx-labs/.agents-system` audit: no hooks, skills, commands, or rules invoke Cursor `chatMeta.title` or this cleaner. No companion PR.

## Spec / changelog

- SES-14a pins generated titles to `cleanGeneratedSessionLabel`.
- Unreleased note queued at `cli/.changelog/next/PHNX-3123.md` (CHANGELOG.md is generated; do not hand-edit).
- **Not retroactive:** already-indexed labels stay until the transcript next changes (RUSH-3122).

Closes [PHNX-3123](https://linear.app/getrush/issue/PHNX-3123/sessions-harness-auto-title-parity-cursors-chatmetatitle-bypasses-the).

## Test plan

- [x] `bun test src/lib/session/prompt.test.ts src/lib/session/__tests__/parse-cursor.test.ts src/lib/session/__tests__/discover.test.ts` — 84 pass
- [x] `bun test scripts/gen-changelog.test.ts` — 5 pass (CI failure was a hand-edited CHANGELOG.md; restored)
- [x] Scaffolded Cursor `chatMeta.title` collapses to `/continue`
- [x] Ordinary Cursor title (`Session command audit`) still lands as-is
- [x] Claude `ai-title` skill collapse and custom-title preservation still pass