### PR TITLE
fix(sessions): stamp custom-harness name on profile launches (PHNX-2935)

### DIFF
--- a/cli/.changelog/next/PHNX-2935.md
+++ b/cli/.changelog/next/PHNX-2935.md
@@ -1,0 +1,1 @@
+- **Custom-harness runs launched via a profile now show their real harness name in agents sessions instead of 'claude' (PHNX-2935).**

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.22.52
 
+- **Custom harness runs (`agents run deepseek`) stamp the profile name on sessions, not the host CLI (PHNX-2935).** A profile launched via `agents run <name>`, a teammate, or a routine/monitor was recorded everywhere as its host agent (`claude`): `AGENTS_AGENT_NAME`, the pid registry, and the session index had no harness column, so `agents sessions` / `--active` / the preview header could not tell a deepseek run from a native claude run. The host agent stays the execution identity (binary, transcript path, parsers); the profile name now rides `AGENTS_AGENT_NAME`, `PidSessionEntry.harness`, a durable `sessions.harness` column joined from the launch sidecar, and the listing/preview/`--active` display. `--device` dispatch, teams, and routines already re-enter `agents run <name>`, so they pick the stamp up on the executing side. Source: `cli/src/lib/exec.ts`, `cli/src/lib/session/{pid-registry,actor-sidecar,db,active,types}.ts`, `cli/src/commands/{exec,sessions,sessions-picker}.ts`.
+
 - **`agents artifacts share --visibility me|org` — identity-gated share pages (PHNX-3260).**
   Extends the P1 `public|unlisted` tiers (RUSH-3135) with two Phoenix-gated GET
   visibilities. `me` is visible only to the signed-in owner (the viewer's Phoenix

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 1.22.52
 
-- **Custom harness runs (`agents run deepseek`) stamp the profile name on sessions, not the host CLI (PHNX-2935).** A profile launched via `agents run <name>`, a teammate, or a routine/monitor was recorded everywhere as its host agent (`claude`): `AGENTS_AGENT_NAME`, the pid registry, and the session index had no harness column, so `agents sessions` / `--active` / the preview header could not tell a deepseek run from a native claude run. The host agent stays the execution identity (binary, transcript path, parsers); the profile name now rides `AGENTS_AGENT_NAME`, `PidSessionEntry.harness`, a durable `sessions.harness` column joined from the launch sidecar, and the listing/preview/`--active` display. `--device` dispatch, teams, and routines already re-enter `agents run <name>`, so they pick the stamp up on the executing side. Source: `cli/src/lib/exec.ts`, `cli/src/lib/session/{pid-registry,actor-sidecar,db,active,types}.ts`, `cli/src/commands/{exec,sessions,sessions-picker}.ts`.
-
 - **`agents artifacts share --visibility me|org` — identity-gated share pages (PHNX-3260).**
   Extends the P1 `public|unlisted` tiers (RUSH-3135) with two Phoenix-gated GET
   visibilities. `me` is visible only to the signed-in owner (the viewer's Phoenix

--- a/cli/src/commands/exec.ts
+++ b/cli/src/commands/exec.ts
@@ -2153,6 +2153,7 @@ agents run auto --device yosemite-s0 "fix the flaky test"   # pin the device
       let accountConfigVersion: string | undefined;
       let profileProvider: string | undefined;
       let fromProfile = false;
+      let profileName: string | undefined;
       let profileFallbackModel: { envKey: string; model: string } | undefined;
       let workflowModel: string | undefined;
       // WORKFLOW.md capability scoping, translated to Claude headless flags below.
@@ -2241,6 +2242,7 @@ agents run auto --device yosemite-s0 "fix the flaky test"   # pin the device
           profileProvider = readProfile(rawAgent).provider;
           profileFallbackModel = resolved.fallbackModel;
           fromProfile = true;
+          profileName = resolved.profileName;
           process.stderr.write(chalk.gray(`Resolved custom harness '${resolved.profileName}' -> ${agent}${version ? `@${version}` : ''}\n`));
           if (resolved.tierNote) {
             process.stderr.write(chalk.gray(`[agents] ${resolved.tierNote}\n`));
@@ -3121,6 +3123,7 @@ agents run auto --device yosemite-s0 "fix the flaky test"   # pin the device
 
       const execOptions: ExecOptions = {
         agent,
+        harnessName: profileName,
         version,
         configVersion: accountConfigVersion,
         prompt,

--- a/cli/src/commands/sessions-picker.test.ts
+++ b/cli/src/commands/sessions-picker.test.ts
@@ -187,6 +187,14 @@ describe('buildPreview — ticket + PR links line', () => {
     _resetLinearWorkspaceCache();
   });
 
+  it('shows the custom-harness name in the preview header, not the host (PHNX-2935)', () => {
+    const preview = stripVTControlCharacters(
+      buildPreview(mk({ agent: 'claude', harness: 'deepseek' })),
+    );
+    expect(preview).toContain('Deepseek');
+    expect(preview).not.toMatch(/\bClaude\b/);
+  });
+
   it('shows the ticket id and PR number in the preview', () => {
     const preview = stripVTControlCharacters(
       buildPreview(mk({ ticketId: 'RUSH-1864', prUrl: 'https://github.com/o/r/pull/42', prNumber: 42 })),

--- a/cli/src/commands/sessions-picker.ts
+++ b/cli/src/commands/sessions-picker.ts
@@ -10,6 +10,7 @@ import path from 'node:path';
 import chalk from 'chalk';
 import { truncate, humanDuration } from '../lib/format.js';
 import type { SessionEvent, SessionMeta, TodoItem, TodoProgress } from '../lib/session/types.js';
+import { sessionDisplayAgent } from '../lib/session/types.js';
 import { fetchPeerPreviewDigest } from '../lib/session/remote-list.js';
 import { parseSession, sanitizeForTerminal, SNAPSHOT_TODO_TOOLS } from '../lib/session/parse.js';
 import { safeTeamText } from '../lib/session/team-filter.js';
@@ -470,7 +471,7 @@ function formatHeader(session: SessionMeta, events: SessionEvent[]): string {
 
   // Line 1: Agent v version · shortId · model · account
   const line1: string[] = [];
-  line1.push(chalk.gray(`${displayAgent(session.agent)}${session.version ? ` v${session.version}` : ''}`));
+  line1.push(chalk.gray(`${displayAgent(sessionDisplayAgent(session))}${session.version ? ` v${session.version}` : ''}`));
   if (session.shortId) line1.push(chalk.dim(session.shortId));
   if (model) line1.push(chalk.bold.white(shortenModel(model)));
   if (session.account) line1.push(chalk.gray(session.account));

--- a/cli/src/commands/sessions.active-row.test.ts
+++ b/cli/src/commands/sessions.active-row.test.ts
@@ -77,6 +77,16 @@ describe('renderActiveRowLines', () => {
 
   // RUSH-2336: every process-backed row now surfaces its exact machine + pid
   // handle; a cloud row surfaces its provider + task id instead of a pid.
+  it('shows the custom-harness name instead of the host process (PHNX-2935)', () => {
+    const [line1] = renderActiveRowLines(
+      active({ kind: 'claude', harness: 'deepseek', cwd: undefined, topic: undefined, label: undefined }),
+      '  ',
+      120,
+    );
+    expect(line1).toContain('deepseek');
+    expect(line1).not.toMatch(/\bclaude\b/);
+  });
+
   it('shows a machine:pid locator for a process row', () => {
     const s = active({ context: 'terminal', machine: 'yosemite-s0', pid: 48213, cwd: undefined, topic: undefined, label: undefined });
     const lines = renderActiveRowLines(s, '  ', 120);

--- a/cli/src/commands/sessions.ts
+++ b/cli/src/commands/sessions.ts
@@ -20,7 +20,7 @@ import { listProjectDefs, resolveProjectNameForCwd, type ProjectDef } from '../l
 import ora from 'ora';
 import type { AgentId } from '../lib/types.js';
 import type { SessionAgentId, SessionMeta, ViewMode } from '../lib/session/types.js';
-import { SESSION_AGENTS, isAgentTmuxAlias } from '../lib/session/types.js';
+import { SESSION_AGENTS, isAgentTmuxAlias, sessionDisplayAgent } from '../lib/session/types.js';
 import { discoverArtifacts, readArtifact, resolveArtifact } from '../lib/session/artifacts.js';
 import { looksLikePath, toComparablePath, homeDir, needsWindowsShell, composeWin32CommandLine } from '../lib/platform/index.js';
 import { getActiveSessions, describeActiveDiscoveryHealth, sessionProcessIsLocal, backfillActiveRowsFromIndex, backfillActiveRowsFromMeta, isRunningLiveSession, serializeActiveSessionsForJson, serializeSessionsJson, shortIdFromName, type ActiveSession, type BackfillMeta } from '../lib/session/active.js';
@@ -407,10 +407,11 @@ async function renderArtifactsForSession(
     return;
   }
 
-  const agentColor = colorAgent(session.agent);
+  const shown = sessionDisplayAgent(session);
+  const agentColor = colorAgent(shown);
   console.log('');
   console.log(
-    agentColor(session.agent) +
+    agentColor(shown) +
     chalk.gray(` · ${session.shortId} · ${formatRelativeTime(session.timestamp)}`)
   );
   console.log(chalk.gray('─'.repeat(72)));
@@ -933,7 +934,8 @@ function fitCell(content: string, room: number): string {
  */
 export function renderActiveRowLines(s: ActiveSession, indent: string, termW: number): string[] {
   const idCol = chalk.dim(padToWidth((s.sessionId?.slice(0, 8)) ?? '-', ROW_ID_W));
-  const kindCol = colorAgent(s.kind as any)(padToWidth(truncateToWidth(s.kind, ROW_AGENT_W), ROW_AGENT_W + 1));
+  const shownKind = sessionDisplayAgent({ agent: s.kind, harness: s.harness });
+  const kindCol = colorAgent(shownKind)(padToWidth(truncateToWidth(shownKind, ROW_AGENT_W), ROW_AGENT_W + 1));
   const versionCol = chalk.gray(padToWidth(truncateToWidth(s.version ?? '', ROW_VERSION_W), ROW_VERSION_W + 1));
   const statusCol = statusColor(s.status)(padToWidth(truncateToWidth(activityLabel(s), ROW_STATUS_W - 1), ROW_STATUS_W));
   const ownerCol = chalk.cyan(padToWidth(truncateToWidth(ownerLabel(s), ROW_OWNER_W - 1), ROW_OWNER_W));
@@ -1237,6 +1239,7 @@ export function serializeResolvedSessionsJson(sessions: SessionMeta[]): string {
     id: session.id,
     shortId: session.shortId,
     agent: session.agent,
+    harness: session.harness,
     origin: session.origin,
     timestamp: session.timestamp,
     lastActivity: session.lastActivity,
@@ -2136,7 +2139,8 @@ function runOutcomeDetail(meta: RunMeta): string {
 /** Compact per-session metadata line under a linked session row. */
 function linkedSessionMeta(session: SessionMeta): string {
   const parts: string[] = [];
-  parts.push(session.version ? `${session.agent} v${session.version}` : session.agent);
+  const shown = sessionDisplayAgent(session);
+  parts.push(session.version ? `${shown} v${session.version}` : shown);
   if (session.account) parts.push(session.account);
   if (session.model) parts.push(shortenModel(session.model));
   if (typeof session.outputTokens === 'number') parts.push(`${formatTokenCount(session.outputTokens)} out`);
@@ -3410,7 +3414,8 @@ export function flatSessionRow(
   cols: PickerColumns = {},
   bookmarked = false,
 ): string {
-  const agentColor = colorAgent(session.agent);
+  const shown = sessionDisplayAgent(session);
+  const agentColor = colorAgent(shown);
   const age = sessionAgeParts(session.timestamp, session.lastActivity);
   const project = session.project || '-';
   const tag = originTag(session) || teamTag(session);
@@ -3463,7 +3468,7 @@ export function flatSessionRow(
   return (
     bookmarkCell +
     chalk.white(padToWidth(truncateToWidth(session.shortId, 9), 10)) +
-    agentColor(padToWidth(truncateToWidth(session.agent, 8), 9)) +
+    agentColor(padToWidth(truncateToWidth(shown, 8), 9)) +
     chalk.yellow(padToWidth(truncateToWidth(session.version || '-', 7), 8)) +
     (modelW ? chalk.yellow(padToWidth(truncateToWidth(modelLabel(session.model), modelW - 1), modelW)) : '') +
     machineCell +
@@ -3480,7 +3485,8 @@ export function flatSessionRow(
 
 /** One tree-mode row (grouped under a dir header): id · agent · badges · topic · time. No version/project column. */
 function treeSessionRow(session: SessionMeta, live?: ActiveSession): string {
-  const agentColor = colorAgent(session.agent);
+  const shown = sessionDisplayAgent(session);
+  const agentColor = colorAgent(shown);
   const age = sessionAgeParts(session.timestamp, session.lastActivity);
   const tag = originTag(session) || teamTag(session);
   const label = (session as any).label;
@@ -3504,7 +3510,7 @@ function treeSessionRow(session: SessionMeta, live?: ActiveSession): string {
   return (
     '  ' +
     chalk.dim(padToWidth(session.shortId, 9)) +
-    agentColor(padToWidth(truncateToWidth(session.agent, 7), 8)) +
+    agentColor(padToWidth(truncateToWidth(shown, 7), 8)) +
     (badges ? badges + ' ' : '') +
     (glyph ? glyph + ' ' : '') +
     statusCell +
@@ -3686,7 +3692,8 @@ const TEAM_HANDLE_W = 16;
  * identity the `--teams` view exists to show (RUSH-1997).
  */
 function teamMemberRow(session: SessionMeta, live?: ActiveSession): string {
-  const agentColor = colorAgent(session.agent);
+  const shown = sessionDisplayAgent(session);
+  const agentColor = colorAgent(shown);
   const origin = session.teamOrigin;
   const age = sessionAgeParts(session.timestamp, session.lastActivity);
   const handle = safeTeamText(origin?.handle) ?? session.shortId;
@@ -3709,7 +3716,7 @@ function teamMemberRow(session: SessionMeta, live?: ActiveSession): string {
   return (
     '  ' +
     chalk.dim(padToWidth(session.shortId, 9)) +
-    agentColor(padToWidth(truncateToWidth(session.agent, 7), 8)) +
+    agentColor(padToWidth(truncateToWidth(shown, 7), 8)) +
     chalk.yellow(padToWidth(truncateToWidth(mode || '-', TEAM_MODE_W), TEAM_MODE_W + 1)) +
     (badges ? badges + ' ' : '') +
     (glyph ? glyph + ' ' : '') +
@@ -3896,13 +3903,14 @@ function renderArchivedSession(
     }, null, 2));
     return;
   }
-  const agentColor = colorAgent(session.agent);
+  const shown = sessionDisplayAgent(session);
+  const agentColor = colorAgent(shown);
   const absTime = formatAbsoluteTime(session.timestamp);
   const title = (session as any).label || session.topic;
   console.log('');
   if (title) console.log(chalk.bold.white(title));
   console.log(
-    agentColor(session.agent) +
+    agentColor(shown) +
     (session.version ? chalk.yellow(` ${session.version}`) : '') +
     (session.project ? chalk.cyan(`  ${session.project}`) : '') +
     chalk.gray(`  ${absTime} (${formatRelativeTime(session.timestamp)})`) +
@@ -3939,20 +3947,21 @@ async function renderSession(
     }
     console.log(chalk.yellow('Session transcript not available (file no longer exists).'));
     console.log(chalk.gray(`Path: ${session.filePath}`));
-    if (session.version) console.log(chalk.gray(`Version: ${session.agent} ${session.version}`));
+    if (session.version) console.log(chalk.gray(`Version: ${sessionDisplayAgent(session)} ${session.version}`));
     if (session.project) console.log(chalk.gray(`Project: ${session.project}`));
     if (session.account) console.log(chalk.gray(`Account: ${session.account}`));
     console.log(chalk.gray(`Time: ${session.timestamp}`));
     return;
   }
 
-  const spinner = ora(`Parsing ${session.agent} session...`).start();
+  const spinner = ora(`Parsing ${sessionDisplayAgent(session)} session...`).start();
   const parsedEvents = parseSession(session.filePath, session.agent);
   spinner.stop();
 
   let events = filterEvents(parsedEvents, filters);
 
-  const agentColor = colorAgent(session.agent);
+  const shown = sessionDisplayAgent(session);
+  const agentColor = colorAgent(shown);
   console.log('');
 
   if (mode === 'summary') {
@@ -3969,7 +3978,7 @@ async function renderSession(
       console.log(chalk.bold.white(title) + (badges ? '  ' + badges : ''));
     }
     console.log(
-      agentColor(session.agent) +
+      agentColor(shown) +
       (session.version ? chalk.yellow(` ${session.version}`) : '') +
       modelStr +
       (session.project ? chalk.cyan(`  ${session.project}`) + branchStr : branchStr) +
@@ -3986,7 +3995,7 @@ async function renderSession(
 
   if (mode === 'markdown') {
     console.log(
-      agentColor(session.agent) +
+      agentColor(shown) +
       (session.version ? chalk.yellow(` ${session.version}`) : '') +
       (session.project ? chalk.cyan(` ${session.project}`) : '') +
       chalk.gray(` ${formatRelativeTime(session.timestamp)}`) +
@@ -4197,7 +4206,8 @@ export function formatPickerLabel(
   bookmarked = false,
   live?: ActiveSession,
 ): string {
-  const agentColor = colorAgent(s.agent);
+  const shown = sessionDisplayAgent(s);
+  const agentColor = colorAgent(shown);
   const age = sessionAgeParts(s.timestamp, s.lastActivity);
   const project = s.project || '-';
   // SSH-launch origin (live rows only): mirrors the flat listing's `ssh←<device>`
@@ -4269,7 +4279,7 @@ export function formatPickerLabel(
     // live row with no session id is named by its pid or cloud task, which can
     // run past the column and shunt every later column out of alignment.
     chalk.white(padRight(truncate(s.shortId, 9), 10)) +
-    agentColor(padRight(truncate(s.agent, 8), 9)) +
+    agentColor(padRight(truncate(shown, 8), 9)) +
     chalk.yellow(padRight(truncate(versionStr, 7), 8)) +
     machineCell +
     hostCell +

--- a/cli/src/lib/daemon/runner.ts
+++ b/cli/src/lib/daemon/runner.ts
@@ -1511,10 +1511,17 @@ async function executeJobPlaced(config: JobConfig, deps: LoopDeps | undefined, a
   // Workflows run via `agents run <workflow>` which delegates to claude under the hood.
   // Use 'claude' as the effective agent for report extraction and metadata when workflow is set.
   // (command jobs branched out earlier, so config.agent is set on the non-workflow path.)
+  // Custom harness/profile name (e.g. `deepseek`) stays on harnessName; the
+  // HOST CLI is effectiveAgent. The loop path spawns in-process via runLoop
+  // and never re-enters `agents run`, so it must stamp harnessName itself
+  // (PHNX-2935) — same field commands/exec.ts sets on ExecOptions.
+  const harnessName = !config.workflow && config.agent && isCustomHarnessName(config.agent)
+    ? config.agent
+    : undefined;
   const effectiveAgent: AgentId = config.workflow
     ? 'claude'
-    : isCustomHarnessName(config.agent!)
-      ? readProfile(config.agent!).host.agent
+    : harnessName
+      ? readProfile(harnessName).host.agent
       : config.agent! as AgentId;
   if (!dispatchesViaAgentsRun(config)) {
     const { findUnifiedAccount, resolveAccountSelection, resolveCredentialAccount } = await import('../account-registry.js');
@@ -1580,6 +1587,7 @@ async function executeJobPlaced(config: JobConfig, deps: LoopDeps | undefined, a
     const spawnEnv = buildRoutineSpawnEnv(baseEnv, effectiveAgent, primaryVersion, config.timezone, overlayHome);
     const execOptions: ExecOptions = {
       agent: effectiveAgent,
+      harnessName,
       // Routine-supported self-updating CLIs (Cursor/Droid) use one global
       // binary; a versioned shim would point at a nonexistent isolated install.
       version: isSelfUpdatingAgent(effectiveAgent) ? undefined : primaryVersion,

--- a/cli/src/lib/exec.test.ts
+++ b/cli/src/lib/exec.test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, resolveTmuxWrap, buildTmuxAgentCommand, writeTmuxEnvFile, formatPaneTail, detectRateLimit, detectOutOfCredits, classifyClaudeRunRefusal, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, resolveLaunchId, shouldRecapDeadPane, isPaneKnownAliveFromQueryResult, tmuxRunExitCode, UNKNOWN_OUTCOME_EXIT_CODE, type TmuxWrapContext } from './exec.js';
+import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, stampedAgentName, customHarnessName, resolveTmuxWrap, buildTmuxAgentCommand, writeTmuxEnvFile, formatPaneTail, detectRateLimit, detectOutOfCredits, classifyClaudeRunRefusal, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, resolveLaunchId, shouldRecapDeadPane, isPaneKnownAliveFromQueryResult, tmuxRunExitCode, UNKNOWN_OUTCOME_EXIT_CODE, type TmuxWrapContext } from './exec.js';
 import type { ExecOptions } from './exec.js';
 import { isTmuxInstalled } from './tmux/binary.js';
 import { mailboxDir } from './mailbox.js';
@@ -211,6 +211,32 @@ describe('buildExecEnv — AGENTS_MAILBOX_DIR wiring (mailbox loop-closer)', () 
       env: { AGENTS_MAILBOX_DIR: runBox },
     }));
     expect(env.AGENTS_MAILBOX_DIR).toBe(runBox);
+  });
+});
+
+describe('buildExecEnv — custom harness identity (PHNX-2935)', () => {
+  it('stamps AGENTS_AGENT_NAME with the profile name, not the host CLI', () => {
+    // The bug: `agents run deepseek` resolved the host to claude and then
+    // stamped AGENTS_AGENT_NAME=claude, so feed posts and sessions could not
+    // tell a deepseek run from a native claude run.
+    const env = buildExecEnv(execOpts({ agent: 'claude', harnessName: 'deepseek' }));
+    expect(env.AGENTS_AGENT_NAME).toBe('deepseek');
+  });
+
+  it('keeps AGENTS_AGENT_NAME as the host for a native run', () => {
+    expect(buildExecEnv(execOpts({ agent: 'claude' })).AGENTS_AGENT_NAME).toBe('claude');
+  });
+
+  it('stampedAgentName prefers a non-empty harness name', () => {
+    expect(stampedAgentName({ agent: 'claude', harnessName: 'deepseek' })).toBe('deepseek');
+    expect(stampedAgentName({ agent: 'claude' })).toBe('claude');
+    expect(stampedAgentName({ agent: 'claude', harnessName: '  ' })).toBe('claude');
+  });
+
+  it('customHarnessName is sparse — only set when the profile differs from the host', () => {
+    expect(customHarnessName({ agent: 'claude', harnessName: 'deepseek' })).toBe('deepseek');
+    expect(customHarnessName({ agent: 'claude' })).toBeUndefined();
+    expect(customHarnessName({ agent: 'claude', harnessName: 'claude' })).toBeUndefined();
   });
 });
 

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -217,6 +217,14 @@ export type ExecEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'auto';
 /** Options for spawning an agent process. Omitting `prompt` launches the CLI interactively. */
 export interface ExecOptions {
   agent: AgentId;
+  /**
+   * Custom harness / profile name when this run was launched via
+   * `agents run <profile>` (e.g. `deepseek`). `agent` stays the HOST CLI
+   * that actually executes. Stamped onto `AGENTS_AGENT_NAME`, the pid
+   * registry, and the session-actor sidecar so listings can tell the
+   * profile apart from a native host run (PHNX-2935).
+   */
+  harnessName?: string;
   version?: string;
   /** Version home whose native auth/config is overlaid onto this run's binary. */
   configVersion?: string;
@@ -300,6 +308,27 @@ export interface ExecOptions {
    * session. Also forced off by AGENTS_NO_TMUX=1. No effect on headless runs.
    */
   raw?: boolean;
+}
+
+/**
+ * Identity a custom-harness run stamps on env / pid-registry / sidecars.
+ * `agent` is the host CLI; `harnessName` is the profile the user launched.
+ * Empty/whitespace harness names fall back to the host so a blank stamp
+ * never hides a real agent.
+ */
+export function stampedAgentName(options: Pick<ExecOptions, 'agent' | 'harnessName'>): string {
+  const harness = options.harnessName?.trim();
+  return harness || options.agent;
+}
+
+/**
+ * Profile name when it differs from the host agent. Undefined for a native
+ * run, so pid-registry / sidecar records stay sparse.
+ */
+export function customHarnessName(options: Pick<ExecOptions, 'agent' | 'harnessName'>): string | undefined {
+  const harness = options.harnessName?.trim();
+  if (!harness || harness === options.agent) return undefined;
+  return harness;
 }
 
 /**
@@ -489,8 +518,11 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
   );
   result.AGENTS_HISTORY_DIR = getHistoryDir();
   // So activity / feed posts stamp the right harness without re-detecting.
+  // A custom-harness run (`agents run deepseek`) must stamp the PROFILE name,
+  // not the host CLI (`claude`) — otherwise sessions and feed posts cannot
+  // tell the two apart (PHNX-2935).
   if (options.agent) {
-    result.AGENTS_AGENT_NAME = options.agent;
+    result.AGENTS_AGENT_NAME = stampedAgentName(options);
   }
   if (options.cwd) {
     result.AGENTS_CWD = options.cwd;
@@ -1795,6 +1827,7 @@ async function runInTmux(options: ExecOptions, executable: string, args: string[
     writePidSessionEntry({
       pid: panePid,
       agent: options.agent,
+      harness: customHarnessName(options),
       sessionId: options.sessionId,
       cwd,
       actor: resolveActor().id,
@@ -1813,6 +1846,7 @@ async function runInTmux(options: ExecOptions, executable: string, args: string[
         sessionId: options.sessionId,
         actor: resolveActor().id,
         initiatedBy: resolveActor().kind,
+        harness: customHarnessName(options),
         startedAtMs: Date.now(),
       });
     }
@@ -2022,6 +2056,7 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
     writePidSessionEntry({
       pid: child.pid ?? 0,
       agent: options.agent,
+      harness: customHarnessName(options),
       sessionId: options.sessionId,
       cwd: options.cwd || process.cwd(),
       actor: resolveActor().id,
@@ -2036,6 +2071,7 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
         sessionId: options.sessionId,
         actor: resolveActor().id,
         initiatedBy: resolveActor().kind,
+        harness: customHarnessName(options),
         startedAtMs: Date.now(),
       });
     }

--- a/cli/src/lib/session/README.md
+++ b/cli/src/lib/session/README.md
@@ -87,7 +87,7 @@ with what, and how big it got.** The nine fields below are that contract.
 | # | Field | Meaning | In preview today | In the data model |
 |---|-------|---------|------------------|-------------------|
 | 1 | owner / account | who ran it | yes — `sessions-picker.ts:178` | `SessionMeta.account` (`types.ts:136`) |
-| 2 | harness (agent) | claude / codex / … | yes — `sessions-picker.ts:175` | `SessionMeta.agent` (`types.ts:109`) |
+| 2 | harness (agent) | claude / codex / …, or a custom profile name | yes — `sessions-picker.ts` `formatHeader` via `sessionDisplayAgent` | `SessionMeta.agent` (host) + `SessionMeta.harness` (profile, PHNX-2935) |
 | 3 | version | agents-cli version | yes — `sessions-picker.ts:175` | `SessionMeta.version` (`types.ts:135`) |
 | 4 | model | model used | yes* — `sessions-picker.ts:177` | **not persisted** — only `SessionEvent.model` (`types.ts:51`), read via `extractModel` |
 | 5 | tokens burned | total (and output) | yes — `sessions-picker.ts:201` | `SessionMeta.tokenCount` (`types.ts:128`), `outputTokens` (`types.ts:130`) |

--- a/cli/src/lib/session/__tests__/db.migrations.test.ts
+++ b/cli/src/lib/session/__tests__/db.migrations.test.ts
@@ -63,6 +63,19 @@ describe('empty-shortId repair migration (v16)', () => {
   });
 });
 
+describe('harness column migration (v41)', () => {
+  it('adds the harness column to a v40 index', () => {
+    const db = getDB();
+    db.exec(`ALTER TABLE sessions DROP COLUMN harness`);
+    db.prepare(`INSERT OR REPLACE INTO meta(key, value) VALUES ('schema_version', '40')`).run();
+    closeDB();
+
+    const reopened = getDB();
+    const cols = (reopened.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map(c => c.name);
+    expect(cols).toContain('harness');
+  });
+});
+
 describe('model column migration (v20)', () => {
   it('adds the model column to a v19 index', () => {
     const db = getDB();

--- a/cli/src/lib/session/__tests__/db.migrations.test.ts
+++ b/cli/src/lib/session/__tests__/db.migrations.test.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-db-migrations-'));
 process.env.HOME = TEST_HOME;
 
-const { getDB, closeDB, upsertSession, getSessionById } = await import('../db.js');
+const { getDB, closeDB, upsertSession, getSessionById, SCHEMA_VERSION } = await import('../db.js');
 type SessionMeta = import('../types.js').SessionMeta;
 
 function openDBInChild(): Promise<void> {
@@ -73,6 +73,34 @@ describe('harness column migration (v41)', () => {
     const reopened = getDB();
     const cols = (reopened.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map(c => c.name);
     expect(cols).toContain('harness');
+  });
+
+  it('adds the harness column when schema_version is missing (migrateSchema skipped)', () => {
+    // currentVersion === undefined stamps SCHEMA_VERSION and never calls
+    // migrateSchema. The v41 ALTER lives only inside migrateSchema, so a
+    // sessions table that already exists without `harness` would stay that
+    // way — and the next upsertSession INSERT naming the column would throw
+    // — unless the unconditional post-migration repair adds it (PHNX-2935).
+    const db = getDB();
+    db.exec(`ALTER TABLE sessions DROP COLUMN harness`);
+    db.prepare(`DELETE FROM meta WHERE key = 'schema_version'`).run();
+    closeDB();
+
+    const reopened = getDB();
+    const cols = (reopened.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map(c => c.name);
+    expect(cols).toContain('harness');
+    const stamped = reopened.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
+    expect(Number(stamped.value)).toBe(SCHEMA_VERSION);
+
+    expect(() => upsertSession({
+      id: 'harness-repair-undefined',
+      shortId: 'hrepair',
+      agent: 'claude',
+      harness: 'deepseek',
+      timestamp: '2026-08-27T00:00:00.000Z',
+      filePath: '/tmp/harness-repair/session.jsonl',
+    } as SessionMeta, 'custom harness stamp')).not.toThrow();
+    expect(getSessionById('harness-repair-undefined')?.harness).toBe('deepseek');
   });
 });
 

--- a/cli/src/lib/session/active.ts
+++ b/cli/src/lib/session/active.ts
@@ -174,7 +174,7 @@ type ActiveContext = 'terminal' | 'teams' | 'cloud' | 'headless';
 
 /** The SessionMeta fields the live-row backfill reads — the enrichment a running process cannot report. */
 export type BackfillMeta = Pick<SessionMeta,
-  'version' | 'timestamp' | 'label' | 'ticketId' | 'prUrl' | 'prNumber' | 'origin' | 'routineName'
+  'version' | 'timestamp' | 'label' | 'ticketId' | 'prUrl' | 'prNumber' | 'origin' | 'routineName' | 'harness'
 >;
 
 export function backfillActiveRowsFromMeta(
@@ -195,6 +195,7 @@ export function backfillActiveRowsFromMeta(
     }
     if (!s.origin && m.origin) s.origin = m.origin;
     if (!s.routineName && m.routineName) s.routineName = m.routineName;
+    if (!s.harness && m.harness) s.harness = m.harness;
   }
 }
 
@@ -299,6 +300,13 @@ export type RecapSource = 'label' | 'last' | 'prompt';
 export interface ActiveSession {
   context: ActiveContext;
   kind: string;
+  /**
+   * Custom harness / profile name when this live process was launched via
+   * `agents run <profile>` (e.g. `deepseek`). `kind` stays the HOST process
+   * (claude) so transcript lookup and live-signal parsers keep working.
+   * `sessions --active` displays this when set (PHNX-2935).
+   */
+  harness?: string;
   /** Specific host app — 'code', 'cursor', 'codium', 'iterm', 'terminal', 'warp', 'tmux', etc. */
   host?: string;
   pid?: number;
@@ -1398,6 +1406,7 @@ export async function listTeamsActive(opts: { localOnly?: boolean } = {}): Promi
     return applyState({
       context: 'teams',
       kind: a.agentType,
+      harness: a.profileName ?? undefined,
       pid: a.pid ?? undefined,
       sessionId: resolvedId,
       machine: offloaded ? execHost : undefined,
@@ -1461,6 +1470,7 @@ export async function listTerminalsActive(): Promise<ActiveSession[]> {
     return applyState({
       context: 'terminal',
       kind: t.kind,
+      harness: pidEntry?.harness,
       host: detectHost(t.pid, procByPid),
       tty: procByPid.get(t.pid)?.tty,
       pid: t.pid,
@@ -1958,6 +1968,7 @@ async function listUnattributedActiveLive(attributed: Set<number>): Promise<Acti
     out.push(applyState({
       context,
       kind,
+      harness: entry?.harness,
       host,
       tty: procByPid.get(pid)?.tty,
       pid,
@@ -1985,6 +1996,8 @@ async function listUnattributedActiveLive(attributed: Set<number>): Promise<Acti
 /** One tmux pane's resolved agent identity for the authoritative source. */
 interface PaneIdentity {
   agent: string;
+  /** Custom harness/profile name from the launch registry, when set. */
+  harness?: string;
   /** Exact session id when resolvable (launch registry, or the hook join). */
   sessionId?: string;
   /** The agent's OS pid from the launch registry (may differ from `pane_pid`). */
@@ -2038,7 +2051,7 @@ export function resolvePaneIdentity(
         terminalId: liveEntry.terminalId,
       })?.session_id
       ?? nameSessionId;
-    return { agent: liveEntry.agent, sessionId, pid: liveEntry.pid };
+    return { agent: liveEntry.agent, harness: liveEntry.harness, sessionId, pid: liveEntry.pid };
   }
   // No live-registry entry. Session-meta labels are the wrapped-origin fallback;
   // prefer them, then fall back to the name so a pane with neither a registry
@@ -2191,6 +2204,7 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
     out.push(applyState({
       context: 'terminal',
       kind: id.agent,
+      harness: id.harness,
       host: 'tmux',
       pid,
       sessionId: id.sessionId ?? sessionIdFromFile(sessionFile),

--- a/cli/src/lib/session/actor-sidecar.test.ts
+++ b/cli/src/lib/session/actor-sidecar.test.ts
@@ -106,6 +106,26 @@ describe('upsertSession joins the actor sidecar (RUSH-2019)', () => {
     return { id, shortId: id.slice(0, 8), agent: 'claude', timestamp: '2026-08-01T10:00:00.000Z', filePath };
   }
 
+  it('fills harness from the sidecar so a deepseek run is not indexed as claude (PHNX-2935)', () => {
+    writeSessionActorRecord({ sessionId: 'joined-harness', harness: 'deepseek', startedAtMs: 1 });
+    upsertSession(scanMeta('joined-harness'), '');
+    const meta = getSessionById('joined-harness');
+    expect(meta?.agent).toBe('claude');
+    expect(meta?.harness).toBe('deepseek');
+  });
+
+  it('preserves a stored harness on rescan and backfills a NULL-first row', () => {
+    upsertSession(scanMeta('harness-backfill'), '');
+    expect(getSessionById('harness-backfill')?.harness).toBeUndefined();
+    writeSessionActorRecord({ sessionId: 'harness-backfill', harness: 'deepseek', startedAtMs: 1 });
+    upsertSession(scanMeta('harness-backfill'), '');
+    expect(getSessionById('harness-backfill')?.harness).toBe('deepseek');
+
+    fs.rmSync(path.join(TEST_HOME, '.agents', '.history', 'by-session', 'harness-backfill.json'), { force: true });
+    upsertSession({ ...scanMeta('harness-backfill'), topic: 'rescanned' }, '');
+    expect(getSessionById('harness-backfill')?.harness).toBe('deepseek');
+  });
+
   it('fills actor/initiatedBy from the sidecar when the scanned meta has none', () => {
     writeSessionActorRecord({ sessionId: 'joined-1', actor: 'grace@example.com', initiatedBy: 'human', mode: 'edit', startedAtMs: 1 });
     upsertSession(scanMeta('joined-1'), '');

--- a/cli/src/lib/session/actor-sidecar.ts
+++ b/cli/src/lib/session/actor-sidecar.ts
@@ -27,6 +27,13 @@ export interface SessionActorRecord {
   initiatedBy?: 'human' | 'agent';
   /** Effective permissions mode used by the launcher. */
   mode?: SessionRunMode;
+  /**
+   * Custom harness / profile name when launched via `agents run <profile>`
+   * (e.g. `deepseek`). Joined onto the session index at scan time so a
+   * durable listing can distinguish the profile from its host agent
+   * (PHNX-2935).
+   */
+  harness?: string;
   /** Stable wrapper names that resolve to this native session id. */
   aliases?: string[];
   startedAtMs: number;
@@ -58,6 +65,7 @@ function isSafeAlias(alias: string): boolean {
 function hasRecordData(record: SessionActorRecord): boolean {
   return typeof record.actor === 'string'
     || typeof record.mode === 'string'
+    || typeof record.harness === 'string'
     || (Array.isArray(record.aliases) && record.aliases.some(alias => typeof alias === 'string'));
 }
 
@@ -101,6 +109,7 @@ export function writeSessionAliasRecord(sessionId: string, alias: string): void 
       actor: previous?.actor,
       initiatedBy: previous?.initiatedBy,
       mode: previous?.mode,
+      harness: previous?.harness,
       aliases: normalizedAliases([...(previous?.aliases ?? []), alias]),
       startedAtMs: previous?.startedAtMs ?? Date.now(),
     });

--- a/cli/src/lib/session/db.ts
+++ b/cli/src/lib/session/db.ts
@@ -38,7 +38,7 @@ const DB_PATH = getSessionsDbPath();
 /** Current schema version; bumped when migrations are added. Exported so tests
  * assert against the constant instead of hardcoding a number that every bump
  * then has to chase (docs/sessions.md calls the constant the source of truth). */
-export const SCHEMA_VERSION = 40;
+export const SCHEMA_VERSION = 41;
 
 /**
  * Bump to force `agents sessions backfill resources` to re-derive every
@@ -77,6 +77,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   id TEXT PRIMARY KEY,
   short_id TEXT NOT NULL,
   agent TEXT NOT NULL,
+  harness TEXT,
   origin TEXT DEFAULT 'cli',
   routine_name TEXT,
   routine_run_id TEXT,
@@ -432,6 +433,8 @@ interface SessionRow {
   id: string;
   short_id: string;
   agent: string;
+  /** Custom harness/profile name; NULL for a native host run (PHNX-2935). */
+  harness: string | null;
   origin: string | null;
   routine_name: string | null;
   routine_run_id: string | null;
@@ -1214,6 +1217,20 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     }
   }
 
+  if (fromVersion < 41) {
+    // v40 -> v41: persist the custom-harness / profile name a run was launched
+    // as (PHNX-2935). Transcript discovery still keys `agent` on the HOST
+    // (the file lives under the host's session dir), so without this column
+    // `agents sessions` cannot tell `agents run deepseek` from a native claude
+    // run. Additive, no ledger flush — the name is launch metadata joined from
+    // the actor sidecar, not parsed from the transcript. Pre-upgrade rows stay
+    // NULL (native / unknown) until a sidecar-backed rescan fills them.
+    const cols = new Set(
+      (db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map((c) => c.name),
+    );
+    if (!cols.has('harness')) db.exec(`ALTER TABLE sessions ADD COLUMN harness TEXT`);
+  }
+
 }
 
 /**
@@ -1790,7 +1807,7 @@ export function recordDirScans(
 
 const upsertSessionStmt = (db: Database.Database) => db.prepare(`
   INSERT INTO sessions (
-    id, short_id, agent, origin, routine_name, routine_run_id,
+    id, short_id, agent, harness, origin, routine_name, routine_run_id,
     version, account, account_key, account_org, mode, timestamp, last_activity,
     project, cwd, git_branch, topic, label, message_count, token_count,
     output_tokens, input_tokens, cache_read_tokens, cache_write_tokens,
@@ -1801,7 +1818,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     recent_directories_touched, linear_project, linear_project_url, machine,
     actor, initiated_by, used_browser, used_computer
   ) VALUES (
-    @id, @short_id, @agent, @origin, @routine_name, @routine_run_id,
+    @id, @short_id, @agent, @harness, @origin, @routine_name, @routine_run_id,
     @version, @account, @account_key, @account_org, @mode, @timestamp, @last_activity,
     @project, @cwd, @git_branch, @topic, @label, @message_count, @token_count,
     @output_tokens, @input_tokens, @cache_read_tokens, @cache_write_tokens,
@@ -1815,6 +1832,11 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
   ON CONFLICT(id) DO UPDATE SET
     short_id = excluded.short_id,
     agent = excluded.agent,
+    -- Custom harness/profile name is launch metadata, not transcript-derived.
+    -- COALESCE(existing, incoming) keeps a stored stamp on rescan (the scanner
+    -- carries none) and backfills a NULL-first row once the sidecar lands —
+    -- the same write-once pattern as actor/initiated_by (PHNX-2935).
+    harness = COALESCE(sessions.harness, excluded.harness),
     origin = excluded.origin,
     routine_name = excluded.routine_name,
     routine_run_id = excluded.routine_run_id,
@@ -2136,6 +2158,7 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     id: meta.id,
     short_id: meta.shortId,
     agent: meta.agent,
+    harness: meta.harness ?? actorRec?.harness ?? null,
     origin: meta.origin ?? 'cli',
     routine_name: meta.routineName ?? null,
     routine_run_id: meta.routineRunId ?? null,
@@ -2355,6 +2378,7 @@ export function upsertSessionsBatch(
         id: meta.id,
         short_id: meta.shortId,
         agent: meta.agent,
+        harness: meta.harness ?? actorIndex.get(meta.id)?.harness ?? null,
         origin: meta.origin ?? 'cli',
         routine_name: meta.routineName ?? null,
         routine_run_id: meta.routineRunId ?? null,
@@ -2598,6 +2622,7 @@ function rowToMeta(row: SessionRow): SessionMeta {
     id: row.id,
     shortId: row.short_id,
     agent: row.agent as SessionAgentId,
+    harness: row.harness ?? undefined,
     origin: (row.origin === 'routine' ? 'routine' : 'cli'),
     routineName: row.routine_name ?? undefined,
     routineRunId: row.routine_run_id ?? undefined,

--- a/cli/src/lib/session/db.ts
+++ b/cli/src/lib/session/db.ts
@@ -1363,6 +1363,22 @@ export function getDB(): Database.Database {
     db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_agent_ts ON sessions(agent, timestamp DESC)`);
   }
 
+  // harness column: only after the column is guaranteed present.
+  // Fresh SCHEMA (v41) includes the column; older DBs get it from migrate v41.
+  // schema_version can be stamped at SCHEMA_VERSION without the column existing
+  // — getDB writes the marker for any DB whose meta has no row (a hand-built
+  // or partially-created index), and migrateSchema never runs in that path
+  // (`currentVersion === undefined`). If a partial upgrade left schema_version
+  // ahead of the column, repair here so the next upsertSession INSERT naming
+  // `harness` does not throw (PHNX-2935). Same shape as the `machine` repair
+  // above, for the same reason.
+  {
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some((c) => c.name === 'harness')) {
+      db.exec(`ALTER TABLE sessions ADD COLUMN harness TEXT`);
+    }
+  }
+
   // One-shot cleanup of the pre-SQLite JSONL indexes. Safe — nothing reads
   // them anymore. Guarded by a meta flag so we only try once.
   const cleaned = db.prepare(`SELECT value FROM meta WHERE key = 'legacy_indexes_removed'`).get() as { value: string } | undefined;

--- a/cli/src/lib/session/live-metadata.test.ts
+++ b/cli/src/lib/session/live-metadata.test.ts
@@ -46,6 +46,7 @@ describe('activeSessionToSessionMeta', () => {
     expect(meta!.id).toBe('b947a623-1111-2222-3333-444444444444');
     expect(meta!.shortId).toBe('b947a623');
     expect(meta!.agent).toBe('claude');
+    expect(meta!.harness).toBeUndefined();
     // The transcript path rides across, so buildPreview parses the real digest
     // when the file is on disk.
     expect(meta!.filePath).toBe('/home/me/.claude/projects/p/b947a623.jsonl');
@@ -61,6 +62,20 @@ describe('activeSessionToSessionMeta', () => {
     expect(meta!.gitBranch).toBe('feat');
     expect(meta!.timestamp).toBe(new Date(now - 5_000).toISOString());
     expect(meta!.lastActivity).toBe(new Date(now - 1_000).toISOString());
+  });
+
+  it('carries the custom-harness stamp so preview of a live deepseek run is not claude (PHNX-2935)', () => {
+    const meta = activeSessionToSessionMeta(
+      active({
+        sessionId: 'b947a623-1111-2222-3333-444444444444',
+        kind: 'claude',
+        harness: 'deepseek',
+      }),
+      self,
+      now,
+    );
+    expect(meta!.agent).toBe('claude');
+    expect(meta!.harness).toBe('deepseek');
   });
 
   it('leaves filePath empty when the transcript has no path yet (renders header + live note)', () => {

--- a/cli/src/lib/session/live-metadata.ts
+++ b/cli/src/lib/session/live-metadata.ts
@@ -44,6 +44,7 @@ export function activeSessionToSessionMeta(
     id,
     shortId: deriveShortId(id),
     agent: active.kind,
+    harness: active.harness,
     timestamp: new Date(startedMs).toISOString(),
     lastActivity: new Date(lastMs).toISOString(),
     // An empty file path is honest — a just-created session may have no

--- a/cli/src/lib/session/pid-registry.test.ts
+++ b/cli/src/lib/session/pid-registry.test.ts
@@ -49,6 +49,19 @@ describe('pid session registry', () => {
     expect(got?.initiatedBy).toBe('human');
   });
 
+  it('round-trips a custom-harness stamp so --active can show deepseek not claude (PHNX-2935)', () => {
+    writePidSessionEntry({
+      pid: FAKE_PID,
+      agent: 'claude',
+      harness: 'deepseek',
+      sessionId: 'abc-123-uuid',
+      startedAtMs: 1,
+    });
+    const got = readPidSessionEntry(FAKE_PID);
+    expect(got?.agent).toBe('claude');
+    expect(got?.harness).toBe('deepseek');
+  });
+
   it('returns undefined for a pid with no entry', () => {
     expect(readPidSessionEntry(FAKE_PID + 7)).toBeUndefined();
   });

--- a/cli/src/lib/session/pid-registry.ts
+++ b/cli/src/lib/session/pid-registry.ts
@@ -24,6 +24,13 @@ import { getTerminalsDir } from '../state.js';
 export interface PidSessionEntry {
   pid: number;
   agent: string;
+  /**
+   * Custom harness / profile name when this pid was launched via
+   * `agents run <profile>` (e.g. `deepseek`). `agent` stays the HOST
+   * CLI (`claude`) so process matching and transcript discovery keep
+   * working. `sessions --active` displays this when set (PHNX-2935).
+   */
+  harness?: string;
   /** The launch session id. Present for agents launched with a known id (Claude). */
   sessionId?: string;
   cwd?: string;

--- a/cli/src/lib/session/types.ts
+++ b/cli/src/lib/session/types.ts
@@ -42,6 +42,17 @@ export function isSessionTrackedAgent(agent: string): agent is SessionAgentId {
   return (SESSION_AGENTS as string[]).includes(agent);
 }
 
+/**
+ * The name `agents sessions` shows for a run. A custom harness launched via a
+ * profile (`agents run deepseek`) keeps its host agent for transcript discovery
+ * and parsing (`claude`) and stamps the profile name on `harness`. Display
+ * prefers that stamp so a deepseek run is not listed as claude (PHNX-2935).
+ */
+export function sessionDisplayAgent(session: { agent: string; harness?: string | null }): string {
+  const harness = session.harness?.trim();
+  return harness || session.agent;
+}
+
 /** A single normalized event within a session (message, tool call, thinking, etc.). */
 export interface SessionEvent {
   type: 'message' | 'tool_use' | 'tool_result' | 'thinking' | 'error' | 'init' | 'result' | 'usage' | 'attachment' | 'hook' | 'interrupt';
@@ -175,6 +186,13 @@ export interface SessionMeta {
   id: string;
   shortId: string;
   agent: SessionAgentId;
+  /**
+   * Custom harness / profile name when this session was launched via
+   * `agents run <profile>` (e.g. `deepseek`). `agent` stays the HOST
+   * harness that produced the transcript (`claude`, …) so discovery and
+   * parsing keep working. Display surfaces this when set (PHNX-2935).
+   */
+  harness?: string;
   /** Where the indexed transcript came from. Routine rows are archived from a run directory. */
   origin?: 'cli' | 'routine';
   /** Routine name for transcripts archived from ~/.agents/.history/runs/<name>/<runId>/. */

--- a/cli/tests/runner-loop.test.ts
+++ b/cli/tests/runner-loop.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, rmSync, mkdtempSync } from 'fs';
+import { mkdirSync, rmSync, mkdtempSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import type { JobConfig } from '../src/lib/scheduling/routines.js';
@@ -123,6 +123,28 @@ describe('executeJob — loop driver (issue #400)', () => {
 
     // Loop driver must not have been invoked.
     expect(calls.length).toBe(0);
+  });
+
+  it('stamps harnessName on loop ExecOptions for a custom-harness profile (PHNX-2935)', async () => {
+    // The loop path resolves the profile to its host agent and spawns
+    // in-process via runLoop — it never re-enters `agents run <name>`, so
+    // ExecOptions.harnessName must be set here or a deepseek loop-routine
+    // is recorded as claude.
+    mkdirSync(join(hoistedState.TEST_DIR, 'profiles'), { recursive: true });
+    writeFileSync(
+      join(hoistedState.TEST_DIR, 'profiles', 'deepseek.yml'),
+      'name: deepseek\nhost:\n  agent: claude\nenv:\n  ANTHROPIC_MODEL: deepseek/deepseek-chat-v3-0324\n',
+    );
+    const calls: ExecOptions[] = [];
+    const result = await executeJob(makeConfig({
+      agent: 'deepseek',
+      loop: { maxIterations: 1, interval: '0' },
+    }), makeLoopDeps(calls));
+
+    expect(result.meta.status).toBe('completed');
+    expect(calls.length).toBe(1);
+    expect(calls[0].agent).toBe('claude');
+    expect(calls[0].harnessName).toBe('deepseek');
   });
 
   it('marks status failed when runLoop stops with error', async () => {


### PR DESCRIPTION
## Summary

Custom harness runs (`agents run deepseek`, a deepseek teammate, or a deepseek routine/monitor after RUSH-2930) were recorded as their **host** agent. `exec.ts` resolved the profile to `claude`, `buildExecEnv` set `AGENTS_AGENT_NAME=claude`, `writePidSessionEntry` stored `agent=claude`, and the session index had no harness column — so `agents sessions` / `--active` / the preview header could not distinguish a deepseek run from a native claude run.

This stamps the profile name without changing execution:

- `agent` stays the host CLI (binary, transcript path, parsers, process matching).
- `harnessName` / `harness` is the profile (`deepseek`).
- `AGENTS_AGENT_NAME` is the profile name.
- Pid registry + launch sidecar carry `harness`.
- Session index v41 adds `sessions.harness`, joined from the sidecar at scan (write-once, same COALESCE pattern as `actor`).
- Listings, `--active`, and the preview header display `harness ?? agent`.

`--device` dispatch, teams, and routines already re-enter `agents run <name>` on the executing side, so they pick the stamp up there. Teams `--active` also surfaces `profileName` from the teammate record.

Fixes PHNX-2935.

## Tests

Beside the source, no mocks. Vitest on the affected files:

- `buildExecEnv` stamps `AGENTS_AGENT_NAME=deepseek` when `harnessName` is set, `claude` for a native run.
- Pid-registry round-trips `harness`.
- Sidecar join fills `sessions.harness`; rescan preserves it and backfills a NULL-first row.
- Schema v41 adds the column.
- Preview header shows `Deepseek`, not `Claude`.
- `--active` row shows `deepseek`, not `claude`.
- Live-registry → SessionMeta carries `harness`.

```
vitest run src/lib/exec.test.ts src/lib/session/pid-registry.test.ts \
  src/lib/session/actor-sidecar.test.ts src/lib/session/live-metadata.test.ts \
  src/commands/sessions.active-row.test.ts src/commands/sessions-picker.test.ts \
  src/lib/session/__tests__/db.migrations.test.ts
```

253 passed on the affected files (1 pre-existing `FORCE_COLOR` assertion in `renderLastResponse`, unrelated).