### PR TITLE
fix(usage): worker daemon pulls primary usage on a null cache (PHNX-3392)

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -97,6 +97,12 @@ if (process.argv[2] === '__usage-ingest') {
   process.exit(await runUsageIngest());
 }
 
+if (process.argv[2] === '__usage-export') {
+  const { exportClaudeUsageCacheRows } = await import('./lib/accounting/usage.js');
+  process.stdout.write(JSON.stringify({ v: 1, rows: exportClaudeUsageCacheRows() }));
+  process.exit(0);
+}
+
 if (process.argv[2] === '__daemon-run') {
   const { runDaemon, log: daemonLog } = await import('./lib/daemon/daemon.js');
 

--- a/cli/src/lib/accounting/usage-sync.test.ts
+++ b/cli/src/lib/accounting/usage-sync.test.ts
@@ -1,13 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it, expect } from 'vitest';
 
 import {
   planUsagePush,
+  pullUsageFromPrimary,
   syncFleetUsageSnapshots,
   type UsagePushTarget,
   type UsageSyncDeps,
 } from './usage-sync.js';
 import type { DeviceProfile } from '../devices/registry.js';
-import type { CachedUsageSnapshot } from './usage.js';
+import {
+  exportClaudeUsageCacheRows,
+  ingestPeerClaudeUsageRows,
+  readClaudeUsageCache,
+  writeClaudeUsageCache,
+  type CachedUsageSnapshot,
+} from './usage.js';
 
 // The planner is pure (roles/reachability injected) so every skip/push branch is
 // covered with no SSH; the driver test injects a fake push to assert routing.
@@ -20,6 +30,11 @@ const TARGETS: UsagePushTarget[] = [
   { name: 'offline-box', role: 'worker', online: false, pinned: true },
   { name: 'unpinned-box', role: 'worker', online: true, pinned: false },
 ];
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
 
 function pushesOf(items: ReturnType<typeof planUsagePush>): string[] {
   return items.filter((i) => i.action === 'push').map((i) => i.device);
@@ -107,5 +122,84 @@ describe('syncFleetUsageSnapshots (driver, injected deps)', () => {
     const result = syncFleetUsageSnapshots(baseDeps({ exportRows: () => ({}) }));
     expect(result.pushed).toEqual([]);
     expect(result.skipped.every((s) => /no local usage snapshot/.test(s.reason))).toBe(true);
+  });
+});
+
+describe('pullUsageFromPrimary', () => {
+  it('pulls a 7d-100% primary row through the real cache export and ingest path', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agents-usage-pull-'));
+    tempDirs.push(dir);
+    const primaryCache = join(dir, 'primary.json');
+    const workerCache = join(dir, 'worker.json');
+    const capturedAt = new Date();
+    const resetsAt = new Date(capturedAt.getTime() + 7 * 24 * 60 * 60_000);
+    const usageKey = 'claude:org=alpha';
+    writeClaudeUsageCache(usageKey, {
+      source: 'api',
+      sourceLabel: 'Anthropic',
+      capturedAt,
+      windows: [{
+        key: 'week' as any,
+        label: 'Weekly',
+        shortLabel: 'W',
+        usedPercent: 100,
+        resetsAt,
+        windowMinutes: 7 * 24 * 60,
+      }],
+      plan: null,
+      refreshHint: null,
+    }, primaryCache);
+
+    const primary = { name: 'zion', tailscale: { online: true } } as DeviceProfile;
+    const result = pullUsageFromPrimary({
+      selfRole: () => 'worker',
+      listDevices: () => [primary],
+      listRoles: () => ({ zion: 'personal' }),
+      isPinned: () => true,
+      exportRows: () => exportClaudeUsageCacheRows(workerCache),
+      readRow: (key) => readClaudeUsageCache(key, workerCache),
+      pull: () => ({
+        ok: true,
+        stdout: JSON.stringify({ v: 1, rows: exportClaudeUsageCacheRows(primaryCache) }),
+      }),
+      ingestRows: (rows) => ingestPeerClaudeUsageRows(rows, workerCache),
+    });
+
+    expect(result).toEqual({ pulledFrom: 'zion', merged: 1, skipped: null, error: null });
+    expect(exportClaudeUsageCacheRows(workerCache)[usageKey]).toMatchObject({
+      capturedAt: capturedAt.toISOString(),
+      windows: [{ key: 'week', usedPercent: 100, windowMinutes: 7 * 24 * 60 }],
+    });
+  });
+
+  it('does not cross the ssh boundary when the worker cache is fresh', () => {
+    const rows: Record<string, CachedUsageSnapshot> = {
+      'claude:org=alpha': {
+        capturedAt: new Date().toISOString(),
+        windows: [{ key: 'week' as any, label: 'Weekly', shortLabel: 'W', usedPercent: 10, resetsAt: null, windowMinutes: 7 * 24 * 60 }],
+      },
+    };
+    let pulled = false;
+    const result = pullUsageFromPrimary({
+      selfRole: () => 'worker',
+      exportRows: () => rows,
+      readRow: () => ({ windows: [{} as any] }),
+      pull: () => { pulled = true; return { ok: true, stdout: '' }; },
+    });
+    expect(result.skipped).toBe('local usage cache is fresh');
+    expect(pulled).toBe(false);
+  });
+
+  it('fails loud when the primary returns a non-protocol response', () => {
+    const primary = { name: 'zion', tailscale: { online: true } } as DeviceProfile;
+    const result = pullUsageFromPrimary({
+      selfRole: () => 'worker',
+      listDevices: () => [primary],
+      listRoles: () => ({ zion: 'personal' }),
+      isPinned: () => true,
+      exportRows: () => ({}),
+      pull: () => ({ ok: true, stdout: 'login banner' }),
+    });
+    expect(result.error).toBe('primary returned malformed JSON');
   });
 });

--- a/cli/src/lib/accounting/usage-sync.ts
+++ b/cli/src/lib/accounting/usage-sync.ts
@@ -37,10 +37,17 @@ import {
   selfConfiguredDeviceRole,
   type ConfiguredDeviceRole,
 } from '../device-config.js';
-import { exportClaudeUsageCacheRows, type CachedUsageSnapshot } from './usage.js';
+import {
+  exportClaudeUsageCacheRows,
+  ingestPeerClaudeUsageRows,
+  readClaudeUsageCache,
+  type CachedUsageSnapshot,
+  type UsageSnapshot,
+} from './usage.js';
 
 /** How long a single peer push may take before it is abandoned for this tick. */
 export const USAGE_PUSH_DEADLINE_MS = 20_000;
+export const USAGE_PULL_DEADLINE_MS = 20_000;
 
 /** The stdin envelope the `__usage-ingest` verb reads. `v` guards the shape. */
 export interface UsageSyncPayload {
@@ -116,6 +123,25 @@ export interface UsageSyncDeps {
   push?: (device: DeviceProfile, payload: string) => { ok: boolean; message?: string };
 }
 
+export interface UsagePullResult {
+  pulledFrom: string | null;
+  merged: number;
+  skipped: string | null;
+  error: string | null;
+}
+
+export interface UsagePullDeps {
+  selfRole?: () => ConfiguredDeviceRole | undefined;
+  listDevices?: () => DeviceProfile[];
+  listRoles?: () => Record<string, ConfiguredDeviceRole>;
+  isPinned?: (name: string) => boolean;
+  exportRows?: () => Record<string, CachedUsageSnapshot>;
+  readRow?: (usageKey: string) => Pick<UsageSnapshot, 'windows'> | null;
+  ingestRows?: (rows: Record<string, CachedUsageSnapshot>) => number;
+  /** Read the versioned payload from the primary. Default: ssh `__usage-export`. */
+  pull?: (device: DeviceProfile) => { ok: boolean; stdout?: string; message?: string };
+}
+
 /** Production push: pipe the payload to the peer's `agents __usage-ingest` over ssh. */
 function defaultUsagePush(device: DeviceProfile, payload: string): { ok: boolean; message?: string } {
   const target = sshTargetFor(device);
@@ -131,6 +157,76 @@ function defaultUsagePush(device: DeviceProfile, payload: string): { ok: boolean
   if (res.timedOut) return { ok: false, message: 'timed out' };
   if (res.code !== 0) return { ok: false, message: res.stderr.trim() || `remote exit ${res.code}` };
   return { ok: true };
+}
+
+/** Production pull: read the primary's cache through its hidden export verb. */
+function defaultUsagePull(device: DeviceProfile): { ok: boolean; stdout?: string; message?: string } {
+  const target = sshTargetFor(device);
+  const os = resolveRemoteOsSync(device.name);
+  const remoteCmd = buildRemoteAgentsInvocation(['__usage-export'], undefined, os);
+  const res = sshExec(target, remoteCmd, { timeoutMs: USAGE_PULL_DEADLINE_MS });
+  if (res.timedOut) return { ok: false, message: 'timed out' };
+  if (res.code !== 0) return { ok: false, message: res.stderr.trim() || `remote exit ${res.code}` };
+  return { ok: true, stdout: res.stdout };
+}
+
+/**
+ * Pull usage from the fleet's primary headed device when this worker's local
+ * cache is empty or contains an expired row. `personal` is the primary role;
+ * a `desktop` is used only when the fleet has no personal device.
+ */
+export function pullUsageFromPrimary(deps: UsagePullDeps = {}): UsagePullResult {
+  const result: UsagePullResult = { pulledFrom: null, merged: 0, skipped: null, error: null };
+  if ((deps.selfRole ?? selfConfiguredDeviceRole)() !== 'worker') {
+    result.skipped = 'this device is not a worker';
+    return result;
+  }
+
+  const localRows = (deps.exportRows ?? exportClaudeUsageCacheRows)();
+  const readRow = deps.readRow ?? readClaudeUsageCache;
+  const localEntries = Object.entries(localRows);
+  if (localEntries.length > 0 && localEntries.every(([key, row]) => {
+    const fresh = readRow(key);
+    return fresh !== null && fresh.windows.length === row.windows.length;
+  })) {
+    result.skipped = 'local usage cache is fresh';
+    return result;
+  }
+
+  const devices = deps.listDevices?.() ?? Object.values(loadDevicesSync());
+  const roles = deps.listRoles?.() ?? (deps.listDevices
+    ? listConfiguredDeviceRoles(devices.map((device) => device.name))
+    : listConfiguredDeviceRoles());
+  const isPinned = deps.isPinned ?? isHostPinned;
+  const primary = devices
+    .filter((device) => roles[device.name] === 'personal')
+    .concat(devices.filter((device) => roles[device.name] === 'desktop'))
+    .find((device) => device.tailscale?.online !== false && isPinned(device.name));
+  if (!primary) {
+    result.error = 'no reachable, pinned personal or desktop device is configured as the usage primary';
+    return result;
+  }
+
+  const outcome = (deps.pull ?? defaultUsagePull)(primary);
+  if (!outcome.ok) {
+    result.error = outcome.message ?? 'pull failed';
+    return result;
+  }
+
+  let payload: UsageSyncPayload;
+  try {
+    payload = JSON.parse(outcome.stdout ?? '') as UsageSyncPayload;
+  } catch {
+    result.error = 'primary returned malformed JSON';
+    return result;
+  }
+  if (!payload || payload.v !== 1 || typeof payload.rows !== 'object' || payload.rows === null || Array.isArray(payload.rows)) {
+    result.error = 'primary returned an unrecognized usage-sync payload shape';
+    return result;
+  }
+  result.pulledFrom = primary.name;
+  result.merged = (deps.ingestRows ?? ingestPeerClaudeUsageRows)(payload.rows);
+  return result;
 }
 
 /**

--- a/cli/src/lib/daemon/AGENTS.md
+++ b/cli/src/lib/daemon/AGENTS.md
@@ -17,17 +17,18 @@ sessions (`cli/src/lib/session/remote/watch.ts:245`). This means every
 cross-device feature in this repo is built on top of one primitive (ssh +
 CLI verb), not a shared daemon protocol.
 
-**Two runtime models coexist today (RUSH-3193 plus PHNX-3265 migrated 16 of 17
+**Two runtime models coexist today (RUSH-3193 plus PHNX-3265 migrated 17 of 18
 declared services; 1 declared service remains inline).** `cli/src/lib/daemon-services.ts`
-defines `DaemonServiceId` (17 ids:
+defines `DaemonServiceId` (18 ids:
 `secrets-broker`, `scheduler`, `monitors`, `browser-ipc`,
 `webhook-receiver`, `self-heal`, `keychain-reap`, `account-state`,
 `watchdog`, `device-probe`, `state-dir-check`, `session-index`, `auth-sync`,
-`daemon-heartbeat`, `tmux-reap`, `browser-task-reap`, `session-state`) — the
+`daemon-heartbeat`, `tmux-reap`, `browser-task-reap`, `session-state`,
+`usage-sync`) — the
 catalog every id in `runDaemon()` is expected to register under, whichever
 model it uses.
 
-- **Supervised (`ServiceSupervisor`, `supervisor.ts`), 16 services:**
+- **Supervised (`ServiceSupervisor`, `supervisor.ts`), 17 services:**
   `secrets-broker` (`secrets-broker-service.ts`), `browser-ipc`
   (`browser-ipc-service.ts`), `account-state`
   (`account-state-daemon-service.ts`), `session-index`
@@ -40,7 +41,7 @@ model it uses.
   (`webhook-receiver-service.ts`), `daemon-heartbeat`
   (`heartbeat-service.ts`), `tmux-reap` (`tmux-reap-service.ts`), and
   `browser-task-reap` (`browser-task-reap-service.ts`), and `auth-sync`
-  (`auth-sync-service.ts`). Each implements the
+  (`auth-sync-service.ts`), and `usage-sync` (`usage-sync-service.ts`). Each implements the
   `DaemonService` contract (`service.ts`) — `id`,
   `start`/`stop`/`restart`/`health()`, plus `intervalMs`/`deadlineMs`/`tick()`
   for the periodic ones — and is `supervisor.register()`ed in `runDaemon()`
@@ -195,7 +196,7 @@ supervised total to 10. PHNX-3265 moved live-session publishing and webhook
 ingress plus every fixed-cadence maintenance loop onto the same supervisor,
 and fixed manual periodic restarts so they
 replace, rather than duplicate, the timer. `agents daemon services` now reports
-measured health for 16 of 17 declared services and infers only `scheduler`.
+measured health for 17 of 18 declared services and infers only `scheduler`.
 This doc's Current architecture section
 above is the source of truth for all of it.
 

--- a/cli/src/lib/daemon/usage-sync-service.ts
+++ b/cli/src/lib/daemon/usage-sync-service.ts
@@ -2,9 +2,9 @@
  * Fleet usage-snapshot sync as a `PeriodicService` (PHNX-3392 usage-sync).
  *
  * On a headed box (personal/desktop) each tick pushes the local identity-keyed
- * Claude usage rows to worker peers that cannot read usage themselves. A no-op on
- * a worker/unmarked box or when the local cache is empty — the driver
- * ({@link syncFleetUsageSnapshots}) gates on the self role, so this service is
+ * Claude usage rows to worker peers that cannot read usage themselves. On a
+ * worker whose cache is empty or stale, the same tick pulls those rows from the
+ * primary headed device. Both drivers gate on the self role, so this service is
  * safe to register everywhere. Single-executor per destination: each daemon only
  * writes the DESTINATION's own cache, and the merge is newest-wins + idempotent.
  */
@@ -30,13 +30,18 @@ export class UsageSyncService extends BasePeriodicService {
   }
 
   protected async onTick(ctx: DaemonContext): Promise<void> {
-    const { syncFleetUsageSnapshots } = await import('../accounting/usage-sync.js');
-    const result = syncFleetUsageSnapshots();
-    if (result.pushed.length > 0) {
-      ctx.log('INFO', `usage-sync: pushed usage to ${result.pushed.join(', ')}`);
+    const { pullUsageFromPrimary, syncFleetUsageSnapshots } = await import('../accounting/usage-sync.js');
+    const pushResult = syncFleetUsageSnapshots();
+    if (pushResult.pushed.length > 0) {
+      ctx.log('INFO', `usage-sync: pushed usage to ${pushResult.pushed.join(', ')}`);
     }
-    for (const err of result.errors) {
+    for (const err of pushResult.errors) {
       ctx.log('WARN', `usage-sync: ${err.device}: ${err.message}`);
     }
+    const pullResult = pullUsageFromPrimary();
+    if (pullResult.pulledFrom) {
+      ctx.log('INFO', `usage-sync: pulled usage from ${pullResult.pulledFrom}; merged ${pullResult.merged} row(s)`);
+    }
+    if (pullResult.error) ctx.log('WARN', `usage-sync: pull: ${pullResult.error}`);
   }
 }


### PR DESCRIPTION
## Summary
- add the stdout-only `__usage-export` read verb for identity-keyed Claude usage rows
- make `UsageSyncService` bidirectional: headed devices keep pushing, while workers with null/stale cache pull from the primary over SSH and merge newest-wins
- correct the daemon service inventory from 17 to 18 ids and include `usage-sync`

## Verification
- `bun run test src/lib/accounting/usage-sync.test.ts` — 10 tests passed
- `scripts/build.sh --skip-tests` — Ready (1640 files, 14351 KB)
- `node dist/index.js run claude --help` — rendered run help successfully
- composed test: worker null cache pulled a 7d/100% row through real export + ingest cache functions (`pulledFrom: zion`, `merged: 1`)

Tracking: PHNX-3392