### PR TITLE
test(daemon): fix macOS-only socketsvcs park — bind browser IPC socket under a short root (PHNX-3113)

### DIFF
--- a/cli/src/lib/daemon/daemon.socketsvcs.test.ts
+++ b/cli/src/lib/daemon/daemon.socketsvcs.test.ts
@@ -41,9 +41,15 @@ import type { DaemonServiceId } from '../daemon-services.js';
 // ---------------------------------------------------------------------------
 
 // Unix-domain sockets have a short platform path limit (104 bytes on macOS).
-// Keep this fixture prefix compact so the real BrowserIPCServer can bind under
-// macOS's already-long per-user os.tmpdir().
-const BROWSER_HELPER_DIR = path.join(os.tmpdir(), `a-sv-${process.pid}`);
+// macOS's per-user os.tmpdir() (/var/folders/…/T) is itself long enough that
+// appending `browser/browser.sock` overflows that limit, which parks the real
+// BrowserIPCServer's onStart() — so bind under a short root, the same POSIX-`/tmp`
+// convention the sibling socket tests use (ipc.test.ts, daemon.registry.test.ts,
+// daemon.supervisor-wiring.test.ts). Windows uses a named pipe, no path limit.
+const BROWSER_HELPER_DIR = path.join(
+  process.platform === 'win32' ? os.tmpdir() : '/tmp',
+  `a-sv-${process.pid}`,
+);
 
 vi.mock('../state.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../state.js')>()),


### PR DESCRIPTION
## What

`daemon.socketsvcs.test.ts` fails **only on the macOS CI matrix legs** (ubuntu, windows, and local all pass), keeping the nightly/`workflow_dispatch` cross-platform matrix red:

```
FAIL src/lib/daemon/daemon.socketsvcs.test.ts:335
  ServiceSupervisor — real socket services > starts, reports healthy, ...
  AssertionError: expected 'parked' to be 'running'   // browser-ipc
```
(latest matrix run [33083690781](https://github.com/phnx-labs/agents-cli/actions/runs/33083690781), both macOS 22 + 24 legs)

## Root cause

`getSocketPath()` = `getHelpersDir()/browser/browser.sock`. The test mocked `getHelpersDir()` to `os.tmpdir()/a-sv-<pid>`. On GitHub's macOS runners `os.tmpdir()` is a long `/var/folders/…/T` path, so the derived socket path exceeds the **macOS AF_UNIX `sun_path` limit (104 bytes)**. `net.Server.listen()` then errors, `BrowserIPCServer.onStart()` rejects, and `ServiceSupervisor` **parks** the service. Linux (`/tmp`, limit 108) and Windows (named pipes, no limit) are unaffected — exactly the observed matrix.

Production is unaffected: real `getHelpersDir()` is `~/.agents/.cache/helpers` (short). This is purely the test planting its unix socket under `os.tmpdir()`.

## Fix

Bind the fixture under the short POSIX-`/tmp` root — the **same convention the sibling socket tests already use** and which is why they're green on macOS CI:
- `src/lib/browser/ipc.test.ts:20` (binds the identical `browser.sock`)
- `src/lib/daemon/daemon.registry.test.ts:61`
- `src/lib/daemon/daemon.supervisor-wiring.test.ts:24`

One-file, test-only change; no new abstraction (the idiom is already established inline across those tests). Windows keeps `os.tmpdir()` (named pipes have no path-length limit).

## Verification

- **Reproduced deterministically on Linux** by forcing a `TMPDIR` past the 108-byte limit → identical `expected 'parked' to be 'running'`. With the fix, the test passes 15/15 under that long `TMPDIR` and under a normal one.
- **macOS CI**: triggering the `ci.yml` cross-platform matrix on this branch to confirm macOS 22 + 24 go green (comment to follow).

## Note — the ticket (PHNX-3113) was stale

Its two originally-named tests (`drift-sync.test.ts` apply path, `self-heal.integration.test.ts` isolated-home) now **pass on every leg**, and its secondary ask (narrow the `ci.yml` trigger off `release/**`) is **already done**. This PR fixes the *current* macOS-only regression that keeps the matrix red.