### PR TITLE
PHNX-3382: Validate Rush Cloud session expiry

### DIFF
--- a/cli/.changelog/next/PHNX-3382.md
+++ b/cli/.changelog/next/PHNX-3382.md
@@ -1,0 +1,1 @@
+Rush Cloud now reports unavailable when its saved session is expired or has no expiry.

--- a/cli/src/lib/cloud/rush.test.ts
+++ b/cli/src/lib/cloud/rush.test.ts
@@ -7,20 +7,58 @@ import { MAX_IMAGES_PER_DISPATCH, normalizeProviderStatus } from './types.js';
 import type { ImageAttachment, SkillRef } from './types.js';
 
 let tmpDir: string;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rush-cloud-test-'));
+  process.env.HOME = tmpDir;
+  process.env.USERPROFILE = tmpDir;
 });
 
 afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
 });
+
+function writeRushSession(expiresAt?: number): void {
+  const rushDir = path.join(tmpDir, '.rush');
+  fs.mkdirSync(rushDir, { recursive: true });
+  const expiry = expiresAt === undefined ? '' : `  expires_at: ${expiresAt}\n`;
+  fs.writeFileSync(
+    path.join(rushDir, 'user.yaml'),
+    `session:\n  access_token: test-token\n${expiry}`,
+  );
+}
 
 describe('Rush status normalization', () => {
   it('maps stopped-but-resumable Factory Floor states to idle', () => {
     expect(normalizeProviderStatus('rush', 'idle')).toBe('idle');
     expect(normalizeProviderStatus('rush', 'paused')).toBe('idle');
     expect(normalizeProviderStatus('rush', 'needs_review')).toBe('idle');
+  });
+});
+
+describe('Rush capabilities', () => {
+  it('is unavailable when the session has expired', () => {
+    writeRushSession(Date.now() - 60_000);
+
+    expect(new RushCloudProvider().capabilities().available).toBe(false);
+  });
+
+  it('is unavailable when the session has no expiry', () => {
+    writeRushSession();
+
+    expect(new RushCloudProvider().capabilities().available).toBe(false);
+  });
+
+  it('is available when the session expiry is in the future', () => {
+    writeRushSession(Date.now() + 60_000);
+
+    expect(new RushCloudProvider().capabilities().available).toBe(true);
   });
 });
 

--- a/cli/src/lib/cloud/rush.ts
+++ b/cli/src/lib/cloud/rush.ts
@@ -27,7 +27,9 @@ import { getAccountInfo } from '../agents.js';
 import { selectBalancedVersion } from '../accounting/rotate.js';
 
 const PROXY_BASE = process.env.RUSH_PROXY_BASE ?? 'https://api.prix.dev';
-const USER_YAML = path.join(os.homedir(), '.rush', 'user.yaml');
+function userYamlPath(): string {
+  return path.join(os.homedir(), '.rush', 'user.yaml');
+}
 
 // Native OAuth/session credentials never cross the cloud boundary. A server
 // token request fails loud rather than materializing a harness login (see dispatch()).
@@ -48,12 +50,24 @@ interface Installation {
   repository_selection?: string;
 }
 
+/** Read the Rush session from ~/.rush/user.yaml, if it is parseable. */
+function readSession(): UserYaml['session'] | undefined {
+  try {
+    const raw = fs.readFileSync(userYamlPath(), 'utf-8');
+    const data = yaml.parse(raw) as UserYaml;
+    return data?.session;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Read the Rush session access token from ~/.rush/user.yaml. */
 function readToken(): string {
-  if (!fs.existsSync(USER_YAML)) {
+  const file = userYamlPath();
+  if (!fs.existsSync(file)) {
     throw new Error('Not logged in to Rush. Run `rush login` first.');
   }
-  const raw = fs.readFileSync(USER_YAML, 'utf-8');
+  const raw = fs.readFileSync(file, 'utf-8');
   const data = yaml.parse(raw) as UserYaml;
   const token = data?.session?.access_token;
   if (!token) {
@@ -64,13 +78,7 @@ function readToken(): string {
 
 /** Read the user's email from the Rush session config, if available. */
 function readEmail(): string | undefined {
-  try {
-    const raw = fs.readFileSync(USER_YAML, 'utf-8');
-    const data = yaml.parse(raw) as UserYaml;
-    return data?.session?.email;
-  } catch {
-    return undefined;
-  }
+  return readSession()?.email;
 }
 
 /** Make an authenticated request to the Rush API proxy. */
@@ -286,8 +294,13 @@ export class RushCloudProvider implements CloudProvider {
   name = 'Rush Cloud';
 
   capabilities(): ProviderCapabilities {
+    const session = readSession();
     return {
-      available: fs.existsSync(USER_YAML),
+      available: Boolean(
+        session?.access_token
+        && typeof session.expires_at === 'number'
+        && session.expires_at > Date.now()
+      ),
       dispatch: true,
       status: true,
       list: true,


### PR DESCRIPTION
## Summary
- fail closed when the Rush session is expired or omits `expires_at`
- exercise expired, absent-expiry, and future-expiry sessions through real temporary `user.yaml` files
- add the PHNX-3382 changelog fragment

Scope: PHNX-3382 item 1 only. Item 2 operational login work remains out of scope.

## Verification

```text
$ bun run test src/lib/cloud/rush.test.ts
Test Files  1 passed (1)
Tests  24 passed (24)
Duration  2.80s
```