### PR TITLE
docs(installations): fix 3 stale `agents trash restore` comments (PHNX-3391)

### DIFF
--- a/cli/src/lib/installations/store.ts
+++ b/cli/src/lib/installations/store.ts
@@ -577,7 +577,7 @@ export function getIsolatedDefault(agent: AgentId): string | null {
  *
  * It lives at the version-dir root (a sibling of `home/`), so it is carried
  * along when `softDeleteVersionDir` moves the whole directory to trash and is
- * restored intact by `agents trash restore`. Its mere presence is the marker;
+ * restored intact by `agents restore`. Its mere presence is the marker;
  * the contents are an informational timestamp only.
  */
 function getIsolatedMarkerPath(agent: AgentId, version: string): string {

--- a/cli/src/lib/installations/versions.ts
+++ b/cli/src/lib/installations/versions.ts
@@ -1805,7 +1805,7 @@ export async function reconcileStaleLatestDir(
  * re-install) without collision and gives a chronological audit trail.
  *
  * The whole versionDir moves — including `home/` (transcripts, sessions). The
- * user can recover everything via `agents trash restore <agent>@<version>`.
+ * user can recover everything via `agents restore <agent>@<version>`.
  * Nothing is ever hard-deleted.
  */
 export function softDeleteVersionDir(agent: AgentId, version: string): string | null {
@@ -1838,7 +1838,7 @@ export function softDeleteVersionDir(agent: AgentId, version: string): string | 
  * Remove a specific version of an agent.
  *
  * Soft-delete only: moves the entire version directory (including `home/`)
- * to ~/.agents/.system/trash/versions/. Recoverable via `agents trash restore`.
+ * to ~/.agents/.system/trash/versions/. Recoverable via `agents restore`.
  * Nothing is hard-deleted.
  */
 export function removeVersion(agent: AgentId, version: string): boolean {


### PR DESCRIPTION
## What

Three docstrings still instruct users to recover a soft-deleted version via `agents trash restore`, which **#3212 removed** (it was an exact duplicate of the top-level `agents restore`, both calling `restoreVersion`). #3212 fixed the comments in `trash.ts` it touched, but these three live in files it never opened. Point them at the surviving command.

- `cli/src/lib/installations/store.ts:580`
- `cli/src/lib/installations/versions.ts:1808`
- `cli/src/lib/installations/versions.ts:1841`

`agents trash restore` → `agents restore` in each.

## Not touched (intentional references)

- `cli/src/lib/startup/command-registry.ts:65` — historical note explaining the removal
- `cli/src/commands/nest-surface-retired.test.ts:156,173` — test names asserting the removal
- `cli/src/lib/session/db.ts:3154`, `db.archived.test.ts:165` — the `recoverable-trash` compound word (unrelated to the command)

## Scope

Comment-only, no behavior change. Closes the reviewer-noted loose end recorded on PHNX-3391. No CHANGELOG entry (#3212 already documented the command removal); no new test (`nest-surface-retired.test.ts` already pins the removed command).

## Verification

- `cd cli && bun run build` (tsc) — green.
- `git grep -n "agents trash restore" cli/src/lib/` → only the intentional historical note at `command-registry.ts:65` remains.