### PR TITLE
fix(daemon): boot-time test-home tripwire so a leaked routines test daemon can't tick against the real host (PHNX-2545)

### DIFF
--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -3356,6 +3356,19 @@ a machine-wide process sweep.)
   (`lib/secrets/reaper.ts:156-180`, wired into the reap tick at `lib/daemon/daemon.ts:911`).
   Every daemon-owned process class — daemon, browser, tunnel, and keychain helper
   including the `watch-lock` watcher — has a recovery layer.
+- **SING-11c (MUST).** A daemon spawned by the test suite MUST NOT run its scheduler
+  against the operator's real state. Where SING-11b reaps a leaked test daemon *after
+  the fact*, this is the *boot-time* preventive guard for the same class (PHNX-2545,
+  the routines suite leaving real `__daemon-run` processes alive on a fleet box): the
+  test-daemon spawn sets `AGENTS_DAEMON_TEST_HOME` to the isolated home it provisioned,
+  and `runDaemon` (`lib/daemon/daemon.ts`, `assertTestDaemonHome`) MUST — before it
+  claims an instance, writes a pid, or fires any tick — refuse to boot when its resolved
+  state dir does not sit under that home, i.e. when the isolated `HOME` override failed
+  to reach the child and the daemon would otherwise schedule against the real host. The
+  marker is never set in production, so the guard is a no-op there. The routines
+  daemon-spawn helper (`commands/routines.test-fixture.ts`, `startIsolatedDaemon`) sets
+  the marker, and the per-file leak detector it registers (`registerLeakDetector`)
+  remains the after-the-fact backstop for a worker killed before its own `finally`.
 - **SING-12 (MUST).** `stopDaemon` (`lib/daemon/daemon.ts`) MUST assert its postcondition,
   not assume it: after the SIGTERM → grace → `killTree` sequence it MUST verify the
   browser IPC binding was released, the secrets broker socket was released (a stale

--- a/cli/src/commands/routines.test-fixture.ts
+++ b/cli/src/commands/routines.test-fixture.ts
@@ -186,6 +186,11 @@ export function createDaemonHarness(fileSlug: string): {
         // and kills real tmux-wrapped processes every five-minute tick (RUSH-2545).
         AGENTS_HISTORY_DIR: path.join(home, '.agents', '.history'),
         AGENTS_SKIP_MIGRATION: '1',
+        // PHNX-2545 test-home tripwire: name the isolated home this daemon must
+        // resolve its state dir under. If the HOME override above ever failed to
+        // reach the child, runDaemon()'s assertTestDaemonHome() refuses to boot
+        // instead of ticking its scheduler against the operator's real host.
+        AGENTS_DAEMON_TEST_HOME: home,
       },
       detached: true,
       stdio: 'ignore',

--- a/cli/src/lib/daemon/daemon.lifecycle.test.ts
+++ b/cli/src/lib/daemon/daemon.lifecycle.test.ts
@@ -19,7 +19,7 @@ import * as os from 'os';
 import * as net from 'net';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
-import { startDetached, startDaemon } from './daemon.js';
+import { startDetached, startDaemon, assertTestDaemonHome } from './daemon.js';
 import { ipcEndpoint } from '../platform/index.js';
 import { DIST_ENTRY, REPO_ROOT, installKeychainHermeticity } from './daemon.test-fixture.js';
 
@@ -482,6 +482,85 @@ describe('daemon self-terminate guard on a missing state dir (RUSH-2367)', () =>
         if (pid) { try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ } }
         if (pid) await waitFor(() => !alive(pid!), 5_000);
         try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* already gone */ }
+      }
+    },
+    30_000,
+  );
+});
+
+/**
+ * Test-home tripwire (PHNX-2545). The pure guard, plus a REAL boot: a daemon
+ * whose AGENTS_DAEMON_TEST_HOME marker names a home that does NOT contain its
+ * resolved state dir — the shape of a test spawn whose isolated HOME override
+ * failed to reach the child — must refuse to start rather than schedule its
+ * scheduler/watchdog against the operator's real host.
+ */
+describe('daemon test-home tripwire (PHNX-2545)', () => {
+  it('no-op when the marker is unset (production)', () => {
+    expect(() => assertTestDaemonHome('/anywhere/.agents/.cache/helpers/daemon', undefined)).not.toThrow();
+  });
+
+  it('passes when the daemon dir sits under the marked test home', () => {
+    const home = '/tmp/agents-routines-add-abc';
+    const dir = path.join(home, '.agents', '.cache', 'helpers', 'daemon');
+    expect(() => assertTestDaemonHome(dir, home)).not.toThrow();
+    // The home itself as the dir is degenerate-but-under, still allowed.
+    expect(() => assertTestDaemonHome(home, home)).not.toThrow();
+  });
+
+  it('throws when the daemon dir escapes the marked test home', () => {
+    const testHome = '/tmp/agents-routines-add-abc';
+    const realDir = path.join(os.homedir(), '.agents', '.cache', 'helpers', 'daemon');
+    expect(() => assertTestDaemonHome(realDir, testHome)).toThrow(/test-home tripwire/i);
+    // A sibling prefix must not satisfy the startsWith check (path.sep boundary).
+    expect(() => assertTestDaemonHome('/tmp/agents-routines-add-abc-evil/x', testHome)).toThrow(/test-home tripwire/i);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'a real __daemon-run refuses to boot when its marked test home does not contain its state dir',
+    async () => {
+      if (!fs.existsSync(DIST_ENTRY)) {
+        execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
+      }
+
+      const tmpHome = fs.mkdtempSync(path.join('/tmp', 'agd-triphome-'));
+      const otherHome = fs.mkdtempSync(path.join('/tmp', 'agd-tripother-'));
+      const systemDir = path.join(tmpHome, '.agents', '.system');
+      fs.mkdirSync(systemDir, { recursive: true });
+      execFileSync('git', ['init', '-q', systemDir]);
+
+      const pidFile = path.join(tmpHome, '.agents', '.cache', 'helpers', 'daemon', 'daemon.pid');
+      const alive = (pid: number) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+      const waitFor = async (cond: () => boolean, timeoutMs: number) => {
+        const start = Date.now();
+        while (Date.now() - start < timeoutMs) {
+          if (cond()) return true;
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        return cond();
+      };
+
+      const childEnv = {
+        ...process.env,
+        HOME: tmpHome,
+        // Marker names a DIFFERENT home than the one HOME resolves the state dir
+        // under — the tripwire must fire and the daemon must never come up.
+        AGENTS_DAEMON_TEST_HOME: otherHome,
+      };
+      delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
+
+      let pid: number | null = null;
+      try {
+        pid = startDetached({ agentsBin: DIST_ENTRY, logPath: path.join(tmpHome, 'daemon.log'), env: childEnv }).pid!;
+        expect(pid).toBeTruthy();
+        // It aborts at boot: the process dies quickly and never writes its pid file.
+        expect(await waitFor(() => !alive(pid!), 15_000)).toBe(true);
+        expect(fs.existsSync(pidFile)).toBe(false);
+      } finally {
+        if (pid) { try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ } }
+        if (pid) await waitFor(() => !alive(pid!), 5_000);
+        try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* already gone */ }
+        try { fs.rmSync(otherHome, { recursive: true, force: true }); } catch { /* already gone */ }
       }
     },
     30_000,

--- a/cli/src/lib/daemon/daemon.ts
+++ b/cli/src/lib/daemon/daemon.ts
@@ -717,6 +717,44 @@ export function warnEphemeralDaemonRoot(resolveBin: () => string = getAgentsBinP
   }
 }
 
+/**
+ * Test-home tripwire (PHNX-2545). The routines/daemon test suite spawns real
+ * `agents __daemon-run` processes against an isolated /tmp HOME. If that HOME
+ * override fails to reach the child — an `env: {...process.env}` spawn that
+ * forgot to set it, a login shell that reset HOME — the daemon resolves its
+ * state dir under the operator's REAL home and its scheduler/watchdog then tick
+ * against shared production state. That is the exact leak the ticket reports:
+ * real test daemons found alive on a fleet box, each a second live scheduler
+ * racing the legitimate one, in violation of the execution-singularity spec.
+ *
+ * A test that spawns a daemon sets AGENTS_DAEMON_TEST_HOME to the isolated home
+ * it provisioned. When that marker is present, this daemon's resolved state dir
+ * MUST sit under it; otherwise the daemon refuses to boot — failing loud before
+ * it claims an instance, writes a pid, or fires a single tick (the throw is
+ * caught in index.ts's `__daemon-run` handler, logged, and exits non-zero) —
+ * rather than running in the wrong directory against the real host. In
+ * production the marker is never set, so this is a no-op there.
+ *
+ * `daemonDir`/`testHome` are injectable so the pure guard is unit-testable
+ * without spawning a process; the defaults read the live daemon dir and env.
+ */
+export function assertTestDaemonHome(
+  daemonDir: string = getDaemonDir(),
+  testHome: string | undefined = process.env.AGENTS_DAEMON_TEST_HOME,
+): void {
+  if (!testHome) return;
+  const root = path.resolve(testHome);
+  const dir = path.resolve(daemonDir);
+  if (dir !== root && !dir.startsWith(root + path.sep)) {
+    const msg =
+      `Daemon test-home tripwire (PHNX-2545): AGENTS_DAEMON_TEST_HOME is ${root}, but this ` +
+      `daemon's state dir resolved to ${dir} — the isolated HOME override did not reach this ` +
+      `__daemon-run child, so it would schedule against the real host. Refusing to start.`;
+    log('ERROR', msg);
+    throw new Error(msg);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Module-level periodic maintenance helpers (RUSH-2422)
 //
@@ -733,6 +771,12 @@ export function warnEphemeralDaemonRoot(resolveBin: () => string = getAgentsBinP
 // ---------------------------------------------------------------------------
 
 export async function runDaemon(): Promise<void> {
+  // PHNX-2545 test-home tripwire — FIRST, before this daemon claims an instance,
+  // writes a pid, or fires any tick. A test-spawned daemon that lost its isolated
+  // HOME override must refuse to run against the operator's real state rather than
+  // schedule against the real host. No-op in production (the marker is never set).
+  assertTestDaemonHome();
+
   // Single-instance guard (last-wins, SING-11): a direct `agents __daemon-run`
   // (manual, or a service-manager restart racing a live predecessor) EVICTS the
   // incumbent and becomes the survivor. claimDaemonInstance returns false only


### PR DESCRIPTION
## What & why

PHNX-2545: the routines test suite spawns **real** `agents __daemon-run` processes against an isolated `/tmp` HOME. If that HOME override ever fails to reach the child (an `env: {...process.env}` spawn that forgot it, a login shell that reset HOME), the daemon resolves its state dir under the operator's **real** home and its scheduler/watchdog then tick against shared production state — the exact leak the ticket reports (three real test daemons found alive on a fleet box for up to 3.5 days; a second live scheduler racing the legitimate one, in violation of the execution-singularity spec).

The reaping harness (RUSH-2367/RUSH-2819) already **reaps** leaked daemons after the fact. This PR adds the **boot-time** preventive guard the ticket explicitly asks for — a "cwd/home tripwire so a test daemon can't run in the wrong dir."

## Change

- **`assertTestDaemonHome()`** (`daemon.ts`) runs **first** in `runDaemon()`, before the daemon claims an instance, writes a pid, or fires a single tick. When the test-only `AGENTS_DAEMON_TEST_HOME` marker is set, the daemon's resolved state dir MUST sit under it — otherwise the daemon **refuses to boot** (throws → `index.ts`'s `__daemon-run` handler logs ERROR + exits non-zero). No-op in production (the marker is never set).
- **`startIsolatedDaemon`** (`routines.test-fixture.ts`) sets `AGENTS_DAEMON_TEST_HOME` to the isolated home it provisioned, arming the guard for every routines daemon spawn.
- **Tests** (real path, no mocks): pure unit tests of the guard (unset / under-home / escapes-home, incl. `path.sep` boundary) **plus a real `__daemon-run` boot** that refuses when its marked home doesn't contain its state dir — no pid written, process exits.
- **SING-11c** in `docs/specifications.md` documents the boot-time guard as the sibling of SING-11b's after-the-fact reaping.

No product regression: the positive boot path is unchanged — a correctly-isolated test daemon's state dir **is** under its marked home, so it boots normally (all 46 routines daemon tests still pass).

## Before / after (real `__daemon-run`, mismatched marker vs. state dir)

Spawn a daemon with `HOME` resolving its state dir under one temp dir while `AGENTS_DAEMON_TEST_HOME` names a *different* sanctioned home — i.e. the "HOME override didn't land where the harness will reap" case.

**BEFORE** (guard call removed, rebuilt) — daemon boots and leaks:
```
daemon pid 2450105: state-dir pid written=true process-alive=true
```

**AFTER** (guard present) — daemon refuses to boot, no pid, non-zero exit:
```
daemon pid 2449685: state-dir pid written=false process-alive=false
stderr: [agents] daemon startup failure: Error: Daemon test-home tripwire (PHNX-2545):
  AGENTS_DAEMON_TEST_HOME is /tmp/agd-demo-sanctioned-SL5d3H, but this daemon's state dir
  resolved to /tmp/agd-demo-home-thbHJU/.agents/.cache/helpers/daemon — the isolated HOME
  override did not reach this __daemon-run child, so it would schedule against the real
  host. Refusing to start.
```

## Test runs

```
# tripwire suite (4 unit + real-spawn refusal)
bun run test src/lib/daemon/daemon.lifecycle.test.ts -t "test-home tripwire"
  Tests  4 passed | 7 skipped

# full lifecycle file (self-terminate guard etc. unaffected)
bun run test src/lib/daemon/daemon.lifecycle.test.ts
  Tests  11 passed (11)

# routines daemon suites — positive boot path still works with the marker set
bun run test src/commands/routines.run.test.ts src/commands/routines.add.test.ts
  Tests  46 passed (46)
```

## Ticket

Closes PHNX-2545 (the boot-time tripwire). Reaping (ask #1) already landed in RUSH-2367/RUSH-2819; ask #2/#3 (pin so it can't schedule against the real host / fail loud) are satisfied here.

Do not self-merge — handing off for an independent non-author review + merge.
