### PR TITLE
test(flaky): deterministic scheduler + import walk-up tests (PHNX-3436, PHNX-3434)

### DIFF
--- a/cli/src/lib/__tests__/import.test.ts
+++ b/cli/src/lib/__tests__/import.test.ts
@@ -74,7 +74,11 @@ describe('resolvePackageDirFromBinary', () => {
   });
 
   it('returns null for a binary that has no package.json on the walk-up', () => {
-    const bareDir = path.join(tmp, 'bare');
+    // Nest deep enough that resolvePackageDirFromBinary's bounded 6-level walk-up
+    // stays INSIDE this clean temp tree and never reaches os.tmpdir()'s ancestors.
+    // Some fleet workers set TMPDIR under a dir tree with a package.json within 6
+    // levels, which made this flake by resolving to that ambient package (PHNX-3434).
+    const bareDir = path.join(tmp, 'l1', 'l2', 'l3', 'l4', 'l5');
     fs.mkdirSync(bareDir, { recursive: true });
     const binaryPath = path.join(bareDir, 'standalone');
     fs.writeFileSync(binaryPath, '#!/bin/sh\nexit 0\n');

--- a/cli/src/lib/scheduler.test.ts
+++ b/cli/src/lib/scheduler.test.ts
@@ -77,7 +77,10 @@ describe('JobScheduler.reloadAll — device activation refresh', () => {
 
 describe('fireSlot — aligned, unconditional occurrence key (SING-15)', () => {
   it('floors a jittered fire instant to the aligned schedule boundary', () => {
-    const cron = new Cron('0 9 * * 1-5', { paused: true });
+    // Pin the schedule to UTC: without it, croner uses the worker's LOCAL zone,
+    // so "0 9" fires at 09:00 local (16:00 UTC on a PDT box) and the floored
+    // boundary lands on the previous day — the source of the flake (PHNX-3436).
+    const cron = new Cron('0 9 * * 1-5', { paused: true, timezone: 'UTC' });
     const boundary = new Date('2026-08-28T09:00:00.000Z');
     // croner's currentRun() carries wall-clock jitter — simulate a fire 4 ms late.
     vi.spyOn(cron, 'currentRun').mockReturnValue(new Date(boundary.getTime() + 4));


### PR DESCRIPTION
Fixes the two flaky tests (PHNX-3436, PHNX-3434) that intermittently block every CLI release: `release-attestation-produce.sh` refuses to attest a red tree, and each of these trips shard 4 on some fleet workers.

- **scheduler.test.ts** "floors a jittered fire instant to the aligned schedule boundary": the `Cron` used the worker LOCAL timezone, so on a PDT box `0 9` fires at 16:00 UTC and the floored boundary lands on the previous day (`2026-08-27T16:00` vs expected `2026-08-28T09:00`). Pin `timezone: "UTC"`.
- **import.test.ts** "returns null for a binary that has no package.json on the walk-up": `resolvePackageDirFromBinary` walks up a bounded 6 levels; workers whose `TMPDIR` is nested deep have an ancestor `package.json` within 6 levels, so it resolved non-null. Nest the fixture binary 5 dirs under the clean temp root so the walk-up stays inside our tree.

Verified: both files pass under `TZ=America/Los_Angeles` (the zone that broke the scheduler test). 17/17.

Surfaced while cutting agents-cli 1.22.58 (the Evals durability release) — unblocks it and every future release.
