### PR TITLE
fix(watchdog): append recovery hint on un-addressable stalls (PHNX-3070)

### DIFF
--- a/cli/.changelog/next/PHNX-3070-watchdog.md
+++ b/cli/.changelog/next/PHNX-3070-watchdog.md
@@ -1,0 +1,2 @@
+- **Watchdog un-addressable stalls now include the same recovery command as `agents focus` (PHNX-3070).**
+  Rotate, needs-human declared-block, and nudge-refuse paths append `addressabilityRecoveryHint` so an un-addressable session prints `agents sessions resume <id>` / tmux wrap instead of a reason-only skip. Source: `cli/src/lib/watchdog/runner.ts`.

--- a/cli/src/lib/watchdog/rotate.test.ts
+++ b/cli/src/lib/watchdog/rotate.test.ts
@@ -435,6 +435,8 @@ describe('runWatchdogTick — rotate state machine', () => {
     expect(o.decision).toBe('skip');
     expect(o.addressable).toBe(false);
     expect(o.reason).toMatch(/un-addressable/i);
+    expect(o.reason).toContain('agents sessions resume sess-gho');
+    expect(o.reason).not.toContain('<id>');
     expect(calls).toHaveLength(0);
     expect(readFlags()['sess-ghostty']).toBeDefined();
     expect(readFlags()['sess-ghostty'].reason).toMatch(/rotate:/i);

--- a/cli/src/lib/watchdog/runner.test.ts
+++ b/cli/src/lib/watchdog/runner.test.ts
@@ -251,6 +251,8 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     expect(o.addressable).toBe(false);
     expect(o.injected).toBeUndefined();
     expect(o.reason).toMatch(/un-addressable/i);
+    expect(o.reason).toContain('agents sessions resume sess-gho');
+    expect(o.reason).not.toContain('<id>');
     expect(result.counts.unaddressable).toBe(1);
     // Flagged for the menu-bar to surface.
     const flags = readFlags();
@@ -617,6 +619,8 @@ describe('runWatchdogTick — brain says needs-human → wires the owner feed', 
       expect(published).toHaveLength(1);
       expect(published[0].sessionId).toBe('sess-ghostty');
       expect(published[0].costOfDelay).toBe('high');
+      expect(published[0].questions[0].text).toContain('agents sessions resume sess-gho');
+      expect(published[0].questions[0].text).not.toContain('<id>');
       // Cooldown is recorded.
       expect(readLedger()['sess-ghostty']).toBe(NOW);
     });
@@ -665,6 +669,8 @@ describe('runWatchdogTick — brain says needs-human → wires the owner feed', 
       const o = result.outcomes[0];
       expect(o.decision).toBe('skip');
       expect(o.addressable).toBe(false);
+      expect(o.reason).toContain('agents sessions resume sess-gho');
+      expect(o.reason).not.toContain('<id>');
       // Flagged for the tray, but the owner is NOT paged.
       expect(readFlags()['sess-ghostty']).toBeDefined();
       expect(published).toHaveLength(0);

--- a/cli/src/lib/watchdog/runner.ts
+++ b/cli/src/lib/watchdog/runner.ts
@@ -362,7 +362,7 @@ type DeliveryPlan =
   | { via: 'inject'; rail: InjectRail; target: InjectTarget }
   | { via: 'resume' }
   | { via: 'mailbox'; mailboxId: string }
-  | { via: 'refuse'; reason: string };
+  | { via: 'refuse'; reason: string; hint?: string };
 
 /**
  * Pick the delivery mechanism. resolveAnswerRoute (answer-router.ts) chooses
@@ -396,7 +396,13 @@ function planDelivery(
   // (no open block) would never poll the mailbox, so it is flagged instead of
   // silently dropping a nudge into a spool it will never read.
   if (route.kind === 'mailbox' && isOpenQuestionBlock(block)) return { via: 'mailbox', mailboxId };
-  return { via: 'refuse', reason: route.kind === 'refuse' ? route.reason : resolution.reason };
+  return {
+    via: 'refuse',
+    // answer-router's refuse reason already bakes in the recovery hint; the
+    // resolver's reason does not, so carry hint separately for the caller.
+    reason: route.kind === 'refuse' ? route.reason : resolution.reason,
+    hint: route.kind === 'refuse' ? undefined : resolution.hint,
+  };
 }
 
 /** Default open-block reader — the same lookup `agents message` uses. */
@@ -884,7 +890,9 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
           flags[sid] = { reason: `rotate: ${resolution.reason}`, host: session.host, atMs: nowMs };
           outcomes.push({
             ...base, decision: 'skip', addressable: false,
-            reason: `rate-limited but un-addressable — ${resolution.reason}`,
+            reason: resolution.hint
+              ? `rate-limited but un-addressable — ${resolution.reason} — ${resolution.hint}`
+              : `rate-limited but un-addressable — ${resolution.reason}`,
           });
           continue;
         }
@@ -1029,7 +1037,11 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
               try {
                 const declaredBlock = buildDeclaredBlock(
                   { sessionId: session.sessionId, mailboxId, host: machineHost, runtime, cwd: session.cwd },
-                  { text: `Session genuinely needs Muqsit and is un-addressable — ${decision.reason}. Needs attention.` },
+                  {
+                    text: resolution.hint
+                      ? `Session genuinely needs Muqsit and is un-addressable — ${decision.reason}. Needs attention. ${resolution.hint}`
+                      : `Session genuinely needs Muqsit and is un-addressable — ${decision.reason}. Needs attention.`,
+                  },
                 );
                 publishBlockFn(declaredBlock);
                 ledgerUpdates[session.sessionId] = nowMs;
@@ -1063,7 +1075,9 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
       flags[session.sessionId] = { reason: plan.reason, host: session.host, atMs: nowMs };
       outcomes.push({
         ...base, decision: 'skip', addressable: false,
-        reason: `nudge-worthy but un-addressable — ${plan.reason}`,
+        reason: plan.hint
+          ? `nudge-worthy but un-addressable — ${plan.reason} — ${plan.hint}`
+          : `nudge-worthy but un-addressable — ${plan.reason}`,
         nudgeText: chosenText,
       });
       continue;


### PR DESCRIPTION
## What changed

Follow-up to #3136 (PHNX-3070). The merged PR added `addressabilityRecoveryHint` to `agents focus`, `sessions inject`, `agents message`, and `agents go`. The watchdog — the highest-stakes un-addressable surface — still dropped `resolution.hint`.

- **`cli/src/lib/watchdog/runner.ts`** — rotate skip, needs-human declared-block, and nudge-refuse now append the recovery hint (`agents sessions resume <id>` / tmux wrap). `DeliveryPlan.refuse` carries an optional `hint` when the resolver (not the answer-router) supplied the reason.
- **`cli/src/lib/watchdog/runner.test.ts`**, **`rotate.test.ts`** — un-addressable Ghostty fixtures assert the real session id is in the reason/block text, never the `<id>` placeholder.
- **`cli/.changelog/next/PHNX-3070-watchdog.md`** — fragment for the next release.

## Why

Review on #3136 called this out as a non-blocking SHOULD. Code was written in the original worktree after that PR merged and never landed. The watchdog comment already says this is the case that must never silently vanish.

## Verification

```
cd cli
npm test -- src/lib/watchdog/runner.test.ts src/lib/watchdog/rotate.test.ts scripts/gen-changelog.test.ts
```

74 tests passed (29 runner + 40 rotate + 5 gen-changelog).

## Companion audit

`sessions` / `watchdog` skills in the system repo do not teach the old un-addressable skip copy. No companion PR.

Parent: PHNX-3070 / #3136