### PR TITLE
ci(impact): give lib/secrets its own 240s budget group

### DIFF
--- a/cli/ci/test-ownership.yaml
+++ b/cli/ci/test-ownership.yaml
@@ -188,6 +188,22 @@ groups:
     checks: [typecheck]
     budget_sec: 120
 
+  # 240s, not the default 85s. The secrets suite is the heaviest in the tree: the
+  # vault round-trip tests (secrets/bundles.test.ts, secrets/agent.test.ts) each drive a
+  # real keychain / file-store lifecycle at ~2-8s a case (repo convention forbids
+  # mocking), and a secrets/** edit selects the whole secrets suite plus its
+  # installations/hosts importers. Secrets had NO group of its own, so a secrets change
+  # fell back to whatever else it touched — PR #3218 (a comment-only trim of
+  # secrets+installations+hosts) inherited the installations 120s ceiling and measured
+  # 122-174s of a PASSING vitest run (2195 tests, all green) across 5 runs on loaded AND
+  # idle fleet workers, failing the gate every time. Same pattern as sessions 240 /
+  # daemon 240. Raise this only against a measured run, and lower it when the suite is split.
+  - id: secrets
+    when:
+      - cli/src/lib/secrets/**
+    checks: [typecheck]
+    budget_sec: 240
+
   # 150s, not the default 85s. Moving hooks.ts into hooks/install.ts (PR #2804,
   # run 32397180788) selected companion + importer tests inside a 129s impact
   # run (48 files / 1099 tests, all passed). Under 85s the move cannot merge.


### PR DESCRIPTION
## Problem
The `impact` CI gate fails legitimate PRs that touch `cli/src/lib/secrets/**`. The secrets suite is the heaviest in the tree — the vault round-trip tests (`secrets/bundles.test.ts`, `secrets/agent.test.ts`) drive a real keychain / file-store lifecycle at ~2-8s a case (repo convention forbids mocking) — but secrets had **no impact group of its own**, so a `secrets/**` change fell back to whichever other group it touched.

**Measured:** PR #3218 (a comment-only trim of `secrets` + `installations` + `hosts`, all 2,195 tests passing) inherited the `installations` group's 120s ceiling and ran **122–174s across 5 runs** on both loaded and idle fleet workers — failing the gate every time, with zero code fault. It is structurally unmergeable today.

## Fix
Add a `secrets` group at **240s**, matching the comparably heavy `sessions` (240) and `daemon` (240) groups. Follows the manifest's own documented rule ("Raise this only against a measured run"). With `budgetSec = max(matched groups)`, a secrets-touching change now resolves to 240s > the 174s measured worst case.

## Scope
One entry in `cli/ci/test-ownership.yaml`. No code, no behavior change. Validated: manifest parses, all 66 `scripts/ci-scope.test.ts` tests pass (the `impact-policy` gate for this file). This PR's own impact selects only the fast ci-scope suite, so it clears the budget comfortably.

Unblocks #3218 and every future secrets PR.
