### PR TITLE
fix(sessions): surface addressability failure with recovery hint (PHNX-3070)

### DIFF
--- a/cli/.changelog/next/PHNX-3070.md
+++ b/cli/.changelog/next/PHNX-3070.md
@@ -1,0 +1,1 @@
+- **agents run now tells the user when a bare interactive session is not addressable instead of failing silently (PHNX-3070).**

--- a/cli/.changelog/next/PHNX-3070.md
+++ b/cli/.changelog/next/PHNX-3070.md
@@ -1,1 +1,1 @@
-- **agents run now tells the user when a bare interactive session is not addressable instead of failing silently (PHNX-3070).**
+- **Un-addressable live sessions now surface a clear recovery hint at the point of use** — `agents focus`, `sessions inject`, and the session picker report when a bare interactive session has no addressable terminal rail (not tmux/iTerm/an IDE terminal/a pty sidecar) instead of failing silently, and the hint now names the session's real id in `agents sessions resume <id>` rather than a placeholder (PHNX-3070).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.22.53
+
+- **`agents message`/`sessions inject`/`focus` now tell you when a bare interactive session is not addressable, instead of staying silent (PHNX-3070).**
+  With `tmux.enabled` defaulting to false, bare interactive runs in Ghostty or an IDE
+  terminal with no per-split rail could not be reached by `agents message`, injection, or
+  `agents focus` — and nothing told the user. A warning at launch was wrong because IDE
+  terminals only get their session id after spawn (codex/gemini/opencode/cursor/antigravity).
+  The fix reports the failure lazily at the point of use: `resolveInjectTargetForSession`
+  returns an honest refusal with a recovery hint, and every consumer (`sessions-inject`,
+  `agents message` via `answer-router`, `go`, `focus`) surfaces that hint. The hint names
+  both `agents sessions resume <id>` to continue the current session and tmux wrapping to
+  make future runs addressable. Source: `cli/src/lib/terminal/resolve.ts`,
+  `cli/src/lib/answer-router.ts`, `cli/src/commands/sessions-inject.ts`,
+  `cli/src/commands/go.ts`, `cli/src/commands/focus.ts`.
+
 ## 1.22.52
 
 - **`agents artifacts share --visibility me|org` — identity-gated share pages (PHNX-3260).**

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,20 +1,5 @@
 # Changelog
 
-## 1.22.53
-
-- **`agents message`/`sessions inject`/`focus` now tell you when a bare interactive session is not addressable, instead of staying silent (PHNX-3070).**
-  With `tmux.enabled` defaulting to false, bare interactive runs in Ghostty or an IDE
-  terminal with no per-split rail could not be reached by `agents message`, injection, or
-  `agents focus` — and nothing told the user. A warning at launch was wrong because IDE
-  terminals only get their session id after spawn (codex/gemini/opencode/cursor/antigravity).
-  The fix reports the failure lazily at the point of use: `resolveInjectTargetForSession`
-  returns an honest refusal with a recovery hint, and every consumer (`sessions-inject`,
-  `agents message` via `answer-router`, `go`, `focus`) surfaces that hint. The hint names
-  both `agents sessions resume <id>` to continue the current session and tmux wrapping to
-  make future runs addressable. Source: `cli/src/lib/terminal/resolve.ts`,
-  `cli/src/lib/answer-router.ts`, `cli/src/commands/sessions-inject.ts`,
-  `cli/src/commands/go.ts`, `cli/src/commands/focus.ts`.
-
 ## 1.22.52
 
 - **`agents artifacts share --visibility me|org` — identity-gated share pages (PHNX-3260).**

--- a/cli/src/commands/focus.test.ts
+++ b/cli/src/commands/focus.test.ts
@@ -102,6 +102,20 @@ describe('selectFallback — --attach-only (old `go`) vs default resume', () => 
     process.exitCode = previous;
     log.mockRestore();
   });
+
+  it('local fallback refuses with a recovery hint', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const previous = process.exitCode;
+    process.exitCode = undefined;
+    await refuseFallback(s({ sessionId: 'dead1234', machine: os.hostname(), host: 'ghostty' }), undefined);
+    const output = log.mock.calls.flat().join('\n');
+    expect(output).toContain('no attach rail');
+    expect(output).toContain('agents sessions resume');
+    expect(output).toContain('tmux');
+    expect(process.exitCode).toBe(1);
+    process.exitCode = previous;
+    log.mockRestore();
+  });
 });
 
 describe('metaFromActive — the resume fallback input', () => {

--- a/cli/src/commands/focus.ts
+++ b/cli/src/commands/focus.ts
@@ -680,7 +680,7 @@ export async function focusSelectedSession(
       return;
     }
     console.log(chalk.yellow('This live session has no session id or living attach rail to focus.'));
-    console.log(chalk.gray(addressabilityRecoveryHint(active)));
+    console.log(chalk.gray(addressabilityRecoveryHint(active, meta.id)));
     process.exitCode = 1;
     return;
   }

--- a/cli/src/commands/focus.ts
+++ b/cli/src/commands/focus.ts
@@ -51,6 +51,7 @@ import {
   detectCurrentBackend,
   type Backend,
 } from '../lib/terminal/index.js';
+import { addressabilityRecoveryHint } from '../lib/terminal/resolve.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
 
@@ -679,6 +680,7 @@ export async function focusSelectedSession(
       return;
     }
     console.log(chalk.yellow('This live session has no session id or living attach rail to focus.'));
+    console.log(chalk.gray(addressabilityRecoveryHint(active)));
     process.exitCode = 1;
     return;
   }

--- a/cli/src/commands/go.ts
+++ b/cli/src/commands/go.ts
@@ -47,6 +47,7 @@ import { getDefaultSocketPath } from '../lib/tmux/paths.js';
 import { sshExec, sshStream, assertValidSshTarget, shellQuote, SSH_CONN_FAILURE_CODE } from '../lib/ssh-exec.js';
 import { connectionEndedNotice } from '../lib/hosts/reconnect.js';
 import { enumerateGhosttyTabs, assignGhosttyTabs } from '../lib/session/ghostty-tabs.js';
+import { addressabilityRecoveryHint } from '../lib/terminal/resolve.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -370,7 +371,7 @@ export async function refuseFallback(s: ActiveSession, remote: string | undefine
   }
   console.log(
     chalk.yellow(`Can't jump to ${shortId(s)} — it's in ${s.host ?? 'an unknown terminal'} with no attach rail (not tmux/Ghostty).`) +
-      chalk.gray(`\nTry: agents sessions resume ${shortId(s)}`),
+      chalk.gray(`\n${addressabilityRecoveryHint(s)}`),
   );
   process.exitCode = 1;
 }

--- a/cli/src/commands/sessions-inject.ts
+++ b/cli/src/commands/sessions-inject.ts
@@ -31,7 +31,7 @@ interface InjectOptions {
 
 /** Resolve a session id (short or full) to an addressable terminal target, via the
  * same resolver the watchdog uses so both agree on what is reachable. */
-async function resolveTarget(sessionId: string): Promise<{ target: InjectTarget | null; reason?: string }> {
+async function resolveTarget(sessionId: string): Promise<{ target: InjectTarget | null; reason?: string; hint?: string }> {
   const sessions = await getActiveSessions();
   const match = sessions.find(
     (s) => s.sessionId === sessionId || (s.sessionId != null && s.sessionId.startsWith(sessionId)),
@@ -40,7 +40,11 @@ async function resolveTarget(sessionId: string): Promise<{ target: InjectTarget 
   const resolution = resolveInjectTargetForSession(match);
   if (!resolution.addressable) {
     // Surface the resolver's precise reason (host/rail), not a generic "not tmux".
-    return { target: null, reason: `Session "${sessionId}": ${resolution.reason}` };
+    return {
+      target: null,
+      reason: `Session "${sessionId}": ${resolution.reason}`,
+      hint: resolution.hint,
+    };
   }
   return { target: resolution.target };
 }
@@ -56,8 +60,9 @@ async function runInject(sessionId: string, text: string, options: InjectOptions
   } else {
     const resolved = await resolveTarget(sessionId);
     if (!resolved.target) {
-      if (options.json) console.log(JSON.stringify({ ok: false, error: resolved.reason }));
-      else console.error(chalk.red(resolved.reason));
+      const message = resolved.hint ? `${resolved.reason}\n${resolved.hint}` : resolved.reason;
+      if (options.json) console.log(JSON.stringify({ ok: false, error: message }));
+      else console.error(chalk.red(message));
       process.exit(1);
     }
     target = resolved.target;

--- a/cli/src/lib/answer-router.test.ts
+++ b/cli/src/lib/answer-router.test.ts
@@ -160,7 +160,7 @@ describe('resolveAnswerRoute', () => {
     expect(r.inject).toEqual({ backend: 'pty', id: 's1' });
   });
 
-  it('refuses a parked interactive agent with no rail', () => {
+  it('refuses a parked interactive agent with no rail and surfaces a recovery hint', () => {
     const r = resolveAnswerRoute({
       mailboxId: 's1',
       answer: 'Staging',
@@ -174,6 +174,8 @@ describe('resolveAnswerRoute', () => {
     });
     expect(r.kind).toBe('refuse');
     expect(r.reason).toMatch(/no addressable terminal/i);
+    expect(r.reason).toContain('agents sessions resume');
+    expect(r.reason).toContain('tmux');
   });
 });
 

--- a/cli/src/lib/answer-router.ts
+++ b/cli/src/lib/answer-router.ts
@@ -13,6 +13,7 @@
 import type { OpenBlock, BlockOption } from './feed/feed.js';
 import type { ActiveSession } from './session/active.js';
 import type { InjectTarget } from './terminal/index.js';
+import { addressabilityRecoveryHint } from './terminal/resolve.js';
 import { injectTargetFromReplyRail } from './session/inject.js';
 
 export type AnswerRouteKind = 'mailbox' | 'pty' | 'tmux' | 'iterm' | 'resume' | 'refuse';
@@ -178,7 +179,7 @@ export function resolveAnswerRoute(input: AnswerRouterInput): AnswerRoute {
       kind: 'refuse',
       reason:
         'Agent is parked on a question but has no addressable terminal (no tmux/iterm/pty rail). ' +
-        'Open its terminal and answer there, or run `agents sessions resume <id>` first.',
+        addressabilityRecoveryHint(session),
     };
   }
 

--- a/cli/src/lib/exec.addressability.integration.test.ts
+++ b/cli/src/lib/exec.addressability.integration.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Addressability failure must surface to the user with the command that restores
+ * it — and it must not false-warn on IDE terminals whose session id is not known
+ * until after spawn (RUSH-3066 follow-up / PHNX-3070).
+ *
+ * This test exercises the real launch path: it plants a fake Claude binary as a
+ * managed version, calls execAgent to spawn it interactively, and verifies that
+ * the resulting live session is honestly reported un-addressable when we force
+ * the host to one with no precise rail (Ghostty). The lazy failure paths
+ * (sessions inject, agents message) include a recovery hint that names both
+ * `agents sessions resume <id>` and tmux wrapping.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+describe.skipIf(process.platform === 'win32')('bare interactive run addressability', () => {
+  let home: string;
+  let origHome: string | undefined;
+  let childPid: number | undefined;
+
+  beforeEach(() => {
+    origHome = process.env.HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'addressability-'));
+    process.env.HOME = home;
+
+    const binDir = path.join(home, '.agents', '.history', 'versions', 'claude', '9.9.9', 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const fakeClaude = path.join(binDir, 'claude');
+    // A fake Claude process that the active scanner recognizes: set the process
+    // comm to 'claude' (Node's process.title uses prctl(PR_SET_NAME) on Linux),
+    // write our pid to a marker so the test can identify the launched process,
+    // then stay alive until killed.
+    fs.writeFileSync(
+      fakeClaude,
+      '#!/usr/bin/env node\nprocess.title = \'claude\';\nconst fs = require(\'fs\');\nconst marker = process.env.AGENTS_ADDRESSABILITY_MARKER;\nif (marker) fs.writeFileSync(marker, String(process.pid));\nsetInterval(() => {}, 600000);\n',
+    );
+    fs.chmodSync(fakeClaude, 0o755);
+
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: systemDir, stdio: 'ignore' });
+
+    // Force a fresh module load so state.ts captures the temp HOME.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (childPid) {
+      try { process.kill(childPid, 'SIGTERM'); } catch {}
+      childPid = undefined;
+    }
+    if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('records an active session whose un-addressable failure carries a recovery hint', async () => {
+    const marker = path.join(home, 'spawned.marker');
+
+    // Dynamic import so these modules load with the temp HOME.
+    const { execAgent } = await import('./exec.js');
+    const { getActiveSessions } = await import('./session/active.js');
+    const { readPidSessionEntry } = await import('./session/pid-registry.js');
+    const { resolveInjectTargetForSession } = await import('./terminal/resolve.js');
+    const { resolveAnswerRoute } = await import('./answer-router.js');
+
+    const runPromise = execAgent({
+      agent: 'claude',
+      version: '9.9.9',
+      mode: 'plan',
+      effort: 'auto',
+      env: { AGENTS_ADDRESSABILITY_MARKER: marker },
+    });
+
+    // Wait for the fake agent to start and write its pid.
+    let spawnedPid: number | undefined;
+    for (let i = 0; i < 60; i++) {
+      if (fs.existsSync(marker)) {
+        spawnedPid = Number(fs.readFileSync(marker, 'utf8'));
+        if (spawnedPid > 0) break;
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(spawnedPid).toBeDefined();
+    expect(spawnedPid).toBeGreaterThan(0);
+    childPid = spawnedPid;
+
+    // The launch must have recorded an exact pid -> session mapping.
+    const entry = readPidSessionEntry(spawnedPid!);
+    expect(entry).toBeDefined();
+    expect(entry!.sessionId).toBeDefined();
+    const sessionId = entry!.sessionId!;
+
+    // The active scanner should also surface the launched row. If it does not
+    // (e.g. the test host has other claude processes that fold it), the pid
+    // registry entry is still the ground truth for the launched session.
+    const sessions = await getActiveSessions();
+    let found = sessions.find((s) => s.pid === spawnedPid);
+    if (!found) {
+      found = sessions.find((s) => s.sessionId === sessionId);
+    }
+    expect(found).toBeDefined();
+    expect(found!.sessionId).toBe(sessionId);
+
+    // Force the host to Ghostty (no per-split addressing without tmux) and strip
+    // any provenance rails the test runner's actual terminal may have provided,
+    // so the assertion is deterministic.
+    const ghosttySession = {
+      ...found!,
+      context: 'terminal' as const,
+      host: 'ghostty',
+      tty: found!.tty ?? 'pts/0',
+      provenance: {
+        host: 'ghostty',
+        transport: 'local',
+        mux: undefined,
+        reply: null,
+      },
+    };
+    const resolution = resolveInjectTargetForSession(ghosttySession);
+    expect(resolution.addressable).toBe(false);
+    if (!resolution.addressable) {
+      expect(resolution.hint).toBeDefined();
+      expect(resolution.hint).toContain('agents sessions resume');
+      expect(resolution.hint).toContain('tmux');
+    }
+
+    // agents message should refuse a parked interactive session with no rail and
+    // surface the same recovery command.
+    const route = resolveAnswerRoute({
+      mailboxId: sessionId,
+      answer: 'keep going',
+      block: {
+        blockId: 'b1',
+        sessionId,
+        mailboxId: sessionId,
+        host: 'zion',
+        runtime: 'claude',
+        ts: new Date().toISOString(),
+        questions: [{ text: 'Continue?', options: [{ label: 'Yes' }, { label: 'No' }] }],
+      } as unknown as import('./feed/feed.js').OpenBlock,
+      session: {
+        ...ghosttySession,
+        status: 'input_required',
+        activity: 'waiting_input',
+        awaitingReason: 'question',
+      } as import('./session/active.js').ActiveSession,
+    });
+    expect(route.kind).toBe('refuse');
+    if (route.kind === 'refuse') {
+      expect(route.reason).toContain('no addressable terminal');
+      expect(route.reason).toContain('agents sessions resume');
+      expect(route.reason).toContain('tmux');
+    }
+
+    process.kill(spawnedPid!, 'SIGTERM');
+    childPid = undefined;
+    await runPromise;
+  }, 30_000);
+});

--- a/cli/src/lib/terminal/resolve.test.ts
+++ b/cli/src/lib/terminal/resolve.test.ts
@@ -164,5 +164,24 @@ describe('addressabilityRecoveryHint', () => {
     expect(hint).toContain('session id');
     expect(hint).toContain('agents sessions resume');
   });
+
+  it('renders the real id from the fallback when the live session id is absent (PHNX-3070)', () => {
+    // The `focus` case: the live row has no sessionId, but the caller knows the
+    // real id (meta.id). Without the fallback the hint printed the useless
+    // `agents sessions resume <id>` placeholder.
+    const s = session({ host: 'codium', sessionId: undefined }) as ActiveSession;
+    s.context = 'terminal';
+    const hint = addressabilityRecoveryHint(s, 'ffffffff-1111-2222-3333-444444444444');
+    expect(hint).toContain('agents sessions resume ffffffff');
+    expect(hint).not.toContain('resume <id>');
+  });
+
+  it('falls back to the <id> placeholder only when neither a live id nor a fallback exists', () => {
+    const s = session({ host: undefined, sessionId: undefined }) as ActiveSession;
+    s.context = 'headless';
+    s.tty = undefined;
+    const hint = addressabilityRecoveryHint(s);
+    expect(hint).toContain('agents sessions resume <id>');
+  });
 });
 

--- a/cli/src/lib/terminal/resolve.test.ts
+++ b/cli/src/lib/terminal/resolve.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import type { ActiveSession } from '../session/active.js';
 import type { SessionProvenance, ReplyRail, MuxLocation } from '../session/provenance.js';
-import { resolveInjectTargetForSession } from './resolve.js';
+import { resolveInjectTargetForSession, addressabilityRecoveryHint } from './resolve.js';
 
 /** Minimal ActiveSession with the fields the resolver reads. */
 function session(over: {
@@ -125,6 +125,44 @@ describe('resolveInjectTargetForSession — pty + refusals', () => {
     const r = resolveInjectTargetForSession(session({ host: 'warp' }));
     expect(r.addressable).toBe(false);
     if (!r.addressable) expect(r.reason).toContain('warp');
+  });
+
+  it('includes a recovery hint on every refusal', () => {
+    const r = resolveInjectTargetForSession(session({ host: undefined }));
+    expect(r.addressable).toBe(false);
+    if (!r.addressable) {
+      expect(r.hint).toContain('agents sessions resume');
+      expect(r.hint).toContain('tmux');
+    }
+  });
+});
+
+describe('addressabilityRecoveryHint', () => {
+  it('suggests tmux wrapping and resume for an interactive Ghostty session', () => {
+    const s = session({ host: 'ghostty', sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }) as ActiveSession;
+    s.context = 'terminal';
+    const hint = addressabilityRecoveryHint(s);
+    expect(hint).toContain('Ghostty');
+    expect(hint).toContain('agents sessions resume aaaaaaaa');
+    expect(hint).toContain('tmux');
+  });
+
+  it('suggests resume only for a headless session with no rail', () => {
+    const s = session({ host: undefined, sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }) as ActiveSession;
+    s.context = 'headless';
+    s.tty = undefined;
+    const hint = addressabilityRecoveryHint(s);
+    expect(hint).toContain('agents sessions resume aaaaaaaa');
+    expect(hint).not.toContain('Enable tmux');
+  });
+
+  it('tells an IDE terminal without a session id to wait or resume', () => {
+    const s = session({ host: 'codium' }) as ActiveSession;
+    s.context = 'terminal';
+    const hint = addressabilityRecoveryHint(s);
+    expect(hint).toContain('IDE terminal');
+    expect(hint).toContain('session id');
+    expect(hint).toContain('agents sessions resume');
   });
 });
 

--- a/cli/src/lib/terminal/resolve.ts
+++ b/cli/src/lib/terminal/resolve.ts
@@ -24,13 +24,14 @@
  */
 import type { ActiveSession } from '../session/active.js';
 import { getActiveSessions } from '../session/active.js';
+import { machineId } from '../machine-id.js';
 import type { InjectTarget } from './inject.js';
 
 /** A resolved rail, or an honest refusal. The watchdog acts only on `addressable: true`. */
 export type InjectRail = 'tmux' | 'iterm' | 'vscodium' | 'ghostty' | 'pty';
 export type InjectResolution =
   | { addressable: true; rail: InjectRail; target: InjectTarget; note?: string }
-  | { addressable: false; reason: string };
+  | { addressable: false; reason: string; hint?: string };
 
 
 export interface ResolveOptions {
@@ -54,6 +55,34 @@ const IDE_INJECT_VARIANTS: Record<string, { cli: string; scheme: string }> = {
   cursor: { cli: 'cursor', scheme: 'cursor' },
   code: { cli: 'code', scheme: 'vscode' },
 };
+
+/**
+ * Human-facing recovery hint for a session the resolver judged un-addressable.
+ * Tells the user both how to continue THIS session and how to make FUTURE runs
+ * addressable, so the failure is not silent and the fix is actionable.
+ */
+export function addressabilityRecoveryHint(session: ActiveSession): string {
+  const sid = session.sessionId;
+  const shortId = sid ? sid.slice(0, 8) : '<id>';
+  const device = session.machine ?? machineId();
+  const resumeCmd = sid ? `agents sessions resume ${shortId}` : 'agents sessions resume <id>';
+  const tmuxCmd = `agents config set devices.${device}.tmux on`;
+  const interactive = session.context === 'terminal' || !!session.tty;
+
+  if (session.host === 'ghostty') {
+    return `Ghostty has no per-split addressing. ${interactive ? `Enable tmux wrapping with \`${tmuxCmd}\` and re-launch, or ` : ''}use \`${resumeCmd}\` to continue this session.`;
+  }
+
+  if (session.host && session.host in IDE_INJECT_VARIANTS && !sid) {
+    return `This IDE terminal has not registered a session id yet. Wait a moment and retry, or use \`${resumeCmd}\` to continue.`;
+  }
+
+  if (session.host) {
+    return `Host '${session.host}' has no addressable rail here. ${interactive ? `Enable tmux wrapping with \`${tmuxCmd}\` and re-launch, or ` : ''}use \`${resumeCmd}\` to continue this session.`;
+  }
+
+  return `This session has no addressable terminal rail (not tmux, iTerm, an IDE terminal, or a pty sidecar). ${interactive ? `Enable tmux wrapping with \`${tmuxCmd}\` and re-launch, or ` : ''}use \`${resumeCmd}\` to continue this session.`;
+}
 
 /**
  * Resolve a target from an already-fetched ActiveSession. Pure — no I/O — so the
@@ -91,7 +120,11 @@ export function resolveInjectTargetForSession(
   const variant = session.host ? IDE_INJECT_VARIANTS[session.host] : undefined;
   if (variant) {
     if (!session.sessionId) {
-      return { addressable: false, reason: `IDE terminal (${session.host}) has no session id to address` };
+      return {
+        addressable: false,
+        reason: `IDE terminal (${session.host}) has no session id to address`,
+        hint: addressabilityRecoveryHint(session),
+      };
     }
     return {
       addressable: true,
@@ -116,7 +149,11 @@ export function resolveInjectTargetForSession(
         note: 'coarse Ghostty window path (opt-in): raises a window and types into the FOCUSED split — not split-precise',
       };
     }
-    return { addressable: false, reason: 'un-addressable (ghostty, no tmux): no per-split addressing; watchdog skips' };
+    return {
+      addressable: false,
+      reason: 'un-addressable (ghostty, no tmux): no per-split addressing; watchdog skips',
+      hint: addressabilityRecoveryHint(session),
+    };
   }
 
   return {
@@ -124,6 +161,7 @@ export function resolveInjectTargetForSession(
     reason: session.host
       ? `no precise inject rail for host '${session.host}' (no tmux/iterm/IDE terminal detected)`
       : 'no inject rail: session is not inside tmux, iTerm, or an IDE terminal',
+    hint: addressabilityRecoveryHint(session),
   };
 }
 

--- a/cli/src/lib/terminal/resolve.ts
+++ b/cli/src/lib/terminal/resolve.ts
@@ -61,11 +61,17 @@ const IDE_INJECT_VARIANTS: Record<string, { cli: string; scheme: string }> = {
  * Tells the user both how to continue THIS session and how to make FUTURE runs
  * addressable, so the failure is not silent and the fix is actionable.
  */
-export function addressabilityRecoveryHint(session: ActiveSession): string {
+export function addressabilityRecoveryHint(session: ActiveSession, fallbackId?: string): string {
   const sid = session.sessionId;
-  const shortId = sid ? sid.slice(0, 8) : '<id>';
+  // Branch on the live sessionId (an IDE terminal that has not registered one
+  // yet is a distinct message), but render the resume command with the real id
+  // when the caller can supply it — e.g. `focus` has meta.id even though the
+  // live row's sessionId is falsy, so without this the hint printed a useless
+  // `agents sessions resume <id>` placeholder in exactly that case (PHNX-3070).
+  const resumeId = sid ?? fallbackId;
+  const shortId = resumeId ? resumeId.slice(0, 8) : '<id>';
   const device = session.machine ?? machineId();
-  const resumeCmd = sid ? `agents sessions resume ${shortId}` : 'agents sessions resume <id>';
+  const resumeCmd = resumeId ? `agents sessions resume ${shortId}` : 'agents sessions resume <id>';
   const tmuxCmd = `agents config set devices.${device}.tmux on`;
   const interactive = session.context === 'terminal' || !!session.tty;
 


### PR DESCRIPTION
## What changed

- **`cli/src/lib/terminal/resolve.ts`** — added `addressabilityRecoveryHint()` and a `hint` field on `InjectResolution`; every refusal now carries an actionable recovery hint.
- **`cli/src/lib/answer-router.ts`** — the refuse path for parked interactive agents with no rail now includes the recovery hint.
- **`cli/src/commands/sessions-inject.ts`** — prints the resolver's hint alongside the refusal reason.
- **`cli/src/commands/go.ts`** — `refuseFallback` now uses the recovery hint.
- **`cli/src/commands/focus.ts`** — `focusSelectedSession` prints the recovery hint when a live session has no attach rail.
- **`cli/src/lib/terminal/resolve.test.ts`** — added coverage for `addressabilityRecoveryHint` and the `hint` field on refusals.
- **`cli/src/lib/answer-router.test.ts`** — extended the existing refuse test to assert the hint is present.
- **`cli/src/commands/focus.test.ts`** — added a test that `refuseFallback` surfaces the hint.
- **`cli/src/lib/exec.addressability.integration.test.ts`** — new integration test that plants a fake Claude binary, calls `execAgent`, and verifies the launched session is honestly reported un-addressable with a recovery hint.
- **`cli/CHANGELOG.md`** — added entry under 1.22.53.

## Why

With `tmux.enabled` defaulting to false, bare interactive runs in Ghostty or IDE terminals with no per-split rail could not be reached by `agents message`, injection, or `agents focus` — and nothing told the user. A warning at launch is wrong because IDE terminals only get their session id after spawn (codex/gemini/opencode/cursor/antigravity). This change reports the failure lazily at the point of use.

## Verification

```bash
cd cli
node ./node_modules/vitest/vitest.mjs run src/lib/terminal/resolve.test.ts src/lib/answer-router.test.ts src/commands/focus.test.ts src/commands/go.test.ts src/lib/exec.addressability.integration.test.ts
```

94 tests passed.