### PR TITLE
fix(test): sandbox desktop openers so vitest cannot launch a browser (PHNX-3072)

### DIFF
--- a/cli/.changelog/next/PHNX-3072.md
+++ b/cli/.changelog/next/PHNX-3072.md
@@ -1,0 +1,7 @@
+- **Vitest can no longer launch the developer's browser (PHNX-3072).** `tests/setup.ts`
+  sandboxed `HOME` but not desktop-opener binaries, so a test that reached a real
+  `spawn('open' | 'xdg-open')` opened the URL on the developer's machine — green on
+  Linux CI, where `xdg-open` is absent, and disruptive locally. The harness now
+  prepends stub `open` / `xdg-open` / `gnome-open` binaries to `PATH` so a spawn
+  cannot reach the real handler; an unauthorized spawn fails the file. Source:
+  `cli/tests/opener-sandbox.ts`.

--- a/cli/tests/opener-sandbox.test.ts
+++ b/cli/tests/opener-sandbox.test.ts
@@ -1,0 +1,139 @@
+/**
+ * PHNX-3072: the vitest suite must be structurally unable to launch the
+ * developer's desktop opener. tests/setup.ts prepends stub `open` /
+ * `xdg-open` / `gnome-open` binaries to PATH before any test file's imports
+ * run (see opener-sandbox.ts).
+ *
+ * These assertions FAIL on the pre-fix setup.ts (which sandboxed HOME but
+ * left PATH pointing at the real `/usr/bin/open`) and PASS once the opener
+ * sandbox is installed. The historical bug: `src/lib/open-url.test.ts` drove
+ * the non-injected viewer path, so `bun run test` on a Mac opened
+ * example.com in the developer's browser; Linux CI had no xdg-open and
+ * stayed green.
+ *
+ * This file declares AGENTS_TEST_ALLOW_OPENER because it *intentionally*
+ * spawns the stubbed openers to prove they intercept. Other test files must
+ * not set that flag — an accidental spawn fails the file.
+ */
+process.env.AGENTS_TEST_ALLOW_OPENER = '1';
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  assertNoUnauthorizedOpenerSpawn,
+  DESKTOP_OPENER_BASENAMES,
+  isDesktopOpenerCommand,
+  openerSandboxTripped,
+} from './opener-sandbox.js';
+
+const stubDir = process.env.AGENTS_TEST_OPENER_STUB_DIR;
+const platformOpener = process.platform === 'darwin' ? 'open' : 'xdg-open';
+
+describe('isDesktopOpenerCommand (PHNX-3072)', () => {
+  it('matches the platform opener names, including absolute paths', () => {
+    expect(isDesktopOpenerCommand('open')).toBe(true);
+    expect(isDesktopOpenerCommand('/usr/bin/open')).toBe(true);
+    expect(isDesktopOpenerCommand('xdg-open')).toBe(true);
+    expect(isDesktopOpenerCommand('/usr/bin/xdg-open')).toBe(true);
+    expect(isDesktopOpenerCommand('gnome-open')).toBe(true);
+  });
+
+  it('does not match ordinary binaries a test is allowed to spawn', () => {
+    expect(isDesktopOpenerCommand('git')).toBe(false);
+    expect(isDesktopOpenerCommand('node')).toBe(false);
+    expect(isDesktopOpenerCommand('/bin/sleep')).toBe(false);
+    expect(isDesktopOpenerCommand('true')).toBe(false);
+  });
+});
+
+describe('vitest opener sandbox (PHNX-3072)', () => {
+  it('PATH is prefixed with the fork-private opener stub dir, not left as the developer PATH', () => {
+    // The class of bug: setup.ts sandboxed HOME but not PATH, so spawn('open')
+    // resolved /usr/bin/open. After the fix the stub dir is first.
+    expect(stubDir).toBeTruthy();
+    expect(path.basename(path.dirname(stubDir as string))).toMatch(/^agents-vitest-/);
+    const first = (process.env.PATH ?? '').split(path.delimiter)[0];
+    expect(first).toBe(stubDir);
+  });
+
+  it('every known opener basename is a real executable stub in that dir', () => {
+    expect(stubDir).toBeTruthy();
+    for (const name of DESKTOP_OPENER_BASENAMES) {
+      const stub = path.join(stubDir as string, process.platform === 'win32' ? `${name}.cmd` : name);
+      expect(fs.existsSync(stub), `${name} stub missing at ${stub}`).toBe(true);
+      if (process.platform !== 'win32') {
+        expect(fs.statSync(stub).mode & 0o111).toBeTruthy();
+      }
+    }
+  });
+
+  it('spawning the platform opener against a real URL hits the stub (exit 1), not a browser', () => {
+    // Historical reproduction: showUrl('https://example.com') with no injected
+    // spawnOpen called spawn('open' | 'xdg-open', [url]). Before the sandbox
+    // that opened the developer's browser on macOS and ENOENT'd on Linux CI.
+    // After, both platforms spawn the stub and the URL never reaches a real
+    // handler.
+    const result = spawnSync(platformOpener, ['https://example.com'], { encoding: 'utf-8' });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(String(result.stderr)).toMatch(/PHNX-3072/);
+    expect(String(result.stderr)).toMatch(new RegExp(platformOpener));
+  });
+
+  it('spawning every opener name against a URL hits the stub, on both macOS and Linux', () => {
+    // Acceptance: a spawn of open/xdg-open/gnome-open is provably the stub
+    // on every platform, not "ENOENT on CI, real browser locally".
+    for (const name of DESKTOP_OPENER_BASENAMES) {
+      const result = spawnSync(name, ['https://example.com'], { encoding: 'utf-8' });
+      expect(result.error, `${name} should resolve to the stub`).toBeUndefined();
+      expect(result.status, `${name} stub must fail loud`).toBe(1);
+      expect(String(result.stderr)).toMatch(/PHNX-3072/);
+    }
+  });
+
+  it('a naive subprocess spawn (env: {...process.env}) inherits the stub PATH for free', () => {
+    const script =
+      'const {spawnSync}=require("child_process");' +
+      `const r=spawnSync(${JSON.stringify(platformOpener)},["https://example.com"],{encoding:"utf-8"});` +
+      'process.stdout.write(String(r.status));' +
+      'process.stderr.write(r.stderr||"");';
+    const result = spawnSync(process.execPath, ['-e', script], {
+      encoding: 'utf-8',
+      env: { ...process.env },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('1');
+    expect(result.stderr).toMatch(/PHNX-3072/);
+  });
+
+  it('non-opener binaries still resolve from the rest of PATH', () => {
+    const result = spawnSync('node', ['-e', 'process.stdout.write("ok")'], { encoding: 'utf-8' });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('ok');
+  });
+
+  it('the tripwire records the spawn, and the allow flag silences afterAll', () => {
+    spawnSync(platformOpener, ['https://example.com'], { encoding: 'utf-8' });
+    const log = openerSandboxTripped();
+    expect(log).toBeTruthy();
+    expect(log as string).toMatch(/example\.com/);
+
+    const prev = process.env.AGENTS_TEST_ALLOW_OPENER;
+    delete process.env.AGENTS_TEST_ALLOW_OPENER;
+    try {
+      expect(() => assertNoUnauthorizedOpenerSpawn()).toThrow(/PHNX-3072/);
+    } finally {
+      process.env.AGENTS_TEST_ALLOW_OPENER = prev;
+    }
+    expect(() => assertNoUnauthorizedOpenerSpawn()).not.toThrow();
+  });
+});
+
+describe('opener stubs do not shadow git (PATH is a prefix, not a cage)', () => {
+  it('git still runs', () => {
+    const out = execFileSync('git', ['--version'], { encoding: 'utf-8' });
+    expect(out).toMatch(/^git version /);
+  });
+});

--- a/cli/tests/opener-sandbox.ts
+++ b/cli/tests/opener-sandbox.ts
@@ -1,0 +1,139 @@
+/**
+ * PHNX-3072: the vitest suite must be structurally unable to launch the
+ * developer's desktop opener (`open` / `xdg-open` / `gnome-open`).
+ *
+ * `tests/setup.ts` already sandboxes HOME so a test cannot write the real
+ * `~/.agents`. PATH was left alone, so a unit test that reached a real
+ * `spawn('open' | 'xdg-open')` resolved the developer's binary. That shipped:
+ * `open-url.test.ts` drove the non-injected viewer path, every Mac `bun run test`
+ * opened example.com, and Linux CI stayed green because `xdg-open` was absent
+ * (ENOENT in ~4ms). The specific test was fixed in agents-cli#2937; this
+ * module closes the class.
+ *
+ * Installed once per fork from tests/setup.ts: stub binaries are prepended to
+ * PATH so a PATH-resolved spawn cannot reach `/usr/bin/open`. Child processes
+ * that inherit `env: {...process.env}` get the stubs for free, the same way
+ * they inherit the sandboxed HOME. This is a prefix, not a cage — git/node/the
+ * CLI still resolve from the rest of PATH.
+ *
+ * An unauthorized spawn still fails the file via the afterAll tripwire
+ * (`assertNoUnauthorizedOpenerSpawn`). Set `AGENTS_TEST_ALLOW_OPENER=1` to
+ * declare intent (the probe tests in opener-sandbox.test.ts do this). The
+ * stubs still run — a test can never launch the real handler.
+ *
+ * Absolute paths (`/usr/bin/open`) skip PATH by construction; those call
+ * sites (today: `setup-computer.ts`) are a different class. The incident
+ * this closes is PATH-resolved spawn, which is how `open-url.ts` launches.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Platform opener names a test must never resolve to a real desktop handler. */
+export const DESKTOP_OPENER_BASENAMES = ['open', 'xdg-open', 'gnome-open'] as const;
+
+const ALLOW_ENV = 'AGENTS_TEST_ALLOW_OPENER';
+const STUB_DIR_ENV = 'AGENTS_TEST_OPENER_STUB_DIR';
+const TRIPWIRE_DIR_ENV = 'AGENTS_TEST_OPENER_TRIPWIRE_DIR';
+const TRIPWIRE_FILE = 'invoked';
+
+function basenameOf(command: string): string {
+  const normalized = command.replace(/\\/g, '/');
+  const i = normalized.lastIndexOf('/');
+  return (i === -1 ? command : normalized.slice(i + 1)).toLowerCase();
+}
+
+/**
+ * True when `command` is a known desktop opener basename or path to one.
+ * `open` here is the macOS Launch Services tool, not an agents subcommand —
+ * those go through `node dist/index.js open …` and never match.
+ */
+export function isDesktopOpenerCommand(command: string): boolean {
+  const base = basenameOf(command);
+  return (DESKTOP_OPENER_BASENAMES as readonly string[]).includes(base);
+}
+
+function openerAllowed(): boolean {
+  return process.env[ALLOW_ENV] === '1';
+}
+
+function writeStub(stubDir: string, name: string): void {
+  if (process.platform === 'win32') {
+    fs.writeFileSync(
+      path.join(stubDir, `${name}.cmd`),
+      [
+        '@echo off',
+        'if defined AGENTS_TEST_OPENER_TRIPWIRE_DIR (',
+        '  echo %~n0 %*>>"%AGENTS_TEST_OPENER_TRIPWIRE_DIR%\\invoked"',
+        ')',
+        'echo hermeticity leak (PHNX-3072): test spawned desktop opener %~n0 %* 1>&2',
+        'exit /b 1',
+        '',
+      ].join('\r\n'),
+    );
+    return;
+  }
+  fs.writeFileSync(
+    path.join(stubDir, name),
+    [
+      '#!/bin/sh',
+      'if [ -n "$AGENTS_TEST_OPENER_TRIPWIRE_DIR" ]; then',
+      '  mkdir -p "$AGENTS_TEST_OPENER_TRIPWIRE_DIR"',
+      '  printf "%s\\n" "$(basename "$0") $*" >> "$AGENTS_TEST_OPENER_TRIPWIRE_DIR/invoked"',
+      'fi',
+      'echo "hermeticity leak (PHNX-3072): test spawned desktop opener $(basename "$0") $*" >&2',
+      'exit 1',
+      '',
+    ].join('\n'),
+    { mode: 0o755 },
+  );
+}
+
+export interface InstallOpenerSandboxOpts {
+  /** Fork-private temp dir from tests/setup.ts. Stubs + tripwire live under it. */
+  tmp: string;
+}
+
+/**
+ * Install the opener sandbox into this process: stub dir on PATH, env pins.
+ * Idempotent enough to call once per fork from setup.ts.
+ */
+export function installOpenerSandbox(opts: InstallOpenerSandboxOpts): { stubDir: string; tripwireDir: string } {
+  const stubDir = path.join(opts.tmp, 'opener-stubs');
+  const tripwireDir = path.join(opts.tmp, 'opener-tripwire');
+  fs.mkdirSync(stubDir, { recursive: true });
+  fs.mkdirSync(tripwireDir, { recursive: true });
+  for (const name of DESKTOP_OPENER_BASENAMES) writeStub(stubDir, name);
+
+  process.env[STUB_DIR_ENV] = stubDir;
+  process.env[TRIPWIRE_DIR_ENV] = tripwireDir;
+  process.env.PATH = `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`;
+
+  return { stubDir, tripwireDir };
+}
+
+export function openerSandboxTripped(): string | null {
+  const dir = process.env[TRIPWIRE_DIR_ENV];
+  if (!dir) return null;
+  const file = path.join(dir, TRIPWIRE_FILE);
+  if (!fs.existsSync(file)) return null;
+  const body = fs.readFileSync(file, 'utf-8').trim();
+  return body.length > 0 ? body : null;
+}
+
+/**
+ * Fail the test file if any desktop opener was spawned without
+ * `AGENTS_TEST_ALLOW_OPENER=1`. Wired from tests/setup.ts afterAll — same
+ * shape as the HOME leak tripwires, but local (not CI-only): the original
+ * bug was invisible on Linux CI and only hurt developers running the suite.
+ */
+export function assertNoUnauthorizedOpenerSpawn(): void {
+  if (openerAllowed()) return;
+  const log = openerSandboxTripped();
+  if (!log) return;
+  throw new Error(
+    `hermeticity leak (PHNX-3072): a test spawned a desktop opener ` +
+      `(open / xdg-open / gnome-open) and would have launched the ` +
+      `developer's browser. Inject spawnOpen (see src/lib/open-url.ts) or set ` +
+      `${ALLOW_ENV}=1 if the spawn is intentional. Invocations:\n${log}`,
+  );
+}

--- a/cli/tests/setup.ts
+++ b/cli/tests/setup.ts
@@ -17,6 +17,7 @@ import * as path from 'node:path';
 import { afterAll } from 'vitest';
 import { seedHermeticE2eWinHost } from './seed-e2e-win-host.js';
 import { shouldArmHermeticGuards } from './hermetic-guards.js';
+import { assertNoUnauthorizedOpenerSpawn, installOpenerSandbox } from './opener-sandbox.js';
 
 // The REAL developer home, captured before anything below overrides it — the
 // baseline every leak tripwire in this file compares against.
@@ -56,6 +57,19 @@ process.env.USERPROFILE = sandboxHome;
 // child processes launched through login shells/service managers may restore
 // HOME to the account home, but they still inherit AGENTS_REAL_HOME.
 process.env.AGENTS_REAL_HOME = sandboxHome;
+
+// PHNX-3072: sandbox desktop openers the same way HOME is sandboxed — at the
+// fork boundary, before any test file's imports run. PATH was previously left
+// alone, so a test that reached a real spawn('open' | 'xdg-open') resolved the
+// developer's binary. That shipped: open-url.test.ts drove the non-injected
+// viewer path, every Mac `bun run test` opened example.com, and Linux CI
+// stayed green because xdg-open was absent. The specific test was fixed in
+// #2937; this closes the class. Stub binaries prepended to PATH catch a
+// PATH-resolved spawn (and any child that inherits env: {...process.env}).
+// The afterAll tripwire fails the file unless AGENTS_TEST_ALLOW_OPENER=1.
+// This is a prefix, not a cage: git/node/the CLI still resolve from the rest
+// of PATH. See tests/opener-sandbox.ts.
+installOpenerSandbox({ tmp });
 
 // Broker: pin the socket dir to a fork-private temp path so nothing in this
 // fork — nor any CLI subprocess it spawns with inherited env — can reach the
@@ -196,6 +210,12 @@ const claudeSettingsBefore = fs.existsSync(realClaudeSettings)
 
 afterAll(() => {
   try {
+    // PHNX-3072: local, not CI-only. The original opener leak was invisible
+    // on Linux CI (xdg-open absent) and only hurt developers running the
+    // suite. A quiet runner is irrelevant — the tripwire is "did this fork
+    // spawn a desktop opener", which a live daemon cannot false-positive.
+    assertNoUnauthorizedOpenerSpawn();
+
     // RUSH-3007: these tripwires assume "CI" means a quiet, single-tenant
     // runner with no concurrent writer to the real ~/.agents. That's false
     // for release-attestation-produce.sh, which used to need CI=true just to


### PR DESCRIPTION
Closes [PHNX-3072](https://linear.app/getrush/issue/PHNX-3072/test-harness-testssetupts-sandboxes-home-but-not-path-so-a-test-can).

## Problem

`cli/tests/setup.ts` sandboxes `HOME` but not `PATH`. A unit test that reaches a real `spawn('open' | 'xdg-open')` therefore runs against the developer's machine.

This shipped: `src/lib/open-url.test.ts` drove the non-injected viewer path, so `bun run test` on a Mac opened example.com in the developer's browser. On the Linux CI image `xdg-open` is absent, so it `ENOENT`ed in ~4ms and CI stayed green. The specific test was fixed in #2937; the class was still open.

## Fix

Class-level, not a call-site stub. At the fork boundary, `tests/setup.ts` prepends stub `open` / `xdg-open` / `gnome-open` binaries to `PATH` (a prefix, not a cage — git/node/the CLI still resolve from the rest of PATH). Child processes that inherit `env: {...process.env}` get the stubs for free, the same way they inherit the sandboxed HOME.

The stubs exit 1 and write a tripwire. `afterAll` fails the file unless `AGENTS_TEST_ALLOW_OPENER=1` (declared only by the probe tests). A spawn is structurally unable to reach `/usr/bin/open` on macOS or `xdg-open` on Linux, and an accidental spawn fails loud on both — rather than passing on CI and opening a browser locally.

## Tests

`cli/tests/opener-sandbox.test.ts` sits next to the source and reproduces the historical spawn (`spawn(platformOpener, ['https://example.com'])`). It fails on the pre-fix setup (PATH still resolves the real opener) and passes once the stub dir is first.

Quoted run:

```
✓ tests/opener-sandbox.test.ts (10 tests) 107ms
✓ tests/home-sandbox.test.ts (4 tests) 36ms
✓ tests/sandbox.test.ts (24 tests) 21ms
✓ src/lib/open-url.test.ts (15 tests) 2650ms

Test Files  4 passed (4)
     Tests  53 passed (53)
```

## Changelog

`.changelog/next/PHNX-3072.md`