### PR TITLE
fix(security): verify system-repo origin before auto-pulling hooks (PHNX-2957)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Everything here — and every other command in this README — is free and needs
 The command surface teaches setup through `agents setup` and group-level `--help`.
 The durable system model starts at [`cli/docs/README.md`](cli/docs/README.md).
 
+**What `agents setup` installs, and what auto-updates.** Setup clones a small public
+**system repo** (`phnx-labs/.agents-system`) into `~/.agents/.system/`. It ships the
+default resources — including **hooks**, which run as shell commands on tool events —
+and its checkout **fast-forwards from its origin** when you run `agents use` (and, only
+if you opt in with `AGENTS_AUTO_PULL=1`, in the background). Two safeguards bound that:
+the pull is `merge --ff-only` (it can never rewrite your local history), and it is
+**verified against the expected origin** — a checkout whose `origin` is not the canonical
+system repo (or the exact repo you named in `AGENTS_SYSTEM_REPO`) is refused, never
+pulled, so a repointed remote cannot slip hook code onto your machine. To pin or opt out:
+set `AGENTS_SYSTEM_REPO=gh:you/your-fork` to track your own audited copy, run
+`agents setup --no-system-repo` to skip the clone entirely, or check out a specific tag
+in `~/.agents/.system/` (a fast-forward only advances a moving branch, so a detached tag
+stays put).
+
 **Learn (concepts):** [Loop + graph engineering](https://agi-cli.sh/learn/loop-and-graph-engineering) · [Teams as graph engineering](https://agi-cli.sh/learn/teams-graph-engineering) · [Sessions · index + cross-device](https://agi-cli.sh/learn/sessions-index) · [Distributed fleet execution](https://agi-cli.sh/learn/distributed-fleet). Also: [harness engineering](https://agi-cli.sh/learn/harness-engineering) · [visual longform](https://share.agents-cli.sh/muqsitnawaz/agents-loop-and-graph-engineering).
 
 Already installed? `agents upgrade` updates agi-cli itself to the latest version (`agents upgrade 1.2.3` for a specific version or dist-tag, `-y` to skip the confirm prompt). The command is `upgrade` on every platform -- do not reach for `agents update`, which updates an installed **agent harness**, not agi-cli (and on macOS, `agents helper update` is a third thing: it reinstalls the keychain helper).

--- a/cli/.changelog/next/PHNX-2957.md
+++ b/cli/.changelog/next/PHNX-2957.md
@@ -1,0 +1,17 @@
+- **The auto-pulled system repo is verified against its expected origin before a
+  fast-forward — a repointed origin is refused, not executed (PHNX-2957).** The
+  system repo (`~/.agents/.system/`) ships **hooks** that register as shell
+  `command` strings run on every tool event, and its checkout auto-fast-forwards
+  from `origin` (on `agents use`, and on the opt-in `AGENTS_AUTO_PULL=1`
+  background worker). Neither path verified that `origin` was the repo the
+  operator actually chose — so an `origin` repointed to an attacker's fork (or a
+  clone seeded from one) would silently fast-forward arbitrary hook code that then
+  ran as shell on the next command. Both pull sites now route through
+  `tryAutoPullSystemRepo`, which pulls only when `origin` is the canonical system
+  repo (`isSystemRepoRemote`) or the exact `AGENTS_SYSTEM_REPO` the operator
+  pointed at; an unexpected origin is **refused loud** (`agents use` prints the
+  offending remote and the re-point/`AGENTS_SYSTEM_REPO` fix), never pulled. The
+  canonical system repo and a legitimate `AGENTS_SYSTEM_REPO` override still sync
+  exactly as before — no regression to trusted pulls. Source:
+  `cli/src/lib/git.ts` (`isExpectedSystemRepoRemote`, `tryAutoPullSystemRepo`),
+  `cli/src/commands/versions.ts`, `cli/src/lib/auto-pull-worker.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -198,6 +198,17 @@ own redirect makes that resolve fine, so there is no forced cutover — and both
 names are recognized as the system origin everywhere a remote is compared, via
 `isSystemRepoRemote` in [`src/lib/git.ts`](src/lib/git.ts).
 
+**The system repo ships hooks that run as shell, so its auto-pull is
+origin-verified (PHNX-2957).** Both fast-forward paths — `agents use`
+(foreground) and the opt-in `AGENTS_AUTO_PULL=1` background worker — route
+through `tryAutoPullSystemRepo`, which pulls **only** when `origin` passes
+`isExpectedSystemRepoRemote`: the canonical `isSystemRepoRemote`, or the exact
+`AGENTS_SYSTEM_REPO` the operator pointed at. A repointed/unexpected origin is
+**refused** (never fast-forwarded), since a pull from an attacker's fork would be
+remote code execution on the next command that loads a system hook. Never widen a
+system-repo pull to bypass this guard; a legitimate alternate upstream is
+expressed through `AGENTS_SYSTEM_REPO`, not an unverified pull.
+
 Extra repos register via `agents repo add <source>` → clone into `~/.agents-<alias>/`
 and participate after the user repo. The companion extras repo
 `phnx-labs/.agents-extras` keeps its name but is now **private and opt-in**: it is

--- a/cli/src/commands/versions.ts
+++ b/cli/src/commands/versions.ts
@@ -85,7 +85,7 @@ import {
   switchHomeFileSymlinks,
 } from '../lib/installations/shims.js';
 import { isInteractiveTerminal, isPromptCancelled, requireInteractiveSelection } from './utils.js';
-import { tryAutoPull } from '../lib/git.js';
+import { tryAutoPullSystemRepo } from '../lib/git.js';
 import { getAgentsDir, getTrashVersionsDir } from '../lib/state.js';
 import { setHelpSections } from '../lib/help.js';
 import { updateSessionFilePaths } from '../lib/session/db.js';
@@ -765,10 +765,25 @@ export function registerVersionsCommands(program: Command): void {
   useCmd.action(async (agentArg: string, versionArg: string | undefined, options) => {
       try {
         const skipPrompts = options.yes || !isInteractiveTerminal();
-        // Auto-pull ~/.agents/.system if it's a git repo with remote (silent on success)
+        // Auto-pull ~/.agents/.system if it's a git repo tracking the EXPECTED
+        // system remote (silent on success). The system repo ships hooks that run
+        // as shell on tool events, so pulling from a repointed origin would be
+        // remote code execution — tryAutoPullSystemRepo refuses that (PHNX-2957).
         const agentsDir = getAgentsDir();
-        const pullResult = await tryAutoPull(agentsDir);
-        if (pullResult.pulled) {
+        const pullResult = await tryAutoPullSystemRepo(agentsDir);
+        if (pullResult.refused) {
+          console.error(
+            chalk.red(
+              `Refusing to auto-sync ~/.agents/.system: its origin (${pullResult.actualRemote}) is not the expected system repo.`,
+            ),
+          );
+          console.error(
+            chalk.gray(
+              'The system repo ships hooks that run on tool events; a fast-forward from an unexpected origin is not applied. ' +
+                'Re-point it (git -C ~/.agents/.system remote set-url origin <expected>) or set AGENTS_SYSTEM_REPO, then re-run `agents setup --force`.',
+            ),
+          );
+        } else if (pullResult.pulled) {
           console.log(chalk.gray('Synced ~/.agents/.system from remote'));
         }
 

--- a/cli/src/lib/auto-pull-worker.ts
+++ b/cli/src/lib/auto-pull-worker.ts
@@ -12,7 +12,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { simpleGit } from 'simple-git';
-import { tryAutoPull, isGitRepo } from './git.js';
+import { tryAutoPullSystemRepo, isGitRepo } from './git.js';
 import {
   getSystemAgentsDir,
   getUserAgentsDir,
@@ -114,7 +114,12 @@ async function processTarget(target: RepoTarget): Promise<void> {
         // by a detached worker.
         await notifyRepo(target);
       } else {
-        await tryAutoPull(target.dir);
+        // Verify origin is the EXPECTED system remote before fast-forwarding —
+        // the system repo ships hooks that run as shell, so a pull from a
+        // repointed origin is RCE. An unexpected origin is refused, not pulled
+        // (PHNX-2957). The detached worker has no terminal to warn on; the
+        // foreground `agents use` path surfaces the refusal to the operator.
+        await tryAutoPullSystemRepo(target.dir);
       }
     } else {
       await notifyRepo(target);

--- a/cli/src/lib/git.test.ts
+++ b/cli/src/lib/git.test.ts
@@ -21,9 +21,11 @@ import {
   commitAndPush,
   commitsBehindUpstream,
   displayHomePath,
+  isExpectedSystemRepoRemote,
   isSystemRepoOrigin,
   isSystemRepoRemote,
   parseSource,
+  tryAutoPullSystemRepo,
   pullRepo,
   pushOrigin,
   resolveGitHubUsername,
@@ -1204,5 +1206,137 @@ describe('pullRepo strict mode (default-branch-fast-forward)', () => {
     // The error names the current branch and the expected default branch.
     expect(res.error).toMatch(/feature\/x/i);
     expect(res.error).toMatch(/main/i);
+  });
+});
+
+// PHNX-2957: the system repo ships hooks that run as shell on tool events and
+// its checkout auto-fast-forwards from origin — so a pull from an unexpected /
+// repointed origin is remote code execution. isExpectedSystemRepoRemote is the
+// pinning predicate; tryAutoPullSystemRepo is the gated pull.
+describe('isExpectedSystemRepoRemote', () => {
+  const SAVED = process.env.AGENTS_SYSTEM_REPO;
+  afterEach(() => {
+    if (SAVED === undefined) delete process.env.AGENTS_SYSTEM_REPO;
+    else process.env.AGENTS_SYSTEM_REPO = SAVED;
+  });
+
+  it('accepts the canonical system repo and its rename target when no override is set', () => {
+    delete process.env.AGENTS_SYSTEM_REPO;
+    expect(isExpectedSystemRepoRemote('https://github.com/phnx-labs/.agents-system.git')).toBe(true);
+    expect(isExpectedSystemRepoRemote('git@github.com:phnx-labs/.agents-system.git')).toBe(true);
+    // The GitHub rename target folds onto the same repo.
+    expect(isExpectedSystemRepoRemote('https://github.com/phnx-labs/.agents.git')).toBe(true);
+  });
+
+  it('rejects an unexpected / repointed origin, and null', () => {
+    delete process.env.AGENTS_SYSTEM_REPO;
+    expect(isExpectedSystemRepoRemote('https://github.com/attacker/evil.git')).toBe(false);
+    expect(isExpectedSystemRepoRemote('git@github.com:someone/.agents-system-fork.git')).toBe(false);
+    expect(isExpectedSystemRepoRemote(null)).toBe(false);
+    expect(isExpectedSystemRepoRemote(undefined)).toBe(false);
+    expect(isExpectedSystemRepoRemote('')).toBe(false);
+  });
+
+  it('honours an AGENTS_SYSTEM_REPO override and then rejects the default', () => {
+    process.env.AGENTS_SYSTEM_REPO = 'gh:acme/dotagents';
+    expect(isExpectedSystemRepoRemote('https://github.com/acme/dotagents.git')).toBe(true);
+    expect(isExpectedSystemRepoRemote('git@github.com:acme/dotagents.git')).toBe(true);
+    // With the operator pointed elsewhere, the canonical default is no longer
+    // the expected origin.
+    expect(isExpectedSystemRepoRemote('https://github.com/phnx-labs/.agents-system.git')).toBe(false);
+  });
+});
+
+describe('tryAutoPullSystemRepo', () => {
+  let root: string;
+  let remote: string; // bare origin
+  let local: string; // the ~/.agents/.system checkout under test
+  let author: string; // a second clone that pushes upstream commits
+  const SAVED = process.env.AGENTS_SYSTEM_REPO;
+
+  async function configIdentity(dir: string): Promise<void> {
+    const g = simpleGit(dir);
+    await g.addConfig('user.email', 'test@example.com');
+    await g.addConfig('user.name', 'Test');
+    await g.addConfig('commit.gpgsign', 'false');
+    await g.addConfig('core.autocrlf', 'false');
+  }
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'sysrepo-pull-'));
+    remote = path.join(root, 'remote.git');
+    local = path.join(root, 'system');
+    author = path.join(root, 'author');
+
+    await simpleGit().raw(['init', '--bare', '-b', 'main', remote]);
+    await simpleGit().clone(remote, author);
+    await configIdentity(author);
+    fs.writeFileSync(path.join(author, '.gitattributes'), '* -text\n');
+    fs.writeFileSync(path.join(author, 'hooks.yaml'), 'v1\n');
+    await simpleGit(author).add('-A');
+    await simpleGit(author).commit('init');
+    await simpleGit(author).push('origin', 'main');
+
+    await simpleGit().clone(remote, local);
+    await configIdentity(local);
+  });
+
+  afterEach(() => {
+    if (SAVED === undefined) delete process.env.AGENTS_SYSTEM_REPO;
+    else process.env.AGENTS_SYSTEM_REPO = SAVED;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('REFUSES a fast-forward when origin is not the expected system remote', async () => {
+    // No override: the local bare remote is not the canonical system repo.
+    delete process.env.AGENTS_SYSTEM_REPO;
+
+    // Upstream advances — a malicious hook change would ride this commit.
+    fs.writeFileSync(path.join(author, 'hooks.yaml'), 'v2-EVIL\n');
+    await simpleGit(author).add('-A');
+    await simpleGit(author).commit('upstream change');
+    await simpleGit(author).push('origin', 'main');
+
+    const res = await tryAutoPullSystemRepo(local);
+
+    expect(res.refused).toBe(true);
+    expect(res.pulled).toBe(false);
+    expect(res.actualRemote).toBe(remote);
+    // The unexpected upstream content was NOT applied.
+    expect(fs.readFileSync(path.join(local, 'hooks.yaml'), 'utf8')).toBe('v1\n');
+  });
+
+  it('fast-forwards cleanly when origin matches AGENTS_SYSTEM_REPO', async () => {
+    // Operator pointed the system repo at this remote — a legit trusted pull.
+    process.env.AGENTS_SYSTEM_REPO = remote;
+
+    fs.writeFileSync(path.join(author, 'hooks.yaml'), 'v2\n');
+    await simpleGit(author).add('-A');
+    await simpleGit(author).commit('upstream change');
+    await simpleGit(author).push('origin', 'main');
+
+    const res = await tryAutoPullSystemRepo(local);
+
+    expect(res.refused).toBeFalsy();
+    expect(res.pulled).toBe(true);
+    expect(fs.readFileSync(path.join(local, 'hooks.yaml'), 'utf8')).toBe('v2\n');
+  });
+
+  it('is a plain no-op (not a refusal) when the checkout has no origin', async () => {
+    delete process.env.AGENTS_SYSTEM_REPO;
+    await simpleGit(local).removeRemote('origin');
+
+    const res = await tryAutoPullSystemRepo(local);
+
+    expect(res.pulled).toBe(false);
+    expect(res.refused).toBeFalsy();
+  });
+
+  it('returns pulled:false for a non-git directory', async () => {
+    const plain = path.join(root, 'not-a-repo');
+    fs.mkdirSync(plain);
+    const res = await tryAutoPullSystemRepo(plain);
+    expect(res.pulled).toBe(false);
+    expect(res.refused).toBeFalsy();
   });
 });

--- a/cli/src/lib/git.ts
+++ b/cli/src/lib/git.ts
@@ -622,6 +622,35 @@ export function isSystemRepoRemote(remote: string | null | undefined): boolean {
   return c === canonicalGitRemote(`https://github.com/${systemRepoSlug(DEFAULT_SYSTEM_REPO)}`);
 }
 
+/**
+ * True when `remote` is the origin the system repo is EXPECTED to track on this
+ * machine, honouring an operator's `AGENTS_SYSTEM_REPO` override.
+ *
+ * The system repo ships hooks that register as shell `command` strings run on
+ * every tool event, and its checkout auto-fast-forwards from origin — so a
+ * fast-forward from an origin the operator never chose is remote code execution
+ * on the next command that loads a system resource (PHNX-2957). This is the
+ * pinning predicate every auto-pull of the system repo gates on: pull only when
+ * origin is the canonical {@link isSystemRepoRemote} repo, or the exact
+ * `AGENTS_SYSTEM_REPO` the operator pointed at instead. Anything else — a
+ * repointed origin, a fork, an unset-then-swapped remote — is refused, not
+ * pulled. Pure string check; no git spawn.
+ */
+export function isExpectedSystemRepoRemote(remote: string | null | undefined): boolean {
+  if (!remote) return false;
+  const override = process.env.AGENTS_SYSTEM_REPO?.trim();
+  if (override) {
+    // The override is a source spec (`gh:owner/repo`) or a full clone URL. Match
+    // the GitHub-slug form the setup path clones, and the raw spec itself, so a
+    // non-GitHub override URL still verifies.
+    return (
+      sameGitRemote(remote, `https://github.com/${systemRepoSlug(override)}`) ||
+      sameGitRemote(remote, override.replace(/^gh:/, ''))
+    );
+  }
+  return isSystemRepoRemote(remote);
+}
+
 /** True when two git remote URLs point at the same repo across transport forms. */
 export function sameGitRemote(a: string | null | undefined, b: string | null | undefined): boolean {
   if (!a || !b) return false;
@@ -1935,6 +1964,50 @@ export async function tryAutoPull(dir: string): Promise<{ pulled: boolean; error
   } catch (err) {
     return { pulled: false, error: (err as Error).message };
   }
+}
+
+/** Result of {@link tryAutoPullSystemRepo}. `refused` is set only when the pull
+ *  was blocked because origin is not the expected system remote. */
+export interface SystemRepoPullResult {
+  pulled: boolean;
+  error?: string;
+  /** True when origin is present but is NOT the expected system remote; no
+   *  fast-forward was attempted. `actualRemote` names what was found. */
+  refused?: boolean;
+  /** The origin fetch URL that was examined (present when a remote exists). */
+  actualRemote?: string;
+}
+
+/**
+ * Auto-pull the system repo ONLY after verifying its origin is the expected
+ * system remote (PHNX-2957). The system repo ships hooks that run as shell on
+ * tool events, so fast-forwarding it from an unexpected/repointed origin is
+ * remote code execution. An origin that fails {@link isExpectedSystemRepoRemote}
+ * is REFUSED loud (`refused: true`), never pulled — the canonical system repo
+ * (or an operator's `AGENTS_SYSTEM_REPO`) still fast-forwards exactly as before.
+ *
+ * A system dir with no origin at all is a plain no-op (`pulled: false`), not a
+ * refusal — there is nothing to pull from and nothing to distrust.
+ */
+export async function tryAutoPullSystemRepo(dir: string): Promise<SystemRepoPullResult> {
+  if (!isGitRepo(dir)) return { pulled: false };
+
+  let remote: string | undefined;
+  try {
+    const git = simpleGit(dir);
+    const remotes = await git.getRemotes(true);
+    remote = remotes.find(r => r.name === 'origin')?.refs?.fetch;
+  } catch {
+    return { pulled: false };
+  }
+
+  if (!remote) return { pulled: false };
+  if (!isExpectedSystemRepoRemote(remote)) {
+    return { pulled: false, refused: true, actualRemote: remote };
+  }
+
+  const res = await tryAutoPull(dir);
+  return { ...res, actualRemote: remote };
 }
 
 /**


### PR DESCRIPTION
## What & why

The system repo (`~/.agents/.system/`) ships **hooks** that register as shell `command` strings run on every tool event (`cli/src/lib/hooks/install.ts`), and its checkout **auto-fast-forwards from `origin`** on `agents use` (foreground, always on) and on the opt-in `AGENTS_AUTO_PULL=1` background worker. Neither path verified that `origin` was the repo the operator actually chose — so an `origin` repointed to an attacker's fork (or a clone seeded from one) would silently fast-forward arbitrary hook code that then ran as shell on the next command. Supply-chain / RCE hardening + disclosure gap flagged in the pre-launch security review (PHNX-2957).

## Fix

- **`isExpectedSystemRepoRemote(remote)`** (`cli/src/lib/git.ts`) — the pinning predicate: origin must be the canonical system repo (`isSystemRepoRemote`, incl. the `.agents` rename target) **or** the exact `AGENTS_SYSTEM_REPO` the operator pointed at. Pure string check.
- **`tryAutoPullSystemRepo(dir)`** (`cli/src/lib/git.ts`) — reads origin, refuses (`refused: true`, no fast-forward) when it isn't expected; a system dir with no origin is a plain no-op, not a refusal.
- Both system-repo pull sites now route through it: `cli/src/commands/versions.ts` (`agents use`, which now prints a loud red refusal naming the offending remote + the re-point/`AGENTS_SYSTEM_REPO` fix) and `cli/src/lib/auto-pull-worker.ts`.
- **No regression to trusted pulls:** the canonical system repo and a legitimate `AGENTS_SYSTEM_REPO` override still fast-forward exactly as before.
- Docs: README auto-pull/hooks disclosure with pin/opt-out guidance, `cli/AGENTS.md` guard note, CHANGELOG fragment.

## Before / after (real command output)

Repro: a local "system" clone whose upstream advances with a malicious hook edit, pulled two ways against the built `dist/`.

**BEFORE** — the old generic `tryAutoPull` (no origin verification) pulls the malicious change:
```
BEFORE (tryAutoPull): pulled=true  hooks.yaml now = "v2-MALICIOUS"
```

**AFTER** — the gated `tryAutoPullSystemRepo` refuses the unexpected origin; content stays put:
```
AFTER  (guarded)      : pulled=false refused=true  hooks.yaml now = "v1"
```

## Tests (real git, no mocks)

`cli/src/lib/git.test.ts` — 7 new tests, all green:
- `isExpectedSystemRepoRemote`: accepts canonical + rename target, rejects unexpected/null, honours `AGENTS_SYSTEM_REPO` override (and then rejects the default).
- `tryAutoPullSystemRepo` against real bare-remote clones: **refuses** an unexpected origin with HEAD/content unchanged; **fast-forwards cleanly** when origin matches `AGENTS_SYSTEM_REPO`; no-origin and non-git dirs are plain no-ops.

```
Test Files  2 passed (2)
     Tests  101 passed (101)   # git.test.ts + auto-pull.test.ts
```

`bun run build` (tsc) clean.

## Ticket
PHNX-2957

🤖 Generated with [Claude Code](https://claude.com/claude-code)