### PR TITLE
test(cli): fix red main — root-help assertions vs the new front-door help

### DIFF
--- a/cli/tests/bare-invocation.test.ts
+++ b/cli/tests/bare-invocation.test.ts
@@ -30,7 +30,7 @@ describe('bare `agents` invocation', () => {
       encoding: 'utf-8',
     });
 
-    expect(result.stdout).toContain('Usage: agents [command] [options]');
+    expect(result.stdout).toContain('Usage: agents [options] [command]');
     expect(result.stdout).toContain('Quick start:');
     expect(result.status).toBe(0);
   });

--- a/cli/tests/prune-command.test.ts
+++ b/cli/tests/prune-command.test.ts
@@ -18,14 +18,15 @@ function runCli(args: string[]): string {
 }
 
 describe('prune command', () => {
-  it('surfaces prune in top-level help', () => {
-    const helpText = runCli(['--help']);
+  it('surfaces prune in the complete help, pointed to from the curated root help', () => {
+    // The root --help is a curated front-door list; it points to --help-all for the
+    // full command set, where prune (a non-front-door command) is listed.
+    const rootHelp = runCli(['--help']);
+    expect(rootHelp).toContain('--help-all');
 
-    expect(helpText).toContain('prune <agent>[@version]');
-    expect(helpText).toContain('Uninstall a version');
-    expect(helpText).toContain('remove <agent>[@version]');
-    expect(helpText).toContain('Alias for prune');
-    expect(helpText).toContain('prune cleanup [target]');
+    const helpText = runCli(['--help-all']);
+    expect(helpText).toContain('prune [options] <specs...>');
+    expect(helpText).toContain('Uninstall agent CLI versions');
   });
 
   it('shows dedicated help for version prune', () => {


### PR DESCRIPTION
## main is RED on the full release suite — this fixes it

The attestation producer (full suite) refuses to attest `origin/main` because two integration tests fail, which **blocks every release for the whole team** (the required PR check is impact-scoped and never ran these full-suite tests). Root cause: the deliberate root-help redesign PRs (`654eb97ff` "surface front-door groups in root help and add --help-all", `f8be03e35` "use cmd.name()") changed the root help, but two integration tests still asserted the old strings.

## Fix (test-only)
- `tests/bare-invocation.test.ts`: Usage line is now commander-default `agents [options] [command]` (was `[command] [options]`).
- `tests/prune-command.test.ts`: prune is a non-front-door command, now under `--help-all` (`prune [options] <specs...>`, "Uninstall agent CLI versions"); the curated root `--help` carries the `--help-all` pointer. Updated block 1 to assert the new surface; the 4 dedicated subcommand-help blocks were already passing.

Reconciles the tests with the **shipped** behaviour (verified by running the actual CLI help). 6/6 in both files green; test-only so CHANGELOG/docs exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)