### PR TITLE
docs(share): Phoenix identity + visibility model, and the two new share surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1300,11 +1300,19 @@ email (`muqsitnawaz@gmail.com` → `muqsitnawaz`); the page slug is readable plu
 short view-id. HTML is stored as one object: local images are inlined, `file://` TOC
 links become in-page hashes, so the published page is actually viewable. `--visibility unlisted` (hidden aliases
 `--unlisted` / `--private`) is a capability URL: GET still works, the gallery hides it,
-and the Worker sends `X-Robots-Tag: noindex`. `share visibility <target> <level>`
+and the Worker sends `X-Robots-Tag: noindex`. `--visibility me` is visible only to
+you (the signed-in owner); `--visibility org` is visible to anyone at your email
+**domain** — derived from your own address, so it needs a **workspace** Google
+account and is refused on a public-inbox domain (`gmail.com`, `outlook.com`,
+`icloud.com`, …). Both need a Phoenix session and are identity-gated at read time (a
+stranger is redirected to sign in, then 404s). `share visibility <target> <level>`
 re-scopes an **already-published** page in place — the slug/URL is preserved and the
 body is untouched (a metadata-only change, like `share edit`, so no revision) — so you
 can promote a draft to `public` or pull a link back to `me`/`org` without re-publishing
-(`me`/`org` need a Phoenix session). **BYO Cloudflare** remains: `setup` reads
+(`me`/`org` need a Phoenix session; `org` needs a workspace domain). Sign-in is a
+single **Phoenix ID** (Google-only device-code OAuth, `agents auth login`) — see
+[`docs/share.md`](cli/docs/share.md) for the full identity + visibility model.
+**BYO Cloudflare** remains: `setup` reads
 a Cloudflare API token from your `cloudflare.com` secrets bundle (or `--token`), creates
 an R2 bucket, uploads a tiny Worker, and enables the free `*.workers.dev` subdomain (or
 maps `--domain share.example.com` when the token owns the zone). Writes are bearer-gated

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -20,12 +20,31 @@ core, browser, computer, secrets, accounts, fleet, share, watchdog, and preferen
 delegates each selected phase to its existing `agents setup <capability>` wizard.
 `agents setup status --json` is the non-interactive view of the same probes.
 
+`agents artifacts share` publishes an artifact under a **single Phoenix ID**
+identity (Google-only device-code OAuth via `agents auth login`,
+`src/lib/identity/client.ts` `PhoenixSession` — there is no separate GetRush
+account and no Supabase). The URL namespace is the signed-in email's local-part
+(`handleFromEmail`, `src/lib/share/backend.ts`). A publish stamps one of four
+visibility levels (`ShareVisibility`, `src/lib/share/publish.ts`): `public`
+(default, gallery + OG card), `unlisted` (= `--private`; capability URL, `noindex`,
+gallery-hidden), `me` (owner-only, Phoenix-gated), and `org` (anyone at the
+**sharer's** email domain, Phoenix-gated). `org` is refused on a public-inbox
+domain (`PUBLIC_INBOX_DOMAINS` in `src/lib/share/worker-template.ts`), so it needs a
+workspace-domain Google account, never a personal `gmail.com`. The full model is
+[`docs/share.md`](docs/share.md); the publication boundary is
+[`docs/observability.md`](docs/observability.md).
+
 `agents artifacts share list` mirrors the public gallery by default. Use
-`--scope unlisted|me|org` or `--all` to list the authenticated owner's hidden
-pages; the CLI forwards the owner's bearer and a `scope=mine` hint to the
-Worker's JSON listing route, which includes hidden pages only after verifying
-that the bearer owns the requested namespace. See `docs/observability.md` for
-the publication boundary.
+`--scope unlisted|me|org` or `--all` (alias for `--scope all`) to list the
+authenticated owner's hidden pages; the CLI forwards the owner's bearer and a
+`scope=mine` hint to the Worker's JSON listing route, which includes hidden pages
+only after verifying that the bearer owns the requested namespace. The filter is
+`--scope` (not `--visibility`) because the parent `share <file>` command owns
+`--visibility`. `agents artifacts share visibility <target> <level>` re-scopes an
+already-published page in place through the same `PATCH` metadata-edit route as
+`share edit`: the slug/URL and body are preserved, so no revision is created; the
+result flag is `--visibility-json` (the same ancestor-collision rename as
+`--scope`/`--for-user`).
 
 `agents feed watch --json` is the canonical thin-client operator stream: it
 composes the existing session watcher with feed attention and activity, while

--- a/cli/docs/README.md
+++ b/cli/docs/README.md
@@ -11,7 +11,7 @@ Read in this order:
 3. [Resources](resources.md) and [execution](execution.md) — inputs and the one launch path.
 4. [Sessions](sessions.md), [fleet](fleet.md), and [orchestration](orchestration.md).
 5. [Automation](automation.md), [interfaces](interfaces.md), and [secrets](secrets.md).
-6. [Observability](observability.md), [distribution](distribution.md),
+6. [Observability](observability.md), [share](share.md), [distribution](distribution.md),
    [behavioral specifications](specifications.md), and [benchmarks](benchmarks.md)
    (measured numbers; not Linear).
 

--- a/cli/docs/share.md
+++ b/cli/docs/share.md
@@ -1,0 +1,171 @@
+# Share — identity, namespace, and visibility
+
+`agents artifacts share` publishes an HTML artifact (a plan, a viz, a report) to a
+world-reachable link. This document is the model behind that link: **who you are
+when you publish, what namespace the link lands in, and who can then read it.** For
+command syntax use `agents artifacts share --help` or the
+[command index](command-index.md); for onboarding use the product README.
+
+There are two backends — a **managed** endpoint you get for free by signing in, and
+a **BYO** Cloudflare R2 + Worker you provision yourself. The publication boundary
+(bearer-gated writes, public reads) is described in
+[observability.md](observability.md); this document covers the identity and
+visibility model that sits on top of it.
+
+## One identity: Phoenix ID
+
+There is a **single** account behind the managed endpoint: a **Phoenix ID**. It is
+the only identity agents-cli authenticates against — there is no separate "GetRush"
+account and no Supabase user. `PhoenixSession` and the API base are the whole
+surface (`src/lib/identity/client.ts:31` `PHOENIX_ID_BASE`, `:39`
+`interface PhoenixSession`).
+
+Sign-in is **Google-only**, over the RFC 8628 device-code flow: `agents auth login`
+opens a Phoenix-branded page and the CLI never sees a password
+(`src/commands/auth.ts:131` — "Sign-in is Google-only and opens a Phoenix-branded
+page; the CLI never sees a password"). On approval the CLI writes the session —
+`{ access_token, email, userId }` — to disk (`src/commands/auth.ts:53`
+`writeSession(...)`). Every managed share request carries that session's bearer.
+
+A signed-in user publishes to `share.agents-cli.sh/<handle>/<slug>` with the
+Phoenix session and **no Cloudflare account, bucket, or write token**. Without a
+session, the BYO Cloudflare path applies instead (`agents artifacts setup` /
+`agents artifacts share join`), gated by a static `WRITE_TOKEN`.
+
+## Namespace = the email local-part
+
+The URL namespace (the `<handle>` segment) is the **local-part of the signed-in
+email** — everything before the `@`, with any `+tag` dropped:
+
+- `muqsitnawaz@gmail.com` → `muqsitnawaz`
+- `muqsitnawaz+dev@gmail.com` → `muqsitnawaz`
+
+`handleFromEmail` derives it (`src/lib/share/backend.ts:81`), and it must match the
+Worker's own `handleFromEmail` so the CLI and the endpoint agree on the same
+namespace. When the email is missing it falls back to a sanitized `userId`
+(`backend.ts:90`). On the BYO path the namespace is instead the resolved GitHub
+username (gh / `git config` / `--for-user`).
+
+## Visibility levels
+
+A publish stamps exactly one of four visibility levels on the stored object
+(`src/lib/share/publish.ts:115` `type ShareVisibility = 'public' | 'unlisted' | 'me'
+| 'org'`; the ordered set is `SHARE_VISIBILITY_LEVELS` at `:119`). `--visibility
+<level>` selects it; `resolveShareVisibility` (`publish.ts:141`) resolves the flag
+plus the aliases below.
+
+| Level | Who can read | In the gallery? | Robots | Requires |
+|---|---|---|---|---|
+| `public` (default) | anyone with the link | **yes** — listed, gets an OG preview card | indexable | — |
+| `unlisted` | anyone with the link (capability URL) | no | `X-Robots-Tag: noindex` | — |
+| `me` | only the signed-in owner | no | `noindex`, `private, no-store` | Phoenix session |
+| `org` | anyone at the sharer's email **domain** | no | `noindex`, `private, no-store` | Phoenix session + a workspace domain |
+
+- **`unlisted` is a capability URL, not a secret.** GET still returns 200; it is
+  only hidden from the gallery/listing and marked `noindex`
+  (`worker-template.ts:356`). `--private` and `--unlisted` are hidden aliases of
+  `--visibility unlisted` (`src/commands/share.ts:794`–`795`;
+  `resolveShareVisibility` maps `unlisted:true` → `'unlisted'`, `publish.ts:142`).
+- **`me` and `org` are identity-gated reads**, enforced at the Worker. An
+  unauthenticated request for either 302-redirects to the Phoenix login
+  (`gateRestrictedGet` → `bounceToLogin`, `worker-template.ts:875`, `:901`). A
+  wrong viewer gets a `404`, so a restricted page never even leaks that it exists.
+- `me` reads require the viewer's `userId` to equal the object's stamped `owner`
+  (`viewerMayRead`, `worker-template.ts:888`). `org` reads require the viewer's
+  email **domain** to equal the `org_domain` stamped at publish time
+  (`worker-template.ts:893`; stamped from `emailDomain(auth.email)` at `:162` /
+  `:252`).
+- `me`/`org` are Phoenix-only. A BYO `WRITE_TOKEN` can publish `public`/`unlisted`
+  only — the Worker rejects `me`/`org` from a non-Phoenix caller with a `400`
+  (`worker-template.ts:94`–`97`), and the CLI surfaces a crisp `agents auth login`
+  hint before the round trip (`share.ts:187`).
+
+### `org` rejects public-inbox domains — the sharp edge
+
+`org` means "anyone at **my** email domain", and the domain is derived from the
+**sharer's own email**, never from any configured value. That only makes sense for a
+real workspace domain, so the Worker **refuses `org` on a public-inbox domain**:
+
+```
+PUBLIC_INBOX_DOMAINS = ['gmail.com', 'googlemail.com', 'outlook.com',
+                        'hotmail.com', 'live.com', 'icloud.com', 'me.com']
+```
+
+(`src/lib/share/worker-template.ts:610`). Publishing `org` from one of these returns
+`400 "org visibility cannot use a public email domain"` (`worker-template.ts:102`,
+and the same check on the in-place edit path at `:246`). So an `org` share is
+possible **only when you are signed in with a workspace-domain Google account**
+(e.g. `you@yourcompany.com`) — never with a personal `gmail.com` / `icloud.com`
+address. A page that reads "Anyone at yourcompany.com" derives `yourcompany.com`
+from the signer's email, not from a setting.
+
+An empty/unverifiable domain is likewise refused (`400 "org visibility requires a
+verified email domain"`, `worker-template.ts:101`).
+
+Every HTML page also carries an always-on **attribution bar** injected at serve
+time that shows the visibility as a visual cue; `?raw` does not strip it
+(`worker-template.ts:366`).
+
+## Listing hidden pages — `share list --scope` / `--all`
+
+By default `agents artifacts share list` mirrors the **public gallery** — it lists
+public pages only (`--scope public`). To see your hidden pages, name a hidden scope:
+
+```bash
+agents artifacts share list                 # public only (default)
+agents artifacts share list --all           # every page, incl. unlisted/me/org (alias for --scope all)
+agents artifacts share list --scope me      # just your owner-only pages
+agents artifacts share list --scope unlisted # just your capability-URL pages
+agents artifacts share list --scope org     # just your org pages
+```
+
+`--scope <level>` takes `public` (default), `unlisted`, `me`, `org`, or `all`;
+`--all` is the convenience alias for `--scope all` (`src/commands/share.ts:1081`–
+`1089`). The filter is named `--scope` (not `--visibility`) because the parent
+`share <file>` command already owns `--visibility` and Commander resolves an
+option's long name against the whole ancestor chain (`share.ts:1077`–`1079`).
+
+Any hidden scope sends the **owner's bearer** and a `scope=mine` hint to the
+Worker's JSON listing route (`runShareList`, `src/commands/share.ts:349`–`362`); the
+Worker returns hidden pages **only after verifying the bearer owns the namespace**
+(`resolveListingScope`, `worker-template.ts:551`). Each human row shows the page's
+visibility so public vs hidden is obvious at a glance
+(`formatShareList`, `share.ts:459`–`460`). A BYO Worker that predates the listing
+route fails loud and points at `agents artifacts share update` rather than returning
+a wrong-or-empty result (`OUTDATED_TEMPLATE_HINT`, `share.ts:225`).
+
+## Changing visibility in place — `share visibility <target> <level>`
+
+`agents artifacts share visibility <target> <level>` re-scopes an
+**already-published** page without re-publishing it:
+
+```bash
+agents artifacts share visibility https://share.agents-cli.sh/octocat/q3-plan me
+agents artifacts share visibility octocat/q3-plan public
+agents artifacts share visibility q3-plan org      # rejected on a public-inbox domain
+agents artifacts share visibility q3-plan me --visibility-json
+```
+
+`<target>` accepts the same three forms as `unshare` — a full URL, `<user>/<slug>`,
+or a bare slug in your namespace; `<level>` is one of `public | unlisted | me | org`
+(`src/commands/share.ts:938`–`942`). It **re-stamps only the visibility** on the
+stored object via the same `PATCH` metadata-edit route as `share edit` — the slug
+(and so the URL) is preserved, and the body, provenance, label, and `--meta` are
+untouched, so **like `share edit` it creates no revision** (`runShareEdit`,
+`share.ts:160`, `:196`). Visibility is a first-class edit field alongside `label`,
+never a `--meta` entry (`visibility` is reserved).
+
+The result flag is `--visibility-json` (not `--json`), the same ancestor-collision
+rename as `--scope`/`--for-user` above (`share.ts:944`). The same gates apply as at
+publish time: `me`/`org` require a Phoenix session and fail loud with an
+`agents auth login` hint when signed out (`share.ts:187`), and `org` is refused on a
+public-inbox domain (`worker-template.ts:246`). A BYO endpoint whose deployed Worker
+predates the visibility edit **fails loud** — it 200s without echoing `visibility`
+back, which the CLI detects and turns into an `agents artifacts share update` hint
+rather than a silent no-op success (`share.ts:211`–`217`).
+
+## Related
+
+- [observability.md](observability.md) — the publication boundary (bearer-gated
+  writes, public reads) and the traces surface.
+- [secrets.md](secrets.md) — the BYO `cloudflare.com` / `WRITE_TOKEN` bundles.

--- a/cli/docs/share.md
+++ b/cli/docs/share.md
@@ -77,8 +77,12 @@ plus the aliases below.
   `:252`).
 - `me`/`org` are Phoenix-only. A BYO `WRITE_TOKEN` can publish `public`/`unlisted`
   only — the Worker rejects `me`/`org` from a non-Phoenix caller with a `400`
-  (`worker-template.ts:94`–`97`), and the CLI surfaces a crisp `agents auth login`
-  hint before the round trip (`share.ts:187`).
+  (`worker-template.ts:94`–`97`). On the initial `share <file>` **publish** path
+  the CLI sends the visibility header unconditionally and surfaces the Worker's
+  raw `400` with a generic "check the write token / `agents artifacts setup`"
+  message (`publish.ts:770`) — no login pre-check. The in-place **`share
+  visibility`** edit path (below) is the one that pre-checks and emits a crisp
+  `agents auth login` hint before the round trip (`runShareEdit`, `share.ts:187`).
 
 ### `org` rejects public-inbox domains — the sharp edge
 


### PR DESCRIPTION
## What

Documents the share **account + visibility model** and the two surfaces the code teammates just merged. Docs-only — no `cli/src` changes.

### PART 1 — account & visibility model (new `cli/docs/share.md`)
- **One identity: Phoenix ID.** Sign-in is Google-only device-code OAuth via `agents auth login`; there is no separate "GetRush" account and no Supabase.
  - `src/commands/auth.ts:131` — "Sign-in is Google-only and opens a Phoenix-branded page; the CLI never sees a password"; session written at `src/commands/auth.ts:53` (`writeSession({ access_token, email, userId })`).
  - `src/lib/identity/client.ts:31` `PHOENIX_ID_BASE`, `:39` `interface PhoenixSession` — the only identity surface.
- **Namespace = email local-part.** `src/lib/share/backend.ts:81` `handleFromEmail` (`muqsitnawaz+dev@gmail.com` → `muqsitnawaz`), fallback to sanitized userId at `:90`.
- **Four visibility levels.** `src/lib/share/publish.ts:115` `type ShareVisibility = 'public' | 'unlisted' | 'me' | 'org'`; `:119` `SHARE_VISIBILITY_LEVELS`; `:141` `resolveShareVisibility`. `--private`/`--unlisted` are hidden aliases of `--visibility unlisted` (`src/commands/share.ts:794`–`795`).
  - `me`/`org` reads are identity-gated: unauthenticated → 302 to Phoenix login (`gateRestrictedGet`→`bounceToLogin`, `worker-template.ts:875`,`:901`); wrong viewer → 404. `me` = owner-only (`viewerMayRead`, `worker-template.ts:888`); `org` = viewer email domain == stamped `org_domain` (`:893`, stamped at `:162`/`:252`).
- **CRITICAL: `org` rejects public-inbox domains.** `PUBLIC_INBOX_DOMAINS` (gmail/googlemail/outlook/hotmail/live/icloud/me) at `worker-template.ts:610`; the 400 at `:102` (publish) and `:246` (in-place edit). So `org` needs a workspace-domain Google account; the "Anyone at &lt;domain&gt;" is derived from the **sharer's** email, not a configured value.

### PART 2 — the two merged surfaces
- **`agents artifacts share list --scope <level>` / `--all`** (from `feat(share): list hidden pages with --scope/--all`, merged `d32307fc9`). Exact flags read from merged `src/commands/share.ts:1081`–`1089` (`--scope` choices `public|unlisted|me|org|all`, `--all` = alias for `--scope all`). Named `--scope` not `--visibility` because the parent `share <file>` owns `--visibility` (`share.ts:1077`–`1079`). Owner bearer + `scope=mine` forwarding in `runShareList` (`share.ts:349`–`362`), Worker gate `resolveListingScope` (`worker-template.ts:551`).
- **`agents artifacts share visibility <target> <level>`** (from `feat(share): change a published page's visibility in place`, merged `fb19e9f19`). Exact usage from merged `src/commands/share.ts:938`–`958`: `<target>` = full URL / `<user>/<slug>` / bare slug; `<level>` = `public|unlisted|me|org`; result flag `--visibility-json`. Reuses the `PATCH` metadata-edit route (`runShareEdit`, `share.ts:160`,`:196`) — slug/URL and body preserved, no revision. Predate-Worker guard fails loud at `share.ts:211`–`217`.

## Files
- `cli/docs/share.md` (new) — the identity + visibility reference; linked from `cli/docs/README.md`.
- `README.md` — added me/org semantics + the org public-inbox gotcha to the Share section and a pointer to the new doc.
- `cli/AGENTS.md` — share identity/visibility note (edited AGENTS.md; CLAUDE.md is its symlink).

CHANGELOG: `cli/.changelog/next/share-list-hidden.md` and `PHNX-share-visibility.md` were already landed by the two code PRs.

## Verification
- No doc references a stale command/flag: grepped for `share list --visibility` (none) and confirmed `--scope`/`--all`/`--visibility-json` against merged source.
- Citations re-checked against exact function-definition lines (`resolveListingScope:551`, `viewerMayRead:888`, `bounceToLogin:901`).