### PR TITLE
feat(ci): PHNX-3033 guard public artifacts against confidential strategy leaks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Optional fast first-line guard against committing confidential strategy
+# content to the public .agents/artifacts/ tree (PHNX-3033).
+#
+# This hook is NOT the enforcement — the CI check in .github/workflows/tests.yml
+# is. To enable locally:
+#
+#   git config core.hooksPath .githooks
+#
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+git -C "$ROOT" diff --cached --name-only --diff-filter=ACMRT \
+  | bun "$ROOT/scripts/guard-artifacts-confidential.ts"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Guard public artifacts against confidential strategy leaks
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bun scripts/guard-artifacts-confidential.ts --base "$BASE_SHA" --head "$HEAD_SHA"
       - name: Pin release-matrix trigger policy, .agents/ layout, and the impact gate
         run: bun test ./.github/workflows/ ./scripts/ci-bench/
       - name: Impact plan

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,14 @@ built from messages or an address book — anonymizing it would destroy it. Put 
 `.agents/artifacts/private/`, which `.gitignore` excludes, and keep it in the repo so the
 work stays with the project instead of drifting into `/tmp` or a home directory.
 
+**Confidential GTM, monetization, pricing, revenue, and competitor material never lands in
+public artifacts.** Files whose names or content signal go-to-market strategy, pricing
+models, revenue/ARR/MRR/churn figures, launch venues, GitHub stars playbooks, or competitor
+intelligence belong in `.agents/artifacts/private/` or a private repo — never in the
+committed `.agents/artifacts/<yyyy-mm-dd>/` tree. The required Linux PR check runs
+`scripts/guard-artifacts-confidential.ts` and fails loud with the offending paths and the
+right home if one is staged.
+
 ## Conventions (repo-wide)
 
 - **`AGENTS.md` is the canonical memory file.** `CLAUDE.md` / `GEMINI.md` are symlinks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **CI guard blocks confidential GTM/monetization content from public `.agents/artifacts/` (PHNX-3033).** The required Linux PR check now runs `scripts/guard-artifacts-confidential.ts`, which fails loud when a staged file under `.agents/artifacts/<yyyy-mm-dd>/` (not the gitignored `.agents/artifacts/private/`) matches sensitive-strategy filename or content signals — GTM, monetization, pricing models, revenue/ARR/MRR/churn figures, launch venues, stars playbooks, or competitor intel. The error points authors to `.agents/artifacts/private/` or a private repo. Source: `scripts/guard-artifacts-confidential.ts`, `scripts/guard-artifacts-confidential.test.ts`, `.github/workflows/tests.yml`.
+
 - **`agents monitors add` refuses immediately when a reachable peer already has the same watcher (PHNX-3299).** The fleet duplicate guard used to collect every peer before reporting a clash, so a single slow box forced the full 12-second timeout even when another peer had already answered with the same fingerprint. The fan-out now aborts remaining SSH captures the moment a peer reports a matching monitor, while the no-match path still waits for the whole fleet so uniqueness can be proved. Source: `cli/src/commands/monitors.ts`, `cli/src/lib/monitors/remote.ts`.
 - **A bare `agents browser start` no longer auto-detects and silently creates a
   logged-out `auto-chrome` profile — the default browser is now a choice you make

--- a/cli/ci/test-ownership.yaml
+++ b/cli/ci/test-ownership.yaml
@@ -226,9 +226,12 @@ groups:
       - scripts/ci-scope.test.ts
       - scripts/ci-impact-bench.ts
       - scripts/ci-bench/**
+      - scripts/guard-artifacts-confidential.ts
+      - scripts/guard-artifacts-confidential.test.ts
       - cli/ci/test-ownership.yaml
       - .github/workflows/tests.yml
       - .github/workflows/tests-gate.test.ts
+      - .githooks/pre-commit
     checks: [impact-tests, workflow-policy]
 
   - id: session-tracker

--- a/scripts/guard-artifacts-confidential.test.ts
+++ b/scripts/guard-artifacts-confidential.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  checkContent,
+  checkFilename,
+  formatError,
+  inspectFiles,
+  isUnderPublicArtifacts,
+} from './guard-artifacts-confidential';
+
+function git(cwd: string, ...args: string[]): string {
+  const proc = Bun.spawnSync({
+    cmd: ['git', ...args],
+    cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_EMAIL: 'guard-test@example.invalid',
+      GIT_AUTHOR_NAME: 'Guard Test',
+      GIT_COMMITTER_EMAIL: 'guard-test@example.invalid',
+      GIT_COMMITTER_NAME: 'Guard Test',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (proc.exitCode !== 0) {
+    throw new Error(Buffer.from(proc.stderr).toString('utf8'));
+  }
+  return Buffer.from(proc.stdout).toString('utf8').trim();
+}
+
+function writeFixture(root: string, file: string, body: string): void {
+  const target = join(root, file);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, body);
+}
+
+describe('isUnderPublicArtifacts', () => {
+  test.each([
+    ['.agents/artifacts/2026-08-27/plan.md', true],
+    ['.agents/artifacts/2026-08-27/gtm-strategy.md', true],
+    ['.agents/artifacts/private/2026-08-27/gtm-strategy.md', false],
+    ['.agents/worktrees/foo/plan.md', false],
+    ['scripts/guard-artifacts-confidential.ts', false],
+  ])('%s -> %s', (file, expected) => {
+    expect(isUnderPublicArtifacts(file)).toBe(expected);
+  });
+});
+
+describe('checkFilename', () => {
+  test.each([
+    ['gtm-strategy.md', true],
+    ['monetization-plan.md', true],
+    ['pricing-model-comparison.md', true],
+    ['revenue-forecast.md', true],
+    ['launch-venues.md', true],
+    ['github-stars-playbook.md', true],
+    ['competitor-intel.md', true],
+    ['go-to-market-plan.md', true],
+    ['arr-targets.md', true],
+    ['mrr-goals.md', true],
+    ['churn-analysis.md', true],
+    ['plan-architecture.md', false],
+    ['report-sessions-bug.md', false],
+    ['dataviz-token-usage.svg', false],
+    ['array-buffer-fix.md', false], // "arr" inside a word must not match
+  ])('%s filename flagged? %s', (name, flagged) => {
+    const result = checkFilename(name);
+    if (flagged) {
+      expect(result).not.toBeNull();
+    } else {
+      expect(result).toBeNull();
+    }
+  });
+});
+
+describe('checkContent', () => {
+  test('flags explicit strategy phrases', () => {
+    expect(checkContent('Our GTM motion targets indie hackers.')).toMatch(/GTM/);
+    expect(checkContent('Monetization strategy: usage-based tiers.')).toMatch(/monetization/);
+    expect(checkContent('Pricing tier breakdown for teams.')).toMatch(/pricing tier/);
+    expect(checkContent('Go-to-market plan for Q3.')).toMatch(/go-to-market/);
+  });
+
+  test('flags competitor intelligence phrases', () => {
+    expect(checkContent('Competitor intel shows Cursor charges $20/mo.')).toMatch(/competitor intel/);
+    expect(checkContent('Competitive intelligence on OpenCode pricing.')).toMatch(/competitive intelligence/);
+  });
+
+  test('flags dollar figures next to strategy words', () => {
+    expect(checkContent('We project $1.2M ARR by year end.')).toMatch(/dollar figure/);
+    expect(checkContent('MRR is currently $50k and churn is 2%.')).toMatch(/dollar figure/);
+    expect(checkContent('Pricing starts at $10/seat for the team tier.')).toMatch(/dollar figure/);
+  });
+
+  test('does not flag engineering artifacts without strategy markers', () => {
+    expect(checkContent('This dataviz shows token usage across workers.')).toBeNull();
+    expect(checkContent('The array buffer grew to $0 because the test freed it.')).toBeNull();
+    expect(checkContent('Refactor churn-test helper to use shared fixtures.')).toBeNull();
+  });
+
+  test('does not flag isolated dollar figures or isolated strategy words', () => {
+    expect(checkContent('The benchmark cost $0.00 to run.')).toBeNull();
+    expect(checkContent('We discussed revenue in the abstract.')).toBeNull();
+  });
+});
+
+describe('inspectFiles', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'guard-artifacts-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('reproduces the leak: sensitive file under public artifacts fails', () => {
+    const files = ['.agents/artifacts/2026-08-27/gtm-strategy.md'];
+    writeFixture(tmp, files[0]!, '# GTM strategy\n\nTarget indie hackers.');
+    const violations = inspectFiles(tmp, files);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.file).toBe(files[0]);
+    expect(violations[0]!.reason).toBe('filename');
+  });
+
+  test('reproduces the leak: content-only strategy with dollar figure fails', () => {
+    const files = ['.agents/artifacts/2026-08-27/q3-plan.md'];
+    writeFixture(tmp, files[0]!, 'We project $1.2M ARR by year end.');
+    const violations = inspectFiles(tmp, files);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.reason).toBe('content');
+  });
+
+  test('legitimate engineering artifact passes', () => {
+    const files = ['.agents/artifacts/2026-08-27/plan-ci-release-near-instant.md'];
+    writeFixture(tmp, files[0]!, '# CI release latency plan\n\nKeep the required PR gate under 90s.');
+    const violations = inspectFiles(tmp, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  test('dataviz / report artifact passes without strategy markers', () => {
+    const files = [
+      '.agents/artifacts/2026-08-27/sessions-dataviz.svg',
+      '.agents/artifacts/2026-08-27/report-usage.md',
+    ];
+    writeFixture(tmp, files[0]!, '<svg><text>sessions active over time</text></svg>');
+    writeFixture(tmp, files[1]!, '# Usage report\n\nMedian token burn per session.');
+    const violations = inspectFiles(tmp, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  test('sensitive file under private/ passes', () => {
+    const files = ['.agents/artifacts/private/2026-08-27/gtm-strategy.md'];
+    writeFixture(tmp, files[0]!, '# Secret GTM strategy\n\n$1.2M ARR target.');
+    const violations = inspectFiles(tmp, files);
+    expect(violations).toHaveLength(0);
+  });
+});
+
+describe('end-to-end git diff guard', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'guard-artifacts-repo-'));
+    git(tmp, 'init', '--quiet');
+    git(tmp, 'config', 'user.email', 'guard-test@example.invalid');
+    git(tmp, 'config', 'user.name', 'Guard Test');
+    // Initial commit on main.
+    writeFixture(tmp, 'README.md', '# repo\n');
+    git(tmp, 'add', '.');
+    git(tmp, 'commit', '--quiet', '-m', 'init');
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('CLI run catches a leak in base..head range', () => {
+    const base = git(tmp, 'rev-parse', 'HEAD');
+    writeFixture(tmp, '.agents/artifacts/2026-08-27/gtm-strategy.md', '# GTM\n');
+    git(tmp, 'add', '.');
+    git(tmp, 'commit', '--quiet', '-m', 'leak');
+    const head = git(tmp, 'rev-parse', 'HEAD');
+
+    const proc = Bun.spawnSync({
+      cmd: ['bun', join(import.meta.dir, 'guard-artifacts-confidential.ts'), '--base', base, '--head', head, '--repo-root', tmp],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(proc.exitCode).toBe(1);
+    const stderr = Buffer.from(proc.stderr).toString('utf8');
+    expect(stderr).toContain('gtm-strategy.md');
+    expect(stderr).toContain('.agents/artifacts/private/');
+  });
+
+  test('CLI run passes for a legit artifact in base..head range', () => {
+    const base = git(tmp, 'rev-parse', 'HEAD');
+    writeFixture(tmp, '.agents/artifacts/2026-08-27/plan-refactor.md', '# Refactor plan\n');
+    git(tmp, 'add', '.');
+    git(tmp, 'commit', '--quiet', '-m', 'legit');
+    const head = git(tmp, 'rev-parse', 'HEAD');
+
+    const proc = Bun.spawnSync({
+      cmd: ['bun', join(import.meta.dir, 'guard-artifacts-confidential.ts'), '--base', base, '--head', head, '--repo-root', tmp],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(proc.exitCode).toBe(0);
+  });
+});
+
+describe('formatError', () => {
+  test('points to private dir and quotes the AGENTS.md rule', () => {
+    const text = formatError([{ file: '.agents/artifacts/2026-08-27/gtm.md', reason: 'filename', detail: 'filename matches sensitive signal: GTM' }]);
+    expect(text).toContain('.agents/artifacts/private/');
+    expect(text).toContain('AGENTS.md');
+    expect(text).toContain('CLAUDE.md');
+    expect(text).toContain('public');
+  });
+});

--- a/scripts/guard-artifacts-confidential.test.ts
+++ b/scripts/guard-artifacts-confidential.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
 import {
-  chmodSync,
   mkdirSync,
   mkdtempSync,
   rmSync,

--- a/scripts/guard-artifacts-confidential.ts
+++ b/scripts/guard-artifacts-confidential.ts
@@ -1,0 +1,280 @@
+#!/usr/bin/env bun
+/**
+ * Server-enforced guard against committing confidential GTM/monetization content
+ * to the PUBLIC `.agents/artifacts/` tree (PHNX-3033).
+ *
+ * `.agents/artifacts/<yyyy-mm-dd>/` is committed by design; anything in it is
+ * public. `.agents/artifacts/private/` is gitignored and is the only artifacts
+ * subtree that may hold confidential/personal strategy material.
+ *
+ * The guard inspects added/modified files under `.agents/artifacts/` (excluding
+ * the private subtree) and fails loud if a filename or content matches
+ * sensitive-strategy signals. It is intentionally conservative: an ambiguous
+ * file is rejected with an actionable error that points the author to the
+ * private dir or a private repo.
+ *
+ * Usage in CI:
+ *   bun scripts/guard-artifacts-confidential.ts --base <sha> --head <sha>
+ *
+ * Local / pre-commit usage:
+ *   git diff --cached --name-only | bun scripts/guard-artifacts-confidential.ts
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+export const GUARD_VERSION = 'confidential-artifacts-v1';
+
+export interface GuardOptions {
+  base?: string;
+  head?: string;
+  repoRoot: string;
+}
+
+export interface Violation {
+  file: string;
+  reason: 'filename' | 'content';
+  detail: string;
+}
+
+const ARTIFACTS_PREFIX = '.agents/artifacts/';
+const PRIVATE_PREFIX = '.agents/artifacts/private/';
+
+// Filename signals. Case-insensitive; short tokens require word boundaries to
+// avoid false positives on engineering terms (e.g. "array", "churn" in
+// "churn-test" is fine, but "churn" alone is flagged). Longer tokens are
+// distinctive enough to match as substrings.
+const FILENAME_SIGNALS: { pattern: RegExp; label: string }[] = [
+  { pattern: /\bgtm\b/, label: 'go-to-market / GTM' },
+  { pattern: /monetiz/, label: 'monetization' },
+  { pattern: /pricing-model/, label: 'pricing model' },
+  { pattern: /\brevenue\b/, label: 'revenue' },
+  { pattern: /launch-venue/, label: 'launch venue' },
+  { pattern: /stars-playbook/, label: 'GitHub stars playbook' },
+  { pattern: /\bcompetitor\b/, label: 'competitor' },
+  { pattern: /go-to-market/, label: 'go-to-market' },
+  { pattern: /\barr\b/, label: 'ARR' },
+  { pattern: /\bmrr\b/, label: 'MRR' },
+  { pattern: /\bchurn\b/, label: 'churn' },
+];
+
+// Explicit content phrases that are inherently confidential strategy.
+const EXPLICIT_CONTENT_SIGNALS: { pattern: RegExp; label: string }[] = [
+  { pattern: /\bmonetization\b/i, label: 'monetization' },
+  { pattern: /\bgtm\b/i, label: 'GTM' },
+  { pattern: /\bpricing\s+tier\b/i, label: 'pricing tier' },
+  { pattern: /\bgo-to-market\b/i, label: 'go-to-market' },
+  { pattern: /\bcompetitor\s+(?:intel|intelligence)\b/i, label: 'competitor intelligence' },
+  { pattern: /\bcompetitive\s+(?:intel|intelligence)\b/i, label: 'competitive intelligence' },
+  { pattern: /\blaunch\s+venue\b/i, label: 'launch venue' },
+  { pattern: /\bstars\s+playbook\b/i, label: 'stars playbook' },
+  { pattern: /\bhow-winners-charge\b/i, label: 'pricing strategy' },
+];
+
+// Strategy context words that, when combined with a dollar figure, indicate
+// confidential business/financial planning. Word boundaries prevent false
+// positives on engineering terms (e.g. "array" contains "arr").
+const STRATEGY_CONTEXT_RES: RegExp[] = [
+  /\brevenue\b/i,
+  /\barr\b/i,
+  /\bmrr\b/i,
+  /\bchurn\b/i,
+  /\bpricing\b/i,
+  /\bmonetization\b/i,
+  /\bgtm\b/i,
+  /\bgo-to-market\b/i,
+  /\bcompetitor\b/i,
+  /\bcompetitive\b/i,
+  /\bcompetition\b/i,
+  /\blaunch\s+venue\b/i,
+  /\bstars\s+playbook\b/i,
+];
+
+const DOLLAR_FIGURE_RE = /\$\d[\d,]*\.?\d*\s*[KMBkmb]?/;
+
+export function posix(file: string): string {
+  return file.split(sep).join('/');
+}
+
+export function repoRootFrom(cwd = process.cwd()): string {
+  const proc = Bun.spawnSync({
+    cmd: ['git', 'rev-parse', '--show-toplevel'],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (proc.exitCode !== 0) return cwd;
+  return Buffer.from(proc.stdout).toString('utf8').trim();
+}
+
+function gitDiffNameStatus(base: string, head: string, cwd: string): string[] {
+  const proc = Bun.spawnSync({
+    cmd: ['git', 'diff', '--name-status', '--find-renames', `${base}...${head}`],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (proc.exitCode !== 0) {
+    throw new Error(Buffer.from(proc.stderr).toString('utf8').trim());
+  }
+  const lines = Buffer.from(proc.stdout).toString('utf8').split('\n');
+  const out: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    // name-status format: "<status>\t<path>" or rename "R100\told\tnew".
+    const parts = trimmed.split('\t');
+    const status = parts[0]![0]!;
+    if (status === 'D') continue; // deleted files are not new leaks
+    const path = parts[parts.length - 1];
+    if (path) out.push(posix(path));
+  }
+  return out;
+}
+
+export function readChangedFilesFromStdin(): string[] {
+  const input = readFileSync(0);
+  const separator = input.includes(0) ? '\0' : '\n';
+  return input.toString('utf8').split(separator).filter(Boolean);
+}
+
+export function isUnderPublicArtifacts(file: string): boolean {
+  const f = posix(file);
+  return f.startsWith(ARTIFACTS_PREFIX) && !f.startsWith(PRIVATE_PREFIX);
+}
+
+export function checkFilename(file: string): string | null {
+  const base = posix(file).split('/').pop()?.toLowerCase() ?? '';
+  for (const { pattern, label } of FILENAME_SIGNALS) {
+    if (pattern.test(base)) {
+      return `filename matches sensitive signal: ${label}`;
+    }
+  }
+  return null;
+}
+
+function hasStrategyContext(text: string): boolean {
+  return STRATEGY_CONTEXT_RES.some((re) => re.test(text));
+}
+
+export function checkContent(text: string): string | null {
+  for (const { pattern, label } of EXPLICIT_CONTENT_SIGNALS) {
+    const match = pattern.exec(text);
+    if (match) {
+      const snippet = text.slice(Math.max(0, match.index - 20), match.index + match[0].length + 20)
+        .replace(/\s+/g, ' ').trim();
+      return `content contains ${label}: "${snippet}"`;
+    }
+  }
+
+  // Revenue/ARR/MRR/etc. next to a dollar figure.
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    if (DOLLAR_FIGURE_RE.test(line) && hasStrategyContext(line)) {
+      const snippet = line.replace(/\s+/g, ' ').trim();
+      return `content couples strategy language with a dollar figure: "${snippet}"`;
+    }
+  }
+
+  return null;
+}
+
+export function inspectFile(repoRoot: string, file: string): Violation | null {
+  if (!isUnderPublicArtifacts(file)) return null;
+
+  const filenameHit = checkFilename(file);
+  if (filenameHit) {
+    return { file, reason: 'filename', detail: filenameHit };
+  }
+
+  const abs = join(repoRoot, file);
+  if (!existsSync(abs)) return null;
+  const text = readFileSync(abs, 'utf8');
+  const contentHit = checkContent(text);
+  if (contentHit) {
+    return { file, reason: 'content', detail: contentHit };
+  }
+
+  return null;
+}
+
+export function inspectFiles(repoRoot: string, files: readonly string[]): Violation[] {
+  return files.map((f) => inspectFile(repoRoot, f)).filter((v): v is Violation => v !== null);
+}
+
+export function changedArtifactFiles(options: GuardOptions): string[] {
+  const files = options.base && options.head
+    ? gitDiffNameStatus(options.base, options.head, options.repoRoot)
+    : readChangedFilesFromStdin();
+  return files.filter(isUnderPublicArtifacts);
+}
+
+const ERROR_LEAD = `\nCONFIDENTIAL-CONTENT GUARD FAILED (PHNX-3033)
+
+The following file(s) under the PUBLIC \`.agents/artifacts/\` tree look like confidential
+GTM, monetization, pricing, revenue, or competitor strategy material. Everything committed
+to \`.agents/artifacts/<yyyy-mm-dd>/\` is public by design; it must not contain strategy
+intel, financial figures, or launch planning.
+`;
+
+const ERROR_TAIL = `
+Move these files to the gitignored \`.agents/artifacts/private/\` directory, or keep them
+in a private repo. See the "The \`.agents/\` workspace" section of AGENTS.md / CLAUDE.md.
+`;
+
+export function formatError(violations: Violation[]): string {
+  const lines = violations.map((v) => {
+    const rel = v.file;
+    return `  - ${rel}\n    ${v.detail}`;
+  });
+  return `${ERROR_LEAD}\n${lines.join('\n\n')}\n${ERROR_TAIL}`;
+}
+
+function parseArgs(argv: string[]): GuardOptions & { help: boolean } {
+  const out: GuardOptions & { help: boolean } = {
+    repoRoot: repoRootFrom(),
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case '--base': out.base = argv[++i]; break;
+      case '--head': out.head = argv[++i]; break;
+      case '--repo-root': out.repoRoot = argv[++i]; break;
+      case '--help': out.help = true; break;
+    }
+  }
+  return out;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(
+      `usage: bun scripts/guard-artifacts-confidential.ts [--base <sha>] [--head <sha>]\n\n`
+      + `Fails if added/modified files under .agents/artifacts/ (excluding private/)\n`
+      + `match confidential-strategy filename or content signals.\n`
+      + `With no --base/--head, reads file paths from stdin.\n`,
+    );
+    return;
+  }
+
+  const files = changedArtifactFiles(args);
+  if (files.length === 0) {
+    process.stdout.write('no public artifact changes to guard\n');
+    return;
+  }
+
+  const violations = inspectFiles(args.repoRoot, files);
+  if (violations.length === 0) {
+    process.stdout.write(`guarded ${files.length} public artifact file(s): clean\n`);
+    return;
+  }
+
+  process.stderr.write(formatError(violations));
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/guard-artifacts-confidential.ts
+++ b/scripts/guard-artifacts-confidential.ts
@@ -23,8 +23,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 
-export const GUARD_VERSION = 'confidential-artifacts-v1';
-
 export interface GuardOptions {
   base?: string;
   head?: string;
@@ -243,6 +241,9 @@ function parseArgs(argv: string[]): GuardOptions & { help: boolean } {
       case '--repo-root': out.repoRoot = argv[++i]; break;
       case '--help': out.help = true; break;
     }
+  }
+  if ((out.base && !out.head) || (!out.base && out.head)) {
+    throw new Error('--base and --head must be supplied together');
   }
   return out;
 }


### PR DESCRIPTION
feat(ci): PHNX-3033 guard public artifacts against confidential strategy leaks

## What changed
- **`scripts/guard-artifacts-confidential.ts`** — new server-enforced guard. Inspects added/modified files under `.agents/artifacts/<yyyy-mm-dd>/` (excluding the gitignored `.agents/artifacts/private/`) and fails loud on filename or content signals for GTM, monetization, pricing models, revenue/ARR/MRR/churn, launch venues, GitHub stars playbooks, and competitor intel.
- **`scripts/guard-artifacts-confidential.test.ts`** — tests reproducing the leak scenario: a sensitive file under public artifacts fails, a legit engineering artifact passes, and a sensitive file under `private/` passes.
- **`.github/workflows/tests.yml`** — runs the guard in the required Linux PR check before impact planning.
- **`cli/ci/test-ownership.yaml`** — maps the new guard files and `.githooks/pre-commit` into the impact-policy group so changes run the planner/workflow tests.
- **`.githooks/pre-commit`** — optional fast first-line hook (enable with `git config core.hooksPath .githooks`); CI remains the enforcement.
- **`AGENTS.md`** — adds the rule that confidential GTM/monetization/pricing/revenue/competitor material never lands in public artifacts.
- **`CHANGELOG.md`** — entry under Unreleased.

## Verification
Selected tests run green locally:

```
$ bun test ./scripts/guard-artifacts-confidential.test.ts
scripts/guard-artifacts-confidential.test.ts:
  33 pass
  0 fail
  50 expect() calls
Ran 33 tests across 1 file.

$ bun test scripts/ci-scope.test.ts
scripts/ci-scope.test.ts:
  66 pass
  0 fail
  137 expect() calls
Ran 66 tests across 1 file.

$ bun test ./.github/workflows/ ./scripts/ci-bench/
  44 pass
  0 fail
  117 expect() calls
Ran 44 tests across 8 files.

$ bun scripts/ci-scope.ts --validate-manifest
ownership manifest covers 2820 tracked files
```

Simulated leak exits 1 and points the author to the right home:

```
$ echo ".agents/artifacts/2026-08-27/gtm.md" | bun scripts/guard-artifacts-confidential.ts
CONFIDENTIAL-CONTENT GUARD FAILED (PHNX-3033)
...
  - .agents/artifacts/2026-08-27/gtm.md
    filename matches sensitive signal: go-to-market / GTM

Move these files to the gitignored `.agents/artifacts/private/` directory, or keep them
in a private repo. See the "The `.agents/` workspace" section of AGENTS.md / CLAUDE.md.
```
