### PR TITLE
fix(codex): fail loud when the Linux userns sandbox can't start (PHNX-3285)

### DIFF
--- a/cli/.changelog/next/PHNX-3285.md
+++ b/cli/.changelog/next/PHNX-3285.md
@@ -1,0 +1,17 @@
+- **Fail loud when codex's Linux sandbox can't start, instead of landing zero tools (PHNX-3285).**
+  Codex ≥0.146 sandboxes its `read-only` and `workspace-write` runs on Linux with a
+  bundled bubblewrap that needs an unprivileged user namespace. On Ubuntu 23.10+
+  (`kernel.apparmor_restrict_unprivileged_userns=1`) that's denied, so bwrap dies with
+  `bwrap: setting up uid map: Permission denied` and a **headless** codex run — an
+  `agents teams` codex teammate, or `agents run codex`, always headless + sandboxed —
+  burned a turn and wrote nothing while still reporting a completed turn. `agents run`
+  now preflights the box before spawning a headless sandboxed codex and **fails loud**
+  with the one-time fix, rather than silently under-delivering. The preflight is scoped
+  to codex + Linux + a headless + sandboxed (non-`skip`) run — an interactive TUI, a
+  `--mode skip` (no-sandbox) run, macOS/Windows, and every other harness are untouched,
+  and the intended `auto`=workspace-write + `approval_policy=never` config is preserved,
+  never downgraded to `danger-full-access`. `cli/scripts/enable-codex-sandbox.sh`
+  re-enables unprivileged userns on a box (sysctl drop-in, idempotent, self-verifying)
+  so codex's sandbox works with its isolation intact; run it once per fleet worker.
+  Source: `cli/src/lib/linux-userns.ts`, `cli/src/lib/exec.ts` (`codexSandboxPreflight`),
+  `cli/scripts/enable-codex-sandbox.sh`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -556,6 +556,38 @@ blanket rules map to `~/.openclaw/openclaw.json` `tools.alsoAllow`/`tools.deny`,
 sessions/config; `agents add gemini`, `agents import gemini`, and
 `agents sync gemini` fail and point users to Antigravity.
 
+### Codex's Linux sandbox needs unprivileged user namespaces (PHNX-3285)
+
+Codex ≥0.146 is the **only** harness that sandboxes its own tool calls on Linux
+with a bundled **bubblewrap** — it extracts `codex-linux-sandbox` + `bwrap` per run
+and sets up mounts inside a fresh unprivileged **user namespace** (`--unshare-user`,
+then a `/proc/self/uid_map` write) for both `read-only` and `workspace-write` modes
+(only `skip` = `--dangerously-bypass-approvals-and-sandbox` uses no bwrap). The
+legacy Landlock backend is gone (`use_linux_sandbox_bwrap` is `removed`,
+`use_legacy_landlock` panics under the permission-profile model), so bwrap is the
+only Linux sandbox path. grok/kimi/cursor/etc. do **not** sandbox this way, so this
+is codex-specific.
+
+Ubuntu 23.10+ ships `kernel.apparmor_restrict_unprivileged_userns=1`, which denies
+that userns to an unconfined binary — bwrap then dies with `bwrap: setting up uid
+map: Permission denied`, and a **headless** codex run (an `agents teams` codex
+teammate, or `agents run codex` — always headless + sandboxed) lands **zero tools**
+while still reporting a completed turn. `spawnAgent` preflights this before the
+spawn (`codexSandboxPreflight` in [`src/lib/exec.ts`](src/lib/exec.ts), probing
+[`src/lib/linux-userns.ts`](src/lib/linux-userns.ts)) and **fails loud** with the
+one-time fix instead of silently under-delivering. Scope is deliberate: codex +
+Linux + headless + a sandboxed (non-`skip`) mode only — an interactive TUI surfaces
+the bwrap error itself, `--mode skip` uses no sandbox, and macOS/Windows never hit
+it. The intended `auto` = workspace-write + `approval_policy=never` config is never
+weakened.
+
+The one-time fix keeps the sandbox intact — re-enable unprivileged userns per box:
+[`scripts/enable-codex-sandbox.sh`](scripts/enable-codex-sandbox.sh) writes the
+`kernel.apparmor_restrict_unprivileged_userns=0` sysctl drop-in, applies it, and
+re-probes to confirm it took. Run it once per fleet worker
+(`sudo bash cli/scripts/enable-codex-sandbox.sh`, or fan out with
+`agents ssh <box> 'sudo bash -s' < cli/scripts/enable-codex-sandbox.sh`).
+
 ## Source layout
 
 ```

--- a/cli/ci/test-ownership.yaml
+++ b/cli/ci/test-ownership.yaml
@@ -251,6 +251,11 @@ testless:
   - cli/scripts/build-keychain-helper.sh
   - cli/scripts/companion-shim/bin/agents.js
   - cli/scripts/companion-shim/scripts/postinstall.js
+  # One-time per-box fleet fix (PHNX-3285): re-enables unprivileged userns so
+  # codex's Linux sandbox works. It mutates host security posture under sudo, so
+  # it can't be unit-tested here; its detection logic lives in linux-userns.ts,
+  # which IS tested.
+  - cli/scripts/enable-codex-sandbox.sh
   - cli/scripts/headless-sign-context.sh
   - cli/scripts/install-helper.js
   - cli/scripts/release-changelog.ts

--- a/cli/scripts/enable-codex-sandbox.sh
+++ b/cli/scripts/enable-codex-sandbox.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# enable-codex-sandbox.sh -- let Codex's Linux sandbox run on this box (PHNX-3285).
+#
+# Codex >=0.146 sandboxes its `read-only` and `workspace-write` runs on Linux with
+# a bundled bubblewrap (`bwrap`) that sets up its mounts inside an unprivileged
+# user namespace (`--unshare-user`, then a write to /proc/self/uid_map). Ubuntu
+# 23.10+ ships `kernel.apparmor_restrict_unprivileged_userns=1`, which denies that
+# to an unconfined binary -- so bwrap dies with
+#
+#     bwrap: setting up uid map: Permission denied
+#
+# and a HEADLESS codex run (an `agents teams` teammate, or `agents run codex`)
+# lands zero tools: no file writes, no shell, while still reporting a completed
+# turn. This script re-enables unprivileged user namespaces so codex's
+# workspace-write sandbox works with its isolation fully intact -- it does NOT
+# weaken codex to `--dangerously-bypass-approvals-and-sandbox`.
+#
+# One-time, per box. Needs root (it writes a sysctl drop-in). Idempotent, and it
+# VERIFIES the fix actually took (re-probes userns) rather than assuming it did.
+#
+# Usage:
+#   sudo bash cli/scripts/enable-codex-sandbox.sh          # apply + verify
+#   bash cli/scripts/enable-codex-sandbox.sh --check        # report only, no writes
+#   sudo bash cli/scripts/enable-codex-sandbox.sh --check   # same (root not needed)
+#
+# Fleet-wide (from any box that can reach the workers over ssh):
+#   for b in yosemite-m0 yosemite-m1 mark-1; do
+#     agents ssh "$b" 'sudo bash -s' < cli/scripts/enable-codex-sandbox.sh
+#   done
+#
+set -euo pipefail
+
+SYSCTL_KNOB="kernel.apparmor_restrict_unprivileged_userns"
+SYSCTL_PROC="/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+DROPIN="/etc/sysctl.d/60-codex-userns.conf"
+
+CHECK_ONLY=0
+[[ "${1:-}" == "--check" ]] && CHECK_ONLY=1
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "not Linux -- codex uses no bwrap/userns sandbox here; nothing to do."
+  exit 0
+fi
+
+# Ground truth: can THIS box create a user namespace and map root inside it?
+# This is exactly what codex's bwrap does. 0 = works, non-zero = restricted.
+probe_userns() {
+  if ! command -v unshare >/dev/null 2>&1; then
+    return 2  # can't probe
+  fi
+  unshare --user --map-root-user true >/dev/null 2>&1
+}
+
+report() {
+  local knob="absent"
+  [[ -r "$SYSCTL_PROC" ]] && knob="$(cat "$SYSCTL_PROC" 2>/dev/null || echo '?')"
+  echo "  ${SYSCTL_KNOB} = ${knob}"
+  if probe_userns; then
+    echo "  userns probe          = OK (codex's sandbox can start here)"
+    return 0
+  else
+    local rc=$?
+    if [[ $rc -eq 2 ]]; then
+      echo "  userns probe          = unknown (\`unshare\` not installed)"
+    else
+      echo "  userns probe          = DENIED (codex's bwrap sandbox will fail)"
+    fi
+    return 1
+  fi
+}
+
+echo "codex Linux sandbox (userns) status on $(hostname -s 2>/dev/null || hostname):"
+if report; then
+  echo "Already good -- codex's sandbox can start. Nothing to change."
+  exit 0
+fi
+
+if [[ $CHECK_ONLY -eq 1 ]]; then
+  echo
+  echo "Restricted. Re-run WITHOUT --check as root to fix:"
+  echo "  sudo bash cli/scripts/enable-codex-sandbox.sh"
+  exit 1
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo
+  echo "error: applying the fix needs root. Re-run:  sudo bash $0" >&2
+  exit 1
+fi
+
+echo
+echo "Applying: ${SYSCTL_KNOB}=0 via ${DROPIN}"
+printf '# Managed by agents-cli enable-codex-sandbox.sh (PHNX-3285).\n# Re-enables unprivileged user namespaces so codex workspace-write sandbox works.\n%s=0\n' \
+  "$SYSCTL_KNOB" > "$DROPIN"
+# Apply now (drop-in makes it persist across reboots).
+sysctl -w "${SYSCTL_KNOB}=0" >/dev/null
+
+echo "Verifying..."
+if report; then
+  echo "Done -- codex's workspace-write sandbox now works on this box."
+  exit 0
+fi
+
+echo >&2
+echo "FAILED: the knob was set but userns is still denied." >&2
+echo "This box may enforce userns via an AppArmor policy the sysctl alone does not lift." >&2
+echo "Inspect: aa-status; and any /etc/apparmor.d profile mediating this binary." >&2
+exit 1

--- a/cli/src/lib/exec-codex-userns.test.ts
+++ b/cli/src/lib/exec-codex-userns.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { codexSandboxPreflight } from './exec.js';
+import type { UsernsStatus } from './linux-userns.js';
+
+const BLOCKED: UsernsStatus = {
+  state: 'blocked',
+  reason: 'the kernel denied creating an unprivileged user namespace (kernel.apparmor_restrict_unprivileged_userns=1)',
+};
+const OK: UsernsStatus = { state: 'ok' };
+
+function base() {
+  return {
+    agent: 'codex' as const,
+    platform: 'linux' as NodeJS.Platform,
+    interactive: false,
+    mode: 'auto' as const,
+    userns: BLOCKED,
+    machine: 'yosemite-m1',
+  };
+}
+
+describe('codexSandboxPreflight', () => {
+  it('blocks a headless codex workspace-write run on a userns-restricted Linux box', () => {
+    const msg = codexSandboxPreflight(base());
+    expect(msg).not.toBeNull();
+    expect(msg).toContain('bwrap: setting up uid map: Permission denied');
+    expect(msg).toContain('yosemite-m1');
+    expect(msg).toContain('PHNX-3285');
+    // Names the sandbox-preserving remediation and the escape hatch.
+    expect(msg).toContain('apparmor_restrict_unprivileged_userns=0');
+    expect(msg).toContain('--mode skip');
+  });
+
+  it('blocks edit and plan too — codex uses bwrap for every sandboxed mode', () => {
+    expect(codexSandboxPreflight({ ...base(), mode: 'edit' })).not.toBeNull();
+    expect(codexSandboxPreflight({ ...base(), mode: 'plan' })).not.toBeNull();
+  });
+
+  it('does NOT block skip mode — codex --dangerously-bypass uses no bwrap', () => {
+    expect(codexSandboxPreflight({ ...base(), mode: 'skip' })).toBeNull();
+  });
+
+  it('does NOT block an interactive run — the TUI surfaces the error itself', () => {
+    expect(codexSandboxPreflight({ ...base(), interactive: true })).toBeNull();
+  });
+
+  it('does NOT block when the box can create a user namespace', () => {
+    expect(codexSandboxPreflight({ ...base(), userns: OK })).toBeNull();
+    expect(codexSandboxPreflight({ ...base(), userns: { state: 'unknown' } })).toBeNull();
+  });
+
+  it('does NOT block non-codex harnesses — only codex ships a userns sandbox', () => {
+    expect(codexSandboxPreflight({ ...base(), agent: 'claude' })).toBeNull();
+    expect(codexSandboxPreflight({ ...base(), agent: 'grok' })).toBeNull();
+    expect(codexSandboxPreflight({ ...base(), agent: 'kimi' })).toBeNull();
+  });
+
+  it('does NOT block on macOS/Windows — no bwrap/userns sandbox there', () => {
+    expect(codexSandboxPreflight({ ...base(), platform: 'darwin' })).toBeNull();
+    expect(codexSandboxPreflight({ ...base(), platform: 'win32' })).toBeNull();
+  });
+});

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -33,6 +33,7 @@ import { isTmuxEnabled, selfConfiguredDeviceRole } from './device-config.js';
 import { machineId } from './machine-id.js';
 import { shellQuote } from './ssh-exec.js';
 import { codexEditWritableRoots, codexPolicyArgs } from './codex-policy.js';
+import { probeUnprivilegedUserns, type UsernsStatus } from './linux-userns.js';
 import { resolveClaudeSetupToken } from './claude-account-token.js';
 import { applyAddDirs } from './add-dir.js';
 import { applyActiveRulesPresetAtRun } from './rules/run-sync.js';
@@ -209,6 +210,55 @@ export function defaultModeFor(agent: AgentId): Mode {
 /** Safe mode used when the user did not provide --mode or a configured default. */
 export function implicitModeFor(agent: AgentId): ExecMode {
   return agent === 'codex' ? 'edit' : 'plan';
+}
+
+/**
+ * Preflight for Codex's Linux sandbox. Codex ≥0.146 sandboxes `read-only` and
+ * `workspace-write` runs with a bundled bubblewrap that needs an unprivileged
+ * user namespace; on a box that restricts it (Ubuntu 24.04
+ * `apparmor_restrict_unprivileged_userns=1`) bwrap dies with "setting up uid map:
+ * Permission denied" and a HEADLESS codex run lands zero tools — no file writes,
+ * no shell — while still reporting a completed turn. That silent under-delivery
+ * is what breaks `agents teams` codex teammates (always headless + workspace-write)
+ * and headless `agents run codex` alike on the fleet. Returns a loud, actionable
+ * message to fail the launch with instead of spawning that doomed run; returns
+ * null when the run is fine to proceed.
+ *
+ * Deliberately scoped: only `codex`, only Linux, only a HEADLESS run (an
+ * interactive TUI surfaces the bwrap error to the operator itself), and only a
+ * SANDBOXED mode — `skip` is codex `--dangerously-bypass-approvals-and-sandbox`,
+ * which uses no bwrap and is unaffected. The intended auto=workspace-write config
+ * is never weakened here; the run fails loud rather than silently downgrading.
+ * PHNX-3285.
+ */
+export function codexSandboxPreflight(args: {
+  agent: AgentId;
+  platform: NodeJS.Platform;
+  interactive: boolean;
+  mode: Mode;
+  userns: UsernsStatus;
+  machine: string;
+}): string | null {
+  if (args.agent !== 'codex') return null;
+  if (args.platform !== 'linux') return null;
+  if (args.interactive) return null;
+  if (args.mode === 'skip') return null;
+  if (args.userns.state !== 'blocked') return null;
+
+  const reason = args.userns.reason ?? 'unprivileged user namespaces are restricted';
+  return (
+    `codex's Linux sandbox can't start on ${args.machine}: ${reason}, so codex's ` +
+    `bundled bubblewrap fails with "bwrap: setting up uid map: Permission denied" ` +
+    `and a headless run lands zero tools. (PHNX-3285)\n` +
+    `\n` +
+    `Enable it once on this box — keeps codex's workspace-write sandbox intact:\n` +
+    `  echo 'kernel.apparmor_restrict_unprivileged_userns=0' | sudo tee /etc/sysctl.d/60-codex-userns.conf\n` +
+    `  sudo sysctl --system\n` +
+    `  # verify: unshare --user --map-root-user true   (exit 0 = fixed)\n` +
+    `(agents-cli ships cli/scripts/enable-codex-sandbox.sh to apply + verify this.)\n` +
+    `\n` +
+    `Or run codex WITHOUT a filesystem sandbox instead: add --mode skip.`
+  );
 }
 
 /** Reasoning effort levels passed to agents that support them. 'auto' defers to the agent's default. */
@@ -1901,6 +1951,28 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
   const timeoutMs = options.timeout ? parseTimeout(options.timeout) : undefined;
   const piped = !process.stdout.isTTY;
   const interactive = resolveInteractive(options);
+
+  // Fail loud before spawning a headless codex whose Linux sandbox can't start —
+  // otherwise it burns a turn and lands zero tools (PHNX-3285). Cheap gate first
+  // so the userns probe (one `unshare`) runs only for the exact case it applies to
+  // (codex + Linux + headless + a sandboxed mode), never for every spawn.
+  if (options.agent === 'codex' && process.platform === 'linux' && !interactive) {
+    const codexMode = options.mode ? normalizeMode(options.mode) : defaultModeFor(options.agent);
+    if (codexMode !== 'skip') {
+      const message = codexSandboxPreflight({
+        agent: options.agent,
+        platform: process.platform,
+        interactive,
+        mode: codexMode,
+        userns: probeUnprivilegedUserns(),
+        machine: machineId(),
+      });
+      if (message) {
+        process.stderr.write(`\x1b[31m${message}\x1b[0m\n`);
+        return { exitCode: 1, stdout: '', stderr: message };
+      }
+    }
+  }
 
   // Budget live kill-switch (issue #346). For headless runs we incrementally
   // parse stream-json usage off stdout, accumulate cost, and kill the child the

--- a/cli/src/lib/linux-userns.test.ts
+++ b/cli/src/lib/linux-userns.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  interpretUsernsInputs,
+  probeUnshare,
+  readApparmorRestrict,
+  probeUnprivilegedUserns,
+  APPARMOR_USERNS_SYSCTL_PATH,
+} from './linux-userns.js';
+
+describe('interpretUsernsInputs', () => {
+  it('non-Linux is always ok (no bwrap/userns sandbox there)', () => {
+    for (const platform of ['darwin', 'win32'] as NodeJS.Platform[]) {
+      expect(
+        interpretUsernsInputs({ platform, apparmorRestrict: '1', unshareProbe: 'denied' }),
+      ).toEqual({ state: 'ok' });
+    }
+  });
+
+  it('a successful probe wins over a restrictive sysctl (a profile may grant userns)', () => {
+    expect(
+      interpretUsernsInputs({ platform: 'linux', apparmorRestrict: '1', unshareProbe: 'ok' }),
+    ).toEqual({ state: 'ok' });
+  });
+
+  it('a denied probe is hard-blocked, and names the AppArmor knob when it is set', () => {
+    const blocked = interpretUsernsInputs({
+      platform: 'linux',
+      apparmorRestrict: '1',
+      unshareProbe: 'denied',
+    });
+    expect(blocked.state).toBe('blocked');
+    expect(blocked.reason).toContain('apparmor_restrict_unprivileged_userns=1');
+  });
+
+  it('a denied probe with the knob off is still blocked (no false "ok")', () => {
+    expect(
+      interpretUsernsInputs({ platform: 'linux', apparmorRestrict: '0', unshareProbe: 'denied' })
+        .state,
+    ).toBe('blocked');
+  });
+
+  it('probe tool missing + knob set => blocked (lean on the sysctl)', () => {
+    expect(
+      interpretUsernsInputs({ platform: 'linux', apparmorRestrict: '1', unshareProbe: 'no-tool' })
+        .state,
+    ).toBe('blocked');
+  });
+
+  it('probe tool missing + knob absent => unknown, never a fabricated ok', () => {
+    expect(
+      interpretUsernsInputs({ platform: 'linux', apparmorRestrict: null, unshareProbe: 'no-tool' })
+        .state,
+    ).toBe('unknown');
+  });
+});
+
+describe('real host probes (no mocks)', () => {
+  it('readApparmorRestrict returns the raw sysctl value or null', () => {
+    const value = readApparmorRestrict();
+    // Either the file is absent (null) or it is a trimmed scalar like "0"/"1".
+    expect(value === null || /^\d+$/.test(value)).toBe(true);
+  });
+
+  it.runIf(process.platform === 'linux')(
+    'probeUnshare observes what THIS kernel actually permits, and agrees with the sysctl',
+    () => {
+      const probe = probeUnshare();
+      expect(['ok', 'denied', 'no-tool']).toContain(probe);
+
+      const restrict = readApparmorRestrict();
+      // When AppArmor restricts unprivileged userns and `unshare` is present, the
+      // probe must observe the denial — this is the exact PHNX-3285 condition and
+      // the whole reason the preflight exists. (Guard on 'no-tool' so a box without
+      // util-linux doesn't fail the assertion.)
+      if (restrict === '1' && probe !== 'no-tool') {
+        expect(probe).toBe('denied');
+      }
+    },
+  );
+
+  it('probeUnprivilegedUserns yields a coherent, cached status', () => {
+    const first = probeUnprivilegedUserns();
+    expect(['ok', 'blocked', 'unknown']).toContain(first.state);
+    // Cached: a second call returns the same object identity on Linux.
+    if (process.platform === 'linux') {
+      expect(probeUnprivilegedUserns()).toBe(first);
+    } else {
+      expect(first).toEqual({ state: 'ok' });
+    }
+  });
+});
+
+describe('constants', () => {
+  it('points at the Ubuntu AppArmor userns knob', () => {
+    expect(APPARMOR_USERNS_SYSCTL_PATH).toBe(
+      '/proc/sys/kernel/apparmor_restrict_unprivileged_userns',
+    );
+  });
+});

--- a/cli/src/lib/linux-userns.ts
+++ b/cli/src/lib/linux-userns.ts
@@ -1,0 +1,157 @@
+/**
+ * Unprivileged user-namespace availability on Linux — the capability Codex's
+ * Linux sandbox needs, and the one Ubuntu 23.10+ restricts by default.
+ *
+ * Codex ≥0.146 implements its `read-only` and `workspace-write` sandbox modes on
+ * Linux with a bundled **bubblewrap** (`bwrap`), extracted per-run to
+ * `$CODEX_HOME/tmp/arg0/codex-XXXX/` and exec'd from a memfd. bwrap sets up its
+ * mounts inside a fresh **unprivileged user namespace** (`--unshare-user`, then a
+ * write to `/proc/self/uid_map`). Ubuntu 24.04 ships
+ * `kernel.apparmor_restrict_unprivileged_userns=1`, which denies that to an
+ * unconfined binary — so bwrap dies with `bwrap: setting up uid map: Permission
+ * denied` and a headless Codex run lands zero tools (no file writes, no shell).
+ * `danger-full-access` (our `skip` mode) drops the sandbox and is the only mode
+ * that avoids bwrap; the legacy Landlock backend is gone (`use_linux_sandbox_bwrap`
+ * is `removed`, `use_legacy_landlock` panics under the permission-profile model).
+ *
+ * This module is the single detector. It is pure at its core
+ * ({@link interpretUsernsInputs}) so the decision is unit-testable without a
+ * shell, and {@link probeUnprivilegedUserns} gathers the real inputs once per
+ * process. See PHNX-3285.
+ */
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+
+/** Path of the AppArmor knob that gates unprivileged userns on Ubuntu 23.10+. */
+export const APPARMOR_USERNS_SYSCTL_PATH =
+  '/proc/sys/kernel/apparmor_restrict_unprivileged_userns';
+
+export type UsernsState =
+  /** A new user namespace with a uid map can be created — Codex's sandbox works. */
+  | 'ok'
+  /** Unprivileged userns is restricted — Codex's bwrap sandbox cannot start. */
+  | 'blocked'
+  /** Could not determine (non-Linux, or the probe could not run). */
+  | 'unknown';
+
+export interface UsernsStatus {
+  state: UsernsState;
+  /** One-line human reason, present when `blocked` or `unknown`. */
+  reason?: string;
+}
+
+/** The raw signals the pure interpreter reasons over. */
+export interface UsernsInputs {
+  platform: NodeJS.Platform;
+  /**
+   * Contents of {@link APPARMOR_USERNS_SYSCTL_PATH} trimmed, or null when the
+   * file is absent (older kernels / no AppArmor userns mediation).
+   */
+  apparmorRestrict: string | null;
+  /**
+   * Result of actually attempting to create a user namespace with a uid map:
+   *   - 'ok'      → the probe created the namespace and mapped root.
+   *   - 'denied'  → the kernel refused the uid_map write (the restricted case).
+   *   - 'no-tool' → the probe binary (`unshare`) was missing or failed to spawn.
+   */
+  unshareProbe: 'ok' | 'denied' | 'no-tool';
+}
+
+/**
+ * Decide userns availability from raw signals. Pure — no I/O.
+ *
+ * The definitive signal is the actual probe: if we successfully created a userns
+ * and wrote a uid map, the sandbox works regardless of the sysctl (an AppArmor
+ * profile may grant a specific binary `userns` even while the global knob is 1).
+ * A denied probe is a hard `blocked`. When the probe tool is missing we fall back
+ * to the sysctl: `1` → `blocked`, `0`/absent → `unknown` (we could not prove it,
+ * and refuse to claim `ok` we did not observe).
+ */
+export function interpretUsernsInputs(inputs: UsernsInputs): UsernsStatus {
+  if (inputs.platform !== 'linux') return { state: 'ok' };
+
+  if (inputs.unshareProbe === 'ok') return { state: 'ok' };
+
+  if (inputs.unshareProbe === 'denied') {
+    const via =
+      inputs.apparmorRestrict === '1'
+        ? ' (kernel.apparmor_restrict_unprivileged_userns=1)'
+        : '';
+    return {
+      state: 'blocked',
+      reason: `the kernel denied creating an unprivileged user namespace${via}`,
+    };
+  }
+
+  // Probe tool unavailable — lean on the AppArmor knob.
+  if (inputs.apparmorRestrict === '1') {
+    return {
+      state: 'blocked',
+      reason:
+        'unprivileged user namespaces are AppArmor-restricted ' +
+        '(kernel.apparmor_restrict_unprivileged_userns=1) and `unshare` was not available to confirm',
+    };
+  }
+  return {
+    state: 'unknown',
+    reason: '`unshare` was not available to probe user-namespace support',
+  };
+}
+
+/** Read the AppArmor userns sysctl, or null when the file is absent. */
+export function readApparmorRestrict(
+  sysctlPath: string = APPARMOR_USERNS_SYSCTL_PATH,
+): string | null {
+  try {
+    return fs.readFileSync(sysctlPath, 'utf8').trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Actually try to create a user namespace and map root inside it — the same
+ * operation bwrap performs (`unshare --user --map-root-user`). This is the ground
+ * truth: it observes exactly what the kernel/AppArmor policy permits for *this*
+ * process, rather than inferring from the sysctl alone.
+ */
+export function probeUnshare(): 'ok' | 'denied' | 'no-tool' {
+  try {
+    execFileSync('unshare', ['--user', '--map-root-user', 'true'], {
+      stdio: 'ignore',
+      timeout: 5000,
+    });
+    return 'ok';
+  } catch (err: unknown) {
+    // ENOENT / spawn failure → the tool isn't here; anything else (nonzero exit
+    // from the denied uid_map write) is the restricted case.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT') return 'no-tool';
+    return 'denied';
+  }
+}
+
+let cached: UsernsStatus | null = null;
+
+/**
+ * Resolve whether an unprivileged user namespace can be created on this host,
+ * cached for the process (the answer is a stable property of the box). Non-Linux
+ * short-circuits to `ok` without spawning anything.
+ */
+export function probeUnprivilegedUserns(
+  platform: NodeJS.Platform = process.platform,
+): UsernsStatus {
+  if (platform !== 'linux') return { state: 'ok' };
+  if (cached) return cached;
+  cached = interpretUsernsInputs({
+    platform,
+    apparmorRestrict: readApparmorRestrict(),
+    unshareProbe: probeUnshare(),
+  });
+  return cached;
+}
+
+/** Test-only: drop the process cache so a test can re-probe. */
+export function resetUsernsCacheForTests(): void {
+  cached = null;
+}


### PR DESCRIPTION
## What & why (PHNX-3285)

`agents teams` codex teammates on the Ubuntu 24.04 fleet failed with `bwrap: setting up uid map: Permission denied` and landed **0 tools**. This PR makes that failure **loud and actionable** instead of a silent under-delivery, and ships a one-time per-box fix that makes codex's sandbox work with its isolation fully intact.

## Confirmed root cause (empirical, on yosemite-m1)

Reproduced deterministically with codex's own `sandbox` subcommand + strace — codex ≥0.146 sandboxes Linux `read-only`/`workspace-write` runs with a **bundled bubblewrap** that creates an unprivileged **user namespace**:

```
$ codex sandbox -c 'sandbox_mode="workspace-write"' -- sh -c 'echo hi > x'
bwrap: setting up uid map: Permission denied

$ strace: codex → ~/.codex/tmp/arg0/codex-XXXX/codex-linux-sandbox
        → bwrap (from /proc/self/fd/3, a memfd) --unshare-user …

$ unshare --user --map-root-user true
unshare: write failed /proc/self/uid_map: Operation not permitted   # same failure, codex-independent
```

Box: Ubuntu 24.04, `kernel.apparmor_restrict_unprivileged_userns=1` (**all reachable Linux fleet boxes = 1**). Only `danger-full-access` skips bwrap.

**Correction to the ticket premise:** headless `agents run codex` does **not** actually work — `agents run codex "<write a file>" --mode auto --headless` in a git repo fails identically (codex emits `Failed to write file … bwrap: setting up uid map: Permission denied`, turn lands 0 tools). The "run works" observation was the interactive TUI. Teams is always headless + workspace-write, so it always fails. **This is a codex-on-Linux issue affecting `run --headless` AND teams, not teams-specific.**

## Options weighed

- **(a) legacy Landlock** — dead on 0.146/0.147: `use_legacy_landlock` panics (`permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock`); `use_linux_sandbox_bwrap` is `removed`. bwrap is the only Linux backend.
- **(b) "make teams use run's launch"** — invalid; run's headless launch fails identically (same exec path).
- **(c) allow unprivileged userns on the box** — the **only** sandbox-preserving fix. One-time root enablement (sysctl / AppArmor). ✅ chosen.

## The fix

1. **Detection** — `cli/src/lib/linux-userns.ts`: a pure interpreter + a cached real probe (`apparmor` sysctl + an actual `unshare --user --map-root-user` uid_map attempt — ground truth, not inference).
2. **Fail-loud preflight** — `codexSandboxPreflight` in `cli/src/lib/exec.ts`, wired into `spawnAgent` (the single spawn path shared by `run` **and** teams). Before spawning a headless sandboxed codex on a userns-blocked box, it fails with the exact one-time remediation + PHNX-3285. Scoped: codex + Linux + headless + non-`skip` only. Interactive TUI, `--mode skip`, macOS/Windows, and every other harness are untouched. The intended `auto`=workspace-write + `approval_policy=never` config is preserved, never downgraded.
3. **Enablement** — `cli/scripts/enable-codex-sandbox.sh`: re-enables unprivileged userns per box (sysctl drop-in, idempotent, **self-verifying** — re-probes to confirm the fix took). Keeps the sandbox intact. `sudo bash cli/scripts/enable-codex-sandbox.sh`, or fan out with `agents ssh <box> 'sudo bash -s' < cli/scripts/enable-codex-sandbox.sh`.

## Evidence

**Before** (installed CLI): codex spawns, burns a 105k-token turn, writes nothing:
```
{"type":"item.completed","item":{"type":"file_change",...,"status":"failed"}}
ERROR codex_core::tools::router: error=Exit code: 1 … Failed to write file /tmp/codex-run-test/proof.txt
{"item":{"type":"agent_message","text":"Unable to create `proof.txt`: … bwrap: setting up uid map: Permission denied."}}
```

**After** (this branch's built CLI) — fails loud before spawning codex, no wasted turn:
```
$ node dist/index.js run codex "Create proof.txt…" --mode auto --headless
[agents] running codex@0.147.0
codex's Linux sandbox can't start on yosemite-m1: the kernel denied creating an unprivileged
user namespace (kernel.apparmor_restrict_unprivileged_userns=1) … (PHNX-3285)
  echo 'kernel.apparmor_restrict_unprivileged_userns=0' | sudo tee /etc/sysctl.d/60-codex-userns.conf
  sudo sysctl --system
Or run codex WITHOUT a filesystem sandbox instead: add --mode skip.
# exit != 0, proof.txt NOT created
```

`enable-codex-sandbox.sh --check` on this box:
```
kernel.apparmor_restrict_unprivileged_userns = 1
userns probe          = DENIED (codex's bwrap sandbox will fail)
```

> Note: applying the sysctl (making a codex teammate reach >0 tools) needs a one-time root step; `sudo` is not available from this agent shell, and every reachable Linux fleet box currently restricts userns, so the >0-tools run is demonstrated after an operator runs the enablement script once per box. The fail-loud path and the detector are verified end-to-end above.

## Harness parity

Only codex ships a userns/bwrap sandbox. grok/kimi/cursor installs carry no bwrap/`unshare` in any executable path (only doc/skill markdown mentions), so they don't hit this wall; the ticket's grok/kimi headless under-delivery is a separate reliability issue, out of scope here.

## Tests (real, no mocks)

- `linux-userns.test.ts` — pure interpreter across every branch + a **real** `unshare` probe on the host that asserts the probe agrees with the live apparmor sysctl.
- `exec-codex-userns.test.ts` — every gate of `codexSandboxPreflight` (mode/interactive/agent/platform/state).
- Full `exec.test.ts` + `__tests__/exec.test.ts` still green (373 tests). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
