### PR TITLE
fix(opencode): honor custom-harness --model pin (PHNX-2577)

### DIFF
--- a/cli/.changelog/next/PHNX-2577.md
+++ b/cli/.changelog/next/PHNX-2577.md
@@ -1,0 +1,5 @@
+- **Honor an OpenCode custom-harness `--model` pin (PHNX-2577).** `agents run`
+  of a harness forked from opencode now forwards the pinned model as
+  `--model` on `opencode run`. OpenCode does not read `OPENCODE_MODEL`, so the
+  pin previously vanished and the host used its configured default. Source:
+  `cli/src/lib/profiles.ts`, `cli/src/lib/exec.ts`.

--- a/cli/src/commands/exec.test.ts
+++ b/cli/src/commands/exec.test.ts
@@ -449,6 +449,64 @@ describe('custom harness names take precedence over native agent ids', () => {
   });
 });
 
+describe('opencode custom harness emits --model for its pinned model (PHNX-2577)', () => {
+  it('agents run <opencode-harness> includes --model <pin> on the host argv', () => {
+    // Repro: `agents harness fork opencode oc-test --model openai/gpt-5.4-mini`
+    // then `agents run oc-test` used to spawn `opencode run --agent plan …`
+    // with no --model, so OpenCode fell back to its configured default.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-opencode-model-'));
+    const binDir = path.join(root, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(path.join(root, '.agents', '.system', '.git'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.agents', 'profiles'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.agents', 'agents.yaml'), 'agents: {}\n');
+    fs.writeFileSync(
+      path.join(root, '.agents', 'profiles', 'oc-test.yml'),
+      [
+        'name: oc-test',
+        'host:',
+        '  agent: opencode',
+        'env:',
+        '  OPENCODE_MODEL: openai/gpt-5.4-mini',
+        '',
+      ].join('\n'),
+    );
+    const spawnLog = path.join(root, 'spawn.json');
+    const opencode = path.join(binDir, process.platform === 'win32' ? 'opencode.cmd' : 'opencode');
+    fs.writeFileSync(
+      opencode,
+      process.platform === 'win32'
+        ? '@echo {"type":"result","subtype":"success","is_error":false,"result":"OK"}\r\n'
+        : '#!/usr/bin/env node\n'
+          + 'require("fs").writeFileSync(process.env.HOME + "/spawn.json", JSON.stringify({argv: process.argv.slice(2)}));\n'
+          + 'process.stdout.write(\'{"type":"result","subtype":"success","is_error":false,"result":"OK"}\\n\');\n',
+      { mode: 0o755 },
+    );
+    try {
+      const tsxImport = pathToFileURL(createRequire(import.meta.url).resolve('tsx')).href;
+      const result = spawnSync(
+        'node',
+        ['--import', tsxImport, path.resolve(import.meta.dirname, '..', 'index.ts'), 'run', 'oc-test', 'hi', '--mode', 'plan', '--cwd', root],
+        {
+          cwd: path.resolve(import.meta.dirname, '..', '..'),
+          env: { ...process.env, HOME: root, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}` },
+          encoding: 'utf8',
+        },
+      );
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stderr).toContain("Resolved custom harness 'oc-test' -> opencode");
+      expect(result.stderr).toMatch(/Running:.*--model openai\/gpt-5\.4-mini/);
+      expect(fs.existsSync(spawnLog), `missing spawn log; stderr=${result.stderr}`).toBe(true);
+      const spawned = JSON.parse(fs.readFileSync(spawnLog, 'utf8')) as { argv: string[] };
+      const modelIdx = spawned.argv.indexOf('--model');
+      expect(modelIdx).toBeGreaterThan(-1);
+      expect(spawned.argv[modelIdx + 1]).toBe('openai/gpt-5.4-mini');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 /**
  * RUSH-2339 — `agents run <agent>` on a machine without that harness.
  *

--- a/cli/src/lib/__tests__/exec.test.ts
+++ b/cli/src/lib/__tests__/exec.test.ts
@@ -776,6 +776,34 @@ describeExec('buildExecCommand', () => {
         fs.rmSync(tmp, { recursive: true, force: true });
       }
     });
+
+    it('opencode custom-harness pin in OPENCODE_MODEL is forwarded as --model (PHNX-2577)', () => {
+      // OpenCode does not read OPENCODE_MODEL. A custom harness stores its pin
+      // there; buildExecCommand must emit --model or the host uses its default.
+      const cmd = buildExecCommand(opts({
+        agent: 'opencode',
+        env: { OPENCODE_MODEL: 'openai/gpt-5.4-mini' },
+      }));
+      const idx = cmd.indexOf('--model');
+      expect(idx).toBeGreaterThan(-1);
+      expect(cmd[idx + 1]).toBe('openai/gpt-5.4-mini');
+    });
+
+    it('opencode explicit --model wins over OPENCODE_MODEL in env', () => {
+      const cmd = buildExecCommand(opts({
+        agent: 'opencode',
+        model: 'anthropic/claude-sonnet-4-6',
+        env: { OPENCODE_MODEL: 'openai/gpt-5.4-mini' },
+      }));
+      const idx = cmd.indexOf('--model');
+      expect(idx).toBeGreaterThan(-1);
+      expect(cmd[idx + 1]).toBe('anthropic/claude-sonnet-4-6');
+    });
+
+    it('opencode with no --model and no OPENCODE_MODEL omits the flag (host default)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'opencode' }));
+      expect(cmd).not.toContain('--model');
+    });
   });
 
   // --- Reasoning effort flags ---

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -984,8 +984,13 @@ export function buildExecCommand(options: ExecOptions): string[] {
   // that maps to reasoning effort on a single-model harness (e.g. Grok, where the
   // tier IS the effort dial). `modelVersion` is null when no version resolves;
   // `tierModel` is the concrete model a tier resolved to (null => drop the flag).
+  // Prefer the user's explicit --model. Codex falls back to ~/.codex/config.toml
+  // (per-version CODEX_HOME may not carry that setting). OpenCode has no model
+  // env var — a custom-harness pin lives in OPENCODE_MODEL and must become
+  // `--model` here, or the host silently uses its configured default (PHNX-2577).
   const effectiveModel = options.model
-    ?? (options.agent === 'codex' ? readCodexConfiguredModel() : undefined);
+    ?? (options.agent === 'codex' ? readCodexConfiguredModel() : undefined)
+    ?? (options.agent === 'opencode' ? options.env?.OPENCODE_MODEL : undefined);
   const modelVersion = effectiveModel && template.modelFlag
     ? (options.version || resolveVersion(options.agent, options.cwd || process.cwd()))
     : null;
@@ -1099,12 +1104,8 @@ export function buildExecCommand(options: ExecOptions): string[] {
     cmd.push('--session-id', options.sessionId);
   }
 
-  // Add model. Prefer the user's explicit --model. Otherwise, for Codex, fall
-  // back to the model configured in the user's active ~/.codex/config.toml:
-  // Codex runs under a per-version CODEX_HOME (see buildExecEnv) that may not
-  // carry that setting, so without this it silently defaults to gpt-5.3-codex,
-  // which a ChatGPT-tier account can't use (HTTP 400). Forwarding keeps the
-  // user's default model setup for both `agents run` and `agents teams`.
+  // Add model. `effectiveModel` already preferred --model, then Codex's
+  // configured default, then an OpenCode custom-harness pin (OPENCODE_MODEL).
   if (effectiveModel && template.modelFlag) {
     if (tierResolved) {
       // Cost tier (cheap|default|best|ultra) -> a concrete model this harness+

--- a/cli/src/lib/profiles.test.ts
+++ b/cli/src/lib/profiles.test.ts
@@ -114,6 +114,15 @@ describe('profileModelEnvKey', () => {
     expect(profileModelEnvKey(p)).toBe('OPENAI_MODEL');
   });
 
+  it('returns OPENCODE_MODEL as a first-class key, not the *_MODEL suffix fallback', () => {
+    const p: Profile = {
+      name: 'p',
+      host: { agent: 'opencode' },
+      env: { OPENCODE_MODEL: 'openai/gpt-5.4-mini' },
+    };
+    expect(profileModelEnvKey(p)).toBe('OPENCODE_MODEL');
+  });
+
   it('falls back to any *_MODEL suffix when no known key matches', () => {
     const p: Profile = {
       name: 'p',
@@ -435,6 +444,45 @@ describe("resolveProfileForRun resolves cost tiers against the profile's OWN mod
     const resolved = resolveProfileForRun('kimi');
     expect(resolved.env.ANTHROPIC_MODEL).toBe('moonshotai/kimi-k2.5');
     expect(resolved.resolvedModel).toBeUndefined();
+  });
+});
+
+describe('resolveProfileForRun copies an OpenCode pin into resolvedModel (PHNX-2577)', () => {
+  it('surfaces OPENCODE_MODEL as resolvedModel so callers emit --model', () => {
+    writeProfile({
+      name: 'oc-test',
+      host: { agent: 'opencode' },
+      env: { OPENCODE_MODEL: 'openai/gpt-5.4-mini' },
+    });
+
+    const resolved = resolveProfileForRun('oc-test');
+    expect(resolved.agent).toBe('opencode');
+    expect(resolved.env.OPENCODE_MODEL).toBe('openai/gpt-5.4-mini');
+    expect(resolved.resolvedModel).toBe('openai/gpt-5.4-mini');
+  });
+
+  it('does not overwrite an explicit --model on an OpenCode profile', () => {
+    writeProfile({
+      name: 'oc-test',
+      host: { agent: 'opencode' },
+      env: { OPENCODE_MODEL: 'openai/gpt-5.4-mini' },
+    });
+
+    const resolved = resolveProfileForRun('oc-test', 'anthropic/claude-sonnet-4-6');
+    expect(resolved.env.OPENCODE_MODEL).toBe('openai/gpt-5.4-mini');
+    expect(resolved.resolvedModel).toBeUndefined();
+  });
+
+  it('leaves a discarded cost-tier token alone so the exec.ts discard guard still fires', () => {
+    writeProfile({
+      name: 'oc-test',
+      host: { agent: 'opencode' },
+      env: { OPENCODE_MODEL: 'openai/gpt-5.4-mini' },
+    });
+
+    const resolved = resolveProfileForRun('oc-test', 'best');
+    expect(resolved.resolvedModel).toBeUndefined();
+    expect(resolved.env.OPENCODE_MODEL).toBe('openai/gpt-5.4-mini');
   });
 });
 

--- a/cli/src/lib/profiles.ts
+++ b/cli/src/lib/profiles.ts
@@ -254,6 +254,7 @@ const MODEL_ENV_KEYS = [
   'OPENAI_MODEL',
   'GEMINI_MODEL',
   'GROK_MODEL',
+  'OPENCODE_MODEL',
 ] as const;
 
 /** Return the configured model env value for display. */
@@ -675,13 +676,14 @@ export interface ResolvedProfileRun {
    */
   tierNote?: string;
   /**
-   * Set when `requestedModel` was a tier token AND this profile resolved it
-   * against its own `models:` map. Callers that forward a `--model` value
-   * downstream (e.g. as `ExecOptions.model`) should substitute this in place
-   * of the original tier token — exec.ts's native tier block only knows how
-   * to resolve a tier against the HOST agent's own catalog, which is the
-   * wrong catalog for a profile's own harness identity. Undefined both when
-   * no tier was requested and when tier resolution degraded (see `tierNote`).
+   * Concrete model id callers should forward as `ExecOptions.model`. Set when:
+   * - `requestedModel` was a cost-tier token resolved against this profile's
+   *   `models:` map, OR
+   * - no `--model` was requested and this is an OpenCode host whose pin lives
+   *   in `OPENCODE_MODEL` (OpenCode does not read that env var, so the pin
+   *   has to become `--model` on the argv).
+   * Undefined when the caller already passed a concrete `--model`, or when
+   * tier resolution degraded (see `tierNote`).
    */
   resolvedModel?: string;
 }
@@ -753,6 +755,16 @@ export function resolveProfileForRun(name: string, requestedModel?: string): Res
     // guard (the "cost tiers don't apply to profile ..." discard) still sees
     // the raw tier token downstream and handles the message -- this function
     // doesn't compete with that canonical fallback for the no-opt-in case.
+  }
+  // OpenCode does not honor OPENCODE_MODEL (unlike claude/codex/gemini/grok,
+  // whose host CLIs read their MODEL env var). Copy the pin into resolvedModel
+  // so callers set ExecOptions.model and buildExecCommand emits `--model`.
+  // An explicit `--model` (including a cost-tier token the caller may still
+  // discard) wins and is left alone.
+  if (resolved.resolvedModel === undefined && !requestedModel && profile.host.agent === 'opencode') {
+    const envKey = profileModelEnvKey(profile) ?? modelEnvKeyForHost('opencode');
+    const pinned = env[envKey];
+    if (pinned) resolved.resolvedModel = pinned;
   }
   return resolved;
 }


### PR DESCRIPTION
Fixes [PHNX-2577](https://linear.app/getrush/issue/PHNX-2577/opencode-custom-harness-ignores-its-pinned-model-runs-opencode-default).

An OpenCode custom harness (`agents harness fork opencode <name> --model <id>`) ignored its pinned model at run time and fell back to OpenCode's configured default. OpenCode does not read `OPENCODE_MODEL`, and `resolveProfileForRun` never copied that pin into `ExecOptions.model`, so `buildExecCommand` never emitted `--model`.

## What changed

- `MODEL_ENV_KEYS` now includes `OPENCODE_MODEL` as a first-class model env key (it was already in `MODEL_ENV_KEY_BY_HOST`).
- `resolveProfileForRun` copies the OpenCode pin into `resolvedModel` when no `--model` was requested, so `agents run <harness>` sets `options.model`.
- `effectiveModel` in `buildExecCommand` falls back to `options.env.OPENCODE_MODEL` for OpenCode (covers discarded cost tiers and any caller that passes profile env without `model`).
- Real-path test: `agents run oc-test` with a fake `opencode` on PATH records argv and asserts `--model openai/gpt-5.4-mini`.

## Evidence

```
bun run test src/lib/profiles.test.ts src/lib/__tests__/exec.test.ts src/commands/exec.test.ts
Tests  312 passed (312)
```

The new `agents run <opencode-harness> includes --model <pin> on the host argv` case passed (stderr `Running:` line and spawn argv both contain `--model openai/gpt-5.4-mini`).

Explicit `--model` still wins over the pin. Claude/codex/gemini/grok profiles are unchanged — their hosts honor their MODEL env vars.

## Out of scope

No command/flag surface change (`gen:index` not required). Teams already route custom harnesses through `agents run <profile>`, so they pick this up.