### PR TITLE
fix(config): PHNX-3315 P3 — device-scope by default + config-drift in sync status

### DIFF
--- a/cli/.changelog/next/PHNX-3315-p3.md
+++ b/cli/.changelog/next/PHNX-3315-p3.md
@@ -1,0 +1,27 @@
+- **Device-scope is now the DEFAULT for new config keys, not a hardcoded set (PHNX-3315).**
+  Routing a `Meta` key used to hinge on a decorative `Record<keyof Meta, 'central' | 'device'>`
+  string map whose values nothing consumed — the real split was a hand-written
+  destructure, so a newly added key that nobody wired silently landed in the synced
+  top-level `agents.yaml` (`central`), the very trap behind the recurring per-box
+  churn and key-loss. Classification is now an OPT-IN `CENTRAL_META_KEYS` allowlist
+  that DRIVES routing: a key not explicitly marked fleet-shared is device-scoped by
+  default and round-trips through this box's `devices/<host>/agents.yaml` under its
+  own name, with no bespoke wiring — so a slipped-through key can never leak to the
+  shared file. A compile-time check keeps the classification exhaustive (a nudge,
+  not a safety gate — the runtime default is still the safe per-box file), and a
+  foreign key an older CLI does not model but a newer one wrote to central is left
+  in place and preserved verbatim (never relocated). Behavior-identical for every
+  existing key. Source: `cli/src/lib/state.ts`.
+- **`agents sync status` now surfaces config drift — a box that hasn't drained its device-scoped state (PHNX-3315).**
+  The one-shot fold-and-delete migrations (P1's frozen-header heal + central
+  `browser:` tombstone drain; P2's `fleet.discovery`/`fleet.ignored`, `hosts:`, and
+  device-scoped `accounts:` folds) run on config access, so a converged box shows
+  nothing — but a box that never re-synced kept carrying that state centrally, and
+  it was INVISIBLE: the report only showed per-agent "N missing", so the un-drained
+  box was found the hard way, as a mystery `agents repo pull` conflict. A distinct
+  drift line now flags (1) a stale top-level `agents.yaml` header (!= the current
+  header) and (2) any lingering central `fleet` / `hosts` / `accounts` (device-scoped)
+  / `browser` block that should have folded into the device doc. The detector is
+  read-only and never triggers the migration; the machine-readable
+  `UnifiedSyncStatus` gains a `config` field. Source: `cli/src/lib/config-drift.ts`
+  (new), `cli/src/lib/{sync-status,state}.ts`, `cli/src/commands/status.ts`.

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -125,7 +125,7 @@ export function registerStatusCommand(syncCmd: Command): void {
     // (PHNX-3315).
     if (status.config.staleHeader || status.config.centralLeaks.length > 0) {
       console.log(
-        `  ${'config (device-scoped)'.padEnd(28)} ${chalk.yellow('not drained — heals on this box\'s next config write / `agents sync`')}`,
+        `  ${'config (device-scoped)'.padEnd(28)} ${chalk.yellow('not drained — folds automatically on normal `agents` use here (idempotent)')}`,
       );
       if (status.config.staleHeader) {
         console.log(chalk.gray('    · top-level agents.yaml header is stale (pre-rename)'));

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -118,6 +118,23 @@ export function registerStatusCommand(syncCmd: Command): void {
       );
     }
 
+    // Config drift is its OWN class, not a per-agent "N missing": a box that has
+    // not folded its device-scoped state still carries a stale top-level header or
+    // a lingering central fleet/hosts/accounts/browser block. Surface it distinctly
+    // so an un-drained box is SEEN here instead of via a mystery pull conflict
+    // (PHNX-3315).
+    if (status.config.staleHeader || status.config.centralLeaks.length > 0) {
+      console.log(
+        `  ${'config (device-scoped)'.padEnd(28)} ${chalk.yellow('not drained — heals on this box\'s next config write / `agents sync`')}`,
+      );
+      if (status.config.staleHeader) {
+        console.log(chalk.gray('    · top-level agents.yaml header is stale (pre-rename)'));
+      }
+      for (const leak of status.config.centralLeaks) {
+        console.log(chalk.gray(`    · central ${leak} should be device-scoped`));
+      }
+    }
+
     // Hand off to the shared interactive/apply flow (summary already printed above).
     await promptDriftSync({ cwd, yes: opts.yes, status, quiet: true });
   });

--- a/cli/src/lib/config-drift.test.ts
+++ b/cli/src/lib/config-drift.test.ts
@@ -99,9 +99,9 @@ describe('config drift detection (PHNX-3315 P3)', () => {
     const { detectConfigDrift } = await freshDrift();
     expect(detectConfigDrift().centralLeaks).toContain('accounts (device-scoped)');
 
-    // A fleet-scoped identity is NOT a leak — it belongs in the shared file.
+    // A version-scoped identity is NOT a leak — it belongs in the shared file.
     writeCentral(
-      CANONICAL_HEADER + 'accounts:\n  native:\n    acct-2:\n      scope: fleet\n      handle: shared\n',
+      CANONICAL_HEADER + 'accounts:\n  native:\n    acct-2:\n      scope: version\n      handle: shared\n',
     );
     const { detectConfigDrift: detect2 } = await freshDrift();
     expect(detect2().centralLeaks).not.toContain('accounts (device-scoped)');

--- a/cli/src/lib/config-drift.test.ts
+++ b/cli/src/lib/config-drift.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// config-drift.ts reads the top-level user agents.yaml through state.ts, which
+// resolves HOME at import time — so point HOME at a throwaway dir and re-import
+// fresh per test. Exercises the REAL detector against real files.
+let TMP = '';
+
+async function freshDrift() {
+  vi.resetModules();
+  return import('./config-drift.js');
+}
+
+function writeCentral(text: string) {
+  fs.mkdirSync(path.join(TMP, '.agents'), { recursive: true });
+  fs.writeFileSync(path.join(TMP, '.agents', 'agents.yaml'), text);
+}
+
+// Byte-for-byte the canonical META_HEADER (state.ts) — a file carrying it is NOT
+// header-stale.
+const CANONICAL_HEADER = `# agents-cli metadata
+# Auto-generated - do not edit manually
+# https://github.com/phnx-labs/agi-cli
+# yaml-language-server: $schema=https://raw.githubusercontent.com/phnx-labs/agi-cli/main/cli/schema/agents-yaml.schema.json
+
+`;
+
+describe('config drift detection (PHNX-3315 P3)', () => {
+  beforeEach(() => {
+    TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-config-drift-'));
+    process.env.HOME = TMP;
+    process.env.AGENTS_SYNC_MACHINE_ID = 'driftbox';
+  });
+  afterEach(() => {
+    delete process.env.AGENTS_SYNC_MACHINE_ID;
+    try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('a drained box shows NO drift (canonical header, no central device-scoped blocks)', async () => {
+    writeCentral(CANONICAL_HEADER + 'run:\n  claude:\n    strategy: balanced\n');
+    const { detectConfigDrift, hasConfigDrift } = await freshDrift();
+    const d = detectConfigDrift();
+    expect(d.staleHeader).toBe(false);
+    expect(d.centralLeaks).toEqual([]);
+    expect(hasConfigDrift(d)).toBe(false);
+  });
+
+  it('flags a fresh box with no top-level file as clean (not drifted)', async () => {
+    const { detectConfigDrift } = await freshDrift();
+    const d = detectConfigDrift();
+    expect(d.staleHeader).toBe(false);
+    expect(d.centralLeaks).toEqual([]);
+  });
+
+  it('flags a STALE top-level header (the P1 frozen-header case)', async () => {
+    // A pre-rename header: repo `agents-cli`, no $schema line — what a box written
+    // before the agi-cli rename keeps until its next central write heals it.
+    writeCentral(
+      '# agents-cli metadata\n' +
+      '# Auto-generated - do not edit manually\n' +
+      '# https://github.com/phnx-labs/agents-cli\n\n' +
+      'run:\n  claude:\n    strategy: balanced\n',
+    );
+    const { detectConfigDrift, hasConfigDrift } = await freshDrift();
+    const d = detectConfigDrift();
+    expect(d.staleHeader).toBe(true);
+    expect(hasConfigDrift(d)).toBe(true);
+  });
+
+  it('flags a lingering central browser: tombstone', async () => {
+    writeCentral(CANONICAL_HEADER + 'browser:\n  work:\n    kind: cdp\n');
+    const { detectConfigDrift } = await freshDrift();
+    expect(detectConfigDrift().centralLeaks).toContain('browser');
+  });
+
+  it('flags lingering central fleet.discovery / fleet.ignored', async () => {
+    writeCentral(
+      CANONICAL_HEADER +
+      'fleet:\n  discovery:\n    mac-mini: approved\n  ignored:\n    - name: old-box\n',
+    );
+    const { detectConfigDrift } = await freshDrift();
+    const leaks = detectConfigDrift().centralLeaks;
+    expect(leaks).toContain('fleet.discovery');
+    expect(leaks).toContain('fleet.ignored');
+  });
+
+  it('flags a lingering central hosts: registry', async () => {
+    writeCentral(CANONICAL_HEADER + 'hosts:\n  prod:\n    hostname: prod.example.com\n');
+    const { detectConfigDrift } = await freshDrift();
+    expect(detectConfigDrift().centralLeaks).toContain('hosts');
+  });
+
+  it('flags central device-scoped native accounts, but leaves fleet-shared ones central', async () => {
+    writeCentral(
+      CANONICAL_HEADER + 'accounts:\n  native:\n    acct-1:\n      scope: device\n      handle: me\n',
+    );
+    const { detectConfigDrift } = await freshDrift();
+    expect(detectConfigDrift().centralLeaks).toContain('accounts (device-scoped)');
+
+    // A fleet-scoped identity is NOT a leak — it belongs in the shared file.
+    writeCentral(
+      CANONICAL_HEADER + 'accounts:\n  native:\n    acct-2:\n      scope: fleet\n      handle: shared\n',
+    );
+    const { detectConfigDrift: detect2 } = await freshDrift();
+    expect(detect2().centralLeaks).not.toContain('accounts (device-scoped)');
+  });
+});

--- a/cli/src/lib/config-drift.ts
+++ b/cli/src/lib/config-drift.ts
@@ -1,0 +1,93 @@
+/**
+ * Config drift: has THIS box drained its device-scoped state into its own
+ * `devices/<host>/agents.yaml`, or is it still carrying per-box state in the
+ * shared top-level `agents.yaml`?
+ *
+ * PHNX-3315 P1 heals a frozen top-level header and drains the central `browser:`
+ * tombstone; P2 folds `fleet.discovery` / `fleet.ignored`, the `hosts:` registry,
+ * and device-scoped native `accounts:` out of central and into the device doc.
+ * Each fold-and-delete migration is idempotent and runs on config access / daemon
+ * boot / install — so a converged box shows NO drift. A box that has NOT run the
+ * fold yet (stale checkout, never re-synced) still holds those blocks centrally,
+ * and until now that was INVISIBLE: `agents sync status` only reported per-agent
+ * "N missing", so an un-drained box was discovered the hard way — as a mystery
+ * `agents repo pull` conflict when two boxes rewrote the same shared map.
+ *
+ * This detector is READ-ONLY and must NOT trigger the migration (that would drain
+ * the very leak it is trying to surface): it reads the raw top-level user file
+ * directly, never `readMeta()` (system-merged) and never the migration hook.
+ */
+
+import { hasStaleMetaHeader, readTopLevelUserMeta } from './state.js';
+
+export interface ConfigDrift {
+  /** Top-level `agents.yaml` header != the current META_HEADER (the P1 case). */
+  staleHeader: boolean;
+  /**
+   * Labels of central blocks that should have folded into this box's device doc
+   * but still linger — the P1 `browser` tombstone and the P2 `fleet` / `hosts` /
+   * `accounts` device-scoped writers. Empty on a drained box.
+   */
+  centralLeaks: string[];
+}
+
+function isMap(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Inspect this box's on-disk state for config drift. Pure read — no migration, no
+ * writes. Mirrors the gather step of {@link migrateDeviceConfigStores} (plus the
+ * browser tombstone) so a leak here is exactly what a fold would drain.
+ */
+export function detectConfigDrift(): ConfigDrift {
+  const staleHeader = hasStaleMetaHeader();
+  const raw = readTopLevelUserMeta();
+  const centralLeaks: string[] = [];
+
+  if (raw) {
+    // P1: the leftover central `browser:` tombstone (should fold into deviceBrowser).
+    if (isMap(raw.browser) && Object.keys(raw.browser).length > 0) {
+      centralLeaks.push('browser');
+    }
+
+    // P2: fleet.discovery / fleet.ignored, and the short-lived per-device config
+    // store under fleet.devices.<name>.config — all fold into the device doc.
+    const fleet = isMap(raw.fleet) ? raw.fleet : undefined;
+    if (fleet) {
+      if (isMap(fleet.discovery) && Object.keys(fleet.discovery).length > 0) {
+        centralLeaks.push('fleet.discovery');
+      }
+      if (Array.isArray(fleet.ignored) && fleet.ignored.length > 0) {
+        centralLeaks.push('fleet.ignored');
+      }
+      if (isMap(fleet.devices)) {
+        const anyDeviceConfig = Object.values(fleet.devices).some(
+          (ov) => isMap(ov) && isMap(ov.config) && Object.keys(ov.config).length > 0,
+        );
+        if (anyDeviceConfig) centralLeaks.push('fleet.devices.*.config');
+      }
+    }
+
+    // P2: the central `hosts:` registry (should fold into deviceHosts).
+    if (isMap(raw.hosts) && Object.keys(raw.hosts).length > 0) {
+      centralLeaks.push('hosts');
+    }
+
+    // P2: central native accounts marked scope:'device' — identity PII that
+    // belongs in the device doc, off the git-tracked shared file. Fleet-shared /
+    // version-scoped identities stay central and are NOT a leak.
+    const accounts = isMap(raw.accounts) ? raw.accounts : undefined;
+    const native = accounts && isMap(accounts.native) ? accounts.native : undefined;
+    if (native && Object.values(native).some((a) => isMap(a) && a.scope === 'device')) {
+      centralLeaks.push('accounts (device-scoped)');
+    }
+  }
+
+  return { staleHeader, centralLeaks };
+}
+
+/** True when either drift class is present. */
+export function hasConfigDrift(d: ConfigDrift): boolean {
+  return d.staleHeader || d.centralLeaks.length > 0;
+}

--- a/cli/src/lib/state.test.ts
+++ b/cli/src/lib/state.test.ts
@@ -104,6 +104,48 @@ describe('pins route to the untracked pins file; the tracked doc is operator-onl
     expect(JSON.parse(fs.readFileSync(pinsPath(), 'utf-8'))).toEqual({});
   });
 
+  it('routes a newly-declared device-scoped key to the device doc by default, never central (PHNX-3315 P3)', async () => {
+    const { updateMeta, readMeta } = await freshState();
+
+    // `probeDeviceKey` is NOT in CENTRAL_META_KEYS, so device-scope is its DEFAULT
+    // — the whole point of P3: a key nobody explicitly marked fleet-shared lands
+    // per-box, never in the synced agents.yaml. Cast because it is not a modeled
+    // Meta field; the generic router keys off the scope classifier, not the type.
+    updateMeta((m) => ({
+      ...m,
+      probeDeviceKey: { hello: 'world' },
+      run: { claude: { strategy: 'balanced' } },
+    } as any));
+
+    // Landed in THIS box's device doc under its own name…
+    const doc = fs.readFileSync(devicePath(), 'utf-8');
+    expect(doc).toContain('probeDeviceKey:');
+    expect(doc).toContain('hello: world');
+
+    // …and never touched the synced central file (a genuine central key still does).
+    const central = fs.readFileSync(centralPath(), 'utf-8');
+    expect(central).not.toContain('probeDeviceKey');
+    expect(central).toContain('strategy: balanced');
+
+    // Round-trips back through the overlay.
+    expect((readMeta() as any).probeDeviceKey).toEqual({ hello: 'world' });
+  });
+
+  it('leaves a foreign central key (unknown, already on disk) in central — never relocates it (PHNX-3315 P3)', async () => {
+    // A newer CLI wrote `futureCentralKey` to the synced file as fleet-shared
+    // config. This older CLI reads it, carries it through a spread write, and must
+    // NOT relocate it to the per-box doc — that would un-sync a fleet-shared key.
+    writeCentral('futureCentralKey: keep-me-central\n');
+    const { updateMeta } = await freshState();
+
+    updateMeta((m) => ({ ...m, run: { claude: { strategy: 'balanced' } } }));
+
+    const central = fs.readFileSync(centralPath(), 'utf-8');
+    expect(central).toContain('futureCentralKey: keep-me-central'); // preserved, still synced
+    const doc = fs.existsSync(devicePath()) ? fs.readFileSync(devicePath(), 'utf-8') : '';
+    expect(doc).not.toContain('futureCentralKey'); // never pushed into the device doc
+  });
+
 });
 
 describe('reading state never writes a tracked agents.yaml (RUSH-1925)', () => {
@@ -135,10 +177,13 @@ describe('reading state never writes a tracked agents.yaml (RUSH-1925)', () => {
     writeCentral('registries:\n  mcp: {}\n  skill: {}\n');
 
     const { updateMeta } = await freshState();
-    updateMeta((m) => ({ ...m, defaultAgent: 'claude' }));
+    // Use a real central key (`source`): P3 makes device-scope the DEFAULT, so an
+    // UNMODELED key would now route to the device doc rather than central. The test's
+    // intent — a central write must not resurrect the seed — is unchanged.
+    updateMeta((m) => ({ ...m, source: 'set-by-write' }));
 
     const after = fs.readFileSync(centralPath(), 'utf-8');
-    expect(after).toContain('defaultAgent: claude');
+    expect(after).toContain('source: set-by-write');
     expect(after).not.toContain('hermes-agent.nousresearch.com');
   });
 });

--- a/cli/src/lib/state.test.ts
+++ b/cli/src/lib/state.test.ts
@@ -146,6 +146,19 @@ describe('pins route to the untracked pins file; the tracked doc is operator-onl
     expect(doc).not.toContain('futureCentralKey'); // never pushed into the device doc
   });
 
+  it('does not surface a legacy device-doc `defaultBrowserProfile:` onto Meta (generic overlay exclusion, PHNX-3315 P3)', async () => {
+    const { readMeta } = await freshState();
+
+    // A pre-migration device doc: a bare top-level `defaultBrowserProfile:` the
+    // config migration later folds into `config:`. The generic overlay must NOT
+    // surface it onto Meta (it never was before P3) — BESPOKE_DEVICE_DOC_KEYS
+    // excludes it. Deleting that exclusion would fail this test.
+    fs.mkdirSync(path.dirname(devicePath()), { recursive: true });
+    fs.writeFileSync(devicePath(), 'defaultBrowserProfile: work\n');
+
+    expect((readMeta() as any).defaultBrowserProfile).toBeUndefined();
+  });
+
 });
 
 describe('reading state never writes a tracked agents.yaml (RUSH-1925)', () => {

--- a/cli/src/lib/state.ts
+++ b/cli/src/lib/state.ts
@@ -954,52 +954,114 @@ function writeIfChanged(filePath: string, content: string): void {
  * `agents:` / `versions:` are not written (no empty committed files).
  */
 /**
- * Every `Meta` key, classified as `central` (synced via agents.yaml) or `device`
- * (routed to the per-machine device file by {@link writeMetaUnlocked}). The
- * `Record<keyof Meta, …>` type makes this EXHAUSTIVE: adding a field to `Meta`
- * without classifying it here is a compile error. That guarantee is what lets
- * `serializeCentral` delete only keys THIS version models — a key a newer CLI
- * version added (absent from this map) is preserved verbatim instead of being
- * dropped and synced fleet-wide as data loss. This is the fix for the recurring
- * agents.yaml key-loss (beta flags, `notify.owner`, and `feed:` all vanished
- * this way when an older-versioned CLI on the fleet rewrote the file).
+ * Fleet-shared (`central`) Meta keys — the OPT-IN allowlist. A key listed here is
+ * written to the synced `~/.agents/agents.yaml`. Device-scope is the DEFAULT:
+ * {@link metaKeyScope} returns `'device'` for every Meta key NOT listed here, so a
+ * newly-added key can never SILENTLY churn the shared file the way a
+ * central-by-default would — the very trap behind the recurring agents.yaml churn.
+ * Making a key fleet-shared is now a deliberate edit HERE, not the path of least
+ * resistance (PHNX-3315).
  */
-const META_KEY_SCOPE: Record<keyof Meta, 'central' | 'device'> = {
-  // Device-local — writeMetaUnlocked destructures these out; never in central.
-  agents: 'device',
-  isolatedAgents: 'device',
-  versions: 'device',
-  deviceRoutines: 'device',
-  deviceConfig: 'device',
-  deviceBrowser: 'device',
-  deviceFleet: 'device',
-  deviceHosts: 'device',
-  deviceAccounts: 'device',
-  // Central — synced via agents.yaml.
-  accounts: 'central',
-  run: 'central',
-  model: 'central',
-  watchdog: 'central',
-  lease: 'central',
-  secrets: 'central',
-  budget: 'central',
-  feed: 'central',
-  beta: 'central',
-  registries: 'central',
-  profiles: 'central',
-  source: 'central',
-  projectRoot: 'device',
-  extraRepos: 'central',
-  brands: 'central',
-  actors: 'central',
-  seededPresets: 'central',
-  hooks: 'central',
-  config: 'central',
-  hosts: 'central',
-  fleet: 'central',
-  share: 'central',
-  notify: 'central',
-};
+const CENTRAL_META_KEYS = [
+  'accounts',
+  'run',
+  'model',
+  'watchdog',
+  'lease',
+  'secrets',
+  'budget',
+  'feed',
+  'beta',
+  'registries',
+  'profiles',
+  'source',
+  'extraRepos',
+  'brands',
+  'actors',
+  'seededPresets',
+  'hooks',
+  'config',
+  'hosts',
+  'fleet',
+  'share',
+  'notify',
+] as const satisfies readonly (keyof Meta)[];
+
+/**
+ * Device-scoped Meta keys with BESPOKE routing — each lands in a special file
+ * (pins JSON / version-resources JSON) or a REMAPPED device-doc sub-block
+ * (`deviceHosts`->`hosts:`, `deviceFleet`->`fleet:`, ...), so their handling is
+ * hand-written in {@link writeMetaUnlocked} / {@link overlayMachineLocal} and kept
+ * behavior-identical. A device-scoped key NOT listed here is a GENERIC device key:
+ * it round-trips through `devices/<host>/agents.yaml` under its OWN name with no
+ * bespoke wiring (see the generic loops in those two functions). The `browser`
+ * tombstone is bespoke too — drained by lib/browser/registry.ts.
+ */
+const BESPOKE_DEVICE_KEYS = [
+  'agents',
+  'isolatedAgents',
+  'versions',
+  'deviceRoutines',
+  'deviceConfig',
+  'deviceBrowser',
+  'deviceFleet',
+  'deviceHosts',
+  'deviceAccounts',
+  'projectRoot',
+] as const satisfies readonly (keyof Meta)[];
+
+const CENTRAL_KEY_SET: ReadonlySet<string> = new Set(CENTRAL_META_KEYS);
+
+/**
+ * Compile-time exhaustiveness: every Meta key must be filed as central or
+ * bespoke-device above. Add a Meta field without filing it and this line stops
+ * compiling — a nudge, NOT a safety gate: {@link metaKeyScope} still defaults an
+ * unfiled key to `'device'` at runtime, so even a slipped-through key lands
+ * per-box and never leaks to the synced file. File it into {@link CENTRAL_META_KEYS}
+ * (fleet-shared) or {@link BESPOKE_DEVICE_KEYS} (per-box).
+ */
+type ClassifiedMetaKey = (typeof CENTRAL_META_KEYS)[number] | (typeof BESPOKE_DEVICE_KEYS)[number];
+const _metaKeysAreExhaustive: keyof Meta extends ClassifiedMetaKey ? true : never = true;
+void _metaKeysAreExhaustive;
+
+/**
+ * Sync-domain of a Meta key. `'central'` ONLY for the opt-in allowlist; `'device'`
+ * by DEFAULT for everything else — so the classification is authoritative (it
+ * DRIVES the generic device-doc router below) rather than a decorative string map,
+ * and forgetting to classify a new key routes it to the SAFE per-box file.
+ */
+function metaKeyScope(key: string): 'central' | 'device' {
+  return CENTRAL_KEY_SET.has(key) ? 'central' : 'device';
+}
+
+/** Bespoke device keys as a runtime Set (the generic router skips these). */
+const BESPOKE_DEVICE_KEY_SET: ReadonlySet<string> = new Set<string>([
+  ...BESPOKE_DEVICE_KEYS,
+  // The `browser` tombstone is device-scoped but bespoke: lib/browser/registry.ts
+  // drains it (collision-checked) into deviceBrowser, so the generic router must
+  // never blindly relocate it.
+  'browser',
+]);
+
+/**
+ * Device-doc sub-block names the read/write paths handle BESPOKE-ly (each maps to
+ * a different `device*` Meta key, or lives in a separate file). The generic
+ * device-doc overlay skips these so it only surfaces genuine generic keys.
+ */
+const BESPOKE_DEVICE_DOC_KEYS: ReadonlySet<string> = new Set<string>([
+  'agents',
+  'isolatedAgents',
+  'routines',
+  'config',
+  'browser',
+  'fleet',
+  'hosts',
+  'accounts',
+  'projectRoot',
+  // Legacy top-level doc key the config migration folds into `config:`; never
+  // surfaced onto Meta before, so keep the generic overlay from doing so.
+  'defaultBrowserProfile',
+]);
 
 /**
  * Every key this version models (central + device). serializeCentral deletes an
@@ -1009,8 +1071,9 @@ const META_KEY_SCOPE: Record<keyof Meta, 'central' | 'device'> = {
  * in central is stale and must be migrated out). A key NOT listed here — e.g. one
  * a newer CLI version added — is preserved verbatim, never dropped + synced away.
  */
-const KNOWN_META_KEYS: ReadonlySet<string> = new Set([
-  ...Object.keys(META_KEY_SCOPE),
+const KNOWN_META_KEYS: ReadonlySet<string> = new Set<string>([
+  ...CENTRAL_META_KEYS,
+  ...BESPOKE_DEVICE_KEYS,
   // Removed browser-profile store. Kept only as a serializer tombstone so the
   // first registry read can migrate it into this device's file and delete it.
   'browser',
@@ -1045,6 +1108,54 @@ function healMetaHeader(serialized: string): string {
   // it (that would rewrite a hand-authored, headerless central file on the first
   // real central change). A current header round-trips to the identical bytes.
   return stripped === serialized ? serialized : META_HEADER + stripped;
+}
+
+/**
+ * True when the top-level `~/.agents/agents.yaml` carries a metadata header that
+ * is NOT the canonical {@link META_HEADER} — the P1 frozen-header case a box only
+ * heals on its next central write (serializeCentral). An absent or headerless
+ * file is NOT stale (a headerless central file is deliberately left alone).
+ * Surfaced as config drift by `agents sync status` (PHNX-3315).
+ */
+export function hasStaleMetaHeader(): boolean {
+  let content: string;
+  try { content = fs.readFileSync(META_FILE, 'utf-8'); } catch { return false; }
+  return healMetaHeader(content) !== content;
+}
+
+/**
+ * Parse the top-level user `agents.yaml` (this box's synced central file) WITHOUT
+ * the system-repo merge, machine-local overlay, or cache — the raw on-disk central
+ * map, or null when the file is absent/unparseable. Used by config-drift detection
+ * to see the central blocks that should have folded into the device doc, without
+ * mis-attributing a system-repo default as this box's own leak (PHNX-3315).
+ */
+export function readTopLevelUserMeta(): Record<string, unknown> | null {
+  let content: string;
+  try { content = fs.readFileSync(META_FILE, 'utf-8'); } catch { return null; }
+  try {
+    const parsed = yaml.parse(content);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch { /* malformed — nothing to report */ }
+  return null;
+}
+
+/**
+ * Top-level keys currently on disk in the central `agents.yaml` ({} when the file
+ * is absent or unparseable). The generic device-doc router uses this to leave a
+ * FOREIGN key — one this version does not model, already written to central by a
+ * newer CLI — in place instead of relocating it to this box's device doc.
+ */
+function readCentralKeys(): ReadonlySet<string> {
+  try {
+    const parsed = yaml.parse(fs.readFileSync(META_FILE, 'utf-8'));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return new Set(Object.keys(parsed as Record<string, unknown>));
+    }
+  } catch { /* absent or malformed — no foreign keys to protect */ }
+  return new Set();
 }
 
 /**
@@ -1217,6 +1328,26 @@ export function writeMetaUnlocked(meta: Meta): void {
   const hasProjectRoot = typeof projectRoot === 'string' && projectRoot.length > 0;
   if (hasProjectRoot) doc.projectRoot = projectRoot;
   else delete doc.projectRoot;
+
+  // Generic device-scoped keys (PHNX-3315): any key left in `central` that this
+  // version classifies as device but does NOT bespoke-route round-trips through
+  // this box's device doc under its OWN name — so a NEWLY DECLARED device-scoped
+  // key lands per-box BY DEFAULT, with no bespoke wiring, and never reaches the
+  // synced central file. Today the bespoke set covers every device key, so this
+  // loop moves nothing (behavior-identical). A key that is UNKNOWN to this version
+  // AND already present in the on-disk central file is a FOREIGN key a newer CLI
+  // wrote as central — left in `central` and preserved verbatim by serializeCentral
+  // (the fleet-wide config-loss guard), never relocated to this box's doc.
+  const centralRecord = central as Record<string, unknown>;
+  const onDiskCentralKeys = readCentralKeys();
+  for (const k of Object.keys(centralRecord)) {
+    if (metaKeyScope(k) !== 'device') continue;            // fleet-shared: stays central
+    if (BESPOKE_DEVICE_KEY_SET.has(k)) continue;           // bespoke (incl. browser tombstone)
+    if (!KNOWN_META_KEYS.has(k) && onDiskCentralKeys.has(k)) continue; // foreign — preserve
+    doc[k] = centralRecord[k];
+    delete centralRecord[k];
+  }
+
   if (Object.keys(doc).length > 0) {
     fs.mkdirSync(path.dirname(devicePath), { recursive: true });
     writeIfChanged(devicePath, META_HEADER + yaml.stringify(doc));
@@ -1331,6 +1462,14 @@ function overlayMachineLocal(meta: Meta): Meta {
           throw new Error(`Device config corrupted at ${devicePath}: routines must be a string list.`);
         }
         meta.deviceRoutines = dm.routines;
+      }
+      // Generic device-scoped keys (PHNX-3315): device-doc keys this overlay does
+      // NOT bespoke-handle map straight back onto Meta under their own name —
+      // symmetry with the generic write in writeMetaUnlocked. The bespoke sub-blocks
+      // are handled above and skipped, so a stock device doc surfaces nothing extra.
+      for (const [k, v] of Object.entries(dm as Record<string, unknown>)) {
+        if (BESPOKE_DEVICE_DOC_KEYS.has(k)) continue;
+        (meta as Record<string, unknown>)[k] = v;
       }
     }
   }

--- a/cli/src/lib/state.ts
+++ b/cli/src/lib/state.ts
@@ -1149,13 +1149,7 @@ export function readTopLevelUserMeta(): Record<string, unknown> | null {
  * newer CLI — in place instead of relocating it to this box's device doc.
  */
 function readCentralKeys(): ReadonlySet<string> {
-  try {
-    const parsed = yaml.parse(fs.readFileSync(META_FILE, 'utf-8'));
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return new Set(Object.keys(parsed as Record<string, unknown>));
-    }
-  } catch { /* absent or malformed — no foreign keys to protect */ }
-  return new Set();
+  return new Set(Object.keys(readTopLevelUserMeta() ?? {}));
 }
 
 /**
@@ -1243,6 +1237,10 @@ function serializeCentral(central: Record<string, unknown>): string {
  * read-snapshot-then-separately-lock race that {@link updateMeta} would impose.
  */
 export function writeMetaUnlocked(meta: Meta): void {
+  // INVARIANT: every key destructured here must also be in BESPOKE_DEVICE_KEYS (and
+  // vice versa) — a bespoke device key that is classified but NOT pulled out here
+  // would fall into `central`, and the generic router skips it (BESPOKE_DEVICE_KEY_SET),
+  // so it would silently sync to the shared file. Keep the two lists in lockstep.
   const { agents, isolatedAgents, versions, deviceRoutines, deviceConfig, deviceBrowser, deviceFleet, deviceHosts, deviceAccounts, projectRoot, ...central } = meta;
 
   // Write the machine-local files FIRST, then strip central — so a crash mid-write

--- a/cli/src/lib/sync-status.ts
+++ b/cli/src/lib/sync-status.ts
@@ -34,6 +34,7 @@ import { loadManifest } from './staleness/index.js';
 import { getSystemAgentsDir, getUserAgentsDir } from './state.js';
 import * as fs from 'fs';
 import { isGitRepo, readOriginUrl } from './git.js';
+import { detectConfigDrift, type ConfigDrift } from './config-drift.js';
 
 /**
  * One stable status per resource, unified across every surface.
@@ -91,6 +92,9 @@ export interface UserRepoStatus {
 export interface UnifiedSyncStatus {
   system: SystemRepoStatus;
   user: UserRepoStatus;
+  /** Config drift: has this box drained its device-scoped state, or is it still
+   *  carrying per-box state in the shared top-level agents.yaml? (PHNX-3315) */
+  config: ConfigDrift;
   agents: AgentVersionStatus[];
   totals: {
     drifted: number;
@@ -219,6 +223,7 @@ export async function computeSyncStatus(
 
   const system = await getSystemRepoStatus();
   const user = await getUserRepoStatus();
+  const config = detectConfigDrift();
 
   const agentsNeedingSync = new Set<AgentId>();
   let drifted = 0, missing = 0, orphan = 0, versionsNeedingSync = 0, versionsNeverSynced = 0;
@@ -236,6 +241,7 @@ export async function computeSyncStatus(
   return {
     system,
     user,
+    config,
     agents,
     totals: {
       drifted,


### PR DESCRIPTION
**Hardening + generalization of the device-scoped config refactor (PHNX-3315 P3)** — code + test, one runnable surface (`agents sync status`).

This is the last phase. P1 healed the frozen top-level header and drained the central browser tombstone; P2 device-scoped `fleet.discovery`/`ignored`, `hosts`, and device `accounts`. P3 makes the pattern durable: new keys default to per-box, and an un-drained box is now *visible*.

## What changed

- **`cli/src/lib/state.ts`** — Device-scope is now the DEFAULT for `Meta` keys. The old `META_KEY_SCOPE` `Record<keyof Meta,'central'|'device'>` (a decorative map nothing consumed — routing was really the hand-written destructure, so an unwired new key silently synced to central) is replaced by an opt-in `CENTRAL_META_KEYS` allowlist that **drives** routing via `metaKeyScope()`. A key not marked fleet-shared round-trips through `devices/<host>/agents.yaml` under its own name with **no bespoke wiring** (generic loops in `writeMetaUnlocked`/`overlayMachineLocal`). A compile-time exhaustiveness check keeps the classification honest (a nudge — the runtime default is the safe per-box file). A foreign key an older CLI doesn't model but a newer one wrote to central is left in place and preserved verbatim (the `readCentralKeys` guard). Behavior-identical for every existing key. Also adds read-only `hasStaleMetaHeader()` + `readTopLevelUserMeta()` for the drift detector.
- **`cli/src/lib/config-drift.ts`** (new) — `detectConfigDrift()`: read-only, never triggers the migration. Flags a stale top-level header and any lingering central `fleet` / `hosts` / `accounts` (device-scoped) / `browser` block that should have folded into the device doc.
- **`cli/src/lib/sync-status.ts`** — `UnifiedSyncStatus` gains a `config: ConfigDrift` field (computed in `computeSyncStatus`); consumed by every surface (menu-bar/Agency get it in `--json`).
- **`cli/src/commands/status.ts`** — `agents sync status` prints a **distinct** config-drift line when this box hasn't drained — previously that class was invisible (only per-agent "N missing"), so it surfaced as a mystery `agents repo pull` conflict.
- **`cli/src/lib/state.test.ts`** — a newly-declared device-scoped key round-trips the device doc and never touches central; a foreign central key is preserved, not relocated.
- **`cli/src/lib/config-drift.test.ts`** (new) — stale header, each leak class (browser / fleet.discovery / fleet.ignored / hosts / device-scoped accounts), fleet-shared accounts NOT flagged, and a drained/fresh box shows no drift.
- **`cli/.changelog/next/PHNX-3315-p3.md`** — changelog fragment.

No `.description()` / help-text change, so `command-index` docs are untouched (doc-freshness stays green).

## Verification

`tsc --noEmit` clean. Real vitest (`node ./node_modules/vitest/vitest.mjs run <files>`, not `bun test`):

```
$ node ./node_modules/vitest/vitest.mjs run \
    src/lib/state.test.ts src/lib/config-drift.test.ts \
    src/lib/sync-status.test.ts src/lib/devices/config-migration.test.ts

 Test Files  4 passed (4)
      Tests  40 passed (40)
   Duration  1.13s
```

Broader no-regression run over state + device/config/account/sync surfaces (`state.test.ts`, `__tests__/state.test.ts`, `config-drift.test.ts`, `sync-status.test.ts`, `config-migration.test.ts`, `device-config.test.ts`, `account-registry.test.ts`, `sync.test.ts`): **156 passed (8 files)**.
