### PR TITLE
fix(pty): darwin-arm64 binding for Node 25/26 + fail loud on load failure (PHNX-2740)

### DIFF
--- a/cli/.changelog/next/PHNX-2740.md
+++ b/cli/.changelog/next/PHNX-2740.md
@@ -1,0 +1,11 @@
+- **`agents pty` now works on macOS/arm64 and Node 25/26 (PHNX-2740).** The pinned
+  `@homebridge/node-pty-prebuilt-multiarch@0.13.1` shipped no darwin-arm64 prebuild
+  above Node 24 (ABI 137), so on a Mac running Node 25 (ABI 141) or 26 (ABI 147) the
+  native binding never resolved and every pty command died with a bare
+  `Cannot find module '.../pty.node'` MODULE_NOT_FOUND. Bumped to `0.14.1`, which
+  publishes darwin-arm64 (and darwin-x64) prebuilds through ABI 147, covering current
+  Node. The PTY sidecar now also **fails loud** when the binding genuinely can't load:
+  instead of a raw MODULE_NOT_FOUND it prints the platform, the running Node ABI, and a
+  concrete remediation (`npm rebuild @homebridge/node-pty-prebuilt-multiarch` / reinstall
+  the CLI), preserving the underlying error. Source: `cli/package.json`,
+  `cli/src/lib/pty-server.ts`.

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@fontsource/inter": "^5.3.0",
         "@fontsource/jetbrains-mono": "^5.3.0",
-        "@homebridge/node-pty-prebuilt-multiarch": "0.13.1",
+        "@homebridge/node-pty-prebuilt-multiarch": "0.14.1",
         "@inquirer/prompts": "8.5.2",
         "@resvg/resvg-wasm": "^2.6.2",
         "@types/proper-lockfile": "4.1.4",
@@ -129,7 +129,7 @@
 
     "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.3.0", "", {}, "sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A=="],
 
-    "@homebridge/node-pty-prebuilt-multiarch": ["@homebridge/node-pty-prebuilt-multiarch@0.13.1", "", { "dependencies": { "node-addon-api": "^7.1.0", "prebuild-install": "^7.1.2" } }, "sha512-ccQ60nMcbEGrQh0U9E6x0ajW9qJNeazpcM/9CH6J8leyNtJgb+gu24WTBAfBUVeO486ZhscnaxLEITI2HXwhow=="],
+    "@homebridge/node-pty-prebuilt-multiarch": ["@homebridge/node-pty-prebuilt-multiarch@0.14.1", "", { "dependencies": { "node-addon-api": "^8.9.0", "prebuild-install": "^7.1.3" } }, "sha512-JaaTsATWPkOhm/cM2t+IjA2lztDFkoWQYU5VS8ThTsa9VbKhHwp83Cww4t8X/BH0k4Q8cWqvOKmYoGrlwLVhbA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -549,7 +549,7 @@
 
     "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
 
-    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+    "node-addon-api": ["node-addon-api@8.9.2", "", {}, "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg=="],
 
     "node-emoji": ["node-emoji@2.2.0", "", { "dependencies": { "@sindresorhus/is": "^4.6.0", "char-regex": "^1.0.2", "emojilib": "^2.4.0", "skin-tone": "^2.0.0" } }, "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw=="],
 

--- a/cli/docs/pty.md
+++ b/cli/docs/pty.md
@@ -69,6 +69,31 @@ the PTY log path, and the recent log tail. The log path is also shown by
 `agents pty server status` and normally lives under
 `~/.agents/.cache/helpers/pty/logs.jsonl`.
 
+### Native binding
+
+The sidecar drives a real PTY through `@homebridge/node-pty-prebuilt-multiarch`, a
+native N-API addon. Linux prebuilds (glibc + musl, every arch and Node ABI) are
+baked into the npm tarball, so Linux needs no compiler or network fetch. The
+**macOS/Windows** binaries are downloaded per host + Node ABI at install time by
+the package's own `prebuild-install` postinstall — which is why the dep sits in
+`package.json`'s `trustedDependencies` (bun otherwise skips install scripts).
+
+That fetch has no prebuild to grab when your Node runtime is newer than any the
+package published (the PHNX-2740 case: `@homebridge/node-pty-prebuilt-multiarch@0.13.1`
+shipped no darwin-arm64 binary above Node 24, so Node 25/26 on Apple Silicon had
+nothing to load). When the binding genuinely can't load, the sidecar now **fails
+loud** with your platform, the running Node ABI, and a remediation instead of a raw
+`MODULE_NOT_FOUND`. To recover:
+
+```bash
+npm rebuild @homebridge/node-pty-prebuilt-multiarch   # fetch/build for your Node
+# or reinstall the CLI so the postinstall reruns:
+npm i -g @phnx-labs/agents-cli
+```
+
+If your Node is newer than every published prebuild, install a current LTS Node
+(or ensure a C++ toolchain is present so the source build can run) and retry.
+
 ## Command Reference
 
 ### Session lifecycle

--- a/cli/package.json
+++ b/cli/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@fontsource/inter": "^5.3.0",
     "@fontsource/jetbrains-mono": "^5.3.0",
-    "@homebridge/node-pty-prebuilt-multiarch": "0.13.1",
+    "@homebridge/node-pty-prebuilt-multiarch": "0.14.1",
     "@inquirer/prompts": "8.5.2",
     "@resvg/resvg-wasm": "^2.6.2",
     "@types/proper-lockfile": "4.1.4",

--- a/cli/src/lib/__tests__/pty-server.test.ts
+++ b/cli/src/lib/__tests__/pty-server.test.ts
@@ -27,7 +27,7 @@ const tmpBase = process.platform === 'darwin' ? '/tmp' : os.tmpdir();
 const TEST_HOME = fs.mkdtempSync(path.join(tmpBase, 'agents-pty-test-'));
 process.env.HOME = TEST_HOME;
 
-const { runPtyServer, captureProcessStartTime, getSocketPath, derivePtyEndpoint, buildSentinelCommand } = await import('../pty-server.js');
+const { runPtyServer, captureProcessStartTime, getSocketPath, derivePtyEndpoint, buildSentinelCommand, describeNativePtyLoadFailure } = await import('../pty-server.js');
 
 // The multiarch fork BAKES Linux prebuilds (glibc + musl, all Node ABIs incl.
 // 22/24) into its npm tarball, so the native binary is present on Linux even
@@ -185,6 +185,64 @@ describe('buildSentinelCommand (shell-aware exec wrapper)', () => {
       .toBe('Get-ChildItem; echo "__AGENTS_PTY_DONE__:$LASTEXITCODE"');
     expect(buildSentinelCommand('pwsh', 'Get-ChildItem'))
       .toBe('Get-ChildItem; echo "__AGENTS_PTY_DONE__:$LASTEXITCODE"');
+  });
+});
+
+// Regression guard for PHNX-2740: the native binding must actually LOAD and
+// spawn on the platform running the suite. The Linux prebuilds are baked into
+// the npm tarball for every Node ABI, so on a Linux runner this is a hard
+// requirement — a bump that drops the ABI the runner uses (or a broken install)
+// fails here instead of silently skipping. It also exercises the real critical
+// path (spawn -> onData -> onExit), no mocks. On macOS/Windows the prebuild is
+// fetched at install and CI does not run those, so we only assert-or-skip there.
+describe('native pty binding loads and spawns on this platform', () => {
+  it.skipIf(process.platform !== 'linux')('LINUX: loads the binding and round-trips a real shell', async () => {
+    const mod: any = await import('@homebridge/node-pty-prebuilt-multiarch');
+    const nodePty = mod.default?.spawn ? mod.default : mod;
+    expect(typeof nodePty.spawn).toBe('function');
+
+    const output = await new Promise<string>((resolve, reject) => {
+      const proc = nodePty.spawn(process.env.SHELL || 'bash', ['-c', 'echo PTY_LOADS_OK'], {
+        name: 'xterm-256color', cols: 80, rows: 24, cwd: TEST_HOME, env: process.env,
+      });
+      let buf = '';
+      proc.onData((d: string) => { buf += d; });
+      proc.onExit(() => resolve(buf));
+      setTimeout(() => reject(new Error('pty spawn did not exit in time')), 5000);
+    });
+    expect(output).toContain('PTY_LOADS_OK');
+  }, 10_000);
+
+  it.skipIf(process.platform === 'linux')('non-Linux: binding must load if present (fetched at install)', async () => {
+    if (!nodePtyLoadable) return; // prebuild not fetched in this env — nothing to assert
+    const mod: any = await import('@homebridge/node-pty-prebuilt-multiarch');
+    const nodePty = mod.default?.spawn ? mod.default : mod;
+    expect(typeof nodePty.spawn).toBe('function');
+  });
+});
+
+describe('describeNativePtyLoadFailure (actionable, not a raw MODULE_NOT_FOUND)', () => {
+  it('names the platform, Node ABI, a remediation, and the underlying error', () => {
+    const err = Object.assign(new Error("Cannot find module '../build/Debug/pty.node'"), {
+      code: 'MODULE_NOT_FOUND',
+    });
+    const lines = describeNativePtyLoadFailure(err);
+    const text = lines.join('\n');
+
+    // Platform + ABI so a user can tell whether their Node is simply too new.
+    expect(text).toContain(`${process.platform}-${process.arch}`);
+    expect(text).toContain(`ABI ${process.versions.modules}`);
+    // A concrete fix, not just "install it".
+    expect(text).toContain('npm rebuild @homebridge/node-pty-prebuilt-multiarch');
+    // The real error is preserved for debugging, never swallowed.
+    expect(text).toContain("Cannot find module '../build/Debug/pty.node'");
+    // Never the bare failure with no guidance.
+    expect(text).not.toBe('MODULE_NOT_FOUND');
+  });
+
+  it('handles a non-Error thrown value without crashing', () => {
+    const lines = describeNativePtyLoadFailure('some string failure');
+    expect(lines.join('\n')).toContain('some string failure');
   });
 });
 

--- a/cli/src/lib/pty-server.ts
+++ b/cli/src/lib/pty-server.ts
@@ -119,6 +119,44 @@ export function buildSentinelCommand(shell: string, command: string): string {
   return `${command}; echo "${SENTINEL}:$?"`;
 }
 
+/**
+ * Turn a native-binding load failure into an actionable, platform-aware message.
+ *
+ * The binding is `@homebridge/node-pty-prebuilt-multiarch`'s `pty.node`. On Linux
+ * it is baked into the npm tarball and always present; on macOS/Windows it is
+ * fetched per host + Node ABI at install time by the package's `prebuild-install`
+ * postinstall. The common failure is a Node runtime whose ABI has no published
+ * prebuild (the PHNX-2740 darwin-arm64 case): `prebuild-install` finds nothing,
+ * the build-from-source fallback also fails, and the loader throws a bare
+ * `Cannot find module '.../pty.node'` / MODULE_NOT_FOUND with no clue what to do.
+ *
+ * Pure (returns the lines) so it can be unit-tested without spawning the server.
+ */
+export function describeNativePtyLoadFailure(err: unknown): string[] {
+  const detail = err instanceof Error ? (err.stack || err.message) : String(err);
+  const abi = process.versions.modules;
+  const nodeVersion = process.version;
+  const platform = `${process.platform}-${process.arch}`;
+  const lines = [
+    `agents pty could not load its native terminal binding (@homebridge/node-pty-prebuilt-multiarch).`,
+    `  platform: ${platform}   node: ${nodeVersion} (ABI ${abi})`,
+    ``,
+    `The prebuilt binary for this platform + Node ABI is missing. On macOS/Windows`,
+    `it is downloaded at install time; a Node version newer than any published`,
+    `prebuild, or an install that skipped the postinstall, leaves it absent.`,
+    ``,
+    `Fix it by reinstalling so the native binding is fetched or built:`,
+    `  npm rebuild @homebridge/node-pty-prebuilt-multiarch   # rebuild for this Node`,
+    `  # or reinstall the CLI:  npm i -g @phnx-labs/agents-cli`,
+    `If your Node (ABI ${abi}) is newer than the shipped prebuilds, install an LTS`,
+    `Node and retry, or ensure a C++ toolchain is present for the source build.`,
+    ``,
+    `Underlying error:`,
+    ...detail.split('\n').map(l => `  ${l}`),
+  ];
+  return lines;
+}
+
 /** Get the PTY helper directory, creating it if needed. */
 function getPtyDir(): string {
   const dir = getPtyDirRoot();
@@ -213,9 +251,16 @@ export async function runPtyServer(): Promise<void> {
   let XtermTerminal: any;
 
   try {
-    // The Homebridge multiarch fork of node-pty: API-identical (same 1.x N-API
-    // codebase) but ships prebuilt binaries for Linux glibc + musl, x64 + arm64
-    // (plus macOS/Windows), so no compiler is needed on Linux/Alpine/arm64.
+    // The Homebridge multiarch fork of node-pty (API-identical to the 1.x N-API
+    // upstream). Its npm tarball BAKES IN the Linux prebuilds (glibc + musl, every
+    // arch + Node ABI), so Linux never needs a compiler or a network fetch. The
+    // darwin-arm64 / win32 binaries are NOT in the tarball — they are downloaded
+    // per host+Node-ABI at install time by the package's own `prebuild-install`
+    // postinstall (gated by bun's `trustedDependencies`). That fetch fails when the
+    // running Node ABI is newer than any published prebuild (e.g. 0.13.1 shipped no
+    // darwin-arm64 above Node 24 / ABI 137, so Node 25/26 fell through to a
+    // build-from-source that also failed — PHNX-2740), leaving a raw MODULE_NOT_FOUND.
+    // Fail loud with the platform/ABI and a concrete remediation instead.
     nodePty = await import('@homebridge/node-pty-prebuilt-multiarch');
     // Handle ESM default export
     if (nodePty.default?.spawn) nodePty = nodePty.default;
@@ -235,8 +280,7 @@ export async function runPtyServer(): Promise<void> {
       }
     } catch {}
   } catch (err) {
-    console.error('node-pty (@homebridge/node-pty-prebuilt-multiarch) is required for PTY support.');
-    console.error('Install: bun add @homebridge/node-pty-prebuilt-multiarch');
+    for (const line of describeNativePtyLoadFailure(err)) console.error(line);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Problem (PHNX-2740, High)

`agents pty` is silently broken on macOS/arm64. The dep
`@homebridge/node-pty-prebuilt-multiarch` was pinned at **0.13.1**, whose
darwin-arm64 prebuilds stop at **ABI 137 (Node 24)**. On a Mac running Node 25
(ABI 141) or Node 26 (ABI 147) the native binding never resolves, so every pty
command dies with a raw `MODULE_NOT_FOUND` and no actionable guidance.

Evidence — ABI coverage per version (GitHub release assets):

| version | darwin-arm64 ABIs | Node 24 (137) | Node 25 (141) | Node 26 (147) |
|---|---|:--:|:--:|:--:|
| 0.13.1 (before) | …120, 127, 131, **137** | ✅ | ❌ | ❌ |
| 0.14.1 (after)  | …131, 137, **141, 147** | ✅ | ✅ | ✅ |

(Node ABIs confirmed from `nodejs/node` `node_version.h`: v26.5.1 → 147,
v25.0.0 → 141, v24 → 137. The npm tarball bakes in **only** Linux prebuilds;
darwin/win32 are fetched at install time by the package's `prebuild-install`
postinstall — which is why it sits in `trustedDependencies`.)

## Before

From the ticket, installed 1.22.39 on mac-mini (macOS arm64, Node v26.5.1):

```
Error: PTY server failed to start within 5 seconds.
...
innerError Error: Cannot find module '../build/Debug/pty.node'
Require stack:
- .../@homebridge/node-pty-prebuilt-multiarch/lib/prebuild-loader.js
  code: 'MODULE_NOT_FOUND'
```
`prebuilds/` on that box held only `linux-*` — no darwin binary could ever resolve.

## After

1. **Bump `0.13.1` → `0.14.1`** (`cli/package.json` + `cli/bun.lock`), which ships
   darwin-arm64 (and darwin-x64) prebuilds through ABI 147 — covering Node 24/25/26.
   API is identical (same 1.x N-API base).

2. **Fail loud** — when the binding genuinely can't load, the sidecar now prints an
   actionable message instead of a bare MODULE_NOT_FOUND:

```
agents pty could not load its native terminal binding (@homebridge/node-pty-prebuilt-multiarch).
  platform: darwin-arm64   node: v26.5.1 (ABI 147)

The prebuilt binary for this platform + Node ABI is missing. On macOS/Windows
it is downloaded at install time; a Node version newer than any published
prebuild, or an install that skipped the postinstall, leaves it absent.

Fix it by reinstalling so the native binding is fetched or built:
  npm rebuild @homebridge/node-pty-prebuilt-multiarch   # rebuild for this Node
  # or reinstall the CLI:  npm i -g @phnx-labs/agents-cli
...
Underlying error:
  Error: Cannot find module '../build/Debug/pty.node'
  ...
```
This surfaces to the user via the existing PTY-server log tail in
`formatServerStartError` (the server's stderr is captured to the log file).

3. **Real load + spawn on Linux/x64 (ABI 137), verified in this worktree:**

```
prebuilds present: linux-arm  linux-arm64  linux-ia32  linux-x64
loaded, node abi 137 platform linux x64
spawn round-trip: "PTY_OK" exit 0
```

## Tests (real path, no mocks)

`cli/src/lib/__tests__/pty-server.test.ts`:
- **Hard regression guard**: on Linux the native binding *must* load and round-trip
  a real shell (`spawn → onData → onExit`) — a failure fails the suite rather than
  silently skipping (the exact silent-pass hole that hid this bug).
- Actionable-message coverage: asserts `describeNativePtyLoadFailure` names the
  platform, Node ABI, a concrete remediation, and preserves the underlying error;
  handles a non-Error thrown value.

```
Test Files  1 passed (1)
     Tests  14 passed | 1 skipped (15)   # 1 skip = the non-Linux branch
```
Full `tsc --noEmit` clean; changelog-drift test passes.

## Docs / changelog
- `cli/docs/pty.md` — new **Native binding** section (prebuild mechanics + recovery).
- `cli/.changelog/next/PHNX-2740.md` + regenerated `CHANGELOG.md`.

## Scope
Touches only `cli/package.json` (dep), `cli/bun.lock`, and `cli/src/lib/pty-server.ts`
(+ its test) and pty docs. No change to session/orphan detection or sync/repo-pull.
No behavior change on linux/x64.

Closes PHNX-2740.