### PR TITLE
fix(accounts): resolve policy-never credentials headlessly (PHNX-2939)

### DIFF
--- a/cli/.changelog/next/PHNX-2939.md
+++ b/cli/.changelog/next/PHNX-2939.md
@@ -1,0 +1,4 @@
+Provider accounts created with `accounts add` now resolve silently in headless
+`--account` launches on macOS. Their `policy never` credentials are stored
+without a biometry ACL and are read through the policy-aware secrets bundle
+path instead of being rejected by the raw-keychain Touch ID guard.

--- a/cli/src/lib/account-registry.keychain.test.ts
+++ b/cli/src/lib/account-registry.keychain.test.ts
@@ -1,0 +1,41 @@
+/**
+ * macOS integration coverage for provider-account custody. This uses the real
+ * signed helper and data-protection Keychain: no backend seam, no mock. The
+ * unique bundle is deleted in finally so the user's keychain is left clean.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { addAccount, resolveCredentialAccount } from './account-registry.js';
+import { accountSecretItem } from './account-schema.js';
+import { deleteBundle } from './secrets/bundles.js';
+import { deleteKeychainToken } from './secrets/index.js';
+import { setInstallRootForTest } from './secrets/install-helper.js';
+
+const realHome = process.env.AGENTS_TEST_REAL_KEYCHAIN_HOME;
+
+describe.skipIf(process.platform !== 'darwin' || !realHome)('provider accounts (real macOS keychain)', () => {
+  it('stores policy-never credentials no-ACL and resolves them in a headless launch', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-account-keychain-'));
+    const name = `phnx-2939-${randomUUID()}`;
+    const secret = `sk-or-v1-${randomUUID()}`;
+    const previousRuntime = process.env.AGENTS_RUNTIME;
+    const previousInstallRoot = setInstallRootForTest(realHome!);
+
+    try {
+      addAccount(name, 'openrouter', 'api-key', secret, root);
+      process.env.AGENTS_RUNTIME = 'test-headless-account-launch';
+
+      expect(resolveCredentialAccount(name, 'claude', undefined, root).env.ANTHROPIC_AUTH_TOKEN).toBe(secret);
+    } finally {
+      if (previousRuntime === undefined) delete process.env.AGENTS_RUNTIME;
+      else process.env.AGENTS_RUNTIME = previousRuntime;
+      deleteKeychainToken(accountSecretItem(name, 'api-key'));
+      deleteBundle(name);
+      setInstallRootForTest(previousInstallRoot);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/src/lib/account-registry.test.ts
+++ b/cli/src/lib/account-registry.test.ts
@@ -158,6 +158,7 @@ describe('credential account registry (bundle-canonical)', () => {
     expect(meta.vars.API_KEY).toBe('keychain:API_KEY');
     expect(typeof meta.vars.ACCOUNT_ID).toBe('string');
     expect(blobs[0]).not.toContain('sk-or-secret'); // secret bytes never in metadata
+    expect(keychain.noAcl.get(secretsKeychainItem('work', 'API_KEY'))).toBe(true);
   });
 
   it('refuses to overwrite an ordinary secrets bundle with the same name', () => {

--- a/cli/src/lib/account-registry.test.ts
+++ b/cli/src/lib/account-registry.test.ts
@@ -180,6 +180,20 @@ describe('credential account registry (bundle-canonical)', () => {
     });
   });
 
+  it('resolves a policy-never account when the optional secrets broker is disabled', () => {
+    const previousConfigDir = process.env.AGENTS_DAEMON_CONFIG_DIR;
+    const configDir = fs.mkdtempSync(path.join(root, 'daemon-config-'));
+    fs.writeFileSync(path.join(configDir, 'services.yaml'), 'services:\n  secrets-broker: false\n', 'utf8');
+    process.env.AGENTS_DAEMON_CONFIG_DIR = configDir;
+    try {
+      addAccount('headless', 'openrouter', 'api-key', 'sk-or-secret', root);
+      expect(resolveCredentialAccount('headless', 'claude', undefined, root).env.ANTHROPIC_AUTH_TOKEN).toBe('sk-or-secret');
+    } finally {
+      if (previousConfigDir === undefined) delete process.env.AGENTS_DAEMON_CONFIG_DIR;
+      else process.env.AGENTS_DAEMON_CONFIG_DIR = previousConfigDir;
+    }
+  });
+
   it('injects a per-account BASE_URL override over the provider default', () => {
     addAccount('gw', 'openrouter', 'api-key', 'sk-or-secret', root, { baseUrl: 'https://gateway.internal/api' });
     expect(inspectAccount('gw', root).baseUrl).toBe('https://gateway.internal/api');

--- a/cli/src/lib/account-registry.ts
+++ b/cli/src/lib/account-registry.ts
@@ -24,9 +24,9 @@ import { atomicWriteFileSync } from './fs-atomic.js';
 import { getUserAgentsDir, readMeta, updateMeta } from './state.js';
 import type { AgentId, Meta } from './types.js';
 import { deleteKeychainToken, getKeychainToken, hasKeychainToken } from './secrets/index.js';
-import { bundleExists, deleteBundle, listBundles, readBundle, renameBundle, writeBundleWithItems } from './secrets/bundles.js';
+import { bundleExists, deleteBundle, listBundles, readAndResolveBundleEnv, readBundle, renameBundle, writeBundleWithItems } from './secrets/bundles.js';
 import { getAccountProvider, type AccountAuthKind } from './account-provider-registry.js';
-import { accountSecretItem, buildAccountBundle, parseAccountBundle, type AccountSchemaRecord } from './account-schema.js';
+import { accountSecretItem, buildAccountBundle, parseAccountBundle, secretVarFor, type AccountSchemaRecord } from './account-schema.js';
 
 export interface CredentialAccount {
   id: string;
@@ -493,6 +493,18 @@ export function resolveCredentialAccount(name: string, host: AgentId, expectedPr
   }
   const envVar = account.auth === 'setup-token' ? 'CLAUDE_CODE_OAUTH_TOKEN' : adapter.envFor(host, account.auth);
   if (!hasKeychainToken(account.secretRef)) throw new Error(`Credential for account '${account.name}' is missing on this device. Add it with 'agents accounts set-key ${account.name}'.`);
+  const secretVar = secretVarFor(account.auth);
+  // Account bundles are policy `never`, so their value items carry no biometry
+  // ACL. Resolve through the bundle path that verifies that policy and attests
+  // `silentNoAcl` to the headless keychain guard. Calling getKeychainToken()
+  // directly makes a headless --account launch reject the prompt-free item as
+  // if it required Touch ID before the helper ever reads it (PHNX-2939).
+  const secret = readAndResolveBundleEnv(account.name, {
+    keys: [secretVar],
+    keyMode: 'storage',
+    agentOnly: true,
+    caller: 'accounts resolve',
+  }).env[secretVar];
   const connectionEnv = { ...adapter.connectionEnvFor(host) };
   if (account.baseUrl) {
     const baseUrlEnv = adapter.baseUrlEnvFor(host);
@@ -504,7 +516,7 @@ export function resolveCredentialAccount(name: string, host: AgentId, expectedPr
     name: account.name,
     provider: account.provider,
     auth: account.auth,
-    env: { ...connectionEnv, [envVar]: getKeychainToken(account.secretRef) },
+    env: { ...connectionEnv, [envVar]: secret },
   };
 }
 

--- a/cli/src/lib/secrets/bundles.test.ts
+++ b/cli/src/lib/secrets/bundles.test.ts
@@ -700,8 +700,21 @@ describe('disabled secrets broker fails loud before keychain fallback', () => {
     else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
   });
 
-  it('throws a clear error on keychain-backed reads when the broker is disabled', () => {
+  it('throws a clear error on ACL-protected keychain reads when the broker is disabled', () => {
     const name = `disabled-${randomBytes(4).toString('hex')}`;
+    writeBundleWithItems(
+      { name, policy: 'hold', vars: { TOKEN: 'keychain:TOKEN' } },
+      new Map([[secretsKeychainItem(name, 'TOKEN'), 'secret-value']]),
+    );
+    const b = readBundle(name);
+    b.backend = 'keychain';
+    writeBundle(b);
+    expect(isSecretsBrokerEnabled()).toBe(false);
+    expect(() => readAndResolveBundleEnv(name)).toThrow(/Secrets broker is disabled/);
+  });
+
+  it('reads a verified no-ACL bundle directly when the optional broker is disabled', () => {
+    const name = `disabled-noacl-${randomBytes(4).toString('hex')}`;
     writeBundleWithItems(
       { name, policy: 'never', vars: { TOKEN: 'keychain:TOKEN' } },
       new Map([[secretsKeychainItem(name, 'TOKEN'), 'secret-value']]),
@@ -710,7 +723,7 @@ describe('disabled secrets broker fails loud before keychain fallback', () => {
     b.backend = 'keychain';
     writeBundle(b);
     expect(isSecretsBrokerEnabled()).toBe(false);
-    expect(() => readAndResolveBundleEnv(name)).toThrow(/Secrets broker is disabled/);
+    expect(readAndResolveBundleEnv(name, { agentOnly: true }).env).toEqual({ TOKEN: 'secret-value' });
   });
 
   it('still allows direct keychain reads when AGENTS_SECRETS_NO_AGENT=1', () => {

--- a/cli/src/lib/secrets/bundles.ts
+++ b/cli/src/lib/secrets/bundles.ts
@@ -1568,7 +1568,7 @@ export function readAndResolveBundleEnv(
   // If the secrets broker is explicitly disabled and this bundle would otherwise
   // fall through to a keychain read (Touch ID prompt), fail loud now. Never-policy
   // bundles are verified below and remain silent; vault/file backends are unaffected.
-  if (backend === 'keychain' && !isSecretsBrokerEnabled() && process.env.AGENTS_SECRETS_NO_AGENT !== '1') {
+  if (backend === 'keychain' && !verifiedNoAclBundle && !isSecretsBrokerEnabled() && process.env.AGENTS_SECRETS_NO_AGENT !== '1') {
     throw new Error(
       `Secrets broker is disabled — re-enable with 'agents daemon services enable secrets-broker'. ` +
       `If you meant to read directly from the keychain, set AGENTS_SECRETS_NO_AGENT=1.`


### PR DESCRIPTION
## Summary

- resolve provider-account credentials through the policy-aware secrets bundle path
- preserve the `never` policy no-ACL attestation through the macOS headless keychain guard
- add regression coverage for the stored value ACL and an opt-in real macOS Keychain round trip

## Verification

- `bunx vitest run src/lib/account-registry.test.ts src/lib/account-registry.keychain.test.ts src/commands/accounts.test.ts src/lib/secrets/bundles.test.ts` — 99 passed, 3 skipped
- `bun run build` — passed
- Real macOS Keychain on `zion`: `AGENTS_TEST_REAL_KEYCHAIN_HOME=/Users/muqsit ... vitest run src/lib/account-registry.keychain.test.ts` — 1 passed; signed helper `set-no-acl` write + `AGENTS_RUNTIME` headless resolve completed in 3.24s and cleanup deleted the disposable bundle

Linear: PHNX-2939