### PR TITLE
fix(daemon): pin ~/.rush/bin and ~/.local/bin on the daemon PATH (PHNX-3075)

### DIFF
--- a/cli/.changelog/next/PHNX-3075.md
+++ b/cli/.changelog/next/PHNX-3075.md
@@ -1,0 +1,9 @@
+- **Daemon PATH now includes `~/.rush/bin` and `~/.local/bin` (PHNX-3075).**
+  systemd/launchd pin a PATH that never sources a login shell, so `which rush`
+  failed inside the daemon even when an interactive shell on the same box
+  resolved `~/.rush/bin/rush`. Monitor `notify` actions and dispatched
+  `agents run` children inherit that PATH and silently never delivered
+  (`rush CLI not found on PATH`) while the watcher kept polling. Both
+  user-bin dirs now sit after the agents shim and Node dirs (so a
+  `~/.local/bin/agents` cannot shadow the daemon binary) and before the
+  platform system dirs. Source: `cli/src/lib/daemon/daemon.ts`.

--- a/cli/src/lib/daemon/daemon.test.ts
+++ b/cli/src/lib/daemon/daemon.test.ts
@@ -19,6 +19,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -535,6 +536,55 @@ describe.skipIf(process.platform === 'win32')('generateSystemdUnit', () => {
     const segs = systemdPath(generateSystemdUnit(path.join(nodeDir, 'agents')));
     expect(segs.length).toBe(new Set(segs).size);
     expect(segs[0]).toBe(nodeDir);
+  });
+
+  it('pins ~/.rush/bin and ~/.local/bin so `which rush` succeeds under the daemon (PHNX-3075)', () => {
+    // systemd/launchd pin PATH and never source ~/.profile, so a login-shell
+    // install at ~/.rush/bin/rush is invisible to the daemon. The notify
+    // preflight (`which rush` in providers/rush.ts) then fails forever while
+    // `agents notify --dry-run` from a login shell reports ok. Reproduce that
+    // split against the generated unit PATH, not a mocked lookup.
+    const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agd-3075-path-'));
+    const prevHome = process.env.HOME;
+    const prevRealHome = process.env.AGENTS_REAL_HOME;
+    process.env.HOME = sandboxHome;
+    process.env.AGENTS_REAL_HOME = sandboxHome;
+    const rushDir = path.join(sandboxHome, '.rush', 'bin');
+    const localDir = path.join(sandboxHome, '.local', 'bin');
+    const rushBin = path.join(rushDir, 'rush');
+    fs.mkdirSync(rushDir, { recursive: true });
+    fs.writeFileSync(rushBin, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(rushBin, 0o755);
+    try {
+      const unitSegs = systemdPath(generateSystemdUnit());
+      const plistSegs = launchdPath(generateLaunchdPlist());
+      for (const segs of [unitSegs, plistSegs]) {
+        expect(segs[0]).toBe(path.dirname(getAgentsBinPath()));
+        expect(segs).toContain(rushDir);
+        expect(segs).toContain(localDir);
+        expect(segs.indexOf(rushDir)).toBeGreaterThan(0);
+        expect(segs.indexOf(rushDir)).toBeLessThan(segs.indexOf('/usr/bin'));
+      }
+
+      const found = spawnSync('which', ['rush'], {
+        encoding: 'utf-8',
+        env: { PATH: unitSegs.join(':') },
+      });
+      expect(found.status).toBe(0);
+      expect(found.stdout.trim()).toBe(rushBin);
+
+      const withoutUserBins = unitSegs.filter((d) => d !== rushDir && d !== localDir);
+      const missed = spawnSync('which', ['rush'], {
+        encoding: 'utf-8',
+        env: { PATH: withoutUserBins.join(':') },
+      });
+      expect(missed.status).not.toBe(0);
+      expect(missed.stdout.trim()).not.toBe(rushBin);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+      if (prevRealHome === undefined) delete process.env.AGENTS_REAL_HOME; else process.env.AGENTS_REAL_HOME = prevRealHome;
+      fs.rmSync(sandboxHome, { recursive: true, force: true });
+    }
   });
 
   it('pins a JavaScript install to the Node runtime that installed the service', () => {

--- a/cli/src/lib/daemon/daemon.ts
+++ b/cli/src/lib/daemon/daemon.ts
@@ -29,6 +29,7 @@ import { startHostedWebhookReceivers, type HostedWebhookReceivers } from '../dae
 import { secretsBrokerSocketPath, brokerPidAlive } from '../secrets/agent.js';
 import { redactSecrets } from '../redact.js';
 import { getAgentsBinPath, getCliLaunch, BUN_VIRTUAL_ROOT } from '../cli-entry.js';
+import { localBinDir } from '../platform/posixpath.js';
 import { isSchedulerEnabled, assertSchedulerEnabled, isDaemonEnabled, resolveBrowserTaskIdleMs } from '../device-config.js';
 import { reapTerminalRoutineProcesses } from '../routine-process-cleanup.js';
 import { recordSubsystemOk, recordSubsystemError, recordSubsystemErrorReason, readSubsystemHealth, SUBSYSTEM_DAEMON_START } from '../daemon-health.js';
@@ -1816,9 +1817,23 @@ function daemonNodeBinDir(): string {
 }
 
 /**
+ * Login-shell user-bin dirs a service-manager-started daemon would otherwise
+ * miss. systemd/launchd pin PATH and never source `~/.profile`, so they never
+ * see `~/.rush/bin` (where `rush` lands) or `~/.local/bin` (XDG user-bin).
+ * Monitor `notify` and dispatched `agents run` children inherit this PATH;
+ * without these dirs the rush-backed owner channel fails with
+ * `rush CLI not found on PATH` (PHNX-3075) while an interactive shell on the
+ * same box succeeds. Uses the same HOME the manifest bakes (RUSH-2639).
+ */
+function daemonUserBinDirs(): string[] {
+  const home = serviceManifestHomeEnv().HOME;
+  return [path.join(home, '.rush', 'bin'), localBinDir(home)];
+}
+
+/**
  * The full PATH value the daemon service manifest pins, in order: the directory
- * of the `agents` shim itself FIRST, then the Node runtime dir, then the
- * platform's system dirs.
+ * of the `agents` shim itself FIRST, then the Node runtime dir, then login-shell
+ * user-bin dirs (`~/.rush/bin`, `~/.local/bin`), then the platform's system dirs.
  *
  * The shim's own dir must lead so a scheduled `command` routine that shells out
  * to the bare name `agents` (`/bin/sh -c 'agents repo pull system'`) resolves the
@@ -1829,12 +1844,19 @@ function daemonNodeBinDir(): string {
  *
  * The Node runtime dir stays second so the shim's shebang (`#!/usr/bin/env node`)
  * still resolves the exact Node that installed the service — never an ancient
- * system node or a pruned nvm version. Deduped across the whole list, so a
+ * system node or a pruned nvm version. User-bin dirs sit after that pair so a
+ * `~/.local/bin/agents` cannot shadow the daemon binary, but `rush` (and other
+ * login-shell CLIs) still resolve. Deduped across the whole list, so a
  * Node/shim dir that already appears among the system dirs (e.g. a
  * `/usr/local/bin` install) never doubles.
  */
 function daemonPathValue(agentsBin: string, systemDirs: readonly string[]): string {
-  return [...new Set([path.dirname(agentsBin), daemonNodeBinDir(), ...systemDirs])].join(':');
+  return [...new Set([
+    path.dirname(agentsBin),
+    daemonNodeBinDir(),
+    ...daemonUserBinDirs(),
+    ...systemDirs,
+  ])].join(':');
 }
 
 /**


### PR DESCRIPTION
## Outcome

Monitor `notify` (and dispatched `agents run` children) failed under the daemon with `rush CLI not found on PATH` while the same send succeeded from a login shell. systemd/launchd pin PATH and never source `~/.profile`, so they never see `~/.rush/bin` (where `rush` lands) or `~/.local/bin`.

`daemonPathValue` now pins both user-bin dirs on the service PATH, after the agents shim and Node dirs (so a `~/.local/bin/agents` cannot shadow the daemon binary) and before the platform system dirs. Dispatched children inherit that PATH.

A real-path test plants a `rush` at `$HOME/.rush/bin`, extracts PATH from the generated systemd unit and launchd plist, and asserts `which rush` finds it — and that stripping those dirs reproduces the original miss.

Not in this PR (ticket items 2–3): `agents monitors view` still has no distinct UNHEALTHY state for a persistent action error, and `agents monitors add --notify` still does not probe the daemon-reachable delivery path at creation time.

## Evidence

```
$ bun run test src/lib/daemon/daemon.test.ts
 Test Files  1 passed (1)
      Tests  40 passed | 2 skipped (42)
```

The new case `pins ~/.rush/bin and ~/.local/bin so \`which rush\` succeeds under the daemon (PHNX-3075)` is the repro: generated PATH finds the planted `rush`; the old system-dirs-only PATH does not.

## Tracking

PHNX-3075