### PR TITLE
fix(feed): write resolution tombstone on Python terminal-answer path (PHNX-3074)

### DIFF
--- a/cli/.changelog/next/PHNX-3074.md
+++ b/cli/.changelog/next/PHNX-3074.md
@@ -1,0 +1,9 @@
+- **Feed terminal answers now write a resolution tombstone (PHNX-3074).**
+  The TypeScript `recordAnswer` / `removeBlock` paths already recorded
+  `resolutions/<id>.json` before clearing an open block, but the Python
+  `UserPromptSubmit` hook (the path that fires when a human types in the
+  TUI) unlinked the block with no tombstone. A later `reconcileAttention`
+  consumer would then resurrect that generation from a stale session
+  re-read at the same cursor. The hook now writes an `answered` tombstone
+  (generation + `sourceCursor` from the still-present block) before
+  unlink, matching the TS writer. Source: `cli/src/lib/feed/feed.ts`.

--- a/cli/src/lib/feed/feed.test.ts
+++ b/cli/src/lib/feed/feed.test.ts
@@ -20,11 +20,14 @@ import {
   getAnswerRecord,
   isBlockAnswered,
   listAskStats,
+  readResolution,
   type OpenBlock,
 } from './feed.js';
 import { classifyBlock, filterBlocksForFeed } from '../ask-classifier.js';
 import { isPhoneUrgent, DEFAULT_POLICY } from '../feed-policy.js';
 import { loadOperators } from '../operator.js';
+import { reconcileAttention } from './attention.js';
+import type { ActiveSession } from '../session/active.js';
 
 const hasPython = spawnSync('python3', ['--version']).status === 0;
 
@@ -834,6 +837,79 @@ describe('feed store', () => {
     expect(listBlocks(feedDir)).toEqual([]);
     expect(isBlockAnswered('block-session-terminal', feedDir)).toBe(true);
     expect(getAnswerRecord('block-session-terminal', feedDir)).toMatchObject({ answeredFrom: 'terminal' });
+  });
+
+  it.runIf(hasPython)('real hook UserPromptSubmit writes an answered tombstone so a stale re-read cannot resurrect (PHNX-3074)', () => {
+    // The Python terminal-answer path used to unlink the block with no
+    // resolutions/<id>.json tombstone. Once reconcileAttention is on the
+    // read path, a session engine still reporting waiting_input at the same
+    // cursor would resurrect the answered ask. This is the producer-side
+    // match of TS recordAnswer: tombstone BEFORE unlink.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-terminal-tombstone-'));
+    const feedDir = path.join(home, '.agents', '.history', 'feed');
+    const sessionId = 'session-tombstone';
+    const blockId = blockIdForSession(sessionId);
+
+    const publish = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: sessionId,
+        hook_event_name: 'PreToolUse',
+        tool_input: { questions: [{ question: 'Choose?', options: [{ label: 'A' }] }] },
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(publish.status).toBe(0);
+    const published = listBlocks(feedDir)[0];
+    expect(published).toBeDefined();
+    expect(published.sourceCursor?.lastActivityMs).toEqual(expect.any(Number));
+
+    const answer = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({ session_id: sessionId, hook_event_name: 'UserPromptSubmit' }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(answer.status).toBe(0);
+    expect(listBlocks(feedDir)).toEqual([]);
+    expect(isBlockAnswered(blockId, feedDir)).toBe(true);
+
+    const tombstone = readResolution(blockId, feedDir);
+    expect(tombstone).toMatchObject({
+      blockId,
+      generation: published.ts,
+      reason: 'answered',
+      sourceCursor: published.sourceCursor,
+    });
+    expect(tombstone?.resolvedAt).toEqual(expect.any(String));
+
+    const cursorMs = published.sourceCursor!.lastActivityMs!;
+    const staleSession = {
+      context: 'terminal',
+      kind: 'claude',
+      status: 'running',
+      host: published.host,
+      sessionId,
+      activity: 'waiting_input',
+      awaitingReason: 'question',
+      question: { text: 'Choose?', reason: 'question', options: [{ label: 'A' }] },
+      lastActivityMs: cursorMs,
+    } as ActiveSession;
+
+    // Same cursor as the answered generation: a stale re-read, must stay gone.
+    expect(reconcileAttention({
+      session: staleSession,
+      resolution: tombstone,
+      nowMs: cursorMs + 10_000,
+    })).toBeUndefined();
+
+    // A strictly later turn is a new generation and is allowed through.
+    const fresh = reconcileAttention({
+      session: { ...staleSession, lastActivityMs: cursorMs + 1, question: { text: 'A later ask?', reason: 'question' } },
+      resolution: tombstone,
+      nowMs: cursorMs + 10_000,
+    });
+    expect(fresh).toBeDefined();
+    expect(fresh!.key).toBe(`${published.host}/${sessionId}/t${cursorMs + 1}`);
   });
 
   it.runIf(hasPython)('real hook clears stale answered marker when a new question is published', () => {

--- a/cli/src/lib/feed/feed.ts
+++ b/cli/src/lib/feed/feed.ts
@@ -929,13 +929,16 @@ def main():
     # Terminal answers (human typed in the TUI) record an answered marker and
     # remove the block file so the feed stops showing it within one poll cycle.
     # The marker stays behind so a concurrent surface cannot double-answer.
+    # A resolution tombstone is written BEFORE unlink (matching TS recordAnswer)
+    # so a stale lifecycle re-read cannot resurrect this generation.
     if hook_event == "UserPromptSubmit":
         os.makedirs(answered_dir, exist_ok=True)
         marker = os.path.join(answered_dir, f"{block_id}.json")
+        now_iso = datetime.now(timezone.utc).isoformat()
         try:
             fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
             record = {
-                "answeredAt": datetime.now(timezone.utc).isoformat(),
+                "answeredAt": now_iso,
                 "answeredFrom": "terminal",
             }
             with os.fdopen(fd, "w") as f:
@@ -944,6 +947,25 @@ def main():
             pass
         except Exception:
             pass
+        # Tombstone first, then drop the open-block view. A missing/corrupt
+        # block means there is nothing to resolve; fail open.
+        existing = read_json(target)
+        if isinstance(existing, dict):
+            generation = existing.get("generation") or existing.get("ts")
+            if generation:
+                tombstone = {
+                    "blockId": block_id,
+                    "generation": generation,
+                    "resolvedAt": now_iso,
+                    "reason": "answered",
+                }
+                source_cursor = existing.get("sourceCursor")
+                if source_cursor:
+                    tombstone["sourceCursor"] = source_cursor
+                write_json(
+                    os.path.join(feed_dir, "resolutions", f"{block_id}.json"),
+                    tombstone,
+                )
         # Remove the visible block so the feed drops the answered question.
         try:
             os.unlink(target)


### PR DESCRIPTION
## Summary

The Python feed-publish hook's `UserPromptSubmit` path (terminal answer) unlinked the open-block file without writing a `resolutions/<id>.json` tombstone. Track A already wired tombstones into the TypeScript `recordAnswer` / `removeBlock` paths; without the matching producer-side write, a later `reconcileAttention` consumer would resurrect a terminal-answered ask from a stale session re-read at the same cursor.

The hook now writes an `answered` tombstone (generation + `sourceCursor` from the still-present block) **before** unlink, matching TS `recordAnswer`.

## Test evidence

Real Python hook, no mocks:

```
$ bun run test src/lib/feed/feed.test.ts src/lib/feed/attention.test.ts
 ✓ src/lib/feed/attention.test.ts (24 tests)
 ✓ src/lib/feed/feed.test.ts (45 tests)
 Test Files  2 passed (2)
      Tests  69 passed (69)
```

The new case publishes a question through `FEED_PUBLISH_HOOK_SCRIPT`, fires `UserPromptSubmit`, asserts `resolutions/<id>.json` (`reason: answered`, generation + `sourceCursor` from the published block), then runs `reconcileAttention` against a stale `waiting_input` re-read (same cursor → suppressed) and a strictly later cursor (new generation → allowed through).

## Scope

- Producer-side Python `UserPromptSubmit` only (PHNX-3074 / Track B feed producers).
- No command/flag surface change; `CHANGELOG.md` not hand-edited. Fragment: `cli/.changelog/next/PHNX-3074.md`.
- `Stop` / `SessionEnd` / `PostToolUse` clear path is unchanged.

Ticket: https://linear.app/getrush/issue/PHNX-3074/feed-attention-python-hook-terminal-answer-path-userpromptsubmit