### PR TITLE
docs: restore subsystem guides removed in the 2026-08-25 sweep

### DIFF
--- a/cli/docs/README.md
+++ b/cli/docs/README.md
@@ -1,10 +1,11 @@
 # Architecture and decisions
 
-This directory explains how agents-cli works and which decisions must survive a
-refactor. It is not a command manual. Use `agents <group> --help` or the generated
-[command index](command-index.md) for syntax, and the product README for onboarding.
+This directory has two layers: **decision docs** (how agents-cli works and which
+choices must survive a refactor) and **guides** (how-to references for each subsystem).
+Use `agents <group> --help` or the generated [command index](command-index.md) for exact
+syntax, and the product README for onboarding.
 
-Read in this order:
+Read the decision docs in this order:
 
 1. [Architecture](architecture.md) — ownership and process boundaries.
 2. [Concepts](concepts.md) — the domain model and vocabulary.
@@ -15,10 +16,26 @@ Read in this order:
    [behavioral specifications](specifications.md), and [benchmarks](benchmarks.md)
    (measured numbers; not Linear).
 
-Authored documents contain boundaries, owners, data flow, state transitions,
-invariants, failure behavior, and accepted tradeoffs. They do not contain setup
-walkthroughs, exhaustive flags, recipes, file maps, key-function inventories,
-ticket-era roadmaps, or mutable provider/model tables.
+Decision docs contain boundaries, owners, data flow, state transitions, invariants,
+failure behavior, and accepted tradeoffs — not walkthroughs or recipes.
+
+## Guides (how-to)
+
+Subsystem references, complementary to the decision docs above. Restored after an
+over-aggressive docs sweep removed them (2026-08-25); kept concise.
+
+- Execution & fleet: [ssh-transport](ssh-transport.md), [hosts](hosts.md),
+  [version-management](version-management.md), [resource-sync](resource-sync.md),
+  [self-healing](self-healing.md)
+- Tools: [browser](browser.md), [computer](computer.md), [pty](pty.md)
+- Orchestration: [teams](teams.md), [routines](routines.md), [monitors](monitors.md),
+  [cloud](cloud.md)
+- Resources: [hooks](hooks.md), [subagents](subagents.md), [plugins](plugins.md),
+  [profiles](profiles.md) (+ [profiles/](profiles/INDEX.md))
+- State & security: [secrets-agent-process-model](secrets-agent-process-model.md),
+  [secrets-trust-boundaries](secrets-trust-boundaries.md),
+  [credential-management](credential-management.md), [projects](projects.md),
+  [watchdog](watchdog.md), [menubar](menubar.md), [terminal-engine](terminal-engine.md)
 
 `command-index.md`, `command-index.json`, and `command-reference.html` are generated
 from the Commander tree. Never edit them by hand.

--- a/cli/docs/browser.md
+++ b/cli/docs/browser.md
@@ -1,0 +1,697 @@
+# Browser
+
+Drive Chromium-family browsers from AI agents via the Chrome DevTools Protocol.
+
+## Overview
+
+`agents browser` gives agents a real browser — the same Chrome, Brave, or Edge you use manually, with your existing cookies, fingerprint, and IP. There is no Playwright subprocess, no automation flags, no relay extension. Sites that block Puppeteer and Playwright let it through because there is nothing to detect.
+
+The CLI manages browser processes, tab lifetimes, and network capture through a background daemon (`agents browser` IPC server). Each agent creates a named **task**. Multiple agents run tasks in parallel without sharing state: profile A has its own `chrome-data/`, profile B has its own — no cookie bleed, no race on focus.
+
+Intended users: LLM agents that need to log in to real web apps, scrape authenticated pages, fill forms, upload files, or capture screenshots to feed back into a reasoning loop.
+
+## Architecture
+
+```
+agent process
+     │
+     ├─ agents browser <subcommand> (one request, then exit)
+     │
+     └─ agents browser stream (long-lived NDJSON; process + socket stay warm)
+        (both resolve $AGENTS_BROWSER_TASK or --task)
+     ▼
+  CLI (browser.ts)
+     │
+     │  JSON-RPC over UNIX socket
+     │  ~/.agents/.cache/helpers/browser.sock
+     ▼
+  Browser Daemon (ipc.ts / service.ts)
+     │
+     │  Chrome DevTools Protocol
+     │  ws://127.0.0.1:<port>/json
+     ▼
+  Browser process
+  (Chrome / Brave / Edge / Chromium / Comet)
+     │
+     ├── Profile A  chrome-data/A/  →  Task swift-crab-a1b2
+     └── Profile B  chrome-data/B/  →  Task bold-phoenix-c3d4
+
+  Remote variant (ssh:// endpoint):
+  CLI → SSH tunnel → CDP on remote host → remote Chrome
+```
+
+The daemon auto-starts on the first command that needs it. Commands that only
+inspect local state (`ps`, `profiles list`) do not start it.
+
+Tasks are addressed by a short machine id (8 hex chars). `browser status`
+shows a human **label** (`--title` if given, else the first navigated host,
+else `untitled`). In the common case you never type a handle: the CLI stamps
+the caller's session/launch identity and the daemon resolves the single live
+task for that caller. Pass `--task` only when deliberately running two tasks
+at once. `$AGENTS_BROWSER_TASK` is still accepted as an explicit override.
+Page verbs (`navigate`, `screenshot`, …) create a task when none resolves;
+`done`/`stop` never create.
+
+## Setup
+
+### 1. Create a profile
+
+A profile names a browser + CDP endpoint pair. **A new profile is machine-local
+by default** (RUSH-2716): it is written to this machine's own
+`~/.agents/devices/<machine>/agents.yaml` under `browser:`, and no other machine
+sees it. That is the right default because a profile pins an OS-specific
+`binary:` path and a locally chosen CDP port, so a synced copy is wrong on every
+other box — and because agents create throwaway profiles freely, syncing each one
+filled the shared file with junk.
+
+A name declared by exactly one device is identity-bearing (the daemon tunnels
+to that device). A name declared by several devices is fungible (use the local
+one). Leftover central `browser:` entries are claimed with
+`agents browser profiles claim` on the machine that hosts the browser.
+
+Runtime state — the Chrome `chrome-data` cookie jar — lives separately under
+`~/.agents/.cache/browser/<profile>@<device>/`, which is gitignored and
+per-machine, so each machine logs in once.
+
+```bash
+# Minimal: let agents pick a free port and auto-detect the binary (this device)
+agents browser profiles create work --browser chrome
+
+# Pin an endpoint explicitly
+agents browser profiles create work --browser chrome --endpoint "cdp://127.0.0.1:9222"
+
+# Remote host via SSH — declare it on the machine that should own the name
+agents browser profiles create staging --browser chrome \
+  --endpoint "ssh://deploy@staging.example.com?port=9222"
+```
+
+`agents browser profiles list` shows a `WHERE` column of declaring devices.
+
+If you skip `--profile`, or pass the reserved name `--profile default`, the
+profile is resolved in this order — the same order in **every** command
+(`start`, `stop`, `status`, `navigate`, `tab add`), not just `start`:
+
+1. **A profile that literally bears the name you typed.** A profile you named
+   `default` yourself resolves to itself and is never redirected.
+2. **Your configured default** — the profile set via `agents browser use <name>`
+   on THIS machine, when it can launch here. If its browser/binary isn't
+   installed on this machine, `start` warns and falls through to auto-detect.
+3. **The auto-detected profile, `auto-chrome`** — or the `default`-named
+   predecessor an older agents-cli wrote on this machine, which keeps working.
+4. **Auto-detect** (`start` only) — the first installed Chromium-family browser,
+   saved as the `auto-chrome` profile. Detection priority:
+   - macOS: Chrome > Brave > Edge > Chromium > Comet
+   - Linux: Chrome > Chromium > Brave > Edge
+   - Windows: Edge > Chrome > Brave > Comet
+
+   An auto-detected profile that came from another OS whose binary is missing
+   here — a `/Applications/...` Chrome path resolved on Linux, say — is
+   **regenerated for this machine** rather than failing with "Custom binary not
+   found". Remote (`ssh://`) defaults skip this check: their browser lives on the
+   far host.
+
+`default` is an **alias**, not a profile: it means "whatever profile this machine
+is configured to use". The auto-detected profile is called `auto-chrome` so the
+two cannot be confused (before RUSH-2709, `default` meant both, and only `start`
+honored the alias — so `--profile default` reached a different profile in
+`navigate` than in `start`).
+
+### Profile names vs runtime keys
+
+`agents browser profiles list`, `status`, and `--profile` all use the **bare**
+profile name (`comet-local`). A running browser is *stored* under a runtime key
+that also names the device it resolved to (`comet-local@zion`), so the same
+name on two machines does not collide on disk. That key is an implementation
+detail you never have to type or read. Leftover `@endpoint-N` dirs from older
+builds are renamed onto the device key. `status` renders the two separately:
+
+```
+comet-local (device: zion, port 9222, pid 4183)
+```
+
+and `status --json` carries them as separate `profile`-side fields:
+
+```json
+{ "name": "comet-local", "device": "zion", "key": "comet-local@zion" }
+```
+
+Passing a runtime key where a name is expected still works, so a key copied out
+of an older listing resolves to its profile.
+
+The configured default is a **per-device setting**: it lives in this machine's
+`browser.profile` config key (`devices/<machine>/agents.yaml` `config:`), so
+each machine keeps its own choice — the profile it points at may hold
+machine-local logins. It is machine-local: only this box can set it. Set it
+once per machine.
+
+Safari and Firefox are not supported. They do not implement the Chrome
+DevTools Protocol.
+
+### 2. First-run onboarding
+
+On the first `start`, Chrome opens to a new user-data directory with no
+cookies or saved state. Complete any first-run screens (agree to terms,
+sign in) before automating. Run `agents browser profiles doctor <name>` to
+check if onboarding is complete.
+
+### 3. Drive the page (no export required)
+
+```bash
+# Implicit task create + navigate — identity tracks the rest of the session
+agents browser navigate https://example.com
+agents browser screenshot
+
+# Explicit start still useful for --profile / --url / --record / --title
+agents browser start --profile work --title "login check"
+agents browser screenshot   # resolves from caller identity
+```
+
+Pass `--task <id>` only when running two tasks at once. `$AGENTS_BROWSER_TASK`
+remains a valid explicit override.
+
+### Keep the action loop warm
+
+Normal `agents browser <command>` calls are convenient for individual actions,
+but each shell invocation starts a new Node process and opens a new daemon IPC
+connection. For an observe-and-act loop, start `browser stream` once and send one
+IPC request object per line. It keeps both the narrow browser CLI process and the
+existing browser-daemon socket open until stdin closes; the daemon continues to
+reuse its existing CDP connection.
+
+```bash
+printf '%s\n' \
+  '{"action":"screenshot","path":"/tmp/page.jpg"}' \
+  '{"action":"click","atX":320,"atY":540}' \
+  | agents browser stream --task "$AGENTS_BROWSER_TASK"
+```
+
+The response is one compact JSON object per non-empty input line, in the same
+order. A long-lived caller can leave stdin open and write later requests to the
+same process. `--task` supplies the default `task` field; a task returned by a
+`start` request becomes the default for subsequent lines. Malformed JSON returns
+an error response without closing the stream. A fleet-remote `start` line obeys
+the same device-local `browser remote-control` consent gate as the ordinary
+`browser start` command.
+
+## Command Reference
+
+### Profile management
+
+| Command | Description |
+|---------|-------------|
+| `agents browser use [name]` | Pick this machine's default profile. No name opens a picker on a TTY or prints the current default headlessly; `--unset` or `auto` restores auto-detect. |
+| `agents browser profiles list` | List all configured profiles and the devices declaring each one (`WHERE`). A `*` marks this machine's configured default — which is NOT the same thing as the profile named `default`. `--json` adds `devices` + `kind` (`identity` \| `fungible`) + `isConfiguredDefault` |
+| `agents browser profiles create <name>` | Create a new profile on this device (`add` is an alias). Prints `Added "<name>" on <device> (port N).` |
+| `agents browser profiles add <name>` | Alias of `create` |
+| `agents browser profiles seed` | Create a machine-local profile for each installed browser (named `<browser>-local`), so you can `browser use` one instead of hand-crafting each. Idempotent — existing profiles are left untouched |
+| `agents browser profiles prune` | Remove dead profiles this device declares — browser not installed here, or never started (see below) |
+| `agents browser profiles edit <name>` | Edit an existing profile in place — description, endpoints, secrets, viewport, binary. Stays in the store it already lives in. The browser type and the name are NOT editable: both key the on-disk profile cache (and its logins), so changing either orphans it — delete and recreate instead |
+| `agents browser profiles rename <from> <to>` | Rename a profile and move its browser data with it, so logins survive. Refuses while the profile is in use. The one safe way to change a name: `edit` refuses it, and delete-and-recreate abandons the `--user-data-dir` |
+| `agents browser profiles claim [name]` | Move leftover central `browser:` entries into this device's declaration file. Only profiles this machine can host are claimed. Run on the machine that actually has the browser. |
+| `agents browser profiles show <name>` | Show profile details |
+| `agents browser profiles use <name>` | Compatibility spelling for `agents browser use <name>` |
+| `agents browser profiles logins` | Per profile: `SERVICE \| ACCOUNT \| CREDS` — live session, the signed-in account (plaintext username, never decrypts), and whether login creds are in the profile's secrets bundle |
+| `agents browser profiles remove <name>` (alias `delete`) | Remove profile config and chrome-data cache |
+| `agents browser profiles doctor <name>` | Diagnose where it is declared, binary, port, user-data-dir, onboarding state. Fails `where` when an identity-bearing name (exactly one declaring device) is a loopback endpoint on a box that is not the declaring device — the original `comet-local` bug. |
+
+`profiles create` flags:
+
+| Flag | Description |
+|------|-------------|
+| `-b, --browser <type>` | Required. One of: `chrome`, `comet`, `chromium`, `brave`, `edge`, `arc`, `custom`. `arc` is recognized but NOT drivable — Arc exposes no CDP page targets and crashes on tab creation, so `agents browser` refuses it with a clear error; pick a Chromium-family browser to automate |
+| `-e, --endpoint <url>` | CDP endpoint URL (repeatable). Auto-assigned if omitted |
+| `-s, --secrets <bundle>` | Secrets bundle for this profile: injected as env vars at launch, AND the credential store for `browser type --secret` (keys `<PREFIX>_USERNAME`/`<PREFIX>_PASSWORD`). Warns if the bundle doesn't exist yet |
+| `-d, --description <text>` | Human-readable description |
+| `--headless` | Run in headless mode |
+| `--window <WxH>` | Window size in CSS pixels (default: 1512x982, MacBook Pro 14") |
+| `--position <X,Y>` | Window position on screen |
+| `--binary <path>` | Absolute path to browser binary (required for `--browser custom`) |
+| `--electron` | Treat as an Electron desktop app; never creates new targets |
+| `--target-filter <expr>` | Pick the visible CDP page target. Format: `url:<substring>` or `title:<substring>`. Requires `--electron` |
+
+### Which browser shows YOU a page (`browser.viewer`)
+
+Two browsers exist on a machine like this, and they are not interchangeable:
+
+- the **OS default handler** — whatever `open`/`xdg-open` resolves to
+- the **configured profile** — what `agents browser` drives, and where the
+  fleet's logins accumulate (`agents browser profiles logins` lists them)
+
+Anything the CLI shows you — a rendered artifact, `agents feedback`, a login
+dashboard, `agents sessions trace --open` — goes through one seam that resolves
+the viewer once:
+
+| `browser.viewer` | Result |
+|---|---|
+| unset | follows `browser.profile`, i.e. the profile agents drive |
+| a profile name | that profile |
+| `os` | the OS default handler |
+
+Set it with `agents config set browser.viewer <name>`, or `agents config set
+browser.viewer os` to keep the OS default handler.
+
+External tools reach the same seam through `agents browser show <url|file>`,
+which is the entry point to use instead of `navigate` for anything a person is
+going to read — `navigate` binds a task, and the abandoned-task reaper closes a
+task's tabs. `--os-browser` forces the OS handler for one call; `--json` reports
+where it landed (`profile`, `os`, or `none`).
+
+Two deliberate carve-outs. Screenshots, PDFs and recordings go to the OS default
+**app** regardless — Preview and QuickTime are the better viewer and a CDP tab is
+a downgrade. And the viewer tab is bound to **no task**, so the abandoned-task
+reaper never closes a page you are reading; `stop`/`done` leave it alone too,
+because it is your tab now.
+
+If the viewer cannot be reached — profile missing, Arc (which exposes no CDP page
+targets), not launchable here — the call falls back to the OS handler and prints
+one line saying why. It never silently ignores your configuration.
+
+### Identity-bearing names vs loopback endpoints
+
+A name declared by exactly one device is identity-bearing. The daemon resolves
+it without the caller naming a machine:
+
+- this device declares it → connect locally
+- only other devices declare it → rewrite `cdp://localhost:N` to
+  `ssh://<device>?port=N` and tunnel; unreachable declaring devices fail loud
+  (never a local logged-out fallback)
+- nobody declares it → loud error. If the name still lives in the central
+  `browser:` map, the error tells you to `profiles claim` it on the machine
+  that hosts the browser; otherwise it lists similar names and who declares them
+
+A name declared by several devices is fungible: each box uses its own.
+
+`cdp://localhost:9333` on an identity-bearing name is the original
+`comet-local` bug when a worker evaluates it locally — five real logins on
+zion, a bare logged-out chromium on the worker, same name. The daemon now
+tunnels that shape. `profiles doctor` still flags it (`FAIL where`) so a
+worker does not report a green local binary/port for someone else's browser,
+and `profiles prune` notes it in the `kept` reason. Diagnose the real browser
+on the declaring device.
+
+Leftover central `browser:` entries (the pre-registry `comet-local` sitting in
+`~/.agents/agents.yaml`) are not claimed on upgrade. On the machine that owns
+the browser:
+
+```bash
+agents browser profiles claim comet-local
+```
+
+Nothing claims implicitly — an implicit claim would race across devices.
+
+`--device` is only valid on `agents browser start`. Later verbs (`navigate`,
+`screenshot`, `type`, `stop --profile`, …) resolve the device from the task
+and reject `--device`. `--device all` is rejected: a task lives on one device.
+
+```bash
+agents browser start --task post --device zion --url https://x.com/
+agents browser type --task post --ref @e3 "hello"
+agents browser screenshot --task post
+```
+
+### Cleaning up dead profiles (`prune`)
+
+Profiles accumulate — an agent mints one for a task and never removes it.
+`agents browser profiles prune` removes the ones that are provably dead:
+
+| Reason | Meaning |
+|--------|---------|
+| `binary-missing` | The profile's browser/binary is not installed on this machine, so it cannot launch here at all |
+| `never-used` | No runtime dir has ever been created for it (`~/.agents/.cache/browser/<name>*` is absent) |
+
+```bash
+agents browser profiles prune --dry-run   # preview; changes nothing
+agents browser profiles prune             # apply
+agents browser profiles prune --json      # machine-readable plan
+```
+
+Four guards, each because removing that profile would be wrong rather than untidy:
+
+- **In use** — a live browser, an SSH tunnel, or an open task on *any* of its
+  runtime dirs, runtime-key (`<name>@<endpoint>`) dirs included.
+- **This machine's configured default** — a bare `agents browser start` resolves
+  to it.
+- **The auto-detected profile** (`auto-chrome`, or a legacy `default`) —
+  regenerated on demand, so pruning it is pure churn.
+
+`prune` only considers profiles this device declares. A name declared only on
+another device is left alone (and reported if it is misfiled).
+
+Removing a profile drops its config entry and wipes its cache dirs, exactly like
+`profiles remove`.
+
+> A profile config records no creation time, so one you created seconds ago and
+> have not started yet is indistinguishable from an abandoned one and reports
+> `never-used`. Preview with `--dry-run` first.
+
+### Session lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `agents browser start` | Start a browser task; prints task name to stdout |
+| `agents browser done` | Complete the task and close its tabs |
+| `agents browser stop` | Stop a task (or `--profile <name>` to detach whole profile) |
+| `agents browser status` | Show running tasks (interactive picker in TTY) |
+| `agents browser tasks` | List all tasks in non-interactive table form |
+| `agents browser ps` | List all tracked browser/electron/tunnel processes, alive or stale |
+| `agents browser history` | Recent task history |
+| `agents browser stream [--task <name>]` | Keep one CLI process and daemon IPC socket open; NDJSON requests in, NDJSON responses out |
+| `agents browser prune [--dry-run]` | Run the abandoned-task reaper now instead of waiting for the daemon's next tick (alias: `gc`) |
+
+`start` flags:
+
+| Flag | Description |
+|------|-------------|
+| `-p, --profile <name>` | Profile to use (auto-picks if omitted) |
+| `--task <name>` | Override auto-generated task name |
+| `-e, --endpoint <name>` | Endpoint preset within the profile |
+| `-u, --url <url>` | Open URL in first tab. If an abandoned task on this profile already holds a tab showing that exact URL, the tab is reclaimed instead of a duplicate being opened (RUSH-2622) — a tab held by a live task, or one you opened yourself, is never taken |
+| `--fresh` | Always open a new tab, skipping the reclaim above |
+| `--no-skills` | Skip domain-skill auto-discovery |
+| `--record` | Start recording immediately after tab opens |
+| `--fps <n>` | Recording frames per second (1–30, default 5) |
+| `--duration <sec>` | Recording duration cap (default 60s) |
+| `--max-mb <mb>` | Recording size cap (default 25 MB) |
+
+### Tab hygiene — automatic reaping (RUSH-2622)
+
+`agents browser done` / `stop` close a task's tabs, but agents routinely never
+call them — the run ends, the process exits, and the tabs stay open in the
+profile window forever. The daemon runs a periodic reaper so leftover tabs
+don't pile up, on the same 5-minute cadence as its other housekeeping ticks:
+
+- **Session-end reap.** When the agent session (or run) that started a task is
+  no longer alive on this host, the daemon closes that task's tabs and marks it
+  done — the same code path `done` uses. This always runs; there is no way to
+  turn it off.
+- **Idle reap.** A task with no IPC action (navigate, click, type, screenshot,
+  evaluate, …) for `browser.task-idle-minutes` (default **30**) is closed the
+  same way. Set it to `0` to disable idle reaping only — a task with no
+  recorded identity then never gets closed by this path, though session-end
+  reaping still catches every task that *does* carry one:
+
+  ```bash
+  agents devices config <this-machine> browser.task-idle-minutes 15
+  agents devices config <this-machine> browser.task-idle-minutes 0   # idle reap off
+  ```
+
+  Machine-local, like `browser.profile` and `browser.remote-control` — it
+  lives in this box's own config and cannot be set for a peer.
+
+Both reasons are conservative: only tabs in `task.tabs` are ever closed (a tab
+you opened yourself is never touched), a task mid-recording is always left
+alone, and the shared profile window itself is never closed or killed.
+
+Run the same pass on demand instead of waiting for the next tick:
+
+```bash
+agents browser prune --dry-run   # list what would be closed, close nothing
+agents browser prune             # actually close it (alias: agents browser gc)
+agents browser prune --idle-minutes 5   # override the idle window for this run
+```
+
+### Driving another machine's browser (`--device`) and consent
+
+`--device` is only valid on `agents browser start`. It binds the task to that
+device; later verbs resolve the device from `--task` (or caller identity) and
+reject `--device`. Identity-bearing profiles do not need `--device` at all —
+the daemon tunnels to the declaring device from the name.
+
+`--device all` is rejected because a task lives on one device. A verb that
+names an unknown task lists the open tasks and exits non-zero.
+
+Because start-with-`--device` lets one machine open a browser on another, the
+**target decides** whether it allows it:
+
+| Command | Description |
+|---------|-------------|
+| `agents browser remote-control` | Print whether this machine accepts remote drives |
+| `agents browser remote-control on` | Allow other fleet machines to drive this browser |
+| `agents browser remote-control off` | Refuse remote drives (the default) |
+
+Consent is a **per-device setting** (the `browser.remote-control` config key,
+in this machine's `devices/<machine>/agents.yaml` `config:`) and **off by
+default**: a `browser --device <this-machine>` request that would **open** a
+browser is refused with a message naming how to enable it, until the owner runs
+`agents browser remote-control on` here. The key is machine-local — only this
+box can set it. Local drives (no `--device`) are never gated.
+
+The gate lives in the browser daemon, at the top of `resolveOrCreateTask` — the
+one chokepoint every task-scoped verb resolves through — plus `BrowserService.start`
+for the task-less `browser start` command. It has to live in the daemon, not on
+the `browser start` command: `navigate`, `click`, `screenshot`, `tab-add` and the
+other page verbs launch *or attach to* a browser implicitly, so gating the one
+command left every one of them ungated. Daemon/profile queries that resolve no
+task — `status`, `profiles list` — are not gated, so a peer can still discover
+what is running without consent.
+
+The gate covers both **launching** and **attaching**. Whether a fleet-remote
+request opens a new browser or resolves to a task that already exists —
+`--task <name>`, or the single-match-by-caller-identity path — it is refused with
+consent off (RUSH-3064). Earlier the two attach early-returns and `tabAdd`
+bypassed a create-only gate, so a remote `tab-add --device <box> --task <name>`
+could drive the owner's authenticated profile with consent off (`status` is
+ungated by design, so task names are discoverable). That bypass is closed: with
+`remote-control off`, any fleet-remote verb that resolves a task — drive
+(`navigate`/`click`/`tab-add`), close (`done`/`stop <task>`), or observe
+(`console`/`tab-list`) — is refused whether or not the task already exists,
+because they all flow through `resolveOrCreateTask`. The one task-less mutation
+that does not — `stop --profile <name>` (terminate a whole profile's browser) —
+is a separate, pre-existing gap tracked in RUSH-3179. Local drives (no
+`--device`) remain ungated.
+
+The marker travels **on the request**, not in the daemon's environment. The
+daemon is shared and long-lived, and one auto-started by a fleet-remote CLI
+inherits `AGENTS_FLEET_REMOTE=1` for its whole life — a daemon that read its own
+environment would refuse every later *local* drive on the machine.
+
+### Navigation
+
+| Command | Description |
+|---------|-------------|
+| `agents browser navigate [url]` | Navigate current tab (positional or `--url`; alias `goto`). Creates a task when none resolves for this caller |
+| `agents browser tabs` | List open tabs |
+| `agents browser tab add --url <url>` | Open URL in a new tab |
+| `agents browser tab focus <tabId>` | Switch to tab by ID, prefix, or URL substring |
+| `agents browser tab close [tabId]` | Close a tab; omit to close all |
+
+### Interaction
+
+| Command | Description |
+|---------|-------------|
+| `agents browser refs` | Get numbered refs for interactive DOM elements |
+| `agents browser click <ref>` | Click element by ref |
+| `agents browser type <ref> --text <text>` | Type text into element; `--clear` to empty first |
+| `agents browser type <ref> --secret <bundle>/<KEY>` | Type a credential resolved in-process from a secrets bundle — the value never crosses stdout or the transcript (leak-free login) |
+| `agents browser press <key>` | Press a key (Enter, Tab, Escape, etc.) |
+| `agents browser hover <ref>` | Hover over element by ref |
+| `agents browser scroll` | Scroll by pixels; `--dx` horizontal, `--dy` vertical, `--at-x/--at-y` origin |
+| `agents browser upload` | Upload files; supports hidden inputs, drag-drop, OS chooser interception |
+| `agents browser set viewport <W> <H>` | Set viewport size; `--mobile`, `--scale` |
+| `agents browser set device <name>` | Emulate a device preset (iPhone 14, iPad, MacBook Pro) |
+| `agents browser devices` | List available device presets |
+| `agents browser download --path <dir>` | Set download directory for a task |
+| `agents browser waitdownload` | Wait for a download to complete |
+
+`upload` flags:
+
+| Flag | Description |
+|------|-------------|
+| `-r, --ref <n>` | Ref of the upload target (file input or drop zone) |
+| `--trigger <n>` | Ref of a button that opens the OS file chooser |
+| `-f, --file <path...>` | Absolute path(s) to file(s) (repeatable) |
+| `--drop` | Force drag-drop pattern |
+| `--input` | Force file-input pattern |
+| `--timeout <ms>` | Timeout for chooser interception |
+
+### Observation
+
+| Command | Description |
+|---------|-------------|
+| `agents browser screenshot` | Capture current tab; path printed to stdout |
+| `agents browser evaluate [expr]` | Run JavaScript (positional, `-e`, or `--file`; alias `eval`) |
+| `agents browser console` | Read console logs; `--level` (log/info/warn/error), `--clear` |
+| `agents browser errors` | Read uncaught page errors; `--clear` |
+| `agents browser requests` | Captured network requests; `--filter <text>` |
+| `agents browser responsebody <url-pattern>` | Wait for and read a response body |
+| `agents browser logs` | Read app JSONL logs; `--task` (or identity), `--source`, `--lines`, `--since`, `--until`, `--level`, `--message`, `--filter` |
+
+`screenshot` flags:
+
+| Flag | Description |
+|------|-------------|
+| `-t, --tab <tabId>` | Tab to capture (defaults to current) |
+| `-o, --output <path>` | Specific output path; auto-saves under sessions/<task>/ if omitted |
+| `-q, --quality <mode>` | `compressed` (JPEG, ~100 KB cap) or `raw` (PNG pixel-faithful) |
+
+### Recording
+
+| Command | Description |
+|---------|-------------|
+| `agents browser record start` | Start recording; auto-saved under sessions/<task>/recordings/ |
+| `agents browser record stop` | Stop recording; prints output path to stdout |
+
+`record start` flags: `--fps`, `--duration <sec>`, `--max-mb`.
+
+### History and discovery
+
+| Command | Description |
+|---------|-------------|
+| `agents browser history` | Recent task history; `--limit <n>` |
+| `agents browser refs --all` | Include non-interactive elements; `--limit <n>` |
+| `agents browser wait` | Wait for a condition: `--time`, `--selector`, `--url`, `--fn`, `--state` |
+| `agents browser sessions` | Browse captured screenshots, PDFs, recordings, and downloads, grouped by task. `agents sessions --browser` is the same view. |
+
+`agents browser sessions` flags: `--profile <name>` (default: every profile with
+captures), `--open [selector]` (open `latest` or a filename match in the OS
+default app), `--json`, `--no-interactive`.
+
+On a real terminal (no `--json`/`--open`/`--no-interactive`), `sessions` opens an
+interactive, **task-first** browser: one row per browser task, newest first —
+not one row per screenshot. Each task records the agent session that started it
+(`AGENT_SESSION_ID`, resolved in the calling CLI process — the shared browser
+daemon cannot know it), plus `owner` and `launchId`. That identity is written
+once at task start to a durable `browser_sessions` row in the local session DB
+and is **never deleted**, so a task still links to its session after
+`agents browser stop` and after a daemon restart. The preview pane then shows
+the same digest as `agents sessions` (prompt, changes, tests, last response),
+followed by that task's captures newest-first with filename/age/size.
+
+A row shows **unresolved** when it recorded an identity this machine cannot
+index (a rotated or peer-owned session), and **unlinked** when no identity was
+recorded at all — captures taken before this shipped, whose identity was
+discarded at stop and cannot be recovered. Either way the captures are still
+listed and openable. Downloads sit in their own row, separate from any task.
+
+The DB row is **metadata only** — task, profile, identity, timing, and the
+capture directory path. The screenshots, PDFs and recordings themselves stay on
+disk under `~/.agents/.cache/browser/<profile>/sessions/<task>/`; nothing copies
+them into the database, and the listing counts captures by reading that
+directory rather than trusting a stored tally.
+
+**Known gap — `--device` drives record no session.** `agents browser start --device
+<device>` runs the CLI on the remote box, and the SSH dispatch forwards only
+`AGENTS_ACTOR*` and `AGENT_TERMINAL_ID` — not `AGENT_SESSION_ID`. A task started
+that way therefore records no session and lists as `unlinked`. Local drives are
+unaffected. Forwarding session identity across the SSH hop is tracked on
+RUSH-2549 and is not fixed here. Search matches task name, profile, the
+linked session's agent/topic, or an artifact filename; `enter` opens the
+highlighted capture directly (or drills into a capture list first when a task
+holds more than one). `--no-interactive` prints the flat per-artifact table
+instead — the stable, scriptable surface `--json` also uses.
+
+## Profile Schema
+
+Profiles are stored in the `browser:` map of each declaring machine's
+`~/.agents/devices/<machine>/agents.yaml`. The fleet registry is the read-time
+union of those files. Use `agents browser profiles show <name> --json` to
+inspect the full config, or `agents browser profiles list --json` to see which
+devices declare each name.
+The fields map to:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Lowercase alphanumeric with hyphens |
+| `browser` | string | `chrome`, `comet`, `chromium`, `brave`, `edge`, `arc`, or `custom` (`arc` is recognized but not drivable — see the `--browser` flag note above) |
+| `endpoints` | string[] or map | CDP URLs: `cdp://host:port`, `ssh://host?port=N`, or `wss://...` |
+| `defaultEndpoint` | string | Key into `endpoints` map to use by default |
+| `binary` | string | Absolute path; required for `browser: custom` |
+| `electron` | boolean | Suppress `Target.createTarget`; bind to visible window |
+| `targetFilter` | string | `url:<substring>` or `title:<substring>` for Electron window selection |
+| `description` | string | Human-readable label |
+| `secrets` | string | Secrets bundle name to inject at browser start |
+| `chrome.headless` | boolean | Run headless |
+| `viewport` | `{width, height, x?, y?}` | Initial window size in CSS pixels |
+| `logDir` | string | Local path to source-side JSONL logs |
+| `logHost` | string | SSH host where `logDir` lives |
+
+## Recipes
+
+### 1. Create a profile and log in manually
+
+```bash
+# Create the profile (auto-assigns a free port)
+agents browser profiles create work --browser chrome
+
+# Start a session and open the app
+export AGENTS_BROWSER_TASK=$(agents browser start --profile work --url https://app.example.com)
+
+# Complete the login in the browser window that opens.
+# Then verify onboarding is done:
+agents browser profiles doctor work
+
+# On future runs, cookies are already there.
+```
+
+Logins persist across browser restarts, including sites that issue
+memory-only session cookies (`expires=-1`, e.g. idealista): each launch pins
+`session.restore_on_startup: 1` in the profile's Preferences, which stops
+Chromium purging session cookies at startup, while `--no-startup-window`
+keeps the visible side of session restore from ever happening — no tabs from
+a previous task reopen. The only logouts left are server-side session
+expiries, which no client can prevent.
+
+### 2. Screenshot a logged-in page
+
+```bash
+export AGENTS_BROWSER_TASK=$(agents browser start --profile work --url https://dashboard.example.com)
+# Wait for the page to load, then capture:
+agents browser wait --state networkidle
+P=$(agents browser screenshot)
+# P is the path to the saved JPEG; pass it to your vision model.
+agents browser done
+```
+
+### 3. Extract data with evaluate
+
+```bash
+export AGENTS_BROWSER_TASK=$(agents browser start --profile work --url https://app.example.com/orders)
+agents browser wait --selector "table.orders"
+agents browser evaluate --expression "
+  Array.from(document.querySelectorAll('table.orders tr')).map(r =>
+    Array.from(r.querySelectorAll('td')).map(c => c.innerText)
+  )
+"
+agents browser done
+```
+
+### 4. Drive an Electron app (e.g. Slack)
+
+```bash
+# Create the profile once
+agents browser profiles create slack \
+  --browser custom \
+  --binary "/Applications/Slack.app/Contents/MacOS/Slack" \
+  --electron
+
+# Then use it exactly like a web profile
+export AGENTS_BROWSER_TASK=$(agents browser start --profile slack)
+agents browser screenshot
+agents browser refs
+agents browser click 7
+agents browser done
+```
+
+### 5. Attach to a remote Chrome via SSH
+
+```bash
+# The profile stores the SSH endpoint; the daemon opens the tunnel at start time
+agents browser profiles create staging \
+  --browser chrome \
+  --endpoint "ssh://deploy@staging.example.com?port=9222"
+
+export AGENTS_BROWSER_TASK=$(agents browser start --profile staging)
+agents browser navigate --url https://internal.staging.example.com
+agents browser screenshot
+agents browser done
+```
+
+## Demo
+
+<video autoplay loop muted playsinline width="100%" src="../assets/videos/browser.mp4"></video>
+
+## See also
+
+- [docs/pty.md](pty.md) — drive REPLs and TUI programs from an agent; part of the automation triad
+- [docs/computer.md](computer.md) — drive native macOS apps via Accessibility; part of the automation triad
+- [docs/concepts.md](concepts.md) — DotAgents repos, resource resolution model

--- a/cli/docs/browser.md
+++ b/cli/docs/browser.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Browser
 
 Drive Chromium-family browsers from AI agents via the Chrome DevTools Protocol.

--- a/cli/docs/cloud.md
+++ b/cli/docs/cloud.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Cloud Dispatch
 
 Run agent tasks on remote infrastructure across multiple cloud backends, with unified status tracking and live log streaming.

--- a/cli/docs/cloud.md
+++ b/cli/docs/cloud.md
@@ -1,0 +1,384 @@
+# Cloud Dispatch
+
+Run agent tasks on remote infrastructure across multiple cloud backends, with unified status tracking and live log streaming.
+
+## Overview
+
+`agents cloud` dispatches tasks to remote agent environments without requiring
+a local CLI session. **Each agent runs in its own cloud** — five managed providers ship
+today: Rush Cloud (Claude against a GitHub repo → PR), Codex Cloud (pre-built
+Codex environments), Factory (Droid on a cloud Droid Computer), and Antigravity
+(Gemini Managed Agents), plus Cursor Cloud Agents. Pass `--agent` and the provider is auto-selected;
+`--provider` overrides. Every dispatched task is tracked in a local SQLite store
+so `agents cloud list` shows the full history across all providers, and transient
+states (`queued`, `allocating`, `running`, `input_required`) are refreshed
+from the live provider API on each `list` call. Tasks continue running after
+you disconnect — reconnect any time with `agents cloud logs <id>`.
+
+### Agent auto-routing
+
+`agents cloud run --agent <id>` routes to that agent's native cloud unless you
+pass `--provider`. Resolution precedence (`resolveProvider` in
+`src/lib/cloud/registry.ts`): explicit `--provider` > the agent's `cloudProvider`
+(declared in the agent registry, `src/lib/agents.ts`) > `cloud.default_provider`
+in `~/.agents/agents.yaml` > `rush`.
+
+| Agent | Native cloud | Why |
+|---|---|---|
+| `claude` | `rush` | Rush runs Claude against a repo → PR. (Claude Code does have a native `claude --cloud` on Anthropic-managed infra since 2026-08; routing to Rush is deliberate — one tracked fleet for every harness.) |
+| `codex` | `codex` | `codex cloud exec` — first-class native CLI. |
+| `droid` | `factory` | Factory Droid Computer (cloud VM) via `droid computer ssh` + remote `droid exec`. |
+| `antigravity` | `antigravity` | Gemini Managed Agents Interactions API (remote sandbox). |
+| `cursor` | `cursor` | Cursor Cloud Agents v1 REST API (repo-backed or no-repo agent). |
+
+### Dispatch from `agents run` — the `--cloud` placement
+
+The same dispatch is a placement on `agents run`
+([#2066](https://github.com/phnx-labs/agents-cli/pull/2066)):
+
+```bash
+agents run claude "fix the flaky e2e" --cloud --repo acme/example
+agents run codex "add parser tests" --cloud --cloud-env env_a1b2c3
+agents run cursor "fix the flaky parser test" --cloud --repo acme/example
+agents run claude "…" --where cloud:codex   # one-door spelling (+ provider)
+```
+
+`--cloud` sits beside `--device` and `--lease` as one of three run
+placements (local, machine, cloud) and is mutually exclusive with them. It
+accepts `--provider`, `--repo` (repeatable), `--branch`, `--cloud-env` (run's
+`--env` stays the KEY=VAL passthrough), `--timeout`, `--model`, `--no-follow`,
+and `--json`; local-run flags (`--loop`, `--resume`, `--secrets`, `--terminal`,
+`--cwd`, account strategy, …) are rejected, not silently dropped. Agents with
+no native cloud (kimi, grok, opencode, …) fail loud with the capable
+list unless `--provider` is given. Both surfaces call the shared dispatch core
+(`executeCloudDispatch` in `src/lib/cloud/dispatch.ts` via
+`src/commands/run-cloud.ts`), so tracking, streaming, and the budget
+kill-switch are identical to `agents cloud run`. See
+[concepts.md#placement](concepts.md#placement) for the placement model.
+
+### Pre-provisioned targets (env / computer)
+
+Two of the clouds don't clone a repo per dispatch — they run *inside* something
+you provision once:
+
+- **Codex** runs in an **environment** (`env_…`) created in the Codex web UI,
+  which bundles a repo + base image + setup scripts. `codex cloud exec` requires
+  `--env`.
+- **Factory** runs on a **Droid Computer** (a persistent cloud VM). Dispatch
+  requires `--computer`.
+
+(Rush is per-repo via `--repo`; Antigravity spins up an on-demand sandbox — no
+pre-provisioned target.)
+
+So you supply the target one of three ways: per-run (`--env` / `--computer`), a
+default in `agents.yaml` (`cloud.providers.codex.env` /
+`cloud.providers.factory.computer`), or — interactively — let the CLI pick it.
+
+**Discover targets:** `agents cloud envs [--provider <id>]` lists what you can
+dispatch into. Factory enumerates Droid Computers via `droid computer list`
+(surfacing the sign-in error verbatim if you're not authenticated). Codex has no
+list-environments CLI, so it prints guidance to browse them with the interactive
+`codex cloud` instead.
+
+**Interactive picker:** if a dispatch is missing its target and you're in a TTY,
+`agents cloud run` offers a picker rather than erroring — a `select` of your
+Droid Computers (Factory), or, where the backend can't enumerate (Codex), the
+actionable guidance. The picker falls back to a free-text prompt if the listing
+is empty, so a dispatch is never hard-blocked.
+
+## Architecture
+
+```
+CLI (agents cloud run ...)
+  │
+  ├─ resolveProvider()               src/lib/cloud/registry.ts
+  │    reads cloud.default_provider  from ~/.agents/agents.yaml
+  │    returns CloudProvider impl
+  │
+  ├─ provider.dispatch(options)      rush.ts | codex.ts | cursor.ts | factory.ts
+  │    POST to remote API
+  │    returns CloudTask { id, status, ... }
+  │
+  ├─ insertTask(task)                src/lib/cloud/store.ts
+  │    SQLite: ~/.agents/.cache/cloud/tasks.db
+  │
+  └─ renderStream(provider.stream(id))   src/lib/cloud/stream.ts
+       SSE parser → CloudEvent union
+       renders to terminal (or --json)
+       returns { status, summary, prUrl }
+
+agents cloud list
+  ├─ listActiveTasks()               refresh transient states from each provider
+  └─ listStoredTasks({ provider, status, limit })
+
+agents cloud providers
+  └─ getAllProviders()                instantiate every provider, report capabilities()
+```
+
+## Command Reference
+
+| Command | Description |
+|---|---|
+| `agents cloud run [prompt]` | Dispatch a task to a cloud agent |
+| `agents cloud list` | List cloud tasks (most recent first) |
+| `agents cloud status <id>` | Show task detail and latest status |
+| `agents cloud logs <id>` | Stream live output from a running task |
+| `agents cloud cancel <id>` | Cancel a running task |
+| `agents cloud message <id> <text>` | Send a follow-up to a finished or needs-review task |
+| `agents cloud providers` | List available providers and their status |
+| `agents cloud envs` | List the pre-provisioned targets (Codex environments / Droid Computers) you can dispatch into |
+
+### `cloud run` options
+
+| Flag | Description |
+|---|---|
+| `--provider <id>` | Cloud backend: `rush`, `codex`, `cursor`, `factory`, `antigravity`, `host` |
+| `--agent <name>` | Agent to run; native cloud routing includes `claude`, `codex`, `cursor`, `droid`, and `antigravity` |
+| `--repo <owner/repo>` | GitHub repository. Repeatable for multi-repo dispatch (Rush Cloud only) |
+| `--branch <name>` | Target git branch |
+| `-p, --prompt <text>` | Inline prompt (alternative to positional argument) |
+| `--timeout <duration>` | Kill after duration (e.g., `30m`, `2h`) |
+| `--model <model>` | Model override |
+| `--env <id>` | Codex Cloud environment ID |
+| `--computer <name>` | Factory/Droid computer target |
+| `--mode <mode>` | Execution mode (`plan`, `edit`, `full`) |
+| `-b, --balanced` | Shortcut for `--strategy balanced` |
+| `--strategy <strategy>` | Account selection strategy for factory: `balanced` — rotates across all healthy accounts on rate-limit |
+| `--json` | Structured JSON output |
+| `--no-follow` | Dispatch and exit without streaming output |
+
+### `cloud list` options
+
+| Flag | Description |
+|---|---|
+| `--provider <id>` | Filter by provider |
+| `--status <status>` | Filter by status |
+| `--limit <n>` | Max results (default 20) |
+| `--json` | JSON output |
+
+### `cloud status` options
+
+| Flag | Description |
+|---|---|
+| `--json` | JSON output |
+
+### `cloud logs` options
+
+| Flag | Description |
+|---|---|
+| `-f, --follow` | Follow output (default for running tasks) |
+| `--json` | JSON event stream |
+
+## Providers
+
+Six providers, including the `host` machine backend, are registered at startup (`src/lib/cloud/registry.ts`):
+
+| ID | Name | Dispatch target | Multi-repo |
+|---|---|---|---|
+| `rush` | Rush Cloud | GitHub repo + branch | Yes — clones each repo into `/workspace/<owner>/<name>/` |
+| `codex` | Codex Cloud | Pre-built Codex environment (`--env`) | No — bundle the repos into the env |
+| `factory` | Factory (Droid) | Droid Computer (`--computer`) via relay SSH + `droid exec` | No |
+| `antigravity` | Antigravity (Gemini) | Gemini Managed Agents remote sandbox | No — raw sandbox, no repo → PR |
+| `cursor` | Cursor Cloud Agents | Cursor-hosted agent with optional GitHub repos | Yes — up to the API limit |
+
+The default provider is read from `cloud.default_provider` in
+`~/.agents/agents.yaml`. If unset, it falls back to `rush`. Note that an
+agent's native cloud (via `--agent`) takes precedence over `default_provider`.
+
+**Factory (Droid).** `droid exec` is synchronous, so a Factory dispatch runs the
+remote exec to completion (no live SSE — output appears when the run finishes)
+and the task id is droid's own `session_id`. Requires the `droid` CLI, a Factory
+login, and a pre-provisioned Droid Computer (`--computer <name>`, or
+`cloud.providers.factory.computer`). Create one in Factory (Settings → Droid
+Computers) or register a machine with `droid computer register`.
+
+**Antigravity (Gemini).** Talks to the Interactions API
+(`POST /v1beta/interactions`, agent `antigravity-preview-05-2026`). The Gemini
+API key comes from an `agents secrets` bundle named in
+`cloud.providers.antigravity.secretsBundle` (or `GEMINI_API_KEY` /
+`GOOGLE_API_KEY` in the env). It is a raw sandbox — no GitHub repo → PR; pass a
+repo and it routes you to `--provider rush` instead.
+
+**Cursor.** Talks directly to `https://api.cursor.com/v1`; it does not invoke
+`cursor-agent --cloud`. The API key comes from `CURSOR_API_KEY` in the
+`agents secrets` bundle named by `cloud.providers.cursor.secretsBundle`.
+Free-plan keys fail with a paid-plan requirement instead of a generic auth error.
+
+### Provider configuration (`~/.agents/agents.yaml`)
+
+```yaml
+cloud:
+  default_provider: rush     # optional; defaults to rush
+
+  providers:
+    codex:
+      env: env_a1b2c3        # default Codex Cloud environment ID
+    factory:
+      computer: linux-vm-1   # default Droid Computer name
+      autonomy: high         # droid exec --auto level (low|medium|high; default high)
+    antigravity:
+      secretsBundle: gemini.com   # agents secrets bundle holding GEMINI_API_KEY
+      # model: antigravity-preview-05-2026   # optional managed-agent override
+    cursor:
+      secretsBundle: cursor    # agents secrets bundle holding CURSOR_API_KEY
+```
+
+Rush Cloud uses the session token injected by `agents` — no separate config
+key is needed.
+
+## Task Lifecycle
+
+Task status values (from `src/lib/cloud/types.ts:19-27`):
+
+```
+queued
+  │
+  ▼
+allocating
+  │
+  ▼
+running ──────────────────────────▶ input_required
+  │                                   (agent paused, awaiting message)
+  │                                        │
+  │        agents cloud message <id> ──────┘
+  │
+  ├── exit OK  ──▶ completed
+  ├── exit err ──▶ failed
+  └── cancel   ──▶ cancelled
+```
+
+`idle` is a long-lived session state — the agent has stopped between turns and
+can be resumed via `agents cloud message`. It is distinct from the terminal
+states (`completed`, `failed`, `cancelled`) which cannot re-enter `running`.
+
+### Stream events
+
+`agents cloud logs` and the post-dispatch follow mode consume a Server-Sent
+Events stream decoded into typed `CloudEvent` values
+(`src/lib/cloud/stream.ts:16-57`):
+
+| Event type | Content |
+|---|---|
+| `text` | Agent's text output — written to stdout |
+| `thinking` | Extended reasoning content — written to stderr |
+| `tool_use` | Tool invocation — written to stderr |
+| `tool_result` | Tool result — acknowledged on stderr |
+| `status` | Lifecycle transition |
+| `usage` | Token counts and model name |
+| `done` | Final status, optional PR URL, optional summary |
+| `error` | Error message from the provider |
+| `unknown` | Provider event not in the known taxonomy — surfaced, not dropped |
+
+Stream disconnect does not cancel the task. The task continues running; reconnect
+with `agents cloud logs <id>`.
+
+## Recipes
+
+### 1. Dispatch to Rush Cloud and stream output
+
+```bash
+agents cloud run "fix the flaky e2e in tests/checkout.spec.ts" \
+  --provider rush \
+  --repo acme/monorepo \
+  --branch main
+```
+
+### 2. Multi-repo dispatch (Rush Cloud)
+
+Each repo is cloned into `/workspace/<owner>/<name>/` in the pod.
+
+```bash
+agents cloud run "rename POST /v1/charge -> /v2/charge across server + extension" \
+  --provider rush \
+  --repo acme/server \
+  --repo acme/extension
+```
+
+### 3. Fire-and-forget, then tail logs later
+
+```bash
+# Dispatch and exit immediately
+TASK=$(agents cloud run "bump tailwind to v4 and fix the breaks" \
+  --provider rush --repo acme/monorepo --no-follow --json | jq -r .id)
+
+# Reconnect later
+agents cloud logs "$TASK"
+```
+
+### 4. Cancel a runaway task
+
+```bash
+agents cloud cancel tsk_4f2a91
+```
+
+### 5. List all active tasks, refreshed from providers
+
+```bash
+# Human-readable table
+agents cloud list
+
+# Filter by provider and status
+agents cloud list --provider rush --status running
+
+# Machine-readable (used by the observability layer)
+agents cloud list --json
+```
+
+### 6. Send a follow-up when the agent needs input
+
+```bash
+# Agent paused at input_required
+agents cloud status tsk_4f2a91
+
+# Unblock it
+agents cloud message tsk_4f2a91 "Looks good — also update the OpenAPI spec"
+```
+
+### 7. Dispatch to a droid's own cloud (Factory Droid Computer)
+
+`--agent droid` auto-routes to Factory; the run executes `droid exec` on the
+named Droid Computer.
+
+```bash
+agents cloud run "add a vitest for src/util/slug.ts" \
+  --agent droid \
+  --computer cloud-vm-1 \
+  --autonomy high
+```
+
+### 8. Dispatch to Antigravity (Gemini Managed Agents)
+
+`--agent antigravity` auto-routes to the Gemini Interactions API. No repo — it's
+a remote sandbox.
+
+```bash
+# key resolved from cloud.providers.antigravity.secretsBundle, or GEMINI_API_KEY
+agents cloud run "benchmark three JSON parsers and report the fastest" --agent antigravity
+```
+
+## Budget Guardrails
+
+Cloud dispatches **inherit the local project's budget caps** (see
+[docs/observability.md](./observability.md#budget-guardrails-agents-budget)).
+Before a run is POSTed, its estimated cost is projected onto current spend;
+under `on_exceed: block`, a dispatch that would breach a cap is **refused
+client-side** with a `[budget] BLOCKED cloud dispatch …` error — the run never
+starts. The target repo slug is the project attribution key, so caps span every
+agent dispatched against that repo.
+
+Cloud budgeting is **pre-flight only** in v1: the client-side estimate blocks a
+dispatch before it is POSTed, but agents-cli does **not** apply its own live
+mid-run hard-cap kill to a running cloud task — once a task starts on the
+provider, the provider's own controls govern it. The agents-cli live mid-run
+kill applies to local headless `agents run` today; a live cloud kill is a
+planned follow-up.
+
+## Demo
+
+<video autoplay loop muted playsinline width="100%" src="../assets/videos/cloud.mp4"></video>
+
+## See Also
+
+- [docs/concepts.md](./concepts.md) — DotAgents repos, resource kinds, `agents.yaml` structure
+- [docs/observability.md](./observability.md) — `agents cloud list --json` as a fleet observability source
+- [docs/teams.md](./teams.md) — use `--cloud rush|codex|factory` on `agents teams add` to dispatch cloud teammates from a DAG

--- a/cli/docs/computer.md
+++ b/cli/docs/computer.md
@@ -1,0 +1,393 @@
+# Computer
+
+Drive native macOS apps from AI agents via the Accessibility API.
+
+## Overview
+
+`agents computer` controls macOS applications through the Accessibility
+(`AXUIElement`) framework, ScreenCaptureKit, and HID-tap event synthesis. It
+requires a separate helper app (Agents Computer) installed in
+`/Applications/Computer Helper.app` with two macOS TCC grants: Accessibility and Screen Recording.
+
+The helper runs as a launchd user agent, listening on a UNIX socket. Agents
+send JSON-RPC calls through the CLI; the helper translates them into AX
+actions and synthesized input events on running apps.
+
+Use this when you need to drive a macOS app that has no web interface and no
+CDP endpoint — a desktop finance tool, a native editor, a VM window, or an app
+that Electron automation cannot reach cleanly.
+
+This is macOS-only. The daemon, socket, and all TCC plumbing are specific to
+macOS APIs (`launchctl`, `AXUIElement`, `ScreenCaptureKit`, `CoreGraphics`).
+
+## Architecture
+
+```
+agent process
+     │
+     │  agents computer <verb>
+     ▼
+  CLI (computer.ts / computer-actions.ts)
+     │
+     │  JSON-RPC over UNIX socket
+     │  ~/.agents/.cache/helpers/computer.sock
+     │  (per-call timeout 30s; COMPUTER_HELPER_RPC_TIMEOUT_MS overrides)
+     │
+     │  Fallback: spawn helper binary as child process
+     │            (for dev builds without setup)
+     ▼
+  Agents Computer
+  /Applications/Computer Helper.app
+  [launchd: com.phnx-labs.computer-helper]
+     │
+     │  AXUIElement  (Accessibility framework)
+     │  ScreenCaptureKit  (window/display capture)
+     │  CGEvent via HID tap  (clicks, drags, keystrokes)
+     ▼
+  macOS app process
+  (any app in the allow list)
+```
+
+The helper reads an allow-list policy file
+(`~/.agents/.cache/helpers/computer-policy.json`) at startup and on SIGHUP.
+By default the policy is deny-all. You must explicitly whitelist each app the
+daemon may drive.
+
+A peer-auth list (`~/.agents/.cache/helpers/computer-peers.json`) controls
+which caller executables may connect to the socket. The CLI writes this list
+at `start` time based on the currently installed Node binary path. This
+prevents a malicious npm postinstall from connecting to the socket through a
+different process.
+
+## Setup
+
+### 1. Install the helper
+
+```bash
+agents computer setup        # alias: install-helper
+```
+
+This installs the helper at `/Applications/Computer Helper.app`,
+verifies its codesign signature, writes a LaunchAgent plist at
+`~/Library/LaunchAgents/com.phnx-labs.computer-helper.plist`, and prints
+the next steps. It does **not** start the daemon.
+
+### 2. Grant TCC permissions (one-time)
+
+Open System Settings on macOS:
+
+```
+System Settings > Privacy & Security > Accessibility   — add Agents Computer
+System Settings > Privacy & Security > Screen Recording — add Agents Computer
+```
+
+These grants are keyed to the app's signed bundle identity at
+`/Applications/Computer Helper.app`. They survive `npm update` as long as the
+app stays at that path and the same certificate signs it.
+
+### 3. Whitelist the apps the daemon may drive
+
+Add a YAML file under `~/.agents/permissions/groups/`:
+
+```yaml
+# ~/.agents/permissions/groups/computer.yaml
+name: computer
+allow:
+  - "Computer(com.apple.mail)"
+  - "Computer(com.apple.notes)"
+  - "Computer(com.apple.finder)"
+```
+
+The bundle ID is the value from `CFBundleIdentifier` in the app's `Info.plist`.
+Find it with:
+
+```bash
+defaults read /Applications/SomeApp.app/Contents/Info CFBundleIdentifier
+```
+
+### 4. Start the daemon when you need it
+
+```bash
+agents computer start
+```
+
+The daemon is not always-on. Start it when you need it, stop it when done.
+This is intentional: Accessibility and Screen Recording are sensitive grants;
+an always-on background listener that can drive any app is a large attack
+surface.
+
+```bash
+agents computer stop   # when finished
+```
+
+## Command Reference
+
+Verbs are grouped the way `agents computer --help` groups them.
+
+### Installation & daemon lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `setup` (alias `install-helper`) | Copy helper to /Applications/, write LaunchAgent plist |
+| `start` | Write policy + peers, load the LaunchAgent, start the daemon |
+| `stop` | Unload the LaunchAgent, remove the socket |
+| `reload` | Reload the allow-list policy from ~/.agents/permissions/groups/ (SIGHUP the daemon); with `--device`, restart the remote Windows daemon |
+| `status` | Report install state, daemon state, TCC trust, policy, and peer list; with `--device`, tunnel + liveness of the remote Windows daemon |
+
+### Observe
+
+| Command | Description |
+|---------|-------------|
+| `apps` | List running allow-listed apps (pid, bundle id, active flag) |
+| `describe` | Dump the accessibility tree; element ids (`@eN`) feed `--id` flags |
+| `screenshot` | Capture a window (default: largest), `--list` windows, or `--display` |
+| `get-text` | Extract visible text from the app (or a subtree via `--id`) without OCR |
+
+`screenshot` flags: `--bundle` / `--pid` (target), `--list` (enumerate windows
+with id/title/layer/`on_screen`/bounds), `--window-id <n>` (capture a specific
+window — the way to shoot a modal or dialog), `--display` (whole display,
+composites stacked windows), `--out <path>`, `--quality <n>`, `--json`.
+
+Every capture reports `origin` (global point origin of the captured region)
+and `scale` (backing-store pixels per point). To click a feature seen at
+screenshot pixel `(px, py)`:
+
+```
+global_x = origin_x + px / scale
+global_y = origin_y + py / scale
+```
+
+Re-capture after any raise or window move — a window on an inactive
+fullscreen Space reports shifted global coordinates.
+
+### Interact
+
+| Command | Description |
+|---------|-------------|
+| `launch` | Launch an app by `--bundle`, `--path`, or `--name` |
+| `raise` | Bring an app — or one window via `--window-id`/`--title` — frontmost; switches Spaces for fullscreen windows |
+| `click` | Click an element (`--id`) or coordinate (`--x --y`); `--count 2` double-clicks |
+| `right-click` | Context-menu click (AXShowMenu when advertised, synthesized otherwise) |
+| `type` | Set an AX field value (`--id`) or paste at a coordinate; `--commit` confirms |
+| `type-text` | Stream unicode keystrokes into the focused field; `--commit` presses Return |
+| `key` | Send a key chord: `enter`, `esc`, `cmd+shift+s`, ... |
+| `drag` | Drag `--from "x,y"` `--to "x,y"` |
+| `scroll` | Scroll by `--dy`/`--dx` at an element or coordinate |
+| `ax-action` | Perform any advertised AX action (`AXConfirm`, `AXCancel`, ...) on an element |
+| `focus` | Set AX keyboard focus to an element |
+| `wait` | Sleep (`--duration`) or poll an element/locator until `exists`/`enabled`/`disappears` |
+
+Shared flags: every interact verb takes `--bundle`/`--pid`; reads take
+`--json`. `click`/`type-text`/`key`/`drag`/`scroll` accept `--raise` to bring
+the target frontmost before acting.
+
+### Focus discipline
+
+Keystrokes are posted to the target pid. Apps that gate input on key-window
+status (VM guests such as Parallels, some Catalyst apps) silently drop them
+when the app is not frontmost. The daemon therefore reports `"frontmost"` in
+every `type-text`/`key` result, and the CLI prints a stderr warning when it is
+`false`. Pass `--require-frontmost` to turn that situation into a hard
+`not_frontmost` error instead. The reliable sequence for key-window-gated
+apps:
+
+```bash
+agents computer raise --bundle <id> --title "<window>"
+agents computer type-text --bundle <id> --text "..." --require-frontmost
+```
+
+### Errors worth knowing
+
+| Error code | Meaning | Fix |
+|------------|---------|-----|
+| `not_frontmost` | Keystrokes would be dropped | `raise`, then retry |
+| `window_offscreen` | Window is on an inactive fullscreen Space; SCK cannot capture it | `raise --window-id <n>`, re-screenshot |
+| `element_not_found` | No window/element matched | `screenshot --list` / re-`describe` |
+| `rpc_timeout` | Daemon did not respond within the per-call timeout | `status`; `stop` + `start` |
+| `permission_denied` | Target app not in the allow list | Add `Computer(<bundle-id>)`, `reload` |
+
+`status` output fields:
+
+| Field | Description |
+|-------|-------------|
+| `installed` | Whether Agents Computer (`/Applications/Computer Helper.app`) exists |
+| `daemon` | Socket up (running) or down (stopped) |
+| `policy` | Count and names of allowed apps from the policy file |
+| `peers` | Count of caller executables allowed to connect |
+| `trust` | `granted` or `denied` from a live `trust_status` RPC call |
+| `pid` | Helper process PID (when trust is probed successfully) |
+
+### History and discovery
+
+| Command | Description |
+|---------|-------------|
+| `agents computer sessions` | Browse computer-driving history, grouped by run. `agents sessions --computer` is the same view. |
+
+`agents computer sessions` flags: `--machine <name>` (only rows on/driving a
+matching hostname, machineId, or `--device` name), `--limit <n>` (cap the flat
+table at this many rows — default 50; the interactive picker and `--json` are
+unbounded), `--json`, `--no-interactive`.
+
+There is no capture directory the way `agents browser sessions` has one per
+task — a computer action drives a live GUI in place and leaves no file behind.
+The durable source is the `computer.action` event every verb already writes
+(`~/.agents/.history/events/`, 7-day/50 MiB default retention, same as any
+other audit event), and each row is every action sharing one CLI process's
+pid: a single explicit verb (e.g. `agents computer click ...`) is a one-action
+row, and a whole `agents computer run --task "..."` loop collapses to one row
+holding every verb the model drove, labeled with the (truncated) task text.
+
+On a real terminal (no `--json`/`--no-interactive`), `sessions` opens an
+interactive, **task-first** browser: one row per run, newest first, showing
+machine, target app/window bundle when known, action counts by verb, and —
+when the run's session identity resolves — the owning agent session. A run
+whose CLI process carried a real `AGENT_SESSION_ID`/`AGENT_LAUNCH_ID` links
+directly to that session's canonical digest (prompt, changes, tests, last
+response); one that carried an identity nothing on this machine can index
+shows **unresolved**; a bare terminal invocation with no agent session env at
+all shows **unlinked** — its actions are still listed, there's just no session
+to attribute them to.
+
+Each invocation's identity is also written to a durable `computer_sessions` row
+in the local session DB. The event ledger is deliberately bounded (7 days /
+50 MiB by default), so once it prunes, a run's individual actions are gone —
+before this, the whole run vanished from the listing with them. It now stays
+listed from that row, carrying identity, timing and a total action count, with
+an empty per-verb breakdown: those actions really are gone, and are never
+reconstructed. The row is metadata only, and the bounded `--task` preview is the
+same text the ledger already stored — no new content is captured.
+
+Search matches task text, machine, target bundle, the
+linked session's agent/topic, or a driven verb; `enter` prints the
+highlighted run's full action list (there's nothing to open — no artifact
+exists per action) and the picker keeps browsing. `--no-interactive` prints
+the flat per-run table instead — the stable, scriptable surface `--json` also
+uses.
+
+**Retention and privacy.** Nothing here adds a second retention policy —
+`agents computer sessions` reads the same bounded, auto-pruned event ledger
+every other `agents <cmd>` audit event already lands in. Nothing sensitive is
+persisted: `type`/`type-text` actions already record only the typed length,
+never the text; a `run --task` description is the agent's own instruction
+(the same class of content `agents sessions` already stores as a session
+prompt), kept but bounded to 200 characters before it is ever written — never
+the full text.
+
+## Remote Windows (`--device`)
+
+Every verb takes `--device <device>` to drive a Windows machine registered with
+`agents devices`: `setup --device` pushes the C# daemon
+(`computer-helper-win.exe`) and registers a LOGON scheduled task,
+`start --device` opens an `ssh -L` tunnel to its loopback port, and every other
+verb reconnects through that tunnel. The daemon mirrors the macOS wire
+contract, with these Windows specifics:
+
+- **Screenshots are pid-scoped, PNG-encoded.** `--list` enumerates the target
+  pid's top-level windows (`window_id` is the Win32 HWND — the same id
+  `raise --window-id` takes), the default capture crops to the pid's largest
+  on-screen window, `--window-id` shoots one window, `--display` the whole
+  display the app is on. `--quality` is ignored (lossless PNG).
+- **Lifecycle:** `status --device <device>` reports the recorded tunnel and a
+  live daemon probe; `reload --device <device>` restarts the daemon's scheduled
+  task (the way to pick up a freshly pushed exe) and confirms it answers.
+  There is no allow-list policy on Windows — the daemon is tunnel-gated.
+- **`--require-frontmost` is enforced:** Windows synthetic input lands in the
+  *focused* window, so `type-text`/`key` report `frontmost` and the flag turns
+  a non-foreground target into a hard `not_frontmost` error.
+- **`--background` is rejected** (`action_unsupported`): the macOS
+  focus-safe postToPid delivery has no Win32 analogue — synthetic input is
+  global. Element mode (`--id` on an invokable element) is the focus-safe path.
+- **`get-text` needs `--id`** (from `describe`); `--max-chars` caps the
+  extraction (default 20k).
+
+```bash
+agents computer setup --device win-mini      # push exe + register LOGON task
+agents computer start --device win-mini      # open the tunnel
+agents computer status --device win-mini     # tunnel + daemon liveness
+agents computer screenshot --device win-mini --pid 27180 --list
+agents computer reload --device win-mini     # restart the remote daemon
+agents computer stop --device win-mini       # tear down tunnel + task
+```
+
+## Recipes
+
+### 1. Install helper and grant accessibility
+
+```bash
+# Install
+agents computer setup
+
+# Grant permissions in System Settings (manual step)
+# Then:
+agents computer start
+agents computer status
+# trust: granted means you are ready
+```
+
+### 2. Screenshot the active app
+
+```bash
+agents computer start
+
+# Bring the app you want to the foreground, then:
+agents computer screenshot --out /tmp/app-snapshot.jpg
+
+# Or target a specific app by bundle ID:
+agents computer screenshot --bundle com.apple.mail --out /tmp/mail.jpg
+
+# Or enumerate windows (reveals modals) and capture one:
+agents computer screenshot --bundle com.apple.mail --list --json
+agents computer screenshot --bundle com.apple.mail --window-id 1234 --out /tmp/dialog.jpg
+
+agents computer stop
+```
+
+### 3. Add a new app to the allow list, then reload
+
+```bash
+# Add the bundle ID to your permissions group
+cat >> ~/.agents/permissions/groups/computer.yaml << 'EOF'
+  - "Computer(com.apple.calendar)"
+EOF
+
+# Reload without restarting the daemon
+agents computer reload
+# Output: policy: 4 apps allowed (com.apple.mail, com.apple.notes, ...)
+
+# Now screenshot Calendar
+agents computer screenshot --bundle com.apple.calendar --out /tmp/calendar.jpg
+```
+
+### 4. Drive a native app end-to-end
+
+The loop is observe → act → verify: act, then re-screenshot and compare —
+a byte-identical image means the action did not land.
+
+```bash
+agents computer start
+agents computer status                                  # confirm trust: granted
+
+agents computer raise --bundle com.apple.notes
+agents computer describe --bundle com.apple.notes       # element ids @eN
+agents computer click --bundle com.apple.notes --id @e7
+agents computer type-text --bundle com.apple.notes --text "meeting notes" --require-frontmost
+agents computer screenshot --bundle com.apple.notes --out /tmp/notes-after.jpg
+
+agents computer stop
+```
+
+For AX-opaque surfaces (VM guests, Chromium/UXP canvases) `describe` shows
+nothing useful inside the content area — work in coordinate mode from
+screenshot `origin`/`scale` instead, and gate keystrokes with
+`--require-frontmost`. The `computer` skill in the system DotAgents repo
+(`skills/computer/`) is the agent-facing playbook for both modes.
+
+## Demo
+
+<video autoplay loop muted playsinline width="100%" src="../assets/videos/computer.mp4"></video>
+
+## See also
+
+- [docs/browser.md](browser.md) — drive real browsers via CDP; part of the automation triad
+- [docs/pty.md](pty.md) — drive REPLs and TUI programs from an agent; part of the automation triad
+- [docs/concepts.md](concepts.md) — DotAgents repos, resource resolution model

--- a/cli/docs/computer.md
+++ b/cli/docs/computer.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Computer
 
 Drive native macOS apps from AI agents via the Accessibility API.

--- a/cli/docs/credential-management.md
+++ b/cli/docs/credential-management.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Credential management — the fleet auth model
 
 Status: design (target state). Companion to

--- a/cli/docs/credential-management.md
+++ b/cli/docs/credential-management.md
@@ -1,0 +1,275 @@
+# Credential management — the fleet auth model
+
+Status: design (target state). Companion to
+[`secrets-trust-boundaries.md`](secrets-trust-boundaries.md).
+
+## The problem
+
+Every agent harness authenticates with a **rotating, interactive OAuth login**
+stored on disk (Claude Code's `.claude/.credentials.json`, `.codex/auth.json`,
+`.grok/auth.json`, `.kimi-code/…`, antigravity's Google token, droid's encrypted
+blob). Measured on a live box, all of them are the same shape: a short-lived access
+token plus a **single-use refresh token that rotates server-side on every refresh**.
+
+Two failures follow from treating that login as fleet state:
+
+1. **Fleet-wide logout.** `agents fleet apply` copies the login file across machines
+   (`FLEET_AUTH_FILES`). When one box refreshes, the server rotates the refresh
+   token and invalidates every other copy — the whole fleet drops to "run /login"
+   (the codebase already documents this: `fleet/remote-login.ts` — "droid collapsed
+   10 boxes → 1 overnight").
+2. **Touch ID storm.** On macOS the login lives in the login Keychain, ACL-bound to
+   the harness (Claude Code, etc.). agents-cli isn't on that ACL, so every time it
+   reads the token — to draw `ag view` usage bars, to select an account — macOS
+   pops a Touch ID sheet.
+
+Both come from the same mistake: **agents-cli touching the interactive login.**
+
+## The invariants (non-negotiable)
+
+1. **The daemon holds no token.** No fallback, no injected, no per-account token. It
+   never reuses a live/interactive token, never refreshes or rotates one, never logs
+   in for the user. A routine runs the *exact same* `agents run` process a user runs
+   directly. (Shipped: PR #1583.) See [`routines.md`](routines.md).
+
+2. **The interactive/rotating login is untouchable.** agents-cli never reads,
+   stores, syncs, or references a harness's interactive OAuth login. Not for usage,
+   not for fleet sync, not for account selection. It is never written to the keychain
+   by us and never copied across devices. It stays on the box that minted it and
+   refreshes itself there. Enforced on the transfer paths too (RUSH-2527): neither
+   `agents run --host --copy-creds` nor `agents run --lease` serializes a native
+   login (Claude OAuth + codex/grok/gemini `auth.json`) to another device — both
+   **refuse** and steer to a portable provider account, sharing the one
+   `isNativeOAuthRuntime` predicate (`src/lib/hosts/credentials.ts` →
+   `buildHostCredentialScript`, `src/lib/crabbox/runtimes.ts` →
+   `buildCredentialScript`; SING-1b). Portable account bundles still cross the
+   fleet through the explicit `agents accounts sync` path.
+
+3. **The only credential agents-cli manages is a deliberate, durable credential.** A
+   long-lived, **non-rotating** OAuth setup-token / API key / bearer token
+   (`claude setup-token`, `OPENAI_API_KEY`, `XAI_API_KEY`, `FACTORY_API_KEY`, …).
+   Valid until explicitly revoked → **safe to reuse on many devices, no repeated
+   logouts, no revocation cascade.** That safety property is the whole reason it, and
+   only it, is shareable.
+
+4. **Shipped (RUSH-2470): each provider account is its own named `agents secrets`
+   bundle, not one reserved bundle.** `agents accounts add <name> --provider <p>
+   --auth <type>` creates a bundle named after the account, with secrets policy
+   `never` set unconditionally — never the OS keychain's biometry ACL, so reading
+   it raises no Touch ID prompt. There is no shared "auth" bundle name; a user can
+   hold as many named accounts as they need, and only the accounts they explicitly
+   `agents accounts sync <name> --device <device>` cross the fleet. That sync (and
+   every `agents secrets` transport that moves credential bytes) rides a hardened
+   SSH posture (RUSH-2527): the destination is verified against the CLI-managed
+   known_hosts store — a **changed** host key is refused — and the credential
+   connection is never multiplexed, so it leaves no reusable authenticated control
+   master behind. Secret bytes cross on ssh **stdin** (push) / **stdout** (resolve),
+   never on argv.
+
+5. **Usage probes read the setup-token**, not the interactive login — and never
+   a prompting keychain read. Caveat (RUSH-2392): Anthropic's
+   `claude setup-token` is scoped `user:inference` only; the usage endpoint
+   requires `user:profile`, so a setup-token cannot populate bars through that
+   endpoint. Interactive Claude sessions populate the same per-account cache
+   without exposing a credential: Claude Code sends its native five-hour and
+   seven-day rate limits to the managed status-line command after responses.
+   `agents view` reads those snapshots. A headless account that has not produced
+   a native snapshot still renders `usage unavailable (headless)`.
+
+   **Claude is event-fed, not polled.** The managed Claude settings command is
+   `agents __claude-statusline`. Resource sync merges that command into each
+   version home's existing `settings.json`, preserving every other setting and
+   delegating a prior custom status-line command. Claude Code invokes it with
+   `rate_limits` only after a real inference response; launching Claude without
+   receiving a response can therefore show host/model while leaving quota
+   unchanged. The five-hour and seven-day fields may arrive independently, so
+   ingestion merges each window into the last snapshot instead of replacing the
+   other one. `agents view claude` always reserves both `S` and `W` slots: a
+   provider-omitted window is a filled red `unavailable` slot, distinct from a real
+   zero-percent window. Do not restore `/api/oauth/usage` polling or read/copy the
+   interactive OAuth credential to fill these bars.
+
+6. **Zero Touch ID** — `ag view`, agent launch, usage, any op — across **every
+   harness**, including the hard ones (Droid, Kimi). Solution decided per credential
+   *type*, not per agent name.
+
+## One account namespace: provider credentials and named native logins (RUSH-2527)
+
+An **account** is one authorization identity, and it comes in two kinds that share
+a single name namespace (`meta.accounts`):
+
+- **Provider credential accounts** — a durable API key, setup token, or bearer
+  token the CLI stores as a policy-`never` secrets bundle (invariant 4 above).
+  Created with `agents accounts add`; portable, so `accounts sync` copies it.
+- **Native account records** — a durable *name* for a harness's own signed-in
+  login. `agents accounts name <source> <name>` (e.g.
+  `agents accounts name claude@2.1.220 work`) records **metadata only** — a stable
+  id, the harness, the identity key, and a friendly label — in `meta.accounts.native`.
+  The harness-owned OAuth/session credential is **never copied**, so a native
+  account cannot be `sync`ed. A native lookup reads only `meta`, never the provider
+  bundle store or the keychain.
+
+**Only a safely-identifiable native login is nameable/attachable.**
+`account-capabilities.ts` is the canonical table, and it is deliberately
+conservative — a `NativeAccount` stores no device-id discriminator, so a login
+whose identity can't be proven unique across synced metadata is marked
+**unsupported** rather than falsely supported:
+
+| Harness | Native account naming |
+|---|---|
+| Claude, Codex, Grok | **supported** — version-scoped, strong account key; attach to an exact `agent@version` |
+| Muse | **conditional** — version-scoped, email-only; nameable only when the login exposes an email |
+| Antigravity, Kimi, Droid, OpenCode | **unsupported** — device-scoped but opaque/singleton; the identity can't be proven distinct across devices (Droid exposes no account key; Antigravity/OpenCode can alias two credentials as one) |
+| Cursor | **unsupported (blocked)** — multi-account isolation unresolved; use its API-key provider account instead |
+| everything else | **unsupported** / discovery-only |
+
+`agents accounts name`/`attach` refuse an unsupported harness with a named
+reason (for example, `kimi accounts can't be isolated by agents-cli yet
+(device-scoped login). Supported today: claude, codex, grok.`). That gate
+applies only to native naming/attachment. Provider `accounts add <name>
+--provider <p>` stays unrestricted. For a supported (version-scoped) login,
+`attach` validates the target is currently signed in to the same identity
+before binding, and injects no secret or env.
+
+The commands read like the task, object first:
+
+| Command | Behavior |
+|---|---|
+| `agents accounts` / `list` | Unified list: provider account bundles + named native logins |
+| `agents accounts name <agent@version> <name>` | Name a signed-in native installation (refuses unsupported harnesses) |
+| `agents accounts add <name> --provider <p> --auth <t>` | Store a provider credential account |
+| `agents accounts view <account>` (alias `inspect`) | Show one account — kind, custody, and its attachments |
+| `agents accounts attach <account> <target>` | Bind an account to a target. A **native** account attaches only to a supported `agent@version` installation. A **provider** account attaches to an `agent@version`, a bare harness id, or an existing custom-harness profile. Typos and unsupported targets are rejected before binding. |
+| `agents accounts detach <account> <target>` | Remove one attachment |
+| `agents accounts rename <old> <new>` / `remove <name>` | Rename or remove either kind; `remove` refuses while a binding, a per-harness default, or a harness profile still references the account |
+| `agents accounts switch <harness> [account]` | Fast picker (or direct name) that writes the per-harness default. `--json` lists or reports. Same binding as `set-default`. |
+| `agents accounts sync <account> <device>` | Copy a provider account bundle to a worker (native records have no bytes to copy) |
+
+Account registration is uncapped. (The plan-tier cap that briefly shipped in
+1.22.42-1.22.43 read the billing tier from the Rush/Prix backend; it was removed
+with the rest of that coupling pending the Phoenix-backed account layer,
+RUSH-2581.)
+
+`set-default` / `clear-default` remain the per-harness-default spelling and are
+consulted after an exact `agent@version` or device-scoped binding.
+`agents accounts switch <harness>` (optional `[account]`, `--json`) is the fast
+picker over that same default: it lists named accounts with usage / headroom /
+signed-out state and writes `set-default`. No extra persistent state.
+`resolveAccountSelection` orders resolution: explicit `--account` → exact target
+binding → device-scoped binding → per-harness default. Runtime injection of the
+resolved account (live-fingerprint validation for native, env for provider) and
+the fleet inventory labels are wired by the runtime/fleet-auth track; fleet
+credential transport is owned by the credential-transport track.
+
+## What is "held" and shared (the ingredients)
+
+| ingredient | where | shared across fleet? | why safe |
+|---|---|---|---|
+| Interactive OAuth login | the box that minted it, in its own config home / the harness's own keychain item | **No — never touched by us** | rotates/revokes on cross-use; leaving it alone is the fix |
+| Setup-token / API key (durable) | a named `agents accounts add` bundle, secrets policy `never` | **Yes — synced, explicitly** | non-rotating, revoke-only; reuse never invalidates another holder |
+| daemon / CLI | — | — | hold nothing |
+
+The only thing that crosses the fleet is a provider account bundle the user
+deliberately created with `agents accounts add` and explicitly pushed with
+`agents accounts sync <name> --device <device>`. Nothing rotating is ever copied.
+
+## How each surface changes
+
+- **`agents fleet apply`** does not copy login files. `FLEET_AUTH_FILES` is inventory
+  metadata only; fleet apply has no native-login materialization path. Per
+  agent per box `apply` surfaces: "logged in" / "log in on this box" (interactive or
+  `agents fleet login`) / "add or sync a provider account (`agents accounts add` /
+  `sync`)" — driven by whether the box has its own login or a declared account
+  bundle, never by agent identity.
+- **`agents fleet login`** (per-box device-code over SSH, writes the credential on
+  the box, never transports it) stays as the per-machine login path. Onboarding a
+  new device syncs the needed provider account bundle (`agents accounts sync`)
+  instead of copying logins.
+- **`ag view` / usage** (`usage.ts`) reads the shared per-account usage cache.
+  Interactive Claude sessions feed that cache through Claude Code's native
+  status-line payload; explicit network probes read the setup-token from its
+  named account bundle. Neither path reads the harness's ACL-bound keychain login.
+  No no-ACL cache of the interactive token is needed because the interactive
+  token is never read.
+  Claude's human row ends with one unlabeled last-active timestamp. Auth-health
+  remains available in `--json` for machine consumers; it is not rendered as a
+  second timestamp beside usage because that probe age is neither activity age
+  nor usage-capture age.
+  When Anthropic returns 403 `user:profile` on that token, the probe sets
+  `reason: 'usage_scope'` so auth-health stays `unverified` (not `revoked`) and
+  the row shows `usage unavailable (headless)` (RUSH-2392).
+- **Routines / `agents run`** authenticate via the box's own login (interactive) or
+  the setup-token the user placed; the daemon injects nothing.
+
+## Per-harness credential map (evidence-based, verified)
+
+macOS keychain-ACL (→ Touch ID when we read it) is **claude + antigravity only**
+(`auth-sync.ts:47`). Every other harness reads its login from a plain file and
+**never triggers Touch ID** (`usage.ts` per-provider reads). Setup-token env vars
+are already mapped in `profiles.ts:324-329` for BYOK profiles.
+
+| harness | macOS login store | setup-token / API-key env var | wired in agents-cli? |
+|---|---|---|---|
+| claude | **keychain-ACL** | `CLAUDE_CODE_OAUTH_TOKEN` (`claude setup-token`, 1yr) / `ANTHROPIC_API_KEY` | daemon-inject removed (PR1); `ANTHROPIC_AUTH_TOKEN` via profiles; Linux shim reads `.oauth_token` |
+| codex | file (`.codex/auth.json`) | `OPENAI_API_KEY` | yes (`profiles.ts:326`) |
+| gemini | file | `GEMINI_API_KEY` | yes (`profiles.ts:327`) |
+| grok | file | `XAI_API_KEY` | yes (`profiles.ts:328`) |
+| opencode | file | `OPENCODE_API_KEY` | yes (`profiles.ts:329`) |
+| droid | file (locally-decrypted, no keychain) | `FACTORY_API_KEY` (`fk-…`) | **no** — unwired anywhere |
+| kimi | file (`.kimi-code/…`) | **none** — Kimi reads only `config.toml`, not env | **no** (not possible via env) |
+| antigravity | **keychain-ACL** | `ANTIGRAVITY_API_KEY` (agents-cli claims; upstream issue #78 says unsupported — unresolved) | preset only |
+
+Resolved open items:
+- **Touch ID is Claude-only in practice.** Only claude routes usage/probe through
+  the ACL keychain (`usage.ts:1305-1306`, `loadClaudeOauth`→`getKeychainToken`).
+  Antigravity is keychain-bound but has NO usage read, so it doesn't hit the `ag
+  view` storm. Droid & Kimi are already file-based → **no Touch ID to fix**.
+- **Kimi has no env-var auth** (config.toml only) — a real limitation; its
+  file-based OAuth login stays per-box, no shareable token.
+- **Droid**: `FACTORY_API_KEY` is real but agents-cli wires nothing — a gap to
+  close if we want droid selectable as an `agents accounts` provider.
+
+## The Touch ID fix (concrete)
+
+Only the **token-acquisition step** changes — no endpoint/header change (the usage
+endpoint takes any `sk-ant-oat01-` bearer, `usage.ts:624,957`):
+
+- In `loadClaudeOauth` (and its callers `probeClaudeStatus` / `getClaudeUsageInfo`,
+  `usage.ts:604,938`), **resolve `CLAUDE_CODE_OAUTH_TOKEN` from the named account
+  bundle (or env) BEFORE the keychain-ACL read** (`usage.ts:1348-1353`). If a
+  setup-token is present → use it as the bearer and skip `getKeychainToken`
+  entirely → no ACL-gated `/usr/bin/security` call → no Touch ID.
+- Same for the daemon's every-3-min `probeLocalFleetAuth` (`auth-health.ts:391-410`)
+  — the real storm source — so its warm loop reads the account bundle's
+  setup-token, never the ACL-bound keychain login.
+- The setup-token lives in a bundle written by `agents accounts add`, which
+  always sets secrets policy `never` — a no-biometry-ACL item (keychain on
+  macOS, the platform default elsewhere), never the harness's own ACL'd login.
+  Populated by the user OR **self-minted** by the agent (`claude setup-token`
+  via pty + computer-use).
+
+## Migration (priority order — Touch ID first, it's the live pain)
+
+1. Daemon holds nothing (done, #1583).
+2. **Claude usage/probe read the account bundle's setup-token, not the ACL'd
+   keychain login** → kills the Touch ID storm. Self-mint + store the setup-token
+   per account. **Enforcement landed:** `loadClaudeOauth`'s `accessTokenCache`
+   path (`usage.ts`) now returns `null` when no setup-token is provisioned
+   instead of falling through to the interactive keychain / `.credentials.json`
+   — so the daemon's usage (~60s) and auth-health (~3min) warms can never read
+   or transmit the interactive OAuth login (the transitional fallback + its
+   no-ACL cache are removed). An unprovisioned account reads as `unconfigured`
+   for the probe; a normal interactive response can still populate its usage
+   snapshot through the native status line. Rush Cloud dispatch does not read a Claude credential at all
+   (SING-1b: the account manifest is version + email only). The leftover
+   `readClaudeCredentialsBlob` helper that still read Keychain / `.credentials.json`
+   — the #1767 shape — is deleted (RUSH-2359). `--lease` SING-1b detection reads
+   the wrapped rotating blob itself and rejects anything that is not
+   `{ claudeAiOauth.accessToken }`.
+3. `apply` stops copying rotating login files (Gap B).
+4. **Shipped (RUSH-2470):** `agents accounts add <name>` creates a named,
+   policy-`never` bundle per account; `agents accounts sync <name> --device
+   <device>` copies it explicitly to a worker device (encrypted file backend on
+   Linux, Credential Manager on Windows). No reserved bundle name — every
+   account the user creates is independently named and independently synced.
+5. Fleet upgrade + verify **zero Touch ID** on a real macOS box (the proof).

--- a/cli/docs/hooks.md
+++ b/cli/docs/hooks.md
@@ -1,0 +1,422 @@
+# Hooks
+
+Shell scripts that run automatically in response to agent lifecycle events — session start, tool calls, task completion, and more.
+
+## Overview
+
+Hooks are shell scripts in `~/.agents/hooks/` that fire when an agent crosses a lifecycle event boundary. Each hook is declared in a manifest (the `hooks:` section of `agents.yaml`) that binds it to one or more events, specifies an optional timeout, and optionally declares predicate matchers that gate execution. At agent launch, agents-cli reads the merged system + user manifest and writes the resolved script paths into the agent's native settings file — `settings.json` for Claude, `hooks.json` for Codex, and so on.
+
+All declared predicates AND together at fire time: every predicate in the `matches:` block must pass, or the script is skipped. An empty `matches:` block always passes.
+
+Hooks are separate from plugin-bundled hooks (which use a `hooks/hooks.json` inside the plugin directory). Central hooks in `~/.agents/hooks/` follow the same layered resolution as every other resource: project overrides user overrides system. See [resource-sync.md](resource-sync.md) for the full resolution model.
+
+## Architecture
+
+```
+Central storage (user > system):
+  ~/.agents/hooks/                    User-authored scripts (higher precedence)
+  ~/.agents-system/hooks/             System-shipped scripts
+
+  Manifest declarations:
+  ~/.agents/agents.yaml               User-layer hook manifest  (hooks: section)
+  ~/.agents-system/agents.yaml        System-layer hook manifest (hooks: section)
+
+  Merge rule: user wins on key collision.
+              enabled: false in user layer disables a system hook without forking it.
+
+                         agents hooks add / agents use
+                                    │
+                                    ▼
+  <version-home>/
+    .claude/hooks/<name>.sh          Copied script (Claude)
+    .codex/hooks/<name>.sh           Copied script (Codex)
+    ...
+
+  registerHooksToSettings() writes resolved paths into agent-native config:
+    Claude:   <version-home>/.claude/settings.json        (hooks: {...})
+    Codex:    <version-home>/.codex/hooks.json            + config.toml features.codex_hooks=true
+    Gemini:   <version-home>/.gemini/settings.json        (hooks: {...})
+    Agy:      <version-home>/.gemini/antigravity-cli/settings.json
+
+                         Agent fires event
+                                    │
+                                    ▼
+  Agent reads registered hooks from its settings file and execs the registered
+  command with event context as JSON on stdin. For a hook that declares
+  matches:, cache:, or a bare matcher: (the tool-name filter, e.g. git-guard's
+  matcher: Bash), the registered command is a generated wrapper shim, not the
+  raw script. The shim evaluates the matches: predicates first (a port of
+  shouldFire() in src/lib/hooks/match.ts): if any predicate fails it exits 0
+  without running the script; if all pass it execs the real script (then
+  applies cache: if set) and appends a hook.fire timing sample either way. A
+  hook with none of matches:/cache:/matcher: is registered by its raw script
+  path with no timing wrapper — a bare lifecycle hook with nothing to gate,
+  cache, or filter by tool.
+```
+
+## Command Reference
+
+| Command | Description |
+|---------|-------------|
+| `agents hooks list [agent]` | Show registered hooks per agent version and which events they respond to |
+| `agents hooks add [source]` | Install from GitHub, local path, or pick interactively from `~/.agents/hooks/` |
+| `agents hooks remove [name]` | Delete a hook from agent version homes |
+| `agents hooks view [name]` | Print the shell script source for a hook |
+
+### Options
+
+| Command | Flag | Effect |
+|---------|------|--------|
+| `list` | `-a, --agent <agent>` | Filter to a specific agent; supports `agent@version` syntax |
+| `list` | `-s, --scope <scope>` | `user` (global), `project` (repo), or `all` (default) |
+| `add` | `-a, --agents <list>` | Target specific agents/versions: `claude`, `codex@0.116.0`, `antigravity@default` |
+| `add` | `--names <list>` | Install specific hooks by name from `~/.agents/hooks/` (comma-separated) |
+| `add` | `-y, --yes` | Skip all prompts |
+| `remove` | `-a, --agents <list>` | Limit removal to specific agents |
+
+## Hook Manifest Schema
+
+Hooks are declared in the `hooks:` section of `agents.yaml`. The schema maps to `ManifestHook` in `src/lib/types.ts:110`.
+
+```yaml
+# ~/.agents/agents.yaml  (user layer)
+hooks:
+  post-edit:
+    script: post-edit.sh               # filename in ~/.agents/hooks/
+    events:
+      - PostToolUse
+    timeout: 30s                       # seconds, or a duration string (5s, 2m, 1h30m); default 600
+    matcher: "Edit"                    # optional: tool name filter (PreToolUse/PostToolUse)
+    matches:
+      cwd_includes: /projects/myapp    # predicate: only fire in this path
+    override: true                     # silence shadow warning when overriding system hook
+
+  session-start:
+    script: session-start.sh
+    events:
+      - SessionStart
+    timeout: 10
+
+  prompt-guard:
+    script: prompt-guard.sh
+    events:
+      - UserPromptSubmit
+    matches:
+      prompt_contains: "deploy"        # only fire when prompt mentions deploy
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `script` | string | yes | Filename of the shell script in `~/.agents/hooks/` (or system hooks dir) |
+| `events` | `string[]` | yes | One or more lifecycle events that trigger this hook |
+| `timeout` | number \| string | no | Time before the hook is killed; default `600`. A bare number is seconds; a duration string (`5s`, `2m`, `1h30m`) is also accepted and normalized to seconds |
+| `matcher` | string | no | Tool name substring filter for `PreToolUse`/`PostToolUse` events (Codex) |
+| `matches` | `HookMatches` | no | Predicate set; all predicates AND together |
+| `enabled` | boolean | no | Set `false` in user layer to disable a system-shipped hook of the same name |
+| `override` | boolean | no | Set `true` to silence the shadow warning when a user hook has the same name as a system hook |
+| `cache` | string \| object | no | Opt-in caching + per-invocation timing. See [Caching](#caching). |
+
+## Caching
+
+Any hook that runs slow — API call, heavy script, anything over a few hundred ms — should declare `cache:` so the registrar wraps it in a shim that serves cached output and logs timing. The underlying script stays unchanged.
+
+### Shorthand
+
+```yaml
+hooks:
+  linear-inject-tasks:
+    script: 03-linear-inject-tasks-context.sh
+    events: [SessionStart]
+    cache: 5m         # ttl=5min, key=global, prefetch=none
+```
+
+| Shorthand | Meaning |
+|-----------|---------|
+| `30s` | 30-second TTL, sync refresh on miss |
+| `5m` | 5-minute TTL, sync refresh on miss |
+| `1h` | 1-hour TTL, sync refresh on miss |
+| `5m-bg` | 5-minute TTL, stale-while-revalidate: serve stale immediately + refresh in background |
+
+### Full object form
+
+```yaml
+cache:
+  ttl: 1h                # seconds or "30s" / "5m" / "1h"
+  key: per-cwd           # global | per-cwd | per-session | per-project
+  prefetch: background   # none | background
+```
+
+| Key | Effect | Use when |
+|-----|--------|----------|
+| `global` (default) | One cache file per hook, shared everywhere | SessionStart hooks pulling org-wide context (Linear sprint, GitHub notifications) |
+| `per-cwd` | Cache keyed on the `cwd` field in the hook's stdin JSON | Per-repo context injection |
+| `per-session` | Cache lives for the agent's `session_id` | Memoization within a session for hooks that fire repeatedly |
+| `per-project` | Cache keyed on the nearest git repo root above cwd | Per-project context injection |
+
+`prefetch: background` is the magic flag for SessionStart-style hooks: boot is always instant because the shim serves the cached file immediately, then refreshes in a detached child for the next session.
+
+### What it generates
+
+When the registrar sees `cache:`, `matches:`, or a bare `matcher:` on a hook,
+it writes a per-hook shim under `~/.agents/.cache/shims/hooks/<name>.sh` and
+registers that shim's path in the agent's native settings file
+(`~/.claude/settings.json`, `~/.codex/hooks.json`, etc.) instead of the raw
+script. The shim:
+
+1. Reads stdin once (Claude/Codex/Gemini pass JSON to every hook).
+2. If `cache:` is set: computes the cache file path from `key:`, serves it if
+   fresh (cache=hit), serves stale + spawns a detached refresh when
+   `prefetch: background` (cache=stale-prefetch), or runs the real script +
+   caches the output (cache=miss). A hook with no `cache:` (matches:/matcher:
+   only) is a pure pass-through — it just execs the script, no cache read/write.
+3. Appends one JSONL line per fire to `~/.agents/.cache/logs/events-YYYY-MM-DD.jsonl`.
+4. Appends one NDJSON line to the disposable perf spool
+   (`~/.agents/.cache/perf/spool.jsonl`), drained into `perf.db` on the next
+   `agents perf` / `agents hooks profile` open. This line carries `cwd` and
+   `session_id` when the hook's own stdin JSON has them — that's what lets
+   `agents perf hooks --project <key>` scope a hook's rollup to one repo.
+
+Steps 3-4 (timing) run for EVERY shimmed hook, cache or not — that's what
+makes a matcher-only hook like git-guard show up in `agents perf hooks`.
+
+Stale shim files are garbage-collected automatically when a hook is renamed,
+deleted, or loses its `cache:`/`matches:`/`matcher:` field entirely.
+
+### `agents hooks profile` / `agents perf hooks`
+
+```
+agents hooks profile              # last 7 days, table form
+agents hooks profile --days 30
+agents hooks profile --json | jq
+agents hooks profile --warn-ms 500
+agents perf hooks                 # same rollup under the perf surface
+```
+
+Aggregates hook timings into per-hook p50/p95/p99/mean/max + cache hit rate +
+error/timeout rate. Primary source is the indexed warehouse
+`~/.agents/.cache/perf/perf.db` (safe to wipe). Falls back to the legacy daily
+JSONL when the warehouse is empty. Any hook whose p99 exceeds `--warn-ms`
+(default 2000) and has no cache hits gets flagged as a candidate for `cache:`.
+
+Hooks are instrumented when a generated shim wraps them — `cache:`, `matches:`,
+or a bare `matcher:` are each enough. A hook with none of the three (a plain
+lifecycle hook with nothing to gate, cache, or filter by tool) is the only kind
+that never shows up here; add `matches:`/`matcher:`/`cache:` to opt it in, then
+resync.
+
+See also [`observability.md`](./observability.md) for the `agents perf`
+summary (`commands`, `run`, multi-section default).
+
+
+### Supported Events
+
+| Event | When it fires | Agents |
+|-------|--------------|--------|
+| `SessionStart` | Agent session begins | Claude, Codex, Grok, Copilot (`sessionStart`), Kiro, Goose, Cursor (`sessionStart`), Hermes (`on_session_start`) |
+| `SessionEnd` | Agent session ends | Claude, Grok, Copilot (`sessionEnd`), Goose, Cursor (`sessionEnd`), Hermes (`on_session_end`) |
+| `UserPromptSubmit` | User prompt received before model sees it | Claude, Grok, Copilot (`userPromptSubmitted`), Kiro, Goose, Cursor (`beforeSubmitPrompt`), Hermes (`pre_llm_call`) |
+| `PreToolUse` | Before a tool call executes | Claude, Codex, Antigravity (`before_tool_call`), Copilot (`preToolUse`), Kiro, Goose, Cursor (`preToolUse`), Hermes (`pre_tool_call`) |
+| `PostToolUse` | After a tool call completes | Claude, Codex, Antigravity (mapped to `after_model_call`), Copilot (`postToolUse`), Kiro, Goose, Cursor (`postToolUse`), Hermes (`post_tool_call`) |
+| `SubagentStop` | A subagent finishes | Claude, Cursor (`subagentStop`), Hermes (`subagent_stop`) |
+| `PreCompact` | Before context compaction | Claude, Grok, Copilot (`preCompact`), Cursor (`preCompact`) |
+| `Stop` | Agent stops (final turn) | Claude, Codex, Antigravity (`on_loop_stop`), Grok, Copilot (`agentStop`), Kiro, Goose, Cursor (`stop`), Hermes (`on_session_finalize`) |
+| `Notification` | Agent sends a notification | Claude, Grok, Copilot (`notification`) |
+| `OnError` | Agent encounters an error | Antigravity (`on_error`), Copilot (`errorOccurred`) |
+
+Event name mapping across agents is handled in `src/lib/hooks/install.ts`: `GEMINI_EVENT_MAP`, `ANTIGRAVITY_EVENT_MAP`, Grok's `eventMap`, `COPILOT_EVENT_MAP`, `KIRO_EVENT_MAP`, `GOOSE_EVENT_MAP`, `CURSOR_EVENT_MAP`, and `HERMES_EVENT_MAP`.
+
+## Version-home deduplication
+
+Each installed harness version has its own synced hook scripts. Every native
+registrar emits one entry per logical manifest resource and event. For the
+Claude-shaped and Codex read-modify-write formats, existing registrations are
+also deduplicated by logical hook resource name, not absolute path, so the same
+hook copied under several version homes is registered once and the active
+version's command is authoritative. Other harnesses rewrite their one managed
+hook file from the manifest on each sync and therefore cannot accumulate sibling
+version paths there.
+
+Run `agents doctor` to inspect the copies. Identical same-name scripts across
+versions are warnings because they add runtime noise and cost if registered
+together. Same-name scripts with different SHA-256 hashes are critical drift:
+an older version can otherwise enforce stale rules while the active copy passes.
+The inspection covers every hooks-capable harness. The text report and `agents
+doctor --json` both name every affected version and the authoritative active
+version; JSON consumers such as the menu-bar health view receive the same
+findings under `health.issues` and `duplicateHooks`.
+
+Hermes (Nous Research, ≥ 0.11.0) declares hooks under a `hooks:` block in `~/.hermes/config.yaml` (shared with `mcp_servers`); the registrar read-modify-writes that YAML doc so sibling keys survive. Each entry is `{ command, timeout, matcher? }` (timeout defaults to 60s, capped at 300s).
+
+## Predicate Matchers
+
+All predicates live in `matches:`. They AND together — every declared predicate must pass. Evaluated by `shouldFire()` in `src/lib/hooks/match.ts:120`. The hook input context (`HookInput`) is passed by the agent CLI as JSON to each registered script.
+
+| Matcher | Tests | Example |
+|---------|-------|---------|
+| `prompt_contains` | User prompt string contains this substring (exact) | `prompt_contains: "deploy"` |
+| `prompt_matches` | User prompt matches this regex | `prompt_matches: "^(deploy\|release)"` |
+| `tool_name` | Tool name equals one of these values (`string` or `string[]`) | `tool_name: ["Edit", "Write"]` |
+| `tool_args_match` | Serialized tool arguments match this regex | `tool_args_match: "production"` |
+| `cwd_includes` | Current working directory contains any of these substrings (`string` or `string[]`) | `cwd_includes: "/projects/myapp"` |
+| `project_has` | Project root (nearest `.git` ancestor) contains this file or directory | `project_has: "Cargo.toml"` |
+| `git_dirty` | Working tree dirty state matches this boolean | `git_dirty: true` |
+| `permission_mode` | Reported permission mode is one of these values (`string` or `string[]`). Fail-open: an input with no `permission_mode`/`permissionMode` field passes, because only some harnesses (Claude Code) report the live mode | `permission_mode: "plan"` |
+| `permission_mode_not` | Reported permission mode is **not** one of these values (`string` or `string[]`). Same fail-open rule. Use this — not an enumerated `permission_mode` allowlist — to gate a hook **off** in one mode | `permission_mode_not: "plan"` |
+
+### Matcher Implementation Notes
+
+- `prompt_contains`: `src/lib/hooks/match.ts:125` — `prompt.includes(matches.prompt_contains)`
+- `prompt_matches`: `src/lib/hooks/match.ts:130` — compiled via `compileHookRegex()`; capped at 200 chars and max group depth 3 to prevent ReDoS
+- `tool_name`: `src/lib/hooks/match.ts:137` — accepts a string or array; `arrayOf()` normalizes both
+- `tool_args_match`: `src/lib/hooks/match.ts:156` — serializes `tool_args` to JSON if not already a string, then applies regex
+- `cwd_includes`: `src/lib/hooks/match.ts:166` — `cwd.includes(n)` for each needle; passes if any matches
+- `project_has`: `src/lib/hooks/match.ts:174` — walks up to the nearest `.git` directory via `findProjectRoot()`, then checks `fs.existsSync(path.join(root, matches.project_has))`
+- `git_dirty`: `src/lib/hooks/match.ts:180` — runs `git status --porcelain` in `cwd`; returns true if output is non-empty
+- `permission_mode`: `src/lib/hooks/match.ts:145` — reads `permission_mode` or camelCase `permissionMode` from the input; skips only on an explicit value outside the allowlist. Unlike `tool_name`, absence passes — a harness that never reports a mode keeps firing the hook
+- `permission_mode_not`: `src/lib/hooks/match.ts:156` — the inverse; skips only on an explicit value **inside** the deny list. It exists because the allowlist cannot express "everywhere except plan" without naming every other mode, and such an enumeration silently stops firing the moment a harness adds or renames one — for a guard, that means it quietly stops guarding. Naming the mode to skip keeps unknown modes firing, so the failure direction is "ran unnecessarily", never "did not run". Both forms AND together when declared on the same hook
+
+### Two evaluators, kept in lockstep by test
+
+`shouldFire()` in `match.ts` is the **reference**, not the runtime. A hook fire is
+decided by a hand-mirrored Python copy of that logic embedded in the generated shim
+(`src/lib/hooks/cache.ts`, the `GATE_PY` block), which the shim runs against
+`$MATCHES_JSON` and the event payload before invoking the hook script. Nothing in the
+fire path calls `shouldFire()`.
+
+That means **a predicate added to `match.ts` alone does nothing.** It must land in the
+Python gate in the same change. The gate fails open by design — any evaluation error
+runs the hook — so an unmirrored predicate is silently ignored rather than crashing,
+which is how `permission_mode_not` shipped inert (RUSH-3116).
+
+`cache-matches.test.ts` guards this: it runs the real shim under `bash` for each
+fixture and asserts the decision equals `shouldFire()`, and a completeness test
+derives the predicate list from the `HookMatches` interface in `types.ts` so a new key
+fails the suite until it is exercised against both implementations.
+
+
+## Script Resolution
+
+`resolveHookScriptPath(script)` in `src/lib/hooks/install.ts` resolves a script filename by checking, in order:
+
+1. `~/.agents/hooks/<script>` (user dir)
+2. Each enabled extra repo's `hooks/` directory (insertion order)
+3. `~/.agents-system/hooks/<script>` (system dir)
+
+The first match wins. At agent launch, scripts are copied from the central dirs into the version home (`<version-home>/.claude/hooks/`), and the registered command paths in `settings.json` point to the version-local copies — so scripts remain stable even when the source directories change.
+
+## Disabling System Hooks
+
+To disable a hook shipped by `~/.agents-system/`, add an entry with `enabled: false` in your `~/.agents/agents.yaml`:
+
+```yaml
+hooks:
+  03-linear-inject-tasks-context:
+    script: 03-linear-inject-tasks-context.sh
+    events:
+      - UserPromptSubmit
+    enabled: false          # Disables the system-shipped hook
+```
+
+`parseHookManifest()` in `src/lib/hooks/install.ts` strips entries where `enabled === false` from the returned map before the registrar sees them.
+
+## Recipes
+
+**1. List all registered hooks**
+
+```bash
+agents hooks list
+agents hooks list claude
+agents hooks list claude@2.1.112
+agents hooks list --scope user
+```
+
+**2. Install hooks from GitHub**
+
+```bash
+agents hooks add gh:team/hooks --agents claude,codex
+agents hooks add gh:team/hooks --agents claude@2.1.112
+```
+
+**3. Install a specific hook by name**
+
+```bash
+agents hooks add --names post-edit --agents claude
+agents hooks add --names post-edit,session-start --agents claude@default
+```
+
+**4. Gate a hook to fire only on Edit tool calls**
+
+In `~/.agents/agents.yaml`:
+
+```yaml
+hooks:
+  post-edit:
+    script: post-edit.sh
+    events:
+      - PostToolUse
+    matches:
+      tool_name: "Edit"
+```
+
+**5. Gate a hook to a specific working directory**
+
+```yaml
+hooks:
+  deploy-check:
+    script: deploy-check.sh
+    events:
+      - UserPromptSubmit
+    matches:
+      cwd_includes: /projects/myapp
+      prompt_contains: deploy
+```
+
+**6. Disable a system-shipped hook from user layer**
+
+```yaml
+# ~/.agents/agents.yaml
+hooks:
+  03-linear-inject-tasks-context:
+    script: 03-linear-inject-tasks-context.sh
+    events:
+      - UserPromptSubmit
+    enabled: false
+```
+
+**7. Fire a hook only on session start in dirty repos**
+
+```yaml
+hooks:
+  dirty-tree-warn:
+    script: dirty-tree-warn.sh
+    events:
+      - SessionStart
+    matches:
+      git_dirty: true
+```
+
+**8. View a hook's script source**
+
+```bash
+agents hooks view post-edit
+agents hooks view       # interactive picker
+```
+
+**9. Remove a hook**
+
+```bash
+agents hooks remove post-edit
+agents hooks remove     # interactive picker
+agents hooks remove post-edit --agents claude
+```
+
+## Demo
+
+<video autoplay loop muted playsinline width="100%" src="../assets/videos/hooks.mp4"></video>
+
+## See Also
+
+- [resource-sync.md](resource-sync.md) — hooks participate in the same layered resource sync as commands, skills, and rules
+- [docs/plugins.md](plugins.md) — plugins can bundle hooks alongside skills and MCP servers
+- [docs/workflows.md](workflows.md) — workflow lifecycle events that hooks can observe
+- [docs/subagents.md](subagents.md) — subagent definitions that parent agents dispatch to

--- a/cli/docs/hooks.md
+++ b/cli/docs/hooks.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Hooks
 
 Shell scripts that run automatically in response to agent lifecycle events — session start, tool calls, task completion, and more.
@@ -418,5 +419,5 @@ agents hooks remove post-edit --agents claude
 
 - [resource-sync.md](resource-sync.md) — hooks participate in the same layered resource sync as commands, skills, and rules
 - [docs/plugins.md](plugins.md) — plugins can bundle hooks alongside skills and MCP servers
-- [docs/workflows.md](workflows.md) — workflow lifecycle events that hooks can observe
+- docs/workflows.md — workflow lifecycle events that hooks can observe
 - [docs/subagents.md](subagents.md) — subagent definitions that parent agents dispatch to

--- a/cli/docs/hosts.md
+++ b/cli/docs/hosts.md
@@ -1,0 +1,931 @@
+# Hosts — dispatch agents to your own machines
+
+> **Status:** Implemented. `agents hosts` and the `-D, --device` flag
+> ship today across virtually every first-class group (`repos`, `view`, `inspect`,
+> `usage`, `cost`, `doctor`, `list`, `sync`, `plugins`, `skills`,
+> `teams`, `routines`, …), on `agents run`, and on multi-host aggregators
+> (`sessions`, `feed`, `logs`). Groups with no remote semantics reject the flag
+> with a clear message — never a raw commander `unknown option`.  Every `agents run` option is classified
+> by the forwarding contract (`RUN_OPTION_FORWARDING`,
+> `src/lib/hosts/remote-cmd.ts`) — forwarded, rejected loud, or local-only;
+> nothing silently drops at the SSH boundary. This document is
+> the design rationale; see [concepts.md](concepts.md#devices--hosts) for
+> the concept overview and how hosts relate to the Tailscale-backed
+> `agents devices` registry, and [ssh-transport.md](ssh-transport.md) for
+> the shared, multiplexed SSH transport every `--device` command rides.
+
+`agents hosts` lets you run any agent (`claude`, `codex`, `droid`, …) on any of
+*your* machines — a Mac mini, a Windows mini, a couple of DGX Sparks — addressed
+by name from a small local registry, over plain SSH, with no central service to
+run or pay for.
+
+**Placement** (where the body runs) is one model shared with lease, cloud, and
+routines — see [concepts.md § Placement](concepts.md#placement). On
+`agents run`, prefer `--where`; the older flags remain aliases:
+
+```
+agents run claude "fix the auth bug"   --where device:mac-mini   # = --device mac-mini
+agents run claude "…"                  --where auto              # = --device auto
+agents run claude "fix CI"            --where lease --mode edit # = --lease
+agents run claude "fix the auth bug"   --device mac-mini
+agents run codex  "port this to rust"  --device spark-0
+agents run droid  "triage the inbox"   --device win-mini
+agents run claude                      --device mac-mini          # interactive: TTY forwarded
+agents run claude "…"                  --device auto
+```
+
+Pass `auto` as the `--device` value to pick a host from 14-day session
+affinity (weighted by launch counts on `sessions.db` `machine`; most-used online
+device has highest probability). Harness stays the agent you typed — never
+auto-picked. Affinity failure degrades to local rather than aborting the run.
+
+### Which devices `auto` may pick — device roles
+
+Automatic placement draws from a **pool**, not from every online box. Mark what a
+device is for, once, from any machine:
+
+```
+agents devices role yosemite-s0 worker    # agents run here
+agents devices role yosemite-s1 worker    # …and here
+agents devices role zion personal         # your laptop — keep agents off it
+agents devices role                       # who is marked what, and what auto would pick
+```
+
+| Fleet state | `--device auto` picks from |
+|---|---|
+| nothing marked | every online device (the historical behavior) |
+| any device marked `worker` | ONLY the marked workers |
+| a device marked `personal` | never, under either state |
+
+Marking a worker is what turns the pool into an **allowlist** — that is the whole
+opt-in: two marks and every automatic launch lands on those two boxes. The rule
+lives in one place (`src/lib/devices/pool.ts`) and every automatic-placement
+caller reads it, so `agents run --device auto`, `agents teams add --device auto`,
+`agents ssh auto`, and the AGI EXT `New <Harness>` commands agree. Widen it back
+with `agents config set auto.pool all`; a `personal` box stays excluded, since
+that is what the mark is for.
+
+An empty pool is an error, not a shrug: with workers marked and none of them
+reachable, `--device auto` fails loud naming the fix rather than quietly running
+on the machine you are sitting at — including through `agents ssh auto` and the
+generic `--device auto` passthrough, which resolve `auto` via the same pool.
+
+Roles live in that device's tracked `devices/<name>/agents.yaml` `config.role`
+and travel with `agents repo push` / `pull`. Per-device files are
+conflict-free because each machine writes only its own folder; a role set
+from any box writes that device's folder, not a shared central map.
+`agents devices list` tags marked rows (and shows each box's `spec` —
+cores/RAM/disk — plus live load/mem/disk and the one-line `description`), and
+`agents devices list --json`
+carries `role` plus an `autoPool` boolean per device.
+
+### `agents run auto` — all three routing layers
+
+`auto` as the AGENT name (`agents run auto "…"`, distinct from `--device auto`)
+composes the full dispatch stack:
+
+1. **Host** — with no `--device` flag, the affinity pick above runs
+   (launches^1.3 weighted sample among online devices). A remote pick dispatches
+   `agents run auto …` to that host over the same SSH path, and the harness +
+   account layers resolve THERE (usage is per-machine); the dispatcher marks the
+   host layer resolved (`AGENTS_RUN_AUTO_HOST_RESOLVED=1`) so the remote never
+   re-runs affinity and chain-hops. `--device <name>` pins this layer.
+2. **Harness** — `pickHarnessWeighted` (lib/rotate.ts): installed harnesses with
+   ≥1 healthy account, weighted by best-account headroom
+   (`100 − min routingUsed%`), sampled with the same `weightedRandomByCapacity`
+   the account layer uses. A harness whose accounts are all rate-limited,
+   signed out, or server-revoked (the live auth-health probe saw a genuine
+   401/403 rejection — not Claude's setup-token `user:profile` scope gap,
+   which is `unverified` / RUSH-2392) is excluded outright. Naming a concrete
+   harness (`run claude`) pins this layer.
+3. **Account** — `pickBalancedCandidate` within the chosen harness (or the
+   `--strategy` you passed). Eligibility excludes an account that is
+   rate-limited, out of credits, signed out, or `revoked` (a token the daemon's
+   live auth-health probe saw rejected — so rotation never routes into a login
+   that would fail at spawn). A Claude setup-token that 403s only for missing
+   `user:profile` on the usage endpoint is `unverified`, not `revoked`, and
+   stays eligible to run (RUSH-2392). Fail-open: a missing probe or any
+   non-revoked verdict never blocks; a cached `revoked` keeps gating (the
+   conservative choice for a security signal) until the daemon's next probe
+   clears it.
+
+Every layer fails loud when it finds nothing: zero healthy accounts on any
+harness exits nonzero naming each harness's exclusion reason and the earliest
+window reset; zero healthy accounts within the picked harness exits nonzero
+with `agents: no healthy <agent> account under strategy '<strategy>' — excluded:
+…; earliest window resets <iso-time>. Use --strategy pinned to force the
+default.` (the daemon watchdog tail-detects this text for rotate cooldowns).
+`--session-id` keeps its claude-only semantics — honored when auto picks
+claude, ignored with a stderr note otherwise.
+
+### Choose an account after device placement
+
+A trailing `@` on a concrete harness composes with device routing. agents-cli
+resolves the device first, then renders the installed versions/accounts reported
+by that device:
+
+```bash
+agents run claude@ --device auto         # auto-place, then choose an account
+agents run claude@ --device yosemite-s0  # choose from yosemite-s0 only
+```
+
+The picker remains interactive, and the selected version applies only to that
+run. Account selection cannot be combined with another account selector such as
+`--strategy`, `--balanced`, `--resume`, `--lease`, or `--box`.
+
+For `--device auto`, picker placement prefers a signed-in device but keeps a
+reachable device with the harness installed eligible when every account there
+is signed out or revoked. That fallback is what lets the device-local picker
+offer `launch to sign in`. A device whose picker would contain only throttled
+rows remains excluded; ordinary automatic runs still require a healthy,
+signed-in account before placement.
+
+**One carve-out: a missing login is not an exhausted account.** When the only
+thing wrong is that an account is signed out (or its token was revoked), a
+terminal run does NOT fail loud — it launches so you can authenticate, because
+the harness's own TUI is the login surface and there is nowhere else to do it.
+`agents run <agent>` with a single such account launches it directly (naming the
+version and the login command); with several it opens the account picker, where
+an auth-blocked row is selectable and labelled `launch to sign in`. A
+throttled account is never launched this way — only a window reset clears
+`rate_limited` / `out_of_credits`, so those still exit nonzero with the message
+above.
+
+The launch requires a **human-facing** run, which is two conditions, not one: a
+real TTY *and* no `--json`. Off a TTY nothing can complete a login, and `--json`
+marks a machine consumer that must never be handed a picker or dropped into a
+login TUI — so both keep failing loud, with the harness's login command added
+alongside `--strategy pinned`. `--quiet` does not block the launch; it only
+suppresses the explanatory lines. The gate is `signInLaunchDecision` in
+`src/commands/run-account-picker.ts`, mirroring `Surface.interactive` from
+`src/commands/utils.ts`.
+
+
+Pass `all` as the `--device` value to fan any fleet-aware command out
+across every registered device. The passthrough runs `agents <cmd> --json` on each
+box concurrently, then renders a grouped-by-OS roster with one row per device
+(`○ offline` rows for unreachable devices, `●` rows for successful ones). Add
+`--json` to get the raw device-keyed object instead.
+
+```
+agents view kimi --device all          # every box's kimi version + account
+agents insights output --device all             # per-device burn vs shipped output
+agents view --device all --json        # machine-readable fleet inventory
+```
+
+`--devices all` fans out across every registered device. Commands that already register
+`--all-hosts` (e.g. `agents insights output --all-hosts`) keep their existing behavior.
+
+**The router only speaks for commands that exist.** `--device` is handled
+before commander parses, so a group with no remote semantics gets a clear
+`` `agents <cmd>` does not support --device `` instead of commander's raw
+`unknown option`. That answer is reserved for a **real** command: a name the CLI
+does not register falls straight through to `unknown command '<name>'` (plus its
+did-you-mean). Without that gate `agents session resume --device <box>` — one letter
+off `sessions`, which *does* take `--device` — was answered with a flag-support error
+about a command nobody typed, sending the user looking in the wrong place
+(RUSH-2022). `KNOWN_TOP_LEVEL_COMMANDS`
+([`src/lib/startup/command-registry.ts`](../src/lib/startup/command-registry.ts))
+is the name set, pinned to the real command tree by a test.
+
+It sits next to the vendor clouds (`agents cloud run --provider rush|codex|…`),
+not replacing them: those dispatch to *someone else's* cloud; `hosts` dispatches
+to *your* boxes (owned, or leased on demand via crabbox — see Host sources).
+
+## Motivation — the bottleneck is OS coordination, not RAM
+
+This is grounded in a real incident (Agent Workload Resource Report, 2026-06-27).
+A 30-core workstation became unusable while running agents — but **not** from
+memory pressure (102G used, **25G free**). The failure was **OS-coordination
+starvation**:
+
+```
+Load Avg: 232.61, 306.45, 245.25
+CPU: 18.99% user, 79.35% sys, 1.65% idle
+Processes: 1807 total, 13322 threads
+```
+
+~79% of CPU was spent *inside the kernel* (scheduling, vnode/path resolution,
+symlink handling, filesystem metadata) — a recursive `ripgrep` search-storm from
+an editor extension, plus the general process/file/UI fan-out of agent tooling. A
+Linux 16-vCPU comparison showed the same shape (`system_pct` ~50, `runnable` ~38,
+high fork rate). The report's conclusions map directly onto this design:
+
+- **"Separate headless agent execution from interactive rendering."** Running an
+  agent headless and publishing *summarized state transitions* — instead of
+  rendering its full transcript character-by-character in a desktop UI — is what
+  lets a machine carry more concurrent work. This is exactly the transcript-tail
+  progress model (§4): the agent runs headless on the host; we read summarized
+  events from its transcript, we don't live-render a remote TTY.
+- **"A cloud or Linux box helps only if synchronization overhead is
+  controlled."** Offloading is necessary (your laptop has finite coordination
+  capacity), but the remote run must be bounded — headless, concurrency-capped,
+  no unbounded recursive scans. The design must carry those constraints to the
+  host, not just relocate the storm.
+
+So `hosts` isn't only "I want more cores" — it's "keep my interactive machine
+responsive by moving headless agent execution off it," which the report shows is
+a coordination problem money-can't-buy-RAM doesn't fix.
+
+## Why this is brokerless (the core thesis)
+
+Every hosted-agent product surveyed — OpenAI Codex, Cursor cloud agents, Cognition
+Devin, Factory Droid Computers, Google Jules, Anthropic Managed Agents — runs a
+central relay/control-plane. But they all do it for **one** reason: they are
+multi-tenant and their machines sit behind NAT they don't control, so they need a
+relay for NAT traversal + discovery + identity + heartbeat. Cursor and Factory say
+so directly — the relay exists "so no inbound ports / VPN required" (i.e.
+*because there is no VPN*).
+
+- Cursor self-hosted: outbound HTTPS worker → control plane. <https://cursor.com/blog/self-hosted-cloud-agents>
+- Factory BYOM: outbound WebSocket → Factory relay. <https://docs.factory.ai/cli/features/droid-computers>
+- Anthropic self-hosted: outbound HTTPS poll of a work queue. <https://platform.claude.com/docs/en/managed-agents/self-hosted-sandboxes>
+
+We don't have their constraint. These are **your** machines, few in number, that
+you already know about — so discovery isn't a problem to solve, it's a **list you
+write down**. The entire broker layer collapses to a small local registry plus
+SSH:
+
+| What a relay-broker provides | What we use instead |
+|---|---|
+| connection registry (name → address) | a `hosts:` map in `agents.yaml` you maintain (`name → {address, user, caps}`) |
+| heartbeat / "is it online?" | checked **lazily, on dispatch** — one SSH probe to the *one* host you're targeting, never a fleet-wide poll |
+| NAT traversal | whatever already makes the address reachable — LAN, or a tailnet/VPN you happen to run. Out of scope for agents-cli. |
+| SSH key distribution / rotation | the existing `ssh-keys` bundle / your own `~/.ssh` |
+| identity / always-on nodes | a registry entry; the box is as always-on as you keep it |
+
+So this prior art's relay (rush's `prix/api/src/computers/relay.ts` + the Go daemon's
+outbound WebSocket in `rush/cli/internal/daemon`) is exactly the part we **don't**
+need — and neither do we need a *discovery* layer that enumerates a whole network.
+What a free CLI needs is: resolve a **name** in the registry → `ssh <address>
+'agents run …'`. No metadata service, no DB, no heartbeat, no fleet enumeration.
+
+**On Tailscale specifically (deliberately not a dependency).** A tailnet is a great
+*transport* — if a box is only reachable over yours, you register its `.ts.net`
+name as the `address` and SSH rides the tailnet with zero extra code. But agents-cli
+will **not** call `tailscale status`, enumerate peers, or connect to nodes you
+didn't name. Treating "the tailnet" as the fleet is the wrong default: it pulls in
+machines you don't want to dispatch to and assumes a VPN that not every host needs.
+The registry is the source of truth; Tailscale is one optional way an `address`
+becomes reachable. (A convenience importer — `agents hosts import --from-tailscale`
+— can *prefill* registry entries from `tailscale status` on request; it reads names
+and connects to nothing.)
+
+## What the field actually does (and where we can be better)
+
+Remote-agent UX has converged on two modes:
+
+- **Relay / remote-control** — the agent keeps running on machine A; B is a live
+  window (Claude Code Remote Control, Codex remote-SSH from the phone). Seamless,
+  but A must stay awake. <https://code.claude.com/docs/en/remote-control>
+- **Migrate / handoff** — the session moves (Claude `--teleport`, Codex thread
+  handoff, Cursor "Move to Cloud", Devin `/handoff`). But **every one transfers
+  only committed git + the transcript and either blocks on or silently drops
+  uncommitted changes.** Devin alone moves full state — via proprietary VM
+  block-diff snapshots, only inside its own cloud (<https://cognition.com/blog/blockdiff>).
+
+The uncommitted-changes wall exists because those tools **can't reach into your
+machine** — no direct network path, multi-tenant. We don't have that constraint: we
+control both ends and have an SSH path to each host, so a handoff can `rsync` the
+dirty working tree directly — no "clean git required," no VM snapshots. That is the
+differentiated capability (Phase 2), and it's something Claude Teleport / Cursor
+have open issues asking for.
+
+## The HostProvider seam (the pluggable directory + reachability layer)
+
+The one design decision that keeps this open and general-purpose: **where host
+metadata lives and how a host is reached is a pluggable provider**, not a hardcoded
+mechanism. This mirrors the existing `CloudProvider` registry
+(`src/lib/cloud/registry.ts`) — capability-gated, so partial providers are
+first-class. Two orthogonal concerns:
+
+1. **`HostProvider`** — *"what are my hosts, and how do I reach them?"* Owns the
+   registry/metadata + presence + (optionally) its own dispatch channel.
+2. **Transport** — *how a command actually runs*: SSH to an address, or a provider's
+   own relay. Shared, so every provider benefits.
+
+```ts
+interface HostProvider {
+  id: string                  // 'local' | 'rush' | 'tailscale' | 'crabbox' | <yours>
+  capabilities(): {
+    directory   // list/track hosts            (all)
+    mutate      // add / remove                 (local, rush — not tailscale)
+    presence    // online/offline               (rush relay, tailscale status)
+    relay       // dispatch w/o an SSH address    (rush; others fall back to SSH)
+    lease       // provision new hosts            (crabbox / infra)
+  }
+  list(): Host[]              // {name, address?, user?, os?, caps?, status?, provider}
+  resolve(name): Host | null
+  register?(spec) / remove?(name)
+  presence?(name)
+  dispatch?(name, cmd)       // relay path, if capabilities.relay
+}
+```
+
+**Dispatch is provider-agnostic:** `resolve(name)` → if the owning provider has
+`relay` and the host is online, use it (NAT-free, no address); else SSH to
+`host.address`. Adding a provider is a few `providers.set(...)` lines, no core
+reshape.
+
+| Provider | directory | mutate | presence | relay | lease | What it is |
+|---|---|---|---|---|---|---|
+| `local` | ✓ | ✓ | — | — | — | a `hosts:` map in `agents.yaml` — **the v1 provider**; offline, no account |
+| `rush` | ✓ | ✓ | ✓ | ✓ | — | account-keyed `computers` table + WS relay (fast-follow) |
+| `tailscale` | ✓ | — | ✓ | — | — | reads `tailscale status` as the fleet; SSH transport (fast-follow) |
+| `crabbox` | ✓ | ✓ | partial | — | ✓ | leases boxes from Hetzner/AWS/… then registers them (fast-follow) |
+| *(yours)* | … | … | … | … | … | a VPN/SDN/infra API — implement the contract, register it |
+
+**v1 ships only `local`.** It meets the core "offload from the thrashing laptop to a
+stable SSH box" need with zero account/daemon dependency. The other providers are
+purely additive behind this contract — see Phasing for why deferring `rush` costs
+nothing.
+
+### Why `local` first, not `rush` (cost/benefit)
+
+Rush's `computers` backend is real and fully built (`prix/api/src/computers/` —
+Supabase table keyed by `user_id`, `POST/GET /api/v1/computers`, WS-relay presence,
+`POST /api/v1/computers/:name/exec`). It would give cross-device registry sync,
+presence, and NAT-free relay dispatch. But every one of those benefits is
+**conditional**, and none blocks the primary use case:
+
+| Rush buys | v1 substitute | Blocks core offload? |
+|---|---|---|
+| cross-device registry sync (no git push) | registry on the driver machine | No — you drive from one machine, offload to others |
+| presence (online/offline) | one lazy SSH probe at dispatch | No — you target one host at a time |
+| NAT-free relay exec | SSH to the address | No — your boxes are SSH-reachable (LAN/tailnet/public) |
+
+Costs of taking it in v1: forces `rush login`, requires a daemon holding a WebSocket
+on every machine, and couples the OSS CLI to the proprietary Rush backend. So `rush`
+is a fast-follow `HostProvider`, opt-in when logged in — not a v1 dependency.
+
+## Architecture
+
+```
+agents run <agent> ["<task>"] --device <device>
+  │
+  ├─ resolveHost(name)         one merged lookup (devices registry ∪ agents.yaml
+  │                            overlay ∪ ssh_config) → {address,user,caps,os,…}   [Phase 1]
+  │
+  ├─ ensureHostReady(name)     lazy SSH probe (online?) + config + agent + branch  [Phase 1]
+  │
+  ├─ prompt given?             headless detach-and-follow path
+  │     ssh <node> 'agents run <agent> --json "<task>"'
+  │     progress ◀── incrementally tail the REMOTE transcript file        [Phase 1]
+  │          not the live SSH stdout pipe — the transcript on disk is the
+  │          durable log. Offset-tracked reads, parsed by session/parse.ts.
+  │
+  └─ no prompt?                interactive TTY-forwarded path
+        ssh -tt <node> 'agents run <agent>'   (only when local stdin is a TTY)
+        remote agents-cli launches its normal direct interactive UI
+        with tmux.enabled on: network drop (ssh exit 255) → auto-reattach the live remote pane;
+        clean detach / agent exit → local CLI exits with that code
+```
+
+> Shipped surface: dispatch is `agents run <agent> ["<task>"] --device <name>`.
+> With a prompt, the run is headless, follows live by default, and `--no-follow`
+> detaches; track with `agents hosts ps` and `agents hosts logs <id>`. With no
+> prompt (and a local TTY), the local TTY is forwarded over SSH and the agent runs
+> interactively on the remote host (`ssh -tt`). The remote machine spawns it
+> directly unless its device-local `tmux.enabled` setting opts into the wrapper.
+> Host runs are tracked in a **local** task store, not `agents cloud` (a separate
+> subsystem for Rush/Codex/Factory backends).
+>
+> **Surviving a network drop with tmux enabled.** A remote agent wrapped in a
+> *detached* tmux session survives an SSH blink; a direct run does not. When a
+> wrapped interactive host run has a known session id (Claude, or a
+> `--resume`d run) drops (ssh reports its connection-layer code, 255), the local CLI
+> **re-attaches the live remote pane automatically** — it drives the host's own
+> `agents sessions focus <id> --local` over SSH, which JOINS the live pane when it
+> survived and RESUMES the session in place when the pane is already gone (so a
+> reattach landing after the pane died recovers the agent instead of dead-ending at
+> a bare shell — RUSH-2085), with bounded exponential backoff (2s→30s, up to 6
+> attempts; the budget refills after a genuinely live reconnection — one that
+> reached the host **and** held the pane for at least 10 seconds). A clean detach
+> (`Ctrl-b d`, exit 0) or a real agent exit (any non-255 code) is left alone, and
+> `--raw`/no-tmux runs are not retried (they don't survive a drop). If every attempt
+> fails the CLI prints the manual **`agents reconnect <id>`** to get back in once the
+> link is back.
+>
+> **`agents reconnect [session-id]`** is the manual companion — one verb that always
+> tries hardest to put you back into a dropped agent terminal: attach the live pane
+> if it survived, else resume the session (best-effort: live pane > resumed copy > a
+> clear message about what was lost). Use it after the auto-loop above gave up on a
+> sustained outage, or when a VS Code terminal tab closed with the dead ssh client.
+> With no id it reconnects the most recent session started from the current
+> directory — the terminal that most likely just dropped — not the full fleet
+> picker. It is also spelled `agents sessions reconnect`.
+>
+> The remote `agents sessions focus --local` invocation the reattach
+> drives is wrapped so that whatever exit code it decides on, a 255 is remapped to
+> 254 before this process sees it — so a remote-side path that happened to exit
+> 255 for its own reasons would never be mistaken for the link dropping again.
+> This closes a channel-level flaw (any future remote-side 255 producer would
+> have been indistinguishable from a real drop) rather than a confirmed live bug.
+>
+> **A recurring *local* ssh failure is bounded too (#1884).** The retry budget
+> refills only on a reattach that reached the host **and** held the pane for at
+> least 10 seconds, timed on the attach alone (the reachability probe has already
+> returned by then). A fast-flapping link — or an attach that dies at TTY
+> negotiation on every reconnect — therefore drains the budget like an unreachable
+> host instead of refilling it forever, and the loop gives up with a message that
+> names what actually happened ("kept dropping again within 10 seconds of getting
+> back in"), not the unreachable-host "couldn't reconnect". The floor is
+> deliberately a *hold* requirement rather than a flat cap on total attempts: any
+> fixed total would eventually strand the all-day-blinking session this feature
+> exists for, while the hold floor only ever stops a loop that is failing to put
+> you back into the agent.
+>
+> Pass `--name <slug>` at dispatch to give the run a durable handle instead of an
+> opaque id: `agents hosts ps` shows it under a **NAME** column, and
+> `agents hosts logs <name>` resolves by name (case-insensitive, newest-wins). The
+> name also seeds the run's **session label**, so it shows up as `<name>` in
+> `agents sessions` and `agents sessions <name>` resolves it. Omitting `--name` is
+> a no-op — unnamed runs stay id-only, render `-` in the NAME column, and show the
+> `[host/<name>]` tag as their session label.
+>
+> `agents hosts ps` re-probes each still-`running` task against the remote `.exit`
+> marker so a finished (or crashed) run does not stay stuck at `running` after the
+> local follower dies. `agents hosts stop <id>` (alias `kill`) terminates the
+> remote process group from this machine, writes exit `143`, and keeps the log
+> for `agents hosts logs <id>`.
+>
+> **Steering a detached dispatch.** `agents message <id|name> "<text>"` resolves a
+> `--no-follow` dispatch the same way `agents hosts ps`/`logs` do (dispatch id,
+> `--name` handle, or the remote agent's own session id) and reroutes the message
+> over `--device` to the box that actually owns the live process — no need to know
+> which host it landed on. A task that already finished fails loud naming its
+> status instead of silently doing nothing.
+
+### Host sources — owned (registered) + leased on demand (crabbox)
+
+A "host" comes from one of two sources, but both reduce to **a named SSH target in
+the registry**, so the dispatch path (§2–§4) is identical:
+
+- **Owned, always-on** — your mac-mini, win-mini, DGX Sparks. You register them
+  once in `agents.yaml` (§1); the `address` is a LAN host, a tailnet name, or a
+  public host — whatever is SSH-reachable. Zero provisioning; they're just there.
+- **Leased, on demand** — ephemeral cloud machines provisioned by **crabbox**,
+  which is already installed and already a multi-cloud leasing layer:
+  `--provider hetzner|aws|azure|gcp|proxmox|e2b|modal|sprites|daytona|…`
+  (verified from `crabbox warmup --help`; AWS/EC2 is `--provider aws` with
+  `CRABBOX_AWS_REGION` + spot/on-demand). Crucially, crabbox machines **join your
+  tailnet** (`CRABBOX_TAILSCALE_AUTH_KEY`) and expose SSH (`crabbox ssh --id`),
+  with idle-timeout/TTL auto-expiry (`CRABBOX_IDLE_TIMEOUT`, `CRABBOX_TTL`). So a
+  leased box is the same kind of target as an owned one.
+
+This is the answer to "I need machines but don't own enough": when the laptop is
+starving, lease one.
+
+```
+agents run claude "big refactor" --on new           # crabbox warmup (default provider) → run → idle-release
+agents run codex  "gpu eval"     --on new:aws        # provider/class selector → EC2 → run
+agents run droid  "triage"       --on mac-mini       # owned, always-on
+```
+
+`--on new[:<provider/class>]` leases via crabbox, registers the leased box as a
+**transient registry entry** (its `crabbox ssh` address), runs headless, and
+releases on idle/TTL — tearing the entry down on release. agents-cli **does not**
+reimplement provisioning — crabbox owns lease lifecycle, cost, and multi-cloud;
+`hosts` owns *dispatch*. The overlap is deliberate: `crabbox run --provider ssh
+--static-host mac.local` shows crabbox already unifies leased + static SSH targets;
+we layer harness-agnostic agent dispatch + transcript-tail progress on top.
+
+Open question (carried below): how thin is the crabbox integration — shell out to
+the `crabbox` CLI (`warmup`/`ssh`/`stop`) and register the resulting SSH address,
+or a tighter binding? (Leaning: shell out for lease/release, then the common
+named-SSH dispatch path for everything else.)
+
+### 1. Discovery — an explicit registry (metadata you write down)
+
+The fleet is a curated `hosts:` map in `agents.yaml` — the few machines *you* own,
+with the metadata a driver agent needs to choose one. There is **no auto-discovery
+and no fleet enumeration**: nothing is contacted until you dispatch to a named
+host, and only that host. This matches how the work actually flows — you (or your
+driver agent) name a machine; we resolve its metadata and SSH to it.
+
+```yaml
+hosts:
+  mac-mini: { address: mac-mini.local,            user: muqsit, os: macos }
+  spark-0:  { address: spark-0.tailXXXX.ts.net,   user: muqsit, os: linux, caps: [gpu] }
+  win-mini: { address: 100.84.x.x,                user: muqsit, os: windows }
+```
+
+`address` is **any SSH-reachable target** — LAN hostname, tailnet `.ts.net` name,
+or public host. agents-cli does not care how it's reachable; it just runs SSH.
+`caps`/`os` are free-form metadata for capability-based selection (e.g. a driver
+agent routing a GPU eval to a host tagged `gpu`).
+
+`agents hosts` is a thin layer over this map, stored via the existing atomic+locked
+`readMeta`/`updateMeta` (`Meta` gains a `hosts?: Record<string, HostSpec>` field):
+
+- `agents hosts add <name> <user@address> [--cap gpu] [--os linux]` — write an entry.
+- `agents hosts list [--json]` — print the registry (name · address · os · caps).
+  **No probing** — pure metadata, instant, machine-readable for the driver agent.
+- `agents hosts check <name>` — the *only* command that touches the network: one
+  SSH probe to that host → reachable? remote `agents --version` + `agents list`
+  (which agents are installed). This is also what `ensureHostReady` calls before
+  dispatch (lazy, single-host — never a fleet poll).
+- `agents hosts remove <name>` / `agents hosts import --from-tailscale` (opt-in:
+  prefill entries from `tailscale status` names; reads only, connects to nothing).
+
+Resolution for an address goes through **one** resolver,
+[`matchHost`](../src/lib/hosts/registry.ts) (RUSH-1967), shared by every caller —
+`run --device`, the `sessions --device` fan-out, and `agents ssh` alike, so a token
+can never dial two different boxes depending on which subcommand typed it. It
+merges three directories **per-field**, it does not let one shadow another:
+
+- the **devices** registry (`agents devices`) supplies address, OS, and presence
+  — so the address is always live (`agents devices sync` takes effect without
+  re-enrolling) and a stale enrolled snapshot can't freeze the route;
+- the **agents.yaml** `hosts` overlay supplies capability tags and hints;
+- **`~/.ssh/config`** supplies hosts Tailscale has never seen (dialed by their
+  bare name, so ssh applies the stanza).
+
+One grammar for every caller: `name`, `user@name` (login user overridden, same
+box), a tailnet FQDN, an ssh_config alias, an ad-hoc `user@host`, and two reserved
+sentinels — all resolve identically. The sentinels are `auto` (RUSH-2185:
+`matchHost` resolves it via the same `resolveDeviceAffinity` engine `agents run
+--device auto` uses, so `agents ssh auto` and `agents teams add --device auto`
+pick a device the same way `run` does) and `interactive`, which resolves to the
+device pinned as `interactive.host` — the box a human is sitting at, as opposed
+to `auto`'s pick-by-load. `interactive` refuses rather than falling back to the
+local machine when no host is pinned. Both names are reserved: a device cannot
+be registered under either, and `interactive.host` cannot be pinned to one. `dispatchable` follows the device's auth method,
+so a password-auth device can't be made dispatchable by shadowing it with an
+inline entry. A bare unknown name resolves to nothing, which keeps
+capability-tag routing (`--device gpu`) and the `agents ssh` "Unknown device"
+verdict reachable. `agents ssh` additionally refuses an `auto` pick that lands
+on the machine you're already on — dialing yourself isn't the useful outcome
+`agents ssh auto` exists for — with a clear message instead of self-SSHing.
+
+### 2. Transport — plain SSH (reuse, don't reinvent)
+
+`src/lib/browser/drivers/ssh.ts` already has the whole pattern: `runSSHCommand`,
+`shellQuote`, `startSSHTunnel`, `ensureRemoteBrowser`, with
+`StrictHostKeyChecking=accept-new`, `BatchMode=yes`, `ConnectTimeout` (verified at
+`ssh.ts:132-137`). Note: only `shellQuote` is currently `export`ed; `runSSHCommand`
+/ `startSSHTunnel` / `ensureRemoteBrowser` are module-private, so step one is a
+small lift — extract the ssh-exec primitive into a shared helper both the browser
+driver and `src/lib/hosts/dispatch.ts` import (no behavior change). `dispatch.ts`
+then calls it to run the remote command and inherit stdout/stderr/exit. SSH is the protocol — it gives auth + transport +
+stream + exit code; no custom `command_output`/`command_done` framing (which is
+what the rush daemon had to invent over its WebSocket).
+
+Auth: your existing SSH keys, or a per-device private key configured with
+`agents devices config <name> ssh.identity-file <path>`. The configured
+path is passed to every OpenSSH connection for that device. If a host is reachable only
+over a tailnet, the registered `address` is its tailnet name and SSH rides it
+transparently — no Tailscale-specific code path. (Tailscale SSH / ACL-tag auth
+works too, since it's still `ssh <address> <cmd>` under the hood, but it's not
+required and not assumed.)
+
+#### Windows OpenSSH key enrollment
+
+`agents doctor` audits Windows key enrollment without reading or printing a private
+key or password. It asks `sshd -T` for the effective `AuthorizedKeysFile`, checks
+that the selected file exists and contains a public-key record, and inspects its
+ACL. Administrator accounts use
+`C:\ProgramData\ssh\administrators_authorized_keys`; normal accounts use
+`%USERPROFILE%\.ssh\authorized_keys`. The administrator file must grant
+`FullControl` to `SYSTEM` and `Administrators` and no unrelated principal.
+
+Enroll or rotate by writing the replacement **public** key to the effective file,
+then restore those ACLs and run `agents doctor` again before removing the old key.
+Revoke by deleting that public-key line. If key auth is already locked out, recover
+through the Windows console or a separately configured password-auth device profile,
+repair the effective file and ACL, then return the device to key auth. Doctor is
+read-only: it diagnoses these states but never requests credentials or changes the file.
+
+### 3. Execution — remote `agents run` (harness-agnostic)
+
+Host dispatch has two shapes, chosen by whether a prompt is present:
+
+- **Headless** (`agents run <agent> "<task>" --device <h>`): the remote command is
+  `agents run <agent> "<task>" --json` (+ `--mode`, `--model`, `--quiet`). The local
+  CLI launches it detached, then incrementally tails the remote transcript.
+- **Interactive** (`agents run <agent> --device <h>`): the remote command is
+  `agents run <agent>` with no prompt and no `--quiet`; the local CLI forwards its
+  TTY over SSH (`ssh -tt`) so the remote agent starts its normal interactive UI.
+  The tmux wrapper runs on the remote machine, exactly as it would if you had
+  SSH'd in and typed `agents run <agent>` yourself. Passing both a prompt and
+  `--interactive` with `--device` also takes the interactive path and forwards the
+  prompt to the remote TUI.
+
+Headless dispatch supports Linux, macOS, and Windows OpenSSH hosts. Windows uses
+a hidden detached PowerShell process plus the same durable per-task log and exit
+sentinel as POSIX hosts; follow, reconnect, `hosts logs`, `hosts ps`, and
+`hosts stop` select the matching remote protocol from the task record.
+
+(`--json`/`--quiet`/`--mode`/`--model` are real flags on `agents run`, registered in
+`src/commands/exec.ts`; there is no user-facing `--print` — the per-harness
+headless/`--print` mapping is internal to `buildExecCommand`.) `agents run` already
+produces the right headless or interactive argv per harness via
+`buildExecCommand` (`src/lib/exec.ts`), so **every harness, mode, and
+secret-injection path works remotely for free** — provided agents-cli + that agent
+are installed and authed on the box, which `ensureHostReady` / `agents hosts check`
+guarantee (see Context, below).
+
+**Working directory on the host.** The remote command is prefixed with a
+`cd <dir> &&` computed from the run's flags (see `remoteCdPrefix`,
+`src/lib/hosts/dispatch.ts`):
+
+- `--cwd <dir>` sets the host working directory. A home-anchored path (`~/…`,
+  `$HOME/…`, or a local-home absolute the local shell already expanded) is
+  re-rooted at the **remote** `$HOME`, so it resolves across machines with
+  different homes (`/Users/me` → `/home/me`). Resolution happens locally: the
+  forwarded argv is still a plain `agents run <agent> …`.
+- `-P, --project <slug>[@worktree]` resolves `<slug>` against your projects root
+  (auto-inferred from the launch repo and cached in `agents.yaml`; set via
+  `agents config set project.root <path>`) and lands on the host home-relative
+  (`~/…`), so the host expands it to its own home. `@worktree` targets
+  `<repo>/.agents/worktrees/<worktree>`.
+- `--remote-cwd <dir>` is the explicit escape hatch — a literal remote path used
+  verbatim (never re-rooted). Precedence: `--remote-cwd` > `--project`/`--cwd`;
+  `--project` is mutually exclusive with `--cwd`/`--remote-cwd`.
+- **With none of them, the run mirrors your local cwd** (`deriveMirroredCwd`): a
+  cwd under the local home is re-rooted onto the remote home, so launching from
+  `~/src/x` lands the agent in the host's `~/src/x` rather than its bare `$HOME`.
+  This is the fleet layout where every box holds the same checkout at the same
+  home-relative path. A mirror is best-effort — a host without that directory
+  falls back to its home rather than failing the run — whereas an explicit
+  `--cwd`/`--remote-cwd` you named is never softened: a missing one fails the
+  `cd`. A cwd outside the local home is not mirrored at all, since a path like
+  `/opt/thing` says nothing about the target's filesystem.
+
+Workspace (where the run executes) is a deliberate scoping choice — see Open
+Questions. Phase 1 default: a caller-specified `--remote-cwd` (or the repo's
+existing checkout on the box). The rush per-task git-worktree workspace
+(`rush/cli/internal/daemon/workspace.go`: warm clone + `git worktree add
+--detach` + secret denylist + PATH shim) is the model to port **later** if we
+want isolated, repo-URL-driven runs.
+
+### 4. Progress — incrementally tail the remote transcript (the key idea)
+
+Streaming raw SSH stdout ties progress to the live pipe: drop the connection and
+you lose the run's visibility. Instead, lean on the fact that **every agent already
+writes a JSONL transcript to disk** (Claude/Codex/Gemini/Droid/…), and agents-cli
+**already parses those** (`src/lib/session/parse.ts`: `parseClaude`, `parseCodex`,
+`parseGemini`, … → `SessionEvent[]`; locations via
+`session/discover.ts:getAgentSessionDirs`).
+
+So host progress = **tail the remote transcript file, offset-tracked**, parse the
+new lines, render with the existing `SessionEvent` pipeline. This is the same shape
+as `session/active.ts:200-248`, which already does offset reads
+(`fs.readSync(fd, chunk, 0, chunkSize, totalRead)`) rather than re-reading the
+file or scanning the directory.
+
+Mechanics:
+1. Resolve the run's transcript path on the remote (agent + session id; `agents
+   run --json` surfaces the session id, or we derive it from the agent's dir).
+2. Poll cheaply over SSH from a byte offset — `ssh <node> "tail -c +<offset>
+   <file>"` (or `dd`/`stat` for size), keeping a per-run `{file, offset}` cursor.
+3. Feed new bytes to the matching `parseX` function; render incrementally.
+4. Reconnect = resume from the saved offset. No live-pipe dependency.
+
+This is precisely the user's "use the session parser, read updates from the file,
+efficiently — like the ssh/remote-browser pattern."
+
+### 5. Scheduling — falls out of the existing daemon
+
+Scheduled fleet dispatch needs **no new machinery**: the routines scheduler
+(`src/lib/daemon/daemon.ts`) fires jobs on cron; a job whose command is `agents run …
+--on <host>` is a scheduled remote dispatch. Online-gating is the same lazy SSH
+probe `ensureHostReady` already does (skip/retry if the one targeted host is
+unreachable) — no fleet poll. (We do **not** turn the scheduler into an RPC
+server — see Non-goals.)
+
+### 6. Tracking — reuse the cloud store (Phase 1.5)
+
+To make `agents cloud list/status/logs` show host runs alongside cloud runs, add a
+thin `host` entry to the cloud provider model that records `{host, agent, prompt,
+transcriptPath, offset, status}` in the existing SQLite store
+(`src/lib/cloud/store.ts`) and streams via the transcript tailer above. This makes
+"fleet observability" free and unifies the dispatch surface.
+
+## Context — what travels to the host (and what doesn't)
+
+An agent host is useless until the user's context is on it — but "sync everything"
+is the wrong instinct. The `.history` tree (versions, runs, sessions, backups) is
+large and almost all of it is irrelevant to any one task; bulk-copying it would
+*recreate the exact filesystem/IO storm the incident was about*, just on a second
+machine. The right model decomposes context into four layers, each carried by a
+mechanism that **already exists** — there is no new "sync engine":
+
+| Layer | How it gets there | Mechanism (today) |
+|---|---|---|
+| **`~/.agents` config** (commands, skills, hooks, memory) | The DotAgents user repo is git-backed — the box runs `agents repo pull user` (or `git pull`). One-time/idempotent bootstrap, **not** a per-dispatch push. | `agents repo pull user`; bootstrapped + verified by `ensureHostReady` / `hosts check` |
+| **Working codebase** | Phase 1: committed branch → `git fetch` + checkout on the box (per-repo, caller's `--remote-cwd`/`--branch`). Phase 2: uncommitted working tree → `rsync` over SSH (the differentiator). | per-repo git; rsync (Phase 2) |
+| **Secrets** | Persistent boxes self-auth once via `agents secrets` (keychain). Blank/leased boxes get an on-demand, never-on-disk injection. | `agents secrets export <bundle> --to-ssh --device <t>` (`secrets.ts:1089-1097`, env over ssh stdin) |
+| **Sessions / `.history`** | **Not bulk-copied.** Recall is exposed as a *remote command*, not a file sync (below). | the routines daemon + `agents sessions`; selective `session/sync/` for the rare "make this transcript present" case |
+
+### `ensureHostReady(name)` — the Phase 1 readiness precondition
+
+Before dispatch, ensure the box can actually run the agent. This replaces the
+heavier "syncContext" idea — most of it is already solved by git + the existing
+sync substrate, so the precondition is thin and mostly one-time/cached:
+
+1. **agents-cli present** — `hosts check` already probes `agents --version`; if
+   absent, bootstrap (mirror `scripts/sandbox.sh:218-239`).
+2. **Config current** — `agents repo pull user` on the box so `~/.agents` matches (git-backed;
+   cheap, idempotent).
+3. **Agent installed** — remote `agents view --json` (fallback: `agents list`)
+   confirms the requested harness exists. A **concrete version pin**
+   (`agents run codex@0.145.0 --device <box>`) is checked against that listing and
+   **fails loud** when the pin is missing — naming the box, the missing pin, what
+   *is* installed, and the install command — so a detached `--no-follow` dispatch
+   never prints `Dispatched` for a pin the box cannot run (RUSH-2313). Aliases
+   (`@latest` / `@oldest` / `@pinned`) still resolve on the remote. A bare agent
+   name (no pin) keeps the soft warning.
+
+   The dispatched `agents run` on the box is the backstop for that soft warning:
+   it probes the executable it is about to spawn and exits `1` with
+   `agents: <agent> is not installed on this machine.` plus the
+   `agents add <agent>` fix. Before RUSH-2339 it execed the bare `cliCommand`
+   instead and died as `sh: 1: exec: cursor-agent: not found` (exit 127), behind
+   a `⚠ <agent> looks logged out` banner that was also wrong — the harness was
+   absent, not signed out. The probe is **existence**, not "does agents-cli
+   manage a version" (`resolveLaunchBinary`, [`src/lib/exec.ts`](../src/lib/exec.ts)):
+   a harness the user installed themselves (Homebrew, a vendor `curl | sh`, a
+   distro package) has no version home on the box and still launches, resolved
+   through PATH exactly as `spawnAgent` would. The PATH lookup skips the
+   agents-cli shims dir, so a dispatcher shim planted for an absent harness is
+   never mistaken for an install.
+4. **Codebase present** — the target repo/branch is checked out at the run cwd
+   (`git fetch` + checkout; no working-tree copy in Phase 1).
+
+It does **not** copy `.history`, and it does **not** push secrets unless asked —
+persistent hosts are authed once, out of band.
+
+### Session recall is recall-as-RPC, not recall-as-copy
+
+The killer detail: you almost never want another machine's `.history` *on disk* —
+you want to *query* it. The routines daemon can already run commands on a host, so
+recall becomes a remote call:
+
+```
+agents hosts sessions <box> --search "<topic>"   # runs `agents sessions` ON the box, returns hits
+```
+
+The agent on box A searches box B's history without ever copying it — the same
+"expose a capability over the daemon" shape this design uses for dispatch. For the
+narrow case where a transcript must actually be *present* on the target (resume /
+handoff), `agents sessions migrate` (shipped since this doc was written) ships
+**that one session** selectively over the direct SSH transport
+(`resolveExplicitTargets` + `ssh-exec`) — never the whole tree, and no R2/CRDT
+substrate (that background-sync mechanism this doc originally cited has since
+been removed; see [sessions.md](sessions.md#migration-relocate-a-live-session)).
+
+## Phase 2 — session handoff (the differentiator)
+
+`agents run --resume <session-id> --on <host>` — move a live session, *including
+uncommitted work*, to another box and continue:
+
+1. **Code**: push/sync the git branch; **`rsync` the working tree** (uncommitted
+   included) over SSH — the thing the cloud tools can't do.
+2. **Conversation**: ship the transcript. `agents sessions migrate` already does
+   this over a direct SSH hop (`resolveExplicitTargets` + `ssh-exec`) — the R2/CRDT
+   background-sync substrate this section originally proposed reusing has since
+   been removed; the direct-transport path is the one that shipped.
+3. **Resume**: `agents run <agent> --resume <session-id>` on the target.
+4. **Relay/attach mode**: attach to a still-running remote session by tailing its
+   transcript (Phase 1 §4) and sending follow-ups over SSH — the "remote-control"
+   UX, built on the *existing* daemon, not a new one.
+
+Honest hard parts (consistent across the whole field): model/provider continuity
+and concurrent-session collisions on one branch. Secrets are handled by the Context
+model above (persistent hosts self-auth; blank/leased hosts take an on-demand
+`secrets export --to-ssh` injection) — not an unsolved wall, but the bundle must
+exist on or be pushed to the target. The doc will spell these out before Phase 2
+implementation.
+
+## Non-goals / what we explicitly will NOT build
+
+- **No broker / relay / connection-registry / heartbeat service.** The registry is
+  a local list; reachability is the host's own network (LAN/VPN). No central
+  service, ever.
+- **No discovery / fleet enumeration.** We never scan a network or call `tailscale
+  status` to find machines. The registry is hand-maintained (with an opt-in
+  `import --from-tailscale` prefill); only the targeted host is ever contacted.
+- **No Tailscale dependency.** A tailnet is a fine transport if you use one (just
+  register the `.ts.net` address), but agents-cli neither requires it nor knows
+  about it — SSH to an address is the whole contract.
+- **No provisioning engine.** crabbox already leases across Hetzner/AWS/Azure/GCP/
+  e2b/modal/… `hosts` shells out to crabbox for lease/release and registers the
+  resulting SSH address as a transient host. We do not reimplement multi-cloud
+  provisioning, cost, or lifecycle.
+- **No new daemon.** Phase 2 relay/attach expands the existing routines daemon;
+  it does not add a second long-running process.
+- **No custom wire protocol.** SSH + on-disk transcript are the protocol.
+- **No VM snapshots.** `rsync` over SSH replaces Devin-style block-diff for our
+  single-tenant case.
+
+## Design constraints carried from the incident
+
+The Resource Report is also a list of things the remote run must NOT do (or it
+just relocates the storm):
+
+- **Headless by default** — `agents run --json` when a prompt is supplied.
+  Progress is summarized state from the transcript, not a live char stream.
+  Interactive TTY forwarding is supported only when no prompt is given
+  (`agents run <agent> --device <h>`), so the user can drive the remote agent
+  directly; the remote machine still owns the actual session and tmux wrapper.
+- **Bound concurrency** — cap simultaneous agents per host; a host's value is
+  finite coordination capacity, not infinite parallelism.
+- **No unbounded recursive scans** — the incident's trigger was `rg --no-ignore
+  --follow` over `.agents/worktrees` + `.gocache`. Remote workspace setup must
+  respect ignore boundaries and avoid scanning generated/worktree trees.
+- **Don't sync junk** — a working-tree `rsync` (Phase 2) must exclude
+  `node_modules`, `.gocache`, build caches, nested worktrees.
+
+## Resolved decisions
+
+- **Pluggable `HostProvider` seam** — the directory/metadata/reachability layer is a
+  capability-gated provider (mirrors `CloudProvider`). v1 ships **only `local`**;
+  `rush`/`tailscale`/`crabbox` are additive fast-follows behind the same contract.
+  This is the "open & general-purpose" decision — anyone can swap in their own
+  metadata/network backend.
+- **v1 = `local`, no Rush dependency.** No `rush login`, no daemon, no account.
+  Registry is a `hosts:` map in `agents.yaml`; reach is SSH. The Rush `computers`
+  backend (cross-device sync + presence + relay) is real but its benefits are
+  conditional — deferred to the `rush` provider, which the seam makes free to add
+  later (see "Why `local` first").
+- **Discovery** — an **explicit registry**, not network enumeration. No fleet scan;
+  only the targeted host is contacted, and only at dispatch. Tailscale is **not** a
+  v1 dependency — it's a future `HostProvider`, and an opt-in `import
+  --from-tailscale` can prefill `local` entries.
+- **Driver-agent first.** The primary caller is a conversational driver agent that
+  reads the registry metadata (`agents hosts list --json`), picks a host by
+  task/capability, and dispatches (`agents run --on <name> --json`). The VS Code
+  extension is a second front-end onto the same commands. So Phase 1 prioritizes
+  clean, deterministic, machine-readable `--json` on `hosts list` and `run --on`.
+- **Naming** — `agents hosts` (list/check/add/remove) + `agents run --on <host>`.
+  (The singular `agents computer` macOS-accessibility command is unrelated, stays.)
+- **Provider model** — keep named-SSH dispatch as its own clean path; fold *tracked*
+  host runs into the existing cloud store as a `host` provider so `agents cloud
+  list/status/logs` see them (§6). No big `CloudProvider → AgentHostProvider`
+  rename — observability is unified without it.
+- **Context** — no bulk `.history` sync; `ensureHostReady` + recall-as-RPC over the
+  daemon (see Context). Config via git, codebase via branch (P1) / rsync (P2),
+  secrets via self-auth or `--to-ssh`.
+
+## Open questions (decide before Phase 1 build)
+
+1. **Workspace model for Phase 1** — caller-specified `--remote-cwd` only, or port
+   the rush git-worktree workspace now? (Leaning: `--remote-cwd` first, worktree as
+   a fast follow.)
+2. **Windows targets** — `win-mini` over SSH: do remote `agents run` semantics hold
+   on Windows (shims, paths)? Needs a verification pass.
+3. **Capability routing** — should `--on` accept a capability selector (e.g. `--on
+   gpu`) that resolves to a registered host tagged `gpu`, not just an exact name?
+   (This is the driver-agent's main convenience; leaning yes, thin — filter the
+   registry by `caps`, error if 0 or >1 match unless `--any`.)
+4. **Enrollment scan sources for v1** — `~/.ssh/config` Host blocks + `known_hosts`
+   (leaning both); LAN scan (mDNS/ping) deferred as noisier/more code.
+5. **Concurrency cap** — default max simultaneous agents per host (the incident
+   says "bound it"); per-host override in the `hosts:` map?
+
+## Phasing & verification
+
+- **Phase 1 (v1, no Rush)**: the `HostProvider` seam + the **`local`** provider only.
+  `agents hosts add/list/check/remove` (registry in `Meta.hosts`; `add` scans SSH
+  sources + `checkbox` multi-select enroll, ensures key auth, bootstraps/upgrades
+  agents-cli to match the local version) + `agents run --on <host>` →
+  `ensureHostReady` (lazy SSH probe + config/agent/branch) → remote `agents run
+  --json` → transcript-tailed progress + a `host` row in the cloud store. Verify
+  end-to-end against the live peer node `yosemite-s1`, registered from `yosemite-s0`:
+  dispatch a trivial task, confirm it executed *off-box*, see live progress via the
+  transcript tailer, correct exit code. No account, no daemon.
+- **Phase 1.5 (fast-follows, behind the seam)**: the `rush` provider (account-keyed
+  `computers` registry + presence + relay-exec, opt-in when `rush login` exists),
+  the `tailscale` provider (presence/reachability without an account), and recall-as-
+  RPC (`agents hosts sessions <name>`).
+- **Phase 2**: the `crabbox` provider (lease → register → run → idle-release) and
+  `--resume … --on` handoff (branch + working-tree rsync + transcript sync + resume)
+  + attach/relay mode on the existing daemon.
+
+## Key files (reuse map)
+
+| Need | Existing code to reuse |
+|---|---|
+| SSH transport | `src/lib/browser/drivers/ssh.ts` (`shellQuote` exported; `runSSHCommand`/tunnels private — extract a shared ssh-exec helper) |
+| Host registry storage | `src/lib/state.ts` (`readMeta`/`updateMeta`, atomic+locked) + `Meta.hosts` (new field) |
+| Headless argv per harness | `src/lib/exec.ts` (`buildExecCommand`) + `agents run` (`src/commands/exec.ts`) |
+| Transcript parse → events | `src/lib/session/parse.ts` (`parseClaude`/`parseCodex`/…) |
+| Incremental offset read | `src/lib/session/active.ts:200-248` |
+| Per-agent transcript dirs | `src/lib/session/discover.ts:getAgentSessionDirs` |
+| Cross-machine transcript transport | `src/commands/sessions-migrate.ts` (direct SSH, shipped) — the CRDT G-Set / R2 background-sync substrate this row originally named has been removed |
+| Scheduling | `src/lib/daemon/daemon.ts` (routines scheduler) |
+| Task tracking store | `src/lib/cloud/store.ts` (free-text `provider`, reserved `provider_data`) |
+| Config schema | `src/lib/types.ts` (`Meta`) + `src/lib/state.ts` (`readMeta`) |
+| Config bootstrap on host | `agents repo pull user` (git-backed) + `scripts/sandbox.sh:218-239` |
+| Secret injection (on demand) | `src/commands/secrets.ts:1089-1097` (`--to-ssh`, env over ssh stdin) + `SSH_TARGET_RE`/`assertValidSshTarget` (`secrets.ts:189-195`) |
+| Selective transcript replication | `src/lib/session/sync/agents.ts` (per-agent mirror layout, per-session not whole tree) |
+
+## Prior art studied
+
+- rush "computers": `rush/cli/internal/computer/` (model/fingerprint),
+  `rush/cli/internal/daemon/workspace.go` (warm clone + worktree + env denylist),
+  `prix/api/src/computers/relay.ts` (the WebSocket relay we deliberately drop).
+- Field survey + citations: see the research links inline above (Codex, Cursor,
+  Devin/blockdiff, Factory, Jules, Anthropic Managed Agents, Claude Remote
+  Control/Teleport, Tailscale LocalAPI/SSH/tsnet).

--- a/cli/docs/hosts.md
+++ b/cli/docs/hosts.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Hosts — dispatch agents to your own machines
 
 > **Status:** Implemented. `agents hosts` and the `-D, --device` flag

--- a/cli/docs/menubar.md
+++ b/cli/docs/menubar.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Menu bar
 
 A macOS status-bar item that surfaces live agent activity on the machine.

--- a/cli/docs/menubar.md
+++ b/cli/docs/menubar.md
@@ -1,0 +1,613 @@
+# Menu bar
+
+A macOS status-bar item that surfaces live agent activity on the machine.
+
+## Overview
+
+The menu bar helper (`MenubarHelper.app`) is a no-Dock, `.accessory` status-bar
+app. Its icon — the agents-cli `a` mark — sits in the menu bar and answers, at a
+glance, "what are my agents doing right now, and does anything need me?"
+
+The bundle folder keeps its historical name (`MenubarHelper.app`), but the
+compiled executable inside it is **"AGI Menu"** (RUSH-3101) — that is what
+System Settings > Privacy & Security > Accessibility and the "would like to
+control this computer" prompt show, since launchd execs it directly and
+bypasses LaunchServices name resolution.
+
+It keeps menu state warm with one read-only `agents menubar snapshot --json`
+subprocess every three minutes. That command reads indexed/cache state and never
+re-indexes transcripts. Opening the menu uses the warm result; CLI actions remain
+explicit controls (starting a session, running a routine).
+
+The snapshot carries the same rows and lifecycle status as
+`agents sessions --active --local --json`. After the warm snapshot loads, the
+menu does not infer status again from terminal registries or attention files;
+those cheap files are used only during cold start. The ACTIVE section therefore
+uses the CLI words `working`, `waiting`, `idle`, `orphan`, `abandoned`, and
+`unknown`, and routine sessions carry `routine:<name>` when the indexed name is
+available.
+
+**Bare-active parity (RUSH-2336).** The snapshot applies the CLI's canonical
+`isRunningLiveSession` selector before it ever reaches the menu: a `queued`
+(dispatched, not started), `closed`, or `crashed` row the live registry retains
+for `--queued`/`--closed`/`--crashed` recovery never shows in the ACTIVE
+section, and a real OS process row (terminal/tmux/headless/team) surfaces only
+once it is positively located — a known `machine`, a positive `pid`, AND
+verified liveness (`pidAlive === true`, not merely "not known dead"). A cloud
+row surfaces on the provider's own word (`cloudProvider` + `cloudTaskId`)
+instead. Every session's detail submenu (the "Where" section) shows the exact
+handle behind the row — `machine:pid` for a process, `provider · taskId` for
+cloud — the same locator the CLI's own `--active` row renders. Because the raw
+cache the daemon warm-tick writes is never filtered at write time and does not
+stamp `machine` on a local row (unlike the CLI's own local gather), the
+snapshot self-stamps this machine's id before filtering — see
+`computeMenubarSnapshot` in `src/lib/menubar/snapshot.ts`.
+
+**Header shows the installed version (RUSH-2688).** The dropdown's top row reads
+`agents-cli <version>` — the version `agents --version` prints, carried on the
+snapshot (`cliVersion`) and resolved at runtime, not compiled into the helper. A
+helper that outlived an `agents` upgrade therefore shows the older version at a
+glance. Until the first snapshot lands (and against a CLI too old to emit the
+field) the row falls back to the bare `agents-cli`.
+
+**Project grouping never leaks the harness or a machine (RUSH-2688).** The ACTIVE
+section groups by project: a real working dir → its repo (worktree-aware, so a
+`.agents/worktrees/<slug>` session groups under the enclosing repo). A session
+with **no local cwd** — a cloud task — groups under its own repo when the provider
+names one (reduced to the bare name, so a cloud task for `phnx-labs/agents-cli`
+lands with local `agents-cli` work), else the explicit **`cloud`** bucket. It
+never borrows the harness/provider name (`codex`) or a machine name as a group —
+neither is a project. The one derivation is `activeSessionProjectKey`
+(`src/commands/sessions.ts`) for the serialized rows and `LocalState.groupKey`
+for the menu's cold-start reads.
+
+macOS only. It is auto-enabled for every user (see [Lifecycle](#lifecycle)); opt
+out with `agents menubar disable`.
+
+## Clip paste (`Cmd-Shift-V`)
+
+`Cmd-Shift-V` hands whatever is on the clipboard to the agent in the focused
+terminal as a native scp-style reference — `<host>:<abs-path>` — instead of
+pasting raw bytes that would mangle a terminal or an ssh'd session. A screenshot
+that lives only on the clipboard is written to
+`~/.agents/.history/attachments/`, a copied file is snapshotted there under an
+scp-safe name, and a copied directory is referenced in place. The agent reads
+the path directly when `host` is its own machine and `scp`s it otherwise, so the
+same token works whether the session is local or on another box.
+
+The paste synthesizes a `Cmd-V` keystroke, which needs an **Accessibility**
+grant for "Agents Menu Bar" (System Settings > Privacy & Security >
+Accessibility). Without it the helper copies the reference to the clipboard and
+notifies you to paste it yourself, so the clip is never lost.
+
+### Do not hand-launch the helper
+
+TCC grants are keyed to a code identity, and `RegisterEventHotKey` is
+first-come. A helper started **from an ssh session** therefore breaks the paste
+twice over: macOS attributes its Accessibility request to the responsible
+process, `/usr/libexec/sshd-keygen-wrapper`, so the prompt names a process whose
+grant does nothing for the helper — and granting it would let anything an ssh
+session spawns synthesize keystrokes — and, if it wins the chord, Cmd-Shift-V
+stops reaching the launchd-managed helper that *is* trusted. Which of the two
+wins comes down to which registered the chord first, so the outcome is
+arbitrary.
+
+The interactive mode refuses to start in that situation, and refuses
+unrecognized arguments (an unknown flag used to fall through to the status-bar
+app, leaving a permanent second helper). Start it through launchd instead:
+
+```bash
+agents menubar enable      # works over ssh — launchd starts it in the GUI session
+```
+
+If a chord stops working, `agents menubar status` lists any other live helper
+process with its pid; end it and re-run `agents menubar enable`.
+
+## Quick dispatch
+
+`Cmd-Shift-O` opens the Spotlight-style capture panel. Type a short request,
+optionally attach recent screenshots from the thumbnail strip, pick the repo to
+work in, then pick one agent for **Plan** or one or more agents for **Run**.
+The helper constructs this panel at startup and orders it front with the text
+field focused before refreshing recent repos, decoding thumbnails, or reading
+the Linear cache. Those rows hydrate after the panel accepts typing; the hotkey
+never waits for `agents sessions`, attachment-directory scans, or image decode.
+
+- **Plan** sends the note and selected screenshots to the selected ticket agent,
+  which investigates and returns ticket fields as JSON. The helper then runs
+  `linear create` itself, appending `--image <path>` for every selected
+  screenshot so the image bytes are uploaded at create time and embedded in the
+  issue description — screenshot paths never pass through an LLM-authored shell
+  string.
+- The helper resolves the standalone `linear` executable before dispatching the
+  ticket agent. It prefers `~/.local/bin/linear`, then checks standard Homebrew
+  locations and the inherited `PATH`. A missing or non-executable CLI stops
+  immediately with the install path instead of reporting a generic create
+  failure after the agent has run.
+- **Run** fans out to every selected agent with `agents run <agent> --mode auto
+  --balanced --notify --name <slug-of-your-note>`, so the resulting sessions
+  appear in normal `agents sessions` and menu-bar surfaces instead of as opaque
+  background work.
+
+The repo dropdown comes from recent session working directories, never `$HOME`
+(running an agent straight in the home directory is too broad a permission
+surface), and passes `--cwd` to the dispatch. The last pick is remembered.
+
+`--notify` is what makes a dispatch report back. The run is launched **detached**
+and posts its own "finished"/"failed" notification when it ends (see
+[Notifications](#notifications)). Earlier the helper monitored the child and
+posted from the process-termination callback — which lived in the helper, so a
+helper that restarted mid-run (an upgrade replacing the bundle, a crash) took the
+callback with it. The run carried on, reparented to launchd, and could never
+report back. Nothing about the menu bar's lifetime affects the notice now.
+
+Set `AGENTS_QUICK_DISPATCH_ROSTER=claude,codex` in the helper environment to
+filter which agents appear in the picker, and
+`AGENTS_QUICK_DISPATCH_AGENTS=claude,codex` to change which visible agents are
+preselected. Without a roster override, the picker uses the same roster as the
+menu bar's New Session submenu.
+
+If another app steals focus while you are typing, the panel hides but keeps the
+draft note plus the selected screenshots, action, and agents for the next
+`Cmd-Shift-O` summon. Return submits and clears the draft; Escape clears it
+without dispatching.
+
+### The ticket list
+
+The panel captures new work; the rows under it are the work that already exists —
+the open Linear tickets of the project scoped to the repo you picked, so you can
+pick one up instead of filing a duplicate.
+
+Controls sit on **one compact row** of popups (same language as the repo picker —
+not a chip grid or two-column block):
+
+```
+Tickets  [Agents CLI ▾]  [All open ▾]  [Urgent first ▾]  12/58 · urgent first · ⌘N
+ ⌘1  P1  RUSH-1968  Doing  …
+ ⌘2  …                                    ← scroll when there are more rows
+```
+
+- **Project is 1:1 with Linear.** The project popup is the ticket scope. Switching
+  the repo dropdown auto-selects the matching Linear project (the repo name is
+  matched against `linear projects` after both are reduced to lowercase
+  alphanumerics, so `agents-cli` finds **Agents CLI** with nothing to configure).
+  A repo whose name matches no project says so — pick the project once and that
+  choice is remembered for that repo. A worktree resolves to its parent repo
+  (via git's common dir), not to the worktree's own directory name.
+- **Quick filter (dropdown).** One popup, not chips: All open · Todo · Doing ·
+  Backlog · P1 only · P2 only · Overdue. The last pick is remembered.
+- **Quick sort (dropdown).** Flat list only — no status group headers. Options:
+  Urgent first (default: Linear priority, then overdue, then in progress, then
+  newest) · Newest · Oldest · Due date · Priority. The last pick is remembered.
+- **Scrollable rows.** The list viewport shows about five rows; more matches
+  scroll inside the bar so the capture field stays put. Up to 40 rows are kept
+  after filter+sort.
+- **Typing also filters.** Every word you type has to appear in a row's
+  identifier or title (AND with the filter), so an existing ticket surfaces
+  before Return files a new one.
+- **Click a row to dispatch it** to the selected agents in the picked repo
+  (`⌘1` … `⌘9` for the first nine listed). **Plan** posts an implementation plan
+  as a comment on the ticket and changes no code; **Run** claims the ticket
+  (moving it to whichever state `linear states` reports as `started`), implements
+  it per the repo's `AGENTS.md`, and comments the result. Both are the same
+  headless `agents run --mode auto --balanced --notify` dispatch as a quick Run,
+  named after the ticket (`rush-2098`, `rush-2098-plan`) so it reads as that
+  ticket in `agents sessions`. **`⌘`-click** opens the ticket in Linear instead.
+
+A `linear tasks` round trip costs seconds, so the list renders from a warm cache
+(`~/.agents/.history/menubar/linear-cache.json`) and refreshes in the background;
+entries older than 90 seconds are re-fetched on the next summon.
+
+## The dropdown
+
+One rule shapes the menu: **attention floats up, context groups down.**
+
+```
+ a !                      icon + badge (red ! = needs you, green N = N running)
+ ┌─ agents ──────────────────────────────────────┐
+ │ ⚠ NEEDS YOU (3)                               │   triage strip: wait-time sorted
+ │   ⚠ Claude · api — Apply rename?    ·  2h 25m ›│   across ALL projects, question
+ │   ⚠ Claude · web — awaiting input   ·  3m     ›│   + how long it's waited
+ │   ✕ 2 routines failing                        ›│
+ ├────────────────────────────────────────────────┤
+ │ New Task…                                  ⌘T │   opens the quick-dispatch bar
+ │ New Session                                ⌘N │   submenu: one entry per agent
+ ├────────────────────────────────────────────────┤
+ │ ACTIVE · 3 run · 1 idle · 2 projects          │   projects collapsed by default
+│   ▶ agents-cli  ●2 working ○1 idle  zion      │   accordion: ▶ folds agents open
+│   ▼ web  ●1 working  zion                     │
+ │     ● Codex · zion · 12m  ⌥ PR#42 — title   › │   › side submenu = full detail
+ ├────────────────────────────────────────────────┤
+ │ ROUTINES · 16 · next 7:00 PM · 2 paused       │   next few upcoming + failing
+ │   ◔ triage-tickets  in 22m                  ›  │   inline; All routines… for
+ │   ✕ crm-brief  failed                       ›  │   the rest
+ │   All routines…                             ›  │
+ ├────────────────────────────────────────────────┤
+ │ RECENT TICKETS / RECENT                       │   dedicated, glanceable
+ ├────────────────────────────────────────────────┤
+ │ ◆ NEW DEVICES (2)                             │   pending tailnet nodes to approve
+ │   ◆ ci-runner-fsn1 · linux                  ›  │   Register / Ignore
+ ├────────────────────────────────────────────────┤
+ │ ▶ DEVICES (12)                                │   full fleet roster, folded by default
+ │   ◉ zion (this Mac) · macos · 14%           ›  │   ◉ = interactive host; load% when known
+ ├────────────────────────────────────────────────┤
+ │ System    2 critical · 1 warning · auto-nudge off ›│  doctor findings + watchdog
+ ├────────────────────────────────────────────────┤
+ │ Stop scheduler · Settings · Quit          ⌘Q  │
+ └────────────────────────────────────────────────┘
+```
+
+- **⚠ NEEDS YOU** — the triage strip, pinned on top and never nested in a project
+  group. Blocked sessions are grouped by (agent, repo): a group of 1 renders
+  inline with the actual question it's waiting on (or bare when the Notification
+  hook wrote no message); a group of 2+ collapses to one
+  `<Agent> · <repo> · N waiting · oldest <elapsed> ›` row with a submenu that
+  lists each session (oldest first). Groups themselves sort by their oldest
+  wait. Failed / overdue routines and a stopped scheduler append here. Empty
+  when nothing needs attention.
+- **New Task…** — opens the quick-dispatch bar (the same panel as `Cmd-Shift-O`):
+  type the task, pick agents and a repo, and it runs headless. One panel serves
+  both entry points, so an interrupted capture is restored whichever way you come
+  back to it. Use this when you want work *done*; use New Session when you want
+  to sit in the TUI.
+- **New Session** — shells `agents run <agent> --terminal`, which opens the agent
+  in **the terminal you actually work in**. The CLI resolves that from your live
+  sessions' host app (`agents sessions --active` → `host`), so a Ghostty user gets
+  a Ghostty tab and an iTerm user an iTerm tab; Terminal.app is the fallback when
+  nothing running names a terminal the engine can drive. See
+  [terminal-engine.md → Choosing a terminal](terminal-engine.md#choosing-a-terminal-for-a-gui-caller).
+  (It used to always open Terminal.app.)
+- **ACTIVE** — **project accordion** + **session detail submenu**. Projects are
+  **collapsed by default** as a status strip
+  (`▶ agents-cli  ●8 working ◐1 waiting ○1 idle  zion`).
+  Click `▶`/`▼` to fold the project open **inline** and list its agents.
+  The project header is an embedded menu control, so expanding or collapsing
+  mutates only that project's rows inside the current menu tracking session; it
+  does not dismiss and synthetically reopen the dropdown.
+  Focusing an agent row opens a **side submenu (›)** whose first item is
+  **▶ Focus session** — it lands you in that session, attaching locally or SSHing
+  to the box that owns it (`agents sessions focus`, the same call the ext's Focus
+  button makes), so it works for a session here or on any fleet peer. Below it,
+  richer detail and **linkable actions**: work title (and open URL if the title
+  contains one), local/remote + surface, clickable cwd, Linear ticket, GitHub PR,
+  duration, copy session id, optional preview snippet. Chips on the agent row
+  itself (`🎫 RUSH-…`, `⌥ PR#N`) surface links at a glance. All of that comes from
+  the warm `sessions --active --local` cache; expand never shells the CLI or
+  re-indexes transcripts. Work titles prefer the session `topic` over a bare
+  agent name.
+- **ROUTINES** — kept glanceable: the next few upcoming plus any failed, timed-out,
+  or overdue routine inline. Each submenu leads with a **last-run line** — a live
+  `● running now · started 4m ago` when a run is in flight (server-verified, not a
+  stale flag), else the last outcome (`✓ completed · ran 45s · 2h ago`,
+  `✕ failed exit 1 · yesterday`, `⦸ missed`) — then the failure reason when there
+  is one, then the next fire, above Run now / Pause / Logs. An **overdue** routine
+  is tagged `⚠ overdue` on that line even when its previous run succeeded (overdue
+  is independent of the last outcome — the daemon missed the next fire), so the
+  submenu never contradicts the `overdue` flag shown up in NEEDS YOU. Logs opens
+  the concise routine summary in a text viewer. All of it is read from the routine
+  fields the snapshot already carries
+  (`lastStatus`/`exitCode`/`overdue`/`lastRunStartedAt`/`CompletedAt`), so opening
+  a submenu never shells a fresh fetch.
+  When routines carry a `projectGroup` field (from `agents routines list --json`),
+  both the inline rows and the "All routines…" submenu are grouped by that label.
+  Routines with no `projectGroup` (cross-project or unassigned) appear last,
+  ungrouped.
+- **RECENT TICKETS / RECENT** — tickets filed via quick dispatch and recent
+  sessions, unchanged dedicated sections.
+- **NEW DEVICES** — newly-discovered tailnet nodes awaiting approval, each with a
+  Register / Ignore submenu. Shown only when there are pending nodes, and it now
+  sits just above the DEVICES roster at the bottom (previously it floated up under
+  NEEDS YOU). Sentinels under `~/.agents/.cache/state/devices-pending/` are
+  written by the daemon device-probe; the writer re-subtracts both the ignore-list
+  and the registered roster so already-known or dismissed boxes never appear here
+  (and soft-fail probe ticks still prune them).
+- **DEVICES** — the full registered-fleet roster as **one collapsible block,
+  folded by default** (the fleet is long, so `▶ DEVICES (N)` stays out of the way
+  until you open it — same in-place accordion as ACTIVE, no CLI on toggle). Each
+  row is `<name> · <platform>` — this Mac first, then alphabetical — with live
+  **load%** merged in when the daemon-warmed fleet cache has a fresh reading; a
+  row with no number is simply un-probed, never labelled offline (the roster
+  carries no online/offline state, so the menu never claims one). `◉` marks the
+  configured interactive host. The `›` submenu shows load/mem when known and a
+  **Copy `agents ssh <name>`** action. The roster comes from the same 3-minute
+  `menubar snapshot --json` poll (a cheap local registry read), not a new timer.
+- **System** — setup health + the auto-nudge watchdog collapsed into one row.
+  The health half of the summary is the doctor findings count, `N critical ·
+  M warnings` (bare `all set` when there are none), sourced from `agents doctor
+  --json`'s `findings` field on the 15-minute poll (`DoctorHealth.summary`,
+  [`Models.swift`](../menubar/Sources/MenubarHelper/Models.swift)); it's
+  followed by `auto-nudge on/off` from the watchdog toggle. The submenu lists
+  up to 5 findings, in the order doctor emits them (already prioritized), each
+  as two lines: `<severity> · <device> · <agent> @<version>` (or
+  `<agent> (N versions)` when a finding collapses several versions) then
+  `<message> → <remediation>` truncated to 96 chars. A
+  `+N more — run \`agents doctor\`` row appears when more than 5 findings are
+  actionable. **Legacy fallback (RUSH-2382):** an installed CLI older than the
+  `findings` field returns `findings: null`, not an empty list — the menu bar
+  then falls back to the pre-findings behavior: the summary counts
+  not-installed / stale / never-synced agents (or `all set`), and the submenu
+  lists "Not installed" / "Resources" sections instead of findings rows. Either
+  way the submenu ends with Run agents doctor, Open ~/.agents, and the
+  auto-nudge toggle.
+
+The icon badges **red `!`** when anything needs you, **red `⏻`** when the
+scheduler has been unreachable for ~30s (see
+[Daemon-down watchdog](#daemon-down-watchdog) below — independent of the
+dropdown ever opening), and **green with a count** when sessions are running;
+otherwise it is the bare mark.
+
+## Commands
+
+```
+agents menubar            # status (also: agents menubar status)
+agents menubar setup      # configure end-to-end: one instance, started at login
+agents menubar enable     # install + start the launchd login service
+agents menubar disable    # stop + remove it (sticky opt-out)
+agents menubar status     # installed / running, versions, staleness; --json
+agents menubar doctor     # read-only: signing identity, stale-process check; --json
+```
+
+`setup` is the command to reach for when the menu bar is wrong — a duplicate
+icon, a helper that did not come up, a machine that was never configured. It is
+idempotent, and each concern is a reported step, so a partial failure names
+itself instead of hiding behind "enabled":
+
+```
+$ agents menubar setup
+Menu bar setup
+
+  + duplicates      ended 2 running helpers (93048, 97417) — launchd restarts exactly one
+  ✓ bundle          /Users/me/Library/Application Support/agents-cli/MenubarHelper.app (1.20.89)
+  ✓ signature       valid
+  ✓ login item      com.phnx-labs.agents-menubar — starts at login, restarts if it dies
+  ✓ single instance pid 98566
+
+Menu bar configured.  One agents mark, started at login.
+```
+
+It ends **every** live helper and lets launchd restart one, so the survivor is
+always the login-managed copy — picking a survivor out of a process list cannot
+guarantee that, and keeping the un-managed copy would re-create the duplicate at
+the next login. It also clears a previous `agents menubar disable`, and exits
+nonzero if it cannot reach the one-instance end state. `--check` reports the
+current state without changing anything; `--json` emits the step list.
+
+`status` reports the installed bundle version vs. the current CLI version and
+whether the install is stale (see [Lifecycle](#lifecycle)). Live helper processes
+are split two ways in `--json`: `instances` are copies of the **installed
+bundle**, identified by resolved executable, and `foreignInstances` is every
+other `"AGI Menu"` process. **More than one entry in `instances` is the
+duplicate menu-bar icon** — see [One instance, always](#one-instance-always).
+`RegisterEventHotKey` is first-come, so a second copy may be the one holding the
+global chords — which of the two won is not answerable from a process list, so
+status reports the conflict rather than a winner. See
+[Do not hand-launch the helper](#do-not-hand-launch-the-helper).
+
+`doctor` is read-only — it never installs, restarts, or resets anything.
+It answers "why did Accessibility ask again after an update": the installed
+bundle's signing identity (`ad-hoc` re-prompts on every update; `Developer ID`
+is update-stable since 6fa36f73a), and whether a live helper pid started
+**before** the installed bundle's on-disk mtime — the stale-process case where
+the upgrade self-heal swapped the bundle but the running process is still the
+binary that predates it. `agents menubar setup` is the fix for anything it
+flags.
+
+## One instance, always
+
+The helper refuses to be the second status item. At launch it takes an
+`flock(2)` on `~/.agents/.cache/state/menubar.lock` and holds the descriptor for
+its whole life; a helper that cannot take the lock posts a distributed
+notification that pops the **running** helper's menu open, then exits 0:
+
+```
+$ "…/MenubarHelper.app/Contents/MacOS/AGI Menu"
+AGI Menu: already running (pid 6815) — surfaced it instead of adding a second status item.
+```
+
+Re-launching a menu-bar app means "show me the one I already have", so
+surfacing the incumbent is the answer, and exiting 0 keeps launchd's `KeepAlive`
+from reading the surrender as a crash.
+
+An `flock` rather than a pid file: a helper `SIGKILL`ed by the code-signing
+monitor leaves its pid behind, and every later launch would then read a stale
+"already running" and never start. The kernel releases an `flock` when the holder
+dies however it dies, so the state cannot go stale.
+
+Two copies of the installed bundle used to be reachable through ordinary paths —
+launchd's `KeepAlive` service plus a LaunchServices/`open` launch of the same
+`.app` (a Finder open, a re-open after a crash, a second `agents menubar
+enable`). Both ran the same executable, so status collapsed them to a healthy
+`running: yes` while the user looked at two agents marks. Both halves are fixed:
+the helper can no longer become the second, and `status` now lists every copy.
+
+## Data sources
+
+The helper assembles the menu from these cached/indexed sources through one snapshot
+command every three minutes; the 10-second badge/liveness checks stay local:
+
+| Source | Path | Gives |
+|---|---|---|
+| Terminals | `~/.agents/.cache/terminals/live-terminals.json` | extension-registered terminals (agent, cwd, pid, label) — cold start + 10s badge poll |
+| Menu snapshot | `agents menubar snapshot --json` every three minutes | routines, 40 indexed recent sessions, daemon-warmed local active sessions with the exact `sessions --active` lifecycle status, the registered fleet-device roster (a cheap local registry read), and persisted watchdog status in one subprocess |
+| Doctor | `agents doctor --json` every 15 minutes | install and configuration health; kept separate because it is substantially heavier |
+| Teams | `~/.agents/.history/teams/agents/<id>/meta.json` | running teammate agents |
+| Cloud | `~/.agents/.cache/cloud/tasks.db` (SQLite) | cloud tasks, incl. `input_required` or `needs_review` → "awaiting input" |
+| Attention sentinels | `~/.agents/.cache/state/attention/<sessionId>` | terminal sessions awaiting input — mtime = wait start, content = the awaiting message (written by the Notification hook). On read, sentinels whose sessionId is not in the current live-terminals set are unlinked as orphans (defense against sessions killed hard, hookless Claude versions, or sessionId mismatches). |
+| Installed agents | `~/.agents/.history/versions/<agent>/` | the agent roster |
+| Linear tickets | `linear projects` / `linear tasks --all --project <p> --status open --cycle all` (warm cache, 90s TTL) | the quick-dispatch ticket list, scoped to the picked repo's project |
+
+Liveness is a `kill(pid, 0)` check; running-vs-idle is the transcript file's
+mtime. The teams directory accumulates history, so the periodic badge refresh
+skips it — the full teams scan runs only when the menu opens.
+
+## Lifecycle
+
+The helper is a launchd user service (`com.phnx-labs.agents-menubar`,
+`RunAtLoad` + `KeepAlive`), installed to
+`~/Library/Application Support/agents-cli/MenubarHelper.app`.
+
+- **Auto-enable.** On every macOS CLI invocation a cheap self-heal installs the
+  service if it is missing — so a fresh install brings the icon up without a
+  manual step.
+- **Upgrade refresh.** The installed bundle is stamped with the CLI version. When
+  a newer release ships a newer helper (or the installed copy goes missing), the
+  self-heal re-copies the bundle, rewrites the plist, and restarts it — so
+  `npm update` actually moves users onto the new helper instead of leaving the
+  old one running. `launchctl kickstart -k` against the GUI domain does not
+  resolve from a shell with no Aqua session (an ordinary terminal/tmux/ssh
+  invocation of `agents`), so a real content swap (a version bump, or the
+  ad-hoc -> Developer ID identity migration below) falls back to ending the
+  live helper pid directly — launchd's `KeepAlive` relaunches it from the
+  swapped binary. Without this, a running helper could keep requesting
+  Accessibility under the OLD code identity after an update, and the grant
+  never stuck (RUSH-3019). A plist-only interpreter repoint (same version,
+  same identity — RUSH-3005) does not trigger a restart on top of its own.
+- **Ad-hoc -> Developer ID identity migration.** A machine whose install
+  predates Developer ID signing (6fa36f73a) gets its bundle re-signed on the
+  next heal; TCC keys the Accessibility grant to the signing identity, so the
+  old ad-hoc grant is dead weight the user never sees removed. The heal runs
+  `tccutil reset Accessibility com.phnx-labs.agents-menubar` exactly once per
+  machine (stamped in `.menubar-tcc-migrated`, next to `.menubar-version`),
+  clearing the stale row so the fresh Developer-ID prompt is a clean grant
+  rather than a re-prompt fighting old TCC state.
+- **One owner, when several installs coexist.** The helper lives at one path, but
+  every agents-cli copy on the box runs the self-heal. The plist's `AGENTS_ENTRY`
+  records the owner, and only the owner re-copies the bundle freely — otherwise
+  each copy reads the others' marks as drift and reinstalls over them, killing the
+  running helper every few seconds (#2109). A same-install `npm update` keeps its
+  entry path, so upgrades are unaffected. Another install still gets there:
+  immediately if the recorded owner is gone from disk, otherwise at most once an
+  hour (`.menubar-last-heal`), and never on that timer if its own bundle is
+  ad-hoc/dev-signed — recopying an un-notarized bundle over a good one gets it
+  rejected as "damaged". Repairs (missing executable, Developer-ID heal) are never
+  gated. `agents menubar setup` bypasses all of this and is the immediate fix.
+
+  Two installs that are *both* invoked regularly will keep trading ownership at
+  the cooldown, so the helper restarts about once an hour until one is removed —
+  bounded and survivable, but the real fix is a single install.
+- **Opt-out is sticky.** `agents menubar disable` writes
+  `~/.agents/.cache/state/menubar.disabled`; the auto-enable honors it, so a
+  disabled menu bar never silently returns on the next upgrade. Re-enable with
+  `agents menubar setup` (or `agents menubar enable`), either of which clears the
+  sentinel.
+- **Recovery is one command.** When any of the above has gone wrong on a
+  machine — never configured, helper down, duplicate icon —
+  `agents menubar setup` re-establishes the whole intended state and says which
+  parts it had to change.
+
+## Notifications
+
+The helper doubles as the branded desktop-notification channel for the daemon
+(RUSH-2030) and for any `agents run --notify`. The caller fires a notification by
+spawning the installed bundle in a one-shot mode:
+
+### Daemon-down watchdog
+
+The daemon's own overdue check (`notifyOverdue`, `src/lib/overdue.ts`) can only
+ever fire from **inside** `runDaemon()` — so it is structurally blind to the one
+outage that matters most: the daemon itself being down, at which point no
+routine fires and nothing says so. The menu-bar helper closes that gap because it
+is a **separate** launchd `KeepAlive` service — it stays alive exactly when the
+daemon dies.
+
+`StatusItemController.tick()` (the same 10s timer that refreshes the badge)
+calls `checkDaemonLiveness()` on every fire, independent of whether the dropdown
+is ever opened:
+
+- Liveness combines the cheap `AgentsCLI.daemonPid()` probe with the daemon's
+  one-minute heartbeat. A PID that remains alive while its heartbeat is stale
+  for three daemon ticks is `wedged`, not healthy.
+- A debounce of `daemonDownTickThreshold` (3) consecutive unhealthy ticks — about
+  30 seconds — must elapse before alerting, so a routine restart (a version
+  upgrade, an `agents doctor` self-heal, a crash-relaunch) never pages the user
+  for a blip.
+- A wedged daemon is restarted once through `agents daemon restart`; the helper
+  fails closed when the heartbeat is missing, malformed, or belongs to another
+  PID, so ambiguous state never terminates a live process.
+- Once past the threshold it fires **one** notification per outage —
+  `"Scheduler stopped — routines won't run"` — via `Notifier.post` directly
+  (this persistent process's own `NSUserNotificationCenter` delivery, the same
+  call site `AgentsCLI.swift`'s ticket-flow notices already use), not a spawned
+  `--notify` child process. It also lights the always-visible menu-bar badge
+  (`⏻`, ranked just under NEEDS-YOU attention) so the outage is glanceable
+  without opening the dropdown at all. Both the notification flag and the badge
+  clear the moment the daemon is observed alive again, so the next real outage
+  alerts fresh.
+
+The dropdown's own "Scheduler stopped" row (`addNeedsAttention`, rendered only
+while the menu is open and only when routines exist) is unchanged and
+complementary — the tick-driven watchdog is what makes the outage visible
+*before* you think to open the menu.
+
+```bash
+"AGI Menu" --notify --title T --body B [--subtitle S] [--action A] [--agent claude]
+```
+
+Because the poster is the app bundle, macOS attributes the notification to the
+agents-cli helper and shows its `AppIcon` (the agents-cli mark) instead of the
+generic osascript icon. The one-shot delivers via `NSUserNotificationCenter`,
+briefly spins the runloop so delivery flushes, then exits — it never starts the
+status-bar UI. The persistent menu-bar instance registers the click delegate at
+launch (`Notifier.wireClickHandler`), so clicking a notification runs its
+`--action`: `open:<path>` opens a run report/log, `url:<https…>` opens a web
+target (the PR or ticket a finished run produced — `http`/`https` only, so a
+notification argument can never become an open-anything primitive), and
+`routines:list` opens the runs folder. The Node side lives in
+`src/lib/menubar/notify-desktop.ts` (routing), `src/lib/routine-notify.ts`
+(routine start/finish content + anti-spam threshold; see
+[routines.md](routines.md#desktop-notifications)), and `src/lib/run-notify.ts`
+(the `agents run --notify` finish notice).
+
+**Two images: the app on the left, the agent on the right.** macOS draws the
+sending bundle's icon on the LEFT of a banner and its `contentImage` on the
+RIGHT — the layout a YouTube notification uses for "YouTube" plus the channel's
+avatar. The left slot is the agents-cli mark, resolved by LaunchServices from the
+installed bundle (`refreshBundleIconRegistration` re-registers it at install, or
+that slot renders blank). The right slot is `--agent`: the harness the
+notification is *about*, drawn by `AgentAvatar` (`menubar/Sources/MenubarHelper/
+AgentAvatar.swift`) as a brand-colored tile with the agent's two-letter mark —
+`CL` for claude, `CX` for codex, `GK` for grok. The mark is drawn rather than
+shipped as an image set: fifteen bundled logos would be fifteen more binaries to
+code-sign each release, and the upstream marks are trademarks agents-cli does not
+redistribute. An id with no brand entry falls back to its own initial on the
+agents-cli lime, so a harness new to the registry still renders.
+
+Omit `--agent` when no single harness owns the event — a daemon heal, an overdue
+sweep, a command routine, a fan-out across several agents. The right slot then
+stays empty rather than repeating the left one, which is what it did before
+`--agent` existed (`contentImage` was the app icon, so both slots showed the same
+lime `a`).
+
+**A run notifies for itself.** `agents run --notify` arms the finish notification
+on the run process's own `exit`, so it covers every dispatch path — local spawn,
+`--device`, `--lease`, the error path — and, more importantly, does not depend on
+whatever launched the run still being alive. That is the whole point: the menu
+bar's quick dispatch used to post from its own process-termination callback and
+lost it whenever the helper restarted. A run killed with SIGKILL never reaches an
+exit handler and so never notifies; that is the documented limit.
+
+**Bounded lifetime (no pile-up).** A one-shot posts and exits in well under a
+second, but a stalled delivery — a locked screen, a WindowServer/XPC hiccup —
+could otherwise leave a detached notifier hanging and duplicate "Agents"
+instances accumulating in the menu bar. Two independent watchdogs bound it:
+`runOneShot` arms a background-thread force-exit at 3s (it runs off the main
+queue so a wedged main thread can't starve it, unlike the 0.6s runloop deadline
+it backs up), and the Node spawner (`spawnDetachedQuiet`) SIGKILLs the child at
+4s if it never self-exits. So a notifier can never linger indefinitely. Stale
+helpers that predate `--notify` (and would ignore it and hang) are replaced by
+the upgrade self-heal (`installMenubarLaunchAgentOnUpgrade`), which reinstalls
+the current bundle on any version bump.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `~/Library/LaunchAgents/com.phnx-labs.agents-menubar.plist` | launchd service |
+| `~/Library/Application Support/agents-cli/MenubarHelper.app` | installed helper bundle |
+| `~/Library/Application Support/agents-cli/.menubar-version` | installed-version stamp |
+| `~/Library/Application Support/agents-cli/.menubar-last-heal` | last self-heal reinstall, epoch ms — the non-owner takeover cooldown |
+| `~/Library/Application Support/agents-cli/.menubar-tcc-migrated` | marks the one-time ad-hoc -> Developer ID `tccutil reset Accessibility` as done |
+| `~/.agents/.cache/state/menubar.disabled` | sticky opt-out marker |
+| `~/.agents/.cache/helpers/menubar/menubar.log` | helper stdout / stderr |
+| `~/.agents/.history/menubar/recent-tickets.json` | tickets filed from the quick-dispatch panel (RECENT TICKETS) |
+| `~/.agents/.history/menubar/linear-cache.json` | warm cache of Linear projects + each project's open tickets |

--- a/cli/docs/monitors.md
+++ b/cli/docs/monitors.md
@@ -1,0 +1,353 @@
+# Monitors (Event-Triggered Watchers)
+
+A **monitor** watches a SOURCE, detects a CONDITION change, and fires an ACTION.
+
+> **A monitor is a routine whose trigger is a *watched source* instead of a *clock*.**
+> `Monitor : routines :: event-triggered : time-triggered` — one daemon, one
+> dispatch seam. The monitor owns only the source → condition → action layer;
+> everything below it (spawning the agent, device placement, run history, the
+> daemon lifecycle) is the [routines](routines.md) backbone, reused verbatim.
+
+## The three-part model
+
+```
+   SOURCE                 CONDITION                ACTION
+   (what to watch)        (did it change?)         (what to do)
+ ┌───────────────┐      ┌────────────────┐      ┌──────────────────┐
+ │ command       │      │ on-change      │      │ run: <agent>     │
+ │ poll / http   │ ───► │ match: regex   │ ───► │ routine: <name>  │
+ │ file / device │      │ every          │      │ notify: telegram │
+ │ ws / webhook  │      │ + dedupe key   │      │ webhook-out: url │
+ └───────────────┘      │ + state.json   │      │ ({event} → prompt)│
+                        └────────────────┘      └──────────────────┘
+```
+
+## Architecture
+
+```
+~/.agents/
+  monitors/
+    ci-red.yml                         # Monitor config (YAML)
+    cert-issued.yml
+  .history/monitors/
+    ci-red/
+      state.json                       # last-seen value/hash + fire bookkeeping (written only on fire/baseline)
+      liveness.json                    # per-poll heartbeat: lastCheckedAt, checkCount, lastError (written EVERY poll)
+      fires/<id>/event.json            # fire history
+```
+
+Each monitor is a YAML file in `~/.agents/monitors/` (the user layer) or, for a
+built-in shipped with the CLI, `~/.agents/.system/monitors/` (the system layer,
+from `gh:phnx-labs/.agents-system`). `listMonitors()`/`readMonitor()` union the
+two — the user layer shadows a system built-in of the same name, exactly like
+routines' project/user/system resolution. A system built-in with no `enabled:`
+field is **opt-in**: it stays disabled until you enable it, which materializes a
+user copy (enable/edit/delete always write the user dir; the system mirror is
+pull-only). The same background daemon that runs routines
+(`agents routines start`) hosts a **monitor engine** beside the cron scheduler. On each tick it evaluates every enabled, device-owned monitor that
+is due, applies the condition through the native state-diff store, and on a fire
+dispatches the action through the exact `executeJobDetached` path cron and webhook
+fires use.
+
+### Built-in: `pr-merge-on-green`
+
+Opt-in. Polls every 5 minutes for **this user's** open PRs that are CI-green and
+non-author-approved, then dispatches `claude` to rebase-merge them.
+
+The **built-in YAML** lives in `gh:phnx-labs/.agents-system` (`monitors/pr-merge-on-green.yml`)
+and polls `monitors/pr-merge-on-green.sh` — `gh search prs` plus `gh pr view --repo`,
+verdict via `pr-verdict.py` (the same file `merge-guard.sh` calls). Companion:
+phnx-labs/.agents-system#347.
+
+This CLI also ships a hidden helper with the **same verdict rules**
+(`hasApproveVerdict` / `isCiGreen` match that python), listing registered
+project slugs instead of a global search:
+
+```bash
+agents _internal mergeable-prs    # owner/repo#n, or empty
+```
+
+```bash
+agents monitors enable pr-merge-on-green
+agents monitors test pr-merge-on-green    # dry-run: observation + would-fire
+```
+
+A user copy created by an older `enable` still has the broken `gh pr list`
+command (no `--repo`, `reviewDecision == APPROVED` only). Re-enable to pick up
+the new poll: `agents monitors remove pr-merge-on-green && agents monitors enable pr-merge-on-green`.
+
+### The one genuinely new piece: native state-diff
+
+Routines persist per-*run* metadata but have no last-observed-*value* store.
+Monitors add one (`~/.agents/.history/monitors/<name>/state.json`) — this is what
+replaces the hand-rolled markdown memory files ad-hoc watchers used to need.
+
+## Monitor Config
+
+```yaml
+# ~/.agents/monitors/ci-red.yml
+name: ci-red
+enabled: true
+source:
+  type: poll                 # command | poll | poll-http | file | device | ws | webhook
+  command: gh pr checks 1119 --json name,bucket
+  interval: 30s              # seconds supported (unlike routines' minute-granularity)
+condition:
+  mode: match                # on-change (default) | match | every
+  match: fail                # required for match mode (a regex)
+  dedupeKey: build (\d+)     # optional: first match is the "same event" signature
+action:
+  type: run                  # run | routine | notify | webhook-out
+  agent: claude
+  prompt: "CI failed on #1119: {event}. Diagnose and fix."
+  mode: auto
+device: yosemite-s0          # OWNER — the single machine that evaluates + fires (exactly-once)
+rateLimit:                   # firehose guard — auto-pause if exceeded
+  max: 5
+  per: 1m
+```
+
+## Definition vs. running state
+
+Two different things wear the word "monitor", and they live in different places
+on purpose:
+
+| | Path | Checked in? |
+|---|---|---|
+| **Definition** — what to watch, when, what to do | `~/.agents/monitors/<name>.yml` (user), `~/.agents/.system/monitors/` (built-in) | yes — it should ride the repo to every box |
+| **Running state** — last-seen value, fire history, rate-limit counters | `~/.agents/.history/monitors/<name>/state.json` + `fires/<id>/` | no — it is per-machine and regenerable |
+
+Nothing but the definition is ever written into `monitors/`: the only writers of
+that directory are the monitor file's read, write, and delete. Runtime lives
+under `.history/`, which is excluded, so the split needs no extra rules.
+
+### The double-trigger guard
+
+**A monitor's NAME is not its identity.** Two watchers polling the same source on
+the same interval and firing the same action are one trigger fired twice,
+whatever they are called — and `writeMonitor` overwrites by name, so nothing used
+to notice. One real box accumulated `open-pr-watch`, `pr-ci-fail`, three stale
+`pr2222-*` watchers and an agent-added lander, all polling the same PR queue,
+added without a single warning.
+
+The check runs **across the fleet**, not just this box — reusing the same
+cross-machine fan-out `sessions --active` uses. Two agents on two machines
+creating a watcher for the same work item is the case a local check cannot see.
+When a peer is unreachable the command says which ones it could not consult,
+rather than treating that as "no duplicate".
+
+`agents monitors add` refuses two collisions:
+
+- **Same name** — adding would overwrite an existing monitor.
+- **Same behavior** — an existing monitor (user *or* built-in) already watches
+  that source and fires that action, under any name.
+
+Identity is a fingerprint over the source, condition, and action. Name,
+description, and `enabled` are excluded — a duplicate under a new name is exactly
+the case being caught, and a paused duplicate is still a duplicate. **Placement
+(`device`/`devices`/`runOn`) is excluded too**: placement is who executes, not
+what runs, and hashing it would let the same watcher be re-added N times by
+varying only the owner.
+
+Pass `--force` when the duplication is deliberate.
+
+## Commands
+
+```bash
+# Create (auto-starts the daemon; then WAITS for the engine's first poll and
+# reports whether it was actually picked up — config acceptance is not "running")
+agents monitors add ci-red \
+  --poll 'gh pr checks 1119 --json name,bucket' 30s --match fail \
+  --run claude --prompt 'CI failed on #1119: {event}. Diagnose and fix.' \
+  --device yosemite-s0
+
+# The SSL watcher, reduced to config (replaces a 70-line prompt)
+agents monitors add cert-issued \
+  --poll-http 'https://secure.ssl.com/team/.../co-ec1l5dgjofa' 8h \
+  --match issued --notify telegram --device zion
+
+agents monitors list                  # all monitors, source, action, owner, liveness (checked Nx / never polled / STALLED / fired)
+agents monitors view <name>           # full config + liveness + current watched-state + recent fires
+agents monitors test <name>           # DRY-RUN: evaluate once, print event + would-fire (no action)
+agents monitors edit <name>           # $EDITOR on the YAML
+agents monitors logs <name>           # action run logs (run actions; reuses routines run history)
+agents monitors runs <name>           # fire history
+agents monitors pause / resume <name> # disable / re-enable
+agents monitors device <name> --set X # (re)pin the owner device; --clear to unrestrict
+agents monitors remove <name>
+```
+
+### Sources (`add` flags — exactly one)
+
+| Flag | Source | Observation |
+|---|---|---|
+| `--watch '<cmd>'` | command | the command's stdout |
+| `--poll '<cmd>' <interval>` | poll | stdout, re-run every interval |
+| `--poll-http <url> <interval>` | poll-http | `<status>\n<body>` every interval |
+| `--watch-file <path>` | file | file content (or dir listing) + mtime |
+| `--watch-device <name>` | device | fleet device reachability + headroom bucket |
+| `--ws <url>` | ws | each WebSocket frame (push) |
+| `--on <src:event>` | webhook | a signed github/linear delivery (push) |
+
+### Conditions (how an observation becomes a fire)
+
+- `--on-change` (default) — fire when the observation differs from last-seen. The
+  first observation establishes a **silent baseline**; a later change fires.
+- `--match '<regex>'` — fire when the observation matches; de-duped so it fires
+  **once** per distinct matched token (silent while the match is unchanged).
+- `--every` — fire on every observation (no dedupe). Rate-limit this.
+- `--dedupe-key '<regex>'` — the first match is the "same event" signature
+  (default: the full observation).
+
+### Actions (exactly one; the event is injected as `{event}`)
+
+- `--run <agent> --prompt '…'` — spawn an agent (shares `--mode`/`--effort`/
+  `--action-timeout` with routines), dispatched through `executeJobDetached`.
+  Takes a native harness id or a custom harness name (`agents harness list`);
+  a custom harness is delegated to `agents run <name>` and pins its own host
+  version and auth. The sandboxed child inherits this host's GitHub CLI auth
+  (`GH_CONFIG_DIR` / `~/.config/gh`) the same way interactive `agents run`
+  does — a `--run` that shells out to `gh` is not a hollow success when the
+  daemon user is already logged in (RUSH-2860; see [routines.md §Sandbox
+  Isolation](routines.md#sandbox-isolation)).
+- `--routine <name>` — fire an existing routine (attach a monitor to a routine).
+- `--notify [channel]` — notify the owner through the one channel seam
+  (`lookupTransport` → provider). The recipient and normal channel come from
+  `humans.yaml`; `[channel]` overrides that channel for this dispatch.
+  A channel with no registered provider fails that one dispatch (`ok: false`, the
+  reason logged) and leaves the daemon evaluating every other monitor — the daemon
+  never exits on a bad channel name.
+- `--webhook-out <url>` — POST the event JSON.
+
+### Placement (pin-to-one)
+
+- `--device <name>` — the **OWNER**: the single machine whose daemon evaluates the
+  source and fires. This is the exactly-once guarantee for v1 (no distributed
+  lock). If the owner is down, the monitor is down. A device/fleet is itself a
+  valid watch source (`--watch-device`).
+- `--devices <list>` — allowlist (advanced): each listed device fires
+  independently, like routines' `devices`.
+- `--run-on <host>` — execute the ACTION on a different machine over SSH, distinct
+  from the owner that fires it. With no owner pin, it pins the owner to this
+  machine to avoid duplicate fires across the fleet.
+- `--cwd <path>` — working directory for a `--run` action, home-relative or
+  `~/…`. Defaults to the execution target's home, which stays portable across a
+  `--run-on` hop. A monitor owns no project, so without this the run would be
+  blocked at readiness with `execution_context_missing` (RUSH-2681).
+
+## The `test` dry-run (the DX centerpiece)
+
+`agents monitors test <name>` evaluates the source **once** and prints the emitted
+event plus the would-fire decision — **without acting and without writing state**:
+
+```
+Dry-run: ci-red
+
+  poll: gh pr checks 1119 --json name,bucket @30s  ·  [match]  ·  run claude
+
+Observation
+  ... name ... bucket=fail ...
+  meta: {"exitCode":0}
+
+Would fire: yes
+
+Emitted event
+  summary: fail
+  → would run claude
+
+(dry run — no action taken, no state written)
+```
+
+## Liveness & health (is it actually polling?)
+
+A monitor can be enabled, owned by this box, and listed as `on` while the engine
+never touches it — and until it fires nothing on disk proved otherwise, because
+change-detection `state.json` is written **only** on a fire or a baseline. A
+`--match` monitor that polled steadily but matched nothing therefore showed
+`state: null`, indistinguishable from a monitor the engine never ran (RUSH-2485).
+
+The engine now writes a **liveness heartbeat** (`liveness.json`) on **every**
+poll — fire or not, match or not — so "never checked" is visibly distinct from
+"checked N times, not matching":
+
+```
+agents monitors list
+  ci-red      on  poll: gh pr checks 1119 … @30s
+                  [match] → run claude   owner: yosemite-s0   checked 42x · last 12 sec ago · no match yet
+  cert-issued on  poll-http: … @8h
+                  [match] → notify       owner: zion          never polled          <- yellow: engine hasn't touched it
+  stale-one   on  poll: … @60s
+                  [on-change] → notify   owner: yosemite-s0   STALLED — last poll 2 hours ago   <- red
+```
+
+- **`never polled`** (yellow) — the engine has no heartbeat for it. If it persists
+  after a few seconds, the daemon didn't pick it up: `agents routines status`.
+- **`checked Nx · last <ago> · no match yet`** — alive and polling, condition just
+  hasn't matched. This is the state that used to look dead.
+- **`STALLED — last poll <ago>`** (red) — an enabled, locally-owned monitor whose
+  last poll is more than three intervals behind. The engine has stopped checking it
+  (dead engine, wedged source) even though it's still marked `on`.
+- **`checked Nx · error: <msg>`** (red) — the source is erroring every poll.
+
+`agents monitors view <name>` shows the same under a **Liveness** block
+(`last checked`, `checks`, `last error`), and both commands expose it in `--json`
+as `lastCheckedAt`, `checkCount`, `lastError`, `consecutiveErrors`, and `stalled`.
+
+**Drought escalation.** After **5 consecutive failed checks** — a source that
+errors every poll, or an action that fails every fire — the engine notifies the
+owner **once** that the monitor is doing nothing (the streak clears, and can
+escalate again, on the first good check).
+
+## Fleet / device semantics (pin-to-one, v1)
+
+- `--device <name>` = the owner. Only that machine's daemon evaluates and fires.
+  Everywhere else the monitor is inert (`monitorRunsOnThisDevice` returns false).
+- `~/.agents/monitors/` rides the user repo, so a monitor syncs to every machine;
+  the owner pin is what makes it fire exactly once.
+- **Remote management** (`--device <device>` on a monitors subcommand, like routines)
+  is a follow-up: the top-level `--device` flag names the OWNER here, which
+  collides with the `--device` routing flag, so monitors
+  interpret `--device` locally rather than routing.
+- **The owner pin is the ONLY ownership gate a monitor action passes.** A `run`
+  action synthesizes a one-off job and hands it to the routines dispatch seam
+  (`executeJobDetached`), which normally also checks the per-device ROUTINES
+  activation manifest (`~/.agents/devices/<machine>/agents.yaml` → `routines:`).
+  A monitor is not a routine and can never be a member of that list, so the
+  synthesized job carries `dispatchedBy: 'monitor'` and `jobRunsOnThisDevice`
+  (lib/routines.ts) skips the manifest for it — without that marker every monitor
+  action was refused as `wrong_owner` with an empty allowlist and never ran
+  (RUSH-2681). A `routine` action fires a REAL routine, which keeps its
+  activation gate: a routine defined but not activated on this device is still
+  refused. Monitor names are never written into the routines manifest.
+
+## Hygiene
+
+- **Rate-limit / firehose guard** — `rateLimit: { max, per }` auto-pauses a monitor
+  that fires more than `max` times per `per`.
+- **Notify-on-change discipline** — `on-change` is the default; silent on no-change.
+- **Coverage lint** on `add` — warns when a `--match` names only a success token
+  (e.g. `issued`), since "silence is not success" if the source breaks.
+
+## v1 scope
+
+The engine evaluates the **poll model**: `command`, `poll`, `poll-http`, `file`,
+and `device` sources. Push sources (`ws`, `webhook`) are accepted and validated but
+deliver through a persistent subscription / the webhook receiver, wired in a
+follow-up. Distributed single-owner lease + failover (true HA across `--devices`)
+and monitor→monitor chaining are also out of scope for v1.
+
+## Key Functions
+
+| Function | File | Purpose |
+|---|---|---|
+| `validateMonitor()` | lib/monitors/config.ts | Hand-rolled config validation |
+| `writeMonitor()` / `readMonitor()` | lib/monitors/config.ts | Persist monitor config |
+| `monitorRunsOnThisDevice()` | lib/monitors/config.ts | Owner-device eligibility gate |
+| `hasChanged()` / `writeState()` | lib/monitors/state.ts | Native state-diff store (fire/baseline only) |
+| `recordCheck()` / `readLiveness()` | lib/monitors/state.ts | Per-poll liveness heartbeat (every poll) |
+| `MonitorEngine.runMonitor()` | lib/monitors/engine.ts | One poll: evaluate → decide → fire → record heartbeat |
+| `shouldEscalateDrought()` | lib/monitors/engine.ts | Drought predicate: notify owner after N failed checks |
+| `evaluateSource()` | lib/monitors/sources/index.ts | Source-type → evaluator |
+| `decideFire()` | lib/monitors/engine.ts | Apply the condition to an observation |
+| `dispatchAction()` | lib/monitors/dispatch.ts | Fire the action via executeJobDetached / notify / POST |
+| `MonitorEngine` | lib/monitors/engine.ts | The tick/evaluate loop inside the daemon |

--- a/cli/docs/monitors.md
+++ b/cli/docs/monitors.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Monitors (Event-Triggered Watchers)
 
 A **monitor** watches a SOURCE, detects a CONDITION change, and fires an ACTION.

--- a/cli/docs/plugins.md
+++ b/cli/docs/plugins.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Plugins
 
 Distributable bundles that package skills, commands, hooks, MCP servers, and permissions under a single versioned manifest.
@@ -192,4 +193,4 @@ agents plugins remove rush-toolkit --keep-source
 - [resource-sync.md](resource-sync.md) — how plugins participate in the layered resource sync model
 - [docs/subagents.md](subagents.md) — subagent definitions that plugins can bundle
 - [docs/hooks.md](hooks.md) — hook manifests that plugins can ship
-- [docs/workflows.md](workflows.md) — workflow bundles that can reference plugins
+- docs/workflows.md — workflow bundles that can reference plugins

--- a/cli/docs/plugins.md
+++ b/cli/docs/plugins.md
@@ -1,0 +1,195 @@
+# Plugins
+
+Distributable bundles that package skills, commands, hooks, MCP servers, and permissions under a single versioned manifest.
+
+## Overview
+
+A plugin is a directory in `~/.agents/plugins/` containing a `.claude-plugin/plugin.json` manifest. When you install or sync a plugin, agents-cli copies its contents into a synthetic per-user marketplace inside the agent version home and enables it via `enabledPlugins` in `settings.json`. Plugins are a superset of individual resources: a single plugin can ship skills, slash commands, subagent definitions, hooks, MCP servers, LSP servers, monitors, bin scripts, and permission sets — installed atomically as a unit.
+
+Only agents with `plugins: true` (or a version-gated `since`) in the capability matrix participate — today Claude, OpenClaw, Antigravity, Grok, Kimi, Cursor, Goose, Droid, and Codex >= 0.128.0 (`capableAgents('plugins')` in `src/lib/agents.ts`). Plugins can narrow further by declaring `agents: [...]` in their manifest. Plugins that ship executable surfaces (hooks, `.mcp.json`, `bin/`, `scripts/`, `settings.json`, `permissions/`) require explicit consent via `--allow-exec-surfaces` to be enabled after installation.
+
+For the layered resource model that governs plugin resolution, see [resource-sync.md](resource-sync.md).
+
+## Architecture
+
+```
+~/.agents/plugins/<name>/             Central source (user-authored, git-tracked)
+  .claude-plugin/
+    plugin.json                       Required manifest: name, version, description
+  skills/<skill>/SKILL.md             Slash-command knowledge packs
+  commands/*.md                       Slash commands (converted to skills on Codex >= 0.117.0)
+  agents/*.md                         Subagent definitions
+  hooks/hooks.json         ◄ exec     Hook registrations — triggers exec-surface gate
+  .mcp.json                ◄ exec     MCP server declarations
+  bin/                     ◄ exec     Executable binaries
+  scripts/                 ◄ exec     Arbitrary shell scripts
+  settings.json            ◄ exec     Agent settings merge (non-permissions keys)
+  permissions/             ◄ exec     Permission group YAML files
+  .user-config.json                   Per-install user config values (runtime, not shipped)
+  .source                             Git remote recorded at install time
+
+                                      On agents plugins sync / install
+                                               │
+                                               ▼
+<version-home>/.claude/
+  plugins/
+    known_marketplaces.json           "agents-cli" → marketplaces/agents-cli  (registered)
+    marketplaces/agents-cli/
+      .claude-plugin/marketplace.json Lists every discovered plugin
+      plugins/<name>/                 Copy of source (user-config placeholders resolved)
+    settings.json
+      enabledPlugins["<name>@agents-cli"] = true   (only when exec gate passes)
+```
+
+## Command Reference
+
+| Command | Description |
+|---------|-------------|
+| `agents plugins list` | Table view of all plugins with sync status across agent versions |
+| `agents plugins view <name>` | Metadata, resources, and installation status for one plugin |
+| `agents plugins info <name>` | Alias for `view` |
+| `agents plugins install <spec>` | Install from a git URL or local path |
+| `agents install plugin:<spec>` | Same install path (Phase 5 umbrella); same `--allow-exec-surfaces` gate |
+| `agents plugins update [name]` | Re-pull from original source and re-sync (all plugins if no name given) |
+| `agents plugins sync <name> [agent]` | Apply a plugin to the default version of an agent (all supported agents if none given) |
+| `agents plugins remove [name]` | Unsync from all agent versions; optionally delete source directory |
+
+### Options
+
+| Command | Flag | Effect |
+|---------|------|--------|
+| `install` | `--allow-exec-surfaces` | Enable the plugin even when it ships hooks, MCP, bin, scripts, settings, or permissions |
+| `sync` | `--allow-exec-surfaces` | Same gate override for the sync path |
+| `remove` | `--keep-source` | Unsync from agents but leave `~/.agents/plugins/<name>/` on disk |
+
+## Manifest Schema
+
+`.claude-plugin/plugin.json` is the required entry point. Every field maps directly to `PluginManifest` in `src/lib/types.ts:378`.
+
+```json
+{
+  "name": "git",
+  "version": "1.0.0",
+  "description": "Git workflow commands — atomic grouped commits and merged-branch cleanup.",
+  "agents": ["claude", "openclaw"],
+  "dependencies": ["other-plugin"],
+  "userConfig": [
+    {
+      "key": "api_url",
+      "description": "Base URL for the API",
+      "required": true,
+      "default": "https://api.example.com"
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Plugin identifier; must match the directory name |
+| `version` | string | yes | SemVer string shown in `agents plugins list` |
+| `description` | string | yes | One-line description |
+| `agents` | `AgentId[]` | no | Limit to specific agents; omit to support all capable agents |
+| `dependencies` | `string[]` | no | Other plugin names required; missing deps produce a warning at install |
+| `userConfig` | `PluginUserConfigField[]` | no | Interactive fields prompted at install time; values stored in `.user-config.json` |
+
+### Directory Layout
+
+```
+my-plugin/
+  .claude-plugin/
+    plugin.json         # Required manifest
+  skills/
+    my-skill/
+      SKILL.md          # Skill definition
+  commands/
+    my-command.md       # Slash command
+  agents/
+    my-subagent.md      # Subagent definition
+  hooks/
+    hooks.json          # Hook registrations (exec surface)
+  .mcp.json             # MCP server config (exec surface)
+  bin/
+    my-binary           # Executable (exec surface)
+  scripts/
+    setup.sh            # Setup scripts (exec surface)
+  settings.json         # Settings to merge (exec surface)
+  permissions/
+    my-perms.yaml       # Permission group (exec surface)
+```
+
+## Exec-Surface Consent Gate
+
+Plugins that ship any of `hooks/`, `.mcp.json`, `bin/`, `scripts/`, a non-permissions `settings.json`, or `permissions/` are **installed** (copied to the marketplace) but **not enabled** unless you pass `--allow-exec-surfaces`.
+
+The gate is implemented at `src/commands/plugins.ts:68`:
+
+```typescript
+export function shouldRefusePluginInstall(
+  capabilities: PluginCapabilities,
+  allowExecSurfaces: boolean
+): boolean {
+  return hasPluginExecSurfaces(capabilities) && !allowExecSurfaces;
+}
+```
+
+`PluginCapabilities` maps each surface to a boolean flag (`hasHooks`, `hasMcp`, `hasBin`, `hasScripts`, `hasSettings`, `hasPermissions`). `hasPluginExecSurfaces()` returns true if any flag is true.
+
+Without the flag, the plugin is placed in the marketplace and listed in `known_marketplaces.json`, but `enabledPlugins["<name>@agents-cli"]` is never set to `true` in `settings.json`. The plugin is present but inert until you re-run with consent.
+
+This prevents automated sync flows (`agents use claude@<v>`) from silently activating third-party code that runs shell scripts or registers MCP servers in every new session.
+
+## Recipes
+
+**1. Install a plugin from GitHub**
+
+```bash
+agents plugins install rush-toolkit@https://github.com/user/rush-toolkit.git
+
+# If the plugin ships hooks or MCP and you trust the source:
+agents plugins install rush-toolkit@https://github.com/user/rush-toolkit.git --allow-exec-surfaces
+```
+
+**2. Install from a local path**
+
+```bash
+agents plugins install ~/Projects/my-plugin
+# or with an explicit name:
+agents plugins install rush-toolkit@~/Projects/rush-toolkit
+```
+
+**3. Sync after pulling the repo**
+
+```bash
+# After git pull or manual edits to ~/.agents/plugins/my-plugin/:
+agents plugins sync my-plugin
+agents plugins sync my-plugin claude --allow-exec-surfaces
+```
+
+**4. List what is installed and enabled**
+
+```bash
+agents plugins list
+agents plugins view rush-toolkit
+```
+
+**5. Remove a plugin**
+
+```bash
+# Remove from all agents and delete source:
+agents plugins remove rush-toolkit
+
+# Unsync only, keep source directory:
+agents plugins remove rush-toolkit --keep-source
+```
+
+## Demo
+
+<video autoplay loop muted playsinline width="100%" src="../assets/videos/plugins.mp4"></video>
+
+## See Also
+
+- [resource-sync.md](resource-sync.md) — how plugins participate in the layered resource sync model
+- [docs/subagents.md](subagents.md) — subagent definitions that plugins can bundle
+- [docs/hooks.md](hooks.md) — hook manifests that plugins can ship
+- [docs/workflows.md](workflows.md) — workflow bundles that can reference plugins

--- a/cli/docs/profiles.md
+++ b/cli/docs/profiles.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Profiles
 
 > **Surface note:** the top-level `agents profiles` command was removed.

--- a/cli/docs/profiles.md
+++ b/cli/docs/profiles.md
@@ -1,0 +1,381 @@
+# Profiles
+
+> **Surface note:** the top-level `agents profiles` command was removed.
+> Use `agents harness add|fork|edit|list|view|remove`. Provider API keys are
+> accounts: `agents accounts add|set-key|remove` (RUSH-2981 removed
+> `agents harness login|logout`).
+> Profile YAML under `~/.agents/profiles/` is unchanged.
+
+
+Named bundles of host CLI, endpoint, model, and a durable account reference — run alternative providers through a standard agent interface without a local proxy.
+
+## Overview
+
+A profile pins a host agent binary to a non-default API endpoint and model. Its `account:` field stores the durable account **name** — portable across devices, since profiles sync fleet-wide with `agents repo push` while account ids are minted per-machine; the credential stays in the device keychain. Running `agents run <profile>` resolves the account at spawn time, injects the provider-specific environment, and fails before spawning if the credential is absent. A dangling ref (the account doesn't exist on this device) names the harness and the `agents harness edit <name> --account <name>` repair.
+
+A custom harness runs anywhere an agent name is accepted, not just `agents run`: as a teammate (`agents teams add <team> deepseek "…"`), in a routine (`agents routines add --agent deepseek`), as a monitor action (`agents monitors add --run deepseek`), and on another machine (`agents run deepseek --device <box>` — the profile must exist on the target, which `agents repo push user` handles). Routines and monitors delegate the job to `agents run <name>`; the profile pins its own host version and auth, so `@version` pins, balanced rotation, and account failover don't apply to those jobs.
+
+Built-in presets cover the top open-weight models via OpenRouter (one shared key) and native CLI providers (xAI, Google). Custom profiles work with any OpenAI-compatible endpoint: Ollama, vLLM, LiteLLM Proxy. Profile YAML files live under `~/.agents/profiles/` and are resolved by name at `agents run` time.
+
+> **Status:** Profiles are experimental, but available by default — no enable step needed.
+
+## Custom harnesses (`agents harness`)
+
+A custom harness is a profile you create from a host CLI + model in one command, so a model like Meta Muse Spark 1.1 runs like a native agent type:
+
+```sh
+# OpenCode pinned to Muse Spark, named `spark`
+agents harness add spark --host opencode --model meta/muse-spark-1.1
+agents run spark "refactor api/handlers/checkout.py"
+
+# per-run model override still wins over the profile
+agents run spark --model opencode/big-pickle "quick pass"
+
+# private OpenAI/Anthropic-compatible endpoint using an existing account
+agents harness add corp --host claude --model gpt-x --base-url https://gw.corp/v1 --account corp
+```
+
+The model is written to the host's model env var — `OPENCODE_MODEL` for opencode, `ANTHROPIC_MODEL` for claude, `GROK_MODEL` for grok, `GEMINI_MODEL` for gemini. Native OAuth remains harness-managed; omit `--account` to use that login.
+
+`agents harness list` shows three groups: your custom harnesses, the addable built-in presets, and the native harness registry. `agents harness view <name>` and `agents harness remove <name>` round it out.
+
+A harness *is* a profile — same `~/.agents/profiles/<name>.yml`, same `agents run` resolution, same device sync via `agents repo push user`. The difference from `agents harness add`: `harness add` takes the host+model one-shot (no preset needed) and owns its own `--host` flag, whereas `agents harness --host <device>` is reserved for running the profiles command on a remote device.
+
+### Forking a harness (`agents harness fork`)
+
+`fork` is the one verb for both starting points — a native harness, or a custom one you already tuned:
+
+```sh
+# fork the native OpenCode harness onto a DeepSeek model, keyed by OpenRouter
+agents harness fork opencode deepseek --model deepseek/deepseek-v4-flash-0731 --account openrouter-work
+
+# fork Claude Code onto a private gateway
+agents harness fork claude corp --model gpt-x --base-url https://gw.corp/v1 --account corp
+
+# copy an existing harness and swap only the model
+agents harness fork deepseek deepseek-chat --model deepseek/deepseek-chat-v3
+```
+
+Forking a **native** harness requires `--model` — there is no model to inherit. Forking a **custom** harness copies everything (env, endpoint, account binding, `fallback_model`, host version pin) and applies only the flags you pass; the two diverge from that point, so removing the source never affects the fork. `--force` overwrites an existing harness of the same name. The name `agents view` prints is derived from the harness `name` — `deepseek-flash` renders as `DeepSeek Flash` — so there is no flag to set it. The fork records its parent as `forkedFrom:` in the YAML — display-only lineage.
+
+### Editing and renaming a harness (`agents harness edit` / `rename`)
+
+`edit` applies overrides onto an existing harness **in place** — same name, same lineage — instead of copying it under a new one:
+
+```sh
+# swap the pinned model
+agents harness edit deepseek --model deepseek/deepseek-v3.2
+
+# attach a different durable account
+agents harness edit corp --account corp2
+
+# unpin the host CLI version
+agents harness edit spark --version ""
+
+# add (or clear, with an empty string) a same-host fallback model for rate-limit retries
+agents harness edit deepseek --fallback-model deepseek/deepseek-chat-v3
+```
+
+`edit` takes the same override flags as `fork` (`--model`, `--base-url`, `--account`, `--version`, `--description`) plus one edit-only flag, `--fallback-model`, for `Profile.fallback_model` (see [`routines.md`](routines.md) and the fallback cascade in `runWithFallback`). Unlike `fork`, `edit` never rewrites `forkedFrom` to point at itself.
+
+Giving zero flags **in a terminal** now opens the same interactive wizard `add`/`fork` use, pre-filled with the harness's current values (`agents harness edit deepseek` with no flags). It walks each editable field — model, endpoint, auth, version, fallback, description — and writes only what you change; leaving every prompt at its default is a no-op. Fields the host can't carry are shown disabled with a reason: a host with no custom-endpoint slot (anything but claude/codex) skips the base-URL prompt, and a self-updating host (grok/droid/antigravity/cursor/hermes/muse/kiro/goose) skips the version pin, rather than silently accepting a value a run would drop. Giving zero flags **without** a terminal stays a no-op error naming the available ones, so scripts are unchanged.
+
+`agents harness rename <old-name> <new-name>` renames the underlying YAML file and updates the `name:` field inside it; every other harness whose `forkedFrom:` pointed at the old name is rewritten to the new one. Renaming onto an existing name is a hard error — there is no overwrite path (use `remove` first if that's really the intent).
+
+### Importing a key from an existing secrets bundle
+
+Accounts own credentials; harnesses only reference accounts. Import an existing secret while creating the account, then attach that account wherever it is needed:
+
+```sh
+agents accounts add corp --provider proxy --auth api-key --from-secrets prod:OPENROUTER_KEY
+agents harness add corp-model --host claude --model gpt-x --base-url https://gw.corp/v1 --account corp
+agents accounts set-key corp --from-secrets prod:OPENROUTER_KEY
+```
+
+### Interactive wizard (`agents harness add` / `fork` / `edit`)
+
+Run `add` or `fork` in a terminal without enough flags to build a harness (e.g. bare `agents harness add`, or `agents harness fork claude` with no `--model`) and a picker walks you through it instead of throwing: fork from (every native host plus your existing harnesses) → a built-in preset or "build custom" (host + model + provider) → the harness's name (pre-filled with the preset's own name, e.g. `deepseek`, not a model detail) → how to get the key (type it, or pick a bundle+key via `--from-secrets`). `edit` opens the same wizard pre-filled with a harness's current values when you run it with no flags (see above). Flags remain fully supported for scripts — the wizard only engages when required info is missing **and** stdin+stdout are a TTY; a non-interactive shell still gets the original error.
+
+Both flows drive one shared step engine ([`src/commands/harness-wizard.ts`](../src/commands/harness-wizard.ts)): a `create` and an `edit` step list over a single runner, each step skippable by the matching flag and gated by a `WizardIO` seam that makes the engine testable without a TTY. The model catalog, connection test, per-host edit matrix, and cross-host portability plug into it via typed extension points (`WizardHooks`).
+
+### Custom harnesses are their own agent type
+
+`agents view` lists each custom harness as its own block, beside Claude and Codex rather than indented under whichever host CLI executes it — because `agents run <name>` already launches it the same way a native agent id is launched:
+
+```
+  deepseek-flash (custom)
+    deepseek/deepseek-v4-flash-0731  openrouter stored  via claude
+
+  deepseek-chat (custom · forked from deepseek-flash)
+    deepseek/deepseek-chat-v3        openrouter stored  via claude
+```
+
+The row carries the pinned model, the account/auth state, and `via <host>` — the native harness that actually runs it, with its version when the harness pins one. A harness whose host CLI has no install is flagged `(host <id> not installed)` rather than listed as runnable. `agents view <name>` describes one harness (host, model, provider, auth, lineage, YAML path), and `agents view <name> --json` emits its summary. A native-specific `agents view <agent>` shows only that native harness's versions; it does not include custom harnesses that execute through it. The exact custom name also wins in `agents run`, before native ids and hard-deprecated aliases, so the fork remains runnable through its configured host. The unfiltered `agents view --json` inventory keeps hosted summaries under the `harnesses` key for machine consumers.
+
+## Architecture
+
+```
+~/.agents/
+  profiles/
+    kimi.yml              # profile YAML (no secrets)
+    deepseek.yml
+    local-llama.yml
+
+macOS Keychain
+  agents-cli.openrouter.token    # shared across all openrouter profiles
+  agents-cli.xai.token           # xAI profiles
+  agents-cli.ollama.token        # custom profiles
+
+                  ┌─────────────────────┐
+  agents run kimi │  resolveProfileEnv  │
+  ───────────────▶│  1. read kimi.yml   │
+                  │  2. read Keychain   │──▶ spawn claude
+                  │  3. merge env block │     ANTHROPIC_BASE_URL=...
+                  └─────────────────────┘     ANTHROPIC_MODEL=...
+                                              ANTHROPIC_AUTH_TOKEN=<key>
+```
+
+Profile YAML `host.agent` selects which binary is spawned. Env vars override defaults for that CLI. Auth is resolved last — keychain item name is stored in `auth.keychainItem` and the env var to inject it under is stored in `auth.envVar`.
+
+## Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `harness list` / `ls` | List configured profiles (name, host, provider, model) | `agents harness list` |
+| `harness list` | List custom harnesses and the built-in presets | `agents harness list` |
+| `harness view <name>` / `show` | Inspect a profile (env vars, auth status, preset link) | `agents harness view kimi` |
+| `harness add <name>` | Add a profile from a preset. Prompts for API key once per provider. | `agents harness add kimi` |
+| `harness add <name> --preset <preset>` | Add a profile using an explicit preset name | `agents harness add k2 --preset kimi` |
+| `harness add <name> --version <v>` | Pin the host CLI version | `agents harness add kimi --version 2.1.113` |
+| `harness add <name> --key-stdin` | Read API key from stdin (CI-safe) | `echo $KEY \| agents harness add kimi --key-stdin` |
+| `harness add <name> --force` | Overwrite an existing profile | `agents harness add kimi --force` |
+| `harness remove <name>` / `rm` | Delete a profile (keychain token is kept) | `agents harness remove kimi` |
+| `accounts add <name>` | Store a provider API key as a durable account | `agents accounts add openrouter --provider openrouter --auth api-key` |
+| `accounts set-key <name>` | Rotate an account credential (or `--from-secrets bundle:key` for CI) | `agents accounts set-key openrouter` |
+| `accounts remove <name>` | Remove an account and its device-local credential | `agents accounts remove openrouter` |
+
+## Built-in Presets
+
+All OpenRouter presets share one key (`agents-cli.openrouter.token`). Adding a second OpenRouter preset never re-prompts.
+
+| Preset | Provider | Model | Notes |
+|--------|----------|-------|-------|
+| `kimi` | openrouter | `moonshotai/kimi-k2.5` | 99% HumanEval. REASONING — interactive only; `--print` returns empty output. |
+| `kimi-chat` | openrouter | `moonshotai/kimi-k2-0905` | Non-reasoning sibling. PRINT-SAFE. |
+| `minimax` | openrouter | `minimax/minimax-m2.5` | 80.2% SWE-bench. REASONING — interactive only. |
+| `glm` | openrouter | `z-ai/glm-5` | #1 Chatbot Arena ELO among open-weight. REASONING — interactive only. |
+| `qwen` | openrouter | `qwen/qwen3-coder-next` | Latest coding Qwen. PRINT-SAFE. |
+| `deepseek` | openrouter | `deepseek/deepseek-chat-v3-0324` | Non-reasoning DeepSeek Chat. PRINT-SAFE. |
+| `open-claude` | openrouter | `qwen/qwen3-coder-next` | Open-weight coding inside Claude Code — general open-claude path. PRINT-SAFE. |
+| `claude-spark` | openrouter | `meta/claude-spark-1.1` | Meta Claude Spark 1.1 via OpenRouter inside Claude Code. Open alternative for open-claude spark usage. |
+| `opencode` | opencode | (default) | OpenCode default — uses configured model. Auth via `opencode auth`. |
+| `opencode-spark` | opencode | `meta/claude-spark-1.1` | Meta Claude Spark 1.1 via OpenCode — best for open-claude usage with opencode harness. |
+| `opencode-qwen` | opencode | `qwen/qwen3-coder-next` | Qwen3 Coder Next via OpenCode — free via opencode provider. |
+| `grok-fast` | xai | `grok-build-fast` | Native grok host. |
+| `grok-heavy` | xai | `grok-build` | Native grok host (SuperGrok). |
+| `agy` | google | (CLI default) | Native antigravity host. |
+| `anthropic` | anthropic | `claude-3-5-sonnet-latest` | Direct Anthropic API. |
+| `deepinfra` | deepinfra | `deepseek-ai/DeepSeek-V3` | DeepInfra's OpenAI-compatible API through Codex. |
+| `proxy` | proxy | (custom) | Generic local proxy / gateway. |
+| `truefoundry` | truefoundry | (custom) | TrueFoundry AI Gateway. |
+| `bedrock` | bedrock | (custom) | AWS Bedrock native mode. |
+| `vertex` | vertex | (custom) | Google Vertex AI. |
+| `foundry` | foundry | (custom) | Azure AI Foundry. |
+| `litellm` | litellm | (custom) | LiteLLM proxy. |
+| `vllm` | vllm | (custom) | Self-hosted vLLM. |
+| `ollama` | ollama | `qwen3-coder:30b` (default) | Local Ollama via Codex host. |
+
+Source: `src/lib/profiles-presets.ts`.
+
+**REASONING vs PRINT-SAFE:** Claude Code sends `thinking:{type:"enabled"}` in its Anthropic payload. When the model returns reasoning/redacted_thinking blocks, `--print` consolidation returns empty stdout. Reasoning presets (`kimi`, `minimax`, `glm`) work fine interactively; use print-safe variants (`kimi-chat`, `qwen`, `deepseek`) for `agents run --print` and scripted pipelines.
+
+## Configuration Schema
+
+```yaml
+# ~/.agents/profiles/<name>.yml
+
+name: local-llama              # string, required — must match filename stem
+                               # Pattern: [a-z0-9][a-z0-9-_]{0,48} (case-insensitive)
+
+description: Local Llama 3.3  # string, optional — shown in `harness list` and `view`
+
+host:
+  agent: claude                # AgentId, required — which CLI binary to spawn
+                               # One of: claude, codex, cursor, opencode, grok, antigravity
+                               # (gemini is hard-deprecated — see concepts.md)
+  version: 2.1.113             # string, optional — pin this host CLI version
+
+env:                           # Record<string, string>, required (may be empty {})
+  ANTHROPIC_BASE_URL: http://localhost:11434   # endpoint override
+  ANTHROPIC_MODEL: llama-3.3-70b              # model override
+  ANTHROPIC_SMALL_FAST_MODEL: llama-3.3-70b  # fast-path model (optional)
+
+auth:                          # optional — omit if no token is needed
+  envVar: ANTHROPIC_AUTH_TOKEN # string — which env var to inject the key into
+  keychainItem: agents-cli.ollama.token  # string — keychain item that holds the key
+
+preset: kimi                   # string, optional — preset this profile was created from
+                               # Set automatically by `harness add`; informational only.
+
+provider: openrouter           # string, optional — provider name for display
+                               # Set automatically by `harness add`; informational only.
+
+models:                        # Partial<Record<ModelTier, string>>, optional
+  cheap: deepseek/deepseek-chat-v3        # per-tier model ids for THIS harness's
+  default: deepseek/deepseek-v4-flash-0731 # own catalog — resolves `agents run
+  best: deepseek/deepseek-r1               # <profile> --model cheap|default|best|ultra`
+                               # against the harness's own models instead of the host
+                               # agent's (claude/codex/...) native catalog. An unset
+                               # tier clamps to the next CHEAPER tier that IS set
+                               # (ultra -> best -> default -> cheap). Omit entirely to
+                               # keep today's behavior: a requested tier falls back to
+                               # the single pinned model in `env`, unchanged.
+```
+
+Fields sourced from `Profile` interface at `src/lib/profiles.ts:19-73`.
+
+## Recipes
+
+### 1. Add a preset and run it
+
+```bash
+# Store the OpenRouter key once (all openrouter presets reuse it)
+agents accounts add openrouter --provider openrouter --auth api-key
+
+# Add Kimi (interactive use — reasoning model)
+agents harness add kimi
+agents run kimi "refactor the auth handler"
+
+# Add a print-safe preset for scripted use
+agents harness add deepseek
+agents run deepseek --print "summarize the diff"
+```
+
+### 2. Write a custom YAML for a local Ollama endpoint
+
+Drop a YAML under `~/.agents/profiles/local-llama.yml`:
+
+```yaml
+name: local-llama
+description: Local Llama 3.3 via Ollama
+host:
+  agent: claude
+env:
+  ANTHROPIC_BASE_URL: http://localhost:11434
+  ANTHROPIC_MODEL: llama-3.3-70b
+auth:
+  envVar: ANTHROPIC_AUTH_TOKEN
+  keychainItem: agents-cli.ollama.token
+```
+
+Then store the key and verify:
+
+```bash
+agents accounts add ollama --provider ollama --auth api-key    # or: echo "your-key" | agents harness add local-llama --key-stdin
+agents harness view local-llama
+agents run local-llama "hello"
+```
+
+### 3. Rotate the API key for a provider
+
+Rotation applies to all profiles that share the same provider key:
+
+```bash
+agents accounts set-key openrouter   # prompts for new key, overwrites the old one
+# All kimi, kimi-chat, minimax, glm, qwen, deepseek profiles pick it up immediately
+```
+
+To rotate non-interactively (CI), import from an `agents secrets` entry:
+
+```bash
+agents accounts set-key openrouter --from-secrets openrouter.ai:OPENROUTER_API_KEY
+```
+
+### 4. List and inspect configured profiles
+
+```bash
+agents harness list              # table: NAME HOST PROVIDER MODEL
+agents harness view kimi         # env vars, auth status, signup URL
+agents harness presets           # full preset catalog with descriptions
+```
+
+### 5. Pin a specific host version
+
+```bash
+agents harness add kimi --version 2.1.113
+# spawns claude@2.1.113 for this profile only
+```
+
+### 6. Remove a profile without losing the key
+
+```bash
+agents harness remove kimi
+# YAML deleted; agents-cli.openrouter.token stays in Keychain
+# Other openrouter profiles are unaffected
+
+# To fully remove the key too:
+agents accounts remove openrouter
+```
+
+### 7. Run a profile on a leased box
+
+```bash
+agents run deepseek "summarize this repo" --lease hetzner
+agents run deepseek "summarize this repo" --box warm-one
+```
+
+Leased profile runs install the profile's `host.agent` on the disposable box and
+materialize a temporary profile there for the duration of the run. Profiles with
+their own API key, such as OpenRouter-backed `kimi` and `deepseek`, ship that
+profile auth only; the base runtime's local OAuth credential is copied only when
+the profile has no auth env of its own. `--box <slug>` targets an existing warm
+crabbox box instead of provisioning a disposable lease, so the same box can serve
+profile runs from different repositories and remains running after the command.
+
+`--lease` is reuse-first against one shared `default` pool across repositories:
+before leasing a new box it looks for a warm box with the same network mode that
+`crabbox status` reports SSH-ready, and reuses it instead of paying for one warm
+box per repo. If the pool is empty, the newly warmed box is kept after the run so
+the next caller can reuse it. Each concurrent run copies the synced checkout into its own
+`~/workspaces/<repo>-<run>` directory, then launches there; callers share compute,
+not a working tree, agent home, or credential file. Switching repositories therefore pays a re-sync latency in
+exchange for the lower idle-compute cost.
+
+The generic `.crabbox.yaml` `profile:` key still scopes repo sandbox/CI scripts.
+To opt `agents run --lease` into a dedicated hot-box pool, add a separate lease
+label explicitly:
+
+```yaml
+leaseProfile: private-hot-box
+```
+
+`--fresh` opts out of reuse entirely: it always provisions a brand-new box and
+tears it down after the run.
+
+## Demo
+
+<video autoplay loop muted playsinline width="100%" src="../assets/videos/profiles.mp4"></video>
+
+`agents harness add kimi` stores the OpenRouter key once; `agents run kimi` spawns Claude Code with Kimi K2.5 responding.
+
+## See Also
+
+- `docs/concepts.md` — DotAgents repos, resource resolution order
+- `docs/resource-sync.md` — how profiles sync across machines
+- `docs/secrets.md` — inject secrets bundles into agent runs
+
+## Per-provider guides
+
+For non-preset providers (gateways, self-hosted), the wizard at `agents harness add` walks you through the env vars. Per-provider gotchas are in:
+
+- [TrueFoundry](profiles/truefoundry.md) — LLM Gateway, Bedrock-backed
+- [AWS Bedrock](profiles/bedrock.md) — direct
+- [Google Vertex](profiles/vertex.md)
+- [Microsoft Azure AI Foundry](profiles/foundry.md) — distinct from TrueFoundry
+- [OpenRouter](profiles/openrouter.md) — built-in presets
+- [DeepInfra](profiles/deepinfra.md) — built-in Codex preset with a durable provider account
+- [Self-hosted vLLM](profiles/vllm.md) — native Anthropic endpoint, tool_use clean
+- [LiteLLM Proxy](profiles/litellm.md)
+- [Ollama](profiles/ollama.md) — Codex host recommended
+
+Full table: [profiles/INDEX.md](profiles/INDEX.md).

--- a/cli/docs/profiles/INDEX.md
+++ b/cli/docs/profiles/INDEX.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Per-provider profile guides
 
 | Provider | Host | Caveats | Doc |

--- a/cli/docs/profiles/INDEX.md
+++ b/cli/docs/profiles/INDEX.md
@@ -1,0 +1,15 @@
+# Per-provider profile guides
+
+| Provider | Host | Caveats | Doc |
+|---|---|---|---|
+| truefoundry | claude | Bedrock strict validation; corp cert chain | [truefoundry.md](truefoundry.md) |
+| bedrock | claude | strict validation (DISABLE_PROMPT_CACHING) | [bedrock.md](bedrock.md) |
+| vertex | claude | region-specific model availability | [vertex.md](vertex.md) |
+| foundry | claude | Microsoft Azure AI — not TrueFoundry | [foundry.md](foundry.md) |
+| openrouter | claude | print-safe vs reasoning models | [openrouter.md](openrouter.md) |
+| deepinfra | codex | OpenAI-compatible API through a durable account | [deepinfra.md](deepinfra.md) |
+| openrouter (open-claude, claude-spark) | claude | open-claude: qwen headless-safe; claude-spark: meta/claude-spark-1.1 | [openrouter.md](openrouter.md) |
+| opencode | opencode | free models via opencode auth, use --model flag | [openrouter.md](openrouter.md) |
+| vllm | claude | requires native Anthropic endpoint | [vllm.md](vllm.md) |
+| litellm | claude | tool_use limitations on pass-through | [litellm.md](litellm.md) |
+| ollama | codex | use Codex host, not Claude Code | [ollama.md](ollama.md) |

--- a/cli/docs/profiles/bedrock.md
+++ b/cli/docs/profiles/bedrock.md
@@ -1,0 +1,63 @@
+# AWS Bedrock
+
+Direct AWS Bedrock — Claude Code talks to Bedrock's Anthropic endpoint without a gateway in front of it. For Bedrock fronted by TrueFoundry, see [truefoundry.md](truefoundry.md) instead.
+
+## Quick start
+
+```bash
+agents harness create
+# pick bedrock, fill prompts, run smoke test
+agents run my-profile "hello"
+```
+
+## Required values
+
+| Var | Where to get it |
+|---|---|
+| AWS region | The region where you've enabled the Claude model in Bedrock |
+| Model id | Bedrock model catalog, e.g. `anthropic.claude-sonnet-4-20250514-v1:0` |
+| Auth | Either `AWS_BEARER_TOKEN_BEDROCK` or the standard AWS SDK credential chain (env, profile, IMDS, SSO) |
+
+## Generated profile shape
+
+```yaml
+name: my-profile
+host: { agent: claude }
+env:
+  # static vars (always set):
+  CLAUDE_CODE_USE_BEDROCK: "1"
+  # vars wizard collects:
+  AWS_REGION: us-west-2
+  ANTHROPIC_MODEL: anthropic.claude-sonnet-4-20250514-v1:0
+  ANTHROPIC_SMALL_FAST_MODEL: anthropic.claude-haiku-4-5-20251001-v1:0
+auth:
+  envVar: AWS_BEARER_TOKEN_BEDROCK
+  keychainItem: agents-cli.bedrock.token
+```
+
+If you'd rather use the AWS SDK credential chain (recommended for SSO/IAM Identity Center setups), omit the `auth:` block and let `aws sso login` populate the chain — Claude Code picks it up automatically when `CLAUDE_CODE_USE_BEDROCK=1` is set.
+
+## Known caveats
+
+**Strict request validation.** Bedrock runs a Pydantic validator on inbound payloads and rejects experimental fields Claude Code adds. If you see `extra inputs are not permitted`, set:
+
+```
+DISABLE_PROMPT_CACHING=1
+CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
+CLAUDE_CODE_ATTRIBUTION_HEADER=0
+```
+
+The first one is the most common fix; the other two cover newer Claude Code releases.
+
+**Model availability is region-specific.** Not every `claude-*` model is enabled in every region. Check the Bedrock model catalog for your region before pinning a model id — `anthropic.claude-opus-4-7-*` in particular rolls out gradually.
+
+**Model id format.** Bedrock uses the `anthropic.claude-...-v1:0` form, not the bare `claude-sonnet-4-5` alias. Inference profile ARNs also work (`arn:aws:bedrock:<region>:<account>:inference-profile/...`).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `extra inputs are not permitted` | Bedrock validator rejecting experimental fields | `DISABLE_PROMPT_CACHING=1` (plus the two `CLAUDE_CODE_*` flags if needed) |
+| `AccessDeniedException` on model invoke | Model not enabled in this region/account | Enable the model in the Bedrock console, or pick a region where it's already enabled |
+| `ValidationException: ... model identifier` | Wrong model id format | Use `anthropic.<model>-v1:0` or an inference profile ARN |
+| `UnrecognizedClientException` / `InvalidSignatureException` | AWS credentials missing or stale | Refresh via `aws sso login`, or rotate `AWS_BEARER_TOKEN_BEDROCK` |

--- a/cli/docs/profiles/bedrock.md
+++ b/cli/docs/profiles/bedrock.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # AWS Bedrock
 
 Direct AWS Bedrock — Claude Code talks to Bedrock's Anthropic endpoint without a gateway in front of it. For Bedrock fronted by TrueFoundry, see [truefoundry.md](truefoundry.md) instead.

--- a/cli/docs/profiles/deepinfra.md
+++ b/cli/docs/profiles/deepinfra.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # DeepInfra
 
 DeepInfra exposes an OpenAI-compatible API. The built-in `deepinfra` profile runs it through Codex and reads its API key from a durable account bundle with secrets policy `never`, so headless runs do not request Touch ID.

--- a/cli/docs/profiles/deepinfra.md
+++ b/cli/docs/profiles/deepinfra.md
@@ -1,0 +1,33 @@
+# DeepInfra
+
+DeepInfra exposes an OpenAI-compatible API. The built-in `deepinfra` profile runs it through Codex and reads its API key from a durable account bundle with secrets policy `never`, so headless runs do not request Touch ID.
+
+## Quick start
+
+```bash
+agents accounts add deepinfra --provider deepinfra --auth api-key
+agents harness add deepinfra --account deepinfra
+agents run deepinfra "summarize this repository"
+```
+
+Create an API key at <https://deepinfra.com/dash/api_keys>. The generated profile uses:
+
+```yaml
+name: deepinfra
+host: { agent: codex }
+env:
+  OPENAI_BASE_URL: https://api.deepinfra.com/v1/openai
+  OPENAI_MODEL: deepseek-ai/DeepSeek-V3
+account: <stable account id>
+provider: deepinfra
+```
+
+Use another model by forking the profile and changing its model:
+
+```bash
+agents harness fork deepinfra deepinfra-model \
+  --model <deepinfra-model-id> \
+  --account deepinfra
+```
+
+`agents view` reads DeepInfra's documented `/payment/checklist` endpoint through the daemon-owned BYOK refresh path. It renders current usage against the configured spending limit, or available prepaid credit when the account has no limit.

--- a/cli/docs/profiles/foundry.md
+++ b/cli/docs/profiles/foundry.md
@@ -1,0 +1,55 @@
+# Microsoft Azure AI Foundry
+
+Anthropic models served through Microsoft Azure AI Foundry (formerly Azure AI Studio).
+
+> **Not to be confused with TrueFoundry.** Microsoft Azure AI Foundry and TrueFoundry are different products with overlapping names. TrueFoundry → [docs/profiles/truefoundry.md](truefoundry.md).
+
+## Quick start
+
+```bash
+agents harness create
+# pick foundry, fill prompts, run smoke test
+agents run my-profile "hello"
+```
+
+## Required values
+
+| Var | Where to get it |
+|---|---|
+| Resource name | The Foundry resource name in the Azure portal (the prefix in `<resource>.services.ai.azure.com`) |
+| API key | Azure portal → your Foundry resource → Keys and Endpoint |
+| Model deployment id | Foundry → Deployments — must be a Claude deployment |
+
+## Generated profile shape
+
+```yaml
+name: my-profile
+host: { agent: claude }
+env:
+  # static vars (always set):
+  CLAUDE_CODE_USE_FOUNDRY: "1"
+  # vars wizard collects:
+  ANTHROPIC_BASE_URL: https://<resource>.services.ai.azure.com/anthropic
+  ANTHROPIC_MODEL: claude-sonnet-4-5
+  ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-4-5
+auth:
+  envVar: ANTHROPIC_AUTH_TOKEN
+  keychainItem: agents-cli.foundry.token
+```
+
+The base URL pattern is `<resource>.services.ai.azure.com/anthropic` — note the `/anthropic` suffix that routes to the Anthropic-shaped endpoint.
+
+## Known caveats
+
+**Foundry env vars intermittently ignored.** Known issue [claude-code#11937](https://github.com/anthropics/claude-code/issues/11937) — in some Claude Code releases `CLAUDE_CODE_USE_FOUNDRY=1` is not consistently honored and the CLI falls back to direct Anthropic. If you see requests going to `api.anthropic.com` despite the var being set, pin Claude Code to a release where the integration is stable (check the issue for the current good version).
+
+**Same Bedrock-style strict validation risk.** If Foundry's upstream is configured to relay to Bedrock, you can hit the same `extra inputs are not permitted` error documented in [truefoundry.md](truefoundry.md). The same three suppressor env vars apply.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Requests still hit `api.anthropic.com` | claude-code#11937 — Foundry env vars not picked up | Pin a Claude Code version that honors `CLAUDE_CODE_USE_FOUNDRY=1`; verify with `--debug` |
+| 404 on `/anthropic` path | Base URL missing the `/anthropic` suffix | Set `ANTHROPIC_BASE_URL=https://<resource>.services.ai.azure.com/anthropic` exactly |
+| 401 / 403 | Wrong key or key from a different Foundry resource | Rotate via `agents accounts set-key foundry` |
+| `extra inputs are not permitted` | Upstream Bedrock validator (Foundry-relayed) | Apply the `DISABLE_PROMPT_CACHING=1` + `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` + `CLAUDE_CODE_ATTRIBUTION_HEADER=0` triplet |

--- a/cli/docs/profiles/foundry.md
+++ b/cli/docs/profiles/foundry.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Microsoft Azure AI Foundry
 
 Anthropic models served through Microsoft Azure AI Foundry (formerly Azure AI Studio).

--- a/cli/docs/profiles/litellm.md
+++ b/cli/docs/profiles/litellm.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # LiteLLM Proxy
 
 Generic LLM gateway that fronts 100+ providers behind a single OpenAI-style API, with an Anthropic-shaped pass-through for Claude Code clients.

--- a/cli/docs/profiles/litellm.md
+++ b/cli/docs/profiles/litellm.md
@@ -1,0 +1,65 @@
+# LiteLLM Proxy
+
+Generic LLM gateway that fronts 100+ providers behind a single OpenAI-style API, with an Anthropic-shaped pass-through for Claude Code clients.
+
+## Quick start
+
+```bash
+agents harness create
+# pick litellm, fill prompts, run smoke test
+agents run my-profile "hello"
+```
+
+## Required values
+
+| Var | Where to get it |
+|---|---|
+| Proxy URL | Wherever you've deployed LiteLLM, e.g. `http://litellm.lan:4000` |
+| Master / virtual key | LiteLLM `--master_key` or a virtual key minted via the admin UI |
+| Model alias | The model name as defined in your `config.yaml` `model_list:` |
+
+## Generated profile shape
+
+```yaml
+name: my-profile
+host: { agent: claude }
+env:
+  # static vars (always set):
+  ANTHROPIC_BASE_URL: http://litellm.lan:4000      # the Anthropic pass-through is at /v1/messages
+  # vars wizard collects:
+  ANTHROPIC_MODEL: claude-sonnet-4-5-bedrock
+  ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-4-5-bedrock
+auth:
+  envVar: ANTHROPIC_AUTH_TOKEN
+  keychainItem: agents-cli.litellm.token
+```
+
+LiteLLM exposes both styles on the same port:
+
+- OpenAI-style: `POST /v1/chat/completions`
+- Anthropic pass-through: `POST /v1/messages`
+
+Claude Code talks the Anthropic shape, so it lands on `/v1/messages` automatically when you set `ANTHROPIC_BASE_URL`.
+
+## Known caveats
+
+**Pass-through `tool_use` is historically flaky.** The `/v1/messages` adapter has had recurring issues round-tripping Anthropic `tool_use` blocks — tool calls sometimes arrive as raw text, or the model's `tool_result` payloads get reshaped on the way back. If tool calling matters for your workflow, prefer **vLLM's native Anthropic endpoint** (see [vllm.md](vllm.md)) over a LiteLLM hop.
+
+**Drop unsupported params.** Upstreams reject fields they don't understand (e.g. `thinking`, `reasoning`, Anthropic beta cache controls). Configure LiteLLM to strip them in `config.yaml`:
+
+```yaml
+litellm_settings:
+  drop_params: true
+  additional_drop_params: ["thinking", "reasoning", "cache_control", "anthropic_beta"]
+```
+
+Without `drop_params: true` these surface as `400 Bad Request` from the upstream and Claude Code retries the whole request loop.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Tool calls degrade to plain text | LiteLLM Anthropic pass-through adapter `tool_use` bug | Use vLLM's native Anthropic endpoint instead — see [vllm.md](vllm.md) |
+| `400 Bad Request: unknown parameter 'thinking'` (or similar) | Upstream doesn't accept Anthropic-only fields | Add `drop_params: true` and the field to `additional_drop_params` |
+| 401 / `Invalid proxy server token` | Wrong master/virtual key | `agents accounts set-key litellm` to rotate |
+| `Model ... not in model_list` | Profile's `ANTHROPIC_MODEL` doesn't match any alias in `config.yaml` | Use the exact alias from your LiteLLM `model_list:` |

--- a/cli/docs/profiles/ollama.md
+++ b/cli/docs/profiles/ollama.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Ollama
 
 Local models served by Ollama on `127.0.0.1:11434`. **Recommended host: `codex`**, not Claude Code.

--- a/cli/docs/profiles/ollama.md
+++ b/cli/docs/profiles/ollama.md
@@ -1,0 +1,54 @@
+# Ollama
+
+Local models served by Ollama on `127.0.0.1:11434`. **Recommended host: `codex`**, not Claude Code.
+
+## Quick start
+
+```bash
+ollama serve &
+ollama pull qwen3-coder:30b
+
+agents harness create
+# pick ollama, fill prompts, run smoke test
+agents run my-profile "hello"
+```
+
+## Required values
+
+| Var | Where to get it |
+|---|---|
+| Endpoint | Defaults to `http://127.0.0.1:11434/v1` for the OpenAI-compatible API |
+| Model id | Whatever you've pulled, e.g. `qwen3-coder:30b` |
+| API key | Ollama doesn't require one — pass any non-empty string (`ollama`) |
+
+## Generated profile shape
+
+```yaml
+name: my-profile
+host: { agent: codex }                     # Codex is OpenAI-native; talks to Ollama without a shim
+env:
+  # static vars (always set):
+  OPENAI_BASE_URL: http://127.0.0.1:11434/v1
+  # vars wizard collects:
+  OPENAI_MODEL: qwen3-coder:30b
+auth:
+  envVar: OPENAI_API_KEY
+  keychainItem: agents-cli.ollama.token
+```
+
+## Known caveats
+
+**Use the Codex host, not Claude Code.** Codex speaks OpenAI natively, which is the shape Ollama serves on `/v1`. Pointing Claude Code at Ollama requires a translation shim (CCR, LiteLLM, anyclaude) that converts Anthropic ↔ OpenAI — and every shim available today drops the `tools` array on the way through, breaking the tool_use round-trip. Use Codex and skip the shim.
+
+**Known-working model.** `qwen3-coder:30b` works well end-to-end on Apple Silicon with Codex as the host. Other coding models work too — `deepseek-coder-v2`, `qwen2.5-coder` — but tool-call quality is model-dependent at this size.
+
+**Ollama doesn't authenticate, but Codex demands a key.** Set `OPENAI_API_KEY` to any non-empty string (the keychain entry can be literally `ollama`). The value never leaves your machine.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Tool calls silently ignored | Using Claude Code with an Anthropic→OpenAI translation shim (CCR / LiteLLM / anyclaude) | Switch the profile's `host.agent` to `codex` |
+| `connection refused` on `127.0.0.1:11434` | `ollama serve` not running | Start the daemon, or `brew services start ollama` |
+| Model spins for minutes before first token | Model isn't loaded into memory yet | First request always pays the cold-start cost; subsequent runs are fast |
+| `model 'X' not found` | Model not pulled | `ollama pull <model>` |

--- a/cli/docs/profiles/openrouter.md
+++ b/cli/docs/profiles/openrouter.md
@@ -1,0 +1,69 @@
+# OpenRouter
+
+Single API key, many open-weight models. `agents-cli` ships built-in OpenRouter presets so adding the second profile never re-prompts for a key.
+
+## Quick start
+
+```bash
+agents harness create
+# pick openrouter, fill prompts, run smoke test
+agents run my-profile "hello"
+```
+
+Or use the built-in presets directly:
+
+```bash
+agents accounts add openrouter --provider openrouter --auth api-key   # store key once
+agents harness add kimi                 # reasoning model, interactive
+agents harness add kimi-chat            # non-reasoning sibling, print-safe
+agents run kimi-chat --print "summarize the diff"
+```
+
+## Required values
+
+| Var | Where to get it |
+|---|---|
+| API key | https://openrouter.ai/keys |
+| Model id | https://openrouter.ai/models — `<vendor>/<model-slug>` |
+
+## Generated profile shape
+
+```yaml
+name: my-profile
+host: { agent: claude }
+env:
+  # static vars (always set):
+  ANTHROPIC_BASE_URL: https://openrouter.ai/api/v1
+  # vars wizard collects:
+  ANTHROPIC_MODEL: moonshotai/kimi-k2-0905
+  ANTHROPIC_SMALL_FAST_MODEL: moonshotai/kimi-k2-0905
+auth:
+  envVar: ANTHROPIC_AUTH_TOKEN
+  keychainItem: agents-cli.openrouter.token
+```
+
+## Built-in presets
+
+| Preset | Model | Notes |
+|---|---|---|
+| `kimi` | `moonshotai/kimi-k2.5` | Reasoning — interactive only. |
+| `kimi-chat` | `moonshotai/kimi-k2-0905` | Non-reasoning sibling. Print-safe. |
+| `minimax` | `minimax/minimax-m2.5` | Reasoning — interactive only. |
+| `glm` | `z-ai/glm-5` | Reasoning — interactive only. |
+| `qwen` | `qwen/qwen3-coder-next` | Latest coding Qwen. Print-safe. |
+| `deepseek` | `deepseek/deepseek-chat-v3-0324` | Non-reasoning DeepSeek Chat. Print-safe. |
+
+## Known caveats
+
+**Print-safe vs reasoning models.** Claude Code's `--print` consolidator returns empty stdout when the response contains `thinking` or `redacted_thinking` blocks. That's why running a reasoning model (`kimi`, `minimax`, `glm`) under `agents run --print` looks "silent" — the model is replying, but its top-level blocks are reasoning, and the consolidator strips them.
+
+The fix: use `kimi-chat` (non-reasoning) for scripting and pipelines, and `kimi` (reasoning) for interactive use. The same rule applies to any reasoning model you wire up manually — if `--print` returns empty, switch to a non-reasoning sibling.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `agents run kimi --print "..."` prints nothing | Reasoning model; `--print` consolidator drops thinking blocks | Use `kimi-chat` (or any print-safe preset) for scripted use |
+| 401 / `Invalid API key` | Stale or wrong key in Keychain | `agents accounts set-key openrouter` to rotate |
+| `model not found` | Slug typo or model retired | Look up the current slug at openrouter.ai/models |
+| 429 / rate limit | OpenRouter per-key cap | Add credits or slow down |

--- a/cli/docs/profiles/openrouter.md
+++ b/cli/docs/profiles/openrouter.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # OpenRouter
 
 Single API key, many open-weight models. `agents-cli` ships built-in OpenRouter presets so adding the second profile never re-prompts for a key.

--- a/cli/docs/profiles/truefoundry.md
+++ b/cli/docs/profiles/truefoundry.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # TrueFoundry
 
 TrueFoundry LLM Gateway — a corporate gateway that forwards Anthropic-shaped requests to upstream providers (most commonly AWS Bedrock-hosted Claude).

--- a/cli/docs/profiles/truefoundry.md
+++ b/cli/docs/profiles/truefoundry.md
@@ -1,0 +1,77 @@
+# TrueFoundry
+
+TrueFoundry LLM Gateway — a corporate gateway that forwards Anthropic-shaped requests to upstream providers (most commonly AWS Bedrock-hosted Claude).
+
+> **Not to be confused with…** Microsoft Azure AI **Foundry** is a different product. See [foundry.md](foundry.md).
+
+## Quick start
+
+```bash
+agents harness create
+# pick truefoundry, fill prompts, run smoke test
+agents run my-profile "hello"
+```
+
+## Required values
+
+| Var | Where to get it |
+|---|---|
+| Gateway base URL | Your TrueFoundry workspace, e.g. `https://llm-gateway.<tenant>.truefoundry.tech/api/llm/anthropic` |
+| Model id | TrueFoundry model catalog — format `<provider-account>/<model-id>`, e.g. `bedrock-prod/anthropic.claude-sonnet-4-20250514-v1:0` |
+| API token | TrueFoundry → Settings → Personal Access Tokens |
+
+## Generated profile shape
+
+```yaml
+name: my-profile
+host: { agent: claude }
+env:
+  # static vars (always set):
+  ANTHROPIC_BASE_URL: https://llm-gateway.<tenant>.truefoundry.tech/api/llm/anthropic
+  CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+  CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
+  DISABLE_PROMPT_CACHING: "1"
+  # vars wizard collects:
+  ANTHROPIC_MODEL: bedrock-prod/anthropic.claude-sonnet-4-20250514-v1:0
+  ANTHROPIC_SMALL_FAST_MODEL: bedrock-prod/anthropic.claude-haiku-4-5-20251001-v1:0
+auth:
+  envVar: ANTHROPIC_AUTH_TOKEN
+  keychainItem: agents-cli.truefoundry.token
+```
+
+## Known caveats
+
+**Bedrock strict validation — "extra inputs are not permitted".** TrueFoundry forwards your request body to AWS Bedrock. Bedrock runs a strict Pydantic validator on the inbound payload and rejects experimental fields Claude Code adds (e.g. context-management, beta cache controls, attribution headers). The error surfaces as:
+
+```
+extra inputs are not permitted
+```
+
+The fix is three env vars that suppress those fields at the source:
+
+```
+CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
+CLAUDE_CODE_ATTRIBUTION_HEADER=0
+DISABLE_PROMPT_CACHING=1
+```
+
+Claude Code `>= 2.1.140` is known to send fields that older Bedrock validators reject — these three env vars suppress them. Downgrading the CLI is a fallback only, not the right fix.
+
+**Self-signed / corporate CA chain.** Intra-cluster TrueFoundry gateways often present a corporate root CA your Node TLS store doesn't trust. For a trusted intra-cluster gateway it is acceptable to set:
+
+```
+NODE_TLS_REJECT_UNAUTHORIZED=0
+```
+
+**Warn:** never set `NODE_TLS_REJECT_UNAUTHORIZED=0` against public hosts — it disables certificate validation globally for the process and exposes you to MITM. Use it only for an internal gateway you control. The right long-term fix is to add the corporate CA bundle to `NODE_EXTRA_CA_CERTS`.
+
+**Model id format.** TrueFoundry expects `<provider-account>/<model-id>` (e.g. `bedrock-prod/anthropic.claude-sonnet-4-20250514-v1:0`), not the bare Anthropic model name (`claude-sonnet-4-5`). Look up the exact id in the TrueFoundry model catalog.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `extra inputs are not permitted` | Bedrock validator rejecting Claude Code experimental fields forwarded by the gateway | Set `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1`, `CLAUDE_CODE_ATTRIBUTION_HEADER=0`, `DISABLE_PROMPT_CACHING=1` |
+| `self signed certificate in certificate chain` / `unable to verify the first certificate` | Corporate CA not in Node's trust store | Add the CA bundle via `NODE_EXTRA_CA_CERTS=/path/to/ca.pem`; for a trusted intra-cluster gateway `NODE_TLS_REJECT_UNAUTHORIZED=0` is acceptable |
+| `model not found` / 404 | Wrong model id format | Use `<provider-account>/<model-id>` from the TrueFoundry catalog, not the raw Anthropic name |
+| 401 / 403 | Token expired or wrong scope | `agents accounts set-key truefoundry` to rotate |

--- a/cli/docs/profiles/vertex.md
+++ b/cli/docs/profiles/vertex.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Google Vertex AI
 
 Anthropic models served from Google Cloud Vertex AI.

--- a/cli/docs/profiles/vertex.md
+++ b/cli/docs/profiles/vertex.md
@@ -1,0 +1,54 @@
+# Google Vertex AI
+
+Anthropic models served from Google Cloud Vertex AI.
+
+## Quick start
+
+```bash
+agents harness create
+# pick vertex, fill prompts, run smoke test
+agents run my-profile "hello"
+```
+
+## Required values
+
+| Var | Where to get it |
+|---|---|
+| GCP project id | `gcloud config get-value project` |
+| Region | A Vertex region where the model is available (e.g. `us-east5`, `europe-west1`) |
+| Service-account key | GCP IAM → Service Accounts → Keys → JSON; path goes in `GOOGLE_APPLICATION_CREDENTIALS` |
+| Model id | Vertex model garden, e.g. `claude-sonnet-4-5@20250929` |
+
+## Generated profile shape
+
+```yaml
+name: my-profile
+host: { agent: claude }
+env:
+  # static vars (always set):
+  CLAUDE_CODE_USE_VERTEX: "1"
+  # vars wizard collects:
+  ANTHROPIC_VERTEX_PROJECT_ID: my-gcp-project
+  CLOUD_ML_REGION: us-east5
+  GOOGLE_APPLICATION_CREDENTIALS: /Users/me/.config/gcloud/vertex-sa.json
+  ANTHROPIC_MODEL: claude-sonnet-4-5@20250929
+  ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-4-5@20251001
+# no auth: block — Vertex uses GOOGLE_APPLICATION_CREDENTIALS, not a bearer token
+```
+
+## Known caveats
+
+**Auth is a service-account JSON file, not a bearer token.** `GOOGLE_APPLICATION_CREDENTIALS` must be the **path** to a JSON key file on disk. There is no `ANTHROPIC_AUTH_TOKEN` for Vertex — the Google auth library mints short-lived access tokens from the service-account key on every request. As a result the profile's `auth:` block is typically omitted.
+
+**Region-specific model availability.** `claude-sonnet-4-6` and `claude-opus-4-7` are not in every Vertex region. Check the current availability matrix in the Vertex Model Garden before pinning `CLOUD_ML_REGION` — `us-east5` and `europe-west1` are the broadest, but newer models often land in `us-east5` first.
+
+**Model id includes a date suffix.** Vertex uses `claude-sonnet-4-5@20250929`, not the bare `claude-sonnet-4-5`. The `@<date>` pins a specific snapshot.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Could not load the default credentials` | `GOOGLE_APPLICATION_CREDENTIALS` unset or pointing at a missing file | Re-export the path; verify with `cat $GOOGLE_APPLICATION_CREDENTIALS \| jq .type` returning `"service_account"` |
+| `Publisher Model ... not found` | Model not available in this region | Switch `CLOUD_ML_REGION`, or pick a model id present in your region |
+| `PERMISSION_DENIED: aiplatform.endpoints.predict` | Service account missing the `Vertex AI User` role | Grant `roles/aiplatform.user` on the project to the service account |
+| 429 quota errors | Per-project / per-region Vertex quota exhausted | Request a quota increase, or shift region |

--- a/cli/docs/profiles/vllm.md
+++ b/cli/docs/profiles/vllm.md
@@ -1,0 +1,62 @@
+# Self-hosted vLLM
+
+Run an open-weight model on your own GPUs and point Claude Code at it via vLLM's **native Anthropic endpoint**.
+
+## Quick start
+
+```bash
+# 1. Start vLLM with the native Anthropic entrypoint
+python -m vllm.entrypoints.anthropic \
+  --model Qwen/Qwen3-Coder-30B-A3B-Instruct \
+  --tool-call-parser hermes \
+  --enable-expert-parallel
+
+# 2. Create the profile
+agents harness create
+# pick vllm, fill prompts, run smoke test
+agents run my-profile "hello"
+```
+
+Reference: https://docs.vllm.ai/en/stable/serving/integrations/claude_code/
+
+## Required values
+
+| Var | Where to get it |
+|---|---|
+| Endpoint | The host:port vLLM is bound to, e.g. `http://gpu-box.lan:8000` |
+| Model id | The model you passed to `--model` (vLLM echoes the same id back) |
+| API key | Whatever you set via `--api-key`; can be a dummy string like `EMPTY` for trusted networks |
+
+## Generated profile shape
+
+```yaml
+name: my-profile
+host: { agent: claude }
+env:
+  # static vars (always set):
+  # (none — vLLM's native Anthropic endpoint needs no transport flags)
+  # vars wizard collects:
+  ANTHROPIC_BASE_URL: http://gpu-box.lan:8000
+  ANTHROPIC_MODEL: Qwen/Qwen3-Coder-30B-A3B-Instruct
+  ANTHROPIC_SMALL_FAST_MODEL: Qwen/Qwen3-Coder-30B-A3B-Instruct
+auth:
+  envVar: ANTHROPIC_AUTH_TOKEN
+  keychainItem: agents-cli.vllm.token
+```
+
+## Known caveats
+
+**Use the native Anthropic endpoint.** Prefer `python -m vllm.entrypoints.anthropic` over vLLM's OpenAI-compatible endpoint plus a translation shim — the native path round-trips `tool_use` blocks cleanly. The OpenAI translation path drops or mangles tool calls in both directions, which makes Claude Code's tool loop unreliable.
+
+**Tool-call parser must match the model.** `--tool-call-parser hermes` works for Qwen-Coder. If tool calls come back as raw text instead of structured `tool_use`, try `--tool-call-parser qwen` or `--tool-call-parser llama3_json`. The parser name is per-model; consult the vLLM docs.
+
+**MoE models need expert parallelism.** For mixture-of-experts models like `Qwen3-Coder-30B-A3B`, add `--enable-expert-parallel` or you'll leave most of the model's throughput on the table.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Tool calls arrive as plain text instead of `tool_use` blocks | Wrong `--tool-call-parser` for the model | Switch to `hermes` / `qwen` / `llama3_json` to match the model family |
+| Stalls or OOM on MoE model | Expert parallelism disabled | Add `--enable-expert-parallel` |
+| 404 on `/v1/messages` | Started the OpenAI endpoint, not the Anthropic one | Re-launch with `vllm.entrypoints.anthropic` |
+| 401 from Claude Code | vLLM was started with `--api-key` and the profile's keychain entry doesn't match | Re-run `agents accounts set-key vllm` with the same value you passed to `--api-key` |

--- a/cli/docs/profiles/vllm.md
+++ b/cli/docs/profiles/vllm.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Self-hosted vLLM
 
 Run an open-weight model on your own GPUs and point Claude Code at it via vLLM's **native Anthropic endpoint**.

--- a/cli/docs/projects.md
+++ b/cli/docs/projects.md
@@ -1,0 +1,622 @@
+# Projects (Named Multi-Repo Projects + Progress Rollup)
+
+A **project** names a body of work, binds it to one or more repos, and rolls live
+activity up into one progress card. It is a **definition layer over the existing
+`--project` convention**, not a replacement — an undefined slug resolves exactly as
+before.
+
+> Graduated out of beta — `agents projects` is always on. A leftover `beta.enabled: [projects]` entry is ignored.
+
+## Why
+
+`agents run --project <slug>` already resolves a bare name to `<projectRoot>/<slug>`
+by pure convention (`lib/project-root.ts`). That cannot name a project independently
+of its folder, bind multiple repos, pin a monorepo subpath, or answer *"what is
+happening on project X right now"*. At 50–100 agents the per-agent activity line is
+noise; what matters is the **project**. This subsystem fills both gaps.
+
+## The definition — `~/.agents/projects/<name>.yaml`
+
+One hand-editable YAML file per project, beside `routines/` and `monitors/` in the
+user repo. Paths are stored home-relative (`~/…`) so a definition re-roots on any
+machine.
+
+> **Commit them, or lose them.** Sitting in the user repo makes a definition
+> *syncable*, not synced. `agents projects add` writes the file; nothing commits it.
+> Until you run `agents repo push user`, `projects/` is an **untracked** directory, and
+> any reconcile that cleans the working tree deletes it — this cost one machine its four
+> definitions twice in a day. The only trace afterwards is a
+> `chore(local): save …-sync drift` commit that is unreachable from `HEAD`, so it is
+> recoverable until git collects it and not after. Recover with:
+>
+> ```bash
+> cd ~/.agents
+> git log --all --oneline --diff-filter=A -- 'projects/*'   # find the drift commit
+> git show <sha>:projects/<name>.yaml > projects/<name>.yaml
+> ```
+>
+> (`agents push` was removed; the command is `agents repo push <alias>`. Note that it
+> stages with `git add -A`, so check `git status` for unrelated drift first.)
+
+```yaml
+name: rush                      # stable id == filename; what --project takes
+description: "Rush app"
+root: ~/src/github.com/phnx-labs/rush
+defaultPath: ~/src/github.com/phnx-labs/rush/apps/web   # where an agent's cwd lands
+repo: phnx-labs/rush            # primary GitHub slug (PR / merge rollup)
+repos:                          # every directory this project binds (see below)
+  - slug: phnx-labs/rush-infra
+    path: ~/src/github.com/phnx-labs/rush-infra
+goals:                          # the outcomes this project serves (OKR-shaped)
+  - objective: "Ship Rush 2.0"
+    measure: "all tiers migrated"
+contexts:                       # described starting points — an agent reads `purpose`
+  - path: apps/web
+    purpose: "user-facing Next.js app; funnel + growth surfaces"
+  - path: packages/api
+    purpose: "FastAPI backend; Supabase models live here"
+integrations:                   # external context, surfaced in `projects show`
+  - kind: gdrive
+    url: https://drive.google.com/…
+    label: "design docs"
+linear:
+  projectId: a1b2c3d4-…
+  name: "Rush"                  # display name (used by Fleet / feeds)
+dispatch:
+  enabled: true                 # opt into auto-dispatch from Linear
+  maxAgents: 3                  # cap on concurrent auto-dispatched agents
+  provider: codex               # optional cloud backend pin (otherwise agent-native)
+  host: mac-mini                # pin dispatch to a specific fleet device
+```
+
+| Field | Purpose |
+| --- | --- |
+| `name` | Stable id, == filename. What `--project` takes. |
+| `root` | Repo / monorepo root, home-relative → portable. |
+| `defaultPath` | Where an agent's cwd lands (a monorepo subdir). Defaults to `root`. |
+| `repo` / `repos[]` | GitHub slug(s), each with an optional `subpath`, for the PR/merge rollup. `repos[].path` (home-relative) names that repo's local checkout: it opts the repo into workspace probing (`status`) **and** into the directories an agent spawned on this project can reach (see [A project is a set of directories](#a-project-is-a-set-of-directories)). |
+| `contexts[]` | `{path, purpose}` described starting points — indexed anchors for agents. |
+| `goals[]` | `{objective, measure}` the OKR-shaped outcomes a project serves — a project may have several. The objective is the "why"; `measure` is the optional key result. Milestones (pulled from Linear) are the dated checkpoints toward them. |
+| `integrations[]` | `{kind, url, label}` external context sources. |
+| `linear` | `{projectId, url, name}` — reuses the existing Linear path. All three are written by `agents projects link` and `projects import --from-linear`. `name` is the board's own display label (shown on the `status` card, in Fleet, and in the activity feed) and is **refreshed from Linear on every link**, so renaming a project on the board fixes the label here with one `agents projects link <name> --linear "<new name>"`. It is not the def's identity — the filename is (`agi.yaml` is the local id, `AGI` is what the board calls it). |
+| `dispatch` | `{enabled, maxAgents, provider, host}` — auto-dispatch settings read by `agents __auto-dispatch` and by the Fleet dispatch panel. All subfields are optional. `enabled: true` opts the project into auto-dispatch; `provider` optionally pins a `agents cloud` backend (`rush`, `codex`, `factory`, `host`, …), otherwise the delegated agent's native cloud backend is used; `host` selects a named fleet device when `provider: host`. |
+
+## Resolution — definition first, convention fallback
+
+`resolveProjectRef` (`lib/project-root.ts`) looks up a named definition before the
+`<root>/<slug>` convention. A defined project resolves to its `defaultPath` (or
+`root`); a `@worktree` suffix lands under the repo root's `.agents/worktrees/`. An
+**undefined** slug falls through to the unchanged convention. Home-relative paths mean
+`--project rush --device <box>` re-roots on the remote's home automatically.
+
+Resolution is intentionally **not** beta-gated — only the `agents projects` command
+tree is. A definition exists solely by explicit user action (`projects add`,
+`projects import`, or hand-authoring the YAML), so honoring it in `--project`
+resolution is additive and safe; users without any definitions see zero change.
+
+## A project is a set of directories
+
+A project usually spans more than one checkout — a CLI, its website, and the
+DotAgents repo it ships resources into. Each `repos[]` entry with a `path` is one
+of those directories, and everything that starts an agent resolves all of them:
+
+```bash
+# --root sets where agents start; --dir binds the directories they may reach.
+# The slug is read from EACH directory's own origin remote.
+agents projects add agents-cli \
+  --root ~/src/github.com/muqsitnawaz/agents-cli \
+  --dir ~/src/github.com/muqsitnawaz/agents-cli-web \
+  --dir ~/.agents/.system
+
+agents projects set agents-cli --add-dir ~/.agents/.system     # bind one more
+agents projects set agents-cli --rm-dir  ~/.agents/.system     # unbind it
+agents projects set agents-cli --add-dir ./vendor/thing --slug o/thing  # no origin
+```
+
+**The slug comes from the directory, never from its path.** A checkout at
+`~/src/github.com/muqsitnawaz/agents-cli` whose origin is `phnx-labs/agents-cli`
+records the remote it actually pushes to. `--slug` names it explicitly for a
+directory with no origin; it applies to a single `--add-dir`.
+
+**Which one is the cwd.** `defaultPath ?? root` — set by `--root` / `--path`, and
+**not** by `--dir`. `--dir` binds a directory; it never moves where an agent starts.
+Every bound directory other than that cwd is attached as an `--add-dir` grant:
+
+```bash
+agents run claude --project agents-cli
+#   cwd        ~/src/github.com/muqsitnawaz/agents-cli
+#   --add-dir  ~/src/github.com/muqsitnawaz/agents-cli-web
+#   --add-dir  ~/.agents/.system
+
+agents teams create feat --project agents-cli   # same, for every teammate
+```
+
+This holds for `agents run` (local and `--device`) and for `agents teams`. In a
+team, the project's directory sits **below** `--cwd` and a `--worktree` in the cwd
+precedence chain — an explicit one still wins — but the grants are attached either
+way, since the siblings are what the project binds, not where the teammate sits.
+
+**Who consumes the grants.** Claude, Cursor, and Kimi take the native `--add-dir`
+flag. Codex folds the directories into its `workspace_roots` / permission profile.
+Grok injects a short rules note so the model knows the siblings are in scope, and
+— when a non-off OS sandbox is active (`GROK_SANDBOX` / `--sandbox`) — writes a
+project-local `.grok/sandbox.toml` profile (`agents-project`) with those paths as
+`read_write` and selects it. Every other harness has no multi-root surface, so it
+sees the cwd alone. That is a harness limitation, not a configuration mistake.
+
+**A directory missing on this box is skipped, not an error.** A definition binding
+a checkout that only exists on some machines still loads, and the primary cwd still
+resolves. For a `--device` run the paths stay `~/…` and are **not** filtered against
+this machine's filesystem — the target host has its own checkouts, and the `agents
+run` on that host expands `~` against its own `$HOME` before the harness sees it.
+
+For a team, the grants are resolved **at launch**, not when you run `teams add`. On
+a `--devices` pool an unpinned teammate has no host until the scheduler places it,
+so freezing directories at add time would hand it this machine's absolute paths.
+
+Definitions are syncable, not synced: after binding directories, push them with
+`agents repo push user` and `agents repo pull user` on the other boxes.
+
+## One name everywhere — activity, feed, sessions
+
+Definitions also rename the fleet's activity. `resolveProjectNameForCwd`
+(`lib/projects.ts`) is the single project resolver shared by `agents feed`
+(buckets and row chips), `agents feed post` (the stamped project), and the
+`agents sessions` overview: a cwd inside a defined project's root reads as the
+project's **name** — a multi-repo project is one bucket, not one per repo — and
+anything else falls back to the repository-level key (`lib/project-key.ts`). Each
+machine resolves its own cwds against its own (synced) definitions before events
+cross the wire. `agents feed --project <name>` narrows the stream to one project.
+
+## `status` and `view` are one body
+
+`status`, `view`, and `show` are aliases of a single implementation (`runProjectCard`). There
+is no second renderer to drift.
+
+- **Unnamed** (`agents projects status`) — the multi-project rollup: next milestone only,
+  scannable across every defined project.
+- **Named** (`agents projects status rush`, `view rush`, `show rush`) — the same card for one
+  project, with **every** milestone and the stored definition underneath (each repo with its
+  subpath and checkout, each context with its purpose, each integration with its URL, the
+  Linear link, the docs, and the YAML path). The fleet fan-out — and its
+  `--device`/`--devices` scoping — applies to both forms.
+
+Gathering still goes through `enrichProjectsForRender` so a signal added for the card appears
+whether you typed `status` or `view`.
+
+## The progress card — `agents projects status`
+
+The headline. It matches every live session to a project **by cwd** (longest root
+wins) and rolls up the signals already on disk. The live-agent rollup defaults to this machine's active sessions (the same set
+`agents sessions --active` shows, matched by local-home cwd); the **merged-PR
+count is repo-global** (via `gh`). The live line also includes sessions fanned
+out over SSH across the fleet — but cwd matching is still against the **local**
+home layout, so a peer session whose path uses a different home root may not
+attribute. Full home-relative matching across homes remains deferred (see below):
+
+```
+fleet snapshot · as of 18:40                     # when this fleet-wide rollup was taken (status only)
+
+rush  ·  23 live
+  live     14 running · 6 idle · 3 need-input     # LIVE sessions by lifecycle state
+  dead     4 finished or lost (3 crashed, 1 closed)  # a single dead status reads directly: "dead  41 crashed"
+  agents   @zion        claude · running · RUSH-2107  ·  claude · running ×8
+           @mac-mini    codex · idle  ·  claude · idle ×2
+           @yosemite-s0 claude · running ×5  ·  +6 more
+  ships    4 merged (7d) · 2 open PRs · 3 worktrees · v1.20.91  # gh counts + latest release tag
+  linear   12/30 done (40%) · 5 in progress      # Linear issue counts (needs linear.projectId)
+  next     Beta cut  ·  3/8  ·  due in 6 days     # the next unfinished Linear milestone
+           +2 more milestones — agents projects view <name>
+  tickets  RUSH-1201 · RUSH-1198 · …              # tickets worked or created
+  fleet    6/13 clean · 4 behind · 4 dirty · 1 missing   # health summary, then the per-host table
+           mac-mini: ⚠ ↓172 · main  ·  zion: ✓ clean · main  ·  win-mini: ✗ missing  ·  …
+  proof    11 artifacts (7d) · last: plan-x.html  # artifact.created milestones by cwd
+  repos    phnx-labs/rush · rush-infra
+  context  apps/web · packages/api
+  🔴  4 hosts behind origin/main — yosemite-m2 ↓217, mac-mini ↓172, yosemite-s0 ↓93, yosemite-m1 ↓8
+      pull (or rebase) before agents on these hosts open PRs against a stale base
+  🔴  win-mini: checkout missing
+  ⚠️  4 hosts with uncommitted changes — pinnacles 16, yosemite-s0 3, yosemite-m2 1, zion 1
+```
+
+- **`live`, `agents`, `plan`, open PRs, `tickets`, `worktrees`** come straight from the
+  active session list (`rollupSessionsByProject`) — no network. The `agents` line
+  groups live agents by host (`@zion  claude · running ×9  ·  …`) so the same
+  harness on two machines is not collapsed into one cell. Within a host, cells
+  collapse identical state (`×N`), sorted running-first, capped with `+N more`. Remote sessions carry their peer's hostname.
+- **`ships` merged-count** is a best-effort `gh pr list` on the primary repo
+  (`--no-remote` skips it; a missing `gh`/auth degrades to 0). It counts up to the
+  100 most recent merges within the window. The trailing tag is the **latest release
+  of the primary repo only** (`gh release list -L 1`; `repos[]` are not scanned),
+  absent when the repo has no releases.
+- **`linear`** counts issues by state TYPE (completed → done, started → in progress)
+  in the Linear project bound via `linear.projectId` — set it with
+  `agents projects link <name> --linear`. Best-effort: no credential, offline, or a
+  slow API (>8s) just omits the line, and `--no-remote` skips it too. `total`
+  includes canceled issues; the fetch caps at 2,500 issues and a capped count
+  renders as a lower bound (`2500+ done`), never as the complete total.
+- **`next`** is the project's next unfinished Linear milestone — the earliest
+  `targetDate` that is not yet complete — rendered `name · done/total · due …`.
+  A percentage says how far along a project is; the milestone says what it is due
+  to hit next, which is what a person plans around. Undated milestones sort last;
+  the line is omitted when the project declares none or all are complete.
+
+  The milestone **list comes from the project, not from its issues**
+  (`project.projectMilestones`), because a milestone commonly has nothing filed
+  under it yet — deriving the list from issue assignments hides exactly those.
+  Issues supply only the `done/total` progress, and when none are assigned the
+  fraction is omitted rather than printed as a meaningless `0/0`. The list rides
+  along on the **first** page of the existing issue fetch, so the line costs no
+  extra request and inherits the same 8s budget and best-effort degradation.
+
+  Dates read in human terms — `due today`, `due tomorrow`, `due in 6 days`,
+  `overdue by 3 days`, and `due Aug 21` once a countdown stops being useful.
+  Linear stores a calendar date with no timezone, so both sides are compared at
+  **local** midnight; parsing it as UTC would shift the answer by a day for
+  anyone west of Greenwich.
+- **`proof`** counts `artifact.created` activity milestones whose cwd is inside the
+  project (`lib/project-status.ts`).
+- `--window <days>` sets the merged-PR / artifact window (default 7).
+
+### Fleet workspace drift (default)
+
+Projects are natively multi-device, so `status` adds a `fleet` block per project
+by default, showing the state of its workspace repos on every fleet device —
+present or missing, on which branch, ahead/behind the upstream, and uncommitted
+changes. A one-line **health summary** (`N/M clean · behind · dirty · missing`)
+sits above the per-host table so the block scans without reading every cell; the
+table keeps the branch and per-host drift detail:
+
+```
+rush  ·  3 agents
+  live     2 running · 1 idle
+  ships    4 merged (7d)
+  fleet    1/3 clean · 1 dirty · 1 missing
+           zion: ✓ clean · main  ·  mac-mini: ⚠ 12 dirty · ↑3 · feature/x  ·  gpu-box: ✗ missing
+```
+
+- **What it dials.** One parallel SSH call per online device (the canonical
+  `remote-agents-json` fan-out, 12s per-peer timeout) running the hidden
+  `agents projects probe --json <path...>` on each peer, plus the existing
+  sessions fan-out so the card's `live` line counts agents on every box, not
+  just this machine. Local paths are probed directly.
+- **What's probed.** Each shown def's `root` plus every `repos[].path` — the
+  field that opts an additional repo into drift tracking (the def otherwise
+  only knows the primary `root` on disk). Paths are home-relative, so they
+  re-root on each peer.
+- **Drift is against the last-fetched upstream.** The probe never runs
+  `git fetch` — `↑`/`↓` measure against the peer's remote-tracking refs as they
+  are. A repo with no upstream reports no drift (not zero).
+- **Unreachable or older peers are named once** in a trailing note
+  (`· N devices didn't answer (unreachable, older agents-cli, or timed out): …`)
+  — a peer whose CLI predates the probe subcommand lands in the same skipped
+  list, never a silent gap. Peers answer whenever their binary carries the
+  `probe` subcommand.
+- `--json` includes the fleet data: per project `workspaces: [{host, path,
+  present, branch, upstream, ahead, behind, dirty, lastCommit, error}]`.
+- **Dialed by default.** Scope it to a subset with `--device <name...>`
+  (repeatable) or `--devices a,b,c` (comma-separated); with no filter every
+  registered online device is dialed.
+
+## Warnings footer
+
+Anything that needs attention lands at the **bottom** of the card, not mid-stream:
+
+| Mark | Severity | Examples |
+| --- | --- | --- |
+| 🔴 | critical | missing checkout, ≥10 commits behind, repo slug mismatch, large crash pile |
+| ⚠️ | continue | dirty tree, small behind, schedule not measurable |
+
+**Grouped by root cause.** Workspace warnings collapse per class so a fleet where
+eight hosts drift is a few lines, not sixteen: all behind hosts become one warning
+listing each host with its count (`4 hosts behind origin/main — mac-mini ↓172, …`)
+under **one** shared remediation, and dirty/missing collapse the same way. A lone
+host keeps its full sentence. Grouping is **per probed path**, so two different
+repos never merge into one count. A behind group is critical when **any** host is
+≥10 behind. (`workspaceWarnings` in `lib/project-probe.ts`.)
+
+A local workspace probe always feeds this footer (cheap, no SSH). The full per-host
+`fleet` table is shown by default — scope it with `--device`/`--devices`.
+
+
+## Command surface
+
+| Command | Does |
+| --- | --- |
+| `agents projects list [--json] [--with-agents]` | All defined projects (root, repo, …). Definitions only by default — zero session scan / SSH. `--with-agents` is an explicit opt-in for **local** active counts only. |
+| `agents projects add <name>` | Scaffold `<name>.yaml`; infers `root` + origin slug from the current repo. Flags: `--root`, `--path`, `--repo`, `--dir <path...>` (bind directories; slug read from each one's origin), `--context path:purpose`, `--goal objective:measure`, `--linear`. |
+| `agents projects save --json` | Create or update one project from a complete `ProjectDef` JSON object on stdin; validates against the canonical schema, writes atomically under `~/.agents/projects/`, prints the saved definition as JSON. Used by the ext (and any other machine client). |
+| `agents projects view <name>` / `show` | Alias of `status <name>`: full card, every milestone, stored definition. |
+| `agents projects edit <name>` | Open the YAML in `$EDITOR`. |
+| `agents projects status [name] [--json] [--window N] [--no-remote] [--device name...] [--devices a,b,c]` (aliases `view`, `show`) | Progress card for every project across the whole fleet (per-device workspace drift over SSH), or one named project. Named form also prints every milestone and the stored definition. `--device`/`--devices` scopes the fan-out to a subset. |
+| `agents projects link <name> --linear [query]` | Bind a Linear project into the def (`linear.projectId` + `name` + url). No query → auto-suggests from the def name + repo slug; ambiguous/none lists candidates and exits 1. Powers the `linear` card line. Re-run it to pick up a project renamed on the board — the recorded `name` is refreshed from Linear every time, and the command says which label it replaced. |
+| `agents projects import --from-linear` | Import the workspace's Linear projects (via the `linear` CLI) as definitions. See [Importing](#importing--from-linear). There is no ext import path — `~/.agents/factory/projects.json` is never read. |
+| `agents projects set <name> [--repo\|--root\|--path\|--description\|--goal objective:measure\|--add-dir\|--rm-dir\|--slug]` | Change one field, preserving every other. `--goal` (repeatable) replaces the goals list. `--add-dir` / `--rm-dir` (both repeatable) bind and unbind directories; `--slug` names the remote for a single `--add-dir` whose origin cannot be read. Removals apply before additions, so `--rm-dir old --add-dir new` re-points a directory in one command. Use this rather than `add --force`, which rebuilds the definition from flags alone. |
+| `agents projects remove <name> [--json]` (alias `rm`) | Remove the definition (never touches the repo). `--json` prints `{ ok, name, removed }` (or `{ ok: false, name, error }` on failure). |
+| `agents projects pull <name> [--device name...] [--devices a,b,c] [--json]` | Fast-forward every fleet checkout of a named project to its remote default branch. See [Pulling every reachable checkout](#pulling-every-reachable-checkout). |
+
+`agents teams create <team> --project <name>` binds a whole team to a project.
+
+`agents run --project <name>` is unchanged in spelling — it just resolves richer
+definitions now, and attaches the project's other directories as `--add-dir`
+grants.
+
+## Pulling every reachable checkout
+
+`agents projects pull <name>` fast-forwards every fleet checkout of a named project to
+its remote's default branch. It extends the `status` fleet fan-out — the same directory
+set that `status` probes is the set `pull` updates.
+
+```bash
+agents projects pull rush                        # pull every checkout in the project
+agents projects pull rush --device yosemite-s0  # scope to one device
+agents projects pull rush --devices s0,s1       # scope to multiple devices
+agents projects pull rush --json                # machine-readable results
+```
+
+**Safety contract — what pull will and will not do:**
+
+- **Only fast-forwards** — no rebase, no reset, no history rewrite.
+- **Dirty trees are blocked immediately.** The fetch is never attempted when there are
+  uncommitted changes.
+- **Only checkouts on the remote's default branch** are eligible. A checkout on
+  `feature/x` is blocked and reported.
+- **Local commits ahead of upstream block the pull.** The checkout must be strictly
+  behind (or equal to) its upstream before it is updated.
+- **Missing checkouts are skipped** — never cloned. If a project directory does not
+  exist on a device, it is reported as `missing` and the command moves on.
+- **The declared repo slug is verified first, on every device.** A bound directory whose
+  `origin` is a different repo than the project declares is blocked, as is one whose
+  `origin` cannot be resolved to an `owner/repo` slug at all — the checkout cannot be
+  confirmed to be the right repo, so it is never fast-forwarded.
+- **Git hooks are never installed** during a pull.
+
+Blocked (`blocked`) and failed (`failed`) checkouts drive a non-zero exit code.
+Missing checkouts (`missing`) do not.
+
+**Per-device output:**
+
+```
+rush
+  yosemite-m1
+    ✓ ~/src/github.com/phnx-labs/rush updated (main) a1b2c3d4→e5f6a7b8
+    · ~/src/github.com/phnx-labs/rush-infra already current (main)
+  yosemite-s0
+    ? ~/src/github.com/phnx-labs/rush missing — skipped
+  2 updated · 1 current · 1 missing
+```
+
+The fan-out uses the same `gatherRemoteAgentsJson` seam as `status`, with a
+120-second per-device timeout (vs the default 12s) to allow for large repos and
+slow links.
+
+### Devices that did not answer, and devices that answered unverifiably
+
+These are different states and the command keeps them apart:
+
+| State | Meaning | Reported as | Exit code |
+|---|---|---|---|
+| `unavailable` | The device never answered — offline, no `agents` CLI, or past the 120s budget. Nothing ran there. | `unavailable: <names>` | unaffected |
+| `unverified` | The device answered, but its response failed verification (wrong machine id, a target fingerprint that does not match the targets that were sent, or a malformed row). It already ran a real pull whose outcome cannot be read. | `unverified: <names>` | **non-zero** |
+
+An unverifiable answer is worse than silence, so it is never folded into the results as
+a device with nothing to report. Under `--json` both notes go to **stderr** (the JSON on
+stdout stays a clean result array), matching `projects status --json`.
+
+**How the fan-out stays verifiable.** Each peer runs the hidden
+`agents projects pull-local --json --targets <json>`, where `--targets` carries the full
+`{path, expectedSlug}` list — not bare paths. Both halves of a target have to cross that
+boundary: `expectedSlug` is what makes the peer refuse a directory hosting a different
+repo, and it is hashed into the target fingerprint the caller checks the peer's envelope
+against. A peer that cannot decode its targets exits non-zero rather than pulling a
+guessed subset.
+
+## Importing — from Linear
+
+`--from-linear` imports the workspace's Linear projects through the `linear` CLI.
+Each project becomes a def carrying `linear.projectId` and `linear.name` (+ `url` when
+the CLI reports one), and the `show` backlink lights up immediately. `linear.name` is the
+board's display name verbatim — `AGI`, not the slugified def name `agi`. A Linear project exists because someone
+deliberately created it, so the name and the link are trustworthy.
+
+The local checkout is bound **only on an exact normalized-name match** against the
+directories under the configured projects root (`matchLocalCheckoutExact`,
+`lib/linear-projects.ts`) — "Agents CLI" binds `agents-cli`, and nothing else. The
+containment fallback that powers `projects link`'s suggestion is deliberately not
+used on this write path: it would silently bind "Agents CLI" to `agents-cli-web`
+with nobody looking. A project with no exact local match still imports, carrying
+`name` + `linear` and nothing it cannot prove; fill the rest in with
+`projects set` or by editing the YAML.
+
+Re-importing is safe. An existing def is preserved field-for-field and only
+`linear` is overwritten, so a hand-set `description`, `goals`, `contexts`, or
+`integrations` survives. A def that already carries `root`/`repo` is skipped unless `--force`,
+so a re-import never re-points a project you have already bound by hand.
+
+Drop a bad import with `agents projects remove <name>` — it only unlinks the YAML, never the repo.
+
+## Not yet (fast-follow)
+
+- **Home-relative cwd matching across machines.** `status` now dials the whole
+  fleet by default (live-agent count via the sessions fan-out + per-device
+  workspace drift), but cwd matching is still local-home — a session recorded on
+  a different-home machine only matches once home-relative cwd matching lands.
+- **Re-point `agents factory snapshot`** per-project Linear rollup at defined projects.
+- **Per-repo release lines** — the `ships` release tag is the primary repo only.
+- **Persisted `project_id` session column** — today membership is derived from cwd.
+
+## The stored `repo` must match the checkout's remote
+
+A definition's `repo` is a plain string, so it can be confidently wrong — a repo cloned to
+`~/src/github.com/<you>/agents-cli` whose `origin` is `phnx-labs/agents-cli` might carry
+`<you>/agents-cli` when hand-authored or imported from a path-only heuristic.
+
+Both slugs resolve to real repositories, so no call fails. The card simply reads the merged-PR
+and release counts from a **different repo** — 0 merges in 7 days instead of 100. A wrong
+number that looks right is worse than a missing one. `status` and `show` print the disagreement
+with its fix attached whenever a def's `repo` differs from the remote of its `root`:
+
+  ```
+  repos    muqsitnawaz/agents-cli
+  !        repo is muqsitnawaz/agents-cli but origin is phnx-labs/agents-cli —
+           PR and release counts are being read from the wrong repository
+           agents projects set agents-cli --repo phnx-labs/agents-cli
+  ```
+
+The check is silent when this machine has no checkout to read a remote from — absence of
+evidence is not a finding.
+
+## The Linear line is cached, and degrades to stale rather than absent
+
+Linear meters requests and query complexity separately, and only one of them binds. Measured
+on this workspace's response headers:
+
+```
+x-ratelimit-requests-limit:   2500      remaining: 2
+x-ratelimit-complexity-limit: 3000000   remaining: 2999987
+```
+
+Requests are scarce; complexity is essentially untouched. Since the card pages every issue in
+a project (up to 10 requests each), an agent running `status` in a loop exhausts the budget —
+which is exactly how it was exhausted during this feature's development.
+
+Answers are cached under `~/.agents/.cache/linear-projects/` for 10 minutes, matching the
+repo's existing `SKILL_INDEX_TTL_MS` convention — **one file per project**, written by atomic
+rename. A single shared JSON document would have to be read, modified, and written back, and
+that sequence is not atomic across processes: measured with two concurrent writers of 40
+distinct keys each, **8 of 80 entries survived**. A machine running a dozen agent sessions
+makes that the normal case rather than a corner. Per-key files have nothing to clobber, and the
+same measurement now yields 80 of 80. A second `status` inside the window makes no
+Linear request at all.
+
+The behavior that matters more is on failure: **a stale answer is served and labelled, never
+dropped.** A Linear row that was populated a minute ago must not blank out because one fetch
+timed out — the same invariant `mergeAuthHealthEntries` keeps for account health. A 429 records
+its reset time so subsequent runs skip the call entirely instead of spending a request to learn
+the budget is gone.
+
+`AGENTS_LINEAR_CACHE_PATH` overrides the location (tests use it; `getCacheDir()` resolves
+`HOME` once at module load, so a test swapping `process.env.HOME` would otherwise read and
+write the developer's real cache).
+
+## The headline counts live agents, and `planPct` is gone
+
+Two numbers used to sit on the headline and neither meant what it looked like.
+
+**The agent count included dead sessions.** A real project read `39 agents` while 19 of those
+had crashed. It now reads `19 live`, and the wreckage gets its own row — `dead  19 finished or
+lost (19 crashed)` — because 19 crashed sessions is a thing to go fix, not throughput to brag
+about. `orphaned` counts as **live**: `lib/session/active.ts` defines it as "alive, but no
+client is attached" (the agent outlived its window and is still working), and the repo's own
+dead rule (`commands/sessions.ts`) is `closed` and `crashed` only.
+
+The `agents` roster below the headline is filtered the same way. It used to list every matched
+session, so a card headed `23 live` went on to print `claude · crashed ×25` — the corpses the
+`dead` row already accounts for, shown a second time and contradicting the number above them.
+`isDeadStatus` is the single predicate behind both, and a test pins them to agree across every
+`ActiveStatus` so they cannot drift apart.
+
+**`planPct` measured whichever agent last wrote a todo list.** It summed each matched session's
+most recent checklist snapshot, so:
+
+- no session had ever called `TodoWrite` → `total = 0` → the figure silently disappeared;
+- one agent opened a fresh 40-item plan → `0/40` → the whole project read **`0% plan`** while
+  everyone else worked.
+
+It also counted crashed sessions' frozen final checklists forever, and summed unrelated
+denominators as though they were one plan. No repair makes a cross-session sum of ad-hoc
+checklists mean project progress, so it is removed from the card and from `--json`, replaced
+there by `live` and `dead`.
+
+## Milestones: all of them, and Linear's own "next"
+
+`status` shows the next checkpoint plus a pointer; `view <name>` shows every declared
+milestone with its date and progress. When Linear itself flags one (`status: "next"`) that is
+the one used — it is the answer showing in Linear's UI, whereas earliest-dated-unfinished is
+only our guess, used when nothing is flagged.
+
+A milestone with no issues assigned reports no progress, and `view` says so once rather than
+printing a column of silent `0%`s:
+
+```
+    !          no issues are assigned to any milestone — progress against them
+               cannot be measured
+```
+
+## `focus` — what was actually worked on
+
+The card could say how many agents ran and how many PRs merged, but not *what was worked on*.
+That answer is already in the checkout: every commit names the files it touched. `focus` ranks
+the directories the window's commits landed in, three levels deep so a monorepo reads as
+`cli/src` rather than `apps`:
+
+```
+focus    cli/src 2.3k  ·  cli/docs 302  file-touches (7d)  # git log --name-only buckets
+```
+
+Local `git log --name-only`, no GitHub API, no credential, no rate-limit budget — measured at
+**0.23s** over a 897-commit week, which is why it runs unconditionally rather than behind a flag.
+It reads the local ref and never fetches: a status command must not mutate the repo it describes,
+so the answer is as fresh as your last fetch.
+
+**Changelog fragments and lockfiles are excluded from the ranking, not just the display.** This
+repo files one fragment per PR, so `.changelog` otherwise ranks second by raw file-touches —
+presenting PR count as an engineering focus area.
+
+## `schedule` — only what the dates prove
+
+```
+schedule 3 milestones, no issues filed against any — progress is not measurable
+schedule Beta cut overdue by 6 days
+schedule GA due in 9 days
+```
+
+| Verdict | Fires when |
+| --- | --- |
+| `declared` | a human posted a Linear project health update — relayed and attributed (`per Linear: atRisk`) |
+| `overdue` | a milestone's `targetDate` has passed and it is unfinished |
+| `untracked` | milestones exist but no issue is filed against any of them |
+| `due-soon` | the next dated milestone lands within 14 days |
+| `scheduled` | dated milestones ahead, none due soon, work is filed |
+| `no-dates` | milestones exist, none carries a date |
+| `none` | the project declares no milestones — the line is omitted entirely |
+
+**There is deliberately no `on-track` or `at-risk`.** Producing one requires either project
+start+target dates to interpolate an expected-progress line, or a scope-history series to
+extrapolate a finish date. Probed against a live workspace, every one of those inputs is empty:
+
+```
+health: null       startDate: null        targetDate: null
+scopeHistory: []   completedScopeHistory: []   inProgressScopeHistory: []
+```
+
+So the chip would be invented. A blank is bad; a confident wrong answer that gets trusted is
+worse, and it is unfalsifiable from the card. The union has no such member, so it cannot be
+produced by accident later either.
+
+## Monorepo subprojects: which project owns a session
+
+Attribution (`projectNameForCwd`) matches a session's cwd against the paths each project
+claims, longest match winning so a nested project beats its parent. What a project *claims*
+is the part that needed fixing:
+
+- `root` says where the **checkout** is.
+- `defaultPath`, when nested under `root`, says which **work** is this project's, and takes
+  precedence over `root`.
+- a narrowed `root` still claims the rest of its checkout, but only as a fallback: any other
+  project claiming that path outright wins. So the umbrella takes `apps/web` when one exists,
+  while a lone project keeps attributing work across its own repo.
+- each `repos[].path`, and `repos[].path` + `subpath`, anchor as well.
+
+Without this, two definitions sharing one monorepo checkout — an umbrella `rush` at
+`~/src/rush` and a subproject `rush-cli` at `~/src/rush` with `defaultPath ~/src/rush/cli`
+— both anchored at `~/src/rush`. Longest-match had nothing to separate them, so a session in
+`rush/cli` was attributed to whichever definition was listed first, and the answer
+changed with definition order.
+
+A subproject scoped to `cli` deliberately does **not** own `apps/web`; that work falls to
+the umbrella. Set the scope with `agents projects add <name> --root <monorepo> --path <subdir>`.
+
+When the subproject is the *only* definition on that checkout there is no umbrella to fall to,
+so its `root` still covers `apps/web` and the repo root. `--path` chooses where an agent
+starts, and it must not silently shrink which work counts as the project's.

--- a/cli/docs/projects.md
+++ b/cli/docs/projects.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Projects (Named Multi-Repo Projects + Progress Rollup)
 
 A **project** names a body of work, binds it to one or more repos, and rolls live

--- a/cli/docs/pty.md
+++ b/cli/docs/pty.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # PTY
 
 Drive interactive terminal programs from AI agents — REPLs, TUI wizards, anything that needs a real pseudoterminal.

--- a/cli/docs/pty.md
+++ b/cli/docs/pty.md
@@ -1,0 +1,204 @@
+# PTY
+
+Drive interactive terminal programs from AI agents — REPLs, TUI wizards, anything that needs a real pseudoterminal.
+
+## Overview
+
+`agents pty` allocates a real pseudoterminal (PTY) via `forkpty`, runs a shell
+or program inside it, and exposes read/write/screen operations over a local
+HTTP sidecar. Agents interact through simple CLI calls rather than raw terminal
+I/O.
+
+The primary use cases are:
+
+- Drive REPLs (Python, Node, Ruby irb, psql) from agent code
+- Automate TUI programs (`npm init`, `git add -p`, interactive installers)
+- Test CLI tools that require a real PTY
+- Run the `agents` CLI itself from inside another agent
+
+The sidecar server auto-starts on the first `pty` command and runs in the
+background until you stop it explicitly. You do not need to start it manually.
+
+## Architecture
+
+```
+agent process
+     │
+     │  agents pty <subcommand> <id>
+     ▼
+  CLI (pty.ts)
+     │
+     │  HTTP  →  localhost:<pty-port>
+     ▼
+  PTY sidecar (pty-server.ts)
+  [auto-started on first use]
+     │
+     │  forkpty()
+     ▼
+  child process  (zsh / python3 / node / ...)
+     │
+     ├── stdin  ← write / exec
+     ├── stdout → ring buffer → read / screen
+     └── signals ← signal
+```
+
+The `screen` command renders the current terminal buffer as clean text (no
+ANSI escape codes). This is the interface intended for LLM consumption — parse
+it without a terminal emulator.
+
+## Setup
+
+No installation step. The sidecar starts automatically:
+
+```bash
+SID=$(agents pty start)
+```
+
+The session ID is a short random string. Store it in a variable and pass it to
+every subsequent command.
+
+Verify the server is running at any time:
+
+```bash
+agents pty server status
+```
+
+If the sidecar cannot boot, the failing command prints the exact server command,
+the PTY log path, and the recent log tail. The log path is also shown by
+`agents pty server status` and normally lives under
+`~/.agents/.cache/helpers/pty/logs.jsonl`.
+
+## Command Reference
+
+### Session lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `agents pty start` | Start a new PTY session; prints session ID to stdout |
+| `agents pty stop <id>` | Stop a session and clean it up; ID becomes invalid |
+| `agents pty list` | List all active sessions |
+
+`start` flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-r, --rows <n>` | 24 | Terminal height in rows |
+| `-c, --cols <n>` | 120 | Terminal width in columns |
+| `-s, --shell <shell>` | `$SHELL` | Shell or program to launch (e.g., `python3`, `zsh`) |
+| `-d, --cwd <dir>` | current dir | Working directory |
+| `--json` | — | Output full session metadata as JSON |
+
+### I/O
+
+| Command | Description |
+|---------|-------------|
+| `agents pty exec <id> <command>` | Send a command string (non-blocking; returns immediately) |
+| `agents pty write <id> <input>` | Send raw keystrokes; processes `\n`, `\t`, `\e`, `\xHH` escape codes |
+| `agents pty read <id>` | Read raw output including ANSI codes; use `screen` for clean text |
+| `agents pty screen <id>` | Render the terminal buffer as clean text (no ANSI) |
+
+`exec` flags:
+
+| Flag | Description |
+|------|-------------|
+| `--wait <ms>` | Wait this many milliseconds then return the screen (convenience; default 0) |
+| `--json` | Output as JSON |
+
+`read` flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-m, --ms <ms>` | 200 | Wait up to this many milliseconds for new output (50–5000) |
+| `--json` | — | Output as JSON |
+
+`write` flags:
+
+| Flag | Description |
+|------|-------------|
+| `--raw` | Send input literally without processing `\n \t \e \xHH` escape codes |
+| `--json` | Output as JSON |
+
+`screen` flags:
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output as JSON including cursor position and dimensions |
+
+### Control
+
+| Command | Description |
+|---------|-------------|
+| `agents pty signal <id> [signal]` | Send POSIX signal: INT (default), TERM, or KILL |
+| `agents pty resize <id>` | Resize the terminal; `-r <rows>`, `-c <cols>` |
+
+### Server management
+
+| Command | Description |
+|---------|-------------|
+| `agents pty server status` | Show PID, session count, and log path |
+| `agents pty server start` | Start the server manually (auto-starts anyway) |
+| `agents pty server stop` | Stop the server and kill all active sessions |
+
+## Recipes
+
+### 1. Start a Python REPL and run code
+
+```bash
+SID=$(agents pty start --shell python3)
+sleep 1 && agents pty screen $SID   # see the >>> prompt
+
+agents pty write $SID "import math\n"
+agents pty write $SID "math.sqrt(144)\n"
+sleep 0.5 && agents pty screen $SID  # see 12.0
+
+agents pty stop $SID
+```
+
+### 2. Send a multi-line program
+
+```bash
+SID=$(agents pty start --shell python3)
+sleep 1
+
+# Each \n is processed as a real newline character
+agents pty write $SID "def greet(name):\n    return f'hello, {name}'\n\n"
+agents pty write $SID "greet('world')\n"
+sleep 0.5 && agents pty screen $SID
+
+agents pty stop $SID
+```
+
+### 3. Snapshot the screen after a slow command
+
+```bash
+SID=$(agents pty start)
+
+# exec + --wait avoids a manual sleep in the caller
+agents pty exec $SID "git log --oneline -20" --wait 500
+
+# Or poll manually with screen
+agents pty exec $SID "npm install"
+sleep 5 && agents pty screen $SID
+
+agents pty stop $SID
+```
+
+### 4. Send Ctrl-C to interrupt a running program
+
+```bash
+# Via signal subcommand
+agents pty signal $SID INT
+
+# Or via write with the ETX byte
+agents pty write $SID "\x03"
+```
+
+## Demo
+
+<video autoplay loop muted playsinline width="100%" src="../assets/videos/pty.mp4"></video>
+
+## See also
+
+- [docs/browser.md](browser.md) — drive real browsers via CDP; part of the automation triad
+- [docs/computer.md](computer.md) — drive native macOS apps via Accessibility; part of the automation triad
+- [docs/concepts.md](concepts.md) — DotAgents repos, resource resolution model

--- a/cli/docs/resource-sync.md
+++ b/cli/docs/resource-sync.md
@@ -1,0 +1,504 @@
+# Resource Sync
+
+How agents-cli syncs resources (commands, skills, hooks, memory, MCP, permissions) between central storage, project workspaces, and version homes.
+
+For the conceptual model — what a DotAgents repo is, what resources are, and how layered resolution works — see [concepts.md](concepts.md).
+
+## Resource Types
+
+| Resource | Source layers (resolved project > user > system) | Target Location | Sync Method |
+|----------|-----------------|----------------------|-------------|
+| Commands | `<project>/.agents/commands/*.md` › `~/.agents/commands/*.md` › `~/.agents-system/commands/*.md` | Project sources: `<project>/.{agent}/{commandsSubdir}/`; user/system: `<version-home>/.{agent}/{commandsSubdir}/` | Copy (command-skill conversion where required) |
+| Skills | `…/.agents/skills/{name}/` (same layering) | Project sources: `<project>/.{agent}/skills/`; user/system: `<version-home>/.{agent}/skills/` | Copy |
+| Hooks | `…/.agents/hooks/*.sh` (same layering) | `.{agent}/hooks/` | Symlink |
+| Rules | `…/.agents/rules/AGENTS.md` (same layering) | `.{agent}/{instructionsFile}` | Symlink |
+| MCP | `…/.agents/mcp/*.yaml` (same layering) | `.{agent}/settings.json` | Merge into JSON |
+| Permissions | `…/.agents/permissions/groups/*.yaml` (same layering) | Agent-native config (`settings.json`, TOML, YAML, or `.rules`) | Convert + merge |
+| Plugins | `…/.agents/plugins/{name}/` (same layering) | Agent-native plugin or extension directory | Copy + native manifest/registration |
+
+`resolveResource(kind, name)` returns the single winner; `listResources(kind)` returns the union with `source: 'project' \| 'user' \| 'system'`. Same name in a higher layer overrides lower layers; otherwise everything unions.
+
+### Extra repos
+
+Users can register additional DotAgent repos via `agents repo add <source>`. Extras clone into `~/.agents-system/.repos/<alias>/` and ship the same layout (`skills/`, `commands/`, `hooks/`, `rules/`). They participate as an additional layer below the user repo and above the system repo. Registrations live in `meta.extraRepos` in `~/.agents/agents.yaml`.
+
+## Memory File Mapping
+
+Central `AGENTS.md` maps to agent-specific filenames:
+
+```
+~/.agents/rules/AGENTS.md  ───▶  ~/.claude/CLAUDE.md
+                            ───▶  ~/.codex/AGENTS.md
+                            ───▶  ~/.gemini/antigravity-cli/AGENTS.md
+                            ───▶  ~/.cursor/.cursorrules
+                            ───▶  ~/.opencode/OPENCODE.md
+                            ───▶  ~/.grok/AGENTS.md
+```
+
+Symlinks in `~/.agents/rules/`:
+```
+AGENTS.md       # Real file (source of truth)
+CLAUDE.md -> AGENTS.md
+GEMINI.md -> AGENTS.md     # Legacy only; Gemini sync is hard-deprecated.
+```
+
+## Sync Detection
+
+Sync state is derived, not stored. Three set operations over the filesystem:
+
+```
+available = contents of scoped .agents/{commands,skills,hooks,memory,mcp,permissions}
+synced    = files in <version home> plus project-managed files in <project>/.{agent}/
+new       = available - synced
+```
+
+```
+┌──────────────────────────────┬────────────────────────────────┬─────────────────────────────────┐
+│ Function                     │ Reads                          │ Returns                         │
+├──────────────────────────────┼────────────────────────────────┼─────────────────────────────────┤
+│ getAvailableResources()      │ ~/.agents/*/                   │ { commands: string[],           │
+│                              │ (skip symlinks in memory/)     │   skills: string[],             │
+│                              │                                │   hooks: string[],              │
+│                              │                                │   memory: string[], ... }       │
+├──────────────────────────────┼────────────────────────────────┼─────────────────────────────────┤
+│ getActuallySyncedResources   │ <version home>/.{agent}/*/     │ same shape                      │
+│   (agent, version)           │ (readlink each entry, match    │                                 │
+│                              │  against ~/.agents/)           │                                 │
+│                              │ memory: file content compare   │                                 │
+├──────────────────────────────┼────────────────────────────────┼─────────────────────────────────┤
+│ getNewResources(...)         │ both above                     │ available − synced (per type)   │
+└──────────────────────────────┴────────────────────────────────┴─────────────────────────────────┘
+```
+
+## Sync Flow
+
+```
+agents use claude@2.0.65
+           │
+           ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  1. getNewResources(claude, 2.0.65)                                 │
+│     └─ Returns: { commands: [foo], skills: [], memory: [AGENTS] }  │
+│                                                                     │
+│  2. If new resources found, prompt user                             │
+│     └─ "2 commands, 1 memory file available. Sync now?"            │
+│                                                                     │
+│  3. syncResourcesToVersion(claude, 2.0.65)                          │
+│     └─ Refreshes project resources in <project>/.claude/            │
+│     └─ Copies user/system resources into the version home           │
+│     └─ Records sync manifests for skip-fast staleness checks        │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Project-scope commands, skills, subagents, and workflows are never copied into a
+global version home. They are refreshed into the current workspace's agent
+directory (`.claude/`, `.codex/`, `.cursor/`, `.opencode/`, etc.) with an
+ownership manifest at `.<agent>/.agents-managed.json`. On each refresh,
+agents-cli removes only the paths listed in that manifest, then copies current
+project resources. If a destination exists after manifest-owned paths are
+removed, it is yours: agents-cli leaves it exactly as it is and reports it once
+per sync as a single grouped line (`Kept 6 of your own files in
+.claude/commands: debug.md, doc-gaps.md, image-nbp.md, +3 more`) rather than one
+warning per file. The
+generated `.<agent>/` directory is intentionally not auto-added to `.gitignore`;
+projects that do not want to commit generated agent resources should ignore it
+themselves.
+
+## Sync Targets: Version Selectors, Repo Scoping, and Kind Filtering
+
+`agents sync` accepts the full [agent-spec vocabulary](version-management.md#agent-spec-resolution)
+plus an optional repo scope:
+
+```bash
+agents sync claude              # the resolved default version (interactive preview in a TTY)
+agents sync claude@all          # every installed Claude version
+agents sync claude@all system   # scope to one DotAgent repo: system | user | project | <alias>
+agents sync claude --repo user  # same, via the flag form
+agents sync --json              # machine-readable umbrella result (also used by --device all)
+agents sync --device all        # fan out umbrella sync across every registered device
+```
+
+A repo scope reconciles **only** that layer's resources into the target
+version(s), leaving the other layers' already-synced resources untouched. Bare
+`agents sync` (no agent) runs the umbrella verb — fetch remote state, then
+reconcile every installed agent. `--json` emits a single JSON object on stdout
+(and forces non-interactive mode); the fleet fan-out path (`--device all`)
+injects `--json` on each peer so the roster can parse results.
+
+### Per-kind selector flags
+
+Use kind flags to restrict a sync to one or more resource types. Omitting all
+kind flags syncs everything (the default).
+
+```bash
+agents sync claude --plugins            # every plugin, nothing else
+agents sync claude --plugin fleet       # only the plugin named "fleet"
+agents sync claude --plugin fleet,code  # two plugins, comma-separated
+agents sync claude --plugin fleet --plugin code  # same, repeated flags accumulate
+agents sync claude --plugins --hooks    # plugins AND hooks; all other kinds skipped
+agents sync claude --skills --repo user # user-layer skills only
+```
+
+Each resource kind has a singular flag and a hidden plural alias — they are
+identical in meaning:
+
+| Singular       | Plural (hidden alias)  | Syncs                                      |
+|----------------|------------------------|--------------------------------------------|
+| `--plugin`     | `--plugins`            | Plugins                                    |
+| `--command`    | `--commands`           | Slash commands                             |
+| `--skill`      | `--skills`             | Skills                                     |
+| `--hook`       | `--hooks`              | Hooks                                      |
+| `--subagent`   | `--subagents`          | Subagent definitions                       |
+| `--permission` | `--permissions`        | Permission allowlists                      |
+| `--mcp`        | `--mcps`               | MCP server entries                         |
+| `--workflow`   | `--workflows`          | Workflow definitions                       |
+| `--rule`       | `--rules`              | Rules / memory file (always full recompile)|
+| `--memory`     | —                      | Alias of `--rule` (boolean, no name filter)|
+
+**Bare flag = all of that kind.** `--plugins` (no value) selects every plugin.
+`--plugin fleet` narrows to the plugin named `fleet`. Comma-separated values
+(`--plugin fleet,code`) or repeated flags (`--plugin fleet --plugin code`) both
+accumulate into the same name list.
+
+**Kind flags are additive.** `--plugins --hooks` selects both kinds and nothing
+else. Only the kinds explicitly named are included when any kind flag is present.
+
+**`--rule` / `--rules` / `--memory` always trigger a full memory recompile.**
+The memory file is composed from all rule layers and is not individually filterable
+by rule name; any of these flags selects the entire memory kind regardless of the
+value passed.
+
+### Version auto-promotion
+
+When no version is specified and no default is pinned but multiple versions of an
+agent are installed, `agents sync --agent claude` automatically targets every
+installed version (`claude@all`) rather than exiting with an error.
+
+### Per-resource sync verbs (retired)
+
+`agents hooks sync`, `agents skills sync`, and `agents commands sync` were
+deprecated stubs. They have been removed; calling them now returns commander's
+unknown-command error. Use `agents sync claude --hooks` (or `--skills`,
+`--commands`) instead.
+
+### Repo sync split
+
+Passing a DotAgent repo name as the sole argument (`agents sync system`,
+`agents sync user`) git-syncs that repo. This positional form is deprecated in
+favour of the explicit verb:
+
+```bash
+agents repo sync system    # preferred
+agents repo sync user      # preferred
+agents sync system         # deprecated — still works, prints a warning
+```
+
+## Pruning: resources removed from source disappear from version homes
+
+A reconcile deletes as well as installs. When a **command** or **skill** is
+**removed from a DotAgent repo**, `agents sync` removes its stale copy from each
+version home — so a deleted resource disappears from the `/` menu the same way an
+added one appears, without hand-deleting files. This runs on the repo-scope and
+`@all` reconcile forms:
+
+```bash
+agents sync claude@all system   # reconcile system repo into every claude — prunes what system no longer ships
+agents sync claude system       # same, one version
+```
+
+A pruned resource is reported under a `Pruned from claude@<version> (removed from
+source)` block, and the `--json` payload carries a `pruned: { commands, skills }`
+field.
+
+### Declined resources — a refused write is never a clean sync
+
+A resource agents-cli **refuses** to write (today: an MCP config whose harness
+format is not implemented — see `MCP_TARGETS` `format: null`) is reported, never
+swallowed. An empty synced list on its own reads as "nothing to do", which is how
+a harness could report a successful sync while nothing was written at all
+(RUSH-2677, RUSH-2700):
+
+- **Human output** — a `Not written to <agent>@<version>:` block naming the
+  resource and the reason. The umbrella (`agents sync`) prints a `Not written:`
+  block covering every agent it reconciled.
+- **`--json`** — every payload that can carry a decline sets `ok` from it and
+  includes a `declined: string[]`: `mode: 'agent'`, `mode: 'agent-all'` (per
+  version, under `versions[]`), and `mode: 'umbrella'`. A payload that runs no
+  sync (`nothing to sync`, any dry run, `repo-git`, `launch`) keeps `ok: true`.
+- **Fleet fan-out** — `agents sync --device all` injects `--json` per peer, so a
+  box that refused a write renders as `N not written` instead of `ok`.
+
+A decline does **not** change the exit code: `agents sync` exits 0 whether or not
+something was refused, on one machine and across the fleet alike. A refusal is a
+partial outcome, not a failed command — the sync did everything it could — and
+`ok: false` plus the rendered block are the reporting channel. Scripts that must
+treat a refusal as failure should read `ok` (or `declined`) from `--json` rather
+than `$?`.
+
+Pruning is **manifest-bounded**, so it never over-deletes:
+
+- **Only agents-installed resources are candidates.** The prune set is
+  `(names the last full sync recorded in the manifest) − (names still in source
+  across ALL layers)`, intersected with what is currently in the home. A file you
+  hand-authored into `~/.claude/…` was never recorded, so it is never touched.
+- **No cross-layer deletion.** The "still in source" set spans every layer, so a
+  system command removed from `~/.agents/.system` while a same-named **user**
+  command still exists is kept — it is still provided by a layer.
+- **No manifest → no deletion (fail loud).** With no sync manifest yet (no prior
+  full sync established a baseline), the reconcile prints a one-line notice and
+  prunes nothing rather than guessing. A later `agents sync <agent>` full sync
+  writes the baseline, after which prune works.
+
+Every harness prunes: a native command file (Claude, Grok, Cursor), a
+command-as-skill dir (Codex ≥ 0.117, Kimi), and a Goose recipe are each removed
+through the same writer that installed them. Kinds synced as a wholesale rewrite
+(rules, permissions) or with their own reconciliation (plugins, via
+`cleanOrphanedPluginSkills`) do not need this pass. **Hooks are out of scope
+here** — pruning a hook must also GC its `settings.json`/`hooks.json`
+registration (a Windows-portable-path surface), tracked in **RUSH-2456**; hook
+files stay reconciled by the in-write orphan sweep (`versions.ts`, gated on
+`hooksToSync > 0`). See [`src/lib/staleness/prune.ts`](../src/lib/staleness/prune.ts).
+
+## MCP Servers: Per-Agent JSON Write
+
+MCP is the one resource that isn't symlinked. Each agent stores MCP server
+lists in its own settings file with its own key shape, so sync writes them
+directly into the agent's config.
+
+```
+Source: ~/.agents/mcp/*.yaml       Per-agent destinations:
+
+┌────────────────────┐             Agy     → ~/.gemini/config/mcp_config.json (REAL home,
+│ github.yaml        │                        not version-scoped — agy reads one
+│                    │                        shared file for every version)
+│                    │                      · key: mcpServers.<name> = {command,args,env};
+│                    │                        a remote server is keyed serverUrl
+│ ───────            │
+│ name: github       │                      · key: mcpServers.<name> = {command,args,env}
+│ transport: stdio   │             Cursor  → <home>/.cursor/mcp.json
+│ command: npx ...   │                      · key: mcpServers.<name> = {command,args,env}
+│ args: [...]        │             Claude  → CLI: `claude mcp add ...`
+│ env: { ... }       │                      (claude owns its own settings)
+└────────────────────┘             Codex   → CLI: `codex mcp add ...`
+                                            · HTTP transport not supported
+                                   OpenCode → <home>/.config/opencode/config.toml
+                                            · key: mcp.<name> (TOML)
+                                   Grok    → <home>/.grok/config.toml
+                                            · key: mcp_servers.<name> (TOML)
+                                   Hermes  → <home>/.hermes/config.yaml
+                                            · key: mcp_servers.<name> (YAML)
+```
+
+Behavior rules, per `src/lib/mcp.ts`:
+
+1. **Read existing, set by name, write back.** For JSON-backed agents such as
+   Cursor:
+
+   ```
+   config = readExistingConfig(settings.json)   // {} when absent or empty;
+                                                // THROWS when present-but-unparseable
+   config.mcpServers[server.name] = { command, args, env }  // or { url }
+   fs.writeFileSync(settings.json, JSON.stringify(config, null, 2))
+   ```
+
+   A config that exists but does not parse is refused, never rebuilt from `{}` —
+   these files hold far more than MCP (hermes' whole `config.yaml`, openclaw's
+   `openclaw.json`), so resetting one destroys everything else in it. JSONC
+   configs go through the shared string-literal-aware `stripJsonComments`, so a
+   URL inside a string (`"$schema": "https://opencode.ai/config.json"`) survives.
+
+   User-owned top-level keys (theme, editor settings, etc.) are preserved
+   because the merge only touches `mcpServers`.
+
+2. **No ownership tracking.** There's no `_agents_managed` marker. If a user
+   hand-edits `mcpServers.github`, the next sync silently overwrites it with
+   the YAML's values.
+
+3. **Source delete ≠ destination clean.** `removeMcpServerConfig(name)`
+   (`mcp.ts:381`) only unlinks the YAML file. The matching entry in each
+   agent's settings stays until manually removed.
+
+4. **Claude and Codex delegate.** Instead of editing settings.json directly,
+   agents-cli invokes `claude mcp add` / `codex mcp add` (`mcp.ts:169-186`).
+   Those commands own the merge. Benefit: agent-internal validation runs.
+   Cost: write failures surface as `execSync` errors, not structured results.
+
+## Permissions: Per-Agent Format Conversion
+
+Permissions take a different path: collected into a canonical `PermissionSet`,
+then converted per agent into that agent's native format. Not a JSON merge —
+a format rewrite.
+
+```
+~/.agents/permissions/groups/                     Canonical                    Per-agent native
+*.yaml                                            PermissionSet
+
+┌─────────────────────┐                       ┌──────────────────┐          Claude (JSON):
+│ read-only.yaml      │                       │ allow: [         │          { permissions: {
+│ ───────             │ loadPermission-       │   "Read",        │              allow: [...],
+│ allow: [Read, Grep] │ ─Groups()──────────▶  │   "Grep",        │              deny:  [...]
+│ deny:  [Write]      │ concat per group      │   "Bash(git *)"  │            }}
+│                     │                       │ ],               │
+│ git-safe.yaml       │                       │ deny: [          │          OpenCode (JSONC/JSON):
+│ ───────             │                       │   "Write"        │          { "permission": {
+│ allow: [Bash(git *)]│                       │ ],               │              "bash": {
+│                     │                       │ additional-      │                "git *": "allow",
+│ 99-deny.yaml ──────▶│ rules go to deny      │   Directories:   │                "rm *": "deny"
+│ allow: [Bash(rm *)] │ (naming convention)   │   [...]          │              }}}
+└─────────────────────┘                       └──────────────────┘          Codex (Starlark file):
+                                                                            agents-deny.rules
+                                                                            (generated text)
+```
+
+Group-to-permission-set is concatenation with one naming convention:
+groups ending in `-deny` (e.g. `99-deny.yaml`) contribute to `deny` even
+though their YAML lists appear under `allow`
+(`permissions.ts:230-235`).
+
+Reading back — `agents permissions list <agent>`, and the config-file import
+behind `agents permissions add <path>` — goes through `PERMISSION_TARGETS` (`lib/permissions-registry.ts`), one entry
+per allowlist-capable harness declaring its config path and how to project that
+file onto the canonical `PermissionSet`. A completeness test pins the key set to
+`capableAgents('allowlist')`, so a harness the write path handles can never be
+one the read path silently reports as empty (RUSH-2676). The registry also owns
+the canonical↔native tool vocabularies that the forward serializers below
+import, so the two directions cannot disagree about what `fs_read` or
+`developer__shell` means.
+
+Per-agent conversion is lossy in both directions — the reverse projection
+recovers a set that grants the same access, not the byte-identical rules that
+were written, and each target names its own loss in a `lossyBecause` line:
+
+- Claude's native format is closest to canonical — near 1:1 passthrough
+  (`permissions.ts:362-369`).
+- OpenCode 1.1.1+ maps `Bash(pattern)` rules into the `permission.bash`
+  `allow`/`deny` map in `~/.config/opencode/opencode.jsonc` (or `.json`) for
+  user scope, or project-root `opencode.jsonc` (or `.json`). Non-bash rules are
+  dropped.
+- Codex (>= 0.138.0) writes `approval_policy` and `sandbox_mode` to
+  `.codex/config.toml`, plus `sandbox_workspace_write.network_access=true` when
+  web tools are allowed. It also writes a platform-resolved baseline of
+  `sandbox_workspace_write.writable_roots` — the regenerable toolchain caches
+  (`~/.cargo`, `~/.npm`, `~/go`, `~/.cache` / `~/Library/Caches`, …) so a
+  `workspace-write` run can build/test/install without escalating to
+  danger-full-access; credential dirs (`~/.ssh`, `~/.aws`, `~/.config`) are
+  excluded, and any roots the user set are unioned in, not clobbered
+  (`permissions.ts`: `codexDefaultWritableRoots`, `mergeCodexSandboxWrite`).
+  Native launches then apply the managed `agents-plan`, `agents-edit`, or
+  `agents-auto` named permission profile at runtime. This keeps network
+  independent from filesystem access: plan is read-only with network, while edit
+  and auto add the workspace, `~/.agents`, the cache baseline above, and
+  caller-supplied writable roots. Plan and edit use
+  `approval_policy="on-request"` — a sandbox-denied command comes back as an
+  approval prompt, which is what you want at a terminal. `--mode auto` uses
+  `approval_policy="never"` over the identical sandbox, so an unattended run
+  never stops on a prompt; a denied command just fails and the agent works
+  around it. Only explicit `skip` bypasses approvals and sandboxing.
+  Deny rules are emitted as Starlark to a generated `agents-deny.rules` file
+  (`permissions.ts:38-56`).
+- Kiro 2.8.0+ maps canonical shell, filesystem, and web rules into v3
+  capability rules under `.kiro/settings/permissions.yaml`. Existing user
+  rules are preserved when managed rules are merged.
+- Goose is **not** allowlist-capable. Its `permission.yaml` gates whole tools
+  (`developer__shell`, `developer__text_editor`), so several distinct canonical
+  rules collapse onto one entry and cannot be read back faithfully — the
+  capability is off in the registry rather than half-supported.
+- OpenClaw gates at tool granularity only, so only **blanket** (whole-tool)
+  rules map into `~/.openclaw/openclaw.json` `tools.alsoAllow` (allow) /
+  `tools.deny` (deny): `bash → exec`, `read → read`, `write`/`edit → write`,
+  `webfetch → web_fetch`, `websearch → web_search`. Sub-command/path/domain
+  rules (`Bash(git:*)`, `Write(secrets/**)`, `WebFetch(domain:x)`) have no
+  tool-level equivalent and are skipped. The absolute `tools.allow` list is
+  never touched, and all other keys (`mcp`, `exec`, `agents`, …) are preserved.
+- Hermes maps canonical Bash allow rules to `~/.hermes/config.yaml`
+  `command_allowlist` and Bash deny rules to `approvals.deny`, preserving
+  sibling YAML keys like `mcp_servers` and `hooks`. Hermes has command-glob
+  persistence only; session-scoped `/tools` toggles are not written.
+## Plugins: Synthetic Marketplace + Exec-Surface Gate
+
+Plugins bundle skills, commands, hooks, MCP servers, settings, and permissions
+under a single `.claude-plugin/plugin.json` manifest. Sync copies the bundle
+into each capable version home and writes the agent-native registration:
+Claude-style harnesses use the synthetic `agents-cli` marketplace, and Goose
+receives the bundle under `.agents/plugins/<name>/`.
+
+```
+Source: ~/.agents/plugins/<name>/        Per-version destination:
+
+┌──────────────────────────────┐         <version-home>/.claude/plugins/
+│ .claude-plugin/plugin.json   │         ├── known_marketplaces.json
+│ skills/<name>/SKILL.md       │         │     └ "agents-cli" → marketplaces/agents-cli
+│ commands/*.md                │         ├── marketplaces/agents-cli/
+│ hooks/hooks.json   ◄─ exec   │         │   ├── .claude-plugin/marketplace.json
+│ .mcp.json          ◄─ exec   │         │   │     └ synthesized: lists every
+│ bin/, scripts/     ◄─ exec   │         │   │       discovered plugin
+│ settings.json      ◄─ exec   │         │   └── plugins/<name>/  ← copy
+│ permissions/       ◄─ exec   │         └── settings.json
+└──────────────────────────────┘               └ enabledPlugins["<name>@agents-cli"] = true
+```
+
+Behavior rules, per `src/lib/plugins.ts:379` and `src/lib/plugin-marketplace.ts`:
+
+1. **Discovery requires a valid manifest.** `discoverPlugins()`
+   (`plugins.ts:61`) scans `~/.agents/plugins/<dir>/` and only accepts entries
+   with a parseable `.claude-plugin/plugin.json` containing `name` and
+   `version`. Directories without the manifest are silently skipped.
+
+2. **Copy, not symlink.** Unlike commands/skills/hooks/rules, plugins are
+   copied via `copyPluginToMarketplace()` (`plugin-marketplace.ts`). The copy
+   pre-expands `${user_config.*}` placeholders against the per-plugin
+   `.user-config.json` so each version sees its resolved values. `${CLAUDE_PLUGIN_ROOT}`
+   and `${CLAUDE_PLUGIN_DATA}` are left for Claude to expand at runtime.
+
+   Full refresh also treats trusted plugin `skills/<name>/` directories as
+   authoritative sources for top-level materialized skill homes. That reconciles
+   older homes that still have a legacy `.<agent>/skills/<name>/` copy of a
+   plugin-only skill, and prunes stale top-level skill dirs whose source no
+   longer exists.
+
+3. **Synthetic marketplace per version.** `syncMarketplaceManifest()` writes a
+   `marketplace.json` listing every discovered plugin, and
+   `registerMarketplace()` adds `agents-cli` to `known_marketplaces.json` so
+   Claude treats it as installed (not a remote git source). This is what
+   makes `claude plugin enable <name>@agents-cli` work without contacting a
+   remote.
+
+4. **Exec-surface gate.** Plugins shipping `hooks/`, `.mcp.json`, `bin/`,
+   `scripts/`, non-permissions `settings.json`, or `permissions/` are
+   *installed* (copied + marketplace registered) but *not enabled* unless the
+   caller passes `allowExecSurfaces: true`. `enablePluginInSettings()`
+   (`plugin-marketplace.ts:196`) short-circuits without flipping
+   `enabledPlugins[<name>@agents-cli]` to `true`. The user-facing flag is
+   `--allow-exec-surfaces` on both `agents plugins install` and
+   `agents plugins sync`. The gate's purpose is to prevent unattended sync
+   flows (e.g., `agents use claude@<v>`) from silently arming third-party
+   code on every session.
+
+5. **Capability gating.** Only agents where `supports(agent, 'plugins', version)`
+   passes participate (`capableAgents('plugins')` in `src/lib/agents.ts`). Plugins
+   can additionally declare `agents: [...]` in their manifest to narrow further;
+   `pluginSupportsAgent()` (`plugins.ts:179`) intersects both lists.
+
+6. **Codex command-to-skill fallback.** Codex `>= 0.117.0` dropped
+   command support; for those versions, plugin `commands/*.md` are
+   converted to skills prefixed with `<plugin>-<command>`
+   (`plugins.ts:444-453`) so they remain reachable as `$<plugin>-<command>`.
+
+7. **Source delete ≠ destination clean — but skills get swept.**
+   `cleanOrphanedPluginSkills()` (`plugins.ts:866`) runs every sync and
+   removes plugin-owned skill dirs whose parent plugin no longer exists in
+   `~/.agents/plugins/`. The marketplace copy itself isn't pruned until
+   `agents plugins remove <name>` runs explicitly.
+
+## Key Functions
+
+| Function | File | Purpose |
+|----------|------|---------|
+| `getAvailableResources()` | versions.ts | List central resources |
+| `getActuallySyncedResources()` | versions.ts | Check what's synced to version |
+| `getNewResources()` | versions.ts | Diff available vs synced |
+| `syncResourcesToVersion()` | versions.ts | Create symlinks in version home |
+| `pruneRemovedResources()` | staleness/prune.ts | Remove version-home resources deleted from source (manifest-bounded) |
+| `markdownToToml()` | convert.ts | Legacy command TOML conversion helper |
+| `syncWorkflowToGooseRecipe()` | workflows.ts | Convert workflows into Goose recipes and subrecipes |
+| `transformWorkflowForOpenClaw()` | workflows.ts | Convert workflows into Lobster `.lobster` files |

--- a/cli/docs/resource-sync.md
+++ b/cli/docs/resource-sync.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Resource Sync
 
 How agents-cli syncs resources (commands, skills, hooks, memory, MCP, permissions) between central storage, project workspaces, and version homes.

--- a/cli/docs/routines.md
+++ b/cli/docs/routines.md
@@ -1,0 +1,1647 @@
+# Routines (Scheduled Jobs)
+
+Scheduled agent execution with sandboxed permissions and scheduler-driven cron execution.
+
+## Architecture
+
+```
+~/.agents/
+  routines/
+    daily-review.yml        # Job config (YAML)
+    weekly-cleanup.yml
+  daemon/
+    state.json              # Daemon PID, last reload timestamp
+```
+
+Each job is a YAML file in `~/.agents/routines/`. A background scheduler parses cron expressions with [croner](https://github.com/hucsm/croner), spawns agent processes at trigger time, and captures output.
+
+### Daemon runtime — `agents daemon`
+
+The scheduler above is one job the daemon runs; the daemon itself also hosts the
+secrets broker, browser IPC, and the watchdog pass (RUSH-2354). `agents routines
+start`/`stop`/`status`/`scheduler-logs` remain as scheduler-scoped convenience
+wrappers, but the daemon's own runtime surface is `agents daemon`:
+
+```bash
+agents daemon                # identity, duplicate __daemon-run processes, per-service health
+agents daemon status --json  # same, machine-readable
+
+agents daemon start | stop | restart
+agents daemon enable | disable   # persisted device kill switch — see below
+agents daemon reload             # SIGHUP: reload routines + re-evaluate scheduler.enabled
+agents daemon services           # every hosted service + per-service toggles
+agents daemon webhooks list      # the signed webhook receivers this box hosts
+agents daemon logs -f --level warn --since 1h
+agents daemon doctor             # one-shot check, non-zero exit on problems
+```
+
+There is no `agents daemon jobs` — scheduled work is always `agents routines`;
+`agents daemon status`/`doctor` point at `agents routines stats` for per-routine
+failure detail instead of duplicating it.
+
+**Two independent gates control whether routines fire on a device**, and they are
+not the same thing:
+
+- `scheduler.enabled` (device config) gates only the routines `JobScheduler`
+  inside an already-running daemon — the secrets broker, browser IPC, and
+  watchdog keep running when it is off.
+- `daemon.enabled` (device config, new) is the daemon-wide kill switch. With it
+  `false`, nothing **auto-starts** the daemon — not `routines add`, not
+  `routines start`, not `routines catchup`, not a webhook trigger. `agents daemon
+  start` still starts it explicitly, the same way `systemctl start` works on a
+  disabled unit.
+
+A per-subsystem health record (`{subsystem, lastError, lastErrorAt,
+consecutiveFailures, lastOkAt}`, persisted at
+`~/.agents/.cache/helpers/daemon/health.json`) backs `agents daemon status` and
+`services`: the secrets broker and browser IPC record a success/failure on every
+(re)start attempt, so a failure survives past whatever line of the daemon log it
+would otherwise scroll out of.
+
+A third subsystem, `daemon-start`, records the daemon's own startup and is the
+one record that also **gates** behaviour rather than just reporting. It is
+written from both sides: the launching CLI marks every start it issues as a
+failure up front, and only a daemon that has finished booting — scheduler,
+browser IPC, broker decision and every background tick up — clears it. A daemon
+that spawns and then dies therefore leaves the streak growing, which a check on
+the launch's own return value could never see (the spawn succeeded). After five
+consecutive such starts the **implicit** auto-start refuses: the background
+callers that opportunistically bring the daemon up (`secrets unlock`, `browser
+start`, the watchdog) stop relaunching a daemon that never lives, and point at
+`agents daemon doctor`, which reports the streak and the recorded cause. An
+already-running daemon is still reported, and `agents daemon start` — the
+explicit override — is never gated.
+
+### Project routines (one enabled/disabled flag)
+
+A routine has exactly one state: **enabled** or **disabled**. Project routines in `<project>/.agents/routines/` are surfaced in `agents routines list` (discovered from your registered projects, `agents projects`) as **disabled** rows until you turn one on — there is no separate project-level opt-in.
+
+**A cloned repo never auto-fires.** Enablement lives solely in this device's `meta.deviceRoutines`; a project YAML's own `enabled:` field is never trusted for firing. So a discovered routine stays inert until you enable it locally.
+
+```bash
+# Enable a routine. If it is a project routine not yet materialised (from the
+# current project or a registered one), enable materialises it first — one step.
+agents routines enable security-sweep
+
+# Disable it again (definition stays; only firing stops)
+agents routines disable security-sweep
+
+# Refresh materialised project routines from their source YAML (definition-only,
+# never changes what is enabled). Runs automatically on daemon reload (SIGHUP).
+agents routines sync
+agents routines sync /path/to/repo
+```
+
+What `enable` does for a project routine:
+
+1. Materialises `<project>/.agents/routines/<name>.yml` into `~/.agents/routines/<name>.yml` with a `source:` block (`kind: project`, `projectPath`, and git `repo`/`branch`/`commit` when known) — **without** enabling it.
+2. Turns on the device flag (`meta.deviceRoutines`), which is the only thing that makes the daemon (user + system layers) fire it.
+3. Hand-authored user routines of the same name are never overwritten — `enable` refuses with an error if the name collides with a foreign-source routine.
+
+`agents routines list` groups terminal output by effective device/host scope so it is clear what runs on the current machine, the fleet, cloud, named devices, and named hosts. Use `agents routines list --flat` for the legacy single table, or `--json` for the flat machine-readable payload. Project-sourced routines still show the source repo (and `@branch` when known) in the Repo column; `--json` includes `source`, `sourceRepo`, `sourceBranch`, `hostStrategy`, `oneShot`, and `expired`.
+
+The bare `agents routines` command (no subcommand) opens an **interactive browser** on a terminal — a filterable, grouped picker (built on the same picker primitive as `agents sessions`). The project/device group headers render as inline dividers, typing filters the rows (keeping only groups with a match), and the detail pane / drilling into a routine shows four blocks: Definition, Next fire, Recent runs, and Stats. It falls back to the static `agents routines list` output — byte-for-byte — under `--json` or in any non-interactive shell (a pipe, the menu bar, CI), and `--flat` keeps the legacy table. Separately, `agents inspect <target> --routines` lists routine *definitions* (name, last run, devices, schedule) through the inspect resource view; add a name to drill into one.
+
+A project routine's own `enabled:` field in its YAML is a documentation signal only — daemon firing is governed solely by this device's enable state (`agents routines enable <name>`), so a cloned repo can never turn itself on.
+
+### Host placement strategy
+
+Where the **job body** runs when the daemon fires it (`devices` still controls which daemon may *fire*):
+
+| Strategy | YAML | CLI | Behaviour |
+| --- | --- | --- | --- |
+| `local` | `hostStrategy: local` (default) | `--placement local` | Run on the firing machine |
+| `host` | `hostStrategy: host` + `host: <name>` | `--placement host --run-on <name>` | Run on a named machine over SSH |
+| `fleet` | `hostStrategy: fleet` | `--placement fleet` | Pick one online registered device per run (first eligible by name) |
+| `fleet` (auto) | `hostStrategy: fleet` + `host: auto` | `--run-on auto` | Re-pick a healthy, signed-in, unloaded device AT EACH FIRE — the same picker as `agents run --device auto` |
+| `cloud` | `hostStrategy: cloud` | `--placement cloud` | Dispatch via the agent's native cloud provider |
+
+```bash
+# Pin firing to this machine and place the body on a GPU box
+agents routines add train --schedule "0 2 * * *" --agent claude \
+  --placement host --run-on gpu-box --prompt "Train overnight"
+
+# Fire once from this machine; each run picks any online fleet device
+agents routines add drain --schedule "0 3 * * *" --agent claude \
+  --placement fleet --prompt "Drain the local work queue"
+
+# Health-aware auto placement: each fire re-picks a healthy, signed-in,
+# unloaded device (agents run --device auto semantics)
+agents routines add shepherd --schedule "*/5 * * * *" --agent claude \
+  --strategy balanced --run-on auto --prompt "Own the release through verification"
+
+# Dispatch to Rush Cloud / the agent's native cloud
+agents routines add review --schedule "0 9 * * 1" --agent claude \
+  --placement cloud --repo phnx-labs/agents-cli --prompt "Review open PRs"
+```
+
+```yaml
+# ~/.agents/routines/drain.yml
+name: drain
+schedule: "0 3 * * *"
+agent: claude
+hostStrategy: fleet
+devices: [yosemite-s0]   # firing pin — only this daemon fires (avoids double-fire)
+prompt: "Drain the local work queue"
+```
+
+**Double-fire guard.** `host` / `fleet` / `cloud` require a `devices` pin naming which daemon may *fire* the job. Without it every fleet daemon would fire and each dispatch once. Add and sync auto-pin `devices` to this machine when you omit `--devices`. For `fleet`, that pin is **firing only** — the body still runs on any online fleet device (`pickFleetDevice` does not filter by `devices`). `devices --clear` refuses for off-box strategies. Bare `host:` (without `hostStrategy`) still works and implies `host` strategy (and still needs a pin).
+
+`--device` on `agents routines` is the remote-management passthrough ("manage routines **on** that machine") — do not overload it for placement. Use `--placement` / `--run-on`.
+
+### Ending a recurring routine
+
+Set `endAt` (ISO 8601) on a recurring routine to have the scheduler auto-disable it on or after that time:
+
+```bash
+agents routines add cleanup --schedule "0 3 * * *" --agent claude \
+  --prompt "Tidy logs" --end-at "2026-12-31T23:59:00Z"
+```
+
+## Job Config
+
+```yaml
+# ~/.agents/routines/daily-review.yml
+name: daily-review
+schedule: "0 9 * * *"         # 9am daily (cron syntax)
+agent: claude                 # A native harness id, or a custom harness name (agents harness list) —
+                              # a custom harness is delegated to `agents run <name>` and pins its own
+                              # host version and auth (no version:/strategy: for those jobs)
+account: muqsit@trp.so        # Optional: pin to a signed-in account by identity (see "Pinning an account")
+version: 2.0.65               # Optional: pin to an exact version (or --agent claude@2.0.65); strategy-selected if omitted
+strategy: balanced            # Optional: per-routine selection policy (pinned | available | balanced) —
+                              # beats the firing box's run.<agent>.strategy; conflicts with version:
+mode: auto                    # auto (default), plan (read-only), edit, or skip
+effort: default               # fast, default, or detailed
+timeout: 10m
+runOnce: false                # true for one-shot jobs (--at)
+endAt: "2026-12-31T23:59:00Z" # optional: auto-disable on/after this time
+hostStrategy: local           # local | host | fleet | cloud (see Host placement strategy)
+devices:                      # optional: the ONE device that owns this routine
+  - yosemite-s0               # omit entirely (or --clear) to run on every device
+projects:                     # optional: organises the routine under a project group in `list`
+  - myapp                     # single name → "myapp" group; ["*"] → All projects
+project: myapp                # optional: singular execution anchor from `agents projects`
+cwd: apps/api                 # optional: portable execution directory (see below)
+# source:                     # set by `agents routines enable <name>` / sync
+#   kind: project
+#   projectPath: /path/to/repo
+#   repo: owner/name
+#   branch: main
+#   commit: abc1234
+
+prompt: |
+  Review open PRs and summarize status.
+
+allow:
+  dirs:
+    - ~/projects/myapp
+  tools:
+    - Bash(git *)
+    - Read
+    - Grep
+```
+
+### Execution project and working directory
+
+`projects` and `project` are intentionally different:
+
+- `projects` is a repeatable grouping tag. It affects list/menu organization only.
+- `project` is a singular execution anchor. The CLI resolves its
+  `defaultPath`, falling back to `root`, on the device that will execute the
+  routine.
+- `cwd` selects the execution directory. A relative value is joined to the
+  execution project's base. When the project was imported from Linear without a
+  local `root`/`defaultPath`, or no project is selected, a relative `cwd` is
+  joined to the execution device user's home directory.
+
+The daemon process's own current directory is never an execution default. `repo`
+identifies the external GitHub/cloud/webhook repository and does not determine a
+local checkout path.
+
+```yaml
+# A Linear-imported project may have tracker identity but no checkout binding.
+# This still runs from $HOME/src/github.com/acme/app on the selected device.
+project: acme-app
+cwd: src/github.com/acme/app
+```
+
+For agent and workflow routines, omitting both `project` and `cwd` is incomplete
+setup. The definition is saved but remains paused. Command routines may use the
+target user's home because device-local housekeeping commands commonly operate
+there. Absolute paths outside the user's home are local-device-only; host, fleet,
+and cloud placement rejects them as non-portable.
+
+Creation, edit, and resume all run the same readiness entry point. Every placement
+gets structural project/CWD and portability checks. Local agent routines also
+check the local directory, installed harness, live authentication, and Codex
+workspace trust. An explicit host placement additionally resolves the target's
+HOME/project catalog, proves reachability and real write access there, and probes
+the target harness. Fleet and cloud placement cannot prove a selected target at
+definition time, so target-dependent checks are deferred to the run path and any
+failure remains recorded in attempt history. Workflow and command routines receive
+the structural checks that apply to their execution path. A syntactically valid
+definition with a proven blocker is saved paused with a stable finding and repair
+command. `resume` reruns readiness and does not bypass it.
+
+```bash
+agents routines add morning-briefing \
+  --project-anchor acme-app \
+  --cwd src/github.com/acme/app \
+  --schedule "0 8 * * 1-5" \
+  --agent claude \
+  --prompt "Summarize the pipeline"
+
+agents routines doctor morning-briefing --fix
+agents routines resume morning-briefing
+```
+
+Raw YAML editing is transactional: `agents routines edit <name> --yaml` edits a
+temporary copy, then parses and validates it before replacing the live definition.
+Invalid YAML leaves the prior definition and activation untouched.
+
+Two edits apply without an editor, so an agent with no TTY can repair a routine
+the readiness gate paused:
+
+```bash
+agents routines edit <name> --cwd apps/api            # set the execution directory
+agents routines edit <name> --project-anchor myapp    # set the execution anchor
+```
+
+Both validate before writing and print the remaining blocker, or the
+`agents routines resume <name>` that activates the routine.
+
+### Registering a definition from a file
+
+`agents routines add <path>` copies a definition into `~/.agents/routines/`. When
+the path you pass is already that canonical file — the normal case for a routine
+tracked in the `~/.agents` git repo — the file is left untouched rather than
+re-serialized, so hand-authored keys and formatting survive registration.
+
+A `devices:` key in a definition is legacy input. Activation now lives in each
+device's `agents.yaml` (see [Device activation](#device-activation)), so `add`
+applies the pin to the current box only and tells you to pin the fleet with
+`agents routines devices <name> --set <hosts>`.
+
+### One-Shot Jobs
+
+```bash
+agents routines add reminder --at "14:30" --agent claude --prompt "Remind Muqsit to stand up"
+```
+
+Prefer `--at` for one-time routines. It accepts `"14:30"` (today at that time, or tomorrow if the time already passed) or `"2026-02-24 09:00"` (absolute). The daemon converts it to a cron expression with `runOnce: true` and deletes the routine after it fires.
+
+Raw cron schedules that pin minute, hour, day, and month with wildcard weekday, such as `"0 14 29 7 *"`, are also treated as one-shot at creation time. The CLI prints a warning and persists `runOnce: true`; use `--at` instead when an agent is scheduling a one-time wake-up.
+
+List output marks one-shot routines in the Schedule column. Expired one-shots that missed cleanup show `expired` instead of next year's recurrence.
+
+Remove completed, expired one-shots that still have user-layer YAML:
+
+```bash
+agents routines prune --dry-run
+agents routines prune
+```
+
+### Webhook Triggers
+
+Routines can fire from signed GitHub or Linear webhooks instead of a cron
+schedule, and **Slack** deliveries fire webhook *handlers* (see
+[Slack — tag an agent](#slack--tag-an-agent-it-replies-in-your-thread) below).
+The same detached runner path is used as scheduled jobs.
+
+```bash
+agents routines add agent-labeled-issue \
+  --on linear:Issue \
+  --action update \
+  --team-key RUSH \
+  --label agent \
+  --agent claude \
+  --prompt "Work the Linear issue that was just labeled agent"
+```
+
+Equivalent YAML:
+
+```yaml
+name: agent-labeled-issue
+trigger:
+  type: linear_event
+  event: Issue
+  action: update
+  teamKey: RUSH
+  label: agent
+agent: claude
+prompt: "Work the Linear issue that was just labeled agent"
+```
+
+GitHub triggers use `type: github_event` with optional `repo` and `branch`:
+
+```bash
+agents routines add pr-review \
+  --on github:pull_request \
+  --repo phnx-labs/agents-cli \
+  --branch main \
+  --agent claude \
+  --prompt "Review the pull request"
+```
+
+Add `--action` and `--label` when a routine should fire only for a specific
+GitHub webhook action and label, such as a UX test agent after a human adds
+`ux-approved`:
+
+```bash
+agents routines add ux-tests \
+  --on github:pull_request \
+  --repo phnx-labs/agents-cli \
+  --branch main \
+  --action labeled \
+  --label ux-approved \
+  --agent claude \
+  --prompt "Run Playwright E2E and visual regression checks, then comment the results on the PR."
+```
+
+#### Slack — tag an agent, it replies in your thread
+
+Slack is a third webhook source. A slash command (`/agents AGI: rebase my open PR
+and check CI`) or an `@mention` of your Slack app reaches `POST /hooks/slack`,
+runs the agent that holds that project's context **on your box**, and the agent
+replies in the same thread. Unlike GitHub/Linear (which fire routine `trigger`
+blocks), Slack matches a webhook **handler** in `~/.agents/webhooks/*.yml` — the
+handler is what routes the message to an agent.
+
+The receiver verifies Slack's `v0` request signature (with a 5-minute replay
+guard), answers the one-time `url_verification` handshake, and parses both slash
+commands and `app_mention` events. It exposes a `{{slack.*}}` substitution
+namespace — `prompt`, `project`, `channel`, `thread_ts`, `user`, `text`,
+`command`, `response_url` — where `project` and `prompt` come from a `PROJECT: rest` prefix in
+the message (`AGI: rebase …` → project `AGI`, prompt `rebase …`). A handler may
+template its `project`/`cwd` from that namespace, so one handler serves every
+project:
+
+```yaml
+# ~/.agents/webhooks/slack-agent.yml
+name: slack-agent
+source: slack
+command: /agents          # match this slash command (omit to also match @mentions)
+project: "{{slack.project}}"   # route to the project named in the message
+run:
+  agent: claude
+  prompt: |
+    A Slack request came in from <@{{slack.user}}> in channel {{slack.channel}}.
+    Project: {{slack.project}}
+    Request: {{slack.prompt}}
+
+    Read the project's prior context if useful (`agents sessions -p {{slack.project}}`),
+    do the work, then reply. A slash command carries a `response_url`, which Slack
+    accepts for 30 minutes with no token and no channel membership:
+    curl -s -X POST '{{slack.response_url}}' -H 'Content-type: application/json' \
+      -d '{"response_type":"in_channel","text":"<your result>"}'
+```
+
+`response_url` is empty on an `@mention` delivery — that reply goes into the thread
+through the Slack Web API (`chat.postMessage` with `SLACK_BOT_TOKEN`, which needs the
+bot in that channel), or through `agents send --channel slack`, which routes via the
+Rush daemon's Slack gateway rather than this app's token and so needs `rush` logged
+in there. The full example is in
+[`docs/examples/slack/slack-agent.yml`](examples/slack/slack-agent.yml). Restrict a
+handler to one channel with `channel: C0…`, or drop the `command`/`channel` filters
+to match every mention.
+
+Route with `{{slack.project}}`, not `{{slack.prompt}}`. The project token is a
+single bare word (no slashes, never `..`), so it is safe in `project:`/`cwd:`;
+`{{slack.prompt}}` is free text from the sender and must stay in the prompt body,
+never in an execution path. And note the blast radius: anyone who can message the
+app triggers a `mode: auto` (write-capable) run on the host box — that authority
+is the point, but scope it with `channel:`/`command:` filters and a project the
+handler trusts.
+
+**Setup (once per workspace).** Create the app at
+[api.slack.com/apps](https://api.slack.com/apps) — the manifest and handler in
+[`docs/examples/slack/`](examples/slack/) are ready to paste — then:
+
+```bash
+# 1. Signing secret (verify inbound). The bot token is only needed for an
+#    @mention reply, which posts through the Slack Web API into the thread —
+#    a slash command replies via `{{slack.response_url}}` and needs no token:
+agents secrets add slack SLACK_SIGNING_SECRET <from Slack "Basic Information">
+agents secrets add slack SLACK_BOT_TOKEN <xoxb-… from "OAuth & Permissions">
+
+# 2. Host the receiver publicly (Funnel) on the box that holds your context:
+agents daemon webhooks add --secrets-bundle slack --port 8787 --funnel-port 443
+agents daemon restart
+
+# 3. Point the Slack app's slash-command + Events "Request URL" at:
+#    https://<box>.<tailnet>.ts.net/hooks/slack
+```
+
+#### Hosting the receiver — supervised (recommended) or foreground
+
+**Supervised.** Declare the receiver on the ingress box and the daemon hosts it
+as the `webhook-receiver` service, so it comes back after a reboot and after a
+crash:
+
+```bash
+agents daemon webhooks add --secrets-bundle webhooks --port 8787 --funnel-port 443
+agents daemon webhooks list
+agents daemon restart      # bind the change
+```
+
+The declarations live in `~/.agents/daemon/webhooks.yaml` — per-box operational
+state, deliberately outside the fleet-synced config, because a public receiver
+runs on exactly one machine. Port is the identity: a second `add` on a port
+edits that receiver. `agents daemon webhooks remove <port>` stops hosting it. A
+box with no declarations binds nothing, and the whole service can be turned off
+with `agents daemon services disable webhook-receiver`.
+
+The daemon resolves each receiver's signing secret through the secrets broker,
+so a hosted receiver needs no `AGENTS_SECRETS_PASSPHRASE` and no `nohup`. A
+bundle that is locked or holds neither webhook secret **fails that receiver
+loud** in `agents daemon logs` rather than binding ingress it cannot verify; the
+other receivers are unaffected.
+
+**Foreground.** For a one-off or for testing, run the receiver yourself — same
+HTTP surface, no supervision:
+
+```bash
+agents webhooks serve --secrets-bundle webhooks --port 8787
+```
+
+The bundle may contain any of `GITHUB_WEBHOOK_SECRET`, `LINEAR_WEBHOOK_SECRET`,
+and `SLACK_SIGNING_SECRET` (a Slack app also uses `SLACK_BOT_TOKEN` for the
+reply). The receiver accepts `POST /hooks/github`, `POST /hooks/linear`, and
+`POST /hooks/slack`, rejects unsigned deliveries, dedupes repeated delivery IDs,
+rate-limits each source, and binds `127.0.0.1` by default. Keep webhook signing
+keys in `agents secrets`; do not put keys in webhook URLs, path segments, query
+strings, routine YAML, or Funnel commands.
+
+#### The ack is asynchronous
+
+A verified delivery is answered `202 {"ok":true,"accepted":true,"deliveryId":…}`
+**immediately**, and the matched routines and handlers are dispatched after the
+response. Dispatch starts an agent run and takes 15-20 seconds, which exceeds
+Linear's delivery timeout — the receiver used to hold the socket open across it,
+so every real delivery logged a timeout and a retry on Linear's side.
+
+What this changes for a caller: the HTTP body no longer carries `fired` /
+`runs` / `handlers`, and a dispatch failure no longer surfaces as a 4xx. Fired
+routines appear in `agents daemon logs` (or the foreground receiver's stdout)
+and in the `webhook.fired` event; a failure after the ack is logged and emitted
+as `webhook.failed`.
+
+**A dispatch that fails after the ack does not retry itself.** The 4xx was what
+made GitHub and Linear re-send a delivery, and a sender does not retry a 202. The
+per-job ledger still records exactly which matches completed and the delivery
+stays unmarked, so re-sending it from the provider's UI runs only what did not —
+but nothing triggers that automatically. Watch `agents daemon logs` for
+`dispatch failed after ack`.
+
+Dedup is unchanged. `<source>:<delivery-id>` is still the key, a retry of a
+settled delivery is still answered `200 {"duplicate":true}`, and per-job marking
+still means a retry finishes only the matches that failed. A retry that arrives
+while the first is *still dispatching* is also answered as a duplicate, so the
+async window cannot double-fire.
+
+Expose the receiver publicly from a Linux/macOS Tailscale node with Funnel:
+
+```bash
+agents daemon funnel up yosemite-s0 --local-port 8787 --port 443
+agents daemon funnel status yosemite-s0
+```
+
+Funnel public ports are limited to `443`, `8443`, and `10000`; `agents daemon funnel up`
+validates that before running the remote Tailscale CLI.
+
+Operational runbook:
+
+1. Create or update the secret bundle on the ingress host:
+
+   ```bash
+   agents secrets create webhooks
+   agents secrets add webhooks GITHUB_WEBHOOK_SECRET
+   agents secrets add webhooks LINEAR_WEBHOOK_SECRET
+   ```
+
+   If a key already exists, replace the matching `add` command with
+   `agents secrets rotate webhooks <KEY>`.
+
+2. Host the receiver on the ingress host, bound to localhost:
+
+   ```bash
+   agents daemon webhooks add --secrets-bundle webhooks --port 8787
+   agents daemon restart
+   agents daemon webhooks list
+   ```
+
+3. Enable Funnel only after the receiver is listening:
+
+   ```bash
+   agents daemon funnel up yosemite-s0 --local-port 8787 --port 443
+   agents daemon funnel status yosemite-s0
+   ```
+
+4. Rotate a signing key source by source. Set the new source secret in the
+   `webhooks` bundle, update the provider webhook configuration to sign with the
+   new value, run `agents daemon restart`, then send one signed test delivery
+   before deleting the old provider secret.
+
+5. Disable public ingress before stopping or moving the receiver:
+
+   ```bash
+   agents daemon funnel down yosemite-s0 --port 443
+   agents daemon funnel status yosemite-s0
+   ```
+
+### Webhook handlers
+
+In addition to routine triggers, you can define one-off **webhook handlers** in
+`~/.agents/webhooks/*.yml`. A handler matches incoming webhooks the same way a
+routine trigger does, but instead of scheduling a recurring job it runs an
+agent, workflow, shell command, or an existing routine once.
+
+```yaml
+# ~/.agents/webhooks/linear-status-planner.yml
+name: linear-status-planner
+source: linear
+event: Issue
+action: update
+stateTo: Plan
+devices:
+  - mac-mini
+run:
+  agent: claude
+  prompt: |
+    Issue {{issue.identifier}} moved from {{updatedFrom.state.name}} to {{issue.state.name}}.
+    Create a concise implementation plan and post it as a Linear comment.
+```
+
+#### Handler YAML format
+
+| Field | Description |
+| --- | --- |
+| `name` | Unique handler name. |
+| `enabled` | Set to `false` to disable without deleting the file. |
+| `devices` | Same fleet allowlist as routines — only matching devices run the handler. |
+| `source` | `github` or `linear`. |
+| `event` | Source event name (e.g. `Issue`, `pull_request`). |
+| `action` | Webhook action (e.g. `update`, `opened`, `labeled`). |
+| `run` | One-of `agent`, `workflow`, or `command`, plus an optional `prompt` and `env`. |
+| `host` | Where the action executes: a device name, `fleet`, or `fleet/<platform>`. Omitted runs locally. |
+| `project` | Named `agents projects` execution anchor — a dispatched `agent`/`workflow` run lands in that project's base directory (so it has a repo checkout to edit). Ignored by `run.command`. |
+| `cwd` | Portable execution directory for the dispatched run. Relative resolves under `project`, otherwise the target's `$HOME`. |
+| `mode` | Permission mode for a dispatched `agent`/`workflow` run: `plan`, `edit`, `auto` (default), `skip`, or `full`. |
+| `routine` | Name of a routine to delegate to instead of `run`. `project`/`cwd`/`mode` set here override the routine's own. |
+
+#### Filters
+
+Handlers support the same filters as routine triggers:
+
+- `source`, `event`, `action` — always available.
+- Linear: `teamKey`, `label`, `stateTo`, `stateFrom`.
+- GitHub: `repo`, `branch`, `label`.
+
+`stateTo` matches a **transition into** that state, not merely sitting in it: the
+current state (`payload.data.state.name`) must equal the value AND this delivery's
+`updatedFrom` must record a state change (`payload.updatedFrom.state` or
+`payload.updatedFrom.stateId`), so a later edit that leaves the state unchanged does
+not re-fire. `stateFrom` matches the previous state (`payload.updatedFrom.state.name`).
+
+#### Actions
+
+- `run.agent` — run the agent headlessly with the substituted prompt.
+- `run.workflow` — run `agents run <workflow>` with the prompt.
+- `run.command` — run a shell command directly (the command string is also
+  variable-substituted). Substituted values are **shell-quoted**: the webhook
+  payload is external input, so `{{issue.title}}` and friends arrive as one inert
+  argument and cannot inject extra commands. Your own template is not quoted, so
+  pipes, redirects, and `&&` still work — write `grep {{issue.title}} log.txt`,
+  not `grep '{{issue.title}}' log.txt` (the quotes are added for you). On Windows
+  this path runs through `cmd.exe`, which these quoting rules do not cover, so a
+  `run.command` containing `{{…}}` is refused with an error; use `run.prompt` or
+  a command without placeholders there.
+- `routine` — load the named routine, substitute its prompt, and run it
+  detached. The handler's `devices` pin overrides the routine's for this fire.
+
+#### Environment and placement
+
+`run.env` injects environment variables into the spawned process, on top of the
+sandbox overlay's own. It applies to both the foreground and detached paths.
+
+`host` chooses where the action executes. It is distinct from `devices`:
+`devices` says which daemon may *fire* the handler, `host` says where the fired
+run *executes*.
+
+| `host` | Effect |
+| --- | --- |
+| omitted | run locally |
+| `yosemite-s0` | run on that device over SSH (or locally if it names this machine) |
+| `fleet` | pick any eligible online worker device |
+| `fleet/linux`, `linux/fleet`, `linux` | pick any eligible online worker on that platform |
+
+Platforms are `linux`, `macos`, `windows`. A fleet expression that matches no
+eligible device raises `no eligible online fleet device` rather than falling back
+to this machine — otherwise `fleet/linux` could silently land on a macOS box.
+
+```yaml
+# ~/.agents/webhooks/deploy-on-merge.yml
+source: github
+event: pull_request
+action: closed
+host: fleet/linux
+run:
+  agent: claude
+  prompt: "Deploy {{pull_request.title}}"
+  env:
+    DEPLOY_TARGET: staging
+```
+
+#### Prompt variables
+
+Use `{{dotted.path}}` placeholders in `run.prompt` (and in the delegated
+routine's prompt). For Linear webhooks the context is:
+
+```ts
+{
+  source: 'linear',
+  event: 'Issue',
+  action: 'update',
+  issue: payload.data,
+  updatedFrom: payload.updatedFrom,
+}
+```
+
+Examples: `{{issue.identifier}}`, `{{issue.state.name}}`,
+`{{updatedFrom.state.name}}`, `{{issue.title}}`, `{{issue.description}}`.
+
+For GitHub webhooks the context includes `repository`, `pull_request`, and
+`issue`.
+
+#### mac-mini ingress with funnel
+
+Handlers are fired by the same receiver as routine triggers. On a headless Mac
+(e.g. `mac-mini`), host it under the daemon and expose it with Tailscale Funnel:
+
+```bash
+# On mac-mini
+agents daemon webhooks add --secrets-bundle webhooks --port 8787 --funnel-port 443
+agents daemon restart
+```
+
+Then point Linear/GitHub at `https://mac-mini.<tailnet>.ts.net/hooks/<source>`.
+The handler's `devices: [mac-mini]` pin ensures only that machine dispatches the
+one-off agent run.
+
+### Device activation
+
+Routine YAML files are immutable definitions: they describe what runs and when.
+Enablement is device-owned metadata in
+`~/.agents/devices/<hostname>/agents.yaml`:
+
+```yaml
+routines:
+  - check-updates
+  - drain
+  - watchdog
+```
+
+Membership means enabled; absence means disabled. Each host writes only its own
+file, so toggles on different devices do not conflict when the DotAgents repo
+syncs. The same definition can be active on several devices; each daemon runs it
+against that device's local state.
+
+```bash
+agents routines resume drain
+agents routines resume drain --device yosemite-s0
+agents routines pause drain --device mac-mini
+agents routines devices drain --set yosemite-s0,mac-mini
+agents routines devices drain --clear   # disable everywhere
+```
+
+`agents routines devices` reads the synced manifests and executes each mutation
+on its target host. `routines list --json` exposes `enabledDevices` and
+`runsHere`. Run history remains under
+`~/.agents/.history/runs/<routine>/<run>/`; definitions are never rewritten with
+activation or last-run metadata.
+
+On upgrade, explicit legacy `enabled:` and `devices:` values are materialized
+once into the current host's routine membership. Subsequent toggles edit only the
+device manifest.
+
+### Daemon-core housekeeping (not a routine you manage)
+
+The daemon's own housekeeping — session-cache warming, device probing, and the
+watchdog — runs as plain `setInterval` timers in `lib/daemon/daemon.ts`
+(`runActiveSessionsWarm`, `runDeviceProbeTick`, `runWatchdogTick`), not as
+entries under `agents routines`. This replaced an earlier `builtin-routines.ts`
+registry that surfaced them as `(built-in)`-tagged routines with
+`agents routines pause`/`devices` support; that registry, the
+`__daemon-tick <name>` entrypoint, and the `JobConfig.builtin` field were torn
+out (RUSH-2495) because they doubled a scheduling layer the plain timers already
+covered. `agents routines list` no longer shows them — housekeeping is invisible
+to that command, not degraded.
+
+The `auto-dispatch` and `launch-health` routines, and the **5-minute
+`tmux-reconcile` poll** that used to retrofit a stale `pane-died` hook onto
+managed tmux sessions, were deleted in the same pass and have **no** daemon-core
+replacement timer. `tmux-reconcile`'s job is instead covered by two
+lifecycle-enforcement points that don't need a poll (RUSH-2435): the daemon
+repairs every managed session's hook once at startup, and `agents run
+--resume`/`agents focus`/`agents go`/`agents tmux attach` each repair the ONE
+session they're about to attach to right before attaching
+(`ensureSessionHookRepaired`, `lib/tmux/session.ts`). A version-skew one-shot at
+upgrade time (`runMigration`, `lib/installations/migrate.ts`) covers a machine that upgrades
+without immediately restarting its daemon.
+
+### Legacy device allowlists
+
+> Historical format only. `enabled:` and `devices:` in definition YAML are read
+> during migration but are no longer written or used after a host has a
+> `routines:` manifest. Use the device-activation commands above.
+
+`~/.agents/routines/` rides the user repo, so every routine syncs to every machine —
+and without a restriction, an enabled routine fires on **every** device running the
+scheduler. Set `devices:` to restrict which machines may execute the job:
+
+```yaml
+# ~/.agents/routines/drain.yml
+name: drain
+schedule: "0 3 * * *"
+agent: claude
+devices:
+  - yosemite-s0
+prompt: "Drain the local work queue"
+```
+
+Only the **owner** fires the job — one copy, one run history. Ownership is the
+first device in normalized sort order, computed from the config alone, so every
+daemon agrees without coordination. Listing several devices is a misconfiguration
+(it used to fire the routine once per device) and is refused at creation; omit
+`devices:` entirely for a routine that genuinely belongs on every machine.
+A single-entry list is equivalent to an exclusive pin: `devices: [yosemite-s0]`
+restricts the job to one machine.
+
+Or set the allowlist at creation with `--devices`:
+
+```bash
+agents routines add drain --schedule "0 3 * * *" --agent claude \
+  --devices yosemite-s0 --prompt "Drain the local work queue"
+```
+
+`--devices` is validated against the registered fleet (`agents devices sync`).
+
+For a grouped view of everything, run:
+
+```bash
+agents routines list                    # Default: group by project
+agents routines list --group-by device  # Group by device/placement instead
+agents routines list --flat             # Flat table, no grouping
+```
+
+The default grouping buckets routines under their associated project name, **All projects** (for routines tagged `["*"]`), **Cross-project** (multiple projects), **Operations** (no project tag), or **Unknown projects** (stale project names). Pass `--group-by device` to restore the device-placement view, which buckets routines under **This machine**, **Fleet-wide**, **Cloud**, one section per pinned device, and one section per named host. Offline or unknown registry entries are marked in the section header.
+
+Device names are compared against the local `machineId()` (normalized hostname, as
+shown by `agents devices`), so `Yosemite-S0` and `yosemite-s0.tailnet.ts.net` both
+match `yosemite-s0`.
+
+**A routine runs on exactly one device.** `devices:` is an allowlist, but only its
+**owner** fires — the first entry in normalized sort order. Ownership is derived from
+the config alone, so every daemon independently reaches the same answer with no lease
+and no coordination. Listing several devices is a misconfiguration: it used to fire the
+routine once per listed device (duplicate work, duplicate spend), so `add`/`devices --set`
+now reject it and `agents doctor` reports any that remain on disk.
+
+**Omitting `devices:` at creation means unrestricted** — the job fires on every
+device running the scheduler. That is the genuine fleet-wide case (`watchdog`,
+`check-updates`). Later, `devices --clear` **disables** the routine on every
+registered device (it does not restore unrestricted — re-add without `--devices`
+or enable it on every host if you need fleet-wide again).
+
+On a device not in the allowlist the job is fully inert:
+
+- the cron scheduler skips it
+- webhook triggers never match it
+- it is never counted overdue, so `catchup` won't fire it and the daemon won't nag
+- detached daemon fires and one-shot `--at` jobs skip it
+- `agents routines run <name>` errors, naming the allowed devices and offering a
+  ready-to-paste `--device <device>` command to run it remotely
+
+`agents routines list` shows the allowlist in a **Devices** column. Unrestricted
+jobs display the word `all`; restricted lists are grayed when the local machine
+is not in the list. `--json` includes a `devices` array and `runsHere` boolean.
+
+#### Last Status is per-device
+
+Run records live in the runs dir of whichever machine fired the routine and carry
+no device attribution, so a record only ever describes the device you are reading
+it on. `agents routines list` therefore reports **Last Status only for routines
+this device fires**: a routine pinned elsewhere shows `-` in the table, and
+`--json` returns `null` for `lastStatus`, `exitCode`, `failureReason`,
+`lastRunStartedAt`, and `lastRunCompletedAt` (`runsHere: false` says why). The
+same routine renders one row per pinned device, and only the **This machine** row
+carries a status.
+
+Without this, a routine re-pinned from one device to another kept reporting the
+old device's leftover records — showing a peer's healthy routine as failed, both
+in the table and in the menu bar, which reads this JSON.
+
+Read a peer's status where it actually ran:
+
+```bash
+agents routines list --device yosemite-s0     # that device's own view
+agents routines runs <name> --device yosemite-s0
+```
+
+#### v12 migration
+
+Existing routines that use the legacy singular `device: X` field are automatically
+migrated to `devices: [X]` on the next load. No manual edit is required.
+
+#### Managing the allowlist
+
+`agents routines devices <name>` opens a preselected multi-select so you can toggle
+devices without editing the YAML:
+
+```bash
+agents routines devices drain
+```
+
+The picker starts with the current allowlist pre-checked. Confirm to overwrite.
+`--set` and `--clear` are mutually exclusive.
+
+For scripting:
+
+```bash
+agents routines devices drain --set yosemite-s0            # set the owning device
+agents routines devices drain --clear                      # disable on every registered device
+```
+
+`--set` / `--clear` fan out pause/resume to every registered device so peers
+outside the new set stop firing the routine (`--clear` disables it everywhere;
+it does **not** restore the unrestricted "fires on every scheduler" default —
+omit `--devices` at `add` time for that). An **unreachable** peer (asleep,
+offline, missing address) is **skipped with a warning**, not a hard fail — the
+pin on reachable targets still succeeds, and an offline box cannot be running
+the routine (it picks up the enabled set on its next sync). The command exits
+non-zero only when a **selected** target device could not be enabled.
+
+### Project tagging
+
+Tag a routine to one or more projects defined in `agents projects`. Tagging is
+**metadata-only** — it organises the routine in `agents routines list` and the menu
+bar, and has no effect on scheduling or execution.
+
+```bash
+# Tag to a single project
+agents routines add nightly-build --schedule "0 3 * * *" --agent claude \
+  --project myapp --prompt "Build and run nightly tests"
+
+# Tag to multiple projects (--project is repeatable)
+agents routines add cross-test --schedule "0 4 * * *" --agent claude \
+  --project myapp --project billing --prompt "Run cross-service integration tests"
+
+# Tag to all defined projects
+agents routines add fleet-check --schedule "0 9 * * 1-5" --agent claude \
+  --all-projects --prompt "Check fleet health across every project"
+```
+
+`--all-projects` and `--project` are mutually exclusive. Both validate names
+against `agents projects list` — unknown project names are rejected with a helpful
+message.
+
+Project names appear in the YAML as a `projects:` array. The special value `["*"]`
+means "all defined projects" (set by `--all-projects`). Routines with no `projects:`
+field appear under the **Operations** group.
+
+`agents routines list` groups by project by default:
+
+| Group | Condition |
+| --- | --- |
+| `<project name>` | single entry in `projects:` |
+| **All projects** | `projects: ["*"]` |
+| **Cross-project** | two or more entries |
+| **Operations** | `projects:` absent or empty |
+| **Unknown projects** | project name(s) no longer exist in `agents projects` |
+
+Pass `--group-by device` to switch to the device/placement grouping, or `--flat`
+for a single unordered table.
+
+> **Grouping (`projects`) is not the execution anchor.** The `projects:` list above
+> only organises the routine in listings — it never decides *where* the body runs.
+> The execution directory comes from placement (`devices` / `hostStrategy` / the
+> planned singular `project` anchor below), not from these tags. See
+> [Execution context and readiness](#execution-context-and-readiness).
+
+### Execution context and readiness
+
+> **Status: planned (RUSH-2290).** The singular `project` anchor, the routine-level
+> `cwd`, the readiness/pause behaviour, and the `blocked`/`skipped` run statuses
+> described here are the routine reliability contract and are **not yet on `main`**.
+> They are specified normatively in
+> [specifications.md §Routine execution & readiness](specifications.md#routine-execution--readiness)
+> (RT-1..RT-11, RT-GAP-1). Today a routine carries only the `projects` grouping list
+> and `remoteCwd` for `host`/`fleet` body placement. This section documents the target
+> so hand-authored YAML and downstream tools can align now.
+
+An **agent** or **workflow** routine needs a working directory to run in. Two fields
+set it, and they are deliberately separate from the `projects` grouping tags:
+
+```yaml
+project: myapp          # singular: the ONE execution anchor (an `agents projects` entry).
+                        #   CLI: --project-anchor myapp  (distinct from the repeatable --project grouping flag)
+cwd: services/api       # optional: a directory RELATIVE to the resolved anchor/home
+```
+
+The directory is resolved **on the device that will run the body** — not on the
+daemon that fired it — so a `fleet`/`host`/`cloud` run is checked against the
+*target's* filesystem, and a path that only exists on the firing box is caught as a
+blocker instead of launching in the wrong place:
+
+| Configuration | Resolved directory | Result |
+| --- | --- | --- |
+| `project` anchor with a usable base, no `cwd` | the project's base path | runs there |
+| `project` anchor + relative `cwd` | base joined with `cwd` (must stay inside the base) | runs there |
+| Rootless `project` (e.g. a Linear-imported project with no local checkout) + relative `cwd` | the target's `$HOME` joined with `cwd` (if it exists) | runs there |
+| No `project` + relative `cwd` | the target's `$HOME` joined with `cwd` (if it exists) | runs there |
+| Absolute `cwd` outside `$HOME` | — | **paused** — not portable across devices |
+
+A **`command`** routine (a plain shell body, no agent, no sandbox) may run from the
+target `$HOME` when it has no anchor or `cwd` — housekeeping like `git pull` or
+`npm i -g` is home-relative by nature. An **agent**/**workflow** routine may not:
+with no anchor and no `cwd` it is saved **paused** with `execution_context_missing`
+rather than launched in an arbitrary home.
+
+**Readiness is checked at `add` and `edit`, and a proven blocker saves the routine
+paused** — carrying the exact failing check — instead of activating a routine that
+would fail at fire time. The codes are stable and machine-readable:
+
+| Readiness code | Meaning |
+| --- | --- |
+| `project_not_found` | the named `project` anchor is not in `agents projects` |
+| `project_path_missing` | the anchor has no usable local base path on the target |
+| `cwd_missing` | the resolved `cwd` does not exist on the target |
+| `cwd_not_portable` | an absolute `cwd` outside `$HOME` — would not resolve on another device |
+| `codex_workspace_untrusted` | the Codex workspace-trust check failed for the resolved directory |
+| `agent_auth_failed` | a real headless authenticated smoke failed (a dead/expired account) — not a cache read |
+| `execution_context_missing` | an agent/workflow routine with no anchor and no `cwd` |
+
+`agents routines resume <name>` re-runs these checks and refuses to activate a
+routine whose blocker is still present — resume is not a way to bypass readiness. A
+raw edit of the YAML (or `agents routines edit`) is atomic: the change is parsed and
+validated on a temporary copy and only then replaces the live definition, so an
+invalid edit leaves the prior bytes untouched, and a valid-but-unready edit replaces
+the definition **and** pauses it.
+
+`repo` on a routine is an **external identity**, never the working directory: it is
+the GitHub `owner/repo` a webhook trigger filters on, and the origin remote recorded
+as provenance under `source:` when a routine is materialised from a project. The
+local execution directory is the anchor/`cwd` above; the Git/cloud/webhook `repo`
+identity is separate.
+
+### Remote Routing
+
+`--device <name>` routes any `routines` subcommand to a remote machine over SSH,
+so you can query or trigger a job on another box without an explicit `agents ssh` call:
+
+```bash
+# List another device's routines
+agents routines list --device yosemite-s0
+
+# Trigger a job on a specific machine right now
+agents routines run drain --device yosemite-s0
+
+# Create a job pre-assigned to two hosts, then confirm it looks right on one
+agents routines add drain --schedule "0 3 * * *" --agent claude \
+  --devices yosemite-s0 --prompt "Drain queue" --device yosemite-s0
+```
+
+When you try to run a job on a host outside its allowlist, the CLI prints:
+
+```
+Job 'drain' can only run on: yosemite-s0, mac-mini
+  agents routines run drain --device yosemite-s0
+```
+
+## Sandbox Isolation
+
+Each job runs with `HOME` set to an overlay directory:
+
+```
+~/.agents/routines/daily-review/home/
+  .claude/
+    settings.json             # Generated with allow.tools permissions
+  projects -> ~/projects      # Symlink from allow.dirs
+```
+
+The agent can only:
+- See directories listed in `allow.dirs`
+- Use tools listed in `allow.tools`
+- Cannot access `~/.ssh`, `~/.gitconfig`, etc.
+
+**GitHub CLI auth the overlay would otherwise hide is forwarded** (RUSH-2860):
+`prepareJobHome` links this machine's `~/.config/gh` (or `$GH_CONFIG_DIR`) into
+the overlay, and `buildSpawnEnv` pins `GH_CONFIG_DIR` and forwards
+`GH_TOKEN`/`GITHUB_TOKEN`, so a sandboxed monitor `--run` child sees the same
+GitHub CLI auth as interactive `agents run`. Same-host only — credentials are
+never copied to another box. Nothing else from the host home is linked in: the
+overlay still does not contain `~/.ssh`, `~/.gitconfig`, or `~/.agents` (which
+holds the secrets master key and the encrypted store).
+
+`assertSandboxForwardsHostGhAuth` is a **regression tripwire, not a runtime
+guarantee**. It trips only when a routine's own `env:` overrides
+`GH_CONFIG_DIR`; it checks that a `hosts.yml` exists, not that `gh` can
+authenticate, so a `hosts.yml` left behind by `gh auth logout` still satisfies
+it.
+
+**Windows is not covered.** `resolveHostGhConfigDir` checks `$XDG_CONFIG_HOME/gh`
+and `~/.config/gh` only; `gh` on Windows stores config under
+`%AppData%\GitHub CLI`, so the forwarding is a no-op there and the new tests
+skip on `win32`.
+
+When an agent routine finishes, agents-cli copies the agent transcript out of
+the overlay before the next run recreates it. The durable copy lives beside the
+run metadata:
+
+```
+~/.agents/.history/runs/<routine>/<run-id>/sessions/<agent>/...
+```
+
+Those archives are indexed by `agents sessions` with `origin: "routine"`,
+`routineName`, and `routineRunId`. Use `agents sessions --routine` (or the
+`--routines` alias) to pick a routine interactively, or pass a fuzzy name such
+as `agents sessions --routine nightly-review`, to list them. Routine discovery
+spans every working directory because a scheduled run is not tied to the shell
+where its history is inspected. The picker
+includes last-run and session-count context, and the selected view groups sessions
+by run ID and timestamp. Use `agents sessions <run-id>` to render the existing session summary view
+for a specific routine run.
+
+Archiving is per-agent (`ROUTINE_TRANSCRIPT_SPECS` in `runner.ts`, mirroring
+`SESSION_ROOT_SPECS` in `session/discover.ts`) and covers every on-disk session
+agent: claude, codex, cursor, gemini, antigravity, droid, kimi, grok. `opencode`
+is the one exception — its transcripts live in one incrementally-scanned SQLite
+db (`~/.local/share/opencode/opencode.db`), not a per-session file tree, so
+there's nothing for this mechanism to copy out.
+
+### Account auth for routines
+
+A native Claude identity is pinned to its installed version home:
+`buildRoutineSpawnEnv` sets `CLAUDE_CONFIG_DIR` to that home (`runner.ts`), so even
+under the sandbox overlay — which gives the spawn a clean `HOME` — Claude Code
+resolves the credential it owns from `CLAUDE_CONFIG_DIR`. The routine removes an
+ambient `CLAUDE_CODE_OAUTH_TOKEN`; agents-cli neither copies nor converts native
+OAuth material.
+
+A provider account follows the same adapter path as interactive `agents run`: its
+device-local secret bundle supplies the configured API key, setup token, or bearer
+token. The account may be selected explicitly with `account:` or through the
+agent's provider default. A routine preflights the account metadata and secret on
+the firing device before spawn. A missing bundle, mismatched stable identity, or
+incompatible provider/model fails the run rather than rotating to another account.
+
+To bring a signed-out box back, log in on that box once — `agents run claude` (or
+`claude` directly) drives the interactive login and writes the credential the
+routine then reuses. The daemon does not need restarting; it reads no credential.
+
+### Cursor auth and workspace trust for routines
+
+A sandboxed Cursor routine reuses the login from this same device without copying
+credentials to another host. The routine overlay links the local Cursor auth file
+from `$XDG_CONFIG_HOME/cursor` (or `~/.config/cursor`) and the CLI preferences from
+`~/.cursor/cli-config.json`, then pins `XDG_CONFIG_HOME` to that overlay. If the
+device is signed out, the run fails as `auth_failed` with Cursor's `agent login`
+instruction.
+
+Cursor routines pass `--trust` because configuring a routine with a working
+directory is the user's workspace-trust decision. This is narrower than `--yolo`
+or `-f`: it accepts the workspace without bypassing tool permissions. Cursor's
+read-only plan mode exists in the CLI but is not enabled in the agents-cli
+capability registry yet (RUSH-2101), so `mode: plan` currently warns and runs the
+registry-selected writable mode.
+
+The same trust rule applies to any headless `agents run cursor "<prompt>"` launch:
+agents-cli passes `--trust` because the caller selected both a working directory
+and a non-interactive prompt. Interactive `agents run cursor` launches preserve
+Cursor's own workspace-trust prompt and never add `--trust`.
+
+### Pinning an account (avoid the OAuth-rotation revocation storm)
+
+When no provider default is configured, an unpinned `claude` routine selects a
+native identity by the default `balanced` strategy — a stateless weighted-random
+roll (`rotate.ts`) that can land two
+concurrent runs, on one box or across the fleet, on the *same* account. Claude's
+OAuth refresh token is **single-use and rotates server-side on every refresh**, so
+when a second run refreshes an account the first is still holding, the first run's
+token is revoked mid-flight and the run dies with:
+
+```
+Failed to authenticate. API Error: 401 OAuth access token has been revoked.
+```
+
+Multiplied across ~20 unpinned routines that all wake in the same morning window,
+this is a self-inflicted logout storm (RUSH-1957).
+
+**The durable cure: give each routine (or each device's routines) its own
+account.** Pin by identity with `account:` — the login email, resolved at launch
+to whichever installed version holds that account, run pinned with no rotation and
+no failover onto other accounts:
+
+```yaml
+name: drain-prix
+schedule: "15,45 * * * *"
+agent: claude
+devices: [yosemite-s1]
+account: muqsit@trp.so      # this box's routines all refresh ONE account, no one else's
+```
+
+Prefer `account:` over `version:`: a `version:` pin names a version *number* that
+is garbage-collected on the next `claude` upgrade, after which the routine
+silently falls back to `balanced` and the storm returns. Pinning by account
+identity survives version churn. If the named native identity is not signed in on
+the box at fire time, the routine refuses to run rather than rotating to a sibling
+identity. List native and provider accounts with `agents accounts`.
+
+## Execution Flow
+
+Temporal sequence from cron fire to report saved.
+
+```
+croner            JobScheduler          runner.ts           sandbox.ts       spawned agent       filesystem
+(library)         scheduler.ts:20       executeJob          prepareJobHome   (claude/codex/      ~/.agents-system/runs/
+                                                                              kimi)
+
+     │                  │                  │                    │                │                    │
+     ●──fire callback──▶│                  │                    │                │                    │
+     │                  │                  │                    │                │                    │
+     │                  │──onTrigger(cfg)──▶                    │                │                    │
+     │                  │  (scheduler.ts:42)                    │                │                    │
+     │                  │                  │                    │                │                    │
+     │                  │                  │──resolveJobPrompt──│                │                    │
+     │                  │                  │  + buildJobCommand │                │                    │
+     │                  │                  │  (runner.ts:40)    │                │                    │
+     │                  │                  │                    │                │                    │
+     │                  │                  │  if sandbox≠false: │                │                    │
+     │                  │                  │──prepareJobHome───▶│                │                    │
+     │                  │                  │                    │                │                    │
+     │                  │                  │                    ├─rm old overlay─────────────────────▶│
+     │                  │                  │                    ├─mkdir ~/.agents/routines/{name}/home▶│
+     │                  │                  │                    ├─generateClaudeConfig (etc.)────────▶│ .claude/
+     │                  │                  │                    │                                    │   settings.json
+     │                  │                  │                    ├─symlinkAllowedDirs─────────────────▶│ home/<dir>->...
+     │                  │                  │                    │                │                    │
+     │                  │                  │◀──overlayHome──────│                │                    │
+     │                  │                  │                    │                │                    │
+     │                  │                  │──buildSpawnEnv─────▶│                │                    │
+     │                  │                  │  HOME=overlay      │                │                    │
+     │                  │                  │  + ENV_ALLOWLIST   │                │                    │
+     │                  │                  │  (sandbox.ts:19)   │                │                    │
+     │                  │                  │                    │                │                    │
+     │                  │                  ├─mkdir runDir, open stdout fd────────────────────────────▶│ runs/{job}/{runId}/
+     │                  │                  ├─writeRunMeta(status='running')──────────────────────────▶│   meta.json
+     │                  │                  │                    │                │                    │
+     │                  │                  ├─spawn(cmd, {       │                │                    │
+     │                  │                  │    detached:true,  │                │                    │
+     │                  │                  │    stdio:[ign,     │                │                    │
+     │                  │                  │          fd, fd],  │                │                    │
+     │                  │                  │    env: spawnEnv   │                │                    │
+     │                  │                  │  })  runner.ts:159─────────────────▶●                    │
+     │                  │                  │                    │                │──stdout────────────▶│ stdout.log
+     │                  │                  │                    │                │                    │
+     │                  │                  │  setTimeout(timeout)                │                    │
+     │                  │                  │  runner.ts:170     │                │                    │
+     │                  │                  │                    │                ●──agent runs──       │
+     │                  │                  │                    │                │   prompt, uses     │
+     │                  │                  │                    │                │   allowed tools    │
+     │                  │                  │                    │                ●──exits(code)───    │
+     │                  │                  │◀───────'exit'──────────────────────────────────────────  │
+     │                  │                  │                    │                │                    │
+     │                  │                  ├─writeRunMeta(status=code===0 ? 'completed' : 'failed')──▶│ meta.json
+     │                  │                  │                    │                │                    │
+     │                  │                  ├─extractAndSaveReport(stdoutPath, agent, runDir)─────────▶│ report.md
+     │                  │                  │  runner.ts:271     │                │                    │
+     │                  │                  │                    │                │                    │
+     │                  │◀──resolve────────│                    │                │                    │
+     │                  │                  │                    │                │                    │
+     │                  │  if runOnce:     │                    │                │                    │
+     │                  │  ├─unschedule    │                    │                │                    │
+     │                  │  └─deleteJob     │                    │                │                    │
+     ▼                  ▼                  ▼                    ▼                ▼                    ▼
+```
+
+On timeout: the setTimeout at `runner.ts:170` fires, sends `SIGTERM` to the
+process group (`process.kill(-child.pid, 'SIGTERM')`), waits 5s, then
+`SIGKILL`. Report extraction runs regardless — a truncated stdout is still
+valuable.
+
+## Run State Machine
+
+Each `RunMeta.status` value maps to one terminal state. Transitions are
+one-shot — a run never re-enters `running` once it leaves.
+
+```
+                        ┌─────────────┐
+                        │  (spawned)  │
+                        └──────┬──────┘
+                               │
+                               ▼
+              writeRunMeta(status='running')
+              runner.ts:149
+                               │
+                               │
+         ┌─────────────────────┼─────────────────────┐
+         │                     │                     │
+         │                     │                     │
+         ▼                     ▼                     ▼
+    exit code=0          exit code≠0         timeout fires
+    runner.ts:200        runner.ts:200       runner.ts:184
+         │                     │                     │
+         ▼                     ▼                     ▼
+    ┌─────────┐           ┌────────┐            ┌─────────┐
+    │completed│           │ failed │            │ timeout │
+    └─────────┘           └────────┘            └─────────┘
+                                                      │
+                                                      │
+                                             SIGTERM → wait 5s → SIGKILL
+                                             report still extracted from
+                                             partial stdout
+```
+
+Plus one error branch: `child.on('error')` at `runner.ts:208` (spawn itself
+failed — binary not found, EACCES, etc.) → `status='failed'` with `exitCode=null`.
+
+### `missed` — the run that never started
+
+`missed` is the one status the runner never writes, because no process was ever
+spawned. It records that a scheduled fire **did not happen**: the scheduler was
+down, asleep, or wedged when the routine came due. `claimMissedFire`
+(`catchup.ts`) writes it with `pid: null`, `exitCode: null`, and `startedAt` set
+to the moment the fire was **due** — not the moment it was noticed — so the gap
+lands at the right point in `agents routines runs <name>`.
+
+Without it a miss left no trace at all, and the listing kept showing the previous
+run's `completed` as though it were current.
+
+### `blocked` and `skipped` — planned attempt records (RUSH-2290)
+
+> **Status: planned.** These two statuses and the pre-session attempt records they
+> describe are the routine reliability contract, not yet on `main` (today the status
+> set stops at `missed`). Specified in
+> [specifications.md §Routine execution & readiness](specifications.md#routine-execution--readiness)
+> (RT-6, RT-7) and [§Scheduling & execution singularity](specifications.md#scheduling--execution-singularity) (SING-13).
+
+Two operational states are today invisible because no process spawns for them, and
+the reliability plan makes each its own terminal run so it shows up in
+`agents routines runs` before any session exists:
+
+- **`blocked`** — a **readiness** check failed at fire time (a dead account, an
+  untrusted Codex workspace, a missing anchor/cwd), so the body never ran. Distinct
+  from `failed`, where the body ran and errored: a routine that never launched because
+  its account was dead is a different problem from one that threw mid-run, and
+  collapsing them hides which one you have.
+- **`skipped`** — the routine was **already running** when its next slot arrived
+  (self-overlap). Rather than launch a second concurrent instance, the new occurrence
+  records a `skipped` run linked to the still-active run.
+
+Run history is the canonical record of what a routine did — a session transcript,
+log, report, or artifact is an *optional child* of a run, not the record itself. That
+is why a `missed`, `blocked`, or `skipped` attempt is fully visible with no session
+attached.
+
+### One fire launches once
+
+A single scheduled occurrence launches a routine **at most once**, even if the same
+UTC slot is evaluated by two timer callbacks or replayed on a daemon restart. The
+landed guarantee for the catch-up path is the atomic `mkdir` claim below (a `missed`
+record's run directory is a test-and-set). The reliability plan (RUSH-2290) extends
+the same idea to the primary scheduled path: one atomic claim on the occupancy
+identity `(routine, scheduledFor)` before dispatch, kept separate from the
+active-run claim that prevents self-overlap (`SING-13`, `SING-15`, `SING-16`).
+
+## Catching up a missed fire
+
+Fires are in-process croner timers, and croner only schedules forward from "now".
+A daemon that was not running when a routine came due therefore loses that fire —
+`loadAll()` (`scheduler.ts`) rebuilds every timer looking only at the future, so
+nothing replays it. This is routine on a laptop: close the lid over a 9pm
+schedule and the routine simply never ran.
+
+The daemon recovers from this itself. `detectOverdueJobs` (`overdue.ts`) compares
+each enabled routine's most recent expected fire against its most recent recorded
+run; `runCatchup` (`catchup.ts`) then records each miss and re-runs it via the
+same detached path `agents routines catchup` uses. It runs **at daemon startup
+and every 5 minutes** — a startup-only pass would miss a fire lost while the
+daemon stayed up but its event loop was wedged, or one lost across an OS suspend
+the process survived.
+
+Detection looks back far enough to see the routine's own period. The window widens
+week → month → quarter → year, and only when the narrower one finds nothing, so a
+dense schedule never walks more than a week of occurrences. A fixed one-week
+lookback silently skipped anything sparser: `0 9 1,13,25 * *` has 12-day gaps, so on
+10 of every 28 days it could not be evaluated at all.
+
+A routine past its `endAt`, and a one-shot (by flag *or* by schedule shape), is never
+caught up — catch-up replays a missed fire, it does not resurrect a retired routine.
+
+Catch-up is idempotent without a ledger: the `missed` record advances the overdue
+comparison, so the same missed fire is never reconsidered — across ticks, a daemon
+restart, or a restart storm.
+
+Two callers that overlap are handled by a claim rather than a lock. Writing the
+`missed` record creates its run directory with a non-recursive `mkdir` — an
+atomic test-and-set — and only the caller that wins it runs the routine. So if
+the daemon's 5-minute pass and a manual `agents routines catchup` overlap, the
+routine still starts exactly once; the loser reports `already claimed by the
+scheduler`. This is deliberately at-most-once: a process that dies between
+claiming and spawning leaves that fire un-run, which is the right trade when the
+alternative is spawning an agent twice.
+
+Device scoping still applies: a routine pinned elsewhere is skipped, so a fleet of
+machines never all catch up the same routine.
+
+A routine is also never caught up for a fire that **predates it**. `writeJob` stamps
+`createdAt` once, and overdue detection floors the most recent expected occurrence at
+it (`routineEffectiveStart`, `overdue.ts`), falling back to the routine file's mtime
+for routines written before the field existed. Without that floor, adding a routine on
+any daily or weekly schedule whose slot had already passed would make it instantly
+overdue — and catch-up would run it once, immediately, minutes after you created it.
+
+### Opting out — `catchup: false`
+
+Catch-up defaults to **on**: a routine you scheduled is one you expect to have
+run, so losing a fire silently is never the helpful default.
+
+Set `catchup: false` on a routine whose value is tied to its clock — a 9am
+standup brief is worthless at 3pm:
+
+```yaml
+name: crm-pipeline-brief
+schedule: "0 8 * * 1-5"
+catchup: false
+```
+
+or at creation:
+
+```bash
+agents routines add crm-pipeline-brief --schedule "0 8 * * 1-5" --agent claude \
+  --no-catchup --prompt "Morning pipeline brief"
+```
+
+An opted-out routine still **records** the miss — you see it as `missed` in the
+listing and in `agents routines runs` — it is just not re-run.
+`agents routines list --json` reports the effective value as `catchup`.
+
+Force a pass by hand at any time:
+
+```bash
+agents routines catchup            # record + run every missed fire now
+agents routines catchup --dry-run  # record the misses, run nothing
+```
+
+## Sandbox Data Flow
+
+What `prepareJobHome` produces on disk, given a job config.
+
+```
+Input:  JobConfig                                Output:  ~/.agents/routines/{name}/home/
+
+┌──────────────────────────┐                    ┌─────────────────────────────────────────┐
+│ name: daily-review       │                    │ (cleanJobHome removes any prior overlay)│
+│ agent: claude            │                    │                                         │
+│ mode: plan               │  prepareJobHome    │ .claude/                                │
+│ allow:                   │  sandbox.ts:74     │   settings.json  ← generateClaudeConfig │
+│   dirs:                  │                    │                    - mode → permMode    │
+│     - ~/projects/myapp   │ ─────────────────▶ │                    - allow.tools        │
+│   tools:                 │                    │                    - SAFE_TOOLS expand  │
+│     - Bash(git *)        │                    │                                         │
+│     - Read               │                    │ myapp -> /Users/you/projects/myapp      │
+│     - web_search         │                    │   (symlink, from allow.dirs)            │
+│                          │                    │                                         │
+└──────────────────────────┘                    └─────────────────────────────────────────┘
+
+                                                 Env handed to child process:
+                                                 (sandbox.ts:52, buildSpawnEnv)
+                                                 ┌─────────────────────────────────────────┐
+                                                 │ HOME=~/.agents/routines/daily-review/home│
+                                                 │ + forwarded from parent only if in      │
+                                                 │   ENV_ALLOWLIST (sandbox.ts:19):        │
+                                                 │   PATH, SHELL, TERM, LANG, LC_*, USER,  │
+                                                 │   TMPDIR, XDG_*, NVM_DIR, NODE_PATH,    │
+                                                 │   BUN_INSTALL, EDITOR, VISUAL, NO_COLOR │
+                                                 │   FORCE_COLOR                           │
+                                                 │ + TZ (if config.timezone)               │
+                                                 │                                         │
+                                                 │ Everything else (AWS_*, OPENAI_API_KEY, │
+                                                 │ GITHUB_TOKEN, etc.) is DROPPED.         │
+                                                 └─────────────────────────────────────────┘
+```
+
+Tools in `allow.tools` are expanded per two small tables at `sandbox.ts:43-49`:
+
+- `SAFE_TOOLS` — safe wildcards (`web_search` → `WebSearch(*)`, `web_fetch` → `WebFetch(*)`)
+- `DIR_SCOPED_TOOLS` — always scoped, never wildcarded (`read`, `write`, `edit`, `glob`, `grep`, `notebook_edit`). A bare `Read` in config expands to `Read(dir1)`, `Read(dir2)`… for each entry in `allow.dirs`.
+
+This is the core isolation invariant: the spawned agent's view of the
+filesystem is **only** the symlinks we created in the overlay, plus any
+file:// paths its tools touch via the allowed-tool expansion. No `~/.ssh`,
+no `~/.gitconfig`, no ambient AWS/OPENAI keys.
+
+### Run Output
+
+Each execution creates a run directory with structured output:
+
+```
+~/.agents/
+  runs/
+    daily-review/
+      2026-04-17T09:00:00.000Z/
+        stdout.log                    # Full terminal output
+        stderr.log                    # Error output
+        exit-code                     # Exit status (0, 1, etc.)
+        report.md                     # Extracted report
+        meta.json                     # RunMeta: { agent, version, mode, status, duration, ... }
+```
+
+### Desktop notifications
+
+The daemon fires a native macOS notification on the routine lifecycle, routed
+through the `MenubarHelper.app` companion (`src/lib/menubar/notify-desktop.ts`)
+so it carries the agents-cli mark (the bundle's `AppIcon`) rather than the
+generic AppleScript/Script Editor icon. An agent routine carries the harness it
+runs on as the banner's right-hand avatar (`routineAgent`); a workflow routine
+runs via `agents run <workflow>` (delegated to claude), so it shows the Claude
+avatar — the same harness the finish banner records; a command routine has no
+agent and shows the agents-cli mark alone. When the
+menu-bar helper is not
+installed (Linux, or a machine that disabled it), delivery degrades to
+`osascript`/`notify-send` so a notice is never silently lost.
+
+| Event | When | Threshold |
+| --- | --- | --- |
+| **Start** | The scheduler triggers a routine | Agent/workflow routines only — command (housekeeping) routines are suppressed to avoid spam |
+| **Finish** | The run reaches a terminal state | Always for agent/workflow; command routines notify only on **failure** |
+| **Overdue** | Daemon startup finds a missed recurring routine | Any overdue routine (`src/lib/overdue.ts`) |
+
+All three of the above fire from **inside** `runDaemon()`, so none of them can
+ever notice that the daemon itself has died — the exact outage that means no
+routine will fire again until someone restarts it. That gap is closed by a
+separate, daemon-independent watchdog in the menu-bar helper (which runs as its
+own launchd `KeepAlive` service): see
+[menubar.md → Daemon-down watchdog](menubar.md#daemon-down-watchdog).
+
+"Notable output" is folded into the single **Finish** notification, not sent as
+a third message: on success the body is the first line of `report.md` (the
+routine's user-facing result), on failure it is the error reason. So a normal
+run produces exactly one start + one finish notification.
+
+Notifications are actionable where a target exists: clicking a **Finish** opens
+the run's `report.md`/`stdout.log`; **Start**/**Overdue** open the runs folder.
+The finish notification only fires for locally-run routines — `host:`-placed
+runs are finalized by the monitor sweep and do not emit one.
+
+### Owner notification on failure (RUSH-2288)
+
+Desktop notifications never leave the machine, so a failed routine on a headless
+fleet box was invisible until someone looked. On a **failure only** — a
+`failed`/`timeout` finish, or a pre-spawn failure such as `auth_failed` — the
+daemon also pings the **owner's phone**, through the same channel stack `agents
+notify` uses (the `owner.channels` in `humans.yaml`, or the legacy
+`notify.owner` in `agents.yaml`). This is the failure the per-routine `agents
+notify` prompt can never send itself: when the routine's own agent fails to
+spawn, that prompt never runs.
+
+- **Only failures.** A green routine of any kind stays silent. The desktop
+  thresholds above are unchanged; this is an additional failures-only lane.
+- **In-process, not `ssh`.** The daemon calls the channel providers directly
+  (`src/lib/routine-notify-owner.ts`) — it does not shell out to `ssh mac-mini
+  agents notify`.
+- **Fallback channel.** If the primary owner channel cannot deliver from this
+  box, the daemon walks the remaining configured `owner.channels` in order
+  (e.g. an OpenClaw channel after iMessage). Telegram and intrusive (voice)
+  channels are excluded; an owner whose only channel is Telegram gets no ping.
+- **Deduped** per job+runId, so a run reaches the owner at most once.
+
+## Commands
+
+```bash
+# Lifecycle
+agents routines list                  # List all jobs with next run + status
+agents routines list --device yosemite-s0  # List another device's routines
+agents routines add <name> --schedule "0 9 * * *" --agent claude --prompt "..."  # Inline
+agents routines add <name> --devices yosemite-s0 --schedule "0 3 * * *" \
+  --agent claude --prompt "..."       # Add with device allowlist
+agents routines add <name> --project myapp --schedule "0 9 * * *" \
+  --agent claude --prompt "..."       # Group under a named project (repeatable metadata)
+agents routines add <name> --project-anchor myapp --cwd apps/api \
+  --schedule "0 9 * * *" --agent claude --prompt "..."  # Execution context
+agents routines add <name> --all-projects --schedule "0 9 * * *" \
+  --agent claude --prompt "..."       # Tag to all defined projects
+agents routines add <path.yml>        # Add from YAML file
+agents routines add <name> --at "14:30" --agent claude --prompt "..."            # One-shot
+agents routines edit <name>           # Transactional temporary-YAML editor
+agents routines edit <name> --yaml    # Same editor; explicit compatibility flag
+agents routines remove <name>         # Delete a job
+agents routines pause <name>          # Disable a job
+agents routines resume <name>         # Re-enable a paused job
+agents routines doctor <name>         # Check execution context + harness readiness
+agents routines doctor --all --fix    # Apply safe deterministic readiness repairs
+
+# Device allowlist management
+agents routines devices <name>                         # Interactive multi-select picker
+agents routines devices <name> --set yosemite-s0           # Set the owning device
+agents routines devices <name> --clear                 # Disable on every registered device
+
+# Execution
+agents routines run <name>            # Run immediately in foreground
+agents routines run <name> --device yosemite-s0  # Run on a specific remote device
+agents routines view <name>           # Show job config
+agents routines runs <name>           # Attempt history (session optional)
+agents routines stats                 # Run count/failed/missed/avg/p50/p95 duration, every job
+agents routines stats <name>          # Same rollup, scoped to one job
+agents routines logs <name>           # Show concise summary from latest run
+agents routines logs <name> --run <id>  # Show specific run
+agents routines logs <name> --full    # Show raw stdout from latest run
+agents routines report <name>         # Show report from latest run
+agents routines report <name> --run <id>  # Show specific run report
+agents sessions <run-id>              # Show the archived agent transcript summary
+
+# Scheduler (install/upgrade/setup start the daemon when enabled; these are manual controls)
+agents routines start                 # Start the background scheduler
+agents routines stop                  # Stop the scheduler
+agents routines status                # Show scheduler status + upcoming runs
+agents routines scheduler-logs        # Read scheduler log output
+```
+
+> **Planned (RUSH-2290), not yet on `main`:** the readiness contract above adds an
+> execution anchor and a diagnose/repair command —
+> `agents routines add|edit <name> --project-anchor <name> --cwd <dir>` to set the
+> singular anchor and working directory, and `agents routines doctor [name] [--fix]`
+> to re-check readiness and repair blockers. `--project-anchor` is deliberately
+> distinct from the existing repeatable `--project` grouping flag. See
+> [Execution context and readiness](#execution-context-and-readiness).
+
+### Non-Interactive Usage
+
+For scripting, pass explicit names and flags to avoid interactive pickers:
+
+```bash
+# Add a job without pickers
+agents routines add morning-briefing --schedule "0 8 * * 1-5" \
+  --agent claude --mode plan --prompt "Summarize overnight changes in the repo"
+
+# Run a job in the foreground
+agents routines run morning-briefing
+
+# View the report
+agents routines report morning-briefing
+```
+
+## Scheduler
+
+A background scheduler (historically called "the daemon" internally) watches for cron-triggered jobs. It persists across CLI invocations and auto-reloads when job configs change.
+
+```bash
+agents routines start     # Start manually (usually unnecessary after install)
+agents routines stop      # Stop
+agents routines status    # Check health, PID, binary, heartbeat, and upcoming runs
+```
+
+The daemon **starts at install/upgrade** (`postinstall` on darwin/linux) and on
+first `agents setup` / `agents setup --force` (when `daemon.enabled` is not
+false), so launchd/systemd KeepAlive keep it up. `agents routines add`
+still ensures the scheduler is running and reloads it — you rarely need
+`routines start` manually. When you `add`, `remove`, `pause`, or `resume` a job,
+it auto-reloads. `daemon.enabled=false` suppresses cold starts at install and
+setup, and still gates `ensureDaemonStarted`; deliberate `agents daemon start`
+remains the operator override.
+Scheduled fires use two independent guards. An atomic slot claim keyed by routine
+name and the intended UTC schedule time ensures a delivered slot launches once,
+including across daemon reloads. A separate active-run claim prevents a routine
+from overlapping itself across scheduled, catch-up, webhook, detached, and manual
+foreground paths. A later slot while work is active writes a `skipped` attempt
+linked to the active run and spawns no process.
+
+Every requested attempt receives run metadata before placement, account selection,
+sandbox construction, readiness, or dispatch. `blocked` means the readiness gate
+prevented entry into placement; `failed` means placement, dispatch, or execution
+failed after the run path began;
+`skipped` means another slot/active/owner claim won. Routine history is therefore
+complete even when no transcript was created. `agents sessions --routines` builds
+its routine picker from definitions and run directories so zero-session routines
+remain selectable, but its result rows are archived sessions. Use `agents routines
+runs <name>` for canonical attempt history, including attempts with no transcript.
+
+`agents routines status` reports the scheduler as `running`, `wedged`, or `stopped`. A live PID whose heartbeat is more than three monitor ticks old is `wedged`; the status output includes the restart command. Both `routines list` and `routines status` also finalize orphaned `running` records before rendering. Run metadata records process birth time to reject recycled PIDs and persists the configured execution deadline. Detached children are killed when that deadline expires, including after a scheduler restart.
+
+The status output includes the resolved daemon binary. Startup rejects bun virtual-filesystem paths and warns when the binary lives under an ephemeral root — a git worktree, or a temporary directory (`/tmp`, `/var/folders`, `/dev/shm`) — because deleting that directory would strand the service. The daemon resolves its own job modules from the launch path, so a direct `agents __daemon-run` from such a build wedges every routine with `ENOENT` once the directory is removed; the warning fires both at spawn time (`validateDaemonBinary`) and at the daemon's own startup (`warnEphemeralDaemonRoot`), so a directly-launched daemon still surfaces the risk. Run it from the globally installed binary to root it at a stable version home.
+
+## Key Functions
+
+| Function | File | Purpose |
+|------|------|------|
+| `listJobs()` | routines.ts | List all configured jobs |
+| `writeJob()` / `readJob()` | routines.ts | Persist job config |
+| `executeJob()` | runner.ts | Run job with sandbox isolation |
+| `createOverlay()` | sandbox.ts | Create HOME overlay with permissions |
+| `scheduleJob()` | scheduler.ts | Register cron trigger |
+| `signalDaemonReload()` | daemon.ts | Notify daemon to reload config |
+| `parseAtTime()` | routines.ts | Parse --at time strings to cron |
+| `getLatestRun()` / `listRuns()` | routines.ts | Query execution history |
+| `jobRunsOnThisDevice()` | routines.ts | Check if job is eligible on current machine |
+| `routineStats()` | routines.ts | Fold `listRuns()` into `{count, failed, missed, avgMs, p50, p95}` — `agents routines stats` |

--- a/cli/docs/routines.md
+++ b/cli/docs/routines.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Routines (Scheduled Jobs)
 
 Scheduled agent execution with sandboxed permissions and scheduler-driven cron execution.

--- a/cli/docs/secrets-agent-process-model.md
+++ b/cli/docs/secrets-agent-process-model.md
@@ -1,0 +1,200 @@
+# Secrets-agent process model (design decision)
+
+> Status: **accepted** · Supersedes nothing · Related: [secrets.md](secrets.md), [routines.md](routines.md)
+
+> **Implementation (#416, steps 1 & 2 — landed):** the daemon hosts the broker
+> socket-first. `runDaemon()` calls `startHostedBroker()` before the scheduler
+> and the heavy browser services, so `agents secrets` resolves
+> within ms of daemon start; it only hosts when no broker is already reachable,
+> so a live standalone broker is never orphaned.
+>
+> Step 2 retires the standalone `com.phnx-labs.agents-secrets-agent` service:
+> `ensureAgentRunning()` no longer installs it — it retires any leftover plist
+> (`retireLegacySecretsAgentService()`) and then relies on the daemon (Path 0),
+> with a one-off detached broker as the only fallback. The upgrade migration
+> (`scripts/postinstall.js` → `healLongRunningProcesses`) boots out the legacy
+> service first, then (re)starts the daemon so it takes over the socket. `secrets
+> start` is now a thin alias that brings the daemon up; `secrets stop` locks all
+> bundles and retires any leftover legacy service, leaving the always-on daemon
+> running. **Still to do (#417):** spawn the heavy services as bounded children.
+
+A design record for *where the secrets-agent broker should live as a process* —
+its own service, or folded into the routines daemon. Written after a stretch of
+production incidents (stale daemon reading the keychain, broker cold-start
+starvation, duplicate daemons) made the process model worth pinning down.
+
+## Context
+
+The **secrets-agent broker** (`src/lib/secrets/agent.ts`) is a persistent
+process that holds unlocked bundles in memory behind a `0700` Unix socket, so
+concurrent agents stop re-prompting Touch ID per process. It currently runs as
+its own launchd user service, `com.phnx-labs.agents-secrets-agent`.
+
+The **routines daemon** (`src/lib/daemon/daemon.ts`, `com.phnx-labs.agents-daemon`)
+already hosts a socket IPC service of the same shape — `BrowserIPCServer` — which
+prompted the question: *isn't the broker a second daemon we don't need? Fold it
+into the routines daemon.*
+
+## What the routines daemon actually is today
+
+`runDaemon()` runs, **in-process**:
+
+- the cron **scheduler** (`JobScheduler`),
+- `BrowserService` + `BrowserIPCServer` (a socket server),
+- overdue-job detection + native notification on startup,
+- orphan-process reaping,
+- a 60s monitor interval.
+
+It persists via launchd **or** a detached fallback. Install and upgrade
+(`scripts/postinstall.js` → `healLongRunningProcesses` on darwin/linux) start
+the supervised daemon when `daemon.enabled` is not false so KeepAlive/Restart=always
+apply without waiting for `routines add`. First-run / `--force` `agents setup`
+also calls `startDaemon()` after the system repo is ready. Background-adjacent
+callers still use `ensureDaemonStarted()` (honoring `daemon.enabled` and the
+auto-start circuit breaker).
+
+Observed failure modes this cycle: heavy/slow startup, stale pid file
+(`launchctl … PID: null`), duplicate daemon processes, and cold-start
+starvation under high load (a fresh node process couldn't finish booting at load
+~310).
+
+## Why the broker has different requirements than the scheduler
+
+| | Secrets broker | Routines scheduler |
+|---|---|---|
+| Blast radius of being down | **Loud** — every secret read pops Touch ID | Quiet — a cron job just runs late |
+| Footprint | Tiny (socket + `Map`) | Heavy (browser, sync, scheduler) |
+| Who needs it | Anyone using `agents secrets` | Only users with routines |
+| Cold-start budget | Must be ~instant | Tolerant of slow start |
+
+A reliability/security primitive that *everything* depends on should have the
+**fewest dependencies and the lightest footprint**, and must not inherit the
+failure modes of unrelated subsystems.
+
+A note on an argument we explicitly **reject**: "the daemon is flaky, so keep the
+broker out of it." A daemon is *defined* by being the supervised, always-on,
+bounce-back backbone — robustness is its job. The PID-null / duplicate /
+cold-start incidents are **bugs to fix in the daemon**, not properties to design
+around. Routing a critical service *around* the daemon to dodge its bugs is
+backwards; the fix is to make the daemon worthy of hosting critical services.
+And the reliability isolation a separate broker seems to buy is largely illusory:
+both a standalone broker and the daemon recover the same way — launchd
+`KeepAlive` — so splitting them adds a second thing to supervise without adding
+real resilience.
+
+## Options
+
+1. **Fold into the daemon, and harden the daemon.** Host the broker in the
+   daemon next to `BrowserIPCServer`; make the daemon the always-on,
+   single-instance, self-healing backbone it is meant to be.
+   - One supervised backbone for all background services; one lifecycle; one
+     self-heal path; the broker inherits the daemon's robustness.
+   - Requires real work: the daemon must (a) be **always-on**, not gated on
+     having routines; (b) enforce **single-instance** (no duplicates); (c) start
+     the **broker socket first/fast** so secrets availability never waits on
+     browser/sync init; (d) keep heavy/risky work (browser automation, job runs)
+     in **spawned children** so a crash there can't take the backbone down.
+2. **Keep the broker as its own minimal service.** Fault-isolated, but two
+   services on two lifecycle mechanisms, and the "isolation" is mostly illusory
+   (both rely on `KeepAlive`). Rejected — it treats daemon bugs as permanent.
+
+## Decision
+
+**Fold the broker into the daemon — and harden the daemon into the robust,
+always-on, self-healing backbone (Option 1).** A daemon is the right home for a
+persistent, critical background service precisely *because* it is supposed to be
+the most reliable, supervised component. The broker's reliability should come
+*from* a reliable daemon, not from avoiding it.
+
+The guiding principle (corrected): **make the host (the daemon) reliable enough
+to carry the critical service — don't route the critical service around the
+host.**
+
+This makes the daemon the single backbone that hosts the scheduler, browser IPC,
+and the secrets broker, with heavy/optional work spawned as children to bound
+blast radius.
+
+## Consequences
+
+- The standalone `com.phnx-labs.agents-secrets-agent` launchd service is retired;
+  the broker becomes a service hosted inside `com.phnx-labs.agents-daemon`. The
+  `secrets start/stop` surface either goes away or becomes thin aliases for
+  daemon lifecycle.
+- The daemon must become **always-on** (start for any background need, not only
+  `routines add`) and **single-instance** (the PID-null/duplicate bugs are
+  fixed, not tolerated).
+- In `runDaemon()`, **bind the broker socket before** the browser
+  setup, so secrets resolution is available within milliseconds of daemon start
+  even while the heavier services initialize.
+- Heavy/crash-prone work stays in child processes so a failure there can't take
+  down the broker; the daemon core stays light enough to be trustworthy.
+- Self-heal (heal-on-upgrade + version-skew restart, PR #413) applies to the one
+  daemon, covering the broker for free.
+- Migration: on upgrade, `bootout` the old secrets-agent service and let the
+  daemon take over the socket.
+
+### Single-instance is enforced by two independent signals
+
+"Only one broker owns the socket" is the invariant the whole model rests on, and
+it was enforced by one signal that could lie:
+
+- `stopDaemon()` sent SIGTERM, scheduled its escalation on a `setTimeout`, and
+  cleared the daemon pid file **immediately**. In a short-lived caller (the npm
+  postinstall) that timer never fired, and the cleared pid file made
+  `isDaemonRunning()` report false while the old daemon was still running — so
+  `startDaemon()` launched a second one.
+- `bindBrokerSocket()` then treated a single missed `agentPing` as proof the
+  socket owner was dead. The broker is single-threaded, so a large read or the
+  startup rehydrate can outlast one 700ms ping while the process is healthy.
+
+Together they produced an orphan: the reclaiming broker unlinked the live socket
+and rebound, and the original kept running with every unlocked bundle in RAM,
+unreachable to every client. On a machine with two installs (nvm + homebrew) this
+recurred on every upgrade — `lsof` showed two processes on one socket path at two
+different kernel socket addresses.
+
+Both signals are now required before a socket is reclaimed:
+
+1. **Liveness is observed, not assumed.** `stopDaemon` waits for the process to
+   stop serving before clearing the pid file (`waitForExit` in `daemon.ts`), and
+   escalates to a tree-kill only when it genuinely did not exit. A **zombie counts
+   as exited** — it holds no socket — so a daemon that is the caller's own child
+   is never hard-killed after it has already gone.
+2. **A live socket owner is never evicted.** Whichever broker wins the bind records
+   its pid in `agent.owner` at the moment it is the confirmed owner (the same
+   instant it mints the capability token), and releases it on close.
+   `bindBrokerSocket` probes an in-use socket several times and, even then, refuses
+   to reclaim it while `brokerPidAlive()` reports a live owner.
+
+   `agent.owner` is deliberately a **separate file from `agent.pid`**. `agent.pid`
+   is the standalone service's O_EXCL single-instance claim, held by a standalone
+   that lost the socket race and stays alive and quiescent so launchd's KeepAlive
+   does not restart-loop it, ready to take over if the hosted broker stops.
+   Overloading it as the ownership record made that standalone see a live holder
+   and exit immediately — the very restart loop the guard exists to prevent. The
+   two files answer different questions: *who may run* versus *who is serving the
+   socket right now*. Both broker flavours write `agent.owner`, so the signal is
+   present for the daemon-hosted broker, which is the primary configuration.
+
+3. **Every teardown waits before unlinking.** `ensureAgentRunning`'s one-off
+   fallback and `teardownStaleBroker` used to SIGTERM a possibly-live broker and
+   immediately unlink its socket and pid files. That both orphaned a slow-exiting
+   broker and destroyed the ownership record the check above depends on, so the
+   successor saw an ownerless socket and reclaimed it regardless. Both now wait
+   for the process to stop serving first.
+
+4. **A version-skewed client never evicts a daemon-hosted broker.** The
+   version-skew teardown (`shouldTeardownVersionSkewedBroker`) exists for
+   churning dev installs where no daemon owns the broker. But when the always-on
+   daemon hosts it, `teardownStaleBroker` recognizes only the standalone
+   broker's `pidPath()` claim — the daemon writes `ownerPath()`, not `pidPath()` —
+   so eviction unlinks the daemon's socket *without* stopping the daemon, which
+   then keeps `hostedBroker != null` and `shouldTakeOverBroker` refuses to
+   re-host (point 3's asymmetry), orphaning the broker until the daemon restarts
+   while every reader cold-starts a one-off broker and re-prompts Touch ID.
+   `ensureAgentRunning` now gates the teardown on `shouldClientEvictSkewedBroker`,
+   which defers to a live daemon (`isDaemonRunning()`): a daemon-hosted broker is
+   never client-evicted. Daemon code-version upgrades are handled by the
+   `postinstall.js` daemon restart, and `agentPing()` already gates reachability
+   on `PROTOCOL_VERSION`, so a code-skewed daemon broker stays wire-compatible —
+   deferring to it is safe.

--- a/cli/docs/secrets-agent-process-model.md
+++ b/cli/docs/secrets-agent-process-model.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Secrets-agent process model (design decision)
 
 > Status: **accepted** · Supersedes nothing · Related: [secrets.md](secrets.md), [routines.md](routines.md)

--- a/cli/docs/secrets-trust-boundaries.md
+++ b/cli/docs/secrets-trust-boundaries.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Secrets: trust boundaries & what the agent sees (design)
 
 > Status: **accepted** · Related: [secrets.md](secrets.md) (reference),

--- a/cli/docs/secrets-trust-boundaries.md
+++ b/cli/docs/secrets-trust-boundaries.md
@@ -1,0 +1,198 @@
+# Secrets: trust boundaries & what the agent sees (design)
+
+> Status: **accepted** · Related: [secrets.md](secrets.md) (reference),
+> [secrets-agent-process-model.md](secrets-agent-process-model.md) (broker process model)
+
+A design record for the **one question every operator eventually asks**: when an
+AI coding agent runs a release (or any task) with `agents secrets`, *does the agent
+ever see the plaintext key?* The answer is "only if a command materializes it" —
+and this doc pins down exactly which commands do, why, and where the boundary is
+enforced. It complements the reference doc's [Security model](secrets.md#security-model)
+(which covers the *keychain ACL* threat model) by tracing the **plaintext data-flow**
+past a second boundary the ACL section doesn't name: the agent's own context and
+its session transcript.
+
+## The two boundaries
+
+`agents secrets` defends against **on-disk plaintext** (`.env` files, shell history,
+accidental commits). That is the reference doc's threat model. This doc adds the
+boundary that matters when the *reader* is an agent, not a human:
+
+1. **Storage boundary** — values live in the OS keychain, never on disk as plaintext.
+   Reads are gated (Touch ID / passcode). *Covered by the reference doc.*
+2. **Materialization boundary** — the line between a secret staying inside a child
+   process's environment (invisible to the agent) versus being **printed to stdout**,
+   where it lands in the agent's context window *and* is persisted to the session
+   transcript (`.jsonl`). *This doc.*
+
+The design intent is: **inject into the child process, never into the agent.** Every
+command is on one side of boundary #2 by construction — there is no "sometimes."
+
+## Where values live (storage boundary)
+
+A secret value never exists as a file. On macOS every write goes through the signed
+`Agents CLI.app` helper, which attaches an access control of
+`[.biometryCurrentSet, .or, .devicePasscode]` via `SecAccessControlCreateWithFlags`
+(`src/lib/secrets/keychain-helper.swift:33-45`) — the OS itself gates decryption with
+Touch ID / passcode. Bundle *metadata* (names, var list, policy) is itself a keychain
+JSON blob — nothing about a secret is on disk.
+
+A **bundle** (`SecretsBundle`, `src/lib/secrets/bundles.ts:186`) maps env-var names
+to typed refs (`REF_PATTERN`, `src/lib/secrets/index.ts:51`):
+
+| Ref kind | Where the value is | Reachable by the agent's stdout? |
+|---|---|---|
+| `keychain:<key>` | keychain item, biometry-gated | only via a materializing command (below) |
+| `literal` (`--value`) | inline in metadata JSON — **non-sensitive by contract** | yes (it's not a secret) |
+| `env:<VAR>` | parent `process.env` at run time | only if materialized |
+| `file:<path>` | a file, read at run time | only if materialized |
+| `exec:<cmd>` | stdout of a command, run at resolve time (needs `allow_exec`) | only if materialized |
+
+## The two data-flow paths
+
+### Path A — injection (the agent never sees the value)
+
+This is the release path. `agents secrets exec <bundle> -- <cmd>` and
+`agents run --secrets <bundle>` resolve the bundle in memory and hand it to the child
+as **environment**, not output. The env is built by `buildSecretsExecEnv`
+(`src/lib/secrets/exec` → `src/commands/secrets.ts:353-360`):
+
+```ts
+export function buildSecretsExecEnv(parentEnv, secretEnv) {
+  const env = { ...sanitizeProcessEnv(parentEnv), ...secretEnv };
+  delete env.AGENTS_SECRETS_PASSPHRASE;   // the master key must not reach the child
+  return env;
+}
+```
+
+The resolved values go straight into the spawned process's `env`. They are **never
+written to stdout**, so they never enter the agent's context or the transcript. The
+agent sees only whatever the *child* chooses to print (`npm publish` → `+ pkg@1.2.3`).
+
+```
+  keychain ──(one Touch ID / broker)──▶ resolve in memory ──▶ child process env
+                                                                    │
+                                              agent sees: child's stdout only
+                                              agent does NOT see: the values
+```
+
+`buildSecretsExecEnv` also **strips `AGENTS_SECRETS_PASSPHRASE`** — the file-store
+master key is used to decrypt, then removed before the child (and thus the agent)
+runs, so the one key that unlocks everything never reaches the executed command.
+
+### Path B — materialization (the value is printed → agent + transcript)
+
+Two commands exist to put plaintext *on stdout* on purpose, and both are gated to
+a **human at a real interactive terminal, outside any agent session** (RUSH-2774):
+
+- `agents secrets view <bundle> --reveal` — unmasks values.
+- `agents secrets get <item>` — prints one raw keychain item
+  (`src/commands/secrets.ts:1648`).
+
+Both refuse outright — before resolving anything — when `isAgentInvocationContext()`
+sees an agent marker (`AGENTS_RUNTIME`, `AGENT_SESSION_ID`, `AGENTS_SESSION_ID`,
+`CLAUDECODE`) or when there is no TTY. `view --reveal` additionally has no
+non-interactive escape hatch left: the old `--plaintext` flag that allowed a
+piped/non-TTY reveal is gone. And the bundle-key form, `agents secrets get
+<bundle> <KEY>`, is removed unconditionally — it always refuses and names
+`agents secrets exec <bundle> -- printenv <KEY>` instead. `export`'s old
+shell-eval mode (`eval "$(agents secrets export <bundle> --plaintext)"`) is
+removed the same way: `export` without a destination flag (`--device` /
+`--to-1password` / `--to-file`) refuses and names `secrets exec` / `view
+--reveal`.
+
+When a human runs `view --reveal` or `get <item>` at a terminal, the plaintext is
+legitimate one-off output. When anything tries to run either from *inside* an
+agent session, the refusal is the point: an agent's shell tool output lands in
+the model's context **and** is written verbatim to the session `.jsonl`, so
+letting either command through would cross boundary #2 by construction. The one
+surviving stdout emitter beyond those two is a machine-to-machine transport, not
+a human- or agent-facing command: the SSH remote-resolve path
+(`export <bundle> --plaintext --format json`) that `remoteResolveEnv` /
+`verifyRemoteKeychainPush` build internally, gated on the hidden
+`AGENTS_SECRETS_REMOTE_TRANSPORT=1` marker AND the same agent-context refusal —
+nobody types this form by hand.
+
+## Seen-vs-not-seen, by command
+
+| Command | Plaintext destination | Agent sees it? | In transcript? |
+|---|---|:--:|:--:|
+| `agents secrets exec <b> -- <cmd>` | child process env | **No** | **No** |
+| `agents run --secrets <b>` | agent run's env | **No** | **No** |
+| `agents secrets list` / `view <b>` | masked (`••••`) | No (masked) | No |
+| `agents secrets view <b> --reveal` | **stdout** (human terminal only; refuses in an agent session) | **No** — refuses | **No** — refuses |
+| `agents secrets get <item>` | **stdout** (ungated scripting primitive — a single raw item, not a bundle) | Yes, if the agent runs it | Yes |
+| `agents secrets export <b> --plaintext` (shell-eval mode) | *removed* (RUSH-2774) | n/a | n/a |
+| `agents secrets get <bundle> <KEY>` (bundle-key form) | *removed* (RUSH-2774) | n/a | n/a |
+
+**Rule of thumb for agent-driven flows:** use `exec` / `--secrets`. `view
+--reveal` now refuses to run at all inside an agent session, so a
+key can no longer enter an agent's transcript through either of them — the
+former ungated printers (`export --plaintext`, `get <bundle> <KEY>`) are gone
+outright.
+
+## The transcript corollary
+
+Because Path B output is persisted to the session `.jsonl`, a materialized secret is
+not ephemeral — it is durable in the transcript until that file is deleted. This is
+why the operating rules treat transcripts as confidential (secret-gist attachment on
+private repos; **never** pasted into a public repo, PR, or tracker). A key that only
+ever traveled Path A leaves no transcript residue; a key that traveled Path B does.
+The materialization boundary and the "transcripts are confidential" rule are the same
+boundary seen from two sides.
+
+## How the boundary is enforced (not just documented)
+
+- **Agent-context refusal on every materializing command.** `isAgentInvocationContext()`
+  (`src/lib/secrets/headless.ts`) checks for `AGENTS_RUNTIME`, `AGENT_SESSION_ID`,
+  `AGENTS_SESSION_ID`, or `CLAUDECODE` — present regardless of TTY, since an agent
+  running inside tmux still has one. `view --reveal` consults
+  it before resolving anything and refuse outright when it is set. This is what
+  makes Path B a human-only path rather than an advisory one.
+- **Headless no-prompt.** In a non-interactive/agent context, resolution takes the
+  `agentOnly` / `isHeadlessSecretsContext()` path (e.g. `src/commands/secrets.ts:1052`,
+  `:1642`) — a background agent process must not silently raise a Touch ID sheet on
+  the interactive user's screen. It reads from the broker or fails loudly; it does not
+  prompt behind the user's back.
+- **The broker holds resolved env in memory only.** `agents secrets unlock` caches the
+  resolved bundle behind a Unix socket in a `0700` directory, with the socket file
+  itself chmod'd `0600` (`src/lib/secrets/agent.ts:145`, `:445`; `session-store.ts`) so
+  Path A stays promptless across concurrent runs — still no
+  stdout exposure. See [secrets-agent-process-model.md](secrets-agent-process-model.md).
+- **Auto-mode classifiers.** In hosted agent harnesses, an attempt to scan bundles or
+  materialize a value (`secrets show`, bulk `--reveal`) is challenged as credential
+  exploration — a runtime backstop on top of this design, not a substitute for it.
+
+## What this boundary does NOT do
+
+Inherited from the reference doc's [Security model](secrets.md#security-model),
+restated here because they bound *this* boundary too:
+
+- **Path A env is inherited by the whole subprocess tree.** A value injected into a
+  child is visible to everything that child spawns (npm lifecycle scripts, shells).
+  Only bundle credentials you're willing to expose to the agent's full subprocess tree.
+- **`never`-policy bundles have no gate at all.** A `never` bundle is stored *without*
+  the biometry ACL (`set-no-acl` in `keychain-helper.swift`) and reads fully silently.
+  It is the on-disk-plaintext-equivalent downgrade the rest of the model avoids —
+  never put a high-value secret in one.
+- **Same-user trust is conceded.** The keychain ACL is user-presence, not code-identity;
+  any same-user process that pops the prompt can read. This doc is about not
+  *gratuitously* widening that to "and it's in the agent's transcript too."
+
+## Decision
+
+Keep the two paths **structurally separate and named**: Path A (`exec` / `--secrets`)
+is the default for every agent-driven flow and never materializes; Path B
+(`view --reveal`, plus the deliberately-ungated raw-item `get <item>` that fleet shell hooks capture into their own variables) exists for deliberate use, and
+that restriction is now **enforced, not just advisory** — both refuse outright
+under an agent invocation context, and the two commands that used to materialize
+with no such gate (`export --plaintext` shell-eval, `get <bundle> <KEY>`) are
+removed outright (RUSH-2774). The design guarantee is that *reaching for a normal
+secrets-injecting command cannot accidentally print a secret into an agent's
+context* — materialization is no longer an opt-in an agent could reach for at
+all, only a refusal-gated command a human can run at a real terminal.
+
+## See also
+
+- [secrets.md](secrets.md) — full reference (commands, backends, recipes, ACL threat model)
+- [secrets-agent-process-model.md](secrets-agent-process-model.md) — where the broker lives as a process

--- a/cli/docs/self-healing.md
+++ b/cli/docs/self-healing.md
@@ -1,0 +1,209 @@
+# Self-Healing Installs
+
+How agents-cli keeps a managed agent runnable when its install goes bad — detecting, surfacing, and repairing a broken binary instead of dying with a cryptic error.
+
+> This covers the *runtime integrity* of agent CLIs agents-cli installs. For the
+> normal install/pin/switch mechanics see [Version management](version-management.md).
+
+## The failure it fixes
+
+Several first-class agents ship their real (native) binary as an **optional
+per-arch npm dependency**. Codex is the canonical case:
+
+```
+@openai/codex                       # the package `agents add codex` installs
+  bin/codex.js                      # a thin JS wrapper (this is node_modules/.bin/codex)
+  optionalDependencies:
+    @openai/codex-darwin-arm64      # the ACTUAL binary ships here, in its `vendor/` tree
+    @openai/codex-linux-x64
+    ...
+```
+
+The wrapper `require.resolve`s the platform package and `spawn`s the native
+binary inside its `vendor/` tree. That layout has a blind spot: if the platform
+package's tarball extracts **partially** — an interrupted install, a flaky
+network, or two `agents add codex` runs racing into the same version dir — the
+package's `package.json` lands (so `require.resolve` succeeds) while the
+`vendor/.../codex` binary does not. The wrapper sails **past its own
+"missing optional dependency" guard** and `spawn`s a file that isn't there:
+
+```
+Error: spawn .../@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex ENOENT
+```
+
+Two things made this nasty before self-healing:
+
+1. **A gutted install looked healthy.** `getBinaryPath()` (and therefore
+   `isVersionInstalled()`) only checks the JS wrapper at `node_modules/.bin/<cli>`,
+   which *is* present. So the broken version got recorded as installed, pinned as
+   the default, and picked to run.
+2. **The crash was invisible under the opt-in tmux wrap.** The `pane-died` hook
+   detached the client the instant the agent exited, leaving only a bare
+   `[detached (from session …)]` with no error text.
+
+## Three layers of defense
+
+```
+  agents add <agent>@<ver>                 agents run <agent>
+        │                                        │
+        ▼                                        ▼
+  ┌───────────────────┐                  ┌───────────────────┐
+  │ LAYER 1           │                  │ LAYER 2           │
+  │ install-integrity │                  │ launch self-heal  │
+  │ gate              │                  │ (ensureAgentRunn- │
+  │                   │                  │  able)            │
+  │ probe the binary; │                  │ probe → repair →  │
+  │ FAIL the install  │                  │ fall back →       │
+  │ if it can't run — │                  │ install latest    │
+  │ never pin a       │                  │ → else error      │
+  │ broken version    │                  └─────────┬─────────┘
+  └───────────────────┘                            ▼
+                                          ┌───────────────────┐
+                                          │ LAYER 3           │
+                                          │ surface failures  │
+                                          │                   │
+                                          │ recap the dead    │
+                                          │ tmux pane's real  │
+                                          │ error + exit code │
+                                          │ instead of a bare │
+                                          │ [detached]        │
+                                          └───────────────────┘
+```
+
+Layer 1 stops broken installs from ever being recorded. Layer 2 repairs one that
+already exists (or slips past, e.g. a version that broke *after* install). Layer 3
+guarantees that whatever residual failure reaches the user is *visible*, not
+swallowed.
+
+### Layer 1 — install-integrity gate
+
+After a successful `npm install`, `installVersion()`
+([`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts)) probes the resolved binary via
+`verifyInstalledBinaryLaunches()`. If it can't launch, the install returns
+`success: false` and its `node_modules` is removed — so a gutted install is
+**never** recorded as healthy and its caller never sets it as the default pin.
+
+### Layer 2 — launch self-heal
+
+`ensureAgentRunnable()` runs on the `agents run` path
+([`src/commands/exec.ts`](../src/commands/exec.ts)), right after the version to
+launch is resolved and **before** the launch command is built:
+
+```
+ensureAgentRunnable(agent, version):
+
+  npm-package agent?  ─── no ──▶ return version    (grok/droid: global/native binary, N/A)
+        │ yes
+        ▼
+  verifyInstalledBinaryLaunches(version)
+        │
+   ┌────┴─────┐
+ healthy    broken
+   │          │
+ return     clean reinstall IN PLACE            (wipe node_modules first —
+ version     (installVersion, { clean:true })    npm skips a present-but-gutted
+   │          │                                   platform package otherwise)
+   │     ┌────┴─────┐
+   │  healthy    still broken
+   │     │          │
+   │  return     for each other installed version, newest-first:
+   │  version       └─ verifyInstalledBinaryLaunches → if healthy:
+   │                     setGlobalDefault(cand); return cand   (re-pin so the
+   │                     │                                       shim path heals too)
+   │                     ▼ none healthy
+   │                  install `latest` (clean); pin it; return it
+   │                     │ still fails
+   │                     ▼
+   │                  return null  ──▶  clear error: "not runnable and could not
+   │                                     be repaired. Try: agents add <agent>@latest"
+   ▼
+ (spawn the healed version)
+```
+
+The healed version is then adopted explicitly, so a fallback that re-pins the
+**global** default is not defeated by a **project** pin (`resolveVersion` prefers
+the project pin).
+
+### Layer 3 — surface failures
+
+`runInTmux()` ([`src/lib/exec.ts`](../src/lib/exec.ts)) recaps a dead pane's last
+output (read from scrollback via `capture-pane -S -200`, because the pane's
+visible screen is just the "Pane is dead" banner) plus the exit code to stderr —
+so a launch that still fails lands in the caller's shell instead of a bare
+`[detached]`. A fast failure (dead before attach) always recaps; a post-attach
+**nonzero** exit recaps too; a clean exit or a manual `Ctrl-b d` detach stays
+quiet. Interactive runs spawn directly by default. On a device where
+`tmux.enabled` is on, `--no-tmux` / `--disable-tmux` (or `AGENTS_NO_TMUX=1`)
+bypasses the wrapper for one run, and `agents config set devices.<name>.tmux off`
+turns it off durably on that machine.
+
+## The health probe
+
+The whole system rests on one narrow judgement:
+`verifyInstalledBinaryLaunches()` runs `<binary> --version` under the version's
+isolated `HOME`. Because the `ENOENT` originates in the *child* (the wrapper
+spawns fine, then fails to exec the absent native binary), the probe inspects the
+child's **output**, not merely whether the spawn succeeded.
+
+`isMissingBinarySignature()` decides "broken", and it is deliberately narrow —
+only the missing-file signature counts:
+
+```
+/\bENOENT\b | no such file | cannot find | command not found | is not recognized/i
+```
+
+Everything else is treated as **healthy**: an ordinary nonzero exit (an agent
+that dislikes `--version`) or a timeout (an agent that waits for input) must never
+be mistaken for a gutted install. This asymmetry is intentional — a false
+"healthy" costs a visible ENOENT that Layers 2/3 still catch, whereas a false
+"broken" would needlessly reinstall (Layer 2) or **wipe a good install**
+(Layer 1). The bias is toward never destroying a healthy install.
+
+## Scope and limits
+
+| Aspect | Behavior |
+|---|---|
+| Agents covered | npm-package agents only (the `optionalDependencies` failure class). Agents with a global/native binary (grok → `~/.grok/downloads`, droid → `~/.local/bin`) are returned unchanged. |
+| Windows | The probe **short-circuits to healthy on `win32`**. `getBinaryPath` returns the extensionless `.bin/<cli>` shell wrapper, which isn't directly `execFile`-able there; probing it would ENOENT on a healthy install and Layer 1 would wipe it. `isVersionInstalled` still validates presence on Windows via `getPackageBinaryPath`. |
+| Entry path | Self-heal runs on **`agents run`**. The bare-shim path (typing `codex` directly) relies on the shim's own auto-install plus Layer 1 — it does not call `ensureAgentRunnable`. |
+| Cost | One `--version` spawn per local run for npm agents (fast for a healthy binary). A repair triggers a real `npm install`. |
+| Repair vs. fallback | In-place repair re-fetches the whole tarball; if a specific version is un-fetchable (yanked/offline), self-heal falls back to another installed version rather than blocking the run. `home/` (conversation history) is always preserved across a clean reinstall. |
+
+## Nothing to heal — the harness is not installed at all
+
+Self-heal only runs when a version resolved. With no version, `agents run` used to
+fall through and spawn the bare `cliCommand`, dying as
+`sh: 1: exec: cursor-agent: not found` behind a `⚠ <agent> looks logged out`
+banner that was also wrong — the harness was absent, not signed out (RUSH-2339).
+
+`agents run` now probes the executable it is about to spawn (`resolveLaunchBinary`,
+[`src/lib/exec.ts`](../src/lib/exec.ts)) and exits `1` before any spawn:
+
+```
+agents: cursor is not installed on this machine.
+Install it with: agents add cursor
+```
+
+The probe answers **does this executable exist**, never "does agents-cli manage a
+version" — those are different questions, and two supported states depend on the
+difference:
+
+| State | Resolves to | Why |
+|---|---|---|
+| Managed version home | the versioned shim, else the version home binary | mirrors what `buildExecCommand` puts in `cmd[0]` |
+| Self-installed (Homebrew, vendor `curl \| sh`, distro package) — no version home | the PATH binary | a supported install; keying on `listInstalledVersions().length` would break it |
+| Managed version(s) installed, none pinned as default | the dispatcher shim | the shim resolves the version itself and prints its own `agents use <agent> <version>` guidance — accurate, so it is not pre-empted |
+| Nothing installed; only a leftover dispatcher shim on PATH | `null` → fail loud | the shim is a dead end here; this is the RUSH-2339 case |
+
+## Source map
+
+| Piece | Location |
+|---|---|
+| `ensureAgentRunnable()` — the self-heal engine | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
+| `resolveLaunchBinary()` — the not-installed probe | [`src/lib/exec.ts`](../src/lib/exec.ts) |
+| `verifyInstalledBinaryLaunches()` — the launch probe | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
+| `isMissingBinarySignature()` — the "broken" classifier | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
+| `installVersion(..., { clean })` — Layer 1 gate + wipe-then-reinstall | [`src/lib/installations/versions.ts`](../src/lib/installations/versions.ts) |
+| Self-heal wiring on the run path | [`src/commands/exec.ts`](../src/commands/exec.ts) |
+| `runInTmux()` dead-pane recap (Layer 3) | [`src/lib/exec.ts`](../src/lib/exec.ts) |
+| Tests | `src/lib/versions-integrity.test.ts`, `src/lib/tmux/session.test.ts`, `src/lib/exec.test.ts` |

--- a/cli/docs/self-healing.md
+++ b/cli/docs/self-healing.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Self-Healing Installs
 
 How agents-cli keeps a managed agent runnable when its install goes bad — detecting, surfacing, and repairing a broken binary instead of dying with a cryptic error.

--- a/cli/docs/ssh-transport.md
+++ b/cli/docs/ssh-transport.md
@@ -1,0 +1,300 @@
+# SSH transport — one multiplexed engine (design decision)
+
+> Status: **accepted** · Related: [hosts.md](hosts.md), [optimizations.md](optimizations.md#opt-02-ssh-transport--one-multiplexed-engine), [concepts.md](concepts.md#devices--hosts)
+
+A design record for *how `agents` talks to remote machines over SSH*. Every
+remote surface — `run --device`, `view/usage/cost/doctor/inspect/list/sync --device`,
+`sessions -D`, `teams … --device`, remote `secrets`, the browser CDP tunnel — moves
+bytes over the system `ssh`. This doc pins down the one transport they all share,
+and why it is a set of shared primitives rather than a daemon.
+
+## Context
+
+The fleet is driven from a laptop — frequently an 8 GB MacBook — that fans out to
+Macs, Linux boxes, and a Windows mini over Tailscale. The scarce resource is not
+the remote machine's CPU. It is **local**: every `ssh` the CLI forks is a process
+in the laptop's table, a TCP socket, an ephemeral port, and a full public-key
+handshake against the laptop's kernel and CPU. A transport that reopens a
+connection per logical operation turns a quiet "watch this run" into thousands of
+handshakes an hour on the one machine the user is actually sitting at.
+
+The transport already funnelled through a single hardened choke point,
+`sshExec`/`sshStream` in [`src/lib/ssh-exec.ts`](../src/lib/ssh-exec.ts), and
+OpenSSH connection multiplexing (`ControlMaster`) was already implemented there.
+The problem was that it was **opt-in** and almost nobody opted in.
+
+## Goals / non-goals
+
+**Goals**
+
+- One connection strategy for every remote surface, defined in one place.
+- Minimize *local* cost: process spawns, sockets, handshakes, zombie connections.
+- No new always-on service, port, or protocol to run on every Mac and Linux box.
+- No behavior regressions; multiplexing must never make a reachable host unreachable.
+
+**Non-goals**
+
+- A bespoke agent/relay daemon (see [Alternatives](#alternatives-considered)).
+- Parallelizing the multi-host fan-out (it is deliberately serial — one `ssh`
+  alive at a time is memory-safe on a small laptop; latency is the accepted cost).
+- Changing the detached-dispatch model (`nohup` + offset-tail) that lets a remote
+  job survive a dropped connection — that design is orthogonal and stays.
+
+## The problem, with evidence
+
+Multiplexing was gated behind `multiplex: true` and only 3 of ~13 call paths
+passed it. The un-multiplexed callers were precisely the hot ones:
+
+| # | Where | Cost before |
+|---|---|---|
+| P1 | `followHostTask` ([`progress.ts`](../src/lib/hosts/progress.ts)) — the poll behind every `run --device` / `teams … --watch` | **2 un-muxed ssh / 1.5 s ≈ 4,800 process spawns/hour**, per followed job |
+| P2 | `ensureHostReady` ([`ready.ts`](../src/lib/hosts/ready.ts)) — runs before every dispatch | **3 sequential connections** (reachable + version + agent listing), 2 un-muxed |
+| P3 | `sshExec`/`sshStream` default | multiplexing opt-in; the common paths skipped it |
+| P4 | `runRemoteSessions` ([`session/remote/remote.ts`](../src/lib/session/remote/remote.ts)) | a **private copy** of the ssh options with no multiplexing |
+| P5 | secrets push, the `-N` tunnel, and other direct `spawn('ssh')` sites | bypass the choke point; some under-specified (no `ConnectTimeout`) |
+| P6 | `devices add` / host enrollment ([`lib/hosts/registry.ts`](../src/lib/hosts/registry.ts)) | a duplicate reachability probe |
+| P7 | `SSH_OPTS` | no keepalive — a dropped link hangs instead of dying |
+
+## Design
+
+The transport is **two shared primitives, and everything composes from them.**
+
+### 1. One hardened baseline: `SSH_OPTS`
+
+```
+StrictHostKeyChecking=accept-new   BatchMode=yes   ConnectTimeout=10
+ServerAliveInterval=15   ServerAliveCountMax=3          ← keepalive (P7)
+```
+
+Every `ssh` in the codebase composes this list — directly through
+`sshExec`/`sshStream`, or as `[...SSH_OPTS, …extra]` in the handful of callers
+that need `-L`/`-N`/`ProxyCommand`. The keepalive means a silently-dropped
+connection (laptop sleeps, Wi-Fi flips) is detected and the `ssh` process exits
+within ~45 s (`15 × 3`) instead of pinning a zombie process + socket on the
+laptop. Long-lived `-N` tunnels inherit it by composing the same baseline.
+
+### 2. One multiplex helper: `controlOpts()`, default-on
+
+```
+ControlMaster=auto   ControlPath=~/.agents/.cache/ssh/cm-%C   ControlPersist=60s
+```
+
+The first connection to a host opens a control socket; every later connection —
+even from a *separate* `agents` invocation — rides it, skipping the TCP+auth
+handshake. This is now the **default** (`opts.multiplex === false ? [] :
+controlOpts()`); a caller opts *out* only for a genuine one-shot where a lingering
+60 s master is pure overhead. Flipping this one default is what fixes P1's poll,
+P2's probes, and P4's fan-out at once — they already routed through the engine and
+simply started reusing sockets. It degrades safely: if the socket can't be opened
+ssh falls back to a fresh connection, and on Windows (no `ControlMaster`) the
+helper returns `[]`.
+
+### 2b. Host-key pinning: a managed `known_hosts` (RUSH-1767)
+
+`accept-new` in the baseline is trust-on-first-use: it silently accepts whatever
+key answers on the first connect and never re-checks it, so a
+machine-in-the-middle present in that window is trusted forever. The CLI keeps its
+own `known_hosts` store — `~/.agents/.cache/devices/known_hosts` (mode 0600),
+separate from `~/.ssh/known_hosts` — so a device's key can be *pinned*
+([`known-hosts.ts`](../src/lib/devices/known-hosts.ts)):
+
+```
+UserKnownHostsFile=<managed store>   StrictHostKeyChecking=yes   ← once pinned
+UserKnownHostsFile=<managed store>   StrictHostKeyChecking=accept-new  ← first connect
+```
+
+`agents ssh <device>` learns the key on first connect (`accept-new`, written into
+the managed store) and verifies it with `StrictHostKeyChecking=yes` on every
+subsequent connect — a later key swap is refused, not re-accepted. Native OAuth
+and session credentials never cross this transport: `run --device --copy-creds`
+is retained only as a fail-loud deprecated flag. Explicit portable provider
+account sync (`agents accounts sync <account> --device <device>`) requires the destination
+to already be present in the managed store and uses a fresh, non-multiplexed SSH
+connection. A registered device earns its pin by connecting once with
+`agents ssh <device>` and verifying the host before syncing an account.
+**Remaining:** the broad `accept-new` baseline still governs
+non-credential fan-outs (`sessions --device`, the browser driver, `fleet run`),
+which still use OpenSSH default `~/.ssh/known_hosts`, not the managed store, so
+they neither pin into it nor verify against it. Wiring those call sites onto the
+managed store (so they verify strictly too) is follow-up.
+
+### 2c. One resolver: a token → the same target string everywhere (RUSH-1967)
+
+Multiplexing (§2) only reuses a socket when two calls hand `ssh` the **same
+target string** — `%C` hashes local-host/remote/port/user, so `mac-mini`,
+`muqsit@mac-mini.<tailnet>.ts.net`, and a stale `~/.ssh/config` LAN IP for the
+same box each hash to a different `cm-%C` socket and never share the master. A
+`--device` token therefore has to resolve to one canonical target no
+matter which subcommand typed it.
+
+It used to resolve through **two** disagreeing chains: a local-provider-first
+`resolveHost` (`run --device`, the generic passthrough, teams placement, doctor,
+funnel, remote secrets) and a devices-only `resolveSshTarget` (`sessions --device`,
+session bundles, `agents ssh`). They emitted different strings for the same
+machine — `resolveHost` let an ssh-config stanza win and dialed its bare name,
+while the devices chain dialed the Tailscale `user@dnsName` — so the two never
+shared a `%C` socket and could even dial two different boxes.
+
+Both are now one core, [`matchHost`](../src/lib/hosts/registry.ts). It merges the
+directories **per-field** instead of letting one provider shadow the other:
+
+| Field | Source of truth |
+|---|---|
+| address, OS, presence, dispatchable | the live **devices** registry |
+| capability tags, OS hint (when the device platform is unknown) | the agents.yaml **overlay** |
+| a host Tailscale never saw | **ssh_config** (dial the bare name; ssh applies the stanza) |
+
+One grammar for every caller — `name`, `user@name`, a tailnet FQDN, an ssh_config
+alias, and a literal `user@host` all resolve identically. `resolveHost` (dispatch),
+`resolveExplicitTargets` (fan-out), and `resolveDeviceTarget` (`agents ssh`) are
+thin wrappers that differ only in the shape they return and which literal
+fallbacks they permit. Because the address always comes from the live registry,
+`agents devices sync` takes effect without re-enrolling, and a password-auth
+device can't be made dispatchable by shadowing it with an inline entry.
+
+### 2d. Interactive login mirrors the caller's project directory (RUSH-2412)
+
+`agents ssh <device>` with **no command** lands you in the same home-relative
+directory you launched from, when that checkout exists on the target — the same
+portable-cwd rule `agents run --device` already applies. From
+`~/src/app` on the laptop, `agents ssh yosemite-s0` starts the remote login shell
+in `~/src/app` on yosemite-s0; when that path is absent it falls back to the
+remote home, and the login always succeeds.
+
+There is **one** resolver behind both surfaces. The caller cwd becomes a portable
+`~/…` path with [`deriveMirroredCwd`](../src/lib/project-root.ts) (only a path
+under the local home has a meaningful remote analogue; anything else mirrors
+nothing and keeps the remote home). For POSIX targets the interactive-login
+builder [`buildInteractiveShellCommand`](../src/lib/devices/connect.ts) reuses the
+same best-effort [`remoteCdPrefix`](../src/lib/project-root.ts) mirror `--device`
+runs use — `{ cd "$HOME"/<dir> || cd "$HOME"; } &&` — then `exec "$SHELL" -l` so
+prompt, startup files, and login behavior match a plain `ssh <host>`.
+`"$HOME"` stays unquoted so the *remote* shell expands it (the target home may
+differ, `/home/<me>` vs `/Users/<me>`), and the remainder is shell-quoted, so a
+path with spaces or metacharacters is literal and injection-safe. PowerShell
+targets get a profile-loading interactive shell (`-NoExit`) that `Set-Location`s
+into the mirrored dir when `Test-Path` confirms it, with the path carried through
+`-EncodedCommand`. The `-tt` forced tty that makes an interactive login work is
+allocated whether or not a mirror command is injected.
+
+An **explicit** `agents ssh <device> <cmd…>` is unchanged: the command keeps the
+remote home and its cwd is never silently rewritten — mirroring is interactive-
+login-only.
+
+### 3. The follow loop: one persistent stream (P1)
+
+The original loop made two calls per cycle — `tail -c +offset` for new log bytes,
+then `cat .exit`. PR #551 first rewrote that to a single round-trip:
+
+```
+tail -c +<offset> <log>;  printf '<sentinel>';  cat <exit>
+```
+
+`splitProgressBytes` splits the response on the **last** occurrence of a
+per-task sentinel (`@@AGENTS_HOST_EXIT_<taskId>@@`), so the log tail, an end
+marker, and the exit code come back together and are separated without ever
+miscounting the byte offset (the marker and exit bytes come from `printf`/`cat`,
+never the log). Splitting on the *last* marker means even if the agent's own
+output echoed the token, the real trailing sentinel still wins. The sentinel's
+`printf` format is derived from the same `exitMarker()` the parser uses, so the
+two can never desync. That helper remains for non-interactive consumers that need
+a bounded poll.
+
+The interactive follow path now uses one long-lived stream:
+
+```
+tail -c +<offset> -f <log>        # stdout: raw log bytes
+watch <exit>; printf <sentinel>; cat <exit> >&2
+```
+
+Stdout is pure log data, so the local follower can echo and mirror chunks as soon
+as they arrive. The terminal frame rides stderr after the remote watcher sees a
+non-empty `.exit`; the local parser extracts the exit code from that frame. If
+the ssh stream drops before the frame, the follower reconnects from the byte
+offset already flushed locally. A local timeout aborts the ssh process; the
+remote shell traps exit/HUP/TERM and kills its background `tail`.
+
+### 4. Readiness: three round-trips to one (P2)
+
+`readyProbe` replaces the reachable → version → agent-listing sequence with one
+compound `bash -lc` script. Reachability keys off the returned sentinel, not the
+exit code — so a command that *ran but failed* is never misread as a dead
+connection, and only ssh's own connection-layer failure (no sentinel) reads as
+unreachable.
+
+## Alternatives considered
+
+**A bespoke daemon / relay on every host.** Rejected. It would add a socket
+server, a port or tunnel, a custom wire protocol, and its own auth to every Mac
+and Linux box — for no capability SSH doesn't already give us. SSH is more
+*reliable* (battle-tested, no long-lived process to crash or double-run, host-key
+trust + auth + encryption for free) and, with multiplexing, just as *fast* for
+repeated calls. Reliability for long jobs already comes from detached `nohup`
+dispatch, which survives a dropped connection without any daemon. The scheduling
+daemon stays scoped to scheduling.
+
+**Parallel multi-host fan-out.** Rejected as a default. On a small laptop, N
+concurrent `ssh` processes trade the one resource we are protecting (local
+memory/process pressure) for latency we can tolerate. The serial loop keeps at
+most one `ssh` alive; multiplexing already removes the repeat-handshake cost.
+
+**A persistent `tail -f` stream for follow.** Accepted for interactive follows
+after the PR #551 combined-round-trip change proved the protocol boundary. The
+extra complexity is contained in `progress.ts`: stdout is raw log bytes, stderr
+carries only the terminal frame, and reconnects resume from the saved byte
+offset.
+
+## Results
+
+Measured against a live Tailscale-relayed host (`scripts/bench-ssh.mjs`), stable
+across runs. Each number is wall-clock on the laptop:
+
+| Path | Before | After | Win |
+|---|---|---|---|
+| P3 · repeated `--device` (per call) | ~444 ms | **~75 ms** | **~6–7×** |
+| P2 · readiness per dispatch | 1.5–1.8 s | **~0.8 s** | **~2×** |
+| P1 · follow loop (per cycle) | ~706 ms | **~33 ms**, then **1 ssh per follow** | **~21–23×** for bounded polls; persistent follow removes per-cycle spawns |
+
+The P1 figure is the first-step headline: an old cycle paid two fresh handshakes
+(~706 ms on a relayed link); the combined poll rides the reused socket (~33 ms).
+Interactive follow goes further and holds one socket open for the whole run, so a
+quiet hour-long follow no longer creates one local ssh process per poll cycle.
+
+Reproduce: `bun run build && node scripts/bench-ssh.mjs <host>`.
+
+## Trade-offs and risks
+
+- **A 60 s master lingers after each call.** `ControlPersist=60s` keeps an idle
+  master briefly so back-to-back commands reuse it. The cost is bounded (one idle
+  unix socket per recently-touched host, reaped after 60 s) and is the entire
+  point. An interactive one-shot that must not leave a master can pass
+  `multiplex: false`.
+- **Keepalive terminates a live-but-silent connection after ~45 s.** Intended: a
+  genuinely idle-but-healthy link is re-established on the next call for near-zero
+  cost via the control socket; a dead one no longer hangs.
+- **Sentinel-based framing** assumes the remote login shell runs (a `bash -lc`
+  assumption shared by every remote call in the codebase). A bash-less remote
+  reads as unreachable — the same failure the old code produced, with a clearer
+  message.
+- **Streaming follow has up to one remote poll interval of finish latency.** The
+  remote watcher checks `.exit` once per second, then gives `tail -f` one more
+  interval to flush final bytes before emitting the terminal frame. That buys
+  deterministic final-output capture while still removing local per-cycle ssh
+  churn.
+
+## Rollout and future work
+
+Shipped as one PR: the engine change plus every consumer, unit tests, an A/B
+benchmark harness, and this doc. Behavior-preserving — the only observable change
+is that remote commands are faster and dead connections self-terminate.
+
+Follow-ups (non-blocking):
+
+- Remove the now-unused `sshReachable` export.
+- Keep specialized direct-`ssh` sites (for example `-L`/`-N` tunnels,
+  `ProxyCommand` relays, and browser CDP) composed from
+  `sshConnectOpts(...)` so they inherit the shared baseline while preserving
+  their required extra flags.
+- Consider moving cloud task streaming from bounded polling to the same
+  persistent follow protocol once its async event generator can share the
+  terminal-frame plumbing.

--- a/cli/docs/ssh-transport.md
+++ b/cli/docs/ssh-transport.md
@@ -1,6 +1,7 @@
+<!-- guide -->
 # SSH transport — one multiplexed engine (design decision)
 
-> Status: **accepted** · Related: [hosts.md](hosts.md), [optimizations.md](optimizations.md#opt-02-ssh-transport--one-multiplexed-engine), [concepts.md](concepts.md#devices--hosts)
+> Status: **accepted** · Related: [hosts.md](hosts.md), optimizations.md, [concepts.md](concepts.md#devices--hosts)
 
 A design record for *how `agents` talks to remote machines over SSH*. Every
 remote surface — `run --device`, `view/usage/cost/doctor/inspect/list/sync --device`,

--- a/cli/docs/subagents.md
+++ b/cli/docs/subagents.md
@@ -1,0 +1,167 @@
+# Subagents
+
+Lightweight named agent definitions that parent agents can spawn for focused subtasks.
+
+## Overview
+
+A subagent is a directory in `~/.agents/subagents/<name>/` containing an `AGENT.md` file with YAML frontmatter and an instruction body. Parent agents whose capability matrix declares `subagents` (see `capableAgents('subagents')` in `src/lib/capabilities.ts` — today Claude, Codex, Cursor, OpenCode, OpenClaw, Copilot, Kiro, Goose, Antigravity, Grok, Kimi, and Droid) discover installed subagents and can spawn them using their native task-dispatch mechanism (e.g., Claude's `Task()` tool). Each subagent definition specifies a model, a display color, and a focused instruction set. The resource resolution order is `project > user > system`, matching every other resource kind.
+
+Subagents are one of three patterns for specialization. Plugins can bundle subagent definitions alongside skills and hooks. Workflows declare `allowedAgents` in their frontmatter to constrain which subagents the orchestrator can reach. In all cases the on-disk format is the same `AGENT.md` file.
+
+**How an agent's subagents are stored is declared once, declaratively.** Two things gate a subagent integration: the `subagents` capability flag on `AgentConfig` (`src/lib/agents.ts`) is the *version gate*, and a single entry in the **subagent-target registry** (`src/lib/subagents-registry.ts`, `SUBAGENT_TARGETS`) is the *shape* — target dir, file/dir layout, transform, ownership marker. All install / list / detect / orphan / remove logic is generic over that table, so adding a standard integration is one registry entry, not near-identical `else if (agent === '...')` arms across the writer, detector, and `subagents.ts`. A test pins `Object.keys(SUBAGENT_TARGETS)` to `capableAgents('subagents')` so the two can never drift.
+
+For the sync model that governs how subagents reach version homes, see [resource-sync.md](resource-sync.md).
+
+## Architecture
+
+```
+Central storage (project > user > system):
+  ~/.agents/subagents/<name>/          User-scoped
+  .agents/subagents/<name>/            Project-scoped
+  ~/.agents-system/subagents/<name>/   System-shipped
+
+  <name>/
+    AGENT.md                           Required: frontmatter + instruction body
+
+                      agents subagents add / agents use
+                     (generic engine iterates SUBAGENT_TARGETS)
+                                  │
+                                  ▼
+  <version-home>/                    (target dir + shape per registry entry)
+    .claude/agents/<name>.md         flat-file  (Claude flatten)          [Tier 1]
+    .codex/agents/<name>.toml        flat-file  (Codex TOML)              [Tier 1]
+    .cursor/agents/<name>.md         flat-file  (no color)                [Tier 1]
+    .grok/agents/<name>.md           flat-file  (Claude-compatible)       [Tier 2]
+    .factory/droids/<name>.md        flat-file  (Droid custom droid)      [Tier 2]
+    .copilot/agents/<name>.agent.md  flat-file  (Copilot custom agent)    [Tier 2]
+    .kiro/agents/<name>.json         flat-file  (Kiro JSON)               [Tier 2]
+    .config/opencode/agents/<name>.md   flat-file (OpenCode)             [Tier 2]
+    .config/goose/agents/<name>.yaml    flat-file (Goose recipe)         [Tier 3]
+    .gemini/config/agents/<name>/agent.md   dir-file (Antigravity)       [Tier 3]
+    .openclaw/<name>/AGENTS.md       dir-copy   (AGENT.md → AGENTS.md)    [Tier 2]
+    .kimi-code/agents/<name>.md      flat-file  (Kimi, kimi-code >= 0.29.0)  [Tier 3]
+
+                      Parent agent session (Claude example)
+                                  │
+                                  ▼
+  Parent reads .claude/agents/*.md catalog
+  Spawns subagent via Task() with subagent's model + instructions
+  Subagent executes with its own focused instruction set
+```
+
+## Integration tiers
+
+Not every "wire subagents for X" is worth equal effort. Integrations are tiered by
+importance so a "wire X" ticket can be scoped by tier instead of treated
+identically — the long tail should cost far less than the core.
+
+| Tier | Agents | What it means for a "wire X" ticket |
+|------|--------|-------------------------------------|
+| **Tier 1 — core** | `claude`, `codex`, `cursor` | First-class. Full support; bespoke transform/format work where the native format demands it. New subagent capabilities land here first. |
+| **Tier 2 — established** | `openclaw`, `grok`, `droid`, `copilot`, `kiro`, `opencode` | Supported, ride the generic registry path. A bespoke `transform` only where the on-disk format differs — never bespoke install/list/remove logic. |
+| **Tier 3 — long-tail** | `goose`, `antigravity`, `kimi` | Config-only; spend the minimum. A new one is a single `SUBAGENT_TARGETS` entry. `kimi` is a plain `flatFile` writing Claude-shaped `<name>.md`; the pre-0.29.0 files agents-cli used to write there (a `<name>.yaml` + `<name>.system.md` pair and an `_agents-cli.yaml` index) are folded once by `migrateKimiSubagentsToMarkdown` in `lib/installations/migrate.ts`, never by the target. |
+
+**Adding a standard integration (Tier 2/3) is one entry, not six edits.** Give the
+agent a `subagents` gate in `src/lib/agents.ts`, add one entry to `SUBAGENT_TARGETS`
+in `src/lib/subagents-registry.ts` via a layout builder (`flatFile` / `dirFile` /
+`dirCopy`), and — only if the native format is bespoke — a
+`transformSubagentFor<Agent>` in `src/lib/subagents.ts`. The staleness writer, the
+detector, `listSubagentsForAgent`, `diffVersionSubagents`, and
+`removeSubagentFromVersion` are all generic over the table, so they need no new
+arm. The completeness test (`subagents-registry.test.ts`) fails if the capability
+flag and the registry entry ever disagree.
+
+## Command Reference
+
+| Command | Description |
+|---------|-------------|
+| `agents subagents list` | Table of all installed subagents with sync status across agent versions |
+| `agents subagents view [name]` | Details for one subagent: model, color, file list, sync status |
+| `agents subagents add <source>` | Install from GitHub (`gh:user/repo`) or local path, sync to agent versions |
+| `agents subagents remove [name]` | Delete from central storage and unsync from all agent versions |
+
+### Options
+
+| Command | Flag | Effect |
+|---------|------|--------|
+| `add` | `-a, --agents <agents...>` | Target specific agents: `claude`, `openclaw`, `kiro`, `cursor` (defaults to all capable) |
+| `add` | `-y, --yes` | Skip all prompts and confirmation |
+| `remove` | `-y, --yes` | Skip confirmation prompt |
+
+## AGENT.md Schema
+
+The `AGENT.md` file uses YAML frontmatter followed by the instruction body. The frontmatter maps to `SubagentFrontmatter` in `src/lib/types.ts:416`.
+
+```markdown
+---
+name: code-reviewer
+description: Reads changed files and surfaces bugs, missing tests, and scope creep.
+model: claude-opus-4-7
+color: cyan
+---
+
+You are a focused code reviewer. Your job is to read the diff and the full
+context of every changed file, then produce a structured review with:
+
+- Critical: bugs, regressions, security issues (cite file:line)
+- Concerns: scope creep, missing tests, architectural drift
+- Verdict: Approve / Request changes / Comment
+
+Do not modify any files. Do not commit. Read only.
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Canonical name; must match the directory name |
+| `description` | string | yes | One-line shown in `agents subagents list` |
+| `model` | string | no | Model to use when the subagent is spawned (e.g. `claude-opus-4-7`) |
+| `color` | string | no | Terminal display color for the subagent badge |
+
+Additional `.md` files in the same directory (e.g., `TOOLS.md`, `MEMORY.md`) are collected as supplementary context. All `.md` files in the directory are counted in the `files` field of `InstalledSubagent`.
+
+## Recipes
+
+**1. List installed subagents**
+
+```bash
+agents subagents list
+```
+
+**2. View details for one subagent**
+
+```bash
+agents subagents view code-reviewer
+```
+
+**3. Install from GitHub**
+
+```bash
+agents subagents add gh:team/subagents --agents claude,openclaw,kiro,cursor
+```
+
+**4. Install from a local directory**
+
+The source must contain `subagents/*/AGENT.md` entries.
+
+```bash
+agents subagents add ~/my-subagents --agents claude
+agents subagents add ~/my-subagents --yes
+```
+
+**5. Remove a subagent**
+
+```bash
+agents subagents remove code-reviewer
+agents subagents remove code-reviewer --yes
+```
+
+## Demo
+
+<video autoplay loop muted playsinline width="100%" src="../assets/videos/subagents.mp4"></video>
+
+## See Also
+
+- [resource-sync.md](resource-sync.md) — resource resolution and sync to version homes
+- [docs/workflows.md](workflows.md) — workflows that declare `allowedAgents` to orchestrate subagents
+- [docs/plugins.md](plugins.md) — plugins that bundle subagent definitions alongside skills and hooks
+- [docs/hooks.md](hooks.md) — hooks that fire on subagent lifecycle events

--- a/cli/docs/subagents.md
+++ b/cli/docs/subagents.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Subagents
 
 Lightweight named agent definitions that parent agents can spawn for focused subtasks.
@@ -162,6 +163,6 @@ agents subagents remove code-reviewer --yes
 ## See Also
 
 - [resource-sync.md](resource-sync.md) — resource resolution and sync to version homes
-- [docs/workflows.md](workflows.md) — workflows that declare `allowedAgents` to orchestrate subagents
+- docs/workflows.md — workflows that declare `allowedAgents` to orchestrate subagents
 - [docs/plugins.md](plugins.md) — plugins that bundle subagent definitions alongside skills and hooks
 - [docs/hooks.md](hooks.md) — hooks that fire on subagent lifecycle events

--- a/cli/docs/teams.md
+++ b/cli/docs/teams.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Teams
 
 Coordinate multiple AI agents working in parallel on a shared task, with DAG-based dependency scheduling and live status tracking.
@@ -140,7 +141,7 @@ remote home for you.
 | `-n, --name <name>` | Friendly name (required when using `--after`) |
 | `-m, --mode <mode>` | `plan` (read-only) \| `edit` (write files) \| `full` (write + skip prompts). Default: `edit` |
 | `-e, --effort <effort>` | `low` \| `medium` \| `high` \| `xhigh` \| `max` \| `auto`. Default: `medium` |
-| `--model <model>` | Cost tier (`cheap`\|`default`\|`best`\|`ultra`) or a concrete id (e.g. `claude-opus-4-8`); tiers resolve per harness+version to a supported model. See [Model tiers](model-tiers.md). |
+| `--model <model>` | Cost tier (`cheap`\|`default`\|`best`\|`ultra`) or a concrete id (e.g. `claude-opus-4-8`); tiers resolve per harness+version to a supported model. See Model tiers. |
 | `--env <key=value>` | Set an env var for this teammate (repeatable) |
 | `--cwd <dir>` | Working directory (default: current directory) |
 | `--worktree <name>` | Run in a dedicated git worktree (requires `--enable-worktrees` on the team) |

--- a/cli/docs/teams.md
+++ b/cli/docs/teams.md
@@ -1,0 +1,566 @@
+# Teams
+
+Coordinate multiple AI agents working in parallel on a shared task, with DAG-based dependency scheduling and live status tracking.
+
+## Overview
+
+`agents teams` groups agent processes into a named team. Each teammate runs
+in the background — Claude, Codex, Cursor, OpenCode, Grok, or
+Antigravity — against the same working directory or a dedicated git worktree.
+Teammates can declare `--after` dependencies, forming a directed acyclic graph
+(DAG) that the supervisor drains wave by wave. The state machine lives on disk
+so the supervisor can be restarted mid-flight without losing work, and
+teammates added by other processes (including agents themselves) are picked up
+on the next wave.
+
+## Architecture
+
+```
+CLI invocations                  Supervisor                   Agent processes
+(agents teams add ...)           (teams start --watch)        (claude, codex, ...)
+
+user
+  │
+  ├─ create team ─────────────▶  registry                     ~/.agents/.history/
+  │   (registry.ts)                teams/<name>.yaml            teams/agents/
+  │                                                               <uuid>/
+  ├─ add teammate ─────────────▶  meta.json (PENDING)           │  meta.json
+  │   (api.ts: handleSpawn)         status, prompt, after        │  stdout.log
+  │                                                               │  pid
+  ├─ add teammate --after bob ─▶  meta.json (PENDING)            │
+  │                                                              ...
+  └─ teams start --watch ──────▶  runSupervisor() loop
+                                   │
+                                   ├── rescanFromDisk()
+                                   ├── startReady(team)
+                                   │    ── resolve deps
+                                   │    ── spawn ready agents
+                                   ├── listByTask(team)
+                                   │    ── count pending/running/done/failed
+                                   ├── onWave(summary)
+                                   │    ── print or emit JSON
+                                   ├── wait intervalMs
+                                   └── repeat until drained
+```
+
+Teammate state transitions (from `src/lib/teams/agents.ts:109-115`):
+
+```
+PENDING ──deps resolved──▶ spawned ──▶ RUNNING ──exit 0──▶ COMPLETED
+                                                └─exit ≠0──▶ FAILED
+                                                └─stop cmd──▶ STOPPED
+```
+
+## Command Reference
+
+| Command | Alias | Description |
+|---|---|---|
+| `agents teams list [query]` | `ls` | List teams, most recent first |
+| `agents teams create <team>` | `c`, `new` | Create a new team |
+| `agents teams add <team> <agent> <task>` | `a` | Add a teammate |
+| `agents teams status [team]` | `s`, `st`, `check` | Check team progress |
+| `agents teams active` | — | All teammates running right now, across all teams |
+| `agents teams start [team]` | — | Launch pending teammates whose deps are satisfied |
+| `agents teams message <team> <teammate> <message>` | — | Send a follow-up: steers a running teammate via its mailbox, resumes a stopped one |
+| `agents teams resume <team> <teammate> [message]` | — | Resume a stopped teammate (re-enter its own session with the message) |
+| `agents teams stop [team] [teammate]` | — | Stop a running teammate (resume it later with `teams resume`) |
+| `agents teams remove [team] [teammate]` | `rm` | Remove a stopped teammate's logs |
+| `agents teams disband [team]` | `d` | Stop all teammates and delete the team |
+| `agents teams logs [teammate]` | `log` | Read a teammate's raw stdout |
+| `agents teams doctor` | `dr` | Check which agent CLIs are installed |
+
+### `teams list` options
+
+`agents teams list` renders from the cached team registry and teammate `meta.json`
+records. It does not poll remote hosts or read teammate logs while listing; choosing
+a team or running `agents teams status <team>` performs the full status read.
+
+| Flag | Description |
+|---|---|
+| `-a, --agent <agent>` | Filter to teams containing this agent (e.g. `claude` or `claude@2.1.112`) |
+| `--status <status>` | Filter by team status: `working`, `done`, `failed`, `empty` |
+| `--since <time>` | Teams active after this time (e.g. `2h`, `7d`, ISO date) |
+| `--until <time>` | Teams active before this time |
+| `-n, --limit <n>` | Max results (default 20) |
+| `--json` | Machine-readable JSON |
+
+### `teams create` options
+
+| Flag | Description |
+|---|---|
+| `-d, --description <text>` | One-line summary of what this team is working on |
+| `--enable-worktrees` | Each teammate works in its own git worktree |
+| `--use-worktree <path>` | All teammates share this existing worktree path |
+| `--devices <a,b,c>` | Distributed teams: pool of machines the team may run teammates on (alias `--hosts`). See [Distributed teams](#distributed-teams). |
+| `--repo <url\|path>` | How each **remote** (`--device`) teammate gets the code — one git URL/path for the whole team. Defaults to the local checkout's `origin`. **A team is single-repo:** for work spanning repos, make one team per repo. See [Placement & repos](#placement-and-repos). |
+| `--project <slug>` | Work the team on a defined project (`agents projects`). Its primary directory becomes each local teammate's base cwd; its other bound directories are attached as `--add-dir` grants. Validated at create time, so a slug that does not resolve fails here rather than at the first `teams add`. |
+| `--json` | Machine-readable JSON |
+
+**`--project` vs `--repo`.** They answer different questions and compose. `--repo` is
+*how a remote teammate gets the code* (clone URL / path on the host). `--project` is
+*which directories a teammate can reach* — a project may bind several checkouts, and
+the sibling ones ride along as access grants. A teammate's cwd resolves
+`worktree → --cwd → the project's primary directory → the current directory`, so an
+explicit `--cwd` or `--worktree` still wins; the grants are attached either way.
+Claude, Codex, Cursor, Kimi, and Grok consume `--add-dir` — other harnesses see the cwd alone. Full
+detail: [Projects](projects.md#a-project-is-a-set-of-directories).
+
+### Placement and repos
+
+*The part people get wrong* — the trap that turns one team into a teardown-and-rebuild.
+
+**`--remote-cwd` does NOT place a teammate or set its repo.** It rides the shared
+`--device` option family but is ignored on `teams add` (now **rejected** with
+guidance, so you find out at once instead of after building a whole team on the
+wrong model). A teammate's directory is the team's repo plus its `--worktree` —
+there is no per-teammate repo/path override. Place with `--device <host>`; set
+the code with the team's `--repo`.
+
+**A team's `--repo` is one clone source** shared by all its remote teammates
+(local teammates work in the checkout you run `add` from). If your tasks span two
+repos (e.g. `agents-cli` + a monorepo), create **one team per repo** rather than
+one team you tear down and rebuild:
+
+```bash
+agents teams create wave-cli  --repo ~/src/.../agents-cli --enable-worktrees
+agents teams create wave-mono --repo ~/src/.../monorepo   --enable-worktrees
+agents teams add  wave-cli claude "…" --name mcp --device yosemite-s0 --worktree mcp
+```
+
+For a **raw `--device` run** (not teams), `--remote-cwd` resolves on the host and is
+used verbatim: pass a single-quoted `'$HOME/…'` path (an unquoted `~` expands
+*locally* — `/Users/you` won't exist on a Linux worker) or a valid remote absolute
+path. `--cwd` is the friendlier option — it re-roots a local-home path onto the
+remote home for you.
+
+### `teams add` options
+
+| Flag | Description |
+|---|---|
+| `-n, --name <name>` | Friendly name (required when using `--after`) |
+| `-m, --mode <mode>` | `plan` (read-only) \| `edit` (write files) \| `full` (write + skip prompts). Default: `edit` |
+| `-e, --effort <effort>` | `low` \| `medium` \| `high` \| `xhigh` \| `max` \| `auto`. Default: `medium` |
+| `--model <model>` | Cost tier (`cheap`\|`default`\|`best`\|`ultra`) or a concrete id (e.g. `claude-opus-4-8`); tiers resolve per harness+version to a supported model. See [Model tiers](model-tiers.md). |
+| `--env <key=value>` | Set an env var for this teammate (repeatable) |
+| `--cwd <dir>` | Working directory (default: current directory) |
+| `--worktree <name>` | Run in a dedicated git worktree (requires `--enable-worktrees` on the team) |
+| `--device <host>` | Distributed teams: run THIS teammate on `<host>`. Works with or without a team pool. `<host>` may also be `auto` (RUSH-2185) to affinity-pick a device the same way `agents run --device auto` does — a pick that lands on this machine just runs the teammate locally, same as omitting `--device`. See [Distributed teams](#distributed-teams). |
+| `--after <names>` | Comma-separated teammate names to wait for before starting |
+| `--task-type <type>` | Factory label: `plan` \| `implement` \| `test` \| `review` \| `bugfix` \| `docs` |
+| `--cloud <provider>` | Dispatch to cloud backend: `rush` \| `codex` \| `factory` |
+| `--repo <owner/repo>` | GitHub repository (required for `--cloud rush`) |
+| `--branch <name>` | Target branch for cloud dispatch |
+| `--confirm` | Proceed even when the base checkout/repo is behind `origin/main`. Without it, a stale base [blocks the add](#stale-repo-guard). |
+| `--json` | Machine-readable JSON |
+
+### Stale-repo guard
+
+Before a teammate is bound to a repo, `teams add` fetches `origin` and checks how
+far behind `origin/<default>` the **base checkout** is — the local `--cwd` (default
+current directory) for a local teammate, or the repo provisioned on the box for a
+`--device` teammate. If it is behind, the add is **refused** with a sync command,
+because a team started on stale code reasons and builds against a tree that has
+already moved on (the real trigger: a 71-commit-stale checkout on another box that
+nobody had fetched):
+
+```
+This checkout (/repo) is 71 commits behind origin/main. A team started here would
+build on stale code — bring it up to date with remote main first:
+  git -C /repo merge --ff-only origin/main
+Then re-run `agents teams add wave …`, or pass --confirm to start on the stale repo anyway.
+```
+
+Sync the base to `origin/main` and re-run, or pass `--confirm` to start against it
+anyway (you then get a one-line advisory instead of a block). The check **fetches
+first** on purpose: a checkout nobody fetched has a stale remote-tracking ref, so a
+naive `HEAD..origin/main` would read 0 and hide the drift. An offline / unreachable
+/ non-git base can't be assessed and never blocks; cloud teammates clone fresh in
+the provider and are skipped. This is independent of the [worktree base
+freshness](#base-freshness) below — a `--worktree` teammate still forks off a
+freshly-fetched `origin/<default>` regardless, but the guard flags the base you
+pointed the team at so you keep it in sync.
+
+### `teams start` options
+
+| Flag | Description |
+|---|---|
+| `--watch` | Keep polling; fire new waves as deps complete; exit when DAG drains |
+| `--interval <seconds>` | Seconds between waves in `--watch` mode (default 8) |
+| `--max-waves <n>` | Safety cap on waves (default 1000) |
+| `--json` | Emit one JSON object per wave |
+
+### `teams status` options
+
+| Flag | Description |
+|---|---|
+| `-f, --filter <state>` | Show teammates in state: `running`, `completed`, `failed`, `stopped`, `all` (default: `all`) |
+| `-s, --since <iso>` | Cursor from a previous status call; only show updates after this timestamp |
+| `--agent-id <id>` | Show only this teammate (UUID or UUID prefix) |
+| `-v, --verbose` | Emit full per-teammate detail (prompt, all paths, all messages); default is compact |
+| `--json` | Machine-readable JSON (compact by default; pair with `--verbose` for the full shape) |
+
+### `teams logs` options
+
+| Flag | Description |
+|---|---|
+| `-n, --tail <n>` | Last N lines only |
+| `--team <team>` | Disambiguate when the same name appears in multiple teams |
+
+## Resuming a teammate
+
+A teammate often ends its turn with more to do — a PR opened and waiting on review,
+a headless run that hit a turn cap, a task you want to redirect after the fact.
+`agents teams resume` re-enters that teammate's **own** session with your message as
+the next user turn, so it picks up with full context instead of you finishing the
+work by hand or spawning a fresh, context-less teammate.
+
+```bash
+# A teammate finished with its PR open, waiting on review. Nudge it home:
+agents teams resume my-team backend "prix-cloud approved — rebase-merge the PR, then cut the release"
+```
+
+`teams message` is the same command with automatic routing by the teammate's current
+state:
+
+| Teammate state | What happens |
+|---|---|
+| running | The message is **steered** into its mailbox and delivered at its next tool call (no re-launch). |
+| completed / failed / stopped | The teammate is **resumed** — its session is re-entered with the message. |
+| pending (unmet `--after`) | Rejected — run `teams start` to launch it first. |
+
+The teammate re-launches through the same backend it first used (local process or
+remote host) in its original working directory / worktree, and flips back to
+`running` so `teams status` tracks it live again.
+
+**Every harness.** The resume delegates to `agents run --resume`, so it inherits that
+command's coverage: native resume for Claude (`--resume`) and Codex (`resume`), and a
+universal `/continue` replay for the rest (OpenCode, Grok, Kimi, …). The session id it
+resumes is the teammate's underlying agent session — captured from the agent's own
+output — so a non-Claude teammate that died before emitting its first event (no
+captured id) is refused with a clear message rather than resumed into a fresh run.
+
+## Boundary Contracts
+
+Boundary contracts are the core correctness mechanism for parallel teams. Every
+time you spawn teammates that touch the same codebase, you must declare what
+each one owns, what it must not touch, and which shared artifacts one teammate
+produces for others to consume.
+
+The format from AGENTS.md (the canonical memory file for this repo):
+
+```
+Owns       — explicit files (with line ranges where helpful)
+Must NOT   — files owned by others
+Shared deps — one canonical owner; everyone else imports
+```
+
+The **independence test**: if teammate A must wait for teammate B's output
+before A can start work, the boundary is wrong. Re-cut the split so each
+teammate can start from the same baseline, or sequence them explicitly with
+`--after`.
+
+### Why this matters
+
+Teammates coordinate via git and the filesystem only. There is no direct
+peer-to-peer communication at runtime. The boundary contract is the only
+coordination mechanism that runs before the agents start — once they are
+running, violations (two agents editing the same file) cause merge conflicts,
+test failures, or silent data loss.
+
+### Contract in practice
+
+Before spawning a team, write out the distribution plan:
+
+```
+auth teammate  — owns src/auth/* (all files)
+               — must NOT touch src/ui/*, src/api/*
+               — produces: src/auth/types.ts (shared dep)
+
+ui teammate    — owns src/ui/login.tsx
+               — must NOT touch src/auth/*
+               — imports: src/auth/types.ts (read-only)
+               — must NOT start until auth is done (use --after auth)
+```
+
+The `--after` flag enforces temporal ordering. Without `--after`, both
+teammates start on wave 1 and race. Without a boundary contract, they race
+invisibly — the contract makes the race explicit so you can cut it correctly.
+
+<a id="base-freshness"></a>
+### Worktrees and isolation
+
+When hard filesystem isolation is required, use git worktrees:
+
+```bash
+agents teams create my-feature --enable-worktrees
+agents teams add my-feature claude "..." --name alice --worktree feature-alice
+agents teams add my-feature codex  "..." --name bob   --worktree feature-bob
+```
+
+Each teammate gets its own checkout of the branch. Worktrees are cleaned up on
+`teams stop` or `teams disband` unless uncommitted changes are present, in
+which case the worktree is kept and reported.
+
+**What the worktree forks from** differs by placement, and the difference bites:
+
+| Teammate | Base of the new worktree branch |
+|---|---|
+| **local** (no `--device`) | the **freshly-fetched `origin/<default>`** (`createWorktree` runs `git fetch origin` then bases the branch on `origin/<default>` — never local `HEAD`). |
+| **remote** (`--device host`) | the host's **freshly-fetched `origin/<default>`** (`createRemoteWorktree` fetches first) — same base policy as local. |
+
+So the pre-flight for a **local** worktree team is: fast-forward your checkout to
+the default branch first. A remote team handles this itself. The
+[stale-repo guard](#stale-repo-guard) now enforces this pre-flight — it blocks a
+`teams add` whose base checkout is behind `origin/<default>` until you sync or pass
+`--confirm`.
+
+**Where a local worktree lands.** A new teammate worktree always resolves to
+`<main-repo-root>/.agents/worktrees/<name>` — the MAIN checkout's root, never
+wherever `--worktree` happened to be invoked from. `createWorktree` resolves the
+placement root via `getMainRepoRoot` (a `git rev-parse --git-common-dir` lookup,
+not `--show-toplevel`), so running `agents teams add` from inside a *different*
+teammate's own worktree — e.g. one agent orchestrating another — still places the
+new worktree as a sibling under the main repo, never nested inside the caller's
+worktree.
+
+**A failed `teams add` leaves nothing behind.** The branch is the shared resource
+here, so a half-finished add used to poison every retry: the worktree was created
+before the teammate record was written, and nothing removed it when the add
+failed, so the next `teams add` with the same `--worktree` name died on
+`fatal: a branch named 'agents/<name>' already exists`. Two guarantees now hold:
+
+- **Rejected before anything is created.** Name uniqueness and the `--after`
+  dependency graph are validated *before* `createWorktree` runs
+  (`AgentManager.validateAddPreconditions`), so a duplicate name, an unknown
+  dependency, or a cycle never gets as far as making a branch.
+- **Torn down if it fails afterward.** A failure past that point — the harness CLI
+  missing, a launch error, a cloud dispatch failure, or a `git worktree add` that
+  created the branch ref but not the checkout — removes the worktree *and* its
+  `agents/<name>` branch before the command exits non-zero.
+
+Teardown is scoped twice, because removing a live teammate's worktree would
+destroy real work rather than protect a retry:
+
+| Guard | Why |
+|---|---|
+| Only a worktree **this add created** | A shared `--use-worktree` checkout and a `--device` teammate's remote worktree are never candidates — this add didn't create either. |
+| Only when **no live teammate claims it** (`AgentManager.isWorktreeClaimed`) | The add can fail *after* the record is durably saved: `spawn()` writes a staged teammate's `meta.json` and only then runs the retention pass, which refreshes every sibling's status and can throw on a distributed one. That teammate exists and is merely pending its `--after` dependency, so it keeps its worktree. The check spans **every team**, since worktree names are global to the repo while records are per-team, and counts only **non-terminal** records — a stopped teammate's worktree is already gone, so its lingering record must not strand the branch. |
+
+If we cannot prove a worktree is an orphan, it is left in place and the command
+prints the exact `git worktree remove` / `git branch -D` pair to run — a stranded
+branch is recoverable, a deleted worktree is not.
+
+An unreadable `meta.json` is what makes the check fail closed in the first place,
+so it must not be a *permanent* state. `saveMeta()` writes via a sibling tmp file
++ `fs.rename`, atomic on POSIX, so a process killed mid-write can never leave a
+torn record. If an unreadable `meta.json` is found anyway (e.g. one written before
+this fix), `loadFromDisk()` quarantines it — renaming it to `meta.json.corrupt`
+with a warning — so it stops being mistaken for "no record" and a later
+`isWorktreeClaimed` scan sees genuine absence instead of failing closed on it
+forever (RUSH-2429).
+
+Either way the add exits non-zero with the real error and never prints a success
+block, and re-running the same command with the same name works.
+
+## Distributed teams
+
+Teammates can run on **different machines** across your fleet, not just the box
+running `teams start`. One orchestrator still drives the DAG, polls status, and
+cleans up — teammates just execute over SSH on their assigned host (via the same
+device registry as `agents devices` / `agents ssh`).
+
+There is one vocabulary — `--device` / `--devices` — and everything is optional;
+omit it all and teams behave exactly as before (every teammate local).
+
+**Send one teammate elsewhere** — no pool needed:
+
+```bash
+agents teams create feat
+agents teams add feat claude "build the API"  --name backend --device yosemite-s0
+agents teams add feat claude "build the UI"   --name ui         # stays local
+agents teams start feat --watch
+```
+
+**A distributed team with a device pool** — unpinned teammates auto-schedule:
+
+```bash
+agents teams create feat --devices zion,yosemite-s0,yosemite-s1 \
+  --repo https://github.com/you/your-repo.git
+agents teams add feat claude "..." --name w1                    # auto-scheduled (best viable device)
+agents teams add feat claude "..." --name w2 --device yosemite-s1   # or pin
+agents teams start feat --watch
+```
+
+**Where a teammate runs** — resolved at launch, top-down:
+
+1. teammate has `--device X` → **X** (explicit pin — no pool required, never second-guessed)
+2. else the team pool is a **single** device → that device (whole team there)
+3. else the team pool has **many** devices → **auto-scheduled** (best viable device)
+4. else (no pin, no pool) → **local**, exactly like today
+
+**Auto-scheduling is health-, harness-, and load-aware (RUSH-2002).** At
+`teams start` the pool is probed once (reachability + load via the same snapshot
+`agents devices` shows, plus whether the teammate's agent is installed there), and
+the pick:
+
+- **excludes** an unreachable device, an overloaded one (`loaded` headroom), a
+  device at its `agents.max-concurrent` cap, and one the agent is not installed on;
+- **ranks** the survivors by (a) agent installed **and signed in**, (b) lower load
+  (idle beats busy), (c) fewer running teammates on that device.
+
+If **no** pool device can run a pending teammate's agent, `teams start` **fails
+loud** — e.g. `No device in the team pool can run claude@2.1.112. Run 'agents
+devices ping' to see which devices have the agent installed + signed in.` —
+instead of stranding the teammate; it never silently falls back to a local run you
+did not ask for. Pass
+`--force` to downgrade that to a warning and start anyway. A probe that simply
+could not reach the pool (no positive evidence) does **not** trigger the failure —
+the real error then surfaces at the SSH dispatch. Set a per-device cap with
+`agents devices config <name> agents.max-concurrent N`.
+
+**Repo provisioning.** The team's `--repo` (defaulting to the local checkout's
+`origin`) is used to ensure the code is present on each device — an existing
+checkout is reused, otherwise it is cloned into `~/.agents/repos/<team>`. With
+`--enable-worktrees`, each remote teammate also gets its own worktree on the host,
+branched off the freshly-fetched default branch, and cleaned up on stop/disband.
+
+`--repo` is **one** clone source for the whole team — see
+[Placement & repos](#placement-and-repos). Tasks spanning two repos need two teams
+(e.g. `wave-cli --repo …/agents-cli` and `wave-mono --repo …/monorepo`), each
+teammate placed with its own `--device`. Don't try to point individual teammates
+at different repos with `--remote-cwd` — that flag has no effect on `teams add`.
+
+`teams status` and `teams logs` show which host each teammate is on and stream its
+output back (the local log mirror is capped so a large fleet can't blow up the
+orchestrator). **v1 note:** remote teammates require a POSIX host (Linux/macOS);
+Windows hosts are rejected with a clear message.
+
+## Recipes
+
+### 1. Two-teammate parallel docs job
+
+```bash
+agents teams create docs-update
+
+agents teams add docs-update claude \
+  "Rewrite docs/api.md — cover every endpoint in src/routes/" \
+  --name api-docs --mode plan
+
+agents teams add docs-update codex \
+  "Update docs/config.md — document every option in src/config.ts" \
+  --name config-docs --mode plan
+
+# Both start immediately (no --after)
+agents teams start docs-update
+agents teams status docs-update
+```
+
+### 2. DAG with --after dependency
+
+```bash
+agents teams create pricing-page
+
+agents teams add pricing-page claude \
+  "Rewrite /v2/pricing endpoint" --name backend
+
+agents teams add pricing-page codex \
+  "Build /pricing route with three-tier layout" --name frontend
+
+# QA waits for both
+agents teams add pricing-page claude \
+  "Run Playwright suite, fix flakes" --name qa --after backend,frontend
+
+# Watch mode — supervisor fires QA when backend AND frontend complete
+agents teams start pricing-page --watch
+```
+
+A staged (`--after`) teammate is durable while it waits: retention only ever
+reaps a teammate that has actually **finished** (completed/failed/stopped), so a
+`pending` teammate parked on an unmet dependency is never cleaned up, however
+deep the machine's history of past runs goes.
+
+### 3. Cloud dispatch for one teammate
+
+```bash
+agents teams create backend-fix
+
+agents teams add backend-fix claude \
+  "Fix the flaky payment test" --name fixer \
+  --cloud rush --repo acme/monorepo --branch main
+
+agents teams start backend-fix
+agents teams status backend-fix
+```
+
+### 4. Git worktree per teammate
+
+```bash
+agents teams create parallel-refactor --enable-worktrees
+
+agents teams add parallel-refactor claude \
+  "Refactor auth module" --name auth \
+  --worktree refactor-auth --name auth
+
+agents teams add parallel-refactor codex \
+  "Refactor billing module" --name billing \
+  --worktree refactor-billing
+
+agents teams start parallel-refactor --watch
+```
+
+### 5. Monitor with --watch and inspect JSON per wave
+
+```bash
+# Watch mode, one JSON line per wave — pipe to jq for dashboards
+agents teams start my-team --watch --json | \
+  jq '{ wave, launched, pending, running, completed, failed }'
+```
+
+### 6. Inspect team state via JSON
+
+```bash
+# Compact status as JSON (default; drops prompt, folds file paths to basenames)
+agents teams status my-team --json
+
+# Full status as JSON (legacy shape — prompt, all paths, all messages)
+agents teams status my-team --json --verbose
+
+# All teams as JSON (used by agi-cli observability layer)
+agents teams list --json
+```
+
+## Budget Guardrails
+
+Teammates **inherit the project's budget caps** (see
+[docs/observability.md](./observability.md#budget-guardrails-agents-budget)).
+Before each teammate launches, its estimated cost is projected onto current
+spend; under `on_exceed: block`, a teammate that would breach `per_run`,
+`per_day`, `per_agent`, or `per_project` is **refused** and the spawn fails with
+a `[budget] BLOCKED teammate …` error. Because the caps aggregate across
+vendors, a Claude teammate and a Codex teammate draw down the *same*
+`per_project` / `per_day` pool — one budget governs the whole team regardless of
+which CLIs it uses.
+
+Teammate budgeting is **pre-flight only** in v1: a teammate is estimated and
+blocked *before* it spawns, but there is **no live mid-run hard-cap kill** for
+teammates (they spawn through the teams runner, not the headless `agents run`
+kill path). The live mid-run kill applies to local headless `agents run` today;
+extending it to teams is a planned follow-up.
+
+Set caps in the project's `agents.yaml`:
+
+```yaml
+budget:
+  per_project: 100.00   # the whole team shares this
+  on_exceed: block
+```
+
+## Demo
+
+<video autoplay loop muted playsinline width="100%" src="../assets/videos/teams.mp4"></video>
+
+## See Also
+
+- [docs/concepts.md](./concepts.md) — DotAgents repos, resource resolution model
+- [docs/observability.md](./observability.md) — `agents teams list --json` as a fleet observability source
+- [docs/cloud.md](./cloud.md) — cloud dispatch (`--cloud rush|codex|factory` on `teams add`)

--- a/cli/docs/terminal-engine.md
+++ b/cli/docs/terminal-engine.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Terminal Launch Engine
 
 Open an *interactive* command — as a **tab** or a **split pane** — in iTerm,

--- a/cli/docs/terminal-engine.md
+++ b/cli/docs/terminal-engine.md
@@ -1,0 +1,266 @@
+# Terminal Launch Engine
+
+Open an *interactive* command — as a **tab** or a **split pane** — in iTerm,
+Ghostty, or tmux, on this machine or a remote host over SSH. Lives in
+[`src/lib/terminal/`](../src/lib/terminal/); the first caller is
+`agents sessions resume`.
+
+## Interactive surfaces vs. cloud providers
+
+The engine is deliberately narrow. A **terminal surface** is *attended and live*
+— you watch it and type into it. That is a different thing from a **cloud
+provider** ([`src/lib/cloud/`](../src/lib/cloud/): Rush Cloud, Codex Cloud,
+Factory, Antigravity), which dispatches an *autonomous, headless* task and hands
+back a run id and a PR.
+
+| | Terminal engine | Cloud providers |
+|---|---|---|
+| Opens | a tab / split you attach to now | a queued autonomous task |
+| Backends | iTerm, Ghostty, tmux, Terminal.app, VSCodium | Rush / Codex / Factory / Antigravity |
+| Interface | `buildTab/buildSplit(cwd, command) → argv` | `dispatch(repo, branch, task) → runId` |
+| Lifecycle | foreground, immediate | fire-and-forget, poll later |
+
+They meet only one level up: a "where should this run?" router could offer both
+families and dispatch down to the right subsystem. The engine itself never
+touches the cloud path.
+
+## Architecture
+
+A **backend** is a pure builder — given `cwd`, `command`, and a layout it returns
+the argv (an `osascript` script or a `tmux` invocation) that opens the surface.
+It performs no I/O, so every backend is unit-tested without a display. A single
+**transport** then runs that argv, locally or over SSH.
+
+```
+caller ─▶ openSurfaces(items, {backend, host, packing})
+             │
+             ├─ policy.planLayouts(n)      tab, split-right, tab, …  (2-per-tab)
+             ├─ backend.buildTab/buildSplit → LaunchSpec { argv }     (pure)
+             └─ transport.runSpec(spec, host)
+                   ├─ local:  spawn(argv)                    (wait for exit)
+                   └─ remote: sshExec(target, argv-as-shell) (src/lib/ssh-exec)
+```
+
+| Module | Role |
+|---|---|
+| [`types.ts`](../src/lib/terminal/types.ts) | `Backend`, `Layout`, `LaunchRequest`, `LaunchSpec`, `TerminalBackend`. |
+| [`backends/iterm.ts`](../src/lib/terminal/backends/iterm.ts) · [`ghostty.ts`](../src/lib/terminal/backends/ghostty.ts) · [`tmux.ts`](../src/lib/terminal/backends/tmux.ts) · [`terminal-app.ts`](../src/lib/terminal/backends/terminal-app.ts) | Pure tab + split builders per emulator. |
+| [`backends/index.ts`](../src/lib/terminal/backends/index.ts) | Registry, `detectCurrentBackend`, `availableBackends`. |
+| [`preferred.ts`](../src/lib/terminal/preferred.ts) | `resolveLaunchBackend` — which terminal to open for a caller that isn't in one (see [Choosing a terminal](#choosing-a-terminal-for-a-gui-caller)). |
+| [`run-surface.ts`](../src/lib/terminal/run-surface.ts) | `agents run --terminal` — re-open this run as a tab. |
+| [`policy.ts`](../src/lib/terminal/policy.ts) | `planLayouts` — the packing policy. |
+| [`transport.ts`](../src/lib/terminal/transport.ts) | `runLocal` / `runRemote` / `runSpec`, argv → ssh serialization. |
+| [`engine.ts`](../src/lib/terminal/engine.ts) | `specForRequest`, `buildRequests`, `openSurface`, `openSurfaces`. |
+| [`shell.ts`](../src/lib/terminal/shell.ts) | `zsh -ilc` wrappers (see [Interactive login shell](#interactive-login-shell)). |
+
+## Backends
+
+Each backend opens either a **tab** or a **split** (`right` = side-by-side,
+`down` = stacked). Syntax below is verified against iTerm 3.6 and Ghostty 1.3.
+
+| Backend | Available when | Tab | Split |
+|---|---|---|---|
+| `iterm` | macOS + `/Applications/iTerm.app` | `create tab … command` (a window if none open) | `split vertically`/`split horizontally … command` |
+| `ghostty` | macOS + `/Applications/Ghostty.app` | `new tab … with configuration cfg` | `split (focused terminal of selected tab of front window) direction …` |
+| `tmux` | inside tmux (`$TMUX` set) | `tmux new-window -c <cwd>` | `tmux split-window -h`/`-v -c <cwd>` |
+| `vscodium-agent` | macOS + `/Applications/VSCodium.app` | `codium --open-url 'vscodium://swarmify.swarm-ext/spawn?p=<payload>'` | same URL, payload carries `split` |
+| `terminal` | macOS + Terminal.app, and NOT over SSH (`osascript` can't reach the GUI login there) | `do script … in front window` (a window if none open) | none — Terminal.app has no scriptable split, so a split request opens a **tab** |
+
+`terminal` is registered **last** deliberately: it exists on every Mac, so it is
+the floor that keeps a GUI caller working, and the ordering means a terminal the
+user actually installed still wins the available-backend fallback.
+
+Registering it changes the two existing consumers of the registry, not just
+`--terminal`: on a Mac with none of iTerm / Ghostty / VSCodium installed,
+`agents sessions focus` ([`focus.ts`](../src/commands/focus.ts)) and
+`agents sessions resume` ([`sessions-resume.ts`](../src/commands/sessions-resume.ts))
+used to have no backend and resumed in the current process — they now open a
+Terminal.app tab. `resume`'s picker also gains a Terminal row.
+
+`buildTab`/`buildSplit` return a `LaunchSpec { argv }`. Ghostty carries `cwd`
+natively via the surface configuration; iTerm/tmux `cd` inside the wrapped shell.
+`vscodium-agent` is different in kind — see [VSCodium agent terminals](#vscodium-agent-terminals).
+
+## Layout policy — two panes per tab
+
+`planLayouts(count, packing)` assigns a layout to each surface in a batch:
+
+- **`two-per-tab`** (default) — session 1 opens a new **tab**, session 2 **splits**
+  it (right), session 3 a new tab, session 4 splits it, … so each tab holds a
+  left+right pair. Splits target the front pane, and because the batch runs
+  sequentially the split always lands in the tab just opened.
+- **`tabs`** — every session gets its own tab.
+
+```
+5 sessions, two-per-tab:
+  tab 1            tab 2            tab 3
+  ┌──────┬──────┐  ┌──────┬──────┐  ┌──────┐
+  │ s1   │ s2   │  │ s3   │ s4   │  │ s5   │
+  └──────┴──────┘  └──────┴──────┘  └──────┘
+```
+
+## Remote (`--device`)
+
+`runRemote` serializes the backend argv into one POSIX-quoted string and runs it
+through [`sshExec`](../src/lib/ssh-exec.ts) — the same hardened primitive
+`agents sessions --device` and the browser driver use (target-injection guard,
+connection multiplexing). Host aliases resolve via the `~/.ssh/config.d/agents`
+include that `agents devices` / `agents hosts` maintain, so `--device zion` "just
+works".
+
+Caveat: driving a GUI app (iTerm/Ghostty) over SSH needs the remote user logged
+into the Mac's GUI session — `osascript` reaches the app through it. `tmux` over
+`--device` is unconditional (headless), which is why remote defaults to `tmux`.
+`vscodium-agent` also needs a running editor: `codium --open-url` forwards the URL
+to the already-open VSCodium instance over its user-scoped IPC socket, so it works
+from an SSH session as the same user (no `osascript`, no new window spawned).
+
+## Choosing a terminal for a GUI caller
+
+`detectCurrentBackend` reads `$TMUX` / `$TERM_PROGRAM` — right for a command the
+user typed in a terminal, useless to a caller that has no terminal in its
+ancestry. The menu-bar helper is launched by launchd, so it used to hardcode
+AppleScript at Terminal.app and opened every "New Session" there regardless of
+what the user actually works in.
+
+[`preferred.ts`](../src/lib/terminal/preferred.ts) closes that gap using a signal
+the session engine already computes: `ActiveSession.host` — the host app every
+live session is attributed to, resolved by walking the process table
+([`session/active.ts`](../src/lib/session/active.ts), `HOST_MATCHERS`). The
+terminal the user demonstrably runs agents in is the terminal a new session
+should open in.
+
+```ts
+resolveLaunchBackend(currentContext(), await getActiveSessions());
+// → { backend: 'ghostty', source: 'active-session', host: 'ghostty' }
+```
+
+Resolution order, each step skipped when it names nothing drivable here:
+
+| # | Step | `source` |
+|---|---|---|
+| 1 | the terminal this process runs in (`detectCurrentBackend`) | `current-terminal` |
+| 2 | the host app of the most recent live session | `active-session` |
+| 3 | the first available backend (Terminal.app is the every-Mac floor) | `available` |
+
+**A tmux-hosted session names its viewer, not the multiplexer.** When a device
+opts into `tmux.enabled`, `agents run` wraps eligible interactive runs, so a
+session the user started in Ghostty is attributed `host: 'tmux'` on the discovery
+path — which names no terminal at all. Direct runs are the default.
+`toHostSamples` ([`run-surface.ts`](../src/lib/terminal/run-surface.ts)) fills in
+`viewingApp` for those from `resolveViewingIn`
+([`session/viewing-in.ts`](../src/lib/session/viewing-in.ts)) — the same resolver
+behind `agents sessions`' "viewing in Ghostty tab 2" — by walking the attached
+tmux client's pid to its host app. `viewingApp` takes precedence over `host`. A
+detached session (no client attached) has no viewer and keeps `tmux`, which a GUI
+caller cannot drive, so it correctly contributes nothing.
+
+Cost: resolution is ~3s on a busy machine, dominated by `getActiveSessions()`
+itself (transcript tails across version homes). That is the price of opening in
+the right terminal; a cheaper host-only session query would cut it.
+
+`SESSION_HOST_BACKENDS` maps host → backend and is deliberately **partial**. A
+host is listed only when the engine can really drive it, because a wrong mapping
+opens the wrong app and looks like success:
+
+- `code` / `cursor` / `windsurf` are absent even though there is an editor
+  backend — the registered `vscodium-agent` is bound to the VSCodium variant
+  (`EDITOR_VARIANTS[0]`), so mapping Cursor to it would open VSCodium.
+- `warp` / `kitty` / `wezterm` / `alacritty` / `hyper` / `screen` are absent
+  because no backend drives them yet. Adding one is a backend plus a map entry.
+
+An unmapped host is not an error — resolution moves to the next session, and
+finally to the available-backend floor.
+
+### `agents run --terminal`
+
+The user-facing form. `--terminal` re-opens the run as a tab in the resolved
+terminal instead of running here; `--terminal <backend>` forces one and errors on
+an unknown id rather than quietly auto-detecting. The tab re-invokes the caller's
+own argv with the flag stripped ([`run-surface.ts`](../src/lib/terminal/run-surface.ts)),
+so `--mode`, `--cwd` and a `--` passthrough ride along and only one place knows
+how to spell a run. It cannot combine with `--device` (that opens a tab here, not
+there) and exits non-zero when no terminal could be opened.
+
+```bash
+agents run claude --terminal            # detect from live sessions
+agents run claude --terminal ghostty    # force
+```
+
+This is what the menu bar's **New Session** now shells
+(`menubar/Sources/MenubarHelper/AgentsCLI.swift` → `newSession`).
+
+## Interactive login shell
+
+The `iterm`, `ghostty`, `tmux`, and `terminal` backends wrap their command in `zsh -ilc '…'`.
+The `-i` is load-bearing: the version-pinned shims (`claude@2.1.187`) live in
+`~/.agents/.cache/shims`, which `.zshrc` adds to PATH for *interactive* shells
+only. A non-interactive `zsh -lc` can't find the shim and the surface dies with
+"command not found". The `vscodium-agent` backend does **not** wrap — the command
+is sent (via the extension's `sendText`) into an editor terminal that is already
+an interactive login shell, so the shims are on PATH already.
+
+## Usage
+
+```ts
+import { openSurfaces, availableBackends, currentContext } from '../lib/terminal/index.js';
+
+const items = sessions.map(s => ({ cwd: s.cwd, command: ['claude@' + s.version, '--resume', s.id] }));
+
+await openSurfaces(items, {
+  backend: 'ghostty',       // or detectCurrentBackend(currentContext())
+  host: 'zion',             // omit for local
+  packing: 'two-per-tab',   // or 'tabs'
+});
+```
+
+### `agents sessions resume`
+
+| Flag | Effect |
+|---|---|
+| `--iterm` / `--ghostty` / `--tmux` / `--vscodium` / `--terminal-app` | Force a backend (else auto-detect / prompt). `--terminal-app` is spelled apart from `run --terminal`, which means "open in a terminal", not "use Terminal.app". |
+| `--device <alias>` | Open on the selected sessions' origin host over SSH (defaults to `tmux`); a different host is refused. |
+| `--splits` | Pack two sessions side by side per tab (default is one tab per session). |
+
+Every selected harness goes through the shared session-recovery command. Native
+resume is used only by the healthy origin version; otherwise a healthy version of
+the same harness receives `/continue <id>`. With no GUI backend and no tmux,
+resume falls back to an in-place, sequential takeover of the current terminal.
+
+## VSCodium agent terminals
+
+The `vscodium-agent` backend opens each session as an **agent terminal tab** in a
+running VSCodium (or Cursor / VS Code) window, driven by the **swarmify**
+`swarm-ext` extension. Unlike the terminal-app backends, the editor is already
+running — the engine hands it a URL rather than scripting a GUI app:
+
+```
+codium --open-url 'vscodium://swarmify.swarm-ext/spawn?p=<base64url(JSON)>'
+```
+
+- **The payload is one base64url-encoded JSON param** (`{command, cwd, split?}`),
+  not one param per field. VS Code percent-*decodes* `uri.query` once before the
+  extension parses it, so a `command`/`cwd` containing `&` or `=` would be
+  mis-split by a multi-param query; base64url (`[A-Za-z0-9_-]`) survives that
+  decode untouched and round-trips exactly (see `spawnUri`).
+- **The `/spawn` verb** (swarmify `extension.ts`) opens an editor-tab terminal in
+  `cwd`, sends `command`, and arms *shell adoption* — so a resume command like
+  `claude --resume <id>` is auto-promoted to the Claude chip with session
+  tracking. `split` splits beside the previous `/spawn` pane, giving the same
+  two-per-tab packing as the other backends.
+- **Why `--open-url`, not `open`** — the editor CLI forwards the URL to the
+  running instance. That needs no OS URL-scheme handler registration, works on
+  Linux, and flows over `--device` (the SSH session reaches the same user's editor).
+  The per-product scheme must match the CLI: `codium`→`vscodium://`,
+  `cursor`→`cursor://`, `code`→`vscode://` (see `EDITOR_VARIANTS` /
+  `makeVscodiumAgentBackend`).
+- **No `zsh -ilc` wrap** — the command runs in an editor terminal that is already
+  an interactive login shell (see [above](#interactive-login-shell)).
+
+**Layout:** Every backend defaults to **one full-width tab per session**. `--splits`
+opts into two-per-tab split packing for side-by-side sessions.
+
+Auto-detection is intentionally *not* wired for this backend: a VS Code integrated
+terminal reports `TERM_PROGRAM=vscode` for all three products, so the engine can't
+tell which one to target. Select it explicitly with `--vscodium` (defaults to
+VSCodium), or it appears in the picker when `/Applications/VSCodium.app` is present.

--- a/cli/docs/version-management.md
+++ b/cli/docs/version-management.md
@@ -1,0 +1,456 @@
+# Version Management
+
+How agents-cli installs, switches, and isolates multiple versions of agent CLIs.
+
+> This page covers versions of the *agent CLIs* agents-cli manages (Claude Code,
+> Codex, etc.). To update **agents-cli itself**, run `agents upgrade` (see
+> `agents upgrade --help`) -- unrelated to the mechanism below.
+
+## Architecture
+
+```
+~/.agents/
+  agents.yaml                           # Global defaults: agents.claude = "2.0.65"
+  versions/
+    claude/
+      2.0.65/
+        node_modules/.bin/claude        # Installed CLI binary
+        home/
+          .claude/                      # Isolated config for this version
+            commands/  -> ~/.agents/commands/   (symlink)
+            skills/    -> ~/.agents/skills/     (symlink)
+            CLAUDE.md  -> ~/.agents/rules/AGENTS.md (symlink)
+      2.0.70/
+        node_modules/.bin/claude
+        home/.claude/
+    codex/
+      0.98.0/
+        ...
+  shims/
+    claude                              # Version-resolving wrapper script
+    codex
+  backups/
+    claude/
+      1709856000000/                    # Timestamped backup of original ~/.claude/
+```
+
+## Version Resolution
+
+```
+User runs: claude --help
+           │
+           ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  ~/.agents-system/shims/claude (bash script)                               │
+│                                                                     │
+│  1. Walk up from $PWD looking for project agents.yaml               │
+│     └─ Parse agents.claude: "2.0.70" (skips ~/.agents/agents.yaml)  │
+│                                                                     │
+│  2. If not found, read ~/.agents/agents.yaml (user default)         │
+│     └─ Parse: agents.claude = "2.0.65"                              │
+│                                                                     │
+│  3. If version not installed, auto-install (project versions only)  │
+│                                                                     │
+│  4. exec ~/.agents-system/versions/claude/{version}/node_modules/.bin/claude │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Agent-Spec Resolution
+
+The shim above resolves a version from config for a *bare* `claude` launch. Every
+CLI subcommand that takes an `<agent>[@<qualifier>]` argument — `view`, `inspect`,
+`sync`, `run`, and the `*list*` commands — resolves that spec through one engine,
+[`src/lib/agent-spec/`](../src/lib/agent-spec/). The core is **pure**: it takes a
+`VersionProvider` instead of touching the filesystem (so it is unit-tested with
+in-memory fixtures), and `provider.ts` binds the real one. Entry points:
+`resolveAgentTargets` (multi), `resolveSingleAgentTarget` (exactly one),
+`resolveVersionFilter` / `resolveListFilter` (read/list filters).
+
+### Qualifier vocabulary
+
+| Spec | Resolves to |
+|------|-------------|
+| `claude` (bare) | project pin (`agents.yaml`) → global default → the sole installed version. If more than one is installed with no default, state-changing commands error ("specify one"); `run`/`exec` pick the newest with a note. |
+| `claude@2.1.187` | that exact version (must be installed) |
+| `claude@latest` | newest **installed** version |
+| `claude@oldest` | oldest installed version |
+| `claude@pinned` / `claude@default` | the configured global default (synonyms) |
+| `claude@all` | every installed version (multi-target; rejected where exactly one is required) |
+| `claude@all,codex@latest` | comma-separated multi-spec |
+
+Each resolved target carries a `source` provenance tag (`project-pin`,
+`global-default`, `sole-installed`, `newest-installed`, `alias-latest`/`-oldest`,
+`explicit`, `none`). Exact versions are validated against `VERSION_RE` before any
+filesystem or exec use.
+
+### Two meanings of `latest`
+
+- **Install** — `agents add claude@latest` → the newest version published on
+  **npm** (`getLatestNpmVersion`, network).
+- **Resolve** — `agents view/run/sync claude@latest` → the newest **installed**
+  version (no network).
+
+The engine's domain is installed versions only.
+
+### Non-semver versions
+
+Ordering is by `compareVersions` (numeric per `.`-segment), so date-style schemes
+like OpenClaw's `yyyy.m.d` sort correctly. A trailing `-N` rebuild suffix
+(`2026.2.19-2`) breaks same-day ties — a higher `-N` is newer. This is
+deliberately **not** full semver: OpenClaw's `-N` means *newer*, the opposite of a
+semver pre-release, so a semver comparator would invert it. Suffix-free versions
+are unaffected.
+
+### `@default` in read/list commands
+
+For the read/list commands (`skills list`, `hooks list`, `rules list`, …) a bare
+spec shows **all** installed versions; `@default` / `@pinned` scopes to the
+**configured default version** (matching `view`).
+
+## Installation Flow
+
+```
+agents add claude@2.0.65
+           │
+           ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  installVersion(agent, version)                                     │
+│  src/lib/installations/versions.ts:installVersion()                               │
+│                                                                     │
+│  1. Create ~/.agents-system/versions/claude/2.0.65/                        │
+│  2. npm install @anthropic-ai/claude-code@2.0.65                    │
+│  3. Create home dir: versions/claude/2.0.65/home/.claude/           │
+│  4. syncResourcesToVersion() - symlink central resources            │
+│  5. createShim() - generate ~/.agents-system/shims/claude                  │
+│  6. createVersionedAlias() - generate ~/.agents-system/shims/claude@2.0.65 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Config Symlink Switching
+
+When `agents use claude@2.0.65` runs, the user's `~/.claude/` becomes a symlink:
+
+```
+BEFORE (first use):
+~/.claude/                    # Real directory with user's config
+  settings.json
+  commands/
+  CLAUDE.md
+
+AFTER:
+~/.claude/ -> ~/.agents-system/versions/claude/2.0.65/home/.claude/   (symlink)
+~/.agents-system/backups/claude/1709856000000/                        (backup)
+  settings.json
+  commands/
+  CLAUDE.md
+```
+
+Key behaviors:
+- Only `agents use` can set the global default (via `setGlobalDefault()`)
+- Real directories are backed up before being replaced with symlinks
+- Subsequent switches just update the symlink target (no new backups)
+- Each version has isolated auth in its `home/` directory
+- `agents sync <agent>` self-heals **dangling version pointers**: the global
+  default, the isolated default, and the `~/.<agent>` config symlink are each
+  repointed off any version that is no longer installed before the sync resolves
+  a version. The default goes to the newest non-isolated installed version
+  (never auto-promoting an isolated install), the symlink to the resolved default
+  else the newest non-isolated installed version. A pointer already on an
+  installed version, a real config directory, and isolated-only agents are left
+  untouched (`healDanglingVersionPointers`, RUSH-2471).
+
+## Uninstalling (reversing adoption)
+
+`agents uninstall` is the reverse of `agents setup`: it completely removes
+agents-cli **and restores the config directories adoption took over**, so the
+machine is left as it was before agents-cli was installed.
+
+The ordering matters — the config backups live inside `~/.agents`, so restore
+runs before disposal:
+
+```
+agents uninstall
+    │
+    ▼
+  1. Restore each adopted ~/.<agent>          (lib/uninstall.ts: planUninstall/executeUninstall)
+       owned symlink? (getConfigSymlinkVersion != null)
+         → newest backup exists  → move backups/<agent>/<ts> back to ~/.<agent>
+         → else (importAgent)     → copy the symlink target (version home) back
+       real, un-adopted dir?      → LEFT UNTOUCHED
+  2. Restore owned home files      (~/.claude.json, ...)
+  3. releaseAdoptedLauncher()      restore native binaries on PATH
+  4. stripShimPathLines()          remove the shim dir from every shell rc file
+  5. dispose ~/.agents             move aside to ~/.agents.removed-<ts> (default)
+                                    or hard-delete with --purge
+  6. print `npm uninstall -g @phnx-labs/agents-cli`   (a CLI can't delete its own binary)
+```
+
+Guarantees:
+- **A `~/.<agent>` that agents-cli never adopted is never touched.** Ownership is
+  decided structurally by `getConfigSymlinkVersion()` (non-null only for a symlink
+  into the versions dir) — the same check `removeVersion()` uses.
+- **Recoverable by default.** `~/.agents` (installed versions, session history,
+  secrets metadata) is moved to `~/.agents.removed-<timestamp>`, not deleted.
+  `--purge` hard-deletes it instead.
+- **`--purge` self-downgrades on error.** If any restore step fails, `--purge` is
+  automatically demoted to the recoverable move-aside — a swallowed error can never
+  take the user's only copy of a config with it. The command says so in its output.
+- **Cross-volume safe.** Restores move data with a rename, falling back to
+  copy-then-remove when `~/.agents` lives on a different filesystem than `$HOME`
+  (`renameSync` would throw `EXDEV`). Resource symlinks that point back into
+  `~/.agents` are stripped from a restored config so nothing dangles post-uninstall.
+- **`--dry-run`** prints the full plan (what is restored, what is left untouched,
+  what is removed) without changing anything.
+- `uninstall` is exempt from the setup gate, so it runs even from a broken or
+  half-initialized state.
+
+Note: with `--purge`, macOS Keychain items created by `agents secrets` are not
+removed (they are managed by the signed helper app); remove those with
+`agents secrets` before uninstalling if you want them gone.
+
+## Isolated Installs
+
+`agents add <agent>@<version> --isolated` installs a fully self-contained copy
+that never touches the user's existing setup. It is the escape hatch for "give me
+a clean, separate <agent> without disturbing my current one."
+
+An isolated install deliberately SKIPS every adopting side effect of a normal
+install:
+
+- No global default is set or offered (`setGlobalDefault()` is never called).
+- No bare `<agent>` shim is created, so nothing on `PATH` is shadowed.
+- The real `~/.<agent>` is never backed up or replaced with a symlink
+  (`switchConfigSymlink()` is never called).
+- No settings carry-over and no resource sync — the copy starts pristine, with
+  its own `home/` config and its own login.
+
+What it DOES create is just enough to launch the copy explicitly:
+
+```
+agents add claude@2.1.112 --isolated
+           │
+           ▼
+  installVersion()                 # same npm install into versions/claude/2.1.112/
+  createVersionedAlias()           # ~/.agents-system/shims/claude@2.1.112
+  markVersionIsolated()            # writes versions/claude/2.1.112/.isolated
+```
+
+Run it with an explicit version selector (PATH-independent):
+
+```
+agents run claude@2.1.112 "your prompt"
+```
+
+The `.isolated` sentinel lives at the version-dir root, so it travels to trash on
+removal and is restored intact. Two consequences follow from the marker:
+
+- `removeVersion()` never auto-promotes an isolated version to the global
+  default; if the only survivors are isolated, it clears the default instead.
+- `agents remove <agent>@<version> --isolated` refuses to remove anything that is
+  NOT an isolated install, and its picker only lists isolated versions — so a
+  normal/default install (and the real `~/.<agent>`) can never be removed by
+  accident. Removal is still a soft-delete to trash, recoverable via
+  `agents trash restore`.
+
+`--isolated` cannot be combined with `--project` (an isolated copy is
+global-but-separate; a project pin selects a shared install for one directory).
+
+### The isolation boundary
+
+Once an agent is installed **only** as isolated copies, nothing the framework does
+can adopt it. Protection is derived from the `.isolated` markers already on disk —
+there is no mode to set, and none to forget:
+
+```ts
+isIsolationProtected(agent)   // >=1 installed version, and every one is isolated
+```
+
+Two properties fall out of deriving it that way:
+
+- **Per-agent.** An isolated codex constrains nothing about claude.
+- **The escape hatch is inherent.** Remove the isolated copies and the agent is
+  ordinary again — the state that grants protection is the state you delete to drop
+  it. No `--force` flag, nothing to leave switched off.
+
+Five primitives can carry an agent across the boundary. Each calls
+`assertIsolationBoundary` before doing any work, so the refusal is a property of the
+code rather than a check every future call site must remember:
+
+| Primitive | What it would do |
+|-----------|------------------|
+| `setGlobalDefault` | records the default that owns the launcher and arms `shadowing` |
+| `createShim` | puts a bare `<cli>` shim first on PATH |
+| `switchConfigSymlink` | moves the real `~/.<agent>` aside and symlinks it into a version home |
+| `switchHomeFileSymlinks` | the same for `~/.claude.json` and friends |
+| `adoptShadowingLauncher` | repoints the user's own launcher symlink at our shim |
+
+Clearing a global default is always allowed — `removeVersion` clears one as the last
+non-isolated version goes away, which is the moment an agent *becomes* isolated-only.
+
+`agents add` (without `--isolated`) and `agents import` additionally check the
+boundary at the command entry point. That is not redundant: **import registers the
+adopted install as a normal version first**, so by the time it reaches
+`setGlobalDefault` the agent already has a non-isolated version and the primitive
+gate — which reads state at call time — would let the adoption through. The boundary
+has to be evaluated against the state before the command mutates it.
+
+`doctor --adopt` is the one operation with no isolated-scoped equivalent: hijacking
+PATH is its entire purpose, and isolated copies are deliberately absent from PATH.
+It refuses and explains.
+
+`src/lib/isolation-boundary.test.ts` pins the primitive list and scans `installations/shims.ts` for
+any other exported function that both resolves the real config dir and mutates the
+filesystem without the gate — so a sixth way in fails there rather than silently
+reopening the hole.
+
+### Bringing an existing install into the sandbox
+
+`agents import <agent> --isolated` is the mirror of a plain import. Where the latter
+*adopts* — moving `~/.<agent>` into a version home, symlinking the original away,
+setting the global default and creating a shim — `--isolated` **copies**:
+
+```
+~/.codex  ──copy──▶  versions/codex/1.2.3/home/.codex     (original untouched)
+```
+
+and finalizes the way `agents add --isolated` does: versioned alias plus the
+`.isolated` marker, no default, no bare shim, no config symlink.
+
+This is the supported way in while an agent is protected — plain `import` is refused
+there precisely because adoption is its purpose.
+
+Credentials are **skipped by default and reported**, not silently included. An
+isolated copy is a separate principal that signs in on its own, so copying tokens
+into it should be a choice rather than a side effect of wanting your settings.
+`--with-auth` opts in. Symlinks into `~/.agents` are dropped,
+so the copied config does not depend on the CLI's own tree.
+
+### The isolated default
+
+`agents use <agent>@<isolated-version>` records which isolated copy a bare
+`agents run <agent>` should reach. It is scoped to the sandbox: unlike a normal
+`use` it sets no global default, creates no bare shim, and never repoints the real
+`~/.<agent>` config symlink.
+
+```json
+// ~/.agents/.history/devices/pins-<machine>.json   (machine-local runtime state,
+// untracked — auto-written pins in the tracked device doc caused commit churn)
+{
+  "agents": { "claude": "2.1.220" },          // global defaults — own the launcher, shim and config symlink
+  "isolatedAgents": { "codex": "0.144.6" }    // sandbox pointers — own nothing
+}
+```
+
+Both maps are machine-local for the same reason: each names a version installed on
+*this* machine, so syncing either would hand another machine a pointer to a copy it
+does not have.
+
+The two maps are kept separate deliberately. An entry under `agents:` arms the
+self-heal `shadowing` check and is what `getGlobalDefault` returns; an isolated
+copy must never acquire that, so it is recorded somewhere `getGlobalDefault`
+cannot see.
+
+Resolution order for a bare agent name (`resolveVersion`):
+
+```
+project pin  ->  global default  ->  isolated default
+```
+
+Strictly a fallback, so nothing changes for anyone who has a global default.
+Without it an isolated-only user could not reach their installs by bare name at
+all — the chain ended at the global default, so `agents run codex` fell through to
+whatever `codex` meant on PATH and only `agents run codex@<version>` worked.
+
+The pointer is verified on read (installed *and* still isolated), and `removeVersion`
+re-points it at the newest surviving isolated copy — or clears it — so it can never
+resolve to a directory that is not there.
+### Leaving an isolated install
+
+Remove the isolated version with `agents remove <agent>@<version> --isolated`.
+To adopt an existing native config into agents-cli instead, use
+`agents import <agent>` after removing every isolated copy for that agent.
+
+## Resource Syncing
+
+`syncResourcesToVersion()` copies user/system resources into version homes and
+refreshes project resources into the current workspace's dot-agent directory:
+
+```
+~/.agents/commands/foo.md          ──copy──▶  ~/.agents/.history/versions/claude/2.0.65/home/.claude/commands/foo.md
+~/.agents/skills/bar/              ──copy──▶  ~/.agents/.history/versions/claude/2.0.65/home/.claude/skills/bar/
+<project>/.agents/commands/foo.md  ──copy──▶  <project>/.claude/commands/foo.md
+~/.agents/rules/AGENTS.md          ──copy──▶  ~/.agents/.history/versions/claude/2.0.65/home/.claude/CLAUDE.md
+```
+
+Commands are copied in the target agent's native format, with command-as-skill
+conversion for agents that require it.
+
+## Shim Process Contract
+
+The shim is more than a version router — it's a process-model contract that
+downstream consumers (VS Code extensions, IDEs, daemons) depend on. Two
+guarantees:
+
+### 1. `exec`-replacement, not `fork+exec`
+
+The shim's final line is always:
+
+```bash
+exec "$BINARY" "$@"
+```
+
+`exec` replaces the shim process in place. The shell's direct child pid *is*
+the shim pid — which, after `exec`, *is* the agent CLI. No wrapper process
+remains as a parent of the agent.
+
+```
+Process tree after `claude@2.1.112` runs at the shell:
+
+  zsh(shell_pid)
+    └─ /bin/bash(shim_pid)              ← shim script starts here
+         ├─ (transient) agents sync     ← project resource sync, ~100ms
+         └─ (exec replaces) node claude ← same pid, now IS claude
+```
+
+### 2. Signals propagate cleanly
+
+Because `exec` replaces rather than forks, `SIGINT` (Ctrl+C) and `SIGTERM`
+from the shell hit the agent CLI directly. A second `SIGINT` exits the agent
+and returns control to the shell — `pgrep -P shell_pid` returns empty, the
+shell is idle at prompt.
+
+### Why this matters
+
+Any consumer that drives an agent terminal programmatically — Companion's VS
+Code extension is the primary one today — relies on these two guarantees to
+observe lifecycle transitions via `pgrep`/`ps` without hooking the terminal's
+pty output. Specifically:
+
+- **"Agent is running"** is detectable as "shell has a child pid."
+- **"Agent has exited, shell is idle"** is detectable as "shell has no
+  children."
+- **"Which process is the agent"** is always the immediate child of the
+  shell, not a deeper descendant.
+
+### What would break the contract
+
+| Hypothetical change | Breaks |
+|---|---|
+| Shim uses `$BINARY "$@"` instead of `exec $BINARY "$@"` | `pgrep -P shell_pid` keeps returning the shim pid even after the agent exits; consumers can't detect "shell idle" |
+| Shim wraps the agent in `tmux`/`screen`/`agents pty` as a persistent parent | `pgrep -P shell_pid` returns the wrapper pid; the actual agent is a deeper descendant, requiring a tree-walk |
+| Shim daemonizes or backgrounds the agent | Terminal's pty is not the agent's stdin; typed input goes to the wrong process |
+
+When introducing new launch modes, preserve this contract or provide an
+explicit alternative detection path for consumers.
+
+## Key Functions
+
+| Function | File | Purpose |
+|----------|------|---------|
+| `installVersion()` | versions.ts | Install agent CLI version |
+| `removeVersion()` | versions.ts | Remove installed version |
+| `resolveVersion()` | store.ts | Find version from project/global config |
+| `syncResourcesToVersion()` | versions.ts | Symlink resources into version home |
+| `switchConfigSymlink()` | installations/shims.ts | Replace ~/.{agent} with symlink |
+| `createShim()` | installations/shims.ts | Generate version-resolving wrapper |
+| `setGlobalDefault()` | versions.ts | Set default in agents.yaml |

--- a/cli/docs/version-management.md
+++ b/cli/docs/version-management.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Version Management
 
 How agents-cli installs, switches, and isolates multiple versions of agent CLIs.

--- a/cli/docs/watchdog.md
+++ b/cli/docs/watchdog.md
@@ -1,3 +1,4 @@
+<!-- guide -->
 # Watchdog
 
 The watchdog keeps AI coding agents moving. Agents are expected to drive their task

--- a/cli/docs/watchdog.md
+++ b/cli/docs/watchdog.md
@@ -1,0 +1,199 @@
+# Watchdog
+
+The watchdog keeps AI coding agents moving. Agents are expected to drive their task
+to completion, but they routinely **go idle** — announce a step and never take it,
+finish a thought and stall, or ask themselves a question they could answer. Those
+idle sessions surface nowhere and quietly waste time. The watchdog's job is to find
+them, understand each one, and steer it to finish.
+
+> Normative requirements (MUST/SHOULD, cited to `file:line`) live in
+> [specifications.md#watchdog](specifications.md#watchdog). This doc is the how-it-works.
+
+## Strategy: idle → completion
+
+The single goal is **get idle agents moving to completion**. Everything else follows
+from that one focus.
+
+**Idle is the watchdog's territory; waiting is the feed's.** A session that explicitly
+stopped on a question or a permission prompt (`waiting_input`) already surfaces in the
+user's feed — the user can act on it there, so the watchdog leaves it alone. A session
+that is merely **idle** — stopped with no prompt, nothing surfacing it — is the silent
+tax the watchdog exists to remove. This division is why accurate status detection is the
+watchdog's #1 dependency: it must reliably tell `idle` (its job) from `waiting_input`
+(the feed's), `working` (leave alone), and completed (nothing to do).
+
+## The loop
+
+The watchdog is owned by the agents daemon, not a UI poller or cron routine. When
+`watchdog.enabled` is true in this device's config, the daemon runs one bounded pass
+every three minutes. `agents watchdog --nudge` remains the explicit one-shot command:
+
+The human tick view is timestamped and attention-first. Each stalled/actionable row names
+the session id and label/topic, agent, host app, machine, project, activity, start/activity
+ages, cwd, latest preview, and decision reason. Healthy/non-actionable inspections are
+summarized; pass `--verbose` to render every row or `--json` for the complete tick object.
+
+1. **Detect idle.** Enumerate active sessions, classify each by transcript freshness and
+   inferred activity (`lib/watchdog/read.ts`, `lib/session/state.ts`). A candidate is a
+   session that is stalled (idle past `WATCHDOG_STALL_MS`, before `WATCHDOG_DORMANT_MS`,
+   past its cooldown) — not `working`, not freshly `waiting` for the feed. Prioritize the
+   ones active most recently: a warm session (last activity ~minutes ago) is the one worth
+   steering.
+2. **Analyze.** Collect every idle candidate with its originating task and transcript tail
+   (`lib/watchdog/watchdogTail.ts`). There is no heuristic pre-filter guessing done-vs-stuck
+   — the whole idle set goes to the agent.
+3. **Drive it.** The agent judges each candidate in ONE `agents run --mode plan` call per
+   tick (`makeWatchdogAgentDecider`, `lib/watchdog/watchdog-agent.ts`): idle-but-unfinished
+   → NUDGE; idle-and-done or genuinely-needs-human → SKIP. It crafts the message
+   (`WATCHDOG_SYSTEM_PROMPT`, `lib/watchdog/watchdog.ts`). A nudge is **help, not a shove**:
+   it restates the goal, references the conclusion the agent already reached, and names the
+   concrete next step — the exact action, a tool it forgot, or the sensible default. Never a
+   generic "keep going."
+4. **Escalate only genuine sign-off.** Credentials, a release/publish, an
+   irreversible/outward-facing action, or a real product decision → left for the human
+   (surfaced in the feed), never nudged.
+
+## The brain
+
+The decider is a real agent, not a heuristic script. Every idle session on the machine (its
+task + tail) is judged in ONE `agents run <watchdog-workflow-or-agent> --mode plan` call per
+tick (`makeWatchdogAgentDecider`, `lib/watchdog/watchdog-agent.ts`) — one bounded call for
+the whole idle set, spawned only when something is actually idle, never one agent per
+session. The prompt is `WATCHDOG_SYSTEM_PROMPT` (`lib/watchdog/watchdog.ts`); a user
+playbook at `~/.agents/playbooks/watchdog.md` is appended as **House Rules**
+(`composePromptWithPlaybook`) so per-fleet authorization norms ("rolling an
+already-published version to my own fleet is authorized — proceed") tune the NUDGE/SKIP line
+without editing the built-in prompt. If a `watchdog` workflow resolves (repo > user >
+system), it runs by name so its WORKFLOW.md body + `model:` frontmatter apply; absent one,
+the built-in prompt runs. Because the decision is one batched call spanning every idle
+session (which may live in different projects), the workflow is resolved from the daemon's
+own cwd — so the user/system-layer `watchdog` workflow applies fleet-wide, while a
+project-layer override only takes effect when the daemon runs from that project.
+
+Four rules govern a good nudge:
+
+- **Read, don't guess.** Judge from the transcript (goal + recent reasoning), not a status
+  field alone — an agent that already decided needs "do it," not "decide."
+- **Carry context.** Restate the goal, reference what it already concluded, name the step.
+- **Split the ask.** Drive the reversible, goal-advancing part; surface only the genuinely
+  disruptive part — don't stall the whole task on one risky sub-step.
+- **Point at the tool it forgot.** If a tool resolves the blocker, name it —
+  `agents computer` (drive the local Mac), `agents ssh <mac> "agents computer …"` (drive a
+  Mac from elsewhere), `agents browser` — instead of asking the human.
+
+The rules that ban over-asking are already loaded in every agent's context and ignored
+anyway (the model's deference reflex overrides explicit instruction). The watchdog is the
+**enforcement** layer that the internal instruction cannot deliver — not a reminder.
+
+## Delivery
+
+A nudge is delivered into the exact terminal split the session lives in, resolved by the
+single canonical resolver `resolveInjectTargetForSession` (`lib/terminal/resolve.ts`),
+precedence `tmux > iterm > vscodium > pty`, then injected by `injectIntoTerminal`
+(`lib/terminal/inject.ts`). VSCodium/Cursor/VS Code integrated terminals are addressed via
+the extension's `/inject` URI handler. When no addressable split exists the tick falls back
+to a mailbox enqueue or a headless `--resume`, and refuses (flags for the menu-bar) only
+when nothing can reach the session. `agents sessions inject` shares this same resolver, so
+the manual unblock path and the watchdog agree.
+
+**Confirmed delivery.** A nudge counts as landed — booked in the cooldown ledger and logged
+`nudge` — only when delivery is confirmed. tmux / iterm / pty self-confirm: a successful
+`send-keys` / `write text` / pty write IS delivery (a bad pane or session id errors).
+vscodium's `codium --open-url` is fire-and-forget — exiting 0 only means the editor accepted
+the URL, not that the extension typed anything — so it is recorded `undelivered` (visible in
+`agents watchdog history`) until the swarm-ext extension acks the verb. This ends the
+phantom-nudge ledger, where a nudge the extension silently dropped was booked as delivered.
+
+## Rotate (in-place, same tab)
+
+A stalled session whose tail shows a **hard account limit** — "You've hit your weekly
+limit · resets …", "usage limit reached", "out of credits" (`ROTATE_LIMIT_PATTERNS`,
+`lib/watchdog/rotate.ts`) — cannot be un-stuck by a nudge: "Continue." cannot unspend a
+capped account. The tick routes it to the **rotate** path instead:
+
+1. **Detect.** `classifyTailForRotate` matches the transcript tail and parses the
+   `resets <time>` clause when present (ISO, or claude's `7am (America/Los_Angeles)`
+   time-of-day form).
+2. **Gate (first-party).** Before touching the terminal, the tick runs the *same*
+   selection `agents run auto` would — `collectHarnessCandidates` +
+   `pickHarnessWeighted` (`lib/rotate.ts`, cache-only; no `agents view` subprocess, no
+   Keychain probe). Zero healthy → ONE `rotate` skip event per cooldown window in
+   `watchdog.log` (cooldown = `earliestResetAcross` from the candidates, else the parsed
+   tail reset, else 30m) and the terminal is left untouched.
+3. **Relaunch in place.** The harness's exit sequence (claude: `Esc, Ctrl+C, Ctrl+C`;
+   codex/gemini/cursor/opencode: `Ctrl+C, Ctrl+C` — the table ported from the
+   extension's prewarm configs) is injected as raw bytes into the resolved rail, then
+   `agents run auto --interactive --session-id <uuid>` is typed into the **same tab**.
+4. **Replay.** When the new session's TUI is live, the tick injects the resume replay:
+   "Resume previous work by loading session \<old-id\>. Run `agents sessions <old-id>` …".
+   Readiness is a transcript for the new session id (primary — a claude pick honors
+   `--session-id`), with a **correlated** fallback for non-claude picks: a fresh active
+   session counts only when it started after the rotate began AND shares the old
+   session's cwd AND machine (`isCorrelatedRelaunch`) — an unrelated fresh session on a
+   busy box never satisfies it. The readiness wait is bounded (60s default); on timeout
+   the session is **flagged** and the machine stops — never blind-type into a dead shell.
+   The flag says the terminal may sit at a bare shell and needs a manual
+   `agents run auto`; a failed rotate is suppressed for 15m (`suppressUntilMs` in the
+   state file) before the tick will retry it.
+
+The machine spans ticks — the exit sequence kills the old session, so it drops out of
+the active-session list before the new TUI is live — and persists at
+`~/.agents/.cache/state/watchdog/rotate/<sessionId>.json` as
+`exiting → launching → awaiting-tui → replaying → done | failed`. A post-loop sweep
+advances in-flight rotates whose session left the active list. All rotate activity
+(rotate start / done / failed / skip) is appended to the shared `watchdog.log` as
+`rotate`-kind events, so the Fleet status card keeps working unchanged.
+
+Rotate is **on by default**. `agents watchdog rotate on|off` writes `watchdog.rotate`
+in `~/.agents/agents.yaml` (re-read per tick) and is rotate-only — nudging is
+unaffected. Rotate obeys the same gates as a nudge: it acts only on a `--nudge`
+tick, honors `handsoff` (flag, never rotate), and requires the same addressable-rail
+safety gate — an un-addressable terminal is flagged, never rotated blind.
+`agents watchdog status` (`--json`) reports the rotate config and every persisted
+rotate state.
+
+## Audit history
+
+`agents watchdog history [sessionId]` shows every session inspection plus persisted
+decisions, nudges, rotates, and errors newest-first. Use `--since 24h`, `--limit 100`, or `--all` to include heartbeat
+ticks; `--json` provides the same filtered records for scripts. Raw transcript tails and
+message excerpts are never returned by this command. The optional session id accepts a
+full id or prefix.
+
+## Fleet model
+
+The watchdog reads the **whole fleet** (`agents sessions --active --json` fans out to every
+device, status computed on each origin host) but delivers **locally** on each session's
+origin box, where injection is reliable. Enable it per host with
+`agents watchdog on|off`; this writes the device-local `watchdog.enabled` setting under
+`~/.agents/devices/<hostname>/agents.yaml`. The menu bar only renders the daemon's
+persisted result and never executes a pass.
+
+## Per-session policy
+
+`agents watchdog policy <id> off|keep|handsoff` — `off` excludes a session entirely;
+`handsoff` detects and flags it but never delivers; `keep` (default) is the normal path.
+
+## File map
+
+| File | Role |
+|---|---|
+| `lib/daemon/daemon.ts` | Sole automatic scheduler: one non-overlapping pass every three minutes. |
+| `lib/watchdog/runner.ts` | One tick: enumerate → classify → decide (batched agent) → deliver (confirmed) → log. |
+| `lib/watchdog/watchdog-agent.ts` | The agent decider: batches every idle candidate into ONE `agents run --mode plan` call, maps verdicts by terminalId. |
+| `lib/watchdog/watchdog.ts` | `WATCHDOG_SYSTEM_PROMPT`, playbook composition, prompt render, response parse. |
+| `lib/watchdog/read.ts` | Locate a transcript and read its tail; stall thresholds. |
+| `lib/watchdog/watchdogTail.ts` | Summarize a tail into last-user / last-assistant for the brain + log. |
+| `lib/watchdog/rotate.ts` | In-place rotate: limit detection, exit-sequence table, state machine, health gate. |
+| `lib/watchdog/log.ts`, `history.ts` | Persist, parse, and safely select the Watchdog audit history. |
+| `commands/watchdog.ts` | `agents watchdog` — timestamped attention view, `--verbose`, `on`/`off`/`status`/`history`/`policy`/`--nudge`/`--watch`. |
+| `lib/session/state.ts`, `active.ts` | Status inference (`working`/`waiting_input`/`idle`) the watchdog reads. |
+| `lib/terminal/resolve.ts`, `inject.ts` | Resolve the exact split and deliver the nudge. |
+
+## Roadmap
+
+The strategy is landing in stages. Shipped: idle detection, version-home-safe transcript
+resolution, the unified inject resolver, and the context-carrying/tool-pointing brain
+prompt. Planned: seeding the brain with the full fleet snapshot as its starting context; a
+distinct `done` state (so a finished session is never confused with idle); status coverage
+for non-Claude/Codex harnesses; and the shipped default `watchdog/WORKFLOW.md` decider.

--- a/cli/scripts/verify-docs.sh
+++ b/cli/scripts/verify-docs.sh
@@ -72,9 +72,12 @@ for anchor in coverage-inventory sessions secrets agent-execution scheduling--ex
 done
 
 # --- 2. Authored architecture does not grow command-manual sections ---
+# Guides (docs marked `<!-- guide -->`) are how-to references and MAY use these
+# headings; the rule applies only to the top-level architecture decision docs.
 FORBIDDEN_HEADING_RE='^#{2,3} (Setup|Command [Rr]eference|Recipes|File [Mm]ap|Source [Mm]ap|Key Functions|Roadmap)$'
 while IFS= read -r file; do
   [[ "$file" == "docs/command-index.md" ]] && continue
+  grep -qF '<!-- guide -->' "$file" && continue
   if grep -Eq "$FORBIDDEN_HEADING_RE" "$file"; then
     fail "$file contains a user/reference heading reserved outside architecture docs"
   fi


### PR DESCRIPTION
## What
Commit \`2d96d05d6\` ("docs: replace manuals with architecture decisions", 2026-08-25) deleted ~48 how-to docs. The decision docs it added are good, but the **guides** were the how-to companion that agents and users actually reach for.

This restores **24** subsystem guides and relinks them from \`docs/README.md\` under a new **Guides** section (the index now describes two layers: decision docs + guides).

## Restored
execution/fleet (ssh-transport, hosts, version-management, resource-sync, self-healing) · tools (browser, computer, pty) · orchestration (teams, routines, monitors, cloud) · resources (hooks, subagents, plugins, profiles + profiles/) · state/security (secrets-agent-process-model, secrets-trust-boundaries, credential-management, projects, watchdog, menubar, terminal-engine).

## Scope
Docs only — no code touched. Content is the original well-written text; a concision pass on the largest (routines 1647L, hosts 931L, browser 697L) follows as a second commit. Example session transcripts and thesis/marketing pages were intentionally left deleted.