### PR TITLE
fix(ci-scope): rename-aware impact analysis — a pure git mv selects nothing (PHNX-3200)

### DIFF
--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -23,6 +23,7 @@ import {
   formatGitHubOutputs,
   loadOwnershipManifest,
   matchGlob,
+  parseRenameAwareNameStatus,
   planIsFailing,
   proofFromPlan,
   relatedTestFiles,
@@ -496,6 +497,83 @@ describe('selectImpact policy', () => {
   });
 });
 
+describe('rename-aware changed files (PHNX-3200)', () => {
+  test('parseRenameAwareNameStatus: R100 selects nothing; edited rename + copy select the new path', () => {
+    const z = [
+      'R100', 'cli/src/old.ts', 'cli/lib/old.ts', // pure move -> nothing
+      'M', 'cli/src/b.ts', // modified -> b
+      'R080', 'cli/src/c.ts', 'cli/lib/c.ts', // rename with edits -> new path
+      'A', 'cli/src/d.ts', // added -> d
+      'D', 'cli/src/e.ts', // deleted -> e (consumer exempts it from zero-selection)
+      'C100', 'cli/src/f.ts', 'cli/src/f-copy.ts', // copy -> the new path
+      '',
+    ].join('\0');
+    // Emitted in source order; the R100 move contributes nothing.
+    expect(parseRenameAwareNameStatus(z)).toEqual([
+      'cli/src/b.ts',
+      'cli/lib/c.ts',
+      'cli/src/d.ts',
+      'cli/src/e.ts',
+      'cli/src/f-copy.ts',
+    ]);
+  });
+
+  function initRenameHistory(
+    setup: (repo: string) => void,
+    mutate: (repo: string) => void,
+  ): { repo: string; base: string; head: string } {
+    const dir = mkdtempSync(join(tmpdir(), 'agents-ci-rename-'));
+    const repo = join(dir, 'repo');
+    mkdirSync(repo);
+    git(repo, 'init', '-b', 'main');
+    setup(repo);
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-m', 'base');
+    const base = git(repo, 'rev-parse', 'HEAD');
+    mutate(repo);
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-m', 'head');
+    const head = git(repo, 'rev-parse', 'HEAD');
+    return { repo, base, head };
+  }
+
+  test('a pure git mv is moved-not-changed: it selects neither the old nor the new path', () => {
+    const { repo, base, head } = initRenameHistory(
+      (r) => writeFixture(r, 'cli/src/foo.ts', 'export const foo = 1;\n'),
+      (r) => {
+        mkdirSync(join(r, 'cli/lib'), { recursive: true });
+        renameSync(join(r, 'cli/src/foo.ts'), join(r, 'cli/lib/foo.ts'));
+      },
+    );
+    try {
+      const changed = changedFilesBetween(base, head, repo);
+      expect(changed).not.toContain('cli/src/foo.ts');
+      expect(changed).not.toContain('cli/lib/foo.ts');
+      expect(changed).toEqual([]);
+    } finally {
+      rmSync(dirname(repo), { recursive: true, force: true });
+    }
+  });
+
+  test('a rename WITH an edit selects the new path (content changed there)', () => {
+    const { repo, base, head } = initRenameHistory(
+      (r) => writeFixture(r, 'cli/src/foo.ts', 'a\nb\nc\nd\ne\nf\ng\nh\n'),
+      (r) => {
+        mkdirSync(join(r, 'cli/lib'), { recursive: true });
+        renameSync(join(r, 'cli/src/foo.ts'), join(r, 'cli/lib/foo.ts'));
+        writeFileSync(join(r, 'cli/lib/foo.ts'), 'a\nb\nc\nCHANGED\ne\nf\ng\nh\n');
+      },
+    );
+    try {
+      const changed = changedFilesBetween(base, head, repo);
+      expect(changed).toContain('cli/lib/foo.ts');
+      expect(changed).not.toContain('cli/src/foo.ts');
+    } finally {
+      rmSync(dirname(repo), { recursive: true, force: true });
+    }
+  });
+});
+
 describe('metadata-class diffs stop selecting the full suite (RUSH-2666)', () => {
   function initPackageJsonHistory(before: object, after: object): { repo: string; base: string; head: string } {
     const dir = mkdtempSync(join(tmpdir(), 'agents-ci-pkg-'));
@@ -820,7 +898,12 @@ test('changedFilesBetween ignores changes made only on the updated base branch',
   }
 });
 
-test('changedFilesBetween keeps both sides of a cross-component rename', () => {
+test('changedFilesBetween treats a pure cross-component move as moved-not-changed (PHNX-3200)', () => {
+  // Was: `--no-renames` reported this as a delete of the old path PLUS an add of
+  // the new one, so a pure move read as two changed files (and the #3033 flatten
+  // of ~2100 files read as ~2100 changes → suite=cli-full). Rename-aware, a
+  // 100%-similarity move selects nothing: the content is unchanged, and any
+  // importer whose path broke shows up as its own content change.
   const repo = mkdtempSync(join(tmpdir(), 'agents-ci-rename-'));
   try {
     git(repo, 'init', '-b', 'main');
@@ -838,8 +921,7 @@ test('changedFilesBetween keeps both sides of a cross-component rename', () => {
     const head = git(repo, 'rev-parse', 'HEAD');
 
     const files = changedFilesBetween(base, head, repo);
-    expect(files.sort()).toEqual([oldPath, newPath].sort());
-    expect(classifyCiScope(files, REPO)).toMatchObject({ cli: true, windows: false });
+    expect(files).toEqual([]);
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }

--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -23,7 +24,7 @@ import {
   formatGitHubOutputs,
   loadOwnershipManifest,
   matchGlob,
-  parseRenameAwareNameStatus,
+  parseRenameAwareRawDiff,
   planIsFailing,
   proofFromPlan,
   relatedTestFiles,
@@ -498,23 +499,24 @@ describe('selectImpact policy', () => {
 });
 
 describe('rename-aware changed files (PHNX-3200)', () => {
-  test('parseRenameAwareNameStatus: R100 selects nothing; edited rename + copy select the new path', () => {
+  test('parseRenameAwareRawDiff: a same-mode R100 selects nothing; edits and a mode flip select the new path', () => {
+    // `git diff --raw -z` records: ":<oldmode> <newmode> <oldsha> <newsha> <status>" then path(s).
     const z = [
-      'R100', 'cli/src/old.ts', 'cli/lib/old.ts', // pure move -> nothing
-      'M', 'cli/src/b.ts', // modified -> b
-      'R080', 'cli/src/c.ts', 'cli/lib/c.ts', // rename with edits -> new path
-      'A', 'cli/src/d.ts', // added -> d
-      'D', 'cli/src/e.ts', // deleted -> e (consumer exempts it from zero-selection)
-      'C100', 'cli/src/f.ts', 'cli/src/f-copy.ts', // copy -> the new path
+      ':100644 100644 aaa bbb R100', 'cli/src/old.ts', 'cli/lib/old.ts', // pure move, same mode -> nothing
+      ':100644 100644 aaa bbb M', 'cli/src/b.ts', // modified -> b
+      ':100644 100644 aaa bbb R080', 'cli/src/c.ts', 'cli/lib/c.ts', // rename with edits -> new
+      ':000000 100644 000 ddd A', 'cli/src/d.ts', // added -> d
+      ':100644 000000 eee 000 D', 'cli/src/e.ts', // deleted -> e (consumer exempts from zero-selection)
+      ':100644 100755 fff ggg R100', 'cli/scripts/g.sh', 'cli/lib/g.sh', // move + chmod +x: R100 by content, mode flipped -> new
       '',
     ].join('\0');
-    // Emitted in source order; the R100 move contributes nothing.
-    expect(parseRenameAwareNameStatus(z)).toEqual([
+    // Source order; the same-mode R100 move contributes nothing, the +x move does.
+    expect(parseRenameAwareRawDiff(z)).toEqual([
       'cli/src/b.ts',
       'cli/lib/c.ts',
       'cli/src/d.ts',
       'cli/src/e.ts',
-      'cli/src/f-copy.ts',
+      'cli/lib/g.sh',
     ]);
   });
 
@@ -550,6 +552,26 @@ describe('rename-aware changed files (PHNX-3200)', () => {
       expect(changed).not.toContain('cli/src/foo.ts');
       expect(changed).not.toContain('cli/lib/foo.ts');
       expect(changed).toEqual([]);
+    } finally {
+      rmSync(dirname(repo), { recursive: true, force: true });
+    }
+  });
+
+  test('a rename that also flips the executable bit selects the new path (R100 by content, mode changed)', () => {
+    // git reports this as R100 (content identical), but chmod +x is a real change
+    // to a script the repo runs directly -- --name-status would have hidden it.
+    const { repo, base, head } = initRenameHistory(
+      (r) => writeFixture(r, 'cli/scripts/tool.sh', '#!/usr/bin/env bash\necho hi\n'),
+      (r) => {
+        mkdirSync(join(r, 'cli/lib'), { recursive: true });
+        renameSync(join(r, 'cli/scripts/tool.sh'), join(r, 'cli/lib/tool.sh'));
+        chmodSync(join(r, 'cli/lib/tool.sh'), 0o755);
+      },
+    );
+    try {
+      const changed = changedFilesBetween(base, head, repo);
+      expect(changed).toContain('cli/lib/tool.sh');
+      expect(changed).not.toContain('cli/scripts/tool.sh');
     } finally {
       rmSync(dirname(repo), { recursive: true, force: true });
     }

--- a/scripts/ci-scope.ts
+++ b/scripts/ci-scope.ts
@@ -239,32 +239,39 @@ export function classifyPackageJsonChange(
 // as an add of the new path PLUS a delete of the old one, so a pure structural
 // move (the #3033 flatten renamed ~2100 files 100%) read as ~2100 *changed* files
 // — selecting suite=cli-full and tripping zero-selection on every moved source
-// that carried no test at its new path. Reading rename-aware `--name-status`
-// instead, a 100%-similarity `R` pair is a move, not a change: it selects nothing.
-// A rename WITH edits (similarity < 100) changed content at the new path, so the
-// new path is selected; a copy introduces new content at its destination, so it
-// is selected too.
-export function parseRenameAwareNameStatus(z: string): string[] {
+// that carried no test at its new path. A 100%-similarity move is not a change,
+// so it should select nothing.
+//
+// Parses `git diff --raw -z` (NOT `--name-status`): the raw metadata carries the
+// old and new file MODE, which `--name-status` hides. A `git mv foo.sh bar.sh &&
+// chmod +x bar.sh` is `R100` by content-similarity but flips the executable bit
+// — a real change to a script this repo runs directly. So the destination is
+// selected whenever content changed (similarity < 100) OR the mode changed, and
+// only a truly identical move (same content AND same mode) selects nothing.
+export function parseRenameAwareRawDiff(z: string): string[] {
   const tokens = z.split('\0');
   const out: string[] = [];
   let i = 0;
   while (i < tokens.length) {
-    const status = tokens[i];
-    if (!status) {
+    const meta = tokens[i];
+    // Each record's metadata is one field: ":<oldmode> <newmode> <oldsha> <newsha> <status>".
+    if (!meta || meta[0] !== ':') {
       i++;
       continue;
     }
+    const parts = meta.slice(1).split(' ');
+    const oldMode = parts[0];
+    const newMode = parts[1];
+    const status = parts[4] ?? '';
     const code = status[0];
     if (code === 'R' || code === 'C') {
-      // `R<score>\0<old>\0<new>` — a rename/copy consumes three fields.
+      // A rename/copy carries two paths: `<meta>\0<old>\0<new>`.
       const score = Number.parseInt(status.slice(1), 10);
       const to = tokens[i + 2];
       i += 3;
-      // A pure move (100%) changed no content — select nothing for the pair. A
-      // copy (C) or a rename-with-edits (score < 100) changed content at `to`.
-      if (to && (code === 'C' || !(score === 100))) out.push(to);
+      if (to && (score < 100 || oldMode !== newMode)) out.push(to);
     } else {
-      // A / M / D / T: `<status>\0<path>`.
+      // A / M / D / T carry one path: `<meta>\0<path>`.
       const path = tokens[i + 1];
       i += 2;
       if (path) out.push(path);
@@ -281,9 +288,11 @@ export function changedFilesBetween(base: string, head: string, cwd = process.cw
       // Rename-aware: git pairs an add+delete it recognizes (default 50%
       // similarity) as a single `R<score>` entry, so a structural move stops
       // reading as two changed files. Sub-threshold moves stay add+delete, which
-      // is correct — they really did change.
+      // is correct — they really did change. `--raw` (not `--name-status`) is
+      // what carries the per-file mode, so a rename that also flips +x is not
+      // mistaken for a no-op move.
+      '--raw',
       '--find-renames',
-      '--name-status',
       '--diff-filter=ACMRTD',
       '-z',
       `${base}...${head}`,
@@ -295,7 +304,7 @@ export function changedFilesBetween(base: string, head: string, cwd = process.cw
   if (proc.exitCode !== 0) {
     throw new Error(Buffer.from(proc.stderr).toString('utf8').trim());
   }
-  return parseRenameAwareNameStatus(Buffer.from(proc.stdout).toString('utf8'));
+  return parseRenameAwareRawDiff(Buffer.from(proc.stdout).toString('utf8'));
 }
 
 export function trackedFiles(cwd: string): string[] {

--- a/scripts/ci-scope.ts
+++ b/scripts/ci-scope.ts
@@ -235,14 +235,56 @@ export function classifyPackageJsonChange(
   }
 }
 
+// Rename-aware changed-file parse (PHNX-3200). `--no-renames` reported a `git mv`
+// as an add of the new path PLUS a delete of the old one, so a pure structural
+// move (the #3033 flatten renamed ~2100 files 100%) read as ~2100 *changed* files
+// — selecting suite=cli-full and tripping zero-selection on every moved source
+// that carried no test at its new path. Reading rename-aware `--name-status`
+// instead, a 100%-similarity `R` pair is a move, not a change: it selects nothing.
+// A rename WITH edits (similarity < 100) changed content at the new path, so the
+// new path is selected; a copy introduces new content at its destination, so it
+// is selected too.
+export function parseRenameAwareNameStatus(z: string): string[] {
+  const tokens = z.split('\0');
+  const out: string[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const status = tokens[i];
+    if (!status) {
+      i++;
+      continue;
+    }
+    const code = status[0];
+    if (code === 'R' || code === 'C') {
+      // `R<score>\0<old>\0<new>` — a rename/copy consumes three fields.
+      const score = Number.parseInt(status.slice(1), 10);
+      const to = tokens[i + 2];
+      i += 3;
+      // A pure move (100%) changed no content — select nothing for the pair. A
+      // copy (C) or a rename-with-edits (score < 100) changed content at `to`.
+      if (to && (code === 'C' || !(score === 100))) out.push(to);
+    } else {
+      // A / M / D / T: `<status>\0<path>`.
+      const path = tokens[i + 1];
+      i += 2;
+      if (path) out.push(path);
+    }
+  }
+  return out;
+}
+
 export function changedFilesBetween(base: string, head: string, cwd = process.cwd()): string[] {
   const proc = Bun.spawnSync({
     cmd: [
       'git',
       'diff',
-      '--name-only',
-      '--no-renames',
-      '--diff-filter=ACMRD',
+      // Rename-aware: git pairs an add+delete it recognizes (default 50%
+      // similarity) as a single `R<score>` entry, so a structural move stops
+      // reading as two changed files. Sub-threshold moves stay add+delete, which
+      // is correct — they really did change.
+      '--find-renames',
+      '--name-status',
+      '--diff-filter=ACMRTD',
       '-z',
       `${base}...${head}`,
     ],
@@ -253,7 +295,7 @@ export function changedFilesBetween(base: string, head: string, cwd = process.cw
   if (proc.exitCode !== 0) {
     throw new Error(Buffer.from(proc.stderr).toString('utf8').trim());
   }
-  return Buffer.from(proc.stdout).toString('utf8').split('\0').filter(Boolean);
+  return parseRenameAwareNameStatus(Buffer.from(proc.stdout).toString('utf8'));
 }
 
 export function trackedFiles(cwd: string): string[] {


### PR DESCRIPTION
## What

`changedFilesBetween` read `git diff --name-only --no-renames`, so a `git mv` reported an **add** of the new path **plus** a **delete** of the old one. A pure structural move read as two changed files.

## Why it matters

Surfaced by the flatten PR (#3033): a 100% rename of the whole tree classified ~2100 files as changed → `suite=cli-full`, and tripped zero-selection for every moved source that carried no test at its new path (19 per-file testless exemptions were added there as a workaround).

## Fix

Read rename-aware `git diff --find-renames --name-status` and parse it (`parseRenameAwareNameStatus`, a pure unit-tested function):

- **R100** (pure move) → selects **nothing** for the pair. The content is unchanged; any importer whose path broke shows up as its own content change (M) and is selected.
- **R<100** (rename with edits) → selects the **new** path (content changed there).
- **C** (copy) → selects the destination (new content).
- **A / M / D / T** → unchanged from before.

This keeps the 90s-P99 doctrine honest for structural refactors, and the 19 per-file testless exemptions from #3033 can now be revisited (left for a follow-up).

## Verification

```
$ bun test scripts/ci-scope.test.ts
 65 pass · 0 fail    # 3 new (pure-parser table; real-repo pure-mv → []; rename+edit → new path)
                     # updated the prior test that pinned the old --no-renames both-sides behavior
$ bun scripts/ci-scope.ts --base origin/main --head HEAD --fail-unmapped
unmapped=false · selects only ci-scope's own test + impact-policy checks (dogfooded)
```

`scripts/ci-scope.ts` is repo-root CI tooling (not shipped in the npm package), so no CHANGELOG fragment. Refs PHNX-3200.