### PR TITLE
test(artifacts): pin the share subtree list to include `visibility`

### DIFF
--- a/cli/src/commands/artifacts.test.ts
+++ b/cli/src/commands/artifacts.test.ts
@@ -36,7 +36,7 @@ describe('agents artifacts group', () => {
     // The publish command still takes the file positionally.
     expect(share?.registeredArguments.map((a) => a.name())).toEqual(['file']);
     expect(share?.commands.map((c) => c.name()).sort()).toEqual(
-      ['analytics', 'delete', 'edit', 'join', 'list', 'revisions', 'status', 'update'],
+      ['analytics', 'delete', 'edit', 'join', 'list', 'revisions', 'status', 'update', 'visibility'],
     );
   });
 


### PR DESCRIPTION
## Why

`artifacts.test.ts` → *"nests the whole share subtree under \`artifacts share\`"* asserts the exact sorted list of `share` subcommands. `agents artifacts share visibility <target> <level>` shipped as a real subcommand — it re-scopes an already-published page in place through the same PATCH metadata-edit route as `share edit` — but the test still asserted the pre-`visibility` list. So the assertion failed on `main` and blocked **every** CI run in the repo.

## What

Add `visibility` to the expected list:

```
['analytics', 'delete', 'edit', 'join', 'list', 'revisions', 'status', 'update']
→ ['analytics', 'delete', 'edit', 'join', 'list', 'revisions', 'status', 'update', 'visibility']
```

Test-only; the command itself is unchanged and already correct.

## Evidence

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
   Duration  3.12s
```

Before: `expected [ …, 'update' ] to deeply equal [ …, 'update', 'visibility' ]` — suite failed to the point of blocking impact-scoped CI on unrelated PRs.