### PR TITLE
docs(comments): trim inline comments in lib/session + exec (no behavior change)

### DIFF
--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -1532,29 +1532,8 @@ export type TmuxWrapDecision =
   | { kind: 'undurable' };
 
 /**
- * Decide whether to run an interactive agent INSIDE a detached tmux session on
- * the shared socket (then attach the current TTY) instead of a bare spawn.
- *
- * The wrap is opt-in via this device's `tmux.enabled` (`configEnabled`): a
- * unique `%pane` handle so `agents sessions --active` can tell co-located
- * agents apart and `agents focus` re-attaches without forking, plus scrollback
- * and mouse at the operator's keyboard. Off means OFF, for local and remote
- * runs alike (PHNX-3316) — a followed `--device` run left bare is protected by
- * reconnect-and-resume (lib/hosts/reconnect.ts), which rejoins the live pane
- * when one exists and resumes the harness session from disk when it does not.
- * The RUSH-3125 forced remote wrap conflated durability with that preference
- * and surprised every operator who had explicitly left tmux off.
- *
- * One case still wraps regardless: a followed remote run whose launcher has
- * no TTY (CI, scripts, another agent) gives the peer nothing to attach to —
- * the detached pane is the run's only interface, not an ergonomics choice.
- *
- * The per-run opt-outs bind everything: `--raw` / `--no-tmux` /
- * `AGENTS_NO_TMUX=1` are explicit "I want the bare process" requests, and an
- * escape hatch that silently stopped applying over `--device` would be worse
- * than the bare run the user asked for.
- *
- * Pure, so the gate is unit-tested independently of the (side-effecting) spawn.
+ * Tmux is opt-in except when a TTY-less remote launch would otherwise have no
+ * interface. Explicit per-run opt-outs always win.
  */
 export function resolveTmuxWrap(ctx: TmuxWrapContext): TmuxWrapDecision {
   // A headless `-p` run has no TTY to attach, Windows has no tmux path, and
@@ -1582,24 +1561,6 @@ export function resolveTmuxWrap(ctx: TmuxWrapContext): TmuxWrapDecision {
 }
 
 /**
- * Build the shell command that runs an agent inside a tmux pane with the exact
- * env the bare spawn would use. tmux runs it via `sh -c <cmd>`; we `exec env
- * K=V … <agent> <args…>` so:
- *   - `env` materializes the full agent env INTO the pane, independent of the
- *     (possibly stale, shared) tmux server environment — additive, so tmux's own
- *     $TMUX / $TMUX_PANE still reach the agent for provenance detection;
- *   - `exec` replaces the shell so the agent is the pane's leaf process (clean
- *     `#{pane_pid}`, clean signal delivery on detach/kill).
- * Keys are filtered to valid identifiers so exported shell functions
- * (`BASH_FUNC_*%%`) can't make `env` choke.
- *
- * `redactEnvValues` replaces every value with a `<redacted>` marker while keeping
- * the KEY names. The env map here carries resolved secrets bundles (options.env),
- * so the real string would embed secret VALUES — which get persisted verbatim
- * into SessionMeta.cmd on disk (tmux/session.ts). The launched command uses the
- * real values; the stored/informational copy uses the redacted form (RUSH-1758).
- */
-/**
  * True when `options.sessionId` is an id the HARNESS actually received, and so a
  * real, resumable handle — rather than one the launcher generated for its own
  * bookkeeping and the agent never saw.
@@ -1625,6 +1586,10 @@ export function isHarnessKnownSessionId(
   return agent === 'claude';
 }
 
+/**
+ * Build the pane command without inheriting stale tmux-server env. Redacted
+ * copies keep secret values out of persisted SessionMeta commands.
+ */
 export function buildTmuxAgentCommand(
   executable: string,
   args: string[],

--- a/cli/src/lib/session/active.ts
+++ b/cli/src/lib/session/active.ts
@@ -57,14 +57,7 @@ import { claudeProjectDirName } from '../project-key.js';
 
 const execFileAsync = promisify(execFile);
 
-/**
- * The owner (actor id) to show for a session in `--active`. Prefers the actor
- * recorded on the live-attribution source (the pid registry / teammate record),
- * but falls back to the durable per-session actor sidecar — written at spawn and,
- * unlike the pid entry, NOT overwritten by the SessionStart hook's own by-pid
- * write. Without this fallback a real `agents run` shows no owner whenever the
- * hook's actor-less entry wins the by-pid file (RUSH-2018 fix).
- */
+/** Prefer live actor attribution; the durable sidecar survives actor-less hook rewrites. */
 export function resolveOwner(pidActor: string | null | undefined, sessionId: string | undefined): string | undefined {
   return pidActor ?? (sessionId ? readSessionActorRecord(sessionId)?.actor : undefined) ?? undefined;
 }
@@ -855,18 +848,8 @@ interface LiveTerminalEntry {
 }
 
 /**
- * Read the live-terminals registry, dedupe by sessionId.
- *
- * A pid-alive entry is a live session. A pid-DEAD entry is normally noise — a
- * terminal that closed a moment ago, before its window republished — and is
- * dropped. But a dead pid whose owning window ALSO stopped republishing is the
- * signature of a crash: the window went down hard and never ran the teardown that
- * would have removed this entry. Those are KEPT, so the session reaches the
- * listing at all — it used to vanish outright, a VS Code crash simply erasing its
- * agents from `--active`. Such a row arrives as `closed` (dead pid) carrying the
- * stale `windowHeartbeatMs`, which is what {@link foldHostLink} promotes to
- * `crashed`. `pidDead` is local to the dedupe below: a live entry must win a dead
- * one for the same session.
+ * Keep dead entries only when their window heartbeat also stopped, proving a crash;
+ * a live duplicate always wins.
  */
 function readLiveTerminals(): LiveTerminalEntry[] {
   let raw: string;
@@ -917,20 +900,8 @@ const CLAUDE_SESSION_FILE_CACHE_MAX = 256;
 const claudeSessionFileCache = new Map<string, string>();
 
 /**
- * Locate the active Claude session file for a process. If we know the session
- * UUID (from terminal env or team parent), prefer the exact match. Otherwise
- * fall back to the most-recent-mtime .jsonl in the project's folder.
- *
- * Searches EVERY version-home project root, not just the live `~/.claude`
- * symlink. `~/.claude` points at the currently-installed agent version; a
- * session launched under an EARLIER version keeps its transcript under that
- * version's home (`…/.history/versions/claude/<ver>/home/.claude/projects/`).
- * Resolving only `~/.claude/projects` meant that the instant a newer version
- * was installed, every still-running older-version session lost its transcript
- * here — no `sessionFile`, so no start/activity time, so `agents sessions`
- * rendered it `unknown` and the watchdog skipped it as "no activity timestamp".
- * `getAgentSessionDirs('claude','projects')` is the same version-aware enumerator
- * the rest of the CLI uses, so this stays in lockstep with discovery.
+ * Search every version home because the live ~/.claude symlink moves after upgrades
+ * while older running sessions keep writing to their original home.
  */
 function findClaudeSessionFile(cwd: string, sessionId?: string): string | undefined {
   // Only memoize when the exact session UUID is known. Without an id the
@@ -2512,17 +2483,7 @@ export function foldHostLink(rows: ActiveSession[]): void {
       s.presence = undefined;
     }
     if (link === 'host-gone' && s.status === 'closed') s.status = 'crashed';
-    // Only idle/input_required are promoted — a `running` session keeps its
-    // status (SES-18a). Extending this to a running agent with no client was
-    // tried and reverted: since RUSH-3125 wraps every remote interactive run in
-    // a detached tmux pane, "running with zero attached clients" is the NORMAL
-    // steady state between check-ins, and that path writes no detach record, so
-    // `deliberatelyDetached` is false for it. Promoting it would relabel every
-    // remote agent as orphaned whenever nobody is looking — the over-reporting
-    // this file's header calls worthless. Telling a stranded agent from a
-    // healthy unattended one needs to know a client was EXPECTED and LOST, which
-    // no signal available here carries; that belongs with the peer-side pane
-    // ownership work, not this function.
+    // A clientless running remote pane is normal; only stopped work can be called orphaned.
     else if (link === 'no-client' && (s.status === 'idle' || s.status === 'input_required')) {
       s.status = 'orphaned';
     }
@@ -2536,18 +2497,7 @@ function recapLine(s: string | undefined, max = 120): string | undefined {
   return t.length > max ? t.slice(0, max - 1).trimEnd() + '…' : t;
 }
 
-/**
- * The recap ladder (RUSH-3011): compute a row's shown {@link ActiveSession.title}
- * + {@link RecapSource} from the best available source, plus the cleaned first
- * prompt (`userPromptClean`/`userPromptKind`) and the `lastAgentLine`. Pure over
- * one row; exported for tests and folded in by {@link foldRecap}.
- *
- * Ladder, best-first: a `/rename`/harness `label` → the last assistant line →
- * the first-prompt topic. The `last` rung is agent-derived, so a session that
- * produced work stops showing its stale first prompt as the title. (`topic` is
- * the row's already-extracted first line, so image detection here is
- * path-based; a pure-attachment turn with no first-line text stays on `prompt`.)
- */
+/** Labels win, then the last assistant line, then the first-prompt topic. */
 export function deriveSessionRecap(
   row: Pick<ActiveSession, 'label' | 'topic' | 'tail'>,
 ): { title?: string; recapSource?: RecapSource; userPromptClean?: string; userPromptKind?: UserPromptKind; lastAgentLine?: string } {
@@ -2578,17 +2528,7 @@ export function foldRecap(rows: ActiveSession[]): void {
   }
 }
 
-/**
- * True when a crash-leaked orphan is genuinely DEAD and should be reaped from the
- * reconnectable set rather than shown as resumable forever (RUSH-3011 / issue #3b).
- *
- * The gate is `abandoned` (no transcript write in {@link ABANDONED_STALE_MS}) AND
- * a dead pid — exactly "past the stale threshold whose pid is gone". A live pid
- * (an idle-but-unfinished session, the highest-risk state) is NEVER reaped, and
- * neither is a recently-`closed`/`crashed` session that just exited (still
- * resumable). `pidAlive` absent (a cloud row or an older peer that can't prove
- * death) also stays un-reaped — reaping is fail-safe, never a guess.
- */
+/** Reap only stale sessions with proven-dead pids; unknown or live processes remain recoverable. */
 export function isReapableOrphan(
   row: Pick<ActiveSession, 'status' | 'pidAlive'>,
 ): boolean {

--- a/cli/src/lib/session/db.ts
+++ b/cli/src/lib/session/db.ts
@@ -3919,15 +3919,9 @@ export function topSessionsByCost(
   }));
 }
 
-/** Look up a single session by its unique ID. */
 /**
- * Batch-resolve session ids to the machine each one runs on, in ONE indexed
- * query. `getActiveSessions` needs only this column for every live row, and
- * `getSessionById` would re-`prepare` a `SELECT *` and materialize a full
- * `SessionMeta` per id to read it — mirrors {@link findSessionsByShortIds}'s
- * single-round-trip pattern. Ids absent from the index are simply absent from
- * the map. Best-effort: an unavailable DB yields an empty map, so the live view
- * still renders (the caller then leaves rows attributed to this box).
+ * Read machine attribution in batches without materializing full sessions.
+ * Failure is best-effort so the live view can still render local attribution.
  */
 export function findSessionMachinesByIds(ids: string[]): Map<string, string> {
   const out = new Map<string, string>();
@@ -3956,20 +3950,7 @@ export function getSessionById(id: string): SessionMeta | null {
   return row ? rowToMeta(row) : null;
 }
 
-/**
- * Resolve a full-or-partial session id against the index, exact-first then
- * prefix — the DB-backed equivalent of resolveSessionById() that runs over the
- * SQLite table instead of a pre-loaded array. Matches both the full id and the
- * short id. An exact hit short-circuits so a complete id never also drags in its
- * prefix siblings. `scope` narrows by agent / version / project (cwd) so an
- * ambiguous prefix disambiguates against the caller's context.
- *
- * Routes through the full querySessions existence check (NOT skipExistenceCheck)
- * on purpose (RUSH-2436): that check now KEEPS a file-gone session whose user
- * turns still live in session_text (flagged archived) and only suppresses a
- * contentless phantom — so `agents sessions <id>` resolves an archived session
- * instead of failing with "No session found", while a phantom id still misses.
- */
+/** Exact ids win over prefixes; the normal existence check preserves archived content but excludes phantoms. */
 export function findSessionsById(
   idQuery: string,
   scope: Pick<QueryOptions, 'agent' | 'version' | 'cwd' | 'project'> = {},
@@ -3981,19 +3962,7 @@ export function findSessionsById(
   return querySessions({ ...scope, idPrefix: q });
 }
 
-/**
- * Batch-resolve many 8-char short ids to their sessions in ONE indexed query.
- * The live-scan path (listTmuxAgentSessions) turns every `ag-<agent>-<shortid>`
- * tmux pane name back into a full session id this way, so it pays a single
- * `short_id IN (…)` round-trip per scan instead of N per-pane lookups.
- *
- * Returns a map keyed by short_id (lowercased). Short ids are the first 8 chars
- * of the lowercase session UUID (deriveShortId), so a lowercased `IN` matches and
- * still uses idx_sessions_short_id. When several sessions share a short id — only
- * time-ordered ids (ULID/UUIDv7) ever collide; random UUIDv4 short ids are unique
- * in practice — the most-recently-active one wins (the caller can further
- * disambiguate by cwd).
- */
+/** Batch-resolve pane short ids; on collision the most recently active session wins. */
 export function findSessionsByShortIds(shortIds: string[]): Map<string, SessionMeta> {
   const out = new Map<string, SessionMeta>();
   const uniq = [...new Set(shortIds.map((s) => s.trim().toLowerCase()).filter(Boolean))];

--- a/cli/src/lib/session/discover.ts
+++ b/cli/src/lib/session/discover.ts
@@ -172,12 +172,7 @@ async function applyJsonlAppend(
  */
 const HOT_FILE_WINDOW_MS = 600_000;
 
-/**
- * Kill-switch: set `AGENTS_SESSIONS_NO_DIR_LEDGER=1` to force the old full-walk
- * path (readdir + per-file stat every dir, every run — the pre-A-2 behavior),
- * skipping the dir_ledger short-circuit entirely. One env var reverts a field
- * regression to today's behavior.
- */
+/** Emergency kill-switch for the directory-ledger optimization. */
 function dirLedgerDisabled(): boolean {
   const v = process.env.AGENTS_SESSIONS_NO_DIR_LEDGER;
   return v === '1' || v === 'true';
@@ -229,14 +224,7 @@ export interface DiscoverOptions {
   idExact?: string;
   /** Session id prefix — a targeted indexed lookup with no scan (RUSH-2477). */
   idPrefix?: string;
-  /**
-   * Cold-miss repair: when another live process already holds the scan claim,
-   * wait (bounded) for that in-flight scan to finish before reading the index,
-   * instead of returning the pre-scan snapshot (RUSH-2682). A caller repairing a
-   * "not indexed yet" miss wants the fresh result the concurrent scan is about to
-   * write, not the stale read that just missed. Ignored when THIS process wins
-   * the claim (it scans itself) or no scan is in progress.
-   */
+  /** On a cold miss, briefly await the scan already holding the single-flight claim. */
   waitForScan?: boolean;
 }
 
@@ -404,33 +392,11 @@ export async function discoverSessions(options?: DiscoverOptions): Promise<Sessi
 interface IncrementalScanResult {
   /** True when this process won the single-flight claim and ran the scan. */
   claimed: boolean;
-  /**
-   * Transcripts parsed this scan — i.e. those whose (mtime, size) changed. Zero
-   * is the steady state on an idle box and does NOT mean the scan was skipped;
-   * read `claimed` for that.
-   *
-   * Twelve of the 13 SESSION_AGENTS contribute, including OpenCode, whose
-   * scanner filters to sessions whose own per-session stamp changed and reports
-   * that batch — so a tick whose only changed sessions live there no longer
-   * reports 0 (RUSH-2691). OpenClaw is the exception and contributes nothing:
-   * its scanner has no change detection to report (a TTL gate, a fresh stamp
-   * every run, and an entry list rebuilt as the current inventory), so counting
-   * it would overstate rather than measure. See `scanOpenClawIncremental`.
-   */
+  /** Changed transcripts parsed; zero with `claimed: true` is a successful no-op scan. */
   scanned: number;
 }
 
-/**
- * The write half of {@link discoverSessions}: claim the single-flight scan slot,
- * incrementally index this host's transcript dirs, and report what was parsed.
- *
- * Split out so a caller that only wants the index refreshed — the daemon's warm
- * tick — can run it WITHOUT the listing query `discoverSessions` ends with. That
- * query is not free: it applies a cwd filter, runs the `archived_at`-writing
- * existence check, and can issue a Linear fetch, none of which index anything
- * (RUSH-2691). Keeping one implementation here is also what stops the tick and
- * the foreground path from drifting apart.
- */
+/** Separate write half so daemon warming does not pay for listing or external enrichment. */
 export async function scanSessionsIncremental(options?: {
   agent?: SessionAgentId;
   onProgress?: (p: ScanProgress) => void;
@@ -473,11 +439,7 @@ export async function scanSessionsIncremental(options?: {
   return { claimed: true, scanned };
 }
 
-/**
- * Poll until no live process holds the scan claim, or the bound elapses
- * (RUSH-2682). Bounded so a wedged/slow scan can never hang a foreground preview.
- * Exported for the cold-miss repair test.
- */
+/** Bounded wait so a wedged scan cannot hang a foreground cold-miss repair. */
 export async function waitForScanToSettle(
   timeoutMs: number = WAIT_FOR_SCAN_TIMEOUT_MS,
   pollMs: number = WAIT_FOR_SCAN_POLL_MS,
@@ -519,27 +481,8 @@ export async function queryIndexedSessions(
 }
 
 /**
- * Resolve a full-or-partial session id against the LOCAL SQLite index only.
- *
- * A plain WAL read through `queryIndexedSessions` — same origin-machine
- * attribution and managed scoping every indexed read gets — with NO incremental
- * discovery scan (so none of `tryClaimScan`/`releaseScan`'s `BEGIN IMMEDIATE`
- * writer lock) and NO fleet SSH fan-out. This is the crash-restart storm path
- * (RUSH-2477): dozens of `sessions resume <id>` at once for a known local id must
- * each be a cheap read, never a writer-lock contender or a dial into the
- * not-yet-up tailnet. Exact id first, then prefix (matching `findSessionsById`),
- * so a complete id never also drags in its prefix siblings. Returns `[]` on a
- * genuine local miss, leaving the caller to fall back to the fleet resolver.
- *
- * The existence check is left ON (`skipExistenceCheck: false`), exactly as the old
- * `discoverSessions` path and `findSessionsById` do (RUSH-2436): it KEEPS a
- * file-gone session whose user turns still live in `session_text` (flagged
- * archived) and SUPPRESSES a contentless phantom — so a phantom id misses here and
- * falls through to the fleet resolver, instead of resolving to a row with no real
- * transcript to resume. For a present transcript — the storm's actual case, since
- * the crashed tabs' files are on disk — the check does no writes, so the lock-free
- * guarantee holds; it only writes to (un)archive a genuinely missing or resurrected
- * file, which is not the 20-at-once resume path.
+ * Resolve locally without scanning or fleet I/O, keeping concurrent crash recovery lock-light.
+ * The existence check preserves archived content while rejecting transcriptless phantoms.
  */
 export async function resolveIndexedSessionById(idQuery: string): Promise<SessionMeta[]> {
   const q = idQuery.trim();

--- a/cli/src/lib/session/parse.ts
+++ b/cli/src/lib/session/parse.ts
@@ -137,28 +137,10 @@ export function safeReadSessionFile(filePath: string, maxBytes: number = SESSION
   return fs.readFileSync(filePath, 'utf-8');
 }
 
-/**
- * Auto-detect agent type from file path and parse the session.
- */
 export interface ParseSessionOptions {
   /** Keep normalized tool results compact by default; renderers can request full output. */
   maxToolOutputChars?: number;
-  /**
-   * Emit an `interrupt` event where the transcript records `[Request interrupted`.
-   *
-   * OFF by default, deliberately. That marker is not a user message, and the default
-   * event array is a versioned consumer contract: `agents sessions <id> --json`
-   * serializes it verbatim (see render.ts, issue #743), `computeSummaryStats` folds
-   * every event's timestamp into the session duration, and the live-state reader and
-   * tail renderer inspect fixed-size windows of the last N events. Emitting it
-   * unconditionally changed all four — a measured 12x duration swing on one real
-   * transcript, a new object in a published payload, and an eviction from the
-   * 12-event rate-limit window whose trigger shape (a trailing interrupt) is exactly
-   * a session the user just cancelled.
-   *
-   * `agents insights` opts in: an interruption is a real friction signal, and dropping
-   * it outright is what made it unrecoverable.
-   */
+  /** Opt-in because interrupts are not user messages and would change the published event stream. */
   includeInterrupts?: boolean;
 }
 
@@ -167,14 +149,7 @@ function truncateNormalizedToolOutput(output: string, maxChars: number): string 
   return `${output.slice(0, maxChars)}\n\n[Output truncated: ${output.length - maxChars} characters omitted.]`;
 }
 
-/**
- * Registry-dispatch table: each `SessionAgentId` to its offline transcript
- * parser. Replaces the per-harness `switch` — the harness axis of Move 3. Kept
- * as its own table (not on the HarnessAdapter registry) because its id domain is
- * `SessionAgentId`: `rush` is a session agent with no `AgentId`, and the offline
- * transcript reader is a deliberately separate concern from live team events.
- * The `Record` is total, so a new session harness must add an entry here.
- */
+/** Separate from HarnessAdapter because offline transcripts include session-only agents such as Rush. */
 const TRANSCRIPT_PARSERS: Record<SessionAgentId, (filePath: string, opts: ParseSessionOptions) => SessionEvent[]> = {
   claude: (filePath, opts) => parseClaude(filePath, opts),
   codex: (filePath) => parseCodex(filePath),
@@ -203,13 +178,7 @@ export function parseSession(
 
   const events: SessionEvent[] = TRANSCRIPT_PARSERS[detected](filePath, opts);
 
-  // Chokepoint: every string field that originated in an untrusted session
-  // file gets stripped of terminal escapes here, so renderers downstream can
-  // safely splat values into chalk/console output. Same pass flags
-  // harness-injected `role=user` scaffolding (Claude `<bash-input>`/`<bash-stdout>`
-  // from `!`-prefix runs, `<system-reminder>`, etc.) as `_synthetic` so turn
-  // slicing and `--include user` count only genuine user intent — one place,
-  // every harness, instead of per-consumer regex.
+  // Sanitize untrusted strings and identify synthetic user scaffolding once for every consumer.
   const maxToolOutputChars = opts.maxToolOutputChars ?? 500;
   for (const e of events) {
     if (e.type === 'tool_result' && e.output) {
@@ -1000,26 +969,8 @@ function extractGeminiContent(content: any): string {
   return '';
 }
 
-// ---------------------------------------------------------------------------
-// Antigravity parser
-//
-// Antigravity (Google's Gemini-CLI successor) stores each conversation as a
-// SQLite DB at ~/.gemini/antigravity-cli/conversations/<trajectory-uuid>.db.
-// Table `steps(idx, step_type, ..., step_payload BLOB, ...)`; step_payload is
-// protobuf with no .proto shipped. The wire layout, reverse-engineered and
-// uniform across every tool step, nests a tool-call sub-message with:
-//   f1  (string) = call id       (shared by the request + completion steps)
-//   f2  (string) = tool name     e.g. run_command / view_file / grep_search
-//   f3  (string) = JSON args     e.g. {"CommandLine":"date","Cwd":"…","toolAction":…}
-//   f30 (string) = toolSummary   short human label ("Run date")
-//   f31 (string) = toolAction    ("Running date command")
-// We never decode the step_type enum: extracting the tool name (f2) + JSON args
-// (f3) generically keeps the parser tool-agnostic, so a future tool (web search,
-// etc.) is captured automatically. Each tool surfaces TWICE — a request step
-// (step_type 15) and a completion step share the same f1 call id — so we dedupe
-// by that id. Reads the BLOB payloads via the node/bun SQLite wrapper (portable,
-// no `sqlite3` CLI dependency) and normalizes to SessionEvent[].
-// ---------------------------------------------------------------------------
+// Antigravity's undocumented protobuf stores tool name in f2, JSON args in f3,
+// and repeats request/completion with the same f1 call id, which must be deduplicated.
 
 /** One decoded protobuf field at a single nesting level. */
 type ProtoField = { field: number; wire: number; value: number | Uint8Array };


### PR DESCRIPTION
## Summary

Trimmed stale, historical, and code-restating comments in the five highest-priority files while retaining concise rationale and invariants. No executable code, signatures, imports, or tests changed.

## Before / after

- `cli/src/lib/exec.ts:1534`: the 25-line tmux history/rationale block is now: `Tmux is opt-in except when a TTY-less remote launch would otherwise have no interface. Explicit per-run opt-outs always win.`
- `cli/src/lib/session/discover.ts:483`: the 27-line local-resolution history is now two current-truth lines: `Resolve locally without scanning or fleet I/O...` and `The existence check preserves archived content while rejecting transcriptless phantoms.`
- `cli/src/lib/session/active.ts:2486`: the 12-line reverted-state narrative is now: `A clientless running remote pane is normal; only stopped work can be called orphaned.`

Also fixed the orphaned docblock in `cli/src/lib/exec.ts:1589`: `buildTmuxAgentCommand` now has its own docblock directly above the function, while `isHarnessKnownSessionId` retains its directly attached invariant.

## Verification

- `bunx tsc --noEmit` — passed
- Mechanical zero-context diff audit — every added/removed nonblank line begins with a comment delimiter; output: `COMMENT_ONLY_DIFF_OK`
- `git diff --check` — passed
- Diff stat: `5 files changed, 30 insertions(+), 262 deletions(-)` (net 232 lines removed)

Full test suite intentionally not run per task scope.