### PR TITLE
test: plant a real credential file in two claude-account fixtures (PHNX-2685)

### DIFF
--- a/cli/tests/agents.test.ts
+++ b/cli/tests/agents.test.ts
@@ -651,6 +651,15 @@ describe('getAccountEmail', () => {
       path.join(versionHome, '.claude.json'),
       JSON.stringify({ oauthAccount: { emailAddress: 'version@example.com' } })
     );
+    // Off macOS, getAccountInfo requires a real credential file or it reports
+    // signed-out regardless of oauthAccount (PHNX-2685's credential floor) —
+    // this fixture describes a genuinely signed-in version home, so plant one.
+    fs.mkdirSync(path.join(versionHome, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(versionHome, '.claude', '.credentials.json'),
+      JSON.stringify({ claudeAiOauth: { accessToken: 'at-test', refreshToken: 'rt-test', expiresAt: 1 } }),
+      'utf-8',
+    );
 
     const originalHome = process.env.HOME;
     process.env.HOME = realHome;

--- a/cli/tests/run-defaults-command.test.ts
+++ b/cli/tests/run-defaults-command.test.ts
@@ -36,6 +36,23 @@ describe('agents run defaults', () => {
     fs.mkdirSync(projectDir, { recursive: true });
     const managedBinDir = path.join(home, '.agents', '.history', 'versions', 'claude', '2.1.45', 'node_modules', '.bin');
     fs.mkdirSync(managedBinDir, { recursive: true });
+    // Off macOS, account-strategy resolution requires a real credential file
+    // for a version to count as healthy (PHNX-2685's credential floor) — this
+    // fixture's fake `claude@2.1.45` needs to look genuinely signed in, or
+    // `strategy: pinned` excludes it as signed_out before ever reaching the
+    // fake binary this test is actually exercising.
+    const versionHomeDir = path.join(home, '.agents', '.history', 'versions', 'claude', '2.1.45', 'home');
+    fs.mkdirSync(path.join(versionHomeDir, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(versionHomeDir, '.claude.json'),
+      JSON.stringify({ oauthAccount: { emailAddress: 'fixture@example.com' } }),
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(versionHomeDir, '.claude', '.credentials.json'),
+      JSON.stringify({ claudeAiOauth: { accessToken: 'at-test', refreshToken: 'rt-test', expiresAt: 1 } }),
+      'utf-8',
+    );
     const captureArgvScript = [
       '#!/usr/bin/env node',
       'const fs = require("fs");',


### PR DESCRIPTION
## Summary

Discovered while investigating an unrelated PR (#3103) that happened to trigger a full-suite CI run instead of the usual scoped one — surfaced a real, deterministic, pre-existing regression on `main`.

`b245bc77d` ("fix: treat missing linux claude credentials as signed out", PHNX-2685) added a credential floor to `getAccountInfo`: off macOS, a version home with an `oauthAccount` in `.claude.json` but no `.claude/.credentials.json` (or `.oauth_token`) now correctly reports signed-out, since that's exactly the false-healthy state the fix was written to catch. That commit updated its own colocated `agent-spec/agents.test.ts` fixtures accordingly — but two other pre-existing fixtures elsewhere in the repo only ever wrote the legacy `.claude.json`-only shape and were never touched:

- `tests/agents.test.ts` — `getAccountEmail > uses the Claude version home when oauthAccount exists there`
- `tests/run-defaults-command.test.ts` — both tests, via its fake `claude@2.1.45` version home

Both started failing deterministically as soon as anything runs the full suite. **Verified independent of any PR**: reproduces identically on a clean `origin/main` checkout with zero other changes (confirmed via a disposable worktree + fresh `bun install`).

Fix: plant a real `.claude/.credentials.json` (matching the exact fixture pattern `b245bc77d` already used in its own test file) in both fixtures, so they describe a genuinely signed-in Linux install instead of the now-invalid pre-PHNX-2685 shape.

Audited every other `oauthAccount`-referencing test file in the repo (14 files) for the same pattern — all 524 tests in that set pass as-is, so this is contained to the two files above.

## Test plan
- [x] `tests/run-defaults-command.test.ts` + `tests/agents.test.ts` — 41/41 passing (were 3 failing)
- [x] Swept 14 other `oauthAccount`-referencing test files — 524/524 passing, no other instances of this pattern
- [x] `tsc --noEmit` clean