### PR TITLE
docs(comments): trim inline comments in lib/secrets + installations + hosts (no behavior change)

### DIFF
--- a/cli/src/lib/hosts/reconnect.ts
+++ b/cli/src/lib/hosts/reconnect.ts
@@ -1,160 +1,62 @@
 /**
- * Auto-reconnect for an interactive `agents run --device` session whose
- * SSH link dropped.
+ * Auto-reconnect for an interactive `agents run --device` session whose SSH link
+ * dropped. ssh exit 255 triggers bounded-backoff re-attaches via the peer's own
+ * `agents sessions focus <id> --local`, which joins a surviving tmux pane or
+ * resumes the session in place. The retry window bounds unproductive streaks,
+ * resetting when an attach reaches the host and holds the pane.
  *
- * What the reconnect lands on depends on the peer's `tmux.enabled`
- * (PHNX-3316). With the wrap opted in, the agent runs in a DETACHED tmux
- * session on the peer (see lib/exec.ts `runInTmux`), so a network blink kills
- * only the local ssh client and the reattach below rejoins the live pane.
- * With the wrap off — the fleet default — the remote agent is a child of the
- * sshd session and a blink SIGHUPs it: the in-flight turn is lost, and the
- * reattach RESUMES the harness session from disk instead. Both outcomes go
- * through the same verb below; what changed in PHNX-3316 is that "resumed"
- * is once again an honest, expected result rather than a corpse this file
- * pretended was alive (the pre-RUSH-3125 bug), and RUSH-3125's forced wrap —
- * which made the pane a guarantee by overriding the operator's tmux.enabled —
- * is gone with it.
- *
- * `sshStream` reports that drop as exit code 255 (ssh's
- * own connection-layer failure; see ssh-exec.ts). Without this, exec.ts would
- * `process.exit(255)` and the user would have to notice, find the session id, and
- * `agents sessions focus` by hand. Instead we re-attach over SSH automatically,
- * with bounded backoff, until the user detaches cleanly (the remote returns 0),
- * the agent exits (a non-255 code), or the user interrupts the wait with
- * Ctrl-C ({@link waitOrInterrupt} → 130).
- *
- * The re-attach reuses the peer's OWN recovery verb — `agents sessions focus <id>
- * --local` — which JOINS the live local tmux pane there (a second client, no fork)
- * when it exists, and RESUMES the session in place when there is no pane — which
- * is every drop on a default (wrap-off) box. Dropping `--attach-only` is
- * deliberate: a reattach that finds no pane must not dead-end at a bare shell
- * (the RUSH-2085 bug), it must fall through to resume so the user is put back
- * into the agent. There is one re-attach implementation (the peer's focus) to
- * keep in sync.
- *
- * **What it takes to refill the budget: reached the host AND held the pane.** ssh
- * returns 255 for BOTH "couldn't connect at all" and "connected, then the link
- * dropped." A failed connect still takes up to `ConnectTimeout` (10s) to return, so
- * the duration of the whole call can't tell the two apart — a threshold below the
- * connect timeout would classify every hung connect as a live session and retry
- * forever under a sustained outage (the exact failure this feature exists to
- * survive). So each attempt runs a fast preflight probe FIRST, and only once that
- * probe proves the host reachable does the interactive attach run — which means the
- * ATTACH's own duration is a clean signal, measured with the connect phase already
- * behind it. A reattach that reached the host and then held for at least
- * {@link MIN_HOLD_MS} refills the retry budget, so a long session that blinks all
- * day keeps reconnecting. Everything else — never reached the host, or reached it
- * and died right back — counts against the budget, so a sustained outage and a
- * fast-flapping link both give up once {@link RECONNECT_WINDOW_MS} of unproductive
- * retrying has elapsed.
- *
- * The retry policy is a pure state machine (`reconnectStep`) so it is unit-tested
- * without touching SSH; the loop (`reconnectInteractiveSession`) only adds the real
- * preflight + `sshStream` re-attach and the wait.
- *
- * **255 from the REMOTE side should never be trusted as "the link dropped."**
- * `reattachRemoteSession`'s `connected` flag is set as soon as the fast preflight
- * probe succeeds — it says nothing about whether the interactive attach/resume
- * that follows actually put the user back into the agent. If the REMOTE command
- * (`agents sessions focus <id> --local`) itself ever happened to exit 255 for a
- * reason that has nothing to do with the ssh transport, `sshStream` would return
- * that same 255, `reconnectStep` couldn't tell it apart from a genuine drop, and
- * `connected: true` would refill the retry budget forever — "attempt 1/N" printed
- * on every single cycle, the terminal filling with aborted-TTY escape-code
- * garbage, the retry window never actually bounding anything.
- *
- * The resume fall-through only widens that surface — the peer's focus now runs a
- * full recovery path (`resumeSessionInPlace` / `runOnPeer`) on a dead pane, any
- * step of which could in principle exit 255 for its own reasons. So the channel-
- * level defense is what matters, not an audit of which branch can fire:
- * {@link wrapRemoteExitCode} wraps the entire remote command so that whatever exit
- * code it decides on, a 255 is remapped to {@link REMOTE_EXIT_255_REMAPPED} before
- * `sshStream` ever sees it, regardless of which internal branch produced it and
- * regardless of the peer's `agents` version (the remap happens in the shell
- * wrapper THIS process sends).
- *
- * A recurring LOCAL ssh failure used to defeat the budget the same way, and the
- * remap alone did not close it (agents-cli#1884): `connected` was set by the
- * preflight probe and said nothing about whether the attach that followed held, so
- * a fast-flapping link — or an attach that died at the TTY-negotiation stage every
- * single time — refilled the budget on every cycle, printed "attempt 1" forever,
- * and left the retry window bounding nothing. The {@link MIN_HOLD_MS} floor above is
- * what closes it: an attach that dies immediately is not a reconnection, so the
- * budget drains and the loop gives up with {@link unstableNotice}. A flat total-
- * attempt or wall-clock ceiling that ignored `connected` was the alternative and is
- * deliberately NOT taken — any fixed total eventually strands the all-day-blinking
- * session this feature exists for, while the hold floor only ever stops a loop that
- * is failing to put the user back into the agent.
+ * A remote interactive session MUST be tmux-wrapped: with the wrap on, the agent
+ * runs in a DETACHED tmux pane on the peer, so a blink kills only the ssh client
+ * and the reattach rejoins the live pane; with it off, the agent is a child of
+ * the sshd session and a blink SIGHUPs it, losing the in-flight turn (the
+ * reattach then resumes the harness from disk). See lib/exec.ts `runInTmux`.
  */
 import { sshExec, sshStream, shellQuote, SSH_CONN_FAILURE_CODE } from '../ssh-exec.js';
 import { hostIdentityArgs, sshTargetFor, type Host } from './types.js';
 import { RUN_AUTO_KEYWORD } from '../types.js';
 
-/** ssh's connection-layer failure code — the signal that the link dropped rather
- *  than the remote command exiting on its own. Re-exported from ssh-exec.ts, which
- *  owns the ssh invocation, so the two cannot drift apart. */
+/** ssh's connection-layer failure code — re-exported from ssh-exec.ts. */
 export const SSH_CONN_FAILURE = SSH_CONN_FAILURE_CODE;
 
-/** What a would-be-255 remote-origin exit code is remapped to by
- *  {@link wrapRemoteExitCode} — see the file header. Never produced by the ssh
- *  transport itself, so it can never be confused with {@link SSH_CONN_FAILURE}. */
+/**
+ * ssh returns 255 for BOTH "couldn't connect" and "connected then dropped", so a
+ * remote-origin 255 (the focus command's own exit) is remapped to 254 before the
+ * reconnect loop sees it — inside the loop, 255 therefore always means a network
+ * drop, never a code the remote command chose.
+ */
 export const REMOTE_EXIT_255_REMAPPED = 254;
 
 /**
- * How long the loop keeps trying across an UNPRODUCTIVE streak before giving up.
- *
- * A wall-clock window, not an attempt count, because what it has to outlast is
- * measured in minutes: a laptop lid close, a Wi-Fi handoff, a VPN or Tailscale
- * re-auth, a router reboot. The previous `MAX_ATTEMPTS = 6` over a 2/4/8/16/30/30
- * backoff gave up after about **90 seconds** — shorter than any of them
- * (RUSH-3125). Worse, timers are suspended across sleep, so on wake the whole
- * backoff fired back-to-back before the network was up and the budget was gone in
- * seconds.
- *
- * It bounds the STREAK, not the session: a reattach that reconnects and HOLDS
- * resets it to zero ({@link refillsBudget}), so a session that blinks all day
- * still reconnects every time. That is the property the file header insists on,
- * and a flat total would break it — this changes only how a *streak* is bounded.
+ * Wall-clock window bounding unproductive reconnect streaks, not the total
+ * session. A reattach that reaches the host and holds resets the budget.
  */
 export const RECONNECT_WINDOW_MS = 15 * 60_000;
 
-/** Backoff curve for a streak: 2s, 4s, 8s, 16s, 30s, then 30s until the window
- *  closes. Capped so a long outage keeps probing at a useful cadence instead of
- *  drifting out to multi-minute gaps and missing the moment the link returns. */
+/** Backoff curve: 2s, 4s, 8s, 16s, 30s, then 30s until the window closes. */
 const BASE_BACKOFF_MS = 2_000;
 const MAX_BACKOFF_MS = 30_000;
 
-/** How long a reattach must hold the remote pane before it counts as a genuine
- *  reconnection that refills the budget. Measured on the interactive attach ALONE
- *  — the preflight probe has already returned by then, so this is not the connect
- *  timing the file header rules out. 10s is comfortably longer than any attach that
- *  dies during TTY negotiation and far shorter than a session the user is working
- *  in; a link that drops the user out inside 10s on every attempt is one this loop
- *  should stop retrying, not one it should keep re-entering. */
+/**
+ * A genuine reconnection must hold the remote pane this long before refilling
+ * the retry budget. It is the minimum time to clear TTY negotiation and confirm
+ * a working session, distinguishing that from an attach that reconnects and
+ * immediately re-drops; otherwise a flapping link would retry forever.
+ */
 export const MIN_HOLD_MS = 10_000;
 
 export interface ReconnectState {
-  /** Consecutive unproductive reattaches since the last genuine reconnection — one
-   *  that reached the host and held for {@link MIN_HOLD_MS}. Drives the backoff
-   *  curve and the human-facing attempt number; no longer the give-up condition. */
+  /** Consecutive unproductive reattaches since the last genuine reconnection. */
   attempt: number;
-  /** Wall-clock ms burned on the current unproductive streak — the waits plus the
-   *  time each failed attach itself took. Compared against
-   *  {@link RECONNECT_WINDOW_MS}; reset to 0 by a reattach that held. */
+  /** Ms burned on the current unproductive streak; compared to the window. */
   unproductiveMs: number;
 }
 
 export interface ReconnectOutcome {
-  /** Exit code of the run (initial) or the last re-attach. */
+  /** Exit code of the run or last re-attach. */
   code: number;
-  /** Whether the ssh handshake for this attempt actually completed. The initial run
-   *  and any reattach whose preflight probe succeeded are `connected`; a reattach
-   *  that couldn't reach the host is not. Half of the budget refill (see file head). */
+  /** Whether the ssh handshake completed (preflight probe succeeded). */
   connected: boolean;
-  /** Wall-clock ms the interactive attach ran for, timed from after the preflight
-   *  probe returned. `0` when the attempt never reached the host. The other half of
-   *  the refill: it must be at least {@link MIN_HOLD_MS} to count as a genuine
-   *  reconnection rather than a link that drops the user straight back out. */
+  /** How long the interactive attach held after the probe returned. */
   heldMs: number;
 }
 
@@ -171,36 +73,20 @@ export function backoffMs(attempt: number): number {
   return Math.min(BASE_BACKOFF_MS * 2 ** attempt, MAX_BACKOFF_MS);
 }
 
-/**
- * Did this attempt genuinely put the user back into the agent? Only such an attempt
- * refills the retry budget — it must have reached the host AND held the pane for at
- * least {@link MIN_HOLD_MS}. An attach that reached the host and died right back is
- * a flapping link, not a reconnection, and counts against the budget like an
- * unreachable host (agents-cli#1884; see the file header).
- */
+/** True when the attempt both connected and held long enough to refill the budget. */
 export function refillsBudget(outcome: ReconnectOutcome): boolean {
   return outcome.connected && outcome.heldMs >= MIN_HOLD_MS;
 }
 
 /**
- * Decide what to do after a run/re-attach returned `outcome`. Pure — the only
- * input is the prior state and the outcome, the only output is the next action.
- *
- *  - a non-255 code means the remote command spoke for itself (clean detach = 0,
- *    agent exit / no live session = non-zero) → stop and surface that code.
- *  - a 255 means the link dropped → retry, unless the budget is spent.
- *  - a 255 from an attempt that reconnected AND held ({@link refillsBudget})
- *    refills the budget first; every other 255 counts against it, so a host that
- *    stays unreachable — and a link that keeps dropping the attach immediately —
- *    both give up once the retry window closes.
+ * Decide the next action from a run/re-attach outcome. Non-255 exits stop and
+ * surface that code; 255 retries until the unproductive window is spent.
  */
 export function reconnectStep(state: ReconnectState, outcome: ReconnectOutcome): ReconnectDecision {
   if (outcome.code !== SSH_CONN_FAILURE) return { action: 'stop', code: outcome.code };
   const productive = refillsBudget(outcome);
   const attempts = productive ? 0 : state.attempt;
-  // The attach's own duration counts against the window: a 10s connect timeout
-  // burned on every attempt is real elapsed time the user is waiting, and
-  // ignoring it would stretch a "15 minute" window well past fifteen minutes.
+  // The attach's own duration counts against the window.
   const burned = productive ? 0 : state.unproductiveMs + outcome.heldMs;
   if (burned >= RECONNECT_WINDOW_MS) return { action: 'stop', code: SSH_CONN_FAILURE };
   const waitMs = backoffMs(attempts);
@@ -220,16 +106,7 @@ export function formatDuration(ms: number): string {
   return m > 0 ? `${m}m${String(sec).padStart(2, '0')}s` : `${sec}s`;
 }
 
-/**
- * Notice shown before each reconnect wait.
- *
- * Says how long is left in the window rather than "attempt 2/6": with a
- * wall-clock budget the attempt number no longer tells the user when this stops,
- * and "how much longer will it keep trying" is the actual question during an
- * outage. Ctrl-C is advertised because a user who wants their shell back should
- * not have to guess whether interrupting is safe — it is (the agent keeps
- * running on the peer, which is the whole point).
- */
+/** Notice shown before each reconnect wait. */
 export function reconnectNotice(target: ReconnectTarget, host: string, attempt: number, waitMs: number, remainingMs: number): string {
   const secs = Math.round(waitMs / 1000);
   const when = secs <= 1 ? 'now' : `in ${secs}s`;
@@ -237,56 +114,30 @@ export function reconnectNotice(target: ReconnectTarget, host: string, attempt: 
     + `\n  Reconnecting ${when} · ${formatDuration(remainingMs)} left · attempt ${attempt} · Ctrl-C to stop\n`;
 }
 
-/** Notice shown once the retry budget is spent on a host that stayed UNREACHABLE.
- *  Hands back the one verb that re-enters the terminal — attach the live pane if it
- *  survived, else resume. */
+/** Notice shown once the retry budget is spent on an unreachable host. */
 export function exhaustedNotice(target: ReconnectTarget, host: string): string {
   return `\nCouldn't reconnect to ${host} after ${formatDuration(RECONNECT_WINDOW_MS)}. The agent may still be running — get back in when the network is back:\n${recoveryHint(target, host)}`;
 }
 
-/** Notice shown when the budget is spent the OTHER way: the last reattach reached
- *  the host and the connection dropped again within {@link MIN_HOLD_MS}. Saying
- *  "couldn't reconnect" there would be false — it did reconnect and could not stay
- *  — and the user needs to know the link, not the host, is the problem. It claims
- *  no count of successful reconnections: the budget can also be spent by a run of
- *  unreachable attempts followed by one that reconnected and dropped straight out. */
+/** Notice shown when the host reconnects but drops again within {@link MIN_HOLD_MS}. */
 export function unstableNotice(target: ReconnectTarget, host: string): string {
   const secs = Math.round(MIN_HOLD_MS / 1000);
   return `\nGave up reconnecting to ${host} after ${formatDuration(RECONNECT_WINDOW_MS)} — it kept dropping again within ${secs} seconds of getting back in. The agent may still be running there; reconnect once the link is stable:\n${recoveryHint(target, host)}`;
 }
 
-/** Notice shown when a reattach stops on a remapped remote-side exit
- *  ({@link REMOTE_EXIT_255_REMAPPED} — a would-be-255 the remote command decided
- *  on for its own reasons, not the ssh transport dropping; see
- *  {@link wrapRemoteExitCode}). Distinct from {@link exhaustedNotice}, which is
- *  only for a genuinely spent retry budget. */
+/** Notice shown when a reattach ends with a remapped remote-side exit. */
 export function remoteExitNotice(target: ReconnectTarget, host: string): string {
   return `\nReattach to ${targetLabel(target)} on ${host} ended (not a network drop) — get back in, or check whether it's still live:\n${recoveryHint(target, host)}`;
 }
 
-/** Shown when the user Ctrl-Cs out of the wait. The agent is untouched — it is
- *  detached on the peer — so this says how to get back rather than implying the
- *  work was lost. */
+/** Notice shown when the user stops the wait with Ctrl-C. */
 export function interruptedNotice(target: ReconnectTarget, host: string): string {
   return `\nStopped reconnecting. ${targetLabel(target)} is still running on ${host}:\n${recoveryHint(target, host)}`;
 }
 
 /**
- * Wrap `cmd` in `bash -lc` (the login-shell pattern `buildRemoteAgentsInvocation`
- * in remote-cmd.ts uses for its own POSIX callers — see its doc comment for why
- * a login shell at all; the sibling interactive dispatch in dispatch.ts sends a
- * bare `agents …` with no shell wrapper, so this is a NEW login-shell hop on the
- * reattach path specifically, not something already universal here) with a
- * trailing exit-code remap: whatever `cmd` itself exits with, a 255 becomes
- * {@link REMOTE_EXIT_255_REMAPPED} before the wrapper exits — see the file
- * header for why. Every other code (0, 1, …) passes through unchanged. This
- * carries no PATH bootstrap of its own — `ensureHostReady`/`readyProbe` already
- * gates every `--device` dispatch on `bash -lc 'agents --version'` succeeding
- * before a run is attempted at all, so the peer's login shell resolving `agents`
- * is an established precondition here too. Pure string-building, so it is
- * unit-tested without SSH (and, since the constructed script is ordinary POSIX,
- * also exercised by actually running it through a real shell in the test — no
- * mock needed).
+ * Wrap `cmd` in `bash -lc` with an exit-code remap: 255 becomes
+ * {@link REMOTE_EXIT_255_REMAPPED} so a remote-origin 255 cannot pass as ssh drop.
  */
 export function wrapRemoteExitCode(cmd: string): string {
   const guarded = `${cmd}; rc=$?; [ "$rc" = "${SSH_CONN_FAILURE}" ] && rc=${REMOTE_EXIT_255_REMAPPED}; exit "$rc"`;
@@ -295,18 +146,7 @@ export function wrapRemoteExitCode(cmd: string): string {
 
 /**
  * How a dropped run is named when we go back for it.
- *
- * `session` is the direct case: the id was known before the link died — Claude
- * is handed one up front, and a resumed run already has one.
- *
- * `launch` is what makes reconnect work for every OTHER harness (RUSH-3125).
- * Their real session id is coined on the peer, and the launcher used to read it
- * back over SSH *after* the stream returned — i.e. over the link that had just
- * dropped. That read fails exactly when it matters, leaving `reconnectId`
- * undefined and the process exiting straight to a shell, which is why a Grok tab
- * got no reconnect at all while a Claude tab beside it got a countdown. The
- * launch id is minted locally before the connection exists, so it survives the
- * drop; the peer maps it to the real session with a purely local lookup.
+ * `launch` ids are minted locally before the connection exists, so they survive a drop.
  */
 export type ReconnectTarget =
   | { kind: 'session'; id: string }
@@ -318,23 +158,10 @@ export function targetLabel(target: ReconnectTarget): string {
 }
 
 /**
- * The command to hand a user whose reconnect gave up.
- *
- * A `session` target has a real id, so `agents sessions resume <id>` does the
- * same attach-else-recover the loop was attempting. The full id is labeled on
- * its own `Session` line, not only inside the command (RUSH-3227). (It used to
- * say `agents reconnect`, which is deprecated and hidden — `commands/reconnect.ts`
- * — so the advice printed at the worst possible moment was itself stale; RUSH-3125.)
- *
- * A `launch` target has no id a user-facing verb accepts: the mapping lives in
- * the peer's hook records, which is exactly why reconnect uses it. So point at
- * the peer's own resolver rather than inventing a launch-id selector on every
- * local command for a string no human ever types.
+ * The command a user can run to re-enter a session after reconnect gives up.
+ * The full id is printed on its own line so it remains copyable after a drop.
  */
 export function recoveryHint(target: ReconnectTarget, host: string): string {
-  // The full id is labeled on its own line: burying it only inside a command is
-  // how a dropped SSH tab used to land on a bare shell with nothing copyable
-  // (RUSH-3227). Resume still sits underneath so the user can paste one verb.
   if (target.kind === 'session') {
     return `  Session ${target.id}\n  Resume:  agents sessions resume ${target.id}\n`;
   }
@@ -343,11 +170,8 @@ export function recoveryHint(target: ReconnectTarget, host: string): string {
 }
 
 /**
- * Notice shown when an interactive remote connection has ended and the user is
- * back at a local shell — clean detach, agent exit, or a drop that is NOT
- * about to auto-reconnect. The OpenSSH close line (`Shared connection to …
- * closed.`) names the host and nothing else; this is the handle they need to
- * get back in (RUSH-3227).
+ * Notice shown when an interactive remote connection ends and no auto-reconnect
+ * follows. Prints the session id/handle so the user can get back in.
  */
 export function connectionEndedNotice(
   target: ReconnectTarget,
@@ -359,11 +183,8 @@ export function connectionEndedNotice(
 }
 
 /**
- * Banner printed when an interactive `--device` run whose session id is already
- * known (Claude's forced id, or a resume) is about to take the TTY. The TUI
- * will cover this; it survives in scrollback so the id exists *while* the
- * connection exists, not only after it dies (RUSH-3227 plan B). Launch-id
- * targets are not a resume handle — do not print them here.
+ * Banner printed as an interactive `--device` run takes the TTY, so the id is
+ * visible in scrollback while the connection exists.
  */
 export function connectionStartedNotice(target: ReconnectTarget, host: string): string | undefined {
   if (target.kind !== 'session') return undefined;
@@ -371,10 +192,8 @@ export function connectionStartedNotice(target: ReconnectTarget, host: string): 
 }
 
 /**
- * The id to print as an interactive `--device` stream starts. Resume is a
- * real session id (`resolveHostSessionId` returns undefined on `--resume`);
- * Claude's forced id is the other. `run auto` is excluded: its forwarded
- * `--session-id` is only real if the remote pick is Claude.
+ * The id to print as an interactive `--device` stream starts. `run auto` is
+ * excluded because its forwarded id is only real when the remote picks Claude.
  */
 export function startConnectionTarget(opts: {
   agent: string;
@@ -387,15 +206,8 @@ export function startConnectionTarget(opts: {
 }
 
 /**
- * Decide what happens after an interactive `--device` stream returns.
- *
- * Auto-reconnect fires whenever the link dropped (255) and the run did not opt
- * out with `--raw` (`willReconnect`) — wrap or no wrap. A wrapped run's pane
- * survived, so the reattach rejoins it; a bare run's agent died with the link,
- * so the same verb resumes the session in place from disk (PHNX-3316). `--raw`
- * never reconnects — but it still prints the session id: the user is at a
- * shell, and EXEC-55 does not exempt raw (RUSH-3227). Bundling the notice
- * behind `!isRaw` was the miss.
+ * Decide what happens after an interactive `--device` stream returns. Auto-
+ * reconnect fires on 255 unless `--raw` opted out; otherwise print recovery info.
  */
 export function afterInteractiveRemoteExit(opts: {
   target?: ReconnectTarget;
@@ -414,39 +226,18 @@ export function afterInteractiveRemoteExit(opts: {
   };
 }
 
-/** What the launcher knows about a run once its interactive stream has returned. */
+/** Inputs the launcher has once its interactive stream has returned. */
 export interface ReconnectTargetInputs {
-  /** The harness (or {@link RUN_AUTO_KEYWORD}) that was dispatched. */
   agent: string;
-  /** An id forced by the launcher up front — Claude's `--session-id`. */
   sessionId?: string;
-  /** An id read back off the peer AFTER the stream returned. Absent on a drop. */
   resolvedId?: string;
-  /** The id of a run that was resuming an existing session. */
   resumeId?: string;
-  /** The launcher-minted AGENT_LAUNCH_ID, known before the connection existed. */
   launchId?: string;
 }
 
 /**
- * Choose how to name the dropped run when going back for it.
- *
- * Order matters, and the last clause is the fix (RUSH-3125):
- *
- *  1. `run auto` prefers `resolvedId` — the harness the remote ACTUALLY picked,
- *     which the launcher's own `--session-id` (adopted only by Claude) may not
- *     name. Every other agent prefers the id the launcher forced.
- *  2. `resumeId` covers a run that was continuing a known session.
- *  3. **`launchId` last, and it is what makes this work at all off-Claude.**
- *     Every id above either came from the launcher or was read back over SSH —
- *     and that read happens after the stream returned, i.e. over the link that
- *     just died, so on a real drop it yields nothing. Falling through to the
- *     launch id means the reconnect no longer depends on reaching the host to
- *     learn what to reconnect to; the peer resolves it locally instead.
- *
- * Returns undefined only when the launcher has no handle at all (a hookless
- * harness with no forced id), which is the one case reconnect genuinely cannot
- * serve. Pure, so the precedence is unit-tested without SSH.
+ * Choose how to name the dropped run. `launchId` is last because it is minted
+ * locally before the connection exists, so it survives the drop.
  */
 export function pickReconnectTarget(inputs: ReconnectTargetInputs): ReconnectTarget | undefined {
   const { agent, sessionId, resolvedId, resumeId, launchId } = inputs;
@@ -459,18 +250,8 @@ export function pickReconnectTarget(inputs: ReconnectTargetInputs): ReconnectTar
 }
 
 /**
- * The remote command a reattach runs — the peer's own recovery verb
- * (`agents sessions focus … --local`), wrapped by {@link wrapRemoteExitCode}
- * so a stray remote-origin 255 (from this command, whatever produces it — see the
- * file header) can never masquerade as a network drop. No `--attach-only`: focus
- * joins the live pane when it survived, else RESUMES the session in place, so a
- * reattach landing after the pane died recovers the agent instead of dead-ending
- * (RUSH-2085). Split out from {@link reattachRemoteSession} so it is unit-tested
- * without SSH — mirrors `remoteAgentsJsonCommand` in lib/remote-agents-json.ts.
- *
- * A `launch` target passes `--launch-id`, which focus resolves against the hook
- * records on the peer itself — no network read from this side, which is the
- * whole point (see {@link ReconnectTarget}).
+ * The peer's recovery verb wrapped so a remote-origin 255 cannot masquerade as
+ * a network drop. No `--attach-only`: focus resumes in place when no pane survived.
  */
 export function reattachRemoteCommand(target: ReconnectTarget): string {
   const selector = target.kind === 'launch'
@@ -483,26 +264,18 @@ export function reattachRemoteCommand(target: ReconnectTarget): string {
 }
 
 /**
- * Re-attach the live remote tmux pane for `sessionId` by driving the peer's own
- * `agents sessions focus`. A fast, un-multiplexed preflight probe (`ssh … true`)
- * first establishes whether the host is actually reachable this attempt — that
- * `connected` bit, not the call duration, is what the retry policy keys on. Only on
- * a reachable host do we run the interactive attach-or-resume (which carries no
- * credentials — the agent already runs on the peer — so it rides the normal
- * transport). Returns the ssh exit code (255 = dropped again / unreachable; 0 =
- * clean detach; other = session ended), whether this attempt connected, and how
- * long the attach held — the two inputs {@link refillsBudget} decides on.
+ * Re-attach the live remote pane by driving the peer's `agents sessions focus`.
+ * A fast preflight probe decides reachability; only then do we run the
+ * interactive attach/resume. Returns the exit code, connected bit, and hold time.
  */
 export function reattachRemoteSession(host: Host, target: ReconnectTarget): ReconnectOutcome {
   const sshTarget = sshTargetFor(host);
   const extraSshArgs = hostIdentityArgs(host);
-  // Fresh (non-multiplexed) reachability probe: code 0 means the handshake actually
-  // completed, so a hung/failed connect is never mistaken for a live reconnection.
-  // RUSH-2265: pass host identity on every hop (probe + stream), not only the first.
+  // Fresh (non-multiplexed) reachability probe: only a completed handshake is
+  // counted as connected.
   const probe = sshExec(sshTarget, 'true', { multiplex: false, extraSshArgs });
   if (probe.code !== 0) return { code: SSH_CONN_FAILURE, connected: false, heldMs: 0 };
-  // Timed from AFTER the probe returned, so this is the attach's own duration and
-  // carries none of the connect phase the file header rules out as a signal.
+  // Timed from after the probe returns, so this measures only the attach itself.
   const startedAt = Date.now();
   const code = sshStream(sshTarget, reattachRemoteCommand(target), { tty: true, extraSshArgs });
   return { code, connected: true, heldMs: Date.now() - startedAt };
@@ -511,14 +284,8 @@ export function reattachRemoteSession(host: Host, target: ReconnectTarget): Reco
 /**
  * Wait `ms`, but return early if the user interrupts.
  *
- * Without this, Ctrl-C during the backoff killed the whole `agents` process:
- * node's default SIGINT handler exits, so the loop never got to say what
- * happened, the terminal was left mid-notice, and the user was dropped at a bare
- * shell with no hint that the agent was still alive on the peer — the same
- * dead-end the reconnect exists to prevent. The handler is installed only for
- * the duration of the wait and always removed, so it can never swallow a Ctrl-C
- * meant for the attached agent (during an attach, ssh owns the tty and this
- * process is not in the foreground group anyway).
+ * Installs a SIGINT handler only for the wait so Ctrl-C gives a graceful
+ * "agent still running" message instead of killing the local process silently.
  */
 async function waitOrInterrupt(ms: number): Promise<'elapsed' | 'interrupted'> {
   return new Promise((resolve) => {
@@ -539,40 +306,27 @@ async function waitOrInterrupt(ms: number): Promise<'elapsed' | 'interrupted'> {
 export interface ReconnectLoopOpts {
   host: Host;
   target: ReconnectTarget;
-  /** The exit code from the initial interactive run (which, having run the agent,
-   *  is treated as a connected attempt). */
+  /** Exit code from the initial interactive run (treated as connected). */
   initialExit: number;
-  /** Injected for tests: the real re-attach and wait are swapped for deterministic
-   *  fakes so the loop's control flow is exercised without SSH. Production uses the
-   *  real {@link reattachRemoteSession} + {@link waitOrInterrupt}. */
+  /** Test seams for the re-attach and wait. */
   reattach?: (host: Host, target: ReconnectTarget) => ReconnectOutcome;
-  /** Resolves 'interrupted' when the user Ctrl-Cs out of the backoff. */
   wait?: (ms: number) => Promise<'elapsed' | 'interrupted'>;
   write?: (s: string) => void;
 }
 
-/**
- * Drive the reconnect loop from the initial run's outcome to a terminal code.
- * Only the real SSH re-attach and the wait are side effects; the decision is
- * {@link reconnectStep}. Returns the exit code the process should ultimately use.
- */
+/** Drive the reconnect loop from the initial run's outcome to a terminal code. */
 export async function reconnectInteractiveSession(opts: ReconnectLoopOpts): Promise<number> {
   const write = opts.write ?? ((s: string) => process.stderr.write(s));
   const wait = opts.wait ?? waitOrInterrupt;
   const reattach = opts.reattach ?? reattachRemoteSession;
 
   let state = initialReconnectState();
-  // The initial run reached the point of running the agent, so it connected. Its
-  // hold duration is never measured — exec.ts owns that call — and never needs to
-  // be: refilling is a no-op at attempt 0, which is where the loop starts, so this
-  // outcome can only ever produce the first retry either way.
+  // The initial run connected; its hold duration doesn't matter at attempt 0.
   let outcome: ReconnectOutcome = { code: opts.initialExit, connected: true, heldMs: 0 };
   for (;;) {
     const decision = reconnectStep(state, outcome);
     if (decision.action === 'stop') {
-      // A spent budget has two shapes and one wrong message: `outcome` is the
-      // reattach that spent it, so an unreachable host reads "couldn't reconnect"
-      // and a link that reconnected but kept dropping reads as exactly that.
+      // Spent budget: unreachable host vs. unstable link need different messages.
       if (decision.code === SSH_CONN_FAILURE) {
         write(outcome.connected
           ? unstableNotice(opts.target, opts.host.name)
@@ -580,17 +334,14 @@ export async function reconnectInteractiveSession(opts: ReconnectLoopOpts): Prom
       } else if (decision.code === REMOTE_EXIT_255_REMAPPED) {
         write(remoteExitNotice(opts.target, opts.host.name));
       } else {
-        // Clean detach / agent exit after a reattach: the user is at a local
-        // shell and still needs the session id (RUSH-3227). Spent-budget and
-        // remapped-255 notices already carry recoveryHint.
+        // Clean detach / agent exit: still print the session handle.
         write(connectionEndedNotice(opts.target, opts.host.name));
       }
       return decision.code;
     }
     write(reconnectNotice(opts.target, opts.host.name, decision.state.attempt, decision.waitMs, decision.remainingMs));
     if (await wait(decision.waitMs) === 'interrupted') {
-      // The user asked for their shell back. Nothing was lost — say where the
-      // agent is and how to return, then exit as an interrupt (128 + SIGINT).
+      // User interrupted; the agent is still running on the peer.
       write(interruptedNotice(opts.target, opts.host.name));
       return 130;
     }

--- a/cli/src/lib/installations/migrate.ts
+++ b/cli/src/lib/installations/migrate.ts
@@ -1,9 +1,4 @@
-/**
- * One-shot idempotent migrations for the FOUNDATION refactor.
- *
- * Called from postinstall and as a command-time fallback from agents view/use/pull.
- * Each migration is guarded by an existence check so re-running is safe.
- */
+/** One-shot idempotent migrations. Each is guarded by an existence check so re-running is safe. */
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -36,7 +31,6 @@ const SYSTEM_DIR = path.join(USER_DIR, '.system');
 const HISTORY_DIR = path.join(USER_DIR, '.history');
 const CACHE_DIR = path.join(USER_DIR, '.cache');
 
-/** True when `relPath` is a file tracked by a git repo rooted at `repoDir`. */
 function isTrackedInGitRepo(repoDir: string, relPath: string): boolean {
   try {
     execSync(`git ls-files --error-unmatch -- ${relPath}`, { cwd: repoDir, stdio: 'ignore' });
@@ -47,31 +41,13 @@ function isTrackedInGitRepo(repoDir: string, relPath: string): boolean {
   }
 }
 
-/**
- * Migrate a legacy single-repo agents.yaml into ~/.agents/agents.yaml.
- *
- * The post-fold system dir (~/.agents/.system) is a pull-only mirror of the
- * npm-shipped defaults. Its agents.yaml is a TRACKED file that readMeta() reads
- * in place as the defaults base (see SYSTEM_META_FILE in state.ts). Deleting or
- * moving a tracked file out of the mirror dirties its working tree, which
- * permanently wedges `agents setup`, `agents sync`, and background auto-pull
- * ("Working tree has uncommitted changes.") because the mirror sync refuses a
- * dirty tree. So when agents.yaml is tracked there, treat the mirror as strictly
- * read-only and leave the file alone.
- *
- * Only an UNTRACKED agents.yaml is residue from the pre-split single-repo layout
- * (or a legacy ~/.agents-system fold) and is safe to move/drop.
- *
- * Params default to the real on-disk locations; they are injectable so tests can
- * drive a fixture tree without touching the user's ~/.agents.
- */
+/** Migrate a legacy single-repo agents.yaml into ~/.agents/agents.yaml. Leaves the tracked system-mirror copy alone to avoid dirtying the npm-shipped defaults. */
 export function migrateAgentsYaml(systemDir: string = SYSTEM_DIR, userDir: string = USER_DIR): void {
   const src = path.join(systemDir, 'agents.yaml');
   const dest = path.join(userDir, 'agents.yaml');
   if (!fs.existsSync(src)) return;
 
-  // Tracked in the system mirror → npm-shipped defaults; never mutate. readMeta()
-  // already surfaces it in place, so no user-dir copy is needed either.
+  // Never move the tracked system-mirror copy; doing so would dirty the npm-shipped defaults.
   if (isTrackedInGitRepo(systemDir, 'agents.yaml')) return;
 
   if (fs.existsSync(dest)) {
@@ -86,9 +62,6 @@ export function migrateAgentsYaml(systemDir: string = SYSTEM_DIR, userDir: strin
   } catch { /* best-effort */ }
 }
 
-/**
- * Delete ~/.agents-system/prompts.json (dead file — zero refs in src/).
- */
 function deleteSystemPromptsJson(): void {
   const f = path.join(SYSTEM_DIR, 'prompts.json');
   if (!fs.existsSync(f)) return;
@@ -97,14 +70,7 @@ function deleteSystemPromptsJson(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Move ~/.agents-system/config.json -> ~/.agents/teams/config.json.
- * The teams persistence layer already reads the legacy path as a fallback;
- * moving it here keeps the canonical location consistent.
- */
-// Delete the legacy ~/.agents-system/config.json. This was the teams agent
-// registry, which no longer exists — `agents teams` discovers agents through
-// `listInstalledVersions` and invokes them through `agents run`.
+/** Delete the legacy ~/.agents-system/config.json (dead teams agent registry). */
 function migrateSystemConfigJson(): void {
   const src = path.join(SYSTEM_DIR, 'config.json');
   if (!fs.existsSync(src)) return;
@@ -113,12 +79,7 @@ function migrateSystemConfigJson(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Move promptcuts.yaml from each repo root into hooks/ subdir.
- *   ~/.agents-system/promptcuts.yaml -> ~/.agents-system/hooks/promptcuts.yaml
- *   ~/.agents/promptcuts.yaml        -> ~/.agents/hooks/promptcuts.yaml
- * Idempotent: skips if dest already exists or src absent.
- */
+/** Move promptcuts.yaml from each repo root into hooks/. */
 function migratePromptcutsIntoHooks(): void {
   for (const root of [SYSTEM_DIR, USER_DIR]) {
     const src = path.join(root, 'promptcuts.yaml');
@@ -131,23 +92,7 @@ function migratePromptcutsIntoHooks(): void {
   }
 }
 
-/**
- * Move installed agent versions from the legacy system-root layout
- * (~/.agents-system/versions/<agent>/<ver>/) into the user root
- * (~/.agents/versions/<agent>/<ver>/).
- *
- * Earlier installs (and an inverted prior version of this migrator) put
- * binaries and home dirs under ~/.agents-system/. The current architecture
- * keeps all operational state (versions, sessions, shims, trash) under
- * ~/.agents/, and getVersionsDir() in state.ts resolves there. Without this
- * migration the legacy versions become invisible to listInstalledVersions
- * and every command that depends on it (view, prune, run, sync) writes a
- * second copy to ~/.agents/versions/ while the agent CLIs keep reading the
- * stale ~/.agents-system/versions/ copy via the existing ~/.<agent> symlink.
- *
- * Idempotent and non-destructive: if a same-named dest already exists we
- * leave the legacy copy in place so the user can reconcile manually.
- */
+/** Move installed versions from the legacy ~/.agents-system/versions/ tree into ~/.agents/versions/. Leaves collisions in place for manual reconciliation. */
 function migrateSystemVersionsToUser(): void {
   const sysVersions = path.join(SYSTEM_DIR, 'versions');
   const userVersions = path.join(USER_DIR, 'versions');
@@ -208,10 +153,7 @@ function migrateSystemVersionsToUser(): void {
   }
 }
 
-/**
- * Move ~/. agents/runs/ -> ~/.agents/routines/runs/.
- * Runs now live inside routines directory for cleaner organization.
- */
+/** Move ~/.agents/runs/ into ~/.agents/routines/runs/. */
 function migrateRunsIntoRoutines(): void {
   const src = path.join(USER_DIR, 'runs');
   const dest = path.join(USER_DIR, 'routines', 'runs');
@@ -222,10 +164,7 @@ function migrateRunsIntoRoutines(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Move ~/.agents/trash/ -> ~/.agents/.trash/.
- * Hide the trash directory.
- */
+/** Move ~/.agents/trash/ to ~/.agents/.trash/. */
 function migrateTrashToHidden(): void {
   const src = path.join(USER_DIR, 'trash');
   const dest = path.join(USER_DIR, '.trash');
@@ -235,10 +174,7 @@ function migrateTrashToHidden(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Move ~/.agents/backups/ -> ~/.agents/.backups/.
- * Hide the backups directory.
- */
+/** Move ~/.agents/backups/ to ~/.agents/.backups/. */
 function migrateBackupsToHidden(): void {
   const src = path.join(USER_DIR, 'backups');
   const dest = path.join(USER_DIR, '.backups');
@@ -248,17 +184,7 @@ function migrateBackupsToHidden(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Fold ~/.agents/hooks.yaml into ~/.agents/agents.yaml under a `hooks:` key,
- * then delete the standalone hooks.yaml. Single user file to sync.
- *
- * On collision (a hook name already exists in agents.yaml hooks:), the
- * existing agents.yaml entry wins and the standalone copy is dropped — this
- * matches the behavior a user would get if they had already migrated
- * manually and edited agents.yaml.
- *
- * Idempotent: skips if hooks.yaml is absent or unparseable.
- */
+/** Fold ~/.agents/hooks.yaml into ~/.agents/agents.yaml under `hooks:`, dropping the standalone file. agents.yaml wins on collision. */
 function foldUserHooksYamlIntoAgentsYaml(): void {
   const hooksFile = path.join(USER_DIR, 'hooks.yaml');
   if (!fs.existsSync(hooksFile)) return;
@@ -297,17 +223,7 @@ function foldUserHooksYamlIntoAgentsYaml(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Fold the legacy GLOBAL browser captures root
- * (`~/.agents/.cache/browser/sessions/<task>/`) into the new PER-PROFILE layout
- * (`~/.agents/.cache/browser/<profile>/sessions/<task>/`), so each profile is one
- * self-contained tree and the new `browser sessions` listing finds old captures.
- *
- * Attribution: a legacy `sessions/<task>` dir is owned by whichever profile's
- * `tasks.json` still lists that task name. Tasks no profile claims (the profile
- * was deleted, or tasks.json was cleared) move under a `_legacy` pseudo-profile so
- * nothing is lost. Idempotent — once the global `sessions/` root is gone it no-ops.
- */
+/** Fold the legacy global browser/sessions/<task>/ tree into the per-profile browser/<profile>/sessions/<task>/ layout. Unclaimed tasks move under `_legacy`. */
 export function foldBrowserSessionsIntoProfiles(browserDir: string = path.join(CACHE_DIR, 'browser')): void {
   const legacySessionsDir = path.join(browserDir, 'sessions');
 
@@ -318,7 +234,6 @@ export function foldBrowserSessionsIntoProfiles(browserDir: string = path.join(C
     return; // no legacy global sessions/ root — already folded or never existed
   }
 
-  // Map task name -> owning profile from every profile's tasks.json (first wins).
   const taskOwner = new Map<string, string>();
   let profileDirs: fs.Dirent[] = [];
   try {
@@ -349,15 +264,7 @@ export function foldBrowserSessionsIntoProfiles(browserDir: string = path.join(C
   rmEmptyDirTree(legacySessionsDir);
 }
 
-/**
- * Fold ~/.agents/browser/profiles/*.yaml into ~/.agents/agents.yaml under a
- * `browser:` key, then delete the profiles directory. Single user file to sync.
- *
- * On collision (a profile name already exists in agents.yaml browser:), the
- * existing agents.yaml entry wins and the standalone copy is dropped.
- *
- * Idempotent: skips if profiles dir is absent or empty.
- */
+/** Fold ~/.agents/browser/profiles/*.yaml into ~/.agents/agents.yaml under `browser:`. agents.yaml wins on collision. */
 function foldBrowserProfilesIntoAgentsYaml(): void {
   const profilesDir = path.join(USER_DIR, 'browser', 'profiles');
   if (!fs.existsSync(profilesDir)) return;
@@ -418,10 +325,7 @@ function foldBrowserProfilesIntoAgentsYaml(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Delete ~/.agents/linear.json. The linear-cli now manages its own
- * credentials in the OS keychain; this file was a legacy plaintext store.
- */
+/** Delete the legacy ~/.agents/linear.json plaintext credential store. */
 function deleteUserLinearJson(): void {
   const f = path.join(USER_DIR, 'linear.json');
   if (!fs.existsSync(f)) return;
@@ -430,11 +334,7 @@ function deleteUserLinearJson(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Delete ~/.agents/prompts.json. Dead file with zero refs in src/ (the
- * system-repo copy was cleared by deleteSystemPromptsJson; this is the
- * matching cleanup at the user layer).
- */
+/** Delete the dead ~/.agents/prompts.json file. */
 function deleteUserPromptsJson(): void {
   const f = path.join(USER_DIR, 'prompts.json');
   if (!fs.existsSync(f)) return;
@@ -443,12 +343,7 @@ function deleteUserPromptsJson(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Delete ~/.agents/teams/config.json. The teams subsystem no longer carries
- * its own agent registry — agent discovery flows through `listInstalledVersions`
- * (the same source `agents view` uses) and invocation flows through
- * `agents run`. The on-disk file is pure dead state on existing installs.
- */
+/** Delete the dead ~/.agents/teams/config.json file. */
 function deleteTeamsConfigJson(): void {
   const f = path.join(USER_DIR, 'teams', 'config.json');
   if (!fs.existsSync(f)) return;
@@ -457,23 +352,14 @@ function deleteTeamsConfigJson(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Move ~/.agents/teams/registry.json → ~/.agents/.history/teams/registry.json.
- * The registry is per-machine runtime state (timestamps + absolute worktree
- * paths) and belongs in the durable-runtime bucket, not at the user-root
- * where `agents repo push` would sync it across machines.
- */
+/** Move ~/.agents/teams/registry.json (per-machine runtime state) into ~/.agents/.history/teams/. */
 function moveTeamsRegistryToHistory(): void {
   const src = path.join(USER_DIR, 'teams', 'registry.json');
   const dest = path.join(HISTORY_DIR, 'teams', 'registry.json');
   moveFileOnce(src, dest);
 }
 
-/**
- * Delete ~/.agents/config.json. This was the legacy teams config location;
- * the teams subsystem no longer carries a config file at all, so the legacy
- * copy is simply removed.
- */
+/** Delete the legacy ~/.agents/config.json teams config file. */
 function cleanupUserConfigJson(): void {
   const legacy = path.join(USER_DIR, 'config.json');
   if (!fs.existsSync(legacy)) return;
@@ -482,11 +368,7 @@ function cleanupUserConfigJson(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Remove an empty ~/.agents/runs/ directory left over after the
- * migrateRunsIntoRoutines() rename. Some older code paths re-created the
- * empty parent; this trims it once it has no contents.
- */
+/** Remove an empty ~/.agents/runs/ directory left over after migrateRunsIntoRoutines(). */
 function cleanupEmptyTopLevelRuns(): void {
   const dir = path.join(USER_DIR, 'runs');
   if (!fs.existsSync(dir)) return;
@@ -495,11 +377,7 @@ function cleanupEmptyTopLevelRuns(): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Move ~/.agents-system/aliases.json -> ~/.agents/aliases.json.
- * Aliases are per-user state and were previously written to the system root
- * by mistake. Idempotent: skips if dest already exists or src absent.
- */
+/** Move ~/.agents-system/aliases.json into ~/.agents/aliases.json. */
 function migrateAliasesToUser(): void {
   const src = path.join(SYSTEM_DIR, 'aliases.json');
   const dest = path.join(USER_DIR, 'aliases.json');
@@ -581,11 +459,7 @@ function mergeOverlappingVersionHomes(): void {
   }
 }
 
-/**
- * Rename ~/.agents/permissions/sets/ -> ~/.agents/permissions/presets/.
- * Also handles ~/.agents-system/permissions/sets/ for system repo.
- * Idempotent: skips if dest already exists or src absent.
- */
+/** Rename permissions/sets/ to permissions/presets/ in both user and system repos. */
 function migratePermissionSetsToPresets(): void {
   for (const root of [USER_DIR, SYSTEM_DIR]) {
     const src = path.join(root, 'permissions', 'sets');
@@ -599,16 +473,7 @@ function migratePermissionSetsToPresets(): void {
   }
 }
 
-/**
- * After versions are migrated to ~/.agents/versions/, rewrite the per-agent
- * config symlinks (~/.claude, ~/.codex, …) to point at the user-side
- * version-home so the agent CLIs read fresh resources.
- *
- * Idempotent: if the symlink already points at the right user-path target,
- * leave it. If it points at the legacy system path, re-create it. If a real
- * directory exists there (no symlink yet), leave it alone — version-config
- * switching is owned by `agents use`, not the migrator.
- */
+/** Rewrite per-agent config symlinks to point at the user-side version home after migration. Leaves real directories alone (switching is owned by `agents use`). */
 function repairAgentConfigSymlinks(): void {
   // Version pins live in the machine-local pins JSON (~/.agents/.history/
   // devices/pins-<machine>.json); the tracked device doc and central
@@ -672,36 +537,13 @@ function repairAgentConfigSymlinks(): void {
   }
 }
 
-/**
- * Repair self-referential agent binary symlinks.
- *
- * Some installScript-based agents — notably Factory.ai's `droid`, whose installer
- * drops a standalone native binary at ~/.local/bin/droid — were registered at
- * install time by resolving the post-install binary with `which <cli>`. Because
- * ~/.agents/.cache/shims sits ahead of ~/.local/bin on PATH, `which` could
- * return OUR OWN dispatcher shim, and the install step symlinked
- *   ~/.agents/.history/versions/<agent>/<version>/node_modules/.bin/<cli>
- * back at ~/.agents/.cache/shims/<cli>. Launching that agent then re-execs the
- * dispatcher forever (an infinite exec loop that hangs the terminal).
- *
- * This walks every installed version's node_modules/.bin and, for any entry
- * whose symlink resolves into the shims dir, re-points it at the real binary
- * (found on PATH with the shims dir excluded) — or removes it when no real
- * binary can be found, letting getBinaryPath's per-agent resolver take over.
- * Idempotent: a correctly-pointed link is left untouched on re-run.
- *
- * Params default to the real on-disk locations; they are injectable so tests
- * can drive a fixture tree without touching the user's ~/.agents.
- */
+/** Repair node_modules/.bin/<cli> symlinks that resolve back into our own shims dir (infinite exec-loop fix). */
 export function repairSelfReferentialBinShims(
   versionsRoot: string = path.join(HISTORY_DIR, 'versions'),
   shimsDir: string = path.resolve(CACHE_DIR, 'shims'),
   historyDir: string = path.dirname(versionsRoot),
 ): void {
-  // Normalize the shims dir through realpath so the prefix check below survives
-  // a symlinked ~/.agents (or macOS's /tmp -> /private/tmp): fs.realpathSync on
-  // the link target resolves those symlinks, so the dir we compare against must
-  // too, or every loop would read as "points at a real binary" and be skipped.
+  // realpath the shims dir so the prefix check survives symlinked paths (e.g. macOS /tmp -> /private/tmp).
   shimsDir = path.resolve(shimsDir);
   try {
     shimsDir = fs.realpathSync(shimsDir);
@@ -769,14 +611,7 @@ export function repairSelfReferentialBinShims(
   }
 }
 
-/**
- * Move a directory from `src` to `dest`. No-op when src is absent. When dest
- * already exists, merge by copying everything that isn't already there, then
- * remove the source. Idempotent: re-running converges without duplicating.
- *
- * The merge-on-collision behavior matters because `ensureAgentsDir()` may have
- * pre-created an empty `dest` during startup before the migrator gets to run.
- */
+/** Move `src` to `dest`; when `dest` exists, merge missing entries then remove `src`. Idempotent. */
 function moveDirOnce(src: string, dest: string): void {
   if (!fs.existsSync(src)) return;
 
@@ -796,11 +631,7 @@ function moveDirOnce(src: string, dest: string): void {
   } catch { /* best-effort */ }
 }
 
-/**
- * Move a single file from `src` to `dest`. No-op when src is absent. When
- * dest exists, the source is simply deleted (the in-place version is treated
- * as the canonical state). Idempotent.
- */
+/** Move `src` to `dest`; when `dest` exists, delete `src` (dest is canonical). Idempotent. */
 function moveFileOnce(src: string, dest: string): void {
   if (!fs.existsSync(src)) return;
   if (fs.existsSync(dest)) {
@@ -818,7 +649,6 @@ function moveFileOnce(src: string, dest: string): void {
   }
 }
 
-/** Remove a directory tree if it exists and contains no files (best-effort). */
 function rmEmptyDirTree(dir: string): void {
   if (!fs.existsSync(dir)) return;
   try {
@@ -1582,41 +1412,7 @@ function migrateSplitDeviceLocalMeta(): void {
   }
 }
 
-/**
- * Move the auto-detected `default` browser profile OUT of the committed central
- * agents.yaml and into this machine's per-device file.
- *
- * `browser` is a CENTRAL key because named profiles a user creates are real fleet
- * config, but the ONE `default` entry inside it is machine-local: its `binary` is
- * an OS-specific path and its endpoint is a locally-chosen free port.
- * `createProfile`/`updateProfile` already route that entry to `deviceBrowser`
- * (`isMachineLocalProfile`, browser/profiles.ts) — but nothing ever removed the
- * copy older versions had already written into the shared file, and
- * `serializeCentral` cannot: it deletes whole KEYS that are device-scoped, and
- * `browser` is not one.
- *
- * So the entry sat in the committed file and every box rewrote it with its own
- * browser. Measured 2026-08-13, all three boxes on 1.22.38 (which HAS the writer
- * fix) with an empty `deviceBrowser` and a machine-specific `default` in central:
- *
- *   zion         browser: chrome    binary: /Applications/Google Chrome.app/...
- *   yosemite-s1  browser: brave     binary: /opt/brave.com/brave/brave
- *   mark-1       (same shape)
- *
- * `agents repos pull user` refuses when an incoming change touches a locally
- * modified path, so agents.yaml being permanently dirty wedged the fleet config
- * sync outright — those boxes sat 5, 8 and 79 commits behind. (RUSH-2161)
- *
- * Idempotent: no-op once central carries no `default` entry. The device file is
- * written FIRST so a crash between the two writes can never lose the profile,
- * and an entry already in the device file wins (this machine's live value is
- * newer than the stale central copy by construction).
- *
- * Central is edited through a `yaml.Document` rather than re-stringified, so the
- * hand-written comments in the committed agents.yaml survive — a plain
- * `yaml.stringify` would drop every one of them and rewrite the whole file,
- * which is the same churn this migration exists to stop (see `serializeCentral`).
- */
+/** Move the auto-detected `default` browser profile from committed agents.yaml into the per-device file. The device file is written first so a crash cannot lose the profile; central is edited via yaml.Document to preserve comments. */
 export function migrateMachineLocalBrowserProfileOutOfCentral(
   userDir: string = USER_DIR,
   machine: string = machineId(),
@@ -1684,35 +1480,7 @@ export function migrateMachineLocalBrowserProfileOutOfCentral(
   console.error(`Migrated agents.yaml: browser '${LEGACY_DEFAULT_BROWSER_PROFILE_NAME}' profile -> devices/${machine}/agents.yaml`);
 }
 
-/**
- * Rename the legacy `extras-extras/` plugin-marketplace dir to `agents-extras/`
- * inside every installed agent version-home, and rewrite cross-references in
- * `known_marketplaces.json` and the agent's `settings.json`.
- *
- * A previous dev build of `agents-cli` named the extras-aliased repo's
- * synthesized marketplace dir `extras-extras` (double "extras" because the alias
- * itself was `extras`). The new naming convention is `agents-<alias>`, so the
- * directory should be `agents-extras`. Without this migration the orphan dir
- * stays on disk and Claude Code loads two parallel marketplaces (the legacy
- * `extras-extras` entry from `known_marketplaces.json` plus the freshly
- * synthesized `agents-extras` from the new code path).
- *
- * Strategy per `<historyDir>/versions/<agent>/<ver>/home/.<agent>/plugins/`:
- *   1. `marketplaces/extras-extras/` → `marketplaces/agents-extras/`
- *      (drops `extras-extras/` outright when `agents-extras/` already exists —
- *      previous incomplete migration ran)
- *   2. Inside the renamed dir's `.claude-plugin/marketplace.json`, set
- *      `"name": "agents-extras"`.
- *   3. In `<configDir>/plugins/known_marketplaces.json`, rename the
- *      `extras-extras` key to `agents-extras` and rewrite `source.path` /
- *      `installLocation`.
- *   4. In `<configDir>/settings.json`'s `enabledPlugins`, rename every
- *      `<plugin>@extras-extras` key to `<plugin>@agents-extras` (preserving
- *      its boolean value, skipping if the new key already exists).
- *
- * Idempotent: re-running converges without further writes once everything is on
- * the new name.
- */
+/** Rename the legacy `extras-extras/` plugin marketplace dir to `agents-extras/` in every installed version home, and rewrite cross-references in `known_marketplaces.json` and `settings.json`. */
 export function migrateExtrasExtrasToAgentsExtras(historyDir: string = HISTORY_DIR): void {
   const versionsRoot = path.join(historyDir, 'versions');
   if (!fs.existsSync(versionsRoot)) return;

--- a/cli/src/lib/installations/shims.ts
+++ b/cli/src/lib/installations/shims.ts
@@ -1,12 +1,5 @@
 /**
- * Shim generation and config symlink management for agent version switching.
- *
- * Shims are small shell scripts placed in ~/.agents/shims/ that resolve the
- * active agent version (project-level or user-default), then exec the real
- * binary. Config isolation is achieved by symlinking ~/.{agent} into the
- * per-version home directory. This module also handles versioned aliases
- * (e.g., claude@2.0.65), PATH setup, conflict detection during migration,
- * and resource diffing between versions.
+ * Shim generation, config symlink management, and versioned aliases for agent version switching.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -21,10 +14,7 @@ import { AGENTS, agentConfigDirName, readAuthAccountIdentity } from '../agents.j
 import { codexHomeShimBash } from '../codex-home.js';
 import { resolveHarnessAdapter } from '../harness/index.js';
 
-/**
- * Files and directories to always skip during conflict detection and migration.
- * These are never user config that should be migrated.
- */
+/** Files and directories to always skip during conflict detection and migration. */
 const MIGRATION_IGNORE_LIST = new Set([
   'node_modules',
   '.git',
@@ -37,33 +27,21 @@ const MIGRATION_IGNORE_LIST = new Set([
   'Thumbs.db',
 ]);
 
-/**
- * Check if a file/directory should be ignored during migration.
- */
 function shouldIgnore(name: string): boolean {
   if (MIGRATION_IGNORE_LIST.has(name)) return true;
   if (name.endsWith('.backup')) return true;
   return false;
 }
 
-/**
- * Strategy for handling file conflicts during config migration.
- */
 export type ConflictStrategy = 'keep-dest' | 'overwrite' | 'ask-per-file';
 
-/**
- * Information about conflicts found during config migration.
- */
 export interface ConflictInfo {
   agent: AgentId;
   version: string;
-  conflicts: string[]; // filenames that exist in both src and dest
+  conflicts: string[];
 }
 
-/**
- * Detect conflicting files between source and destination directories.
- * Returns list of filenames that exist in both locations (excluding symlinks in dest).
- */
+/** Detect filenames that exist in both `src` and `dest`, excluding symlinks in `dest`. */
 function detectConflicts(src: string, dest: string, prefix = ''): string[] {
   const conflicts: string[] = [];
 
@@ -115,9 +93,6 @@ function detectConflicts(src: string, dest: string, prefix = ''): string[] {
   return conflicts;
 }
 
-/**
- * Prompt user for conflict resolution strategy.
- */
 async function promptConflictStrategy(
   conflictInfos: ConflictInfo[]
 ): Promise<ConflictStrategy | null> {
@@ -169,18 +144,7 @@ async function promptConflictStrategy(
   return strategy;
 }
 
-/**
- * Generate the shim script content for an agent.
- *
- * The shim resolves the version in order:
- * 1. agents.yaml in project root (walk up from $PWD, skip ~/.agents/agents.yaml)
- * 2. ~/.agents/agents.yaml default
- *
- * If version is specified but not installed, auto-installs it.
- *
- * Config isolation is handled via symlinks:
- * ~/.{agent} -> ~/.agents/versions/{agent}/{version}/home/.{agent}/
- */
+/** Generate the shim script content for an agent. Resolves project/default version, auto-installs if missing, and execs the binary. */
 /**
  * Current shim schema version. Bump whenever `generateShimScript` changes
  * in a way that requires existing on-disk shims to be regenerated (new
@@ -782,9 +746,7 @@ export function shimTargetsFor(platform: NodeJS.Platform): { bash: boolean; cmd:
   return { bash: true, cmd: false };
 }
 
-/**
- * Create a shim for an agent.
- */
+/** Create the shim(s) for an agent. */
 export function createShim(agent: AgentId): string {
   // A bare shim puts agents-cli first on PATH for this agent — the opposite of what
   // an isolated-only install promises.
@@ -908,9 +870,7 @@ function writeWindowsCmdShim(cmdPath: string, spec: string, extraMarkerLines: st
   fs.writeFileSync(cmdPath, content);
 }
 
-/**
- * Remove the shim for an agent.
- */
+/** Remove the shim(s) for an agent. */
 export function removeShim(agent: AgentId): boolean {
   const shimsDir = getShimsDir();
   const agentConfig = AGENTS[agent];
@@ -1346,10 +1306,7 @@ export function versionedAliasExists(agent: AgentId, version: string): boolean {
   return fs.existsSync(versionedAliasOnDiskPath(agent, version));
 }
 
-/**
- * Get the path to the agent's config directory in HOME.
- * e.g., ~/.claude for claude, ~/.codex for codex
- */
+/** Get the agent's config directory path in HOME (e.g. ~/.claude). */
 export function getAgentConfigPath(agent: AgentId): string {
   const agentConfig = AGENTS[agent];
   const home = process.env.AGENTS_REAL_HOME || os.homedir();
@@ -1385,26 +1342,16 @@ export function readCodexConfiguredModel(): string | undefined {
   }
 }
 
-/**
- * Get the path to the version's config directory.
- * e.g., ~/.agents/versions/claude/2.0.65/home/.claude/
- */
+/** Get the version-home config directory path. */
 function getVersionConfigPath(agent: AgentId, version: string): string {
   const agentConfig = AGENTS[agent];
   const versionsDir = getVersionsDir();
-  // Carry the agent's full configDir subpath so nested layouts work.
-  // e.g., antigravity → `.gemini/antigravity-cli`, claude → `.claude`.
+  // Use the agent's full configDir subpath so nested layouts (e.g. antigravity) work.
   const configDirName = path.relative(os.homedir(), agentConfig.configDir);
   return path.join(versionsDir, agent, version, 'home', configDirName);
 }
 
-/**
- * Detect conflicts that would occur when switching config symlink for an agent/version.
- * This allows collecting conflicts upfront before prompting for a strategy.
- *
- * Returns null if no migration is needed (already symlink or doesn't exist),
- * or ConflictInfo with the list of conflicting files.
- */
+/** Detect conflicts between the current config directory and the target version home. */
 function detectMigrationConflicts(agent: AgentId, version: string): ConflictInfo | null {
   const configPath = getAgentConfigPath(agent);
   const versionConfigPath = getVersionConfigPath(agent, version);
@@ -1436,43 +1383,12 @@ function detectMigrationConflicts(agent: AgentId, version: string): ConflictInfo
   }
 }
 
-/**
- * Switch the agent's config symlink to point to a specific version.
- * e.g., ~/.claude -> ~/.agents/versions/claude/2.0.65/home/.claude/
- *
- * If a real directory exists at the config path, it will be backed up
- * to ~/.agents/backups/{agent}/{timestamp}/ and replaced with a symlink.
- *
- * @param agent - The agent ID
- * @param version - The version to switch to
- *
- * Returns: { success: boolean, backupPath?: string, error?: string }
- */
-/**
- * Seed a version's config home with the account credential so switching versions
- * doesn't log the CLI out. Droid/antigravity/kimi (registry `authFiles`) store
- * login as files inside the per-version config dir; sign-in is account-global,
- * so we copy the FRESHEST existing copy (by mtime, across all installed version
- * homes) into `toConfigDir` when its copy is missing or older. mtime is
- * preserved so the "freshest" comparison stays stable and switches don't
- * ping-pong. Best-effort: a failed copy just means the user re-logs in.
- */
-/**
- * Best-effort account identity for the credential *directory* of a file-auth
- * agent (droid / kimi / antigravity), or null when the directory holds no
- * decodable account claim. Delegates to readAuthAccountIdentity, which decrypts
- * / decodes each agent's REAL on-disk format (droid AES-256-GCM + WorkOS JWT,
- * kimi access-token JWT, antigravity refresh-token) — the earlier plaintext
- * top-level-key scan matched NO real credential file, so the guard below never
- * engaged. Two dirs for the SAME account compare equal; DIFFERENT accounts
- * compare distinct. Used by carryForwardAuthFiles to refuse overwriting one
- * account's login with a credential that belongs to a DIFFERENT account
- * (RUSH-1764).
- */
+/** Best-effort account identity for a file-auth agent's credential directory; null when no decodable account claim exists. */
 export function readAuthFileIdentity(agent: AgentId, configDir: string): string | null {
   return readAuthAccountIdentity(agent, configDir);
 }
 
+/** Carry the freshest existing account credential into `toConfigDir` so version switches don't log out file-auth agents. */
 export function carryForwardAuthFiles(agent: AgentId, toConfigDir: string): void {
   const authFiles = AGENTS[agent].authFiles;
   if (!authFiles || authFiles.length === 0) return;
@@ -1543,6 +1459,7 @@ export function carryForwardAuthFiles(agent: AgentId, toConfigDir: string): void
   }
 }
 
+/** Switch the agent's config symlink to point at a specific version, backing up any real directory first. */
 export async function switchConfigSymlink(
   agent: AgentId,
   version: string
@@ -2010,37 +1927,22 @@ async function copyDirContents(
   }
 }
 
-/**
- * Check if shim exists for an agent.
- */
-/**
- * The on-disk shim FILENAME for a platform — derived from `shimTargetsFor` (the
- * write-side source of truth) so the exists/remove/version checks can never
- * drift from what `createShim` actually writes: `<cmd>.cmd` on Windows (the only
- * file written there), the bare `<cmd>` script on POSIX. Pure — testable on any
- * host.
- */
+/** The on-disk shim filename for a platform: `<cmd>.cmd` on Windows, bare `<cmd>` on POSIX. */
 export function onDiskShimFile(cliCommand: string, platform: NodeJS.Platform): string {
   return shimTargetsFor(platform).cmd ? `${cliCommand}.cmd` : cliCommand;
 }
 
-/**
- * The actual on-disk shim path for the current platform. This is what
- * exists/version checks must stat — `getShimPath` returns the logical
- * (extensionless) launch path, which is not always a real file on Windows.
- */
+/** The actual on-disk shim path for the current platform. */
 function onDiskShimPath(agent: AgentId): string {
   return path.join(getShimsDir(), onDiskShimFile(AGENTS[agent].cliCommand, process.platform));
 }
 
+/** Check whether the on-disk shim exists for an agent. */
 export function shimExists(agent: AgentId): boolean {
   return fs.existsSync(onDiskShimPath(agent));
 }
 
-/**
- * Read the schema version embedded in an existing on-disk shim. Returns
- * `null` if the shim doesn't exist or has no version marker (pre-v2 shim).
- */
+/** Read the schema version from the on-disk shim header, or null if missing/unreadable. */
 function readShimSchemaVersion(agent: AgentId): number | null {
   if (!shimExists(agent)) return null;
   try {
@@ -2055,11 +1957,7 @@ function readShimSchemaVersion(agent: AgentId): number | null {
   }
 }
 
-/**
- * True if the on-disk shim's schema version matches `SHIM_SCHEMA_VERSION`.
- * False means either the shim is missing, is pre-v2 (no marker), or is an
- * older version that needs regeneration.
- */
+/** True when the on-disk shim's schema version matches the current schema. */
 export function isShimCurrent(agent: AgentId): boolean {
   const version = readShimSchemaVersion(agent);
   return version === SHIM_SCHEMA_VERSION;
@@ -2139,22 +2037,13 @@ export function pruneOrphanedCommandShim(fileName: string): boolean {
   }
 }
 
-/**
- * Regenerate the shim if it's missing or outdated. Returns a status describing
- * what happened — callers can surface a one-line notice to the user ("Updated
- * shim for codex") when appropriate.
- */
+/** Regenerate the shim if missing or older than the current schema; never downgrade a newer on-disk shim. */
 export function ensureShimCurrent(agent: AgentId): 'created' | 'updated' | 'current' {
   if (!shimExists(agent)) {
     createShim(agent);
     return 'created';
   }
-  // Upgrade-only (newest-wins): regenerate only when the on-disk shim is
-  // unversioned/unreadable (null) or OLDER than this binary. Never downgrade a
-  // shim stamped by a NEWER agents-cli install. Two installs at different
-  // SHIM_SCHEMA_VERSION sharing ~/.agents/.cache/shims/ (e.g. a dev build on
-  // PATH alongside a Hermes-bundled published copy) otherwise ping-pong —
-  // rewriting every shim on each alternating launch and adding boot latency.
+  // Upgrade-only: avoid ping-pong between two installs sharing the shims dir.
   const onDisk = readShimSchemaVersion(agent);
   if (onDisk === null || onDisk < SHIM_SCHEMA_VERSION) {
     createShim(agent);
@@ -2163,26 +2052,14 @@ export function ensureShimCurrent(agent: AgentId): 'created' | 'updated' | 'curr
   return 'current';
 }
 
-/**
- * Get the path to the shim for an agent.
- */
+/** Get the logical (extensionless) shim path for an agent. */
 export function getShimPath(agent: AgentId): string {
   const shimsDir = getShimsDir();
   const agentConfig = AGENTS[agent];
   return path.join(shimsDir, agentConfig.cliCommand);
 }
 
-/**
- * Return the first executable path that would be launched for this agent when
- * resolving against PATH, excluding the managed shim itself.
- *
- * Legacy ~/.agents/shims/<cli> (from the pre-split single-root layout) is NOT
- * treated as a shadow when a current managed shim exists at getShimPath() —
- * that file is dead weight from the old layout and the repair flow removes it
- * separately. Treating it as "shadowing" caused an infinite repair-prompt
- * loop because addShimsToPath() only edits the rc file, never the legacy
- * shim file itself.
- */
+/** Return the first executable on PATH that would shadow the managed shim, excluding the shim itself and legacy pre-split files. */
 export function getPathShadowingExecutable(
   agent: AgentId,
   overrides?: { pathDirs?: string[]; shimPath?: string },

--- a/cli/src/lib/installations/versions.ts
+++ b/cli/src/lib/installations/versions.ts
@@ -1,18 +1,6 @@
 /**
- * Version management module for agents-cli.
- *
- * Handles installing, removing, listing, and switching between agent CLI versions.
- * Each version is installed into an isolated directory under ~/.agents/.system/versions/{agent}/{version}/
- * with its own HOME directory for config isolation. Resources (commands, skills, hooks, memory,
- * MCP servers, permissions, subagents, plugins) from ~/.agents/ are synced into version homes
- * via copies or conversions (not symlinks).
- *
- * Key responsibilities:
- * - Version lifecycle: install, remove, list, resolve (project-level or global default)
- * - Resource discovery: scan ~/.agents/ for available resources across all types
- * - Resource sync: copy/convert resources into a version's isolated config directory
- * - Diff and reconciliation: detect new/unsynced resources and prompt users to sync them
- * - Agent/version target resolution: parse agent@version specs from CLI flags
+ * Version lifecycle, resource sync, and agent@version resolution for agents-cli.
+ * Each version lives in an isolated home under ~/.agents/.history/versions/{agent}/{version}/.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -99,13 +87,7 @@ const RULES_DOC_FILENAME = 'README.md';
 // VERSION_RE and compareVersions now live in ./agent-spec/primitives.ts and are
 // imported above — kept as the single validation/ordering authority.
 
-/**
- * Resource selection for syncing to a version.
- * Each field can be:
- * - 'all' - sync all available resources of this type
- * - string[] - sync only these specific resources
- * - undefined - skip this resource type
- */
+/** Resource selection for syncing to a version: 'all', a name list, or undefined (skip). */
 export interface ResourceSelection {
   commands?: string[] | 'all';
   skills?: string[] | 'all';
@@ -118,14 +100,7 @@ export interface ResourceSelection {
   workflows?: string[] | 'all';
 }
 
-/**
- * Available resources in ~/.agents/ for syncing.
- *
- * `promptcuts` is a boolean, not a list — there is at most one
- * ~/.agents/promptcuts.yaml file. It is NOT version-scoped: the
- * expand-promptcuts hook reads it directly, so no per-version copy
- * is made and no sync step is needed.
- */
+/** Resources available in ~/.agents/ for syncing. `promptcuts` is a boolean because it is a single, version-unscoped file. */
 export interface AvailableResources {
   commands: string[];
   skills: string[];
@@ -219,12 +194,7 @@ function sourceMapFromWorkflows(cwd: string): Map<string, string> {
   );
 }
 
-// A plugin is a directory whose marker is `.claude-plugin/plugin.json`. Attribute
-// each to the layer it actually resolves from (system / user / project / extra) —
-// the same first-wins resolution the plugins staleness checker uses. Hardcoding
-// 'user' here made a `system:*` selection expand to zero plugins, so
-// `agents sync <agent> system` silently skipped system-layer plugins like `swarm`
-// (RUSH-3207).
+// Attribute each plugin to the layer it resolves from so `system:*` selections include system-layer plugins.
 function sourceMapFromPlugins(cwd: string): Map<string, string> {
   return sourceMapFromLayeredDirectory(
     cwd,
@@ -258,9 +228,7 @@ function sourceMapFromPluginSkills(plugins: DiscoveredPlugin[], activePluginName
   return sources;
 }
 
-/**
- * Get all available resources from ~/.agents/.
- */
+/** Discover all resources available for syncing from ~/.agents/. */
 export function getAvailableResources(cwd: string = process.cwd()): AvailableResources {
   const result: AvailableResources = {
     commands: [],
@@ -306,14 +274,7 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
   }
   result.skills = filterNamesForActiveResourceProfile('skills', Array.from(skillNames), sourceMapFromResources('skills', cwd));
 
-  // Hooks:
-  //   - top-level script files
-  //   - one-level *group* dirs that contain top-level scripts (session-starts/*.sh)
-  //     → each script is its own hook resource (install name = basename)
-  //   - other directories (e.g. tests/ with fixtures only) → directory bundles,
-  //     copied wholesale as one resource (pre-existing layout)
-  // Auxiliary content like README.md / promptcuts.yaml is not a hook. Older sync
-  // runs chmod 0o755'd everything, so an exec bit alone is not the signal.
+  // Hooks: top-level scripts, expanded one-level group dirs, or whole-dir bundles. Exec bit alone is not the signal (older syncs chmod'd everything).
   const NON_SCRIPT_EXTS = new Set(['.md', '.markdown', '.rst', '.txt', '.yaml', '.yml', '.json', '.toml', '.ini', '.conf']);
   const SCRIPT_EXTS     = new Set(['.sh', '.bash', '.zsh', '.py', '.js', '.ts', '.mjs', '.cjs', '.rb', '.pl', '.ps1']);
   const HOOK_GROUP_SKIP = new Set(['node_modules', '.git', '.cache']);
@@ -337,8 +298,7 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
           continue;
         }
         if (!stat.isDirectory() || HOOK_GROUP_SKIP.has(name)) continue;
-        // Group vs bundle: if the dir has any top-level script files, expand
-        // them; otherwise treat the whole dir as one hook resource.
+        // Expand dirs containing top-level scripts; bundle dirs without any.
         let nestedNames: string[];
         try {
           nestedNames = fs.readdirSync(full);
@@ -365,10 +325,7 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
   }
   result.hooks = filterNamesForActiveResourceProfile('hooks', Array.from(hookNames), sourceMapFromResources('hooks', cwd));
 
-  // Rules — list available presets across layers (project > user > extras > system).
-  // The composer selects exactly one preset per sync; this list drives the
-  // resource-count display and `agents rules switch` picker. Routes through
-  // the rules-dir getters so test mocks work the same as production paths.
+  // Rules — list available presets across layers.
   const presetNames = new Set<string>();
   const rulesDirs: string[] = [];
   if (projectAgentsDir) rulesDirs.push(path.join(projectAgentsDir, 'rules'));
@@ -398,11 +355,9 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
     new Map(scopedMcp.map(resource => [resource.name, resource.scope])),
   );
 
-  // Permission groups (from permissions/groups/*.yaml)
   const permissionSources = sourceMapFromPermissionGroups(cwd);
   result.permissions = filterNamesForActiveResourceProfile('permissions', Array.from(permissionSources.keys()), permissionSources);
 
-  // Subagents (directories with AGENT.md)
   const subagentNames = new Set<string>();
   for (const { base } of resourceBases) {
     const subagentsDir = path.join(base, 'subagents');
@@ -416,7 +371,6 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
   }
   result.subagents = filterNamesForActiveResourceProfile('subagents', Array.from(subagentNames), sourceMapFromResources('subagents', cwd));
 
-  // Workflows (directories with WORKFLOW.md)
   const workflowSources = sourceMapFromWorkflows(cwd);
   result.workflows = filterNamesForActiveResourceProfile('workflows', Array.from(workflowSources.keys()), workflowSources);
 
@@ -447,10 +401,7 @@ function shouldSkillEntryBeSkipped(name: string): boolean {
   return SKILL_COPY_IGNORE.has(name);
 }
 
-/**
- * Recursively compare two directories: every file in src must exist in dest with identical content.
- * Skips the same entries that copyDir skips (symlinks and SKILL_COPY_IGNORE members).
- */
+/** Recursively compare two directories for identical content, skipping symlinks and ignored entries. */
 function skillDirsMatch(src: string, dest: string): boolean {
   const entries = fs.readdirSync(src, { withFileTypes: true });
   for (const entry of entries) {
@@ -462,9 +413,7 @@ function skillDirsMatch(src: string, dest: string): boolean {
       if (!fs.existsSync(destPath)) return false;
       if (!skillDirsMatch(srcPath, destPath)) return false;
     } else {
-      // Stat-first (RUSH-2320 #2): size mismatch = definitive miss, no reads.
-      // Equal mtimes across different trees are accidental — content-compare
-      // whenever sizes match.
+      // Size-first check avoids reads on mismatch; equal mtimes are unreliable across trees.
       let srcStat: fs.Stats;
       let destStat: fs.Stats;
       try {
@@ -480,10 +429,7 @@ function skillDirsMatch(src: string, dest: string): boolean {
   return true;
 }
 
-/**
- * Get what's ACTUALLY synced to a version by inspecting the version home.
- * This is the source of truth - not the tracking in agents.yaml.
- */
+/** Return what's actually synced to a version home (source of truth, not agents.yaml tracking). */
 export function getActuallySyncedResources(agent: AgentId, version: string, options: { cwd?: string } = {}): AvailableResources {
   const versionHome = path.join(getVersionsDir(), agent, version, 'home');
   const cwd = options.cwd || process.cwd();
@@ -501,10 +447,7 @@ export function getActuallySyncedResources(agent: AgentId, version: string, opti
     promptcuts: false,
   };
 
-  // Dispatch each kind through DETECTORS. The registry guarantees a detector
-  // exists for every supported (agent, kind) pair; unsupported pairs leave
-  // the field empty. The previous per-agent if-ladder silently dropped
-  // antigravity/gemini/grok detection — see PR description for details.
+  // Dispatch through per-kind detectors; unsupported (agent, kind) pairs leave the field empty.
   const ctx = { version, versionHome, cwd };
   result.commands    = getDetector('commands',    agent)?.list(ctx) ?? [];
   result.skills      = getDetector('skills',      agent)?.list(ctx) ?? [];
@@ -528,14 +471,7 @@ export interface ProjectOnlyResources {
   workflows: Set<string>;
 }
 
-/**
- * Names that exist ONLY in the project's `.agents/` layer (no matching entry in
- * user/system/extra layers). Sync intentionally skips project-layer commands,
- * skills, hooks, subagents, plugins, and workflows for security — see the
- * defense comments above each sync branch in syncResourcesToVersion. Without
- * this filter, those names would forever appear in the "New resources" diff
- * because they live in `available` but never reach `actuallySynced`.
- */
+/** Names that exist only in the project's `.agents/` layer. Sync skips project-layer resources for security, so filter them out of the "new resources" diff. */
 export function getProjectOnlyResources(cwd: string = process.cwd()): ProjectOnlyResources {
   const empty: ProjectOnlyResources = {
     commands: new Set(), skills: new Set(), hooks: new Set(),
@@ -611,16 +547,7 @@ export function getProjectOnlyResources(cwd: string = process.cwd()): ProjectOnl
   return empty;
 }
 
-/**
- * Compare available resources with what's ACTUALLY synced to version home.
- * Returns only NEW resources that haven't been synced yet.
- * Source of truth: the actual files/config, NOT agents.yaml tracking.
- *
- * `projectOnly` (recommended): the result of `getProjectOnlyResources(cwd)`.
- * Names listed there are filtered out for kinds that sync intentionally
- * excludes the project layer — otherwise they would re-appear as "new"
- * on every run and "Yes, sync all new" would silently do nothing for them.
- */
+/** Return resources in `available` that are not yet synced to the version home. `projectOnly` filters project-layer resources that sync skips for security. */
 export function getNewResources(
   available: AvailableResources,
   actuallySynced: AvailableResources,
@@ -634,8 +561,7 @@ export function getNewResources(
     commands: available.commands.filter(c => !actuallySynced.commands.includes(c) && !exclude.commands.has(c)),
     skills: available.skills.filter(s => !actuallySynced.skills.includes(s) && !exclude.skills.has(s)),
     hooks: available.hooks.filter(h => !actuallySynced.hooks.includes(h) && !exclude.hooks.has(h)),
-    // Memory/rules presets are mutually exclusive — only one can be active.
-    // If any preset is synced, don't report others as "new".
+    // Only one rules preset can be active; if any is synced, don't report others as new.
     memory: actuallySynced.memory.length > 0
       ? []
       : available.memory.filter(m => !actuallySynced.memory.includes(m)),
@@ -644,16 +570,12 @@ export function getNewResources(
     subagents: available.subagents.filter(s => !actuallySynced.subagents.includes(s) && !exclude.subagents.has(s)),
     plugins: available.plugins.filter(p => !actuallySynced.plugins.includes(p) && !exclude.plugins.has(p)),
     workflows: available.workflows.filter(w => !actuallySynced.workflows.includes(w) && !exclude.workflows.has(w)),
-    // Promptcuts aren't version-scoped — the hook reads ~/.agents/promptcuts.yaml
-    // directly, so there is never a "new" per-version state to reconcile.
+    // Promptcuts are not version-scoped; the hook reads the user/system file directly.
     promptcuts: false,
   };
 }
 
-/**
- * Check if there are any new resources to sync.
- * When version is provided, uses version-specific capability checks.
- */
+/** Return true when `diff` contains any resources the agent/version actually supports. */
 export function hasNewResources(diff: AvailableResources, agent?: AgentId, version?: string): boolean {
   const commandsApply = agent ? supports(agent, 'commands', version).ok : true;
   const hooksApply = agent ? supports(agent, 'hooks', version).ok : true;
@@ -675,17 +597,12 @@ export function hasNewResources(diff: AvailableResources, agent?: AgentId, versi
   );
 }
 
-/**
- * Build a summary string of new resources.
- * E.g., "2 commands, 5 permission groups"
- */
+/** Build a human-readable summary of new resources, e.g. "2 commands, 5 permission groups". */
 function buildNewResourcesSummary(newResources: AvailableResources, agent: AgentId, version?: string): string {
   const agentConfig = AGENTS[agent];
   const parts: string[] = [];
 
-  // Use version-aware gates so Codex >= 0.117.0 (which converts commands to skills) doesn't
-  // double-count and so "16 commands" never appears in the summary when commands have
-  // already been emitted as skills in the version home.
+  // Version-aware gates avoid double-counting commands already emitted as skills (Codex >= 0.117.0).
   const commandsApply = supports(agent, 'commands', version).ok;
   const commandsAsSkills = version ? shouldInstallCommandAsSkill(agent, version) : false;
   const rulesApply = supports(agent, 'rules', version).ok;
@@ -721,10 +638,7 @@ function buildNewResourcesSummary(newResources: AvailableResources, agent: Agent
   return parts.join(', ');
 }
 
-/**
- * Prompt user to select which NEW resources to sync.
- * Only shows resources that haven't been synced yet.
- */
+/** Prompt the user to select which new resources to sync. */
 export async function promptNewResourceSelection(
   agent: AgentId,
   newResources: AvailableResources,
@@ -741,17 +655,14 @@ export async function promptNewResourceSelection(
   const commandsBranch = commandsApply || commandsAsSkills;
   const rulesBranch = supports(agent, 'rules', version).ok;
 
-  // Get permission group info for display
   const permissionGroups = discoverPermissionGroups();
   const newPermissionGroups = permissionGroups.filter(g => newResources.permissions.includes(g.name));
   const totalNewPermissionRules = newPermissionGroups.reduce((sum, g) => sum + g.ruleCount, 0);
 
-  // Build the summary
   const summary = buildNewResourcesSummary(newResources, agent, version);
   console.log(chalk.cyan(`\nNew resources available:`));
   console.log(chalk.gray(`  ${summary}`));
 
-  // Ask how to handle new resources
   const action = await select<'all' | 'specific' | 'skip'>({
     message: 'Sync new resources?',
     choices: [
@@ -767,7 +678,6 @@ export async function promptNewResourceSelection(
   }
 
   if (action === 'all') {
-    // Sync all new resources
     if (newResources.commands.length > 0 && commandsBranch) selection.commands = newResources.commands;
     if (newResources.skills.length > 0) selection.skills = newResources.skills;
     if (newResources.hooks.length > 0 && agentConfig.supportsHooks) selection.hooks = newResources.hooks;
@@ -780,7 +690,6 @@ export async function promptNewResourceSelection(
     return selection;
   }
 
-  // Select specific items for each category
   if (newResources.commands.length > 0 && commandsBranch) {
     const selected = await checkbox({
       message: 'Select new commands to sync:',
@@ -866,22 +775,16 @@ export async function promptNewResourceSelection(
   return selection;
 }
 
-/**
- * Prompt user to select which resources to sync from ~/.agents/.
- * Returns the selection, or null if user cancels.
- */
+/** Prompt the user to select which resources to sync from ~/.agents/. */
 export async function promptResourceSelection(agent: AgentId): Promise<ResourceSelection | null> {
   const available = getAvailableResources();
   const agentConfig = AGENTS[agent];
   const selection: ResourceSelection = {};
 
-  // Get permission group info for display
   const permissionGroups = discoverPermissionGroups();
   const totalPermissionRules = permissionGroups.reduce((sum, g) => sum + g.ruleCount, 0);
 
-  // Build category choices based on what's available.
-  // Constrain to ResourceSelection keys — promptcuts is in AvailableResources
-  // for visibility but is never synced per-version, so it has no ResourceSelection entry.
+  // Promptcuts is visible but never synced per-version, so it is omitted from selectable categories.
   type CategoryKey = keyof ResourceSelection;
   const categories: { key: CategoryKey; label: string; available: boolean; displayCount: string }[] = [
     { key: 'commands', label: 'Commands', available: supports(agent, 'commands').ok && available.commands.length > 0, displayCount: `${available.commands.length} available` },
@@ -901,7 +804,6 @@ export async function promptResourceSelection(agent: AgentId): Promise<ResourceS
     return {};
   }
 
-  // Step 1: Select categories (with "Select All" shortcut at the top)
   console.log();
   const SELECT_ALL_KEY = '__select_all__' as CategoryKey;
   const selectedCategories = await checkbox<CategoryKey>({
@@ -920,7 +822,6 @@ export async function promptResourceSelection(agent: AgentId): Promise<ResourceS
     return {};
   }
 
-  // If "Select All" was picked, or all individual categories are selected, sync everything without per-category prompts
   const allCategoryKeys = availableCategories.map(c => c.key);
   if (selectedCategories.includes(SELECT_ALL_KEY) || allCategoryKeys.every(k => selectedCategories.includes(k))) {
     for (const c of availableCategories) {
@@ -929,11 +830,9 @@ export async function promptResourceSelection(agent: AgentId): Promise<ResourceS
     return selection;
   }
 
-  // Step 2: For each selected category, ask all/specific/skip
   for (const category of selectedCategories) {
     const categoryLabel = categories.find(c => c.key === category)!.label;
 
-    // Special handling for permissions - show groups
     if (category === 'permissions') {
       const choice = await select<'all' | 'specific' | 'skip'>({
         message: `${categoryLabel}:`,
@@ -961,7 +860,6 @@ export async function promptResourceSelection(agent: AgentId): Promise<ResourceS
         }
       }
     } else {
-      // Standard handling for other categories
       const items = available[category];
 
       const choice = await select<'all' | 'specific' | 'skip'>({
@@ -1002,13 +900,7 @@ export interface AgentSpec {
   version: string;
 }
 
-/**
- * Parse agent@version syntax.
- * Examples:
- *   "claude@1.5.0" -> { agent: "claude", version: "1.5.0" }
- *   "claude" -> { agent: "claude", version: "latest" }
- *   "codex@latest" -> { agent: "codex", version: "latest" }
- */
+/** Parse an `agent@version` spec; bare agent means `latest`. */
 export function parseAgentSpec(spec: string): AgentSpec | null {
   const parts = spec.split('@');
   if (parts.length > 2) {
@@ -1034,9 +926,6 @@ export function parseAgentSpec(spec: string): AgentSpec | null {
 }
 
 
-/**
- * Get the latest available version from npm for an agent.
- */
 export async function getLatestNpmVersion(agent: AgentId): Promise<string | null> {
   const agentConfig = AGENTS[agent];
   if (!agentConfig.npmPackage) return null;
@@ -1049,9 +938,6 @@ export async function getLatestNpmVersion(agent: AgentId): Promise<string | null
   }
 }
 
-/**
- * Get the oldest published version from npm for an agent.
- */
 export async function getOldestNpmVersion(agent: AgentId): Promise<string | null> {
   const agentConfig = AGENTS[agent];
   if (!agentConfig.npmPackage) return null;
@@ -1059,8 +945,7 @@ export async function getOldestNpmVersion(agent: AgentId): Promise<string | null
   try {
     const { stdout } = await execFileAsync('npm', ['view', agentConfig.npmPackage, 'versions', '--json'], { shell: process.platform === 'win32' });
     const parsed = JSON.parse(stdout.trim());
-    // `npm view ... versions --json` returns an array (multiple versions) or a
-    // bare string (single published version). Normalize to an array.
+    // npm view returns an array for multiple versions or a bare string for one.
     const versions: string[] = Array.isArray(parsed) ? parsed : [parsed];
     const sorted = versions.filter((v) => VERSION_RE.test(v)).sort(compareVersions);
     return sorted[0] ?? null;
@@ -1069,9 +954,7 @@ export async function getOldestNpmVersion(agent: AgentId): Promise<string | null
   }
 }
 
-/**
- * Check if 'latest' version is already installed (by resolving to actual version).
- */
+/** Check whether the npm `latest` version is installed. */
 export async function isLatestInstalled(agent: AgentId): Promise<{ installed: boolean; version: string | null }> {
   const latestVersion = await getLatestNpmVersion(agent);
   if (!latestVersion) {
@@ -1080,9 +963,7 @@ export async function isLatestInstalled(agent: AgentId): Promise<{ installed: bo
   return { installed: isVersionInstalled(agent, latestVersion), version: latestVersion };
 }
 
-/**
- * Check if 'oldest' published version is already installed (by resolving to actual version).
- */
+/** Check whether the npm `oldest` version is installed. */
 export async function isOldestInstalled(agent: AgentId): Promise<{ installed: boolean; version: string | null }> {
   const oldestVersion = await getOldestNpmVersion(agent);
   if (!oldestVersion) {
@@ -1093,12 +974,9 @@ export async function isOldestInstalled(agent: AgentId): Promise<{ installed: bo
 
 
 /**
- * List every version directory for an agent, including ones missing the
- * binary (typically home-only leftovers from a prior `removeVersion`).
- *
- * Used by `agents prune cleanup` to surface stale installs that the regular
- * `listInstalledVersions` filters out. Do NOT use elsewhere — every other
- * call site assumes a working binary.
+ * List every version directory for an agent, including home-only leftovers, for
+ * `agents prune cleanup` only. Do NOT use elsewhere — every other call site
+ * assumes a working binary.
  */
 export function listInstalledVersionDirs(agent: AgentId): Array<{ version: string; hasBinary: boolean }> {
   const agentVersionsDir = path.join(getVersionsDir(), agent);
@@ -1118,15 +996,9 @@ export function listInstalledVersionDirs(agent: AgentId): Array<{ version: strin
 }
 
 
-/**
- * Set the global default version for an agent.
- */
+/** Set (or clear) the global default version for an agent. */
 export function setGlobalDefault(agent: AgentId, version: string | undefined): void {
-  // A global default is what owns the launcher and arms the self-heal `shadowing`
-  // check, so recording one for an isolated-only agent is the root of the original
-  // breach. Clearing is always allowed — `removeVersion` legitimately clears a
-  // default as the last non-isolated version goes away, which is the very moment
-  // an agent BECOMES isolated-only.
+  // Setting a global default for an isolated-only agent would breach the isolation boundary; clearing is allowed.
   if (version !== undefined) {
     assertIsolationBoundary(agent, 'set a global default');
   }
@@ -1144,13 +1016,7 @@ export function setGlobalDefault(agent: AgentId, version: string | undefined): v
 }
 
 
-/**
- * Set (or clear, with `undefined`) the preferred isolated version.
- *
- * Deliberately does NOT touch the launcher, the bare shim, the `~/.<agent>` config
- * symlink or the global default — the five things `setDefaultVersion` does. This is
- * a pointer inside the sandbox, so it stays inside the sandbox.
- */
+/** Set (or clear) the preferred isolated version without touching the launcher, shim, or global default. */
 export function setIsolatedDefault(agent: AgentId, version: string | undefined): void {
   const meta = readMeta();
   if (!meta.isolatedAgents) {
@@ -1288,9 +1154,7 @@ async function checkGrokAccountCollision(installedVersion: string): Promise<void
   );
 }
 
-/**
- * Install a specific version of an agent.
- */
+/** Install a specific version of an agent. */
 export async function installVersion(
   agent: AgentId,
   version: string,
@@ -1304,9 +1168,7 @@ export async function installVersion(
     return { success: false, installedVersion: version, error: hardDeprecationError(agent) };
   }
 
-  // Validate before deriving filesystem paths or npm package specs. The CLI
-  // parser already enforces this for user input; this guard protects direct
-  // callers and tests the critical install path at the source.
+  // Also validate at the source so direct callers and tests cannot pass invalid versions.
   if (!VERSION_RE.test(version)) {
     throw new Error(`Invalid version: ${JSON.stringify(version)}`);
   }
@@ -1316,12 +1178,7 @@ export async function installVersion(
       return { success: false, installedVersion: version, error: 'Agent has no npm package' };
     }
 
-    // A self-updating agent (droid, grok, …) is a single global binary whose
-    // installer only ever fetches the CURRENT release — there is no semver to
-    // pin. Rather than hard-refuse `<agent>@1.2.3` (the old behavior):
-    //   - if the binary is already installed, a pin is a no-op — it self-updates
-    //     in place, so skip the installer and just refresh our bookkeeping;
-    //   - otherwise redirect the pin to a current-release install.
+    // Self-updating agents have no pinnable semver; an installed binary is a no-op, otherwise redirect to latest.
     let runInstaller = true;
     if (version !== 'latest' && isSelfUpdatingAgent(agent)) {
       const liveVersion = await getLiveVersion(agent);
@@ -2022,24 +1879,7 @@ export async function healDanglingVersionPointers(
   return healed;
 }
 
-/**
- * Normalize a user-supplied @version token across CLI subcommands.
- *
- *   undefined / "" / "default" / "pinned" -> undefined  (caller falls back to project pin or global default)
- *   "any"                       -> undefined  (caller imposes no version constraint — e.g. resume across any version)
- *   "latest"                    -> highest installed version (process.exit if none installed)
- *   "oldest"                    -> lowest installed version (process.exit if none installed)
- *   "x.y.z" (installed)         -> "x.y.z"
- *   "x.y.z" (not installed)     -> process.exit with installed-list hint
- *
- * `pinned` is a synonym for `default`: both name the project pin / global
- * default, which the caller resolves.
- *
- * Use this anywhere the user can type `agents <cmd> claude@<token>` to keep the
- * vocabulary consistent. Subcommands with different semantics for `latest`
- * (install/remove/use, where `latest` means npm-latest) keep their existing
- * parsing.
- */
+/** Normalize a user-supplied `@version` token. `default`/`pinned`/`any` → undefined; `latest`/`oldest` → extreme installed version; concrete versions must be installed. */
 export function resolveVersionAlias(agent: AgentId, raw: string | undefined | null): string | undefined {
   if (!raw || raw === 'default' || raw === 'pinned' || raw === 'any') return undefined;
 
@@ -3230,11 +3070,7 @@ export interface InstalledAgentTargetResult {
   versionSelections: Map<AgentId, string[]>;
 }
 
-/**
- * Thrown when the user references an agent@version that is not installed.
- * Carries the parsed (agentId, version) so callers can react — e.g. prompt
- * to install it on demand — without having to parse the error message.
- */
+/** Thrown when an `agent@version` target is not installed; carries the parsed ids so callers can react without parsing the message. */
 export class VersionNotInstalledError extends Error {
   constructor(
     public readonly agentId: AgentId,
@@ -3247,11 +3083,7 @@ export class VersionNotInstalledError extends Error {
   }
 }
 
-/**
- * Resolve a comma-separated --agents list into concrete version selections.
- * Bare agents target the default version, or the newest installed version when no default exists.
- * Explicit agent@version targets only that installed version.
- */
+/** Resolve a comma-separated `--agents` list into concrete installed version selections. */
 export function resolveAgentVersionTargets(
   value: string,
   availableAgents: readonly AgentId[],
@@ -3369,12 +3201,7 @@ export function resolveAgentVersionTargets(
   return { selectedAgents, versionSelections };
 }
 
-/**
- * Resolve a comma-separated --agents list into install/apply targets.
- * Bare agents target the default version (or newest installed version) when managed,
- * and fall back to the agent's effective HOME when unmanaged.
- * Explicit agent@version targets only that installed version.
- */
+/** Resolve a comma-separated `--agents` list into install/apply targets, distinguishing managed versions from direct homes. */
 export function resolveInstalledAgentTargets(
   value: string,
   availableAgents: readonly AgentId[],
@@ -3494,9 +3321,7 @@ export function resolveInstalledAgentTargets(
   return { selectedAgents, directAgents, versionSelections };
 }
 
-/**
- * Resolve configured manifest targets into direct homes and managed versions.
- */
+/** Resolve configured manifest targets into direct homes and managed versions. */
 export function resolveConfiguredAgentTargets(
   agents: readonly AgentId[] | undefined,
   agentVersions: Partial<Record<AgentId, string[]>> | undefined,
@@ -3532,10 +3357,7 @@ export function resolveConfiguredAgentTargets(
   return resolveInstalledAgentTargets(targetSpecs.join(','), availableAgents, options);
 }
 
-/**
- * Prompt user to select agents and versions for resource installation.
- * Returns selected agents and their version selections.
- */
+/** Prompt the user to select agents and versions for resource installation. */
 export async function promptAgentVersionSelection(
   availableAgents: AgentId[],
   options: { skipPrompts?: boolean } = {}

--- a/cli/src/lib/secrets/agent.ts
+++ b/cli/src/lib/secrets/agent.ts
@@ -1,27 +1,11 @@
 /**
- * The secrets-agent: a local broker that holds resolved bundle env in memory
- * after a single Touch ID unlock, so concurrent agent processes don't each pop
- * their own prompt.
+ * The secrets-agent: an in-memory broker that holds resolved bundle env after one
+ * Touch ID unlock, so concurrent agents don't each prompt.
  *
- * Why this exists: every secret item carries a biometry access control, and
- * macOS refuses to cache that across processes — N concurrent `agents run`
- * spawns = N Touch ID prompts (see src/lib/secrets/bundles.ts). The Swift
- * helper's LAContext only deduplicates reads *within one process*. This broker
- * is the ssh-agent answer: `agents secrets unlock <bundle>` decrypts the bundle
- * once (one prompt), ships the resolved env here, and every later read returns
- * from memory over a user-only Unix socket — no prompt.
- *
- * Security model (deliberate): while a bundle is unlocked, any same-user
- * process that can reach the socket reads it silently. That's strictly the same
- * trust boundary the keychain already concedes (docs/secrets.md: the ACL is
- * user-presence, not code-identity — any same-user process can pop the prompt
- * and read), minus the visible prompt. We bound it with: explicit per-bundle
- * opt-in (nothing is held unless you `unlock` it), an absolute TTL (~7d), an
- * auto-wipe on sleep / logout, and `agents secrets lock`. A bare screen-lock is
- * NOT a wipe (the login password already gates it). Nothing ever touches disk.
- *
- * macOS only: Linux libsecret has no biometry prompt, so there's nothing to
- * deduplicate — every entry point here no-ops off darwin.
+ * Security model: while unlocked, any same-user process reaching the socket can
+ * read it silently — the same trust boundary the keychain already concedes. We
+ * bound it with per-bundle opt-in, a TTL (~7d), auto-wipe on sleep/logout, and
+ * explicit lock. Nothing touches disk. Off-darwin the broker is unused.
  */
 
 import * as net from 'net';
@@ -45,10 +29,7 @@ import { selectLeasedEnv, type SecretLease } from './lease.js';
 import { emitSecretAudit } from './audit.js';
 import { isDaemonServiceEnabled } from '../daemon-services.js';
 
-// Re-exported so callers already reaching for agent.js keep one obvious home for
-// the scope vocabulary; the definitions live in the leaf module scope.ts because
-// agent.ts and session-store.ts import each other and a cyclic `const` read can
-// hit the ESM temporal dead zone at runtime.
+// Re-exported from scope.ts to break the agent.ts ↔ session-store.ts import cycle.
 export { GLOBAL_HARNESS, bundleScopeChain };
 
 /** Bumped when the wire protocol changes; a client that pings a mismatched
@@ -59,9 +40,7 @@ const PROTOCOL_VERSION = 3;
 export const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7d
 
 /**
- * Whether the secrets broker service is enabled in the daemon service config.
- * Off-darwin this is irrelevant (the broker is never used), but the helper is
- * kept synchronous and safe everywhere so callers can fail loud without a prompt.
+ * Whether the secrets broker service is enabled in daemon service config.
  */
 export function isSecretsBrokerEnabled(): boolean {
   return isDaemonServiceEnabled('secrets-broker');
@@ -69,15 +48,9 @@ export function isSecretsBrokerEnabled(): boolean {
 
 /**
  * Reserved store-key prefix for the `secrets list` metadata snapshot cache.
- * The broker holds the resolved bundle-metadata array (names/policy/timestamps,
- * NO resolved secret values beyond the literals already in metadata) keyed by a
- * hash of the current keychain bundle name-set, so the second and later
- * `secrets list` within the hold window read metadata without a Touch ID
- * prompt. Keyed by the name-set hash so adding/removing/renaming a bundle
- * changes the key and misses the cache automatically — no active invalidation.
- * The '!' sentinel can never collide with a real bundle name
- * (BUNDLE_NAME_PATTERN requires an alphanumeric first char) and is safe as
- * spawnSync argv (unlike a NUL byte); `status` hides these entries.
+ * Keyed by a hash of the keychain name-set; adding/removing/renaming a bundle
+ * changes the key and invalidates passively. The '!' sentinel cannot collide
+ * with a real bundle name and is safe as argv.
  */
 export const META_CACHE_PREFIX = '!meta:';
 
@@ -104,21 +77,9 @@ function delay(ms: number): Promise<void> {
 }
 
 /**
- * Timeouts for the three synchronous broker clients, split across the process
- * boundary they now straddle.
- *
- * `SOCKET_*` bound the socket round-trip inside the spawned `__secrets-*`
- * child, and carry over unchanged from the inline `node -e` programs these
- * replaced. `SYNC_*` bound the parent's `spawnSync` and must additionally cover
- * the child's boot, so each is its socket budget plus ~2s of headroom. A parent
- * timeout that fired before the child's own timer would report "broker down"
- * for a broker that is merely slow, which costs a Touch ID prompt — so the
- * parent budget is deliberately the looser of the two.
- *
- * Boot cost, measured on the bun-compiled binary on an M-series Mac (median of
- * 15, against a live broker): ~96ms via the index.ts intercept, ~165ms if the
- * intercept is moved below the startup statements, ~44ms for the `node -e` this
- * replaces. The intercept is what keeps the regression modest; see index.ts.
+ * Timeouts for the synchronous broker clients. Parent `spawnSync` budgets are
+ * looser than socket budgets so a slow child boot isn't misreported as "broker
+ * down" (which costs a Touch ID prompt).
  */
 const SOCKET_GET_TIMEOUT_MS = 2000;
 const SOCKET_PING_TIMEOUT_MS = 700;
@@ -127,21 +88,15 @@ const SYNC_GET_TIMEOUT_MS = 4000;
 const SYNC_PING_TIMEOUT_MS = 2500;
 const SYNC_LOCK_TIMEOUT_MS = 4000;
 
-// The argv tokens live in a leaf module so index.ts can bind the SAME values
-// without importing this one. Re-exported here for callers already reaching for
-// agent.js. See sync-commands.ts for why a shared binding rather than matching
-// literals: the drift it prevents is silent and costs a Touch ID prompt per read.
+// Re-exported from sync-commands.ts so index.ts can share the same argv tokens
+// without importing this module (would create a cycle/startup cost).
 export { SYNC_GET_CMD, SYNC_PING_CMD, SYNC_LOCK_CMD } from './sync-commands.js';
 
 /**
- * Decide whether a persistent broker should self-heal onto freshly-installed
- * code (exit so launchd relaunches it). Only when the store is EMPTY: exiting
- * with bundles still unlocked wipes them from memory, so the next reader falls
- * back to a direct keychain read and re-prompts for Touch ID. Deferring the
- * restart until the cache is idle (TTL-expired / slept) means an
- * in-place `npm i -g` never wipes a hot cache — the new code is adopted at the
- * next quiet moment instead. See #435: rapid repeated upgrades wiped a hot
- * cache on every bump and produced a recurring Touch ID storm.
+ * Decide whether a persistent broker should exit so launchd relaunches it on
+ * freshly-installed code. Only when the store is empty: exiting with held
+ * bundles would force a re-prompt. Deferring protects against rapid upgrades
+ * wiping the hot cache (#435).
  */
 export function shouldSelfHealForUpgrade(
   persistent: boolean,
@@ -156,35 +111,17 @@ export function shouldSelfHealForUpgrade(
 }
 
 /**
- * Client-side twin of shouldSelfHealForUpgrade: whether ensureAgentRunning may
- * tear down a reachable broker whose running version differs from the client's
- * on-disk version. Only while it holds NO real unlocks — tearing down a hot
- * broker wipes every held bundle, so the next read of each one re-prompts for
- * Touch ID. On a machine where installed versions churn (dev builds stamp a
- * fresh 0.0.0-dev.<sha> on every install; an npm copy and a dev copy invoke in
- * turn), an unguarded teardown produced a rolling Touch ID storm — the exact
- * failure #435 fixed on the server side. A hot, protocol-compatible broker
- * keeps serving; its own sweep adopts the new code at the next quiet moment.
+ * Client-side twin: may only tear down a version-skewed broker when it holds
+ * no real unlocks, otherwise every held bundle re-prompts (#435).
  */
 export function shouldTeardownVersionSkewedBroker(realHeldBundles: number): boolean {
   return realHeldBundles === 0;
 }
 
 /**
- * Whether a version-skewed client may evict the reachable broker at all. The
- * held-bundle gate above is necessary but not sufficient: a broker the always-on
- * daemon is hosting must NEVER be client-evicted, even when it holds zero
- * unlocks. teardownStaleBroker() recognizes only the standalone broker's
- * pidPath() O_EXCL claim (the daemon writes ownerPath(), never pidPath()), so
- * evicting a daemon-hosted broker unlinks its socket WITHOUT stopping the daemon;
- * the daemon then keeps hostedBroker != null and shouldTakeOverBroker() refuses
- * to re-host, orphaning its broker until the daemon restarts while every reader
- * falls onto cold one-off brokers that re-prompt Touch ID — the storm. Deferring
- * is safe: daemon code-version upgrades are handled by postinstall.js restarting
- * it, and agentPing() already gated on PROTOCOL_VERSION, so a code-skewed daemon
- * broker is still wire-compatible. Only when NO daemon owns the broker (churning
- * dev installs with a dead/absent daemon — the case #435's client twin was built
- * for) does the zero-held-bundles teardown apply, exactly as before.
+ * Whether a client may evict a version-skewed broker. A daemon-hosted broker
+ * must never be client-evicted: the daemon owns the socket via ownerPath(), so
+ * unlinking it would orphan the broker until daemon restart (#435).
  */
 export function shouldClientEvictSkewedBroker(
   daemonRunning: boolean,
@@ -218,11 +155,8 @@ function onDarwin(): boolean {
 }
 
 /**
- * Build the broker's in-memory store, REHYDRATED from the durable session store
- * (session-store.ts) so an unlock survives a daemon restart / agents-cli upgrade.
- * Expired sessions are dropped; `--durable` and default entries alike come back
- * (SLEEP already pruned the non-durable ones from the keychain while the broker
- * was alive). Empty off darwin or when nothing was held.
+ * Build the broker's in-memory store from durable sessions so unlocks survive
+ * restart/upgrade. Empty off darwin or when nothing was held.
  */
 function rehydrateStore(now: number = Date.now()): Map<string, StoredBundle> {
   const store = new Map<string, StoredBundle>();
@@ -233,9 +167,7 @@ function rehydrateStore(now: number = Date.now()): Map<string, StoredBundle> {
   return store;
 }
 
-/** Broker runtime dir under the regenerable cache, locked to the user (0700).
- * AGENTS_SECRETS_AGENT_DIR overrides the location — a test seam so the suite can
- * run a real broker on a temp socket without touching the user's real dir. */
+/** Broker runtime dir (0700). Override with AGENTS_SECRETS_AGENT_DIR for tests. */
 function agentDir(): string {
   const dir = process.env.AGENTS_SECRETS_AGENT_DIR || path.join(getHelpersDir(), 'secrets-agent');
   fs.mkdirSync(dir, { recursive: true });
@@ -257,34 +189,25 @@ function pidPath(): string {
 }
 
 /**
- * Path of the per-broker capability token. It lives in the 0700 agent dir and is
- * written 0600, so only the same UID that owns the broker can read it — the file
- * permission IS the authorization boundary. See isRequestAuthorized.
+ * Per-broker capability token path (0600 inside the 0700 agent dir). The file
+ * permission is the authorization boundary.
  */
 function tokenPath(): string {
   return path.join(agentDir(), 'agent.token');
 }
 
 /**
- * Path of the CURRENT SOCKET OWNER's pid.
- *
- * Deliberately NOT `agent.pid`: that file is the standalone service's O_EXCL
- * single-instance claim, and a standalone that loses the socket race stays alive
- * and quiescent while holding it (so launchd's KeepAlive doesn't restart-loop
- * it), ready to take over if the hosted broker stops. Overloading it as the
- * socket-ownership record made the standalone see a live holder and exit
- * immediately — the exact restart loop that guard exists to prevent. This file
- * answers a different question: which pid is serving the socket right now.
+ * Path of the current socket owner's pid. NOT `agent.pid`, which is the
+ * standalone service's O_EXCL single-instance claim. Separating them prevents a
+ * standby standalone from seeing a live holder and exiting in a restart loop.
  */
 function ownerPath(): string {
   return path.join(agentDir(), 'agent.owner');
 }
 
 /**
- * Read the current broker capability token, or null if none is present. Clients
- * read it fresh per request and attach it to every non-ping command; a broker
- * restart mints a new token, so a stale read simply fails authorization and the
- * caller falls back to a direct keychain read (soft, never a hard error).
+ * Read the current broker capability token. A restart mints a new token, so a
+ * stale read fails soft and the caller falls back to a direct keychain read.
  */
 export function readAgentToken(): string | null {
   try {
@@ -295,9 +218,7 @@ export function readAgentToken(): string | null {
   }
 }
 
-/** Mint + persist a fresh capability token (0600) at socket-bind time. Only the
- * process that actually binds the socket calls this, so a losing starter never
- * clobbers the live owner's token. Returns the token for in-memory comparison. */
+/** Mint and persist a fresh capability token (0600) at socket-bind time. */
 function writeAgentToken(): string {
   const token = randomBytes(32).toString('hex');
   const fp = tokenPath();
@@ -307,15 +228,9 @@ function writeAgentToken(): string {
 }
 
 /**
- * Argv for re-invoking THIS cli with a hidden subcommand, so a side-by-side dev
- * build spawns its own helpers rather than the registry-installed one. Routed
- * through the shared getCliLaunch so it handles both install shapes — a JS entry
- * (`node dist/index.js …`) and a Bun standalone binary (run directly). The old
- * hand-rolled `[process.execPath, process.argv[1], …]` broke on standalone builds:
- * process.argv[1] is the bun virtual entry `/$bunfs/root/agents` (fs.existsSync
- * reports it as present), so it was passed as an argv element and the broker died
- * with `unknown command '/$bunfs/root/agents'` — the daemon-hosted broker never
- * bound its socket and every unlock reported "Could not start the secrets broker".
+ * Argv for re-invoking this CLI with a hidden subcommand. Uses getCliLaunch so
+ * both JS-entry and Bun-standalone installs work; the old `process.argv[1]`
+ * approach broke on standalone builds with a virtual `/$bunfs/root/agents` path.
  */
 function cliSpawn(sub: string[]): { cmd: string; args: string[] } {
   const { command, args } = getCliLaunch(sub);
@@ -326,21 +241,14 @@ function brokerSpawn(): { cmd: string; args: string[] } {
   return cliSpawn(['secrets', '_agent-run']);
 }
 
-// ─── Legacy standalone launchd service (retired, #416 step 2) ────────────────
-// Earlier versions ran the broker as its own launchd user service
-// (com.phnx-labs.agents-secrets-agent, shipped in 1.20.20) so a heavily-loaded
-// machine couldn't starve an on-demand cold start. That role now belongs to the
-// always-on daemon, which hosts the broker socket-first (#416 step 1) — one
-// supervised backbone instead of a second service. The functions below no
-// longer INSTALL the standalone service; they only DETECT and RETIRE a plist
-// left by an older version so the daemon can take over the socket. The upgrade
-// migration (postinstall) and `ensureAgentRunning` both drive the retire path.
+// ─── Legacy standalone launchd service (retired, #416) ───────────────────────
+// The broker is now hosted by the always-on daemon. The functions below only
+// detect and retire a plist left by older versions so the daemon owns the socket.
 
 const SERVICE_LABEL = 'com.phnx-labs.agents-secrets-agent';
 
-// LaunchAgents dir is relocatable for tests via AGENTS_SECRETS_LAUNCHAGENTS_DIR.
-// A relocated dir is NOT launchd-managed (launchd only bootstraps plists from
-// the real ~/Library/LaunchAgents), so retirement there is a pure file removal.
+// LaunchAgents dir. A relocated test dir is not launchd-managed, so retirement
+// there is pure file removal.
 function launchAgentsDir(): string {
   return process.env.AGENTS_SECRETS_LAUNCHAGENTS_DIR || path.join(os.homedir(), 'Library', 'LaunchAgents');
 }
@@ -355,11 +263,8 @@ export function secretsAgentServiceInstalled(): boolean {
 }
 
 /**
- * Retire the legacy standalone secrets-agent launchd service: bootout the job
- * (falling back to the legacy `unload`) and remove its plist so the always-on
- * daemon owns the broker socket. Idempotent and best-effort — a no-op when no
- * legacy plist is present. Does NOT wipe held bundles: the booted-out process's
- * memory is gone anyway, and the daemon-hosted broker starts fresh.
+ * Retire the legacy standalone launchd service so the daemon owns the socket.
+ * Idempotent; does not wipe held bundles.
  */
 export function retireLegacySecretsAgentService(): void {
   if (!onDarwin() || !secretsAgentServiceInstalled()) return;
@@ -381,11 +286,9 @@ export function retireLegacySecretsAgentService(): void {
 }
 
 /**
- * Stop the persistent broker for `agents secrets stop`: wipe whatever the broker
- * holds (forces Touch ID again on the next read), then retire any legacy
- * standalone service. The daemon-hosted broker itself is left running — it is
- * the always-on backbone, and stopping it would take down unrelated background
- * work (routines, browser IPC, session-sync).
+ * Stop the persistent broker for `agents secrets stop`: wipe held bundles, then
+ * retire any legacy standalone service. The daemon-hosted broker itself is left
+ * running because it backs unrelated background work.
  */
 export async function uninstallSecretsAgentService(): Promise<void> {
   if (!onDarwin()) return;
@@ -417,17 +320,9 @@ export type Response =
 // ─── Broker server (runs in the detached `secrets _agent-run` process) ───────
 
 /**
- * Pure request handler over the in-memory store. Extracted so the store
- * semantics (lazy expiry on get/status, lock-one vs lock-all, load TTL) are
- * unit-testable with a controlled `now`, without a socket or a spawned process.
- * Mutates `store` in place; returns the wire response.
- */
-/**
- * Count of real unlocked bundles in the store, excluding the internal
- * `secrets list` metadata cache. Used to decide broker "warmth" for self-heal
- * and idle-exit: a metadata-only store must read as empty so a disposable list
- * cache never blocks an upgrade restart (#435) or an idle one-off broker from
- * exiting. Pure + exported for unit testing.
+ * Count of real unlocked bundles, excluding the internal `secrets list` metadata
+ * cache. A metadata-only store must read as empty so it doesn't block upgrade
+ * self-heal or idle-exit (#435). Exported for tests.
  */
 export function realBundleCount(store: Map<string, StoredBundle>): number {
   let n = 0;
@@ -439,26 +334,21 @@ export function scopedBundleKey(name: string, harness: string): string {
   return `${harness}:${name}`;
 }
 
+/** Pure request handler over the in-memory store. Exported for tests. */
 export function handleAgentRequest(
   store: Map<string, StoredBundle>,
   req: Request,
   now: number = Date.now(),
-  // Eviction tombstones: `lock` records when each bundle was wiped so a load
-  // whose snapshot predates the eviction (a detached auto-load that raced a
-  // mutating write) is rejected instead of re-populating the store with a
-  // pre-mutation copy. Broker-lifetime state, owned by the caller like `store`.
+  // Eviction tombstones: reject loads whose snapshot predates the eviction so a
+  // detached auto-load can't re-populate stale state.
   evictedAt: Map<string, number> = new Map(),
 ): Response {
   switch (req.cmd) {
     case 'ping':
-      // Report the version of the code this broker is RUNNING (getCliVersion
-      // caches the value from the broker's startup), not the on-disk version.
-      // A client compares this to its own fresh on-disk read; a mismatch means
-      // the broker is running pre-upgrade code and should be restarted.
+      // Report the running version, not on-disk, so clients detect pre-upgrade brokers.
       return { ok: true, cmd: 'ping', version: PROTOCOL_VERSION, cliVersion: getCliVersion() };
     case 'get': {
-      // Walk own-harness → global so an `--agent` grant wins over a global one and
-      // an unscoped unlock serves every harness (bundleScopeChain).
+      // own-harness → global: scoped grants win, unscoped unlocks serve all.
       for (const scope of bundleScopeChain(req.harness)) {
         const key = scopedBundleKey(req.name, scope);
         const e = store.get(key);
@@ -478,9 +368,7 @@ export function handleAgentRequest(
     case 'load': {
       const evictedTs = evictedAt.get(req.name);
       if (evictedTs !== undefined && req.snapshotAt !== undefined && req.snapshotAt <= evictedTs) {
-        // The loader captured its bundle/env before a mutating write evicted
-        // this name; accepting it would serve (and later re-persist) stale
-        // state. A load with no snapshotAt (older client) is accepted as before.
+        // Reject loads captured before a mutating write evicted this name.
         return { ok: false, error: `stale load for '${req.name}': snapshot predates an eviction` };
       }
       const harness = req.harness || GLOBAL_HARNESS;
@@ -522,29 +410,19 @@ export function handleAgentRequest(
 }
 
 /**
- * Decide whether a `watch-lock` helper line should wipe the in-memory store.
- * The helper emits `LOCK` on screen-lock / screensaver and `SLEEP` on system
- * sleep. We wipe on SLEEP only: a bare screen-lock is already gated by the login
- * password, and with the ~7d hold, re-authing after every lock would defeat the
- * point. Logout needs no line — it tears down the launchd session and kills the
- * broker outright. Pure + exported so the LOCK-survives / SLEEP-wipes contract
- * has direct regression coverage (the inline stdout handler isn't unit-testable).
+ * Wipe the in-memory store only on SLEEP, not screen-lock (already gated by the
+ * login password). Exported for regression coverage of the LOCK-survives /
+ * SLEEP-wipes contract.
  */
 export function shouldWipeOnWatchEvent(chunk: string): boolean {
   return /\bSLEEP\b/.test(chunk);
 }
 
 /**
- * Authorization gate applied to every request BEFORE handleAgentRequest touches
- * the store (RUSH-1760). A bare same-UID socket connection is no longer trusted
- * to load/get arbitrary bundle env: each command except the liveness `ping` must
- * carry the per-broker capability token, which lives in a 0600 file inside the
- * 0700 agent dir and so is readable only by the UID that owns the broker.
- *
- * Fail closed: a missing/empty expected token (no token file) rejects every
- * command but ping. `ping` stays unauthenticated — it exposes only the protocol
- * and cli version, and clients need it to detect a reachable broker before they
- * have any reason to read the token. Pure + exported for direct unit testing.
+ * Authorization gate: every request except `ping` must carry the per-broker
+ * capability token from the 0600 token file. `ping` stays unauthenticated so
+ * clients can probe reachability before reading the token. Fail closed. Exported
+ * for tests.
  */
 export function isRequestAuthorized(req: Request, expectedToken: string | null): boolean {
   if (req.cmd === 'ping') return true;
@@ -555,11 +433,9 @@ export function isRequestAuthorized(req: Request, expectedToken: string | null):
 type BrokerConnectionHandler = (conn: net.Socket) => void;
 
 /**
- * Build the socket `connection` handler shared by both brokers (standalone and
- * daemon-hosted): newline-framed JSON in, one response line out, with the
- * authorization gate (isRequestAuthorized) applied before `handle`. `token`
- * resolves the currently-expected capability token per request so a token
- * rotation on broker restart is picked up without rebuilding the handler.
+ * Build the socket `connection` handler shared by standalone and daemon-hosted
+ * brokers. Newline-framed JSON in, one response line out, with per-request token
+ * lookup so rotation on restart is picked up.
  */
 export function makeConnectionHandler(
   handle: (req: Request) => Response,
@@ -592,19 +468,12 @@ export function makeConnectionHandler(
 }
 
 /**
- * Whether a live process still owns the broker pid file.
- *
- * A single missed `agentPing` is NOT proof the owner is dead — the broker is
- * single-threaded, so a big `get` or the rehydrate at startup can blow the
- * 700ms ping budget while the process is perfectly healthy. Treating that as
- * death let a starting broker unlink a live socket and rebind, leaving the old
- * process alive holding every unlocked bundle in RAM that no client could reach
- * any more (observed live: two brokers, one socket path, two kernel sockets).
- * The pid file is the second, independent liveness signal that makes the reclaim
+ * Whether a live process still owns the broker pid file. A single missed ping
+ * isn't proof of death: the single-threaded broker can blow the ping budget
+ * while healthy. The pid file is the second liveness signal that makes reclaim
  * safe.
  */
-/** Drop our ownership record, but only if it is still ours — never clobber a
- *  successor that already claimed the socket. */
+/** Drop our ownership record only if it is still ours. */
 export function releaseBrokerPid(): void {
   try {
     if (parseInt(fs.readFileSync(ownerPath(), 'utf-8').trim(), 10) === process.pid) {
@@ -623,13 +492,8 @@ export function brokerPidAlive(): boolean {
 }
 
 /**
- * Bind the shared broker socket without stealing it from another live owner.
- * Both the standalone service and daemon-hosted broker use this single path so
- * either startup order is safe: a reachable owner wins, while an unreachable
- * stale socket is reclaimed once.
- *
- * "Unreachable" is established with retries plus a pid-file liveness check, never
- * a single ping — see {@link brokerPidAlive}.
+ * Bind the shared broker socket without stealing it from a live owner. Uses
+ * retries plus pid-file liveness, not a single ping, to decide "unreachable".
  */
 async function bindBrokerSocket(
   sock: string,
@@ -645,17 +509,8 @@ async function bindBrokerSocket(
       server.once('error', onError);
       server.listen(sock, () => {
         try { fs.chmodSync(sock, 0o600); } catch { /* dir 0700 already gates it */ }
-        // Mint the capability token here — the one moment this process is the
-        // confirmed socket owner — so a losing starter never clobbers the live
-        // owner's token (RUSH-1760).
+        // Mint the token and record ownership only once we are the confirmed owner.
         try { writeAgentToken(); } catch { /* dir 0700 gates the socket regardless */ }
-        // Record ownership at the same moment, for the same reason. The
-        // daemon-hosted broker deliberately skips the O_EXCL pid-file GUARD (the
-        // daemon owns its instance), but without an ownership RECORD
-        // brokerPidAlive() has nothing to read — so a later starter saw an
-        // ownerless socket and reclaimed the live hosted broker anyway, which is
-        // the primary configuration and the one that actually orphaned here.
-        // Writing it from the confirmed owner covers both broker flavours.
         try { fs.writeFileSync(ownerPath(), String(process.pid)); } catch { /* dir 0700 gates it */ }
         resolve(server);
       });
@@ -664,15 +519,12 @@ async function bindBrokerSocket(
   let bound = await listenOnce();
   if (bound !== 'inuse') return bound;
 
-  // Give a busy owner several chances before concluding it is gone. One slow
-  // ping used to be enough to evict a healthy broker and orphan its RAM.
+  // Give a busy owner several chances before concluding it is gone.
   for (let attempt = 0; attempt < BIND_PROBE_ATTEMPTS; attempt++) {
     if ((await agentPing()).reachable) return null;
     if (attempt < BIND_PROBE_ATTEMPTS - 1) await delay(BIND_PROBE_INTERVAL_MS);
   }
-  // Silent but alive is still alive: refuse to steal the socket from a process
-  // that still owns the pid file, and let the caller surface the wedge instead
-  // of quietly starting a second broker on the same path.
+  // Refuse to steal from a process that still owns the pid file.
   if (brokerPidAlive()) {
     throw new Error(
       `Secrets broker socket is held by a live process that is not answering: ${sock}. ` +
@@ -688,21 +540,18 @@ async function bindBrokerSocket(
 }
 
 /**
- * Run the broker in the foreground. Spawned detached by ensureAgentRunning via
- * `agents secrets _agent-run`. Holds the store in memory, serves the socket,
- * sweeps expired entries, wipes on sleep, and self-exits when idle.
+ * Run the standalone broker in the foreground. Spawned by ensureAgentRunning via
+ * `agents secrets _agent-run`. Serves the socket, sweeps expired entries, wipes
+ * on sleep, and self-exits when idle.
  */
 export async function runSecretsAgent(
   opts: { service?: boolean } = {},
 ): Promise<{ close(): void | Promise<void> } | null> {
   if (!onDarwin()) return null; // nothing to broker without biometry prompts
-  // When launchd keeps us alive as a persistent service, never idle-exit:
-  // exiting would just make launchd cold-start us again, reintroducing the
-  // startup-under-load fragility the service exists to avoid.
+  // Persistent launchd service must never idle-exit; launchd would cold-start again.
   const persistent = opts.service === true;
 
-  // Single-instance guard: O_EXCL pid file. If a live broker already holds it,
-  // exit quietly — the existing one keeps serving.
+  // O_EXCL single-instance guard.
   const pidFile = pidPath();
   try {
     const fd = fs.openSync(pidFile, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY);
@@ -721,8 +570,7 @@ export async function runSecretsAgent(
   }
 
   const store = rehydrateStore();
-  // emptySince tracks the last moment the store held something; the sweep exits
-  // the process once it's been empty for IDLE_EXIT_MS so no idle broker lingers.
+  // Track when the store last held something so idle brokers exit.
   let emptySince = Date.now();
   const sock = socketPath();
 
@@ -734,9 +582,8 @@ export async function runSecretsAgent(
     } catch { /* gone or no longer ours */ }
   };
 
-  // Register lifecycle handlers before socket arbitration. A persistent
-  // launchd service may spend its whole lifetime as the standby loser, and a
-  // kickstart/bootout during that wait must still release its pid-file lease.
+  // Register lifecycle handlers before socket arbitration so a standby service
+  // still releases its pid-file lease on kickstart/bootout.
   let standbyTimer: NodeJS.Timeout | null = null;
   let cleanupActive: (() => void) | null = null;
   let shuttingDown = false;
@@ -760,9 +607,7 @@ export async function runSecretsAgent(
   process.on('SIGTERM', onSigterm);
   process.on('SIGINT', onSigint);
 
-  // Capture the version of the code we're running so the sweep can detect when
-  // an in-place upgrade has landed and self-heal onto it. getCliVersion caches
-  // this value for the process lifetime; getCliVersionFresh re-reads on disk.
+  // Capture the running version so the sweep can self-heal onto upgraded code.
   const runningVersion = getCliVersion();
 
   // "Warmth" for self-heal / idle-exit counts only real unlocked bundles, NOT
@@ -782,12 +627,10 @@ export async function runSecretsAgent(
       }
     }
     const live = realBundleCount(store);
-    // Self-heal onto a newer in-place install — but ONLY while no real unlocks
-    // are held, so we never wipe live unlocks and force a re-prompt (#435). A
-    // metadata-only store still self-heals (the list cache is disposable).
+    // Self-heal only while no real unlocks are held (#435).
     if (live === 0 &&
         shouldSelfHealForUpgrade(persistent, live, runningVersion, getCliVersionFresh())) {
-      shutdown(0); // KeepAlive relaunches on the new code
+      shutdown(0);
       return;
     }
     if (live === 0) {
@@ -816,10 +659,7 @@ export async function runSecretsAgent(
       throw err;
     }
     if (!server && persistent) {
-      // launchd KeepAlive would immediately relaunch a persistent loser if it
-      // returned here. Stay quiescent instead, then claim the socket if the
-      // daemon-hosted owner goes away. The pid file keeps launchd/manual starts
-      // from creating additional waiters while this process is standing by.
+      // Stay quiescent rather than returning, or launchd KeepAlive would restart-loop.
       do {
         await new Promise<void>((resolve) => {
           standbyTimer = setTimeout(() => {
@@ -838,9 +678,7 @@ export async function runSecretsAgent(
 
   let watcher: ChildProcess | null = null;
   let sweepTimer: NodeJS.Timeout | null = null;
-  // Sync cleanup for SIGTERM/SIGINT → process.exit: we cannot await the
-  // server's 'close' event before exit, so fire-and-forget close + unlink.
-  // The public close() path below awaits with a bounded timeout (RUSH-2421).
+  // Sync cleanup for signal-driven exit: can't await 'close', so fire-and-forget.
   cleanupActive = () => {
     store.clear();
     if (sweepTimer) clearInterval(sweepTimer);
@@ -853,14 +691,8 @@ export async function runSecretsAgent(
 
   sweepTimer = setInterval(sweep, SWEEP_INTERVAL_MS);
 
-  // Auto-lock on sleep. The signed helper emits LOCK / SLEEP lines; we wipe
-  // everything on SLEEP (and, implicitly, logout — that tears down the launchd
-  // session and kills this in-memory broker). A bare screen-lock is deliberately
-  // NOT a wipe: with the ~7d hold, re-prompting after every lock would defeat the
-  // point, and a locked screen is already gated by the login password. If the
-  // installed helper predates watch-lock (exits non-zero immediately), we fall
-  // back to TTL-only and log nothing — the unlock already warned when
-  // lock_on_sleep couldn't be armed.
+  // Auto-lock on sleep. Wipe on SLEEP; screen-lock alone survives. If the helper
+  // predates watch-lock, fall back to TTL-only.
   try {
     watcher = spawn(getKeychainHelperPath(), ['watch-lock'], { stdio: ['ignore', 'pipe', 'ignore'] });
     watcher.stdout?.setEncoding('utf-8');
@@ -868,8 +700,7 @@ export async function runSecretsAgent(
       if (shouldWipeOnWatchEvent(chunk)) {
         store.clear();
         emptySince = Date.now();
-        // Split default: delete non-`--durable` durable sessions too, so a default
-        // unlock re-locks on sleep; `--durable` ones survive (session-store.ts).
+        // Default (non-durable) sessions re-lock on sleep; durable ones survive.
         pruneSessionsOnSleep();
       }
     });
@@ -895,28 +726,16 @@ export async function runSecretsAgent(
 }
 
 /**
- * Host the secrets broker inside the always-on daemon (#416).
- *
- * Serves the SAME socket and wire protocol as the standalone `runSecretsAgent`
- * — so every existing client (`agentGetSync`, `agentPing`, `agentAutoLoadSync`)
- * keeps working through the versioned protocol — but it is daemon-safe:
- *
- *   - no pid-file single-instance guard (the daemon owns the instance);
- *   - no `process.exit`, no SIGTERM/SIGINT handlers, no self-heal/idle-exit
- *     (those would kill the daemon — the daemon is the always-on backbone and
- *     manages its own version/lifecycle). The sweep only TTL-evicts.
- *
- * The caller (`runDaemon`) normally invokes this only when no broker answers
- * its initial ping. Binding still arbitrates ownership through the same shared
- * path as the standalone service: a live owner wins, while only an unreachable
- * stale socket is reclaimed. Returns a handle the daemon closes on shutdown,
- * or null off-darwin (nothing to broker without biometry).
+ * Host the secrets broker inside the always-on daemon (#416). Serves the same
+ * socket/protocol as the standalone broker, but daemon-safe: no pid-file guard,
+ * no process.exit/SIG handlers, no self-heal/idle-exit (the daemon owns the
+ * lifecycle). Returns null off-darwin.
  */
 export async function startHostedBroker(): Promise<{ close(): void | Promise<void> } | null> {
-  if (!onDarwin()) return null;
+  if (!onDarwin()) return null; // nothing to broker without biometry prompts
 
   const store = rehydrateStore();
-  const sock = socketPath(); // agentDir() creates the 0700 dir as a side effect
+  const sock = socketPath();
 
   const evictedAt = new Map<string, number>();
   const handle = (req: Request): Response => handleAgentRequest(store, req, Date.now(), evictedAt);
@@ -925,10 +744,7 @@ export async function startHostedBroker(): Promise<{ close(): void | Promise<voi
   const server = await bindBrokerSocket(sock, onConn);
   if (!server) return null;
 
-  // TTL eviction ONLY. Unlike the standalone broker's sweep, there is no
-  // self-heal-exit or idle-exit here — the daemon is always-on and owns the
-  // upgrade/lifecycle path; a broker that called process.exit() would take the
-  // whole daemon down with it.
+  // TTL eviction only. The daemon is always-on and owns its own lifecycle.
   const sweepTimer = setInterval(() => {
     const now = Date.now();
     for (const [name, e] of store) {
@@ -941,8 +757,7 @@ export async function startHostedBroker(): Promise<{ close(): void | Promise<voi
     }
   }, SWEEP_INTERVAL_MS);
 
-  // Auto-lock on sleep, same as the standalone broker: the signed helper emits
-  // LOCK/SLEEP lines; wipe the in-memory store on a wipe-worthy event.
+  // Auto-lock on sleep, same as the standalone broker.
   let watcher: ChildProcess | null = null;
   try {
     watcher = spawn(getKeychainHelperPath(), ['watch-lock'], { stdio: ['ignore', 'pipe', 'ignore'] });
@@ -950,7 +765,7 @@ export async function startHostedBroker(): Promise<{ close(): void | Promise<voi
     watcher.stdout?.on('data', (chunk: string) => {
       if (shouldWipeOnWatchEvent(chunk)) {
         store.clear();
-        pruneSessionsOnSleep(); // split default — see runSecretsAgent's handler
+        pruneSessionsOnSleep();
       }
     });
     watcher.on('error', () => { watcher = null; });
@@ -959,10 +774,6 @@ export async function startHostedBroker(): Promise<{ close(): void | Promise<voi
   }
 
   return {
-    // RUSH-2421: await net.Server's 'close' (bounded) so a caller relying on
-    // close() cannot proceed past a socket that is not actually released yet.
-    // The daemon may fire-and-forget this promise; tests and any awaiter get
-    // the real release boundary.
     async close() {
       store.clear();
       clearInterval(sweepTimer);
@@ -978,10 +789,8 @@ export async function startHostedBroker(): Promise<{ close(): void | Promise<voi
 const SERVER_CLOSE_TIMEOUT_MS = 2_000;
 
 /**
- * Call Node's net.Server.close() and wait for the 'close' event (or a bounded
- * timeout). Without this, close() returned while the listen socket could still
- * be held — a successor bind could race EADDRINUSE against a half-closed server
- * (RUSH-2421). Pure side-effect helper; never throws.
+ * Wait for net.Server.close()'s 'close' event (or a bounded timeout) so a
+ * successor bind doesn't race a half-closed socket (RUSH-2421).
  */
 export function closeServerBounded(
   server: net.Server,
@@ -1007,11 +816,9 @@ export function closeServerBounded(
 
 // ─── Client ──────────────────────────────────────────────────────────────────
 
-/** Open the socket, send one request, resolve the one response. Async path —
- * used by the unlock/lock/status commands, which already run in async actions. */
+/** Open the socket, send one request, resolve the one response. Async path. */
 function request(req: Request, timeoutMs = 2000): Promise<Response | null> {
-  // Attach the capability token to every command except ping (the auth gate;
-  // RUSH-1760). ping stays tokenless so a client can probe reachability first.
+  // Attach the capability token to every command except ping.
   const authedReq: Request = req.cmd === 'ping' ? req : { ...req, token: readAgentToken() ?? undefined };
   return new Promise((resolve) => {
     const conn = net.createConnection(socketPath());
@@ -1038,52 +845,26 @@ function request(req: Request, timeoutMs = 2000): Promise<Response | null> {
   });
 }
 
-/** True if a broker socket exists at all. Cheap; gates the sync read so the
- * never-unlocked path stays a single stat. */
+/** Cheap socket-existence check so the never-unlocked path stays a single stat. */
 export function agentSocketExists(): boolean {
   return onDarwin() && fs.existsSync(socketPath());
 }
 
 /**
- * Spawn one of the `__secrets-*` sync clients and return its result.
- *
- * These three call sites used to hand-roll `spawnSync(process.execPath, ['-e',
- * <inline node program>, …])`. That is correct only for a JS install, where
- * `process.execPath` is `node`. Since 1.20.53 the shipped macOS `agents` is a
- * **bun-compiled Mach-O**, where `process.execPath` is the CLI binary itself —
- * so the spawn became `agents -e <program> …`, which commander rejects with
- * `error: unknown option '-e'` and a non-zero exit. Every sync client then took
- * its own failure path (`agentGetSync` → null, `agentReachableSync` → false,
- * `agentEvictSync` → no-op), which reads as "broker down" and falls through to
- * a real keychain read. Net effect on the standalone binary: the broker cache
- * was never hit, so the `daily` policy's one-prompt-per-7d never applied and
- * every bundle read re-popped Touch ID.
- *
- * Same defect class as the broker-launch bug fixed in 1.20.56 (see cliSpawn's
- * doc comment); these three sites were simply never converted. Routing them
- * through `getCliLaunch` fixes both install shapes at once and keeps a single
- * code path.
- *
- * The subcommands are top-level `__secrets-*` tokens intercepted in index.ts
- * BEFORE commander and before the CLI's startup work, exactly like
- * `__daemon-run` and `__vault-age-helper`. That is load-bearing, not cosmetic:
- * a normal command path runs `checkForUpdates()` and `spawnDetachedSync()` on
- * every invocation (index.ts), so registering these as ordinary hidden
- * subcommands would fire an update check and spawn a detached background sync
- * on every cache hit — turning the hot read path into a process fork storm.
+ * Spawn one of the `__secrets-*` sync clients via `getCliLaunch`. The old
+ * `process.execPath -e` pattern broke on the bun-compiled Mach-O binary
+ * (1.20.53); routing through getCliLaunch fixes both install shapes. The
+ * subcommands are intercepted in index.ts before commander/startup so a cache
+ * hit doesn't fork detached syncs or run update checks.
  */
 export function syncClientLaunch(sub: string[], agentsBin?: string): { command: string; args: string[] } {
   return agentsBin ? getCliLaunch(sub, agentsBin) : getCliLaunch(sub);
 }
 
 function syncClient(sub: string[], timeout: number): SpawnSyncReturns<string> | null {
-  // Soft on every failure: bundles.ts's fast path promises "any failure falls
-  // through to the real keychain read below". spawnSync reports most failures
-  // via r.error rather than throwing, but getCliLaunch/getAgentsBinPath DO
-  // throw on a broken install — a bunfs entry whose execPath is gone, or a
-  // browser/computer shim with no sibling index.js. Without this catch those
-  // turn a graceful fallback into a crash, and only on already-degraded
-  // installs, which is the worst time for it.
+  // Soft on every failure: the fast path must fall through to the real keychain
+  // read. getCliLaunch can throw on broken installs; crashing there turns a
+  // graceful fallback into a failure at the worst time.
   try {
     const { command, args } = syncClientLaunch(sub);
     return spawnSync(command, args, { encoding: 'utf-8', timeout });
@@ -1093,9 +874,8 @@ function syncClient(sub: string[], timeout: number): SpawnSyncReturns<string> | 
 }
 
 /**
- * Synchronous read for the hot path. Returns the cached resolved bundle, or
- * null if the agent isn't running / doesn't hold this bundle / anything fails
- * (soft — caller falls through to the real keychain). macOS only.
+ * Synchronous read for the hot path. Returns null on any failure so the caller
+ * falls through to the real keychain. macOS only.
  */
 export function agentGetSync(name: string, harness: string = GLOBAL_HARNESS): { bundle: SecretsBundle; env: Record<string, string>; lease?: SecretLease } | null {
   if (!isSecretsBrokerEnabled()) return null;
@@ -1112,17 +892,9 @@ export function agentGetSync(name: string, harness: string = GLOBAL_HARNESS): { 
 }
 
 /**
- * Last non-empty line of a child's stdout — the payload line.
- *
- * The inline `node -e` client this replaced was a bare node process that could
- * only ever emit its own JSON. The replacement boots the real CLI, so anything
- * the CLI prints on the way up shares that stream. Today the known chatter (the
- * `~/.agents/ is N commits behind` notice) correctly goes to stderr, but a
- * single future stdout write anywhere in startup would make `JSON.parse` throw
- * and turn every cache hit back into a silent miss — i.e. quietly reintroduce
- * the Touch-ID-on-every-read bug this fix closes, with no failing test to catch
- * it. Anchoring on the last line makes the payload the terminator of the
- * stream rather than the whole of it, so preceding chatter is inert.
+ * Last non-empty line of a child's stdout — the payload line. Anchors on the
+ * terminator so any future CLI startup chatter on stdout doesn't break JSON.parse
+ * and silently turn cache hits into misses.
  */
 export function lastLine(stdout: string): string {
   const lines = stdout.split('\n');
@@ -1134,12 +906,9 @@ export function lastLine(stdout: string): string {
 }
 
 /**
- * Synchronous liveness check: is a broker actually LISTENING and answering (not
- * just a lingering socket file)? Used to decide whether the auto-cache may take
- * the synchronous warm path — a dead broker whose socket outlived it (crash,
- * OOM, version-skew teardown) must NOT drag a foreground read through the
- * worker's 20s cold-start budget. A stale socket refuses instantly, so this is
- * fast in both the alive and dead cases. macOS only.
+ * Synchronous liveness check: is a broker actually listening? Gates the
+ * synchronous warm path so a stale socket doesn't drag a foreground read
+ * through a cold-start. macOS only.
  */
 export function agentReachableSync(): boolean {
   if (!onDarwin()) return false;
@@ -1149,12 +918,8 @@ export function agentReachableSync(): boolean {
 }
 
 /**
- * Synchronously evict one bundle from the broker. Called after a mutating
- * keychain write (add / rotate / remove / rename / delete) so the broker never
- * keeps serving the pre-write snapshot for up to the ~7d hold — the next read
- * re-resolves from the keychain (one prompt) and re-caches fresh values.
- * Best-effort: no broker, no socket, or any failure is a silent no-op.
- * macOS only.
+ * Synchronously evict one bundle after a mutating write so the broker doesn't
+ * serve a stale snapshot for the hold window. Best-effort silent no-op. macOS only.
  */
 export function agentEvictSync(name: string): void {
   if (!onDarwin()) return;
@@ -1164,28 +929,14 @@ export function agentEvictSync(name: string): void {
 }
 
 // ─── Top-level `__secrets-*` sync-client entrypoints ────────────────────────
-// The bodies behind the three spawns above. Each does one socket round-trip and
-// signals the parent through its exit code, mirroring the inline `node -e`
-// programs these replaced: 0 = hit/alive, 3 = miss/down. Lock deviates twice:
-// it reports 0 even when no broker answers, and 3 for an empty name, which it
-// refuses rather than forwarding as a lock-ALL (see runAgentLockSync).
-// Dispatched from index.ts BEFORE commander and before the startup statements,
-// so a cache hit never runs checkForUpdates() or forks a detached sync.
+// Dispatched from index.ts before commander/startup so cache hits stay cheap.
 
-/** Body of `__secrets-get <name>`. Prints `{bundle, env}` as JSON on a
- * cache hit. Exit 0 = hit, 3 = miss or broker down. */
+/** Body of `__secrets-get <name>`. Exit 0 = hit, 3 = miss/down. */
 export async function runAgentGetSync(name: string, harness: string = GLOBAL_HARNESS): Promise<number> {
   const r = await request({ cmd: 'get', name, harness }, SOCKET_GET_TIMEOUT_MS);
   if (r?.ok === true && r.cmd === 'get' && r.hit) {
-    // Trailing newline: the parent reads the LAST line (see lastLine), so the
-    // payload must terminate the stream even if anything ever precedes it.
-    //
-    // Awaited on the write callback, not fire-and-forget: stdout is a pipe here
-    // (the parent captures it), pipe writes are asynchronous, and the caller
-    // exits the process the moment this resolves. An unflushed write would be
-    // truncated on exit — the parent would see a partial or empty payload, treat
-    // it as a miss, and fall through to a keychain read, silently costing the
-    // Touch ID prompt this whole path exists to avoid.
+    // Terminate with a newline and await the write callback; an unflushed pipe
+    // write would be truncated on exit and cost a Touch ID prompt.
     const payload = JSON.stringify({ bundle: r.bundle, env: r.env, lease: r.lease }) + '\n';
     await new Promise<void>((resolve) => { process.stdout.write(payload, () => resolve()); });
     return 0;
@@ -1193,25 +944,16 @@ export async function runAgentGetSync(name: string, harness: string = GLOBAL_HAR
   return 3;
 }
 
-/** Body of `__secrets-ping`. Exit 0 = a broker is listening and speaking
- * our protocol, 3 = nothing there. Deliberately does NOT gate on
- * PROTOCOL_VERSION: this only decides whether the auto-cache may take the
- * synchronous warm path, and a version-skewed broker still answers reads. That
- * matches the inline program this replaced. */
+/** Body of `__secrets-ping`. Exit 0 = listening broker, 3 = nothing there.
+ * Does not gate on PROTOCOL_VERSION so version-skewed brokers still answer reads. */
 export async function runAgentPingSync(): Promise<number> {
   const r = await request({ cmd: 'ping' }, SOCKET_PING_TIMEOUT_MS);
   return r?.ok === true && r.cmd === 'ping' ? 0 : 3;
 }
 
 /** Body of `__secrets-lock <name>`. Best-effort evict; exit 0 even when no
- * broker answers, so a missing broker never fails the mutating write that
- * triggered it (agentEvictSync discards this either way).
- *
- * An empty name is refused rather than forwarded: the broker treats a nameless
- * lock as lock-ALL (handleAgentRequest), so a bare `__secrets-lock` would wipe
- * every held bundle and re-prompt Touch ID for each. That was unreachable while
- * this was an inline `node -e` string; as a top-level argv token it is one typo
- * away, and agentEvictSync only ever locks by name. */
+ * broker answers. An empty name is refused to avoid accidentally locking ALL
+ * bundles. */
 export async function runAgentLockSync(name: string): Promise<number> {
   if (!name) return 3;
   await request({ cmd: 'lock', name }, SOCKET_LOCK_TIMEOUT_MS);
@@ -1222,11 +964,9 @@ export async function runAgentLockSync(name: string): Promise<number> {
 const META_SNAPSHOT_KEY = '__snapshot__';
 
 /**
- * Read the cached `secrets list` metadata snapshot for the given keychain
- * name-set hash, or null on miss / no broker / off-darwin. Reuses the value
- * fast-path socket read (agentGetSync) — no prompt, no wire change. The hash is
- * the cache key: a changed name-set (bundle added/removed/renamed) yields a
- * different key and therefore a clean miss, so the stale set is never served.
+ * Read the cached `secrets list` metadata snapshot for a keychain name-set hash.
+ * Reuses agentGetSync. The name-set hash is the cache key, so add/remove/rename
+ * yields a clean miss.
  */
 export function agentGetMetaSync(nameSetHash: string): SecretsBundle[] | null {
   if (!onDarwin()) return null;
@@ -1242,11 +982,9 @@ export function agentGetMetaSync(nameSetHash: string): SecretsBundle[] | null {
 }
 
 /**
- * Fire-and-forget: populate the broker with a freshly-read metadata snapshot so
- * the next `secrets list` within the hold window renders without a prompt.
- * Stored as an ordinary entry (placeholder bundle, snapshot in env) under the
- * reserved META_CACHE_PREFIX key; the snapshot travels over stdin to the
- * detached worker (never argv/disk), same as value caching. macOS only.
+ * Fire-and-forget: populate the broker with a metadata snapshot so the next
+ * `secrets list` within the hold window is prompt-free. Stored under a reserved
+ * META_CACHE_PREFIX key; snapshot travels over stdin. macOS only.
  */
 export function agentAutoLoadMetaSync(nameSetHash: string, bundles: SecretsBundle[], ttlMs: number): void {
   if (!onDarwin()) return;

--- a/cli/src/lib/secrets/bundles.ts
+++ b/cli/src/lib/secrets/bundles.ts
@@ -1,24 +1,8 @@
 /**
  * Secret bundles — named sets of environment variables backed by a secret store.
- *
- * Bundle metadata (name, description, vars map) is stored as a JSON blob under
- * `agents-cli.bundles.<name>`; secret values live one per item under
- * `agents-cli.secrets.<bundle>.<key>`. Two backends carry those items:
- *
- *  - `keychain` (default): the macOS Keychain (device-local, Touch ID / device
- *    passcode gated) or Linux libsecret — see src/lib/secrets/index.ts.
- *  - `file`: an AES-256-GCM encrypted-file store keyed by a passphrase
- *    (src/lib/secrets/filestore.ts). Opt-in, for headless / remote runs where
- *    no biometry prompt can be satisfied (e.g. a release on a remote Mac over
- *    SSH). The item-name scheme is identical, so the only difference is where
- *    bytes land. A file-backed bundle is discovered by the presence of its
- *    metadata item in the file store.
- *  - `vault`: a single age-encrypted ~/.agents/vault.age file unlocked by
- *    `agents secrets vault unlock`; intended for user-managed cross-machine file sync.
- *
- * Server-backed cross-machine sync is handled by src/lib/secrets/sync.ts via
- * an explicit encrypted export/import flow; the bundle layer also supports the
- * local vault backend for user-managed file sync.
+ * Metadata lives under `agents-cli.bundles.<name>`; values under
+ * `agents-cli.secrets.<bundle>.<key>`. Backends: `keychain` (default),
+ * `file` (headless/passphrase), and `vault` (age-encrypted, user-synced).
  */
 
 import * as fs from 'fs';
@@ -67,16 +51,14 @@ import { createHash } from 'node:crypto';
 export type SecretsBackend = 'keychain' | 'file' | 'vault';
 
 /**
- * Uniform read/write surface over a secret store, so the bundle functions
- * don't branch on backend at every call site.
+ * Uniform read/write surface over a secret store so bundle functions stay
+ * backend-agnostic.
  */
 interface ItemStore {
   has(item: string): boolean;
   get(item: string): string;
   getBatch(items: string[]): Map<string, string>;
-  /** `opts.noAcl` writes the item WITHOUT the biometry access control (the
-   * `never` prompt-policy). Backends with no ACL concept (file store, test
-   * backend) ignore it. */
+  /** `noAcl` skips biometry on keychain; file/test backends ignore it. */
   set(item: string, value: string, opts?: { noAcl?: boolean }): void;
   setBatch(items: Map<string, string>, opts?: { noAcl?: boolean }): void;
   delete(item: string): boolean;
@@ -95,11 +77,9 @@ const keychainStore: ItemStore = {
   list: listKeychainItems,
 };
 
-// The file store auto-provisions a stable machine-local passphrase on EVERY
-// platform (macOS included) — a 0600 key file, encryption-at-rest with the same
-// posture as an SSH key — so `agents secrets` "just works" with no passphrase to
-// set, type, or remember, and no Touch ID. Set AGENTS_SECRETS_PASSPHRASE to opt
-// into an off-disk key.
+// File store auto-provisions a machine-local 0600 key on every platform,
+// so `agents secrets` works headless without a passphrase. Override with
+// AGENTS_SECRETS_PASSPHRASE.
 const fileItemStore: ItemStore = {
   has: (item) => fileStore.has(item),
   get: (item) => fileStore.get(item),
@@ -138,10 +118,8 @@ function itemStore(backend: SecretsBackend): ItemStore {
 }
 
 /**
- * Discover a bundle's backend by location: a file-backed bundle's metadata
- * item exists in the encrypted-file store. This is a plain file-existence
- * check — no passphrase, no Touch ID — so it sidesteps the chicken-and-egg of
- * "read metadata to learn where metadata lives." Absent ⇒ keychain.
+ * Discover a bundle's backend by location. File store is checked first (a plain
+ * existence test, no passphrase); absent/locked vault falls back to keychain.
  */
 export function bundleBackend(name: string): SecretsBackend {
   const item = BUNDLE_META_PREFIX + name;
@@ -176,62 +154,35 @@ export const SECRET_TYPES = [
 ] as const;
 export type SecretType = typeof SECRET_TYPES[number];
 
-/** Per-secret metadata. All fields optional; absent ones omitted at write time. */
+/** Per-secret metadata; absent fields are omitted at write time. */
 export interface VarMeta {
   type?: SecretType;
-  /** ISO date 'YYYY-MM-DD'. Always future-dated at write time. */
+  /** Future-dated ISO date ('YYYY-MM-DD'). */
   expires?: string;
-  /** Singular freeform note. */
   note?: string;
 }
 
 /**
- * A bundle's prompt policy — how often macOS asks for Touch ID to read it:
- * - `hold` (default): ask once, then serve it silently for the configured hold
- *   duration (`secrets.agent.holdMs`, 7d by default). Named for what it does —
- *   it was called `daily`, which stated a period it never had.
- *   (Historical name — the window is now a rolling ~1 week, not one calendar day.)
- *   Eligible for the secrets-agent — the first real keychain read auto-loads it
- *   (auto-cache is on by default) so concurrent runs read it silently, or `unlock`
- *   it explicitly. Held from that unlock (not refreshed on use); re-asks sooner
- *   after sleep, logout, or `agents secrets lock`. A bare screen-lock does NOT
- *   drop it (the login password already gates a locked screen).
- * - `always`: asks every time. Never auto-held — only an explicit `agents
- *   secrets unlock` ever holds it; every other read pops Touch ID. Opt a
- *   high-value bundle into this when you want to confirm every single read.
- * - `never`: stored WITHOUT the biometry access control — reads are fully
- *   silent (no Touch ID, no broker). The least-safe tier: any code running as
- *   the user reads it with no user-presence check. Reserved for low-sensitivity,
- *   automation-only credentials. Writing a `never` item needs the signed helper's
- *   `set-no-acl` path (see keychain-helper.swift); an older pinned helper rejects
- *   it loudly rather than silently downgrading to `always`.
- *
- * The default is configurable via `secrets.policy` in agents.yaml. Stored on disk
- * under the legacy `tier` key (`session` == `hold`, `biometry` == explicit
- * `always`, `none` == `never`, absent == inherit the default) so bundles stay
- * readable across mixed CLI versions on synced machines. The user-facing
- * vocabulary is `policy`/`always`/`hold`/`never`.
+ * Bundle prompt policy. `hold` (default): one Touch ID per hold window (~7d),
+ * then silent via the secrets-agent. `always`: prompt every read. `never`: no
+ * biometry ACL — least-safe, automation-only. Configurable via `secrets.policy`;
+ * persisted under the legacy `tier` key for cross-version sync.
  */
 export type SecretsPolicy = 'always' | 'hold' | 'never';
 
-/** A named set of environment variable definitions backed by various secret providers. */
+/** A named set of environment variable definitions backed by secret stores. */
 export interface SecretsBundle {
   name: string;
   description?: string;
   allow_exec?: boolean;
-  /** Which store carries this bundle's items. Absent ⇒ `keychain` (the default). */
+  /** Absent ⇒ `keychain`. */
   backend?: SecretsBackend;
-  /** Prompt policy. Absent ⇒ the configured default (`hold`). Serialized under
-   * the legacy `tier` key — see SecretsPolicy. */
+  /** Absent ⇒ configured default (`hold`). */
   policy?: SecretsPolicy;
-  /** ISO 8601 UTC timestamp. Set once on the first writeBundle() for a bundle. */
   created_at?: string;
-  /** ISO 8601 UTC timestamp. Refreshed on every writeBundle(). */
   updated_at?: string;
-  /** ISO 8601 UTC timestamp. Stamped by resolveBundleEnv (throttled). */
   last_used?: string;
   vars: Record<string, BundleValue>;
-  /** Optional per-var metadata, keyed by var name (parallel to `vars`). */
   meta?: Record<string, VarMeta>;
 }
 
@@ -241,7 +192,7 @@ export interface LegacyBundleCandidate {
   keys: string[];
 }
 
-/** Minimum gap between last_used updates so the keychain isn't written on every secrets injection. */
+/** Throttle last_used writes so the keychain isn't touched on every injection. */
 const LAST_USED_THROTTLE_MS = 60_000;
 
 export const BUNDLE_NAME_PATTERN = /^[a-z0-9][a-z0-9\-_.]{0,48}$/i;
@@ -257,11 +208,8 @@ export const RESERVED_ENV_NAMES = new Set([
 ]);
 
 /**
- * The reserved FILE-BACKED bundle that holds long-lived Claude setup-tokens.
- * Usage/probe reads authenticate with these instead of the ACL-bound login item,
- * so they never pop Touch ID and they can cross the fleet. A keychain- or
- * vault-backed bundle of this name is a misconfiguration: the consumer used to
- * return null (SEC-GAP-3) and silently fall through to Touch ID.
+ * Reserved FILE-BACKED bundle for long-lived setup tokens. Must be file-backed;
+ * a keychain/vault `auth` bundle is a misconfiguration and is ignored.
  */
 export const AUTH_BUNDLE_NAME = 'auth';
 export const AUTH_BUNDLE_BACKEND: SecretsBackend = 'file';
@@ -287,7 +235,7 @@ export class ReservedBundleWrongBackendError extends Error {
   }
 }
 
-/** Fail loud when `name` is reserved and `backend` is not the required one. */
+/** Fail loud when a reserved bundle is on the wrong backend. */
 export function assertReservedBundleBackend(name: string, backend: SecretsBackend): void {
   if (!isReservedBundleName(name)) return;
   if (backend !== AUTH_BUNDLE_BACKEND) {
@@ -296,8 +244,7 @@ export function assertReservedBundleBackend(name: string, backend: SecretsBacken
 }
 
 /**
- * Presence + backend of the reserved `auth` bundle. `ok` is true when the
- * bundle is absent (nothing to fix) or present and file-backed.
+ * Check the reserved `auth` bundle. `ok` is true when absent or file-backed.
  */
 export function inspectReservedAuthBundle(): {
   exists: boolean;
@@ -312,10 +259,9 @@ export function inspectReservedAuthBundle(): {
 }
 
 /**
- * After a file-backed import, actually decrypt the keys and fail if any are
- * unreadable. Import used to print "Imported N key(s)" from the write tally
- * alone — ciphertext sealed under a forwarded AGENTS_SECRETS_PASSPHRASE that
- * the destination daemon does not hold still counted as success.
+ * After a file-backed import, verify the keys actually decrypt. Import used to
+ * report success for ciphertext sealed under a forwarded passphrase this process
+ * does not hold.
  */
 export function assertFileBundleDecryptable(name: string, keys: string[]): void {
   if (keys.length === 0) return;
@@ -409,9 +355,8 @@ export function validateSecretType(t: string): asserts t is SecretType {
 }
 
 /**
- * Validate an `expires` value. Accepts strict 'YYYY-MM-DD' only and rejects
- * any date <= now. We compare against end-of-day UTC for the chosen date so
- * "today" is treated as past (per spec).
+ * Validate a future `expires` date. Accepts strict 'YYYY-MM-DD'; end-of-day UTC
+ * means "today" is past.
  */
 export function validateExpiresFutureDated(iso: string): void {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) {
@@ -434,12 +379,9 @@ export function bundleExists(name: string): boolean {
 }
 
 /**
- * Thrown by `readBundle` for the one state `readBundleIfDecryptable` may treat
- * as "present but permanently unreadable": file-store ciphertext on disk that
- * will not decrypt with the passphrase in effect (lost/rotated key or a tampered
- * store). It is deliberately narrow — a bundle that is merely *locked for this
- * run* (headless macOS without `AGENTS_SECRETS_PASSPHRASE`, or a vault that is
- * not logged in) is recoverable and must not be collapsed into this.
+ * Thrown for file-store ciphertext that will not decrypt (lost/rotated key or
+ * tampered store). Narrow: temporarily-locked bundles are recoverable and must
+ * not be collapsed here.
  */
 export class BundleUndecryptableError extends Error {
   constructor(message: string) {
@@ -449,18 +391,9 @@ export class BundleUndecryptableError extends Error {
 }
 
 /**
- * Read a bundle, or return null when its metadata is present but genuinely
- * cannot be decrypted — a lost or rotated file-store passphrase, or a tampered
- * file store (signalled by `BundleUndecryptableError`).
- *
- * Deleting such a bundle is the only way out of that state, and deletion needs
- * no plaintext, so it must not be gated behind a successful decrypt. Every other
- * failure rethrows: a genuinely missing bundle ("not found"), and — critically —
- * a bundle that is only *temporarily locked* for this run (headless macOS with no
- * `AGENTS_SECRETS_PASSPHRASE`, or a not-logged-in vault). Collapsing that
- * recoverable "set the env / log in" state into "unreadable, safe to delete"
- * would let `secrets delete <name> --yes` silently destroy a perfectly healthy
- * bundle from a cron/launchd run that merely forgot to export the passphrase.
+ * Read a bundle, returning null only when metadata is present but permanently
+ * unreadable (`BundleUndecryptableError`). Other failures — including temporary
+ * lockout — rethrow so a healthy bundle is never deleted by mistake.
  */
 export function readBundleIfDecryptable(name: string): SecretsBundle | null {
   try {
@@ -477,17 +410,13 @@ export function readBundle(name: string): SecretsBundle {
   if (backend === 'vault') assertVaultBackendUsable(name);
   let json: string;
   try {
-    // Bundle metadata carries no biometry ACL (SEC-4), so this read is silent
-    // even in a headless context — attest that to the raw-read storm guard so
-    // a headless `readBundle` never trips the fail-fast. (A legacy
-    // pre-metadata-heal ACL'd metadata item can still prompt once; it heals on
-    // the next interactive read.)
+    // Metadata is no-ACL by contract; attest silentNoAcl so headless reads don't
+    // trip the raw-read storm guard. A legacy ACL'd item may prompt once, then heals.
     json = backend === 'keychain'
       ? getKeychainToken(bundleMetaItem(name), { silentNoAcl: true })
       : itemStore(backend).get(bundleMetaItem(name));
   } catch (err) {
-    // A file-backed bundle whose metadata is on disk but fails to decrypt is a
-    // wrong-passphrase error, not a missing bundle — surface that clearly.
+    // File-backed metadata that fails to decrypt is a wrong-passphrase error.
     if (backend === 'file' && fileStore.has(bundleMetaItem(name))) {
       throw new BundleUndecryptableError(
         `Bundle '${name}': failed to decrypt — wrong AGENTS_SECRETS_PASSPHRASE or tampered file store. (${(err as Error).message})`,
@@ -496,18 +425,13 @@ export function readBundle(name: string): SecretsBundle {
     if (vaultExists() && !getVaultSession().loggedIn) {
       throw new Error(`Synced secrets are locked. Run: agents secrets vault unlock`);
     }
-    // Distinguish a genuinely-absent bundle from a present-but-unreadable one
-    // (a locked login keychain, or a legacy ACL'd metadata item before first
-    // unlock). `has` counts an unreadable item as present, so a metadata item
-    // that exists but could not be read must not report as "not found" — an
-    // existence answer and a read answer may not contradict (RUSH-2253).
+    // A present-but-unreadable keychain item must not report "not found".
     if (backend === 'keychain') {
       let present: boolean;
       try {
         present = hasKeychainToken(bundleMetaItem(name));
       } catch (probeErr) {
-        // Keychain unreachable (RUSH-2235 fail-loud): neither absent nor
-        // add-the-key — surface the reachability failure, not a false absence.
+        // Keychain unreachable — fail loud rather than report false absence.
         throw new Error(`Secrets bundle '${name}': ${(probeErr as Error).message}`);
       }
       if (present) {
@@ -528,9 +452,7 @@ export function readBundle(name: string): SecretsBundle {
   if (!parsed || typeof parsed !== 'object') {
     throw new Error(`Bundle '${name}' is malformed.`);
   }
-  // Unknown fields on the JSON (e.g. legacy sync flags) are silently dropped
-  // here; the SecretsBundle shape is the only source of truth. `backend` is
-  // authoritative from location discovery, not the persisted field.
+  // Drop unknown fields; `backend` is authoritative from location discovery.
   const bundle: SecretsBundle = {
     name,
     description: parsed.description,
@@ -554,12 +476,7 @@ export function readBundle(name: string): SecretsBundle {
   return bundle;
 }
 
-/** Normalize the persisted prompt policy. The on-disk `tier` key uses legacy
- * tokens for cross-version compatibility: `session` ⇒ `hold`, `biometry` ⇒ an
- * explicit `always`. An absent token ⇒ undefined, which resolves to the
- * configured default policy (`hold`). Persisting an explicit `always` as the
- * legacy `biometry` token keeps older CLIs correct — they don't know `hold`,
- * read `biometry` as undefined, and fall back to their own always default. */
+/** Normalize the persisted `tier` token to the current policy vocabulary. */
 function parsePolicy(raw: unknown): SecretsPolicy | undefined {
   if (raw === 'hold' || raw === 'daily' || raw === 'session') return 'hold';
   if (raw === 'always' || raw === 'biometry') return 'always';
@@ -567,11 +484,7 @@ function parsePolicy(raw: unknown): SecretsPolicy | undefined {
   return undefined;
 }
 
-/** The default prompt policy applied to bundles without an explicit per-bundle
- * policy. Configurable via `secrets.policy` in agents.yaml; `hold` (one Touch ID
- * per hold window — `secrets.agent.holdMs`, 7d by default) unless the user
- * explicitly opts back into prompt-every-time with `always`. Best-effort: an
- * unreadable config falls back to the `hold` default. */
+/** Default policy for bundles without an explicit one (`secrets.policy`). */
 export function secretsDefaultPolicy(): SecretsPolicy {
   try {
     return readMeta().secrets?.policy === 'always' ? 'always' : 'hold';
@@ -580,7 +493,7 @@ export function secretsDefaultPolicy(): SecretsPolicy {
   }
 }
 
-/** The effective prompt policy of a bundle (absent ⇒ the configured default). */
+/** Effective prompt policy of a bundle. */
 export function bundlePolicy(bundle: SecretsBundle): SecretsPolicy {
   return bundle.policy ?? secretsDefaultPolicy();
 }
@@ -588,24 +501,16 @@ export function bundlePolicy(bundle: SecretsBundle): SecretsPolicy {
 /** Options for writeBundle. */
 export interface WriteBundleOptions {
   /**
-   * Skip evicting the bundle from the secrets-agent broker after the write.
-   * Only for writers that change nothing the broker serves — today that is
-   * stampLastUsed (a usage-telemetry timestamp, fired on every broker HIT):
-   * evicting there would make the cache destroy itself on first use. Every
-   * mutating writer (add / rotate / remove / rename / policy / import) must
-   * leave this unset so a broker-held copy never serves stale values for up
-   * to the ~7d hold.
+   * Skip evicting the broker-held copy. Only for no-op writers such as
+   * stampLastUsed; mutating writes must evict so stale values aren't served.
    */
   skipBrokerEviction?: boolean;
 }
 
 /**
- * Whether a bundle write should evict the broker-held copy. Pure + exported
- * for regression coverage. Skips when the writer opted out (stampLastUsed),
- * when the broker integration is disabled (AGENTS_SECRETS_NO_AGENT — the same
- * kill-switch the read fast-path honors), or when a test keychain backend is
- * installed (an in-memory backend has no real keychain behind it, and a test
- * writing bundle 'prod' must never evict the user's real 'prod' unlock).
+ * Whether a bundle write should evict the broker-held copy. Exported for tests.
+ * Skips when the writer opted out, the broker is disabled, or a test backend is
+ * active (so tests don't evict the user's real unlocks).
  */
 export function shouldEvictAfterBundleWrite(
   skipRequested: boolean,
@@ -632,7 +537,7 @@ function prepareBundleWrite(bundle: SecretsBundle): PreparedBundleWrite {
   for (const key of Object.keys(bundle.vars)) {
     validateEnvKey(key);
   }
-  // Strip empty/all-undefined meta entries so the JSON stays tidy.
+  // Strip empty meta entries so the JSON stays tidy.
   let meta: Record<string, VarMeta> | undefined;
   if (bundle.meta) {
     for (const [key, m] of Object.entries(bundle.meta)) {
@@ -646,26 +551,17 @@ function prepareBundleWrite(bundle: SecretsBundle): PreparedBundleWrite {
       }
     }
   }
-  // Stamp timestamps on the bundle so callers see what got persisted. created_at
-  // is sticky — once set we never overwrite it, including on legacy bundles
-  // that already carry one. updated_at always advances.
+  // created_at is sticky; updated_at always advances.
   const now = new Date().toISOString();
   if (!bundle.created_at) bundle.created_at = now;
   bundle.updated_at = now;
   const payload = {
-    // The bundle's own name, persisted since #316: with hashed service names
-    // the keychain item name is opaque, so listBundles recovers the display
-    // name from this field. Older CLIs drop unknown fields on read — safe.
+    // Persist the display name so hashed keychain items remain listable.
     name: bundle.name,
     description: bundle.description,
     allow_exec: bundle.allow_exec ? true : undefined,
     backend: backend === 'keychain' ? undefined : backend,
-    // Wire format: persist the policy under the legacy `tier` token so older CLI
-    // versions on other synced machines keep reading it — `hold`⇒`session`,
-    // explicit `always`⇒`biometry`, `never`⇒`none`. An absent policy omits the
-    // token entirely and resolves to the configured default (`hold`) on read.
-    // An older CLI that doesn't know `none` reads it as undefined and falls back
-    // to its own default — safe, since it also lacks the no-ACL write path.
+    // Legacy wire token for cross-version sync.
     tier: bundle.policy === 'hold' ? 'session'
       : bundle.policy === 'always' ? 'biometry'
       : bundle.policy === 'never' ? 'none'
@@ -685,26 +581,18 @@ function prepareBundleWrite(bundle: SecretsBundle): PreparedBundleWrite {
 
 function finishBundleWrite(bundle: SecretsBundle, opts: WriteBundleOptions): void {
   emit('secrets.set', { module: 'secrets', bundle: bundle.name });
-  // A broker-held snapshot predates this write; evict it so the next read
-  // re-resolves from the keychain instead of serving stale values.
+  // Evict the broker-held snapshot and durable session so the next read resolves fresh.
   if (shouldEvictAfterBundleWrite(Boolean(opts.skipBrokerEviction), process.env.AGENTS_SECRETS_NO_AGENT, isKeychainBackendOverridden())) {
     agentEvictSync(bundle.name);
-    // Also drop any durable session snapshot, or a broker restart would rehydrate
-    // the stale env after a rotate/rename (session-store.ts).
     deleteSession(bundle.name);
   }
 }
 
 export function writeBundle(bundle: SecretsBundle, opts: WriteBundleOptions = {}): void {
   const prepared = prepareBundleWrite(bundle);
-  // Bundle metadata (name, description, policy, var names + refs, and any
-  // non-sensitive `--value` literals) is stored WITHOUT the biometry ACL at
-  // EVERY tier. It is non-sensitive by contract — the real secret values live in
-  // separate agents-cli.secrets.* items that keep the bundle's policy ACL — so a
-  // no-ACL metadata item is what lets `secrets list` and crabbox's `agents
-  // devices list` enumerate bundles with no Touch ID prompt (RUSH-1759). On an
-  // un-updated pinned helper this write fails loudly (the no-ACL command is
-  // missing) rather than silently landing an ACL'd item.
+  // Metadata is non-sensitive by contract and stored no-ACL so `secrets list`
+  // can enumerate without Touch ID. A pinned helper without the no-ACL command
+  // fails loudly rather than silently landing an ACL'd item.
   itemStore(prepared.backend).set(prepared.metadataItem, prepared.metadataJson, { noAcl: true });
   if (prepared.backend === 'keychain') addBundleToMetaIndex(bundle.name);
   finishBundleWrite(bundle, opts);
@@ -718,21 +606,16 @@ export function writeBundleWithItems(
   const prepared = prepareBundleWrite(bundle);
   const store = itemStore(prepared.backend);
   if (prepared.backend === 'keychain') {
-    // Only the keychain backend has a biometry ACL. Secret VALUE items carry the
-    // bundle's policy ACL (`never` ⇒ no-ACL); the metadata item is ALWAYS no-ACL
-    // (see writeBundle). The two must NOT ride one batch flag — a single noAcl
-    // over both would either strip biometry off the real secrets or re-ACL the
-    // metadata. Write the values first, then the metadata last: bundle discovery
-    // keys on the metadata item's presence, so metadata-last means a partial
-    // write reads as "no bundle yet", never as a bundle with missing values.
+    // Keychain values carry the policy ACL; metadata is always no-ACL. They cannot
+    // share one batch flag, and metadata is written last so partial writes read as
+    // "no bundle yet".
     if (items.size > 0) {
       store.setBatch(new Map(items), { noAcl: bundle.policy === 'never' });
     }
     store.set(prepared.metadataItem, prepared.metadataJson, { noAcl: true });
     addBundleToMetaIndex(bundle.name);
   } else {
-    // file / vault: no ACL concept (noAcl is ignored), so one batched write is
-    // both correct and cheaper — e.g. a single age re-encrypt for the vault.
+    // File/vault have no ACL; one batched write is cheaper.
     const batch = new Map(items);
     batch.set(prepared.metadataItem, prepared.metadataJson);
     store.setBatch(batch, { noAcl: bundle.policy === 'never' });
@@ -756,16 +639,9 @@ export function deleteBundle(name: string): boolean {
 }
 
 /**
- * Parse a stored metadata JSON blob into a SecretsBundle, applying the lenient
- * posture listBundles wants (skip malformed / invalid-key bundles rather than
- * throw). `backend` is authoritative from where the item was found. Returns
- * null to skip.
- *
- * `nameHint` is the name recovered from a cleartext service name (Linux, the
- * file store, pre-re-key items) — authoritative when present, and the only
- * source for legacy metadata that predates the persisted `name` field. With
- * hashed service names (macOS, #316) the hint is undefined and the name comes
- * from the JSON payload written by writeBundle.
+ * Parse a stored metadata JSON blob into a SecretsBundle, skipping malformed
+ * bundles. `backend` is authoritative. `nameHint` is cleartext (Linux/file/
+ * legacy); hashed keychain items recover the name from the persisted payload.
  */
 function parseBundleMeta(nameHint: string | undefined, json: string, backend: SecretsBackend): SecretsBundle | null {
   let parsed: Partial<SecretsBundle>;
@@ -796,9 +672,8 @@ function parseBundleMeta(nameHint: string | undefined, json: string, backend: Se
   return bundle;
 }
 
-// Sentinel marking the one-time RUSH-1759 metadata-ACL heal as done. Lives under
-// the regenerable helpers dir (same tree as the secrets-agent runtime state), so
-// a cache wipe just re-runs the heal — harmless, since it is idempotent.
+// Sentinel for the one-time metadata-ACL heal. Lives in the regenerable helpers
+// dir, so a cache wipe re-runs it harmlessly.
 const METADATA_NOACL_SENTINEL = 'bundles-metadata-noacl-healed';
 
 function metadataNoAclSentinelPath(): string {
@@ -819,51 +694,31 @@ function markBundleMetadataAclHealed(): void {
     fs.mkdirSync(path.dirname(file), { recursive: true });
     fs.writeFileSync(file, '', 'utf8');
   } catch {
-    // Best effort — a missing sentinel just means the (idempotent) heal re-runs
-    // on the next broker-miss listing.
+    // Best effort — missing sentinel just re-runs the idempotent heal later.
   }
 }
 
-// ── No-ACL bundle-metadata name index (kills the enumeration Touch ID storm) ──
-// listBundles cannot ask the keychain for "just the metadata items": with hashed
-// service names (#316) the metadata names are opaque (`agents-cli.h.<ns>.m`), so
-// listKeychainItems(BUNDLE_META_PREFIX) falls back to a BROAD `agents-cli.` scan
-// that also MATCHES the ACL'd secret VALUE items. On some machines macOS
-// evaluates those value ACLs during that attributes-only scan and pops a generic
-// "Agents CLI needs to authenticate" sheet — on EVERY launch (session-title
-// generation, `agents devices list`, every agent run), because listBundles runs
-// on essentially every secrets touch. Neither UIFail nor LAContext can list the
-// no-ACL items while skipping the ACL'd ones (both return nothing), so the fix is
-// to NOT do the broad scan: keep a per-machine index of the metadata items'
-// STORAGE names in the regenerable helpers dir and read THAT (a silent file read)
-// instead. The index holds opaque hashes only — no cleartext bundle names, so it
-// leaks nothing #316 didn't already. It self-heals: absent/unbuilt → listBundles
-// rebuilds it from the one-time broad scan; a stale entry only makes `secrets
-// list` cosmetically incomplete and never affects a resolve-by-name (which
-// computes the hashed name directly, never through this index).
+// No-ACL bundle-metadata name index. With hashed service names (#316), listing
+// metadata falls back to a broad `agents-cli.` scan that matches ACL'd secret
+// values and pops Touch ID. We keep a per-machine index of opaque metadata
+// storage names in the regenerable helpers dir to avoid that scan. Stale entries
+// only make `secrets list` cosmetically incomplete; resolve-by-name never uses it.
 function bundleMetaIndexPath(): string {
-  // Test-only override (mirrors AGENTS_DAEMON_DIR): redirect to a fork-private
-  // temp so unit tests never touch the real helpers dir. Never set in prod.
+  // Test-only redirect so the suite never touches the real helpers dir.
   return (
     process.env.AGENTS_SECRETS_META_INDEX_FILE ||
     path.join(getHelpersDir(), 'secrets-agent', 'bundle-meta-index.json')
   );
 }
 
-// Changes iff the service-name hashing key changes (the #316 re-key, or a
-// cleartext<->hashed transition). Stamped into the index so an index built under
-// an OLD key reads as absent and is rebuilt — otherwise a re-key would leave
-// stale hashed names that resolve to nothing and make every bundle "vanish".
+// Fingerprint invalidates the index when the hashing key changes (#316 re-key),
+// so stale storage names don't make bundles "vanish".
 function metaIndexFingerprint(): string {
   return keychainServiceAlias(`${BUNDLE_META_PREFIX}meta-index-fingerprint`);
 }
 
 function readBundleMetaIndex(): string[] | null {
-  // A test-installed in-memory keychain is NOT the real store this index mirrors;
-  // reading (and later writing) the real ~/.agents index from a mock-backend test
-  // would leak fixture bundle names into a developer's live cache. Same guard the
-  // sibling healKeychainBundleMetadataAclOnce uses — treat the index as absent so
-  // listBundles falls back to the (mock) scan.
+  // Never read/write the real index from a mock-backend test.
   if (isKeychainBackendOverridden()) return null;
   try {
     const parsed = JSON.parse(fs.readFileSync(bundleMetaIndexPath(), 'utf-8'));
@@ -881,24 +736,18 @@ function writeBundleMetaIndex(services: string[]): void {
     const file = bundleMetaIndexPath();
     fs.mkdirSync(path.dirname(file), { recursive: true });
     const payload = { fp: metaIndexFingerprint(), services: [...new Set(services)].sort() };
-    // Atomic write (unique temp + rename) so a concurrent reader/writer never
-    // sees a half-written file. The read-modify-write in add/remove can still
-    // race two concurrent BUNDLE mutations and drop an entry, but that only makes
-    // a `secrets list` cosmetically incomplete (never a resolve-by-name) and
-    // self-heals on the next rebuild — an acceptable trade for rare bundle edits.
+    // Atomic write. Concurrent edits may still race and drop an entry, but that
+    // only makes `secrets list` cosmetically incomplete and self-heals.
     const tmp = `${file}.${process.pid}.tmp`;
     fs.writeFileSync(tmp, JSON.stringify(payload), 'utf8');
     fs.renameSync(tmp, file);
   } catch {
-    // Best effort — a missing index just means listBundles rebuilds it from the
-    // one-time broad scan on the next enumeration.
+    // Best effort — listBundles rebuilds from a broad scan on the next enumeration.
   }
 }
 
-// Append a metadata item's STORAGE name to an ALREADY-BUILT index. No-op when the
-// index has not been built yet (null): never create a one-entry index that would
-// hide every OTHER bundle — listBundles builds the complete index on its first
-// scan, and this newly-written bundle is included in that scan.
+// Append a storage name to an already-built index. No-op when null: a one-entry
+// index would hide every other bundle until the next rebuild.
 function addBundleToMetaIndex(name: string): void {
   const cur = readBundleMetaIndex();
   if (cur === null) return;
@@ -922,20 +771,16 @@ export const __metaIndexForTest = {
 };
 
 /**
- * Re-write already-read keychain bundle metadata items WITHOUT the biometry ACL.
- * `metaJsonByName` maps bundle name → the exact metadata JSON listBundles just
- * batch-read, so writing it back only flips the ACL (via the helper's
- * delete-then-add `set-no-acl`) — contents and updated_at are preserved and no
- * extra keychain read is issued. Exported for tests. Returns the count healed.
+ * Re-write keychain metadata items without the biometry ACL. The caller supplies
+ * the JSON already read, so contents are preserved and no extra read is issued.
+ * Exported for tests.
  */
 export function healKeychainBundleMetadata(metaJsonByName: Map<string, string>): number {
   let healed = 0;
   for (const [name, json] of metaJsonByName) {
     try {
-      // Cleartext meta-item name → hashed by keychainStore.set (#316) to the same
-      // service the read enumerated, so this overwrites the existing item in
-      // place, no-ACL. A per-item failure (e.g. a pinned helper without
-      // set-no-acl) must not abort the rest.
+      // keychainStore.set hashes the cleartext name back to the same service,
+      // overwriting in place no-ACL. Per-item failures must not abort the rest.
       keychainStore.set(bundleMetaItem(name), json, { noAcl: true });
       healed++;
     } catch {
@@ -946,10 +791,8 @@ export function healKeychainBundleMetadata(metaJsonByName: Map<string, string>):
 }
 
 /**
- * One-time driver around healKeychainBundleMetadata (RUSH-1759). macOS + real
- * keychain only — libsecret/CredMan have no biometry ACL to shed, and a test
- * backend has no real keychain — and gated by a sentinel so it runs at most
- * once. Best-effort: a heal failure never breaks bundle listing.
+ * One-time driver for healKeychainBundleMetadata. macOS + real keychain only;
+ * gated by a sentinel. Best-effort: a heal failure never breaks listing.
  */
 export function healKeychainBundleMetadataAclOnce(metaJsonByName: Map<string, string>): void {
   if (metaJsonByName.size === 0) return;
@@ -966,17 +809,8 @@ export function healKeychainBundleMetadataAclOnce(metaJsonByName: Map<string, st
 export function listBundles(): SecretsBundle[] {
   const out: SecretsBundle[] = [];
 
-  // Keychain-backed bundles: batch all metadata reads behind ONE Touch ID
-  // prompt instead of N. Bundle metadata items carry user-presence ACLs (same
-  // as secret values), so a naive loop over readBundle() spawns a fresh
-  // LAContext per item — meaning N biometric prompts for `secrets list`.
-  //
-  // SKIP this entirely when the keychain backend is routing to the encrypted
-  // file store (Linux headless / locked-collection fallback): there,
-  // listKeychainItems() returns the SAME items the file enumeration below
-  // reads, so running both would list every file-backed bundle twice — once
-  // mislabeled `keychain`, once correctly `[file]`. Under the fallback the
-  // file store is the single source of truth, so the block below covers all.
+  // Batch keychain metadata reads behind one prompt. Skip when the keychain
+  // backend is routing to the file fallback to avoid listing file bundles twice.
   if (!keychainUsesFileFallback()) {
     let keychainServices: string[] = [];
     // Prefer the no-ACL metadata-name index (a silent file read) over the broad
@@ -1002,19 +836,9 @@ export function listBundles(): SecretsBundle[] {
     // pre-re-key items) still carry the name; it's kept as the parse hint so
     // legacy metadata without the persisted `name` field keeps listing.
     if (keychainServices.length > 0) {
-      // Daily-policy fast-path (macOS). Bundle metadata items are biometry-gated,
-      // so the getKeychainTokens batch below pops Touch ID on every `secrets
-      // list` — the broker/`daily` mechanism only ever covered value reads, not
-      // this listing. Serve a broker-cached metadata snapshot when one is held,
-      // so only the first list per ~7d prompts. The cache key is a hash of the
-      // current keychain name-set (enumerated silently above): add / remove /
-      // rename a bundle and the key changes, so the stale snapshot is never
-      // served. A same-name metadata edit (e.g. `secrets policy <b> always`)
-      // does NOT change the key, so the POLICY column in `secrets list` can lag
-      // by up to the hold window (~7d) until the next name-set change or `lock`.
-      // This is cosmetic only — enforcement always reads the bundle's live
-      // policy (readBundle), never this snapshot, and `secrets view <b>` shows
-      // the fresh value immediately. Values are never cached here; metadata only.
+      // Serve a broker-cached metadata snapshot so only the first list per hold
+      // window prompts. Cache key is the name-set hash; policy edits can lag
+      // cosmetically, but enforcement always reads live policy. Values are not cached.
       const useAgent =
         process.env.AGENTS_SECRETS_NO_AGENT !== '1' &&
         !isKeychainBackendOverridden() &&
@@ -1027,12 +851,8 @@ export function listBundles(): SecretsBundle[] {
       if (cached) {
         for (const bundle of cached) out.push(bundle);
       } else {
-        // Metadata enumeration must stay silent in ANY context (SEC-11):
-        // bundle metadata items are no-ACL by contract (SEC-4), so attest that
-        // to the raw-read storm guard — a headless `listBundles` (session
-        // start, crabbox env, devices fan-out) must never fail fast on the
-        // guard nor pop a sheet. (A legacy pre-heal ACL'd metadata item can
-        // still prompt once; it heals on the next interactive scan.)
+        // Metadata is no-ACL by contract; attest silentNoAcl so headless listing
+        // doesn't fail fast or pop a sheet.
         const fetched = getKeychainTokens(keychainServices, { silentNoAcl: true });
         const keychainBundles: SecretsBundle[] = [];
         for (const service of keychainServices) {
@@ -1047,10 +867,7 @@ export function listBundles(): SecretsBundle[] {
           }
         }
         for (const bundle of keychainBundles) out.push(bundle);
-        // Populate the broker for the rest of the hold window (fire-and-forget).
-        // Same configurable cap as the value read-path — otherwise `secrets list`
-        // would keep serving a stale metadata snapshot for 7d even when the user
-        // capped the hold at 24h via secrets.agent.holdMs.
+        // Populate the broker using the same hold cap as value reads.
         if (useAgent && keychainBundles.length > 0) {
           agentAutoLoadMetaSync(nameSetHash, keychainBundles, secretsHoldMs());
         }
@@ -1058,9 +875,7 @@ export function listBundles(): SecretsBundle[] {
     }
   }
 
-  // File-backed bundles live in the encrypted-file store. Enumeration is a
-  // silent directory listing; only decryption needs the passphrase, so a
-  // `secrets list` without one still shows the names (values stay sealed).
+  // File-backed bundles: enumeration is silent; only decryption needs the passphrase.
   let fileServices: string[] = [];
   try {
     fileServices = fileStore.list(BUNDLE_META_PREFIX);
@@ -1075,8 +890,7 @@ export function listBundles(): SecretsBundle[] {
     try {
       json = fileItemStore.get(bundleMetaItem(name));
     } catch {
-      // No passphrase (or wrong one): surface the bundle by name so it isn't
-      // invisible, with empty vars. `agents secrets view` reports the error.
+      // No passphrase: surface the name with empty vars so it isn't invisible.
       out.push({ name, backend: 'file', vars: {} });
       continue;
     }
@@ -1110,7 +924,6 @@ export function listBundles(): SecretsBundle[] {
   return out.filter((bundle) => activeNames.has(bundle.name)).sort((a, b) => a.name.localeCompare(b.name));
 }
 
-// Classify each var for UI rendering.
 export interface BundleEntryInfo {
   key: string;
   kind: 'literal' | 'keychain' | 'env' | 'file' | 'exec';
@@ -1130,19 +943,10 @@ export function describeBundle(bundle: SecretsBundle): BundleEntryInfo[] {
   return out;
 }
 
-// Bump `last_used` and persist it, but no more than once per throttle window
-// so we don't pay a keychain write on every agent run. Failures are swallowed —
-// usage tracking is never allowed to break secret resolution.
-// Set AGENTS_NO_USAGE_TRACK=1 to disable the stamp entirely (used by tests).
-//
-// The passed bundle is often the BROKER'S snapshot (this fires on every broker
-// hit), which can be stale — a detached auto-load captured before a mutating
-// write can land after its eviction. Persisting that snapshot wholesale used to
-// write its whole `vars` map back over the authoritative store, resurrecting
-// removed keys (or, for a since-deleted bundle, the bundle itself). The stamp
-// is telemetry: it re-reads the store's own current copy (bundle metadata is a
-// silent no-ACL read) and writes ONLY the timestamp onto that.
-// Exported for regression coverage, like shouldEvictAfterBundleWrite.
+// Bump `last_used` at most once per throttle window. The passed bundle is often
+// the broker's snapshot, which can be stale, so re-read the authoritative
+// metadata and write ONLY the timestamp. Failures are swallowed.
+// Set AGENTS_NO_USAGE_TRACK=1 to disable entirely.
 export function stampLastUsed(bundle: SecretsBundle): void {
   if (process.env.AGENTS_NO_USAGE_TRACK) return;
   const nowMs = Date.now();
@@ -1154,10 +958,8 @@ export function stampLastUsed(bundle: SecretsBundle): void {
     const fresh = readBundle(bundle.name); // throws if the bundle is gone — swallowed below
     const stamp = new Date(nowMs).toISOString();
     fresh.last_used = stamp;
-    // Keep the caller's (possibly broker-held) copy throttling correctly.
     bundle.last_used = stamp;
-    // skipBrokerEviction: this stamp fires on every broker HIT; letting it
-    // evict would make the cache destroy itself on first use.
+    // Stamping fires on every broker hit; evicting would destroy the cache.
     writeBundle(fresh, { skipBrokerEviction: true });
   } catch {
     // Swallow — telemetry must never block secret resolution.
@@ -1166,59 +968,27 @@ export function stampLastUsed(bundle: SecretsBundle): void {
 
 /** Options for resolveBundleEnv. */
 export interface ResolveBundleOptions {
-  /**
-   * Human-readable label for who is requesting the secrets. Currently
-   * informational only — the helper's Touch ID prompt is set by the OS and
-   * cannot be reliably customized once we drop the per-batch reason path,
-   * but we keep this in the API so call sites stay explicit about who's
-   * about to read the bundle.
-   */
   caller?: string;
-  /** Harness type whose unlock may be reused (claude, codex, kimi, ...). */
+  /** Harness type whose unlock may be reused. */
   agent?: string;
-  /** Human duration rendered in the Touch ID prompt. */
+  /** Duration shown in the Touch ID prompt. */
   duration?: string;
-  /** Explicitly permit this agent request to raise interactive authentication. */
+  /** Allow this call to raise an interactive biometric prompt. */
   interactiveUnlock?: boolean;
-  /**
-   * Skip the secrets-agent fast-path and read straight from the keychain
-   * (popping Touch ID). Set by callers that must NOT serve a cached snapshot —
-   * `unlock` (which populates the agent in the first place) and any flow that
-   * needs live values. Also honored via AGENTS_SECRETS_NO_AGENT=1.
-   */
+  /** Skip the broker fast-path and read from the keychain directly. */
   noAgent?: boolean;
-  /**
-   * Resolve only from an already-unlocked secrets-agent snapshot. If the
-   * broker has no snapshot, fail before touching Keychain or any other store.
-   * Background processes use this to guarantee they never surface a biometric
-   * prompt that nobody can answer.
-   */
+  /** Resolve only from an already-unlocked broker snapshot; fail before prompting. */
   agentOnly?: boolean;
-  /**
-   * Inject only this subset of keys from the bundle. Keys not in this list are
-   * silently excluded from the returned env map. An error is thrown if any
-   * requested key is absent from the bundle (fail-loud, never silent skip).
-   * When absent or empty, all keys are injected (original behaviour).
-   */
+  /** Inject only these keys. Errors if any requested key is absent. */
   keys?: string[];
-  /**
-   * When true, skip the pre-run expiry check and inject keys even if their
-   * `expires` date is in the past. By default any expired key (or a key whose
-   * bundle-level expiry has passed) aborts the run before Touch ID is popped.
-   */
+  /** Skip the per-key expiry gate. */
   allowExpired?: boolean;
-  /**
-   * `process` projects dotted account keys like `GITHUB_USERNAME.personal` to
-   * the shell-safe base env name (`GITHUB_USERNAME`). Direct value lookups and
-   * backup/export flows use `storage` to preserve the exact bundle key names.
-   */
+  /** `process` projects dotted keys to shell-safe env names; `storage` preserves them. */
   keyMode?: 'process' | 'storage';
 }
 
 /**
- * Abort if any of the selected keys has an `expires` date in the past.
- * Bundle-level expiry is not a concept today (expiry is per-key via `meta`),
- * so we iterate only the per-key meta entries.
+ * Abort if any selected key's per-key `expires` date is in the past.
  */
 function assertNotExpired(bundle: SecretsBundle, selectedKeys: string[], allowExpired: boolean): void {
   if (allowExpired) return;
@@ -1240,9 +1010,7 @@ function assertNotExpired(bundle: SecretsBundle, selectedKeys: string[], allowEx
 }
 
 /**
- * Resolve the requested key subset against a bundle's `vars` map. Throws a
- * fail-loud error listing available keys if any requested key is absent. When
- * `requested` is undefined or empty, every key in the bundle is selected.
+ * Select the requested key subset, failing loud if any key is absent.
  */
 function selectRequestedKeys(bundle: SecretsBundle, requested: string[] | undefined): Set<string> {
   const req = requested?.length ? requested : undefined;
@@ -1333,14 +1101,8 @@ export function canCacheResolvedEnv(bundle: SecretsBundle, selectedKeys: Set<str
 }
 
 /**
- * Apply the --keys subset + expiry gate to an already-resolved snapshot from
- * the secrets-agent fast-path. The agent stores either a full unlock or a
- * scoped lease env, so a naive fast-path return could silently defeat --keys
- * and inject expired values. Mirrors the slow-path pre-checks in `resolveBundleEnv` /
- * `readAndResolveBundleEnv` and returns a new env whose keys match the subset.
- *
- * Exported for tests; production callers reach it via the fast-path branch in
- * `readAndResolveBundleEnv`.
+ * Apply --keys and --allow-expired to a broker snapshot so the fast path
+ * mirrors the slow path's gates. Exported for tests.
  */
 export function filterAgentHitBySubsetAndExpiry(
   hit: { bundle: SecretsBundle; env: Record<string, string> },
@@ -1349,21 +1111,14 @@ export function filterAgentHitBySubsetAndExpiry(
   const selectedKeys = selectRequestedKeys(hit.bundle, opts.keys);
   assertNotExpired(hit.bundle, [...selectedKeys], opts.allowExpired ?? false);
   const env = projectResolvedEnv(hit.bundle, hit.env, selectedKeys, opts.keyMode);
-  // When no subset/projection was requested, return the cached env untouched —
-  // same reference the agent handed back, so no per-call allocation on the hot path.
+  // Return the cached reference unchanged when no subset/projection was applied.
   if (env === hit.env) return hit;
   return { bundle: hit.bundle, env };
 }
 
 /**
- * Guard for remote-bundle callers (`bundle@host` / `--device`) — the SSH
- * resolver in `remoteResolveEnv` does not thread --keys or --allow-expired
- * yet. Silently applying them would inject the full remote env or an expired
- * value, defeating the least-privilege intent, so we fail loud.
- *
- * Exported so `agents run --secrets bundle@host` and `agents secrets exec
- * --device` share the exact same error text; the tests exercise this helper
- * directly instead of driving the whole CLI.
+ * Fail loud when remote bundle resolution is asked for flags the SSH resolver
+ * does not yet thread. Exported so callers share the same error text.
  */
 export function assertRemoteBundleFlagsUnsupported(
   bundleName: string,
@@ -1380,24 +1135,9 @@ export function assertRemoteBundleFlagsUnsupported(
 }
 
 /**
- * A declared `keychain:` ref resolved to NO value in the batch read. Classify
- * genuinely-absent vs present-but-unreadable before choosing the error, so a
- * read can never contradict what `agents secrets view` reports (RUSH-2248,
- * RUSH-2253). `view`'s "stored" badge comes from `hasKeychainToken` — the exact
- * existence probe used here — which counts a biometry-ACL'd or locked-keychain
- * item (`errSecInteractionNotAllowed`) as present. So:
- *
- *   - present  ⇒ the item exists but this context could not read it (keychain
- *     locked, or Touch ID not granted). Report HOW to unlock; NEVER
- *     "add the key", whose remediation (`secrets add`) would overwrite a good
- *     secret.
- *   - absent   ⇒ genuinely not stored on this machine — the honest "not found"
- *     with the `secrets add` remediation.
- *   - probe throws ⇒ the keychain itself is unreachable (RUSH-2235 fail-loud):
- *     neither absent nor add-the-key — surface the reachability failure verbatim.
- *
- * Only the keychain backend has a locked/biometry state; a file/vault miss is
- * genuinely absent.
+ * Build the right error for a missing `keychain:` ref. Classifies
+ * present-but-unreadable (locked/denied) vs genuinely absent so `view` and reads
+ * stay consistent. Only keychain has a locked state; file/vault misses are absent.
  */
 function missingBundleKeychainItemError(
   bundleName: string,
@@ -1428,17 +1168,9 @@ function missingBundleKeychainItemError(
 }
 
 /**
- * Resolve every selected key of an already-read bundle into a flat env map,
- * given a pre-fetched keychain batch. The single per-key resolution loop shared
- * by `resolveBundleEnv` and `readAndResolveBundleEnv` so the keychain lookup and
- * the missing-item classification can never diverge again (RUSH-2252: the two
- * paths drifted — one did the hashed-alias fallback lookup and one did not, and
- * only one classified a missing item honestly).
- *
- * The keychain lookup tries the cleartext name first (Linux / file store), then
- * its hashed storage alias (macOS with #316 hashing active) — the batch keys its
- * results by the names it was ASKED for, which for the metadata + declared keys
- * is the cleartext form and for an enumerated leftover is the hashed form.
+ * Shared per-key resolver for `resolveBundleEnv` and `readAndResolveBundleEnv`.
+ * Looks up keychain items by cleartext name then hashed alias; classifies misses
+ * consistently so the two paths cannot diverge.
  */
 function assembleBundleEnv(
   bundle: SecretsBundle,
@@ -1479,17 +1211,11 @@ function assembleBundleEnv(
   return env;
 }
 
-// Walk the bundle and produce a flat env map. Every keychain: ref is gathered
-// into a single batch read so macOS shows ONE Touch ID prompt for the whole
-// bundle — including the metadata fetch that already happened in readBundle
-// (the helper's auth context survives across separate invocations only via
-// the per-process LAContext, so we still get one prompt for the batch even
-// if metadata triggered an earlier one). Literals/env/file/exec refs are
-// resolved inline and never reach the keychain.
+// Resolve the bundle into a flat env map, batching keychain refs into one read
+// so macOS shows one Touch ID prompt. Literals/env/file/exec refs resolve inline.
 export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOptions = {}): Record<string, string> {
   stampLastUsed(bundle);
 
-  // Key-subset validation and expiry pre-check.
   const selectedKeys = selectRequestedKeys(bundle, _opts.keys);
   assertNotExpired(bundle, [...selectedKeys], _opts.allowExpired ?? false);
 
@@ -1506,10 +1232,8 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
   }
 
   const store = itemStore(bundle.backend ?? 'keychain');
-  // keychainStore.getBatch IS getKeychainTokens — call it directly so a
-  // `never`-policy bundle (no biometry ACL on its items) attests `silentNoAcl`
-  // and stays readable in a headless context, while an ACL'd policy hits the
-  // raw-read storm guard and fails fast there.
+  // Direct getKeychainTokens so `never`-policy bundles attest silentNoAcl in
+  // headless contexts, while ACL'd bundles fail fast.
   const fetched = keychainItemsToFetch.length > 0
     ? (bundle.backend ?? 'keychain') === 'keychain'
       ? getKeychainTokens(keychainItemsToFetch, { silentNoAcl: bundlePolicy(bundle) === 'never' })
@@ -1524,8 +1248,7 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
     _opts.keyMode,
     bundle.backend ?? 'keychain',
   );
-  // `caller` is intentionally unused; see ResolveBundleOptions.
-  void _opts.caller;
+  void _opts.caller; // informational only
   return env;
 }
 
@@ -1540,16 +1263,8 @@ export { isHeadlessSecretsContext, isAgentInvocationContext } from './headless.j
 
 /**
  * Read a bundle's metadata AND resolve its env in a single Touch ID prompt.
- *
- * `readBundle` + `resolveBundleEnv` issued two separate `LAContext` calls
- * (metadata read via `get-auth`, then secret values via `get-batch`) which
- * surfaced as two consecutive Touch ID prompts. macOS does not honor
- * "Always Allow" for items protected with `kSecAttrAccessControl`+biometry,
- * so caching at the OS level was never an option. This collapses both reads
- * into one `get-batch` call: we enumerate the bundle's secret items first
- * (silent — `list` returns attrs only and does not trigger biometry) and
- * include the metadata item in the same batch. One prompt, correctly scoped
- * to the bundle name and caller.
+ * `readBundle` + `resolveBundleEnv` used to issue two LAContext calls (two
+ * prompts). This collapses them into one batch that includes the metadata item.
  */
 export function readAndResolveBundleEnv(
   name: string,
@@ -1560,17 +1275,10 @@ export function readAndResolveBundleEnv(
 
   const backend = bundleBackend(name);
 
-  // Fast-path: if the secrets-agent holds this bundle (user ran
-  // `agents secrets unlock <name>`), return the cached snapshot with no Touch
-  // ID. Soft — any failure falls through to the real keychain read below. macOS
-  // / keychain only — the agent exists to dedup Touch ID prompts, and a
-  // file-backed bundle has none to dedup. The never-unlocked path is a single
-  // stat (agentSocketExists) so it costs nothing when the agent isn't running.
+  // Fast-path: broker-held snapshot ⇒ no Touch ID. Soft: any failure falls
+  // through to the real keychain read. macOS/keychain only.
   if (backend === 'keychain' && !opts.noAgent && process.env.AGENTS_SECRETS_NO_AGENT !== '1') {
-    // The scope this reader asks under. Falls back to the GLOBAL scope, not to a
-    // literal `'cli'` harness — the broker and the durable store both resolve
-    // own-harness → global (bundleScopeChain), so an unscoped unlock is visible
-    // here whether this process was launched by an agent or typed in a terminal.
+    // Falls back to GLOBAL so an unscoped unlock is visible in any harness.
     const harness = opts.agent || process.env.AGENTS_AGENT_NAME || GLOBAL_HARNESS;
     const hit = agentGetSync(name, harness);
     if (hit) {
@@ -1579,10 +1287,7 @@ export function readAndResolveBundleEnv(
         emitSecretAudit({ event: 'secrets.lease-denied', bundle: name, operation: opts.caller, source: 'agent', status: 'error', keys: denied, keyCount: denied.length, agent: harness, error: 'key outside lease scope' });
         throw new Error(`Secret lease '${hit.lease?.id}' does not grant key(s): ${denied.join(', ')}`);
       }
-      // The agent stores a full unlock or a scoped lease env. Apply the same subset filter and
-      // expiry gate as the slow path — without this, `--secrets-keys X` would
-      // silently inject every key and an expired key would flow through after
-      // the first cache-populating run.
+      // Apply the same subset and expiry gates as the slow path.
       const filtered = filterAgentHitBySubsetAndExpiry(hit, opts);
       stampLastUsed(filtered.bundle);
       emitSecretAudit({
@@ -1597,12 +1302,8 @@ export function readAndResolveBundleEnv(
       return filtered;
     }
 
-    // Durable-session fallback (Correction B). After a daemon restart / agents-cli
-    // upgrade the broker RAM is empty, so the fast-path above misses — but the
-    // unlock persisted a no-ACL session item (session-store.ts) that reads with NO
-    // Touch ID. Serve from it and re-warm the broker, so a warm bundle stays warm
-    // across restart — this fixes BOTH the interactive re-prompt and the headless
-    // throw below (which now fires only when there is genuinely no session).
+    // Durable-session fallback: after restart the broker RAM is empty, but a
+    // no-ACL session item lets us re-warm the broker without Touch ID.
     const resolved = resolveSession(name, Date.now(), harness);
     if (resolved) {
       const session = resolved.entry;
@@ -1613,14 +1314,9 @@ export function readAndResolveBundleEnv(
       }
       const filtered = filterAgentHitBySubsetAndExpiry({ bundle: session.bundle, env: session.env }, opts);
       stampLastUsed(filtered.bundle);
-      // Re-warm the broker with the remaining TTL so later reads hit RAM and
-      // `agents secrets status` is honest. Re-warm under the scope the grant was
-      // MADE in (resolved.harness), never the asking scope — re-warming a global
-      // grant as `claude` would silently narrow it for every other harness.
-      // No snapshotAt: the session's bundle was read at unlock time, not now —
-      // claiming freshness here would defeat the broker's eviction tombstones.
-      // An undated load is accepted (legacy behavior); the durable-session
-      // staleness window itself is a known, separate concern.
+      // Re-warm under the scope the grant was made in so a global grant isn't
+      // narrowed to the asking harness. No snapshotAt: the session bundle predates
+      // this read; claiming freshness would defeat eviction tombstones.
       agentAutoLoadSync(name, session.bundle, session.env, Math.max(1, session.expiresAt - Date.now()), resolved.harness, session.lease);
       emitSecretAudit({
         event: 'secrets.get',
@@ -1635,12 +1331,8 @@ export function readAndResolveBundleEnv(
     }
   }
 
-  // Never/no-ACL bundles remain prompt-free regardless. Every ordinary caller
-  // sets agentOnly; only the unlock handler opts into interactive authentication.
   const interactiveUnlock = opts.interactiveUnlock ?? false;
-  // A `never`-policy bundle's items carry no biometry ACL, so once the policy
-  // check below proves that, the batch read is silent even in a headless
-  // context — attest it to the raw-read storm guard via `silentNoAcl`.
+  // A `never`-policy bundle is prompt-free; attest silentNoAcl once verified.
   let verifiedNoAclBundle = false;
   if (opts.agentOnly && backend === 'keychain' && !interactiveUnlock && !keychainAgentOnlyBypassForTest) {
     try { verifiedNoAclBundle = bundlePolicy(readBundle(name)) === 'never'; } catch { /* fail closed */ }
@@ -1653,9 +1345,8 @@ export function readAndResolveBundleEnv(
     }
   }
 
-  // If the secrets broker is explicitly disabled and this bundle would otherwise
-  // fall through to a keychain read (Touch ID prompt), fail loud now. Never-policy
-  // bundles are verified below and remain silent; vault/file backends are unaffected.
+  // Fail loud when the broker is disabled and this would otherwise prompt.
+  // Never-policy bundles remain silent; vault/file are unaffected.
   if (backend === 'keychain' && !verifiedNoAclBundle && !isSecretsBrokerEnabled() && process.env.AGENTS_SECRETS_NO_AGENT !== '1') {
     throw new Error(
       `Secrets broker is disabled — re-enable with 'agents daemon services enable secrets-broker'. ` +
@@ -1669,11 +1360,9 @@ export function readAndResolveBundleEnv(
   const metaItem = bundleMetaItem(name);
   const bundleSecretPrefix = `${SECRETS_ITEM_PREFIX}${name}.`;
   let enumeratedSecretItems: string[] = [];
-  // Agent launches must never enumerate the macOS Keychain: a per-bundle
-  // prefix becomes a broad `agents-cli.` scan after service-name hashing and
-  // macOS evaluates unrelated biometry ACLs during that scan (RUSH-2440).
-  // Interactive reads retain the existing enumeration side of the union so
-  // legacy/aliased items keep their established behavior.
+  // Agent-only launches must not enumerate the keychain: hashed names turn a
+  // per-bundle prefix into a broad scan that evaluates unrelated ACLs (RUSH-2440).
+  // Interactive reads keep the legacy enumeration path.
   if (backend !== 'keychain' || !opts.agentOnly) {
     try {
       enumeratedSecretItems = store.list(bundleSecretPrefix);
@@ -1685,16 +1374,11 @@ export function readAndResolveBundleEnv(
     ? `read ${name} secrets (for ${opts.caller})`
     : `read ${name} secrets`;
 
-  // Captured BEFORE the first keychain read: if a mutating write evicts this
-  // bundle while the read is in flight, the broker's tombstone must beat this
-  // snapshot, so the conservative (earliest) timestamp is the correct one.
+  // Capture snapshotAt before the first read so broker eviction tombstones beat
+  // any concurrent load.
   const snapshotAt = Date.now();
-  // Fetch metadata first (it's always no-ACL), then derive secret item names
-  // from its declared keys instead of enumerating. This eliminates the broad
-  // Keychain scan that triggered Touch ID on every run (RUSH-2440). The
-  // metadata is authoritative for declared keys; undeclared keys (union with
-  // legacy/orphaned items) are not supported in agent-only mode and would
-  // fail the agentOnly gate anyway.
+  // Fetch metadata (always no-ACL) and derive secret item names from declared
+  // keys, eliminating the broad keychain scan that triggered Touch ID (RUSH-2440).
   const metaFetched = backend === 'keychain'
     ? getKeychainTokens([metaItem], { silentNoAcl: true })
     : store.getBatch([...new Set([metaItem, ...enumeratedSecretItems])]);
@@ -1716,9 +1400,8 @@ export function readAndResolveBundleEnv(
     throw new Error(`Bundle '${name}' is malformed.`);
   }
 
-  // Compute exact storage names from declared keychain references. The env key
-  // and stored item name may differ (`TOKEN=keychain:actual-token`), so deriving
-  // item names from Object.keys(vars) would silently read the wrong secret.
+  // Derive exact storage names from declared keychain refs. The env key and
+  // stored item name may differ, so vars keys alone would read the wrong secret.
   const declaredSecretItems: string[] = [];
   if (parsed.vars && typeof parsed.vars === 'object') {
     for (const raw of Object.values(parsed.vars)) {
@@ -1730,15 +1413,11 @@ export function readAndResolveBundleEnv(
   }
   const secretItems = [...new Set([...enumeratedSecretItems, ...declaredSecretItems])];
 
-  // Now fetch both metadata and secret values in one batch.
-  // The interactive path keeps the enumeration + declared-item union; the
-  // agent-only path contains declared items only and therefore never scans.
+  // Fetch metadata and secret values in one batch.
   const fetched = backend === 'keychain'
     ? getKeychainTokens([...new Set([metaItem, ...secretItems])], {
         agent: opts.agent || process.env.AGENTS_AGENT_NAME || 'Agents CLI',
         bundle: name,
-        // The session that triggered the read, so a Touch ID prompt is
-        // attributable when several agents run at once. Exported by exec.ts.
         sessionId: process.env.AGENT_SESSION_ID || process.env.AGENTS_SESSION_ID,
         reason: opts.caller ? `to ${opts.caller}` : reason,
         duration: opts.duration || humanUnlockDuration(secretsHoldMs()),
@@ -1746,16 +1425,13 @@ export function readAndResolveBundleEnv(
         forceDuration: Boolean(opts.duration),
         silentNoAcl: verifiedNoAclBundle,
       })
-    // File/vault enumeration is complete and prompt-free. Reuse its initial
-    // batch so metadata-first Keychain safety does not double-decrypt every
-    // file-backed credential read.
+    // File/vault: reuse the initial batch to avoid double-decrypting.
     : metaFetched;
   const bundle: SecretsBundle = {
     name,
     description: parsed.description,
     allow_exec: Boolean(parsed.allow_exec),
     backend: backend === 'keychain' ? undefined : backend,
-    // Legacy wire key: the policy is persisted under `tier` (`session` == `hold`).
     policy: parsePolicy((parsed as { tier?: unknown }).tier),
     vars: parsed.vars && typeof parsed.vars === 'object' ? parsed.vars : {},
   };
@@ -1767,7 +1443,6 @@ export function readAndResolveBundleEnv(
     validateEnvKey(key);
   }
 
-  // Key-subset validation and expiry pre-check (mirrors resolveBundleEnv logic).
   const selectedKeys = selectRequestedKeys(bundle, opts.keys);
   assertNotExpired(bundle, [...selectedKeys], opts.allowExpired ?? false);
 
@@ -1806,19 +1481,10 @@ export function readAndResolveBundleEnv(
   };
 
   try {
-    // Shared per-key resolver: same keychain lookup (cleartext name, then hashed
-    // storage alias) and same missing-item classification as resolveBundleEnv, so
-    // the two paths can never diverge again (RUSH-2252, RUSH-2253).
     const env = assembleBundleEnv(bundle, selectedKeys, parsedByKey, fetched, opts.keyMode, backend);
     emitReadAudit('success');
-    // Auto-cache: this was a real keychain read (the agent fast-path returned
-    // earlier on a hit). If the bundle opts into the `daily` policy and the user
-    // enabled `secrets.agent.auto`, populate the broker so the next concurrent
-    // run reads silently. Skipped when noAgent (e.g. `unlock`, which loads the
-    // agent itself). When a broker is already up this warms it synchronously
-    // (bounded ~3s) so `daily` reliably sticks; only a cold-start broker uses the
-    // detached fire-and-forget path (see agentAutoLoadSync). The costly Touch ID
-    // prompt already happened, so the bounded wait is invisible.
+    // Auto-cache into the broker so the next read is silent. Synchronous warm
+    // when a broker is already up; cold-start uses the detached path.
     if (
       backend === 'keychain' &&
       !opts.noAgent &&
@@ -1861,9 +1527,8 @@ export interface RotateOptions {
 }
 
 /**
- * Rotate a keychain-backed secret in `bundle`. Errors if `key` is not present
- * in the bundle (use `add` to introduce a new key). Preserves existing meta
- * unless `clearMeta` or a `meta` patch is supplied.
+ * Rotate a keychain-backed secret. Errors if the key is absent; preserves meta
+ * unless cleared or patched.
  */
 export function rotateBundleSecret(bundle: SecretsBundle, key: string, opts: RotateOptions): void {
   validateBundleName(bundle.name);
@@ -1872,8 +1537,7 @@ export function rotateBundleSecret(bundle: SecretsBundle, key: string, opts: Rot
     throw new Error(`Key '${key}' not in bundle '${bundle.name}'. Use 'agents secrets add' to add a new key.`);
   }
   const raw = bundle.vars[key];
-  // We only rotate keychain-backed values. Literals/refs aren't "secrets" in
-  // the same sense — pivot the user back to add/remove.
+  // Only keychain-backed values are rotated.
   if (typeof raw !== 'string' || !raw.startsWith('keychain:')) {
     throw new Error(`Key '${key}' in bundle '${bundle.name}' is not keychain-backed; cannot rotate.`);
   }
@@ -1896,46 +1560,28 @@ export function rotateBundleSecret(bundle: SecretsBundle, key: string, opts: Rot
 }
 
 /**
- * Reconcile a bundle's keychain-backed VALUE items to its CURRENT policy, then
- * write the (always no-ACL) metadata.
- *
- * `writeBundle` only rewrites the metadata item, so a policy change alone leaves
- * every value item carrying the ACL it was created with — and macOS gates each
- * read on the ITEM's ACL, not the bundle's declared tier (spec SEC-19). Without
- * this reconcile, `agents secrets policy <b> never` reports "silent" while the
- * still-ACL'd value keeps popping Touch ID on every read, forever.
- *
- *   hold/always -> never  strips the biometry ACL (helper `set-no-acl`: delete+add)
- *   never -> hold/always  re-attaches it (helper `set`)
- *
- * The current values are read in ONE batch, so the reconcile costs at most a
- * single Touch ID — the last prompt a hold->never bundle will ever raise (a
- * never->* flip reads silently, since the items are already no-ACL). No-op on the
- * ACL to write for non-keychain backends (file/vault have no biometry concept),
- * and a metadata-only write when the bundle has no keychain-backed values.
+ * Reconcile keychain value items to the bundle's current policy. macOS gates
+ * reads on each item's ACL, not the bundle's declared policy, so a policy change
+ * alone would leave stale ACLs. hold/always → never strips ACL; never → *
+ * re-attaches it. Non-keychain backends no-op.
  */
 export function reAclBundleItems(bundle: SecretsBundle): void {
   if ((bundle.backend ?? 'keychain') !== 'keychain') {
-    // No biometry ACL off the keychain backend — only metadata needs persisting.
     writeBundle(bundle);
     return;
   }
   const store = itemStore('keychain');
-  // keychainItemsForBundle already returns ONLY keychain-backed value items
-  // (via parseBundleValue), so no extra ref-shape filtering here.
   const entries = keychainItemsForBundle(bundle);
   if (entries.length === 0) {
-    // Literal/ref-only bundle: nothing to re-ACL, just refresh metadata.
     writeBundle(bundle);
     return;
   }
-  // One batched read = at most one Touch ID for the whole reconcile.
+  // One batch read ⇒ at most one Touch ID for the whole reconcile.
   const values = store.getBatch(entries.map((e) => e.item));
   const rewrite = new Map<string, string>();
   for (const { item } of entries) {
     const value = values.get(item);
-    // A key present in metadata but with no readable value item is real
-    // corruption, not something to silently skip (no fallbacks — fail loud).
+    // A declared key with no readable value is corruption — fail loud.
     if (value === undefined) {
       throw new Error(
         `Cannot change policy for '${bundle.name}': a keychain value is missing or unreadable. Rotate that key, then retry.`,
@@ -1943,30 +1589,19 @@ export function reAclBundleItems(bundle: SecretsBundle): void {
     }
     rewrite.set(item, value);
   }
-  // writeBundleWithItems re-stores each value with { noAcl: policy === 'never' }
-  // and the metadata no-ACL (metadata-last), and evicts any broker-held copy.
+  // writeBundleWithItems applies the correct noAcl flag and evicts the broker.
   writeBundleWithItems(bundle, rewrite);
 }
 
 /** Options for renameBundle. */
 export interface RenameOptions {
-  /** When true, overwrite an existing destination bundle (purges its keychain items first). */
+  /** Overwrite an existing destination bundle. */
   force?: boolean;
 }
 
 /**
- * Rename a bundle: move metadata + every keychain-backed value to a new name.
- *
- * Sequence is ordered so the source stays intact if anything in the copy
- * phase fails:
- *   1) read source, validate dest
- *   2) purge dest if --force, refuse otherwise
- *   3) copy each keychain value source -> dest
- *   4) write new bundle metadata
- *   5) delete the old per-key keychain items + old metadata
- *
- * Steps 1-4 are reversible. If 5 partially fails, running `rename` again is
- * a safe no-op for the source items.
+ * Rename a bundle: copy metadata + keychain values to the new name, then delete
+ * the source. Steps are ordered so a copy-phase failure leaves the source intact.
  */
 export function renameBundle(oldName: string, newName: string, opts: RenameOptions = {}): void {
   validateBundleName(oldName);
@@ -1978,8 +1613,6 @@ export function renameBundle(oldName: string, newName: string, opts: RenameOptio
     throw new Error(`Bundle '${oldName}' not found.`);
   }
   const source = readBundle(oldName);
-  // Rename stays within the source's backend. The store carries both the
-  // per-key secret items and (via writeBundle/deleteBundle) the metadata.
   const store = itemStore(source.backend ?? 'keychain');
 
   if (bundleExists(newName)) {
@@ -1994,8 +1627,7 @@ export function renameBundle(oldName: string, newName: string, opts: RenameOptio
     deleteBundle(newName);
   }
 
-  // Copy phase: read old item, write new item. Old items stay in place
-  // until step 5 so a partial failure here leaves the source intact.
+  // Copy to the new name, leaving old items in place until cleanup.
   const sourceItems = keychainItemsForBundle(source);
   for (const { key, item: oldItem } of sourceItems) {
     const raw = source.vars[key];
@@ -2006,8 +1638,6 @@ export function renameBundle(oldName: string, newName: string, opts: RenameOptio
     store.set(newItem, value, { noAcl: bundlePolicy(source) === 'never' });
   }
 
-  // writeBundle preserves source.created_at, refreshes updated_at, and keeps
-  // the source backend (spread carries source.backend).
   const renamed: SecretsBundle = { ...source, name: newName };
   writeBundle(renamed);
 
@@ -2021,11 +1651,8 @@ export function renameBundle(oldName: string, newName: string, opts: RenameOptio
 }
 
 /**
- * The store (keychain or encrypted file) that carries a bundle's items. The
- * CLI uses this to read/write/delete per-key items (built with
- * secretsKeychainItem) in the same store as the bundle's metadata, for `add` /
- * `import` / `remove` / `delete`. Pass the bundle's resolved backend
- * (`bundle.backend ?? 'keychain'`).
+ * The item store (keychain or encrypted file) for a bundle's per-key secrets.
+ * Pass the resolved backend (`bundle.backend ?? 'keychain'`).
  */
 export function bundleItemStore(
   backend: SecretsBackend | undefined,
@@ -2037,17 +1664,13 @@ export function bundleItemStore(
   has(item: string): boolean;
 } {
   const store = itemStore(backend ?? 'keychain');
-  // `never`-policy bundles write their per-key values without the biometry ACL
-  // (same rationale as the metadata write in writeBundle). Wrap `set` so every
-  // value the add/import paths write inherits the no-ACL flag; reads, deletes,
-  // and existence checks are ACL-independent and pass through untouched.
+  // `never`-policy bundles write per-key values without the biometry ACL.
   if (opts?.noAcl) {
     return { ...store, set: (item, value) => store.set(item, value, { noAcl: true }) };
   }
   return store;
 }
 
-// Iterate all keychain-backed keys in a bundle for cleanup on rm/unset.
 export function keychainItemsForBundle(bundle: SecretsBundle): Array<{ key: string; item: string }> {
   const items: Array<{ key: string; item: string }> = [];
   for (const [key, raw] of Object.entries(bundle.vars)) {
@@ -2059,7 +1682,6 @@ export function keychainItemsForBundle(bundle: SecretsBundle): Array<{ key: stri
   return items;
 }
 
-// Parse a dotenv string into key=value pairs, preserving last-wins on duplicates.
 export function parseDotenv(content: string): Record<string, string> {
   const out: Record<string, string> = {};
   for (const raw of content.split('\n')) {

--- a/cli/src/lib/secrets/reaper.ts
+++ b/cli/src/lib/secrets/reaper.ts
@@ -1,25 +1,19 @@
 /**
  * Reaper for orphaned / wedged keychain-helper processes.
  *
- * macOS keychain-helper calls are synchronous spawnSync invocations. When
- * coreauthd / LocalAuthentication hangs, the helper process (and sometimes its
- * parent `agents` process) can pile up forever. This module detects two classes
- * of stale process and kills them.
- *
- * The design splits cleanly into:
- *   - a pure planner ({@link planKeychainReap}) that is unit-testable without a
- *     real `ps` shell, and
- *   - an impure driver ({@link reapOrphanedKeychainProcesses}) that shells `ps`
- *     once per tick and executes kills through {@link killTree}.
+ * coreauthd / LocalAuthentication hangs can leave helper (and parent `agents`)
+ * processes pile up. The pure planner ({@link planKeychainReap}) is unit-testable
+ * without a real `ps`; the driver ({@link reapOrphanedKeychainProcesses}) shells
+ * `ps` once per tick and kills through {@link killTree}.
  */
 
 import { execFileSync } from 'child_process';
 import { killTree, captureProcessStartTime } from '../platform/process.js';
 import { getKeychainHelperPath } from './install-helper.js';
 
-/** Elapsed grace before a helper whose parent exited is considered an orphan. */
+/** Grace before a helper whose parent exited is considered an orphan. */
 export const ORPHAN_GRACE_SEC = 30;
-/** Elapsed grace before a helper with a live parent is considered stuck. */
+/** Grace before a helper with a live parent is considered stuck. */
 export const STUCK_GRACE_SEC = 90;
 
 /** Snapshot of one process row from `ps`, fed into the pure planner. */
@@ -28,33 +22,20 @@ export interface KeychainProcessSnapshot {
   ppid: number;
   /** Elapsed seconds since the process started. */
   elapsedSec: number;
-  /**
-   * Stable start-time fingerprint from {@link captureProcessStartTime}.
-   * `null` means "could not capture" — the planner must fail closed.
-   */
+  /** Stable start-time fingerprint from {@link captureProcessStartTime}; null fails closed. */
   startTime: string | null;
-  /**
-   * True when this process is a REAP-ELIGIBLE helper invocation — the installed
-   * helper binary running a short-lived keychain verb. False for a non-helper
-   * process AND for the long-lived `watch-lock` watcher (see
-   * {@link isReapableHelperCommand}).
-   */
+  /** True for a reap-eligible helper invocation (short-lived keychain verb). */
   isHelper: boolean;
   /**
-   * True when this process is the deliberately long-lived `watch-lock` watcher
-   * (auto-lock-on-sleep). Mutually exclusive with {@link isHelper}:
-   * {@link isReapableHelperCommand} keeps live-parent watch-locks out of the
-   * stuck-helper path, and a SEPARATE orphan path in {@link planKeychainReap}
-   * reaps them only once the owning daemon is provably dead (RUSH-2419).
+   * True for the deliberately long-lived `watch-lock` watcher
+   * (auto-lock-on-sleep). Mutually exclusive with {@link isHelper}; killing it
+   * silently disables auto-lock-on-sleep, so it is reaped only once the owning
+   * daemon is provably dead (RUSH-2419).
    */
   isWatchLock?: boolean;
 }
 
-/**
- * Tracked state for a stuck `agents` parent that has a live helper child.
- * Keyed by parent PID. The two-sweep debounce avoids acting on a racy `ps`
- * snapshot; the `stage` field drives child-first kill then parent escalation.
- */
+/** Tracked state for a stuck parent across two-sweep debounce. */
 export interface StuckParentCandidate {
   pid: number;
   startTime: string | null;
@@ -66,7 +47,7 @@ export interface StuckParentCandidate {
 
 /** Result of one planning pass. */
 export interface ReapPlan {
-  /** PIDs that should be killed this tick. */
+  /** PIDs to kill this tick. */
   kill: number[];
   /** Candidates to carry forward to the next sweep. */
   nextCandidates: Map<number, StuckParentCandidate>;
@@ -75,25 +56,13 @@ export interface ReapPlan {
 /**
  * Pure predicate: decide which processes to kill given a `ps`-like snapshot.
  *
- * Mirrors the shape of {@link isExpiredPoolStray} in `lib/crabbox/lease.ts`:
- * a side-effect-free classifier that the impure driver shells `ps` for. Three
- * conservative reap classes:
+ * Three conservative classes:
+ *   1. Orphaned helper: PPID == 1, helper path, alive longer than grace.
+ *   2. Stuck `agents` parent: helper child alive longer than stuck grace,
+ *      recorded on first sight, child killed on second sweep, parent on third.
+ *   3. Orphaned `watch-lock`: long-lived watcher whose owning daemon is gone.
  *
- *   1. Orphaned helper: PPID == 1, path-matches the helper, alive longer than
- *      {@link ORPHAN_GRACE_SEC}.
- *   2. Stuck `agents` parent: helper child alive longer than
- *      {@link STUCK_GRACE_SEC}. Recorded on first sight, child killed on the
- *      second consecutive sweep with the same PID + startTime, parent killed on
- *      the third sweep if the helper child is still present.
- *   3. Orphaned `watch-lock` watcher (RUSH-2419): the long-lived auto-lock
- *      child whose owning daemon is provably dead. {@link isReapableHelperCommand}
- *      still excludes live-parent watch-locks from class 1/2; this path only
- *      reaps when the parent is gone from the snapshot (Unix reparents to init
- *      after daemon death) and the watcher itself has a start-time fingerprint.
- *
- * Never reaps a process whose start time could not be captured, whose path does
- * not match the helper, or (for stuck parents) whose parent is no longer in the
- * snapshot. A watch-lock whose parent IS still in the snapshot is never touched.
+ * Fails closed when start time can't be captured.
  */
 export function planKeychainReap(
   snapshots: KeychainProcessSnapshot[],
@@ -108,16 +77,14 @@ export function planKeychainReap(
     if (!s.isHelper) continue;
 
     if (s.ppid === 1) {
-      // Orphaned helper: parent is init/launchd. Fail closed if we can't prove
-      // the process identity with a start-time fingerprint.
+      // Orphaned helper: fail closed without a start-time fingerprint.
       if (s.elapsedSec <= ORPHAN_GRACE_SEC) continue;
       if (s.startTime == null) continue;
       kill.push(s.pid);
       continue;
     }
 
-    // Stuck agents: a helper with a live parent that has been wedged for longer
-    // than the interactive timeout. The parent must still exist in the snapshot.
+    // Stuck agents: helper with a live parent wedged longer than the timeout.
     if (s.elapsedSec <= STUCK_GRACE_SEC) continue;
     const parent = pidMap.get(s.ppid);
     if (!parent) continue;
@@ -131,13 +98,12 @@ export function planKeychainReap(
       prev.startTime === parent.startTime
     ) {
       if (prev.stage === 'watch') {
-        // Second sweep: kill the child first so the parent's spawnSync returns.
-        // Keep the parent candidate at stage 'escalate' for the next sweep.
+        // Second sweep: kill the child first so spawnSync returns; escalate next.
         kill.push(s.pid);
         nextCandidates.set(parent.pid, { ...prev, stage: 'escalate' });
         continue;
       }
-      // Third sweep: child did not free the parent, so the parent itself is wedged.
+      // Third sweep: child did not free the parent, so the parent is wedged.
       kill.push(parent.pid);
       continue;
     }
@@ -153,29 +119,18 @@ export function planKeychainReap(
     });
   }
 
-  // Separate path for orphaned watch-lock watchers (RUSH-2419). Does NOT
-  // weaken {@link isReapableHelperCommand}: a watch-lock with a live parent
-  // stays isHelper=false and is skipped above. Here we only kill when the
-  // owning daemon is provably absent from the process table.
+  // Separate path for orphaned watch-lock watchers: only reap when the owning
+  // daemon is provably absent from the process table.
   for (const s of snapshots) {
     if (!s.isWatchLock) continue;
-    // Fail closed: no start-time fingerprint → refuse to kill (pid-reuse guard
-    // for the process we are about to target, same as orphan helpers).
     if (s.startTime == null) continue;
     if (s.elapsedSec <= ORPHAN_GRACE_SEC) continue;
 
-    // Live parent in this snapshot → owning daemon is still up. Leave it alone
-    // (this is the property isReapableHelperCommand protects for stuck-helper
-    // reaping; re-assert it here so a mis-tagged row cannot be killed either).
     if (s.ppid !== 1) {
       const parent = pidMap.get(s.ppid);
       if (parent) continue;
-      // Parent pid not listed: the process occupying that slot is gone. On Unix
-      // a dead parent reparents the child to init; a missing parent with a
-      // non-1 ppid is the race window before reparenting. Either way the owner
-      // is dead — safe to reap after grace + fingerprint.
+      // Parent missing means the owner is dead (or reparenting race); safe to reap.
     }
-    // ppid===1 (reparented to init/launchd) or parent missing → orphaned.
     kill.push(s.pid);
   }
 
@@ -185,11 +140,8 @@ export function planKeychainReap(
 /**
  * Parse macOS `ps -o etime=` elapsed time into whole seconds.
  *
- * BSD `etime` renders as `[[dd-]hh:]mm:ss` (e.g. `05:03`, `01:02:03`,
- * `14-04:10:52`). This is the portable keyword: `etimes` (raw seconds) is a
- * GNU/Linux procps extension that macOS `ps` rejects with a non-zero exit, so
- * the reaper — which only ever runs on darwin — must read `etime`.
- * Returns null for an unparseable value so the caller drops the row.
+ * BSD `etime` renders as `[[dd-]hh:]mm:ss`. `etimes` (raw seconds) is a GNU
+ * extension that macOS `ps` rejects, so darwin uses `etime`.
  */
 export function parseEtimeToSeconds(raw: string): number | null {
   const m = raw.match(/^(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)$/);
@@ -207,8 +159,6 @@ export function parseEtimeToSeconds(raw: string): number | null {
  *
  * Expected format from `ps -ax -o pid=,ppid=,etime=,command=`:
  *   "<pid> <ppid> <etime> <command...>"
- * where `<etime>` is BSD elapsed time (`[[dd-]hh:]mm:ss`). The command field is
- * the remainder of the line and may contain spaces.
  */
 function parsePsLine(line: string): {
   pid: number;
@@ -228,23 +178,13 @@ function parsePsLine(line: string): {
   return { pid, ppid, elapsedSec, command };
 }
 
-/**
- * The one helper verb that is DELIBERATELY long-lived: the broker's auto-lock
- * sleep/lock watcher (`spawn(getKeychainHelperPath(), ['watch-lock'], …)` in
- * `agent.ts`). It lives for the broker's whole hold — potentially days — as a
- * healthy child of the live broker/daemon, emitting LOCK/SLEEP lines that wipe
- * the in-memory secret store on sleep. It is NOT a stuck keychain read, so the
- * reaper must never target it: killing it silently disables auto-lock-on-sleep.
- */
+/** The one helper verb that is deliberately long-lived: the auto-lock watcher. */
 const HELPER_WATCH_LOCK_VERB = 'watch-lock';
 
 /**
- * Whether a `ps` command line is a REAP-ELIGIBLE helper invocation: the installed
- * helper binary running a short-lived keychain verb (get/has/list/set/delete/
- * migrate-*) that a wedged `coreauthd` can hang. Returns false for a non-helper
- * command AND for the deliberately long-lived `watch-lock` watcher — matching by
- * the full argv (`ps … command=`), so a live-parent `watch-lock` child is never
- * mistaken for a stuck read and killed. Pure; unit-tested.
+ * Whether a `ps` command line is a reap-eligible helper invocation: the installed
+ * helper binary running a short-lived keychain verb. Returns false for the
+ * long-lived `watch-lock` watcher, which must never be mistaken for a stuck read.
  */
 export function isReapableHelperCommand(command: string, helperPath: string): boolean {
   if (command === helperPath) return true; // bare exec, no verb — never watch-lock
@@ -255,9 +195,7 @@ export function isReapableHelperCommand(command: string, helperPath: string): bo
 
 /**
  * Whether a `ps` command line is the deliberately long-lived `watch-lock`
- * watcher (auto-lock-on-sleep). Inverse of {@link isReapableHelperCommand} for
- * the watch-lock verb only — used by the orphaned-watch-lock reaper path
- * (RUSH-2419). Pure; unit-tested.
+ * watcher. Inverse of {@link isReapableHelperCommand} for the watch-lock verb.
  */
 export function isWatchLockHelperCommand(command: string, helperPath: string): boolean {
   if (!command.startsWith(`${helperPath} `)) return false;
@@ -277,11 +215,8 @@ export function resetKeychainReaperCandidatesForTest(): void {
  * Impure driver: snapshot all processes once with `ps`, plan the reap, then
  * execute kills through {@link killTree}.
  *
- * Path-matching uses the full helper path (proc_pidpath-style), not just the
- * executable name, so an unrelated binary named "Agents CLI" is never targeted.
- *
- * Returns on non-darwin platforms without shelling anything — the helper only
- * exists on macOS.
+ * Path-matches the full helper path so an unrelated binary named "Agents CLI" is
+ * never targeted. Returns on non-darwin without shelling anything.
  */
 export function reapOrphanedKeychainProcesses(): {
   reaped: number;
@@ -310,11 +245,8 @@ export function reapOrphanedKeychainProcesses(): {
     return { reaped: 0, details: [`ps failed: ${(err as Error).message}`], plan: { kill: [], nextCandidates: new Map() } };
   }
 
-  // Parse the snapshot cheaply, then capture start-time fingerprints ONLY for
-  // helper processes, orphan-candidate watch-locks, and (for stuck helpers)
-  // their parents. captureProcessStartTime shells `ps` per unseen pid; doing
-  // it for every process on the machine would create the very pileup the
-  // reaper exists to prevent.
+  // Capture start-time fingerprints only for helper processes, orphan-candidate
+  // watch-locks, and (for stuck helpers) their parents.
   type PrelimRow = {
     pid: number;
     ppid: number;
@@ -328,11 +260,8 @@ export function reapOrphanedKeychainProcesses(): {
     const parsed = parsePsLine(line);
     if (!parsed) continue;
     const { pid, ppid, elapsedSec, command } = parsed;
-    // Reap-eligible = the helper binary running a short-lived keychain verb. The
-    // full-argv match excludes the deliberately long-lived `watch-lock` watcher,
-    // whose live-parent child would otherwise be killed as if it were stuck
-    // (RUSH-2232 — that silently disabled auto-lock-on-sleep). Orphaned
-    // watch-locks are tracked separately via isWatchLock (RUSH-2419).
+    // Match the full argv so the long-lived `watch-lock` watcher is never
+    // mistaken for a stuck read. Orphaned watch-locks are tracked separately.
     const isHelper = isReapableHelperCommand(command, helperPath);
     const isWatchLock = isWatchLockHelperCommand(command, helperPath);
     rows.push({ pid, ppid, elapsedSec, isHelper, isWatchLock, startTime: null });

--- a/cli/src/lib/secrets/remote.ts
+++ b/cli/src/lib/secrets/remote.ts
@@ -1,19 +1,9 @@
 /**
  * Remote secrets — read and use `agents secrets` bundles that live on another
- * host, over the same hardened SSH path that `agents secrets export --device`
- * (the write inverse) already uses.
+ * host over the same SSH path that `agents secrets export --device` uses.
  *
- * This is the READ / USE direction:
- *   - browse:  drive the remote `agents secrets list|view` and stream its
- *              stdout back verbatim (lossless, no parsing).
- *   - use:     resolve a remote bundle to an env map (JSON over ssh stdout) and
- *              inject it ephemerally — never written to this machine's keychain.
- *
- * Trust model: relies on the operator's existing SSH access to the host (same
- * boundary as `export --device` / `run --device`). Bundle names are shell-quoted
- * into the remote command; resolved VALUES return over ssh stdout. File-backend
- * import never forwards AGENTS_SECRETS_PASSPHRASE (PHNX-2371). Nothing is
- * persisted locally.
+ * Browse streams remote stdout verbatim; use resolves a bundle to an env map
+ * and injects it ephemerally without persisting it locally.
  */
 
 import { sshExec, sshStream, assertValidSshTarget, shellQuote, type SshExecResult } from '../ssh-exec.js';
@@ -33,21 +23,8 @@ function hostKeyLookupName(target: string): string {
 }
 
 /**
- * SSH options for a SECRET-carrying transport (RUSH-2527). Every `agents secrets
- * --host` operation moves credential bytes — over ssh stdin (push) or ssh stdout
- * (resolve/read-back) — so it MUST NOT ride the shared `accept-new` baseline
- * against the user's own `~/.ssh/known_hosts` with a reusable control socket.
- * Two hardenings over that baseline, matching the posture the `--copy-creds`
- * dispatch already uses (`hosts/dispatch.ts` -> `hostKeyCheckingOpts`):
- *
- *   - **Managed pinned host keys.** Verify against the CLI-owned known_hosts
- *     store (`known-hosts.ts`), not `~/.ssh/known_hosts`. A CHANGED key on a
- *     known host is refused (`StrictHostKeyChecking` `yes` once pinned,
- *     `accept-new` before that). Callers that copy durable provider credentials
- *     must separately require an existing pin before invoking this transport.
- *   - **No multiplex reuse.** `multiplex: false` — a credential channel never
- *     leaves a persistent `ControlMaster` socket lingering (60s `ControlPersist`)
- *     that any other `agents` invocation to that host would silently reuse.
+ * SSH options for secret-carrying transport. Pins the managed host key and
+ * disables multiplex so no reusable control socket lingers for other invocations.
  */
 export function credentialTransportSshOpts(target: string): { hostKeyOpts: string[]; multiplex: false } {
   return { hostKeyOpts: hostKeyCheckingOpts(isHostPinned(hostKeyLookupName(target))), multiplex: false };
@@ -63,45 +40,32 @@ export function assertCredentialTransportHostPinned(target: string, pinned = isH
 }
 
 /**
- * Trust boundary for a remote-resolved env map. A peer's `secrets export` output
- * is untrusted input: a compromised or misconfigured host could return keys that
- * silently reshape THIS process's behavior once merged into the agent env
- * (bundles.ts:251 `sanitizeProcessEnv` only strips loader vars from process.env,
- * never the remote bundle). Block the dangerous-override classes here — at the
- * source — so every consumer (`run --secrets b@host`, `secrets exec --host`) is
- * protected, not just one call site:
- *   - LD_* / DYLD_* / NODE_OPTIONS and the other loader/interpreter injections
- *     (reuses the canonical bundles.ts predicate);
- *   - GIT_*        — GIT_SSH_COMMAND et al. hijack every git subprocess;
- *   - *_PROXY      — HTTP(S)_PROXY / ALL_PROXY reroute outbound traffic (MITM);
- *   - *_BASE_URL   — ANTHROPIC_BASE_URL / OPENAI_BASE_URL redirect the model API.
- * These keys are already rejected on the ADD side (validateEnvKey for loaders),
- * so a legitimate bundle never carries them — only a hostile peer would.
+ * Trust boundary for a remote-resolved env map. A peer's export output is
+ * untrusted input that could reshape this process once merged into the env, so
+ * block dangerous override classes here for every consumer:
+ * loader/interpreter vars, GIT_*, *_PROXY, and *_BASE_URL.
  */
 export function isDangerousRemoteEnvKey(name: string): boolean {
   const upper = name.toUpperCase();
   if (isLoaderOrInterpreterEnv(upper)) return true;
-  if (upper.startsWith('GIT_')) return true;
-  if (upper.endsWith('_PROXY')) return true;
-  if (upper.endsWith('_BASE_URL')) return true;
+  if (upper.startsWith('GIT_')) return true; // GIT_SSH_COMMAND hijacks git subprocesses
+  if (upper.endsWith('_PROXY')) return true; // *_PROXY = MITM
+  if (upper.endsWith('_BASE_URL')) return true; // *_BASE_URL = model API redirect
   return false;
 }
 
 /** Remote OS for a host name or target string. Prefer the original host name
- * because enrolled inline hosts resolve to `user@address`, while the OS
- * registry is keyed by the host name. */
+ *  because enrolled inline hosts resolve to `user@address`, while the OS
+ *  registry is keyed by the host name. */
 function osForTarget(target: string, lookupName?: string): string | undefined {
   const byName = lookupName ? resolveRemoteOsSync(lookupName) : undefined;
   return byName ?? resolveRemoteOsSync(target.split('@').pop() ?? target);
 }
 
 /**
- * Resolve a `--device` value to an ssh target STRING for the remote-secrets path.
- * Delegates to the single host/device resolver (`resolveHost`, RUSH-1967) so a
- * name here dials the exact same box `run --device` does; on a miss, treats the
- * value as a raw ssh target and validates it against injection. Named distinctly
- * from `../devices/resolve-target.ts` (which returns richer shapes) so importing
- * the wrong one can't silently change which machine you dial.
+ * Resolve a `--device` value to an ssh target string for the remote-secrets
+ * path. Delegates to the same resolver `run --device` uses; on a miss, treats
+ * the value as a raw ssh target and validates it.
  */
 export async function resolveHostSshTarget(nameOrAlias: string): Promise<string> {
   const host = await resolveHost(nameOrAlias);
@@ -111,11 +75,8 @@ export async function resolveHostSshTarget(nameOrAlias: string): Promise<string>
 }
 
 /**
- * Merge `--host <single>` / `--hosts <a,b,c>` (and their `--device` / `--devices`
- * aliases) into an ordered, de-duplicated list. All four flags compose; any alone
- * works. `--device`/`--devices` resolve identically to `--device`/`--hosts` so the
- * fleet-wide `--device` vocabulary (see `agents run --device`, `agents feed --host`)
- * works on the secrets remote commands too. Empty when none is set.
+ * Merge `--host` / `--hosts` (and their `--device` / `--devices` aliases) into
+ * an ordered, de-duplicated list. Empty when none is set.
  */
 export function parseHostsOption(opts: {
   host?: string;
@@ -140,11 +101,9 @@ export function parseHostsOption(opts: {
 }
 
 /**
- * Split a `bundle@host` reference. No `@` → a local bundle (host undefined).
- * Bundle names can't contain `@` (BUNDLE_NAME_PATTERN), so the FIRST `@`
- * separates the bundle from the ssh target — and the target itself may be a
- * `user@host` (e.g. `r2.backups@muqsit@box` → bundle `r2.backups`, host
- * `muqsit@box`).
+ * Split a `bundle@host` reference. No `@` → a local bundle. Bundle names can't
+ * contain `@`, so the FIRST `@` separates bundle from ssh target; the target
+ * itself may be `user@host` (e.g. `r2.backups@muqsit@box`).
  */
 export function splitBundleRef(ref: string): { bundle: string; host?: string } {
   const at = ref.indexOf('@');
@@ -159,9 +118,8 @@ export function splitBundleRef(ref: string): { bundle: string; host?: string } {
 
 /**
  * Run `agents secrets <args>` on a remote host over ssh and return the raw
- * result. Used by the browse commands — the remote's human-readable stdout is
- * streamed back unchanged. `tty` forces an interactive ssh session (`-tt`) so a
- * remote Touch-ID / passphrase prompt can surface (e.g. `view --reveal`).
+ * result. Used by browse commands; `tty` forces `-tt` so remote passphrase
+ * prompts can surface.
  */
 export function remoteSecretsRaw(
   target: string,
@@ -169,13 +127,8 @@ export function remoteSecretsRaw(
   opts: { tty?: boolean; input?: string; osLookupName?: string; secret?: boolean } = {},
 ): SshExecResult {
   const remoteCmd = buildRemoteAgentsInvocation(['secrets', ...args], undefined, osForTarget(target, opts.osLookupName));
-  // A secret-bearing call (`secret: true`) pins the managed host key and refuses
-  // to multiplex — see `credentialTransportSshOpts` (RUSH-2527). A `-tt` session
-  // (a remote reveal/passphrase prompt) additionally allocates a PTY and never
-  // multiplexes, and it COMPOSES with the secret posture: a `view --reveal` over
-  // `--device` both prompts AND streams the plaintext value back over ssh stdout,
-  // so it needs the managed host-key pin too — `tty` must not short-circuit past
-  // `secret`. A plain browse `list` passes neither and keeps the shared baseline.
+  // `secret: true` pins the managed host key and refuses multiplex; `-tt`
+  // additionally allocates a PTY and never multiplexes. The two compose.
   const posture = opts.secret ? credentialTransportSshOpts(target) : {};
   const conn = opts.tty
     ? { ...posture, extraSshArgs: ['-tt'], multiplex: false as const }
@@ -188,38 +141,23 @@ export function remoteSecretsRaw(
 }
 
 /**
- * Run a remote `agents secrets <args>` FOREGROUND, with the local stdio wired
- * straight through (`stdio: 'inherit'` + `-tt`), and return its exit code.
- *
- * Unlike `remoteSecretsRaw` — which pipes stdin, so even with `-tt` the remote
- * process's `process.stdin.isTTY` is false and a passphrase prompt refuses to
- * appear (the macOS file-store guard then hard-errors "needs
- * AGENTS_SECRETS_PASSPHRASE") — this inherits the caller's real terminal, so the
- * remote sees a genuine TTY and its hidden passphrase prompt surfaces and reads
- * the keystrokes. This is the transport for `unlock --device`: you type the remote
- * bundle's passphrase at your own terminal. Output is NOT captured (it streams
- * to the terminal); only the exit code is returned.
+ * Run a remote `agents secrets <args>` foreground with local stdio inherited,
+ * so the remote sees a real TTY and its passphrase prompt surfaces and reads
+ * keystrokes. Output streams to the terminal; only the exit code is returned.
  */
 export function remoteSecretsStream(target: string, args: string[], opts: { osLookupName?: string } = {}): number {
   const remoteCmd = buildRemoteAgentsInvocation(['secrets', ...args], undefined, osForTarget(target, opts.osLookupName));
-  // `unlock --device` carries the remote bundle's passphrase to the destination over
-  // this interactive channel, so it is secret-bearing: pin the managed host key
-  // (a changed key is refused) and never multiplex (RUSH-2527).
   return sshStream(target, remoteCmd, { tty: true, ...credentialTransportSshOpts(target) });
 }
 
 /**
  * Resolve a remote bundle to a plaintext env map by driving the remote's
  * `agents secrets export <bundle> --plaintext --format json`. Values cross over
- * ssh stdout (encrypted in transit), parsed in memory, never persisted.
+ * ssh stdout, parsed in memory, never persisted.
  *
- * The remote unlocks the bundle with ITS OWN credentials — the owner host's
- * keychain/secrets-agent, or its own `AGENTS_SECRETS_PASSPHRASE` (in the login
- * env) for a file-backed bundle. We deliberately do NOT forward this machine's
- * passphrase: the remote bundle is encrypted with the remote's passphrase, so
- * overriding it would break the read. (A macOS remote under non-interactive
- * SSH will block on Touch-ID — use `view`/`exec` with a remote `file` bundle,
- * an already-unlocked remote secrets-agent, or an interactive `-tt` session.)
+ * The remote unlocks the bundle with its own credentials; this machine does NOT
+ * forward its passphrase because the remote bundle is encrypted with the
+ * remote's passphrase.
  */
 export async function remoteResolveEnv(
   target: string,
@@ -227,20 +165,14 @@ export async function remoteResolveEnv(
   opts: { osLookupName?: string } = {},
 ): Promise<Record<string, string>> {
   assertValidSshTarget(target);
-  // AGENTS_SECRETS_REMOTE_TRANSPORT is the marker that lets the remote's
-  // `export --plaintext --format json` emit at all — the public shell-eval
-  // export mode was removed (RUSH-2774), and this machine-to-machine resolve is
-  // the only surviving caller of the JSON emitter. Riding the legacy argv keeps
-  // a new driver compatible with an old remote during a fleet rollout.
+  // AGENTS_SECRETS_REMOTE_TRANSPORT marks this as the machine-to-machine JSON
+  // resolve path (the public shell-eval export mode was removed).
   const remoteCmd = buildRemoteAgentsInvocation(
     ['secrets', 'export', bundle, '--plaintext', '--format', 'json'],
     undefined,
     osForTarget(target, opts.osLookupName),
     { AGENTS_SECRETS_REMOTE_TRANSPORT: '1' },
   );
-  // Resolving a remote bundle streams its plaintext values back over ssh stdout,
-  // so this read is secret-bearing: pin the managed host key and never leave a
-  // reusable control master to the source (RUSH-2527, `credentialTransportSshOpts`).
   const res: SshExecResult = sshExec(target, remoteCmd, {
     timeoutMs: REMOTE_TIMEOUT_MS,
     ...credentialTransportSshOpts(target),
@@ -272,8 +204,7 @@ export async function remoteResolveEnv(
   const env: Record<string, string> = {};
   const blocked: string[] = [];
   for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-    // Drop dangerous-override keys returned by the (untrusted) peer before they
-    // can reshape this process — see isDangerousRemoteEnvKey.
+    // Drop dangerous-override keys returned by the (untrusted) peer.
     if (isDangerousRemoteEnvKey(k)) {
       blocked.push(k);
       continue;
@@ -286,10 +217,7 @@ export async function remoteResolveEnv(
         `(remote override blocked): ${blocked.join(', ')}\n`,
     );
   }
-  // The remote host audits its own `secrets export` read; this emit records the
-  // event on the INITIATING host too (values were pulled into this process and
-  // injected locally). Covers `secrets exec --host` and `run --secrets b@host`.
-  // Values never enter the payload — only the bundle, target host, and count.
+  // Audit the event on the initiating host too; values never enter the payload.
   emitSecretAudit({
     event: 'secrets.get',
     bundle,
@@ -303,17 +231,10 @@ export async function remoteResolveEnv(
 }
 
 /**
- * Outcome of a post-push read-back verification (see verifyRemoteKeychainPush).
- *   - `ok`               — the pushed keys materialized readably on the remote.
- *   - `locked-keychain`  — the read-back gave the SPECIFIC signal of a keychain
- *                          that didn't persist (the remote's headless "not unlocked
- *                          in the secrets agent" guard, or a "stored item … not
- *                          found" on read-back, or pushed keys simply absent). Only
- *                          this verdict earns the locked-login-keychain diagnosis +
- *                          `--remote-backend file` steer.
- *   - `error`            — a DIFFERENT failure (flaky SSH, timeout, unparseable
- *                          payload). The raw error is re-surfaced verbatim, never
- *                          mislabeled as a locked keychain.
+ * Outcome of a post-push read-back verification.
+ *   - `ok`              — the pushed keys materialized readably.
+ *   - `locked-keychain` — read-back gave the specific locked-keychain signal.
+ *   - `error`           — a different failure (SSH, timeout, etc.).
  */
 export type RemoteKeychainWriteVerification =
   | { ok: true }
@@ -321,42 +242,24 @@ export type RemoteKeychainWriteVerification =
   | { ok: false; kind: 'error'; reason: string };
 
 /**
- * The remote's headless read-back raises one of these when a keychain-backed bundle
- * has metadata but no readable value items — the exact locked-login-keychain
- * signature. Anything else (connection refused, timeout, host key error) is a
- * transient/unrelated failure and must NOT be mislabeled as a locked keychain.
+ * True when the remote's headless read-back raised the locked-login-keychain
+ * signature. Anything else must NOT be mislabeled as a locked keychain.
  */
 function isLockedKeychainReadBackError(stderr: string): boolean {
   const s = stderr.toLowerCase();
   return (
-    // bundles.ts agentOnly guard: "…is not unlocked in the secrets agent…"
     s.includes('not unlocked') ||
     s.includes('secrets agent') ||
-    // resolveBundleEnv: "Bundle '<b>' key '<k>': stored item '<item>' not found."
     s.includes('stored item') ||
     s.includes('not found')
   );
 }
 
 /**
- * Decide whether a keychain-backed push to a remote actually PERSISTED its secret
- * value items, given the read-back of that bundle from the remote's own store.
- *
- * The silent-failure this guards: pushing `--remote-backend keychain` (default) to
- * a macOS host over headless SSH lands the bundle METADATA but not readable value
- * items — the remote login keychain is locked in the non-interactive SSH context,
- * so Security accepts the item WRITE at the DB level but the biometry-ACL'd item is
- * unreadable, and the remote `import` still reports success (values written first,
- * metadata `noAcl` last — bundles.ts writeBundleWithItems). The metadata-only bundle
- * then fails every later read with the confusing `Bundle '<b>' key '<k>': stored
- * item '<item>' not found` (bundles.ts resolveBundleEnv). We catch it by reading
- * the bundle back the same way a later `secrets exec`/resolve will (the marker-gated
- * json transport, driven headlessly on the remote so its `agentOnly` guard FAILS FAST
- * before any keychain read — no Touch ID prompt) and confirming every pushed key
- * returned.
- *
- * Pure so both branches are unit-testable without a real locked keychain: inject the
- * "read-back failed / key absent" condition through `readBack`.
+ * Decide whether a keychain-backed push to a remote actually persisted its
+ * secret value items by reading the bundle back the same way a later resolve
+ * will. Catches the silent failure where headless SSH writes metadata but not
+ * readable value items to a locked macOS login keychain.
  */
 export function evaluateKeychainWriteVerification(
   pushedKeys: string[],
@@ -367,17 +270,12 @@ export function evaluateKeychainWriteVerification(
   if (!readBack.ok) {
     const stderr = readBack.stderr.trim();
     if (isLockedKeychainReadBackError(stderr)) {
-      // The remote's own headless read raised the not-unlocked / not-found signal —
-      // exactly the confusing error the user hits later. Surface it now, at push
-      // time, with the fix.
       return {
         ok: false,
         kind: 'locked-keychain',
         reason: `the remote could not read it back${stderr ? ` (${stderr})` : ''}`,
       };
     }
-    // A transient / unrelated failure (flaky SSH, timeout, bad payload). Re-surface
-    // verbatim — do NOT diagnose a locked keychain from a connection error.
     return {
       ok: false,
       kind: 'error',
@@ -387,8 +285,6 @@ export function evaluateKeychainWriteVerification(
   const present = new Set(readBack.keys);
   const missing = pushedKeys.filter((k) => !present.has(k));
   if (missing.length > 0) {
-    // Read-back succeeded but some pushed keys are absent — the value items didn't
-    // persist. Same locked-keychain cause and fix.
     return {
       ok: false,
       kind: 'locked-keychain',
@@ -401,10 +297,8 @@ export function evaluateKeychainWriteVerification(
 }
 
 /**
- * The actionable error message for a failed keychain-over-SSH push verification.
- * Names the cause (locked remote login keychain) and steers to the two real fixes:
- * re-run with the headless-readable file backend, or unlock the remote keychain.
- * Pure + exported so the exact guidance is asserted in tests.
+ * Actionable error message for a failed keychain-over-SSH push. Names the cause
+ * (locked remote login keychain) and steers to the two real fixes.
  */
 export function keychainWriteFailureMessage(
   host: string,
@@ -423,13 +317,9 @@ export function keychainWriteFailureMessage(
 }
 
 /**
- * Read a bundle back from a remote over SSH (headlessly, so it fails fast rather
- * than prompting Touch ID) and confirm the pushed keys materialized. Drives the
- * remote's marker-gated json transport (`secrets export <bundle> --plaintext
- * --format json` under AGENTS_SECRETS_REMOTE_TRANSPORT) but keeps only the KEY
- * NAMES; the plaintext values are dropped immediately and never retained or
- * logged. Returns a verification verdict; the caller renders
- * `keychainWriteFailureMessage` on failure.
+ * Read a bundle back from a remote over SSH and confirm the pushed keys
+ * materialized. Drives the marker-gated json transport but keeps only KEY NAMES;
+ * plaintext values are discarded immediately. Returns a verification verdict.
  */
 export function verifyRemoteKeychainPush(
   target: string,
@@ -441,13 +331,8 @@ export function verifyRemoteKeychainPush(
     ['secrets', 'export', bundle, '--plaintext', '--format', 'json'],
     undefined,
     osForTarget(target, opts.osLookupName),
-    // Same transport marker as remoteResolveEnv — see the comment there (RUSH-2774).
     { AGENTS_SECRETS_REMOTE_TRANSPORT: '1' },
   );
-  // This read-back streams the just-pushed plaintext over ssh stdout, so it is
-  // as secret-bearing as the push itself — the push path passes `secret: true`
-  // so it too pins the managed host key and leaves no reusable control master to
-  // the destination (RUSH-2527).
   const res: SshExecResult = sshExec(target, remoteCmd, {
     timeoutMs: REMOTE_TIMEOUT_MS,
     ...(opts.secret ? credentialTransportSshOpts(target) : {}),
@@ -457,8 +342,7 @@ export function verifyRemoteKeychainPush(
     const stderr = `${why}${(res.stderr || res.stdout || '').trim() ? `: ${(res.stderr || res.stdout).trim()}` : ''}`;
     return evaluateKeychainWriteVerification(pushedKeys, { ok: false, stderr });
   }
-  // Take the outer { … } object (tolerate login-shell banner noise), read the key
-  // names, and immediately discard the values — we only need presence here.
+  // Tolerate login-shell banner noise; keep only key names and discard values.
   const raw = res.stdout;
   const start = raw.indexOf('{');
   const end = raw.lastIndexOf('}');
@@ -483,18 +367,12 @@ export function verifyRemoteKeychainPush(
 }
 
 /**
- * The `bash -lc` command + stdin payload that drives a **file-backed** remote
- * import for `secrets export --device … --remote-backend file`.
+ * `bash -lc` command + stdin payload for a file-backed remote import.
  *
- * The file store is passphrase-free: the remote `agents secrets import --backend
- * file` auto-provisions the remote's own machine-local key (0600 under
- * `~/.agents/.secrets-key/`), so its reads are HEADLESS — no passphrase, no
- * Touch ID. AGENTS_SECRETS_PASSPHRASE is a deprecated override and MUST NOT be
+ * The file store is passphrase-free: the remote auto-provisions its own machine-
+ * local key, so reads are headless. AGENTS_SECRETS_PASSPHRASE must NOT be
  * forwarded (PHNX-2371): a remote keyed to a secret its daemon does not hold
  * reports "Imported N key(s)" then fails every later decrypt.
- *
- * Pure — no I/O — so the exact command string and stdin ordering are unit-testable
- * against the SSH boundary the same way `remoteSecretsRaw` is.
  */
 export function buildRemoteFileImportCommand(
   bundle: string,
@@ -504,7 +382,6 @@ export function buildRemoteFileImportCommand(
   const force = opts.force ? ' --force' : '';
   const policy = opts.policyNever ? ' --policy never --i-understand' : '';
   const importCmd = `agents secrets import ${shellQuote(bundle)} --from - --backend file${force}${policy}`;
-  // No prologue — AGENTS_SECRETS_PASSPHRASE stays unset on the remote, so the
-  // file store falls back to its machine-local key (headless).
+  // No prologue — AGENTS_SECRETS_PASSPHRASE stays unset on the remote.
   return { remoteCmd: `bash -lc ${shellQuote(importCmd)}`, input: dotenv };
 }


### PR DESCRIPTION
Kimi teammate's comment-cleanup pass over `lib/secrets`, `lib/installations`, and `lib/hosts`. Comments-only, no behavior change.

## Result
8 files, net **-1,616 comment lines** (579 insertions / 2,195 deletions). Trims verbose blocks, WHAT-restating lines, and stacked ticket-history (incl. the `reconnect.ts` header, previously comment:code 1.72).

## Review + correction
The initial pass was over-aggressive: a non-author `code-reviewer` review found 35 load-bearing comment removals (routing rationale, security one-liners, invariants). Corrected before this PR:
- **`hosts/remote-cmd.ts` reverted to main** - its `RUN_OPTION_FORWARDING` routing table's per-entry WHY comments are load-bearing.
- **Restored** the biometry-broker gate rationale, the bundle-rehydration + mock-backend-index guards, the `isDangerousRemoteEnvKey` threat annotations, the watch-lock/auto-lock-on-sleep invariant, the SHIM/alias schema-version histories, the `listInstalledVersionDirs` trap, and the `reconnect.ts` 255->254 remap + tmux-wrap invariants.

## Verification
- **Comments-only**, confirmed by a comment-aware multiset check: 0 executable lines changed either direction.
- `bunx tsc --noEmit` passes.
