### PR TITLE
fix(feed): stamp sourceCursor at block-write time (PHNX-3073)

### DIFF
--- a/cli/.changelog/next/PHNX-3073.md
+++ b/cli/.changelog/next/PHNX-3073.md
@@ -1,0 +1,9 @@
+- **Feed attention stamps `sourceCursor` at block-write time (PHNX-3073).**
+  `coveredByResolution` conservatively suppresses a candidate with no comparable
+  cursor when a tombstone exists, which is correct for a stale lifecycle re-read
+  but buried a genuinely new open block whenever `session.lastActivityMs` was
+  unresolvable (cloud / remote / index-lag) because neither writer stamped a
+  cursor. `buildDeclaredBlock` and the feed-publish hook now stamp
+  `sourceCursor.lastActivityMs` from the write instant, so a fresh generation
+  compares strictly newer than any prior tombstone. Source:
+  `cli/src/lib/feed/feed.ts`.

--- a/cli/src/lib/feed-blocked.test.ts
+++ b/cli/src/lib/feed-blocked.test.ts
@@ -73,6 +73,7 @@ describe('buildDeclaredBlock', () => {
     expect(read[0].kind).toBe('declared');
     expect(read[0].questions[0].text).toBe('force-push denied by git-guard on PR #1749');
     expect(read[0].sessionId).toBe(AGENT.sessionId);
+    expect(read[0].sourceCursor).toEqual({ lastActivityMs: Date.parse(block.ts) });
   });
 });
 

--- a/cli/src/lib/feed/attention.test.ts
+++ b/cli/src/lib/feed/attention.test.ts
@@ -238,6 +238,39 @@ describe('reconcileAttention', () => {
     expect(item).toBeDefined();
   });
 
+  it('a new declared block is not suppressed when the session cursor is unresolvable', () => {
+    // PHNX-3073: coveredByResolution defaults to suppress when the candidate has
+    // no comparable sourceCursor.lastActivityMs. A declared block must stamp its
+    // own cursor at write time so a fresh generation is not buried by a prior
+    // tombstone while lastActivityMs is missing (cloud / remote / index-lag).
+    const ts = '2026-08-27T12:00:00.000Z';
+    const block = buildDeclaredBlock(
+      { sessionId: 'sess-cloud', mailboxId: 'mbx', host: 'zion', runtime: 'claude' },
+      { text: 'Need a new decision?', ts },
+    );
+    expect(block.sourceCursor?.lastActivityMs).toBe(Date.parse(ts));
+
+    const resolution: AttentionResolution = {
+      blockId: blockIdForSession('sess-cloud'),
+      generation: '2026-08-27T11:00:00.000Z',
+      resolvedAt: '2026-08-27T11:05:00.000Z',
+      sourceCursor: { lastActivityMs: Date.parse('2026-08-27T11:00:00.000Z') },
+      reason: 'answered',
+    };
+
+    const item = reconcileAttention({
+      block,
+      // No lastActivityMs — the session-derived fallback cannot prove advancement.
+      session: session({ sessionId: 'sess-cloud', activity: 'working' }),
+      resolution,
+      nowMs: Date.parse(ts),
+    });
+    expect(item).toBeDefined();
+    expect(item!.kind).toBe('declared');
+    expect(item!.key).toBe(`zion/sess-cloud/${ts}`);
+    expect(item!.sourceCursor?.lastActivityMs).toBe(Date.parse(ts));
+  });
+
   it('an open block whose generation was already resolved cannot resurrect', () => {
     // The write-ordering window the plan names: the tombstone is appended BEFORE
     // the open-block view is cleared, so a still-'open' block of the resolved

--- a/cli/src/lib/feed/feed.test.ts
+++ b/cli/src/lib/feed/feed.test.ts
@@ -225,6 +225,16 @@ describe('feed store', () => {
     expect(noCwd.project).toBeUndefined();
   });
 
+  it('buildDeclaredBlock stamps sourceCursor from ts at write time', () => {
+    const ts = '2026-08-27T12:00:00.000Z';
+    const block = buildDeclaredBlock(
+      { sessionId: 's-cursor', mailboxId: 'm1', host: 'zion', runtime: 'claude' },
+      { text: 'Need a decision?', ts },
+    );
+    expect(block.sourceCursor).toEqual({ lastActivityMs: Date.parse(ts) });
+    expect(block.generation).toBe(ts);
+  });
+
   it.runIf(hasPython)('real hook publishes every question and runtime into the shared feed', () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-hook-'));
     const mailbox = path.join(home, '.agents', '.history', 'mailbox', 'session-123');
@@ -286,6 +296,27 @@ describe('feed store', () => {
     const blocks = listBlocks(path.join(home, '.agents', '.history', 'feed'));
     expect(blocks).toHaveLength(1);
     expect(blocks[0].project).toBe('agents-cli');
+  });
+
+  it.runIf(hasPython)('real hook stamps sourceCursor at publish time', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-hook-cursor-'));
+    const before = Date.now();
+    const result = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'session-cursor',
+        tool_input: { questions: [{ question: 'Which approach?' }] },
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    const after = Date.now();
+    expect(result.status).toBe(0);
+    const blocks = listBlocks(path.join(home, '.agents', '.history', 'feed'));
+    expect(blocks).toHaveLength(1);
+    const cursor = blocks[0].sourceCursor?.lastActivityMs;
+    expect(typeof cursor).toBe('number');
+    expect(cursor).toBeGreaterThanOrEqual(before - 1000);
+    expect(cursor).toBeLessThanOrEqual(after + 1000);
   });
 
   it.runIf(hasPython)('real hook publishes waiting notifications with routing identity', () => {

--- a/cli/src/lib/feed/feed.ts
+++ b/cli/src/lib/feed/feed.ts
@@ -115,7 +115,12 @@ export interface OpenBlock {
   source?: AttentionSource;
   /** Lifecycle state. Derived from the answer/continue markers when absent — see {@link deriveBlockState}. */
   state?: AttentionState;
-  /** Where in the source this block's generation sits — carried onto its resolution tombstone. */
+  /**
+   * Where in the source this block's generation sits — stamped at write time
+   * (`buildDeclaredBlock`, the feed-publish hook) and carried onto its resolution
+   * tombstone. Without a write-time cursor a new generation is suppressed whenever
+   * `session.lastActivityMs` is unresolvable (cloud / remote / index-lag).
+   */
   sourceCursor?: SourceCursor;
   /** Indexed launch origin, added at read time when the live session is known. */
   origin?: 'cli' | 'routine';
@@ -630,6 +635,9 @@ export interface DeclareBlockInput {
  * `costOfDelay: high` because a declared block is, by definition, an agent that
  * has already stopped making progress — that is what makes it worth interrupting
  * someone over, and what `feed --dispatch`'s urgency filter keys off.
+ *
+ * `sourceCursor` is stamped from `ts` at write time so a fresh generation is
+ * comparable even when the live session's `lastActivityMs` is unresolvable.
  */
 export function buildDeclaredBlock(agent: DeclaringAgent, input: DeclareBlockInput): OpenBlock {
   const text = input.text.trim().replace(/\s+/g, ' ');
@@ -656,6 +664,9 @@ export function buildDeclaredBlock(agent: DeclaringAgent, input: DeclareBlockInp
     generation: ts,
     source: 'declared',
     state: 'open',
+    // Write-time cursor so a new generation is not suppressed when
+    // session.lastActivityMs is unresolvable (cloud / remote / index-lag).
+    sourceCursor: { lastActivityMs: Date.parse(ts) },
     kind: 'declared',
     questions: [{ text, header: 'Needs you', ...(options.length ? { options } : {}) }],
     blockClass: input.safeDefault ? 'approval' : 'decision',
@@ -1027,7 +1038,9 @@ def main():
         os.environ.get("AGENTS_MAILBOX_DIR", "").rstrip("/")
     ) or session_id
 
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+    now_ms = int(now.timestamp() * 1000)
     stats_path = os.path.join(asks_dir, f"{safe_session_id}.json")
     stats = read_json(stats_path) or {}
     recent = stats.get("recentAskTimestamps") if isinstance(stats, dict) else []
@@ -1061,6 +1074,9 @@ def main():
         "host": host,
         "runtime": runtime,
         "ts": now_iso,
+        # Write-time cursor so a new generation is not suppressed when
+        # session.lastActivityMs is unresolvable (cloud / remote / index-lag).
+        "sourceCursor": {"lastActivityMs": now_ms},
         "questions": normalized_questions,
         "kind": kind,
     }


### PR DESCRIPTION
## What

Stamp `sourceCursor.lastActivityMs` at block-write time so a genuinely new open block is not suppressed when the live session cursor is unresolvable.

Closes [PHNX-3073](https://linear.app/getrush/issue/PHNX-3073/feed-attention-stamp-sourcecursor-at-block-write-time-else-a-new-open). Follow-up from Track A review ([PR #2958](https://github.com/phnx-labs/agi-cli/pull/2958#issuecomment-5386611221)).

## Why

`coveredByResolution` conservatively returns true when a candidate has no comparable `sourceCursor.lastActivityMs` and its generation differs from the tombstone. That is the correct anti-resurrection default for a stale lifecycle re-read.

It is wrong for a **new** open block: neither writer stamped a cursor, so `attentionFromBlock` fell back to `sessionCursor(session)`. `session.lastActivityMs` is missing for cloud/remote/index-lag rows, the new generation then has a null cursor, and the fresh ask is suppressed forever.

## How

- `buildDeclaredBlock` stamps `sourceCursor: { lastActivityMs: Date.parse(ts) }` — the same instant as `generation`.
- The Python feed-publish hook stamps `sourceCursor.lastActivityMs` from the write instant.
- `coveredByResolution` is **not** relaxed. Stamping at the producer is the canonical source; the conservative default stays for lifecycle re-reads. An authoritative open block of a different generation is comparable once writers stamp.

## Tests

Real path, no mocks. Quoted from this worktree:

```
bun vitest run src/lib/feed/attention.test.ts src/lib/feed/feed.test.ts src/lib/feed-blocked.test.ts

 Test Files  3 passed (3)
      Tests  85 passed (85)
```

- `attention.test.ts` reproduces the bug: a new declared block + prior tombstone + session with no `lastActivityMs` is **not** suppressed.
- `feed.test.ts` asserts `buildDeclaredBlock` stamps from `ts`, and the real Python hook stamps a write-time cursor.
- `feed-blocked.test.ts` round-trips the stamp through the real store.

## Changelog

`cli/.changelog/next/PHNX-3073.md` (do not edit `CHANGELOG.md` by hand).