### PR TITLE
feat(devices): honor auto-launch enable/disable/prefer in --device auto placement (PHNX-2092)

### DIFF
--- a/cli/.changelog/next/PHNX-2092.md
+++ b/cli/.changelog/next/PHNX-2092.md
@@ -1,0 +1,15 @@
+- **`agents devices disable/prefer` now actually change `--device auto` placement (PHNX-2092).**
+  The per-device `auto-launch.enabled` / `auto-launch.preferred` flags (written by
+  `agents devices disable/enable` and `prefer/unprefer`, and by `agents devices config
+  <name> auto-launch.*`) were stored and synced but never consulted by the CLI's one
+  placement path, so a disabled box was still picked and a preferred box got no boost.
+  They now feed the single automatic-placement rule: `filterAutoPool` drops any device
+  with `auto-launch.enabled` = false from EVERY auto path (`run`, `teams`, `ssh auto`,
+  the AGI EXT launch commands, which resolve placement through the CLI) exactly as a
+  `personal`/`desktop` role does, and `pickBestDevice` ranks an `auto-launch.preferred`
+  device ahead of its load-equal peers — after the signed-in tier, before load, so an
+  operator boost overrides load-based ordering without overriding hard health. A
+  fleet-wide default (`--fleet`) reaches doc-less devices via the candidate roster. No
+  second placement path was added — the existing `filterAutoPool`/`pickBestDevice`
+  rule was extended. Source: `cli/src/lib/devices/pool.ts`,
+  `cli/src/lib/teams/scheduler.ts`, `cli/src/lib/smart-launch.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -677,6 +677,25 @@ list` folds the `★ interactive` star INTO the `personal` role rather than
 printing both (the star still shows for a non-personal box pinned as
 `interactive.host`).
 
+`auto-launch.enabled` / `auto-launch.preferred` are the per-device switches that
+modulate that SAME `filterAutoPool` pool — one placement rule, not a second one.
+`agents devices disable <name>` sets `auto-launch.enabled` = false and drops the
+box from the pool the same way a `personal`/`desktop` role does, so it leaves
+EVERY automatic-placement path (`run`, `teams`, `ssh auto`, the AGI EXT launch
+commands) at once; `agents devices enable <name>` (the default) restores it.
+`agents devices prefer <name>` sets `auto-launch.preferred` = true, which does NOT
+narrow the pool — it BOOSTS the box in the ranker: `autoLaunchPreferredSet`
+(`pool.ts`) feeds `pickBestDevice` (`teams/scheduler.ts`), which ranks a preferred
+device ahead of its load-equal peers, after the signed-in tier and before load, so
+the boost overrides load-based ordering without overriding hard health;
+`agents devices unprefer <name>` removes it. Both flags are **shared** device-scope
+keys living in `devices/<name>/agents.yaml` `config.autoLaunch{Enabled,Preferred}`
+(a fleet-wide default rides `fleet.defaults.config`, set with `--fleet`), so they
+sync with `agents repo push/pull`. The four verbs are task-shaped forwarding
+spellings for `agents devices config <name> auto-launch.{enabled,preferred}
+<on|off>` — the one canonical per-device settings surface — so they print a
+deprecation-style "running that for you" notice and defer to it.
+
 `devices.<name>.description` (stored as `description`) is the free-text sibling
 of `role`: one line saying what the box is FOR — "gpu box — cuda 12.4", "release
 runner" — where `role` is the two-value placement switch. Like `role` it is

--- a/cli/src/lib/device-config.ts
+++ b/cli/src/lib/device-config.ts
@@ -373,7 +373,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     visibility: 'shared',
     type: 'bool',
     defaultValue: true,
-    description: 'Whether AGI EXT auto-launch may pick this device (default on).',
+    description: 'Whether `--device auto` (run, teams, AGI EXT) may pick this device (default on). Off drops it from every automatic-placement path.',
   },
   {
     name: 'auto-launch.preferred',
@@ -382,7 +382,7 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     visibility: 'shared',
     type: 'bool',
     defaultValue: false,
-    description: 'Boost this device in AGI EXT auto-launch ranking (default off).',
+    description: 'Boost this device in `--device auto` ranking (default off) — picked ahead of load-equal peers when eligible.',
   },
 ];
 
@@ -835,7 +835,11 @@ export function autoPoolMode(): AutoPoolMode {
 
 // ─── Auto-launch preferences (Factory auto-host selection) ────────────────────
 
-/** A device's auto-launch flags, as read by Factory's launch ranking. */
+/**
+ * A device's auto-launch flags, read by the automatic-placement pool
+ * (`filterAutoPool` drops `enabled: false`; `pickBestDevice` boosts
+ * `preferred: true` — see `lib/devices/pool.ts`) and by the menu-bar snapshot.
+ */
 export interface AutoLaunchPreference {
   enabled?: boolean;
   preferred?: boolean;

--- a/cli/src/lib/devices/pool.test.ts
+++ b/cli/src/lib/devices/pool.test.ts
@@ -3,56 +3,90 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { filterAutoPool, isAutoPoolMember, listWorkerDevices, describeAutoPool } from './pool.js';
+import { filterAutoPool, isAutoPoolMember, listWorkerDevices, describeAutoPool, autoLaunchPreferredSet } from './pool.js';
 
 // The pure rule (roles + mode injected) is exercised directly; the stored-config
 // path re-imports against a throwaway HOME so it reads a REAL agents.yaml, the
-// same pattern device-config.test.ts uses. No mocks either way.
+// same pattern device-config.test.ts uses. No mocks either way. The pure calls
+// inject `autoLaunch: {}` alongside `roles` so neither role nor auto-launch rule
+// touches disk.
 
 const FLEET = ['zion', 'yosemite-s0', 'yosemite-s1', 'mac-mini', 'iphone'];
 
 describe('filterAutoPool (the allowlist rule)', () => {
   it('leaves the pool untouched when nothing is marked', () => {
-    expect(filterAutoPool(FLEET, { mode: 'workers', roles: {} })).toEqual(FLEET);
+    expect(filterAutoPool(FLEET, { mode: 'workers', roles: {}, autoLaunch: {} })).toEqual(FLEET);
   });
 
   it('narrows to the marked workers once ANY device is marked worker', () => {
     const roles = { 'yosemite-s0': 'worker', 'yosemite-s1': 'worker' } as const;
-    expect(filterAutoPool(FLEET, { mode: 'workers', roles })).toEqual(['yosemite-s0', 'yosemite-s1']);
+    expect(filterAutoPool(FLEET, { mode: 'workers', roles, autoLaunch: {} })).toEqual(['yosemite-s0', 'yosemite-s1']);
   });
 
   it('never picks a personal device, even with no worker marked', () => {
     const roles = { zion: 'personal' } as const;
-    expect(filterAutoPool(FLEET, { mode: 'workers', roles })).toEqual(['yosemite-s0', 'yosemite-s1', 'mac-mini', 'iphone']);
+    expect(filterAutoPool(FLEET, { mode: 'workers', roles, autoLaunch: {} })).toEqual(['yosemite-s0', 'yosemite-s1', 'mac-mini', 'iphone']);
   });
 
   it('never picks a desktop device — the headed release/credential box is off-limits too', () => {
     const roles = { 'mac-mini': 'desktop' } as const;
-    expect(filterAutoPool(FLEET, { mode: 'workers', roles })).toEqual(['zion', 'yosemite-s0', 'yosemite-s1', 'iphone']);
+    expect(filterAutoPool(FLEET, { mode: 'workers', roles, autoLaunch: {} })).toEqual(['zion', 'yosemite-s0', 'yosemite-s1', 'iphone']);
   });
 
   it('auto.pool=all drops the worker allowlist but keeps personal AND desktop out', () => {
     const roles = { 'yosemite-s0': 'worker', zion: 'personal', 'mac-mini': 'desktop' } as const;
-    expect(filterAutoPool(FLEET, { mode: 'all', roles })).toEqual(['yosemite-s0', 'yosemite-s1', 'iphone']);
+    expect(filterAutoPool(FLEET, { mode: 'all', roles, autoLaunch: {} })).toEqual(['yosemite-s0', 'yosemite-s1', 'iphone']);
+  });
+
+  it('drops a device the operator disabled (auto-launch.enabled = false), whatever the mode', () => {
+    // `agents devices disable zion` removes it from EVERY auto path — here even
+    // with no worker mark and even under auto.pool=all.
+    const autoLaunch = { zion: { enabled: false } };
+    expect(filterAutoPool(FLEET, { mode: 'workers', roles: {}, autoLaunch })).toEqual(['yosemite-s0', 'yosemite-s1', 'mac-mini', 'iphone']);
+    expect(filterAutoPool(FLEET, { mode: 'all', roles: {}, autoLaunch })).toEqual(['yosemite-s0', 'yosemite-s1', 'mac-mini', 'iphone']);
+  });
+
+  it('a disabled worker is dropped even though it carries the worker mark', () => {
+    // disable wins over the allowlist: a worker turned off is not a candidate.
+    const roles = { 'yosemite-s0': 'worker', 'yosemite-s1': 'worker' } as const;
+    const autoLaunch = { 'yosemite-s0': { enabled: false } };
+    expect(filterAutoPool(FLEET, { mode: 'workers', roles, autoLaunch })).toEqual(['yosemite-s1']);
+  });
+
+  it('preferred does NOT narrow the pool — it only boosts ranking', () => {
+    // A preference is a rank hint, never an exclusion; every device stays.
+    const autoLaunch = { 'mac-mini': { preferred: true } };
+    expect(filterAutoPool(FLEET, { mode: 'workers', roles: {}, autoLaunch })).toEqual(FLEET);
+  });
+
+  it('disable matches by normalized name, so an FQDN candidate is still dropped', () => {
+    const autoLaunch = { zion: { enabled: false } };
+    expect(filterAutoPool(['ZION', 'mac-mini'], { mode: 'workers', roles: {}, autoLaunch })).toEqual(['mac-mini']);
   });
 
   it('returns empty rather than widening back to the fleet when no worker is a candidate', () => {
     // Both marked workers are offline, so neither is in the candidate list. The
     // caller must fail loud; silently re-adding the laptop is the bug this pins.
     const roles = { 'yosemite-s0': 'worker', 'yosemite-s1': 'worker' } as const;
-    expect(filterAutoPool(['zion', 'mac-mini'], { mode: 'workers', roles })).toEqual([]);
+    expect(filterAutoPool(['zion', 'mac-mini'], { mode: 'workers', roles, autoLaunch: {} })).toEqual([]);
   });
 
   it('matches hosts by normalized name, so an FQDN candidate still resolves', () => {
     const roles = { 'yosemite-s0': 'worker' } as const;
-    expect(filterAutoPool(['YOSEMITE-S0', 'zion'], { mode: 'workers', roles })).toEqual(['YOSEMITE-S0']);
+    expect(filterAutoPool(['YOSEMITE-S0', 'zion'], { mode: 'workers', roles, autoLaunch: {} })).toEqual(['YOSEMITE-S0']);
   });
 
   it('isAutoPoolMember answers for one host', () => {
     const roles = { 'yosemite-s0': 'worker', zion: 'personal' } as const;
-    expect(isAutoPoolMember('yosemite-s0', { mode: 'workers', roles })).toBe(true);
-    expect(isAutoPoolMember('zion', { mode: 'workers', roles })).toBe(false);
-    expect(isAutoPoolMember('mac-mini', { mode: 'workers', roles })).toBe(false);
+    expect(isAutoPoolMember('yosemite-s0', { mode: 'workers', roles, autoLaunch: {} })).toBe(true);
+    expect(isAutoPoolMember('zion', { mode: 'workers', roles, autoLaunch: {} })).toBe(false);
+    expect(isAutoPoolMember('mac-mini', { mode: 'workers', roles, autoLaunch: {} })).toBe(false);
+  });
+
+  it('isAutoPoolMember answers false for a disabled host', () => {
+    const autoLaunch = { 'yosemite-s0': { enabled: false } };
+    expect(isAutoPoolMember('yosemite-s0', { mode: 'all', roles: {}, autoLaunch })).toBe(false);
+    expect(isAutoPoolMember('yosemite-s1', { mode: 'all', roles: {}, autoLaunch })).toBe(true);
   });
 
   it('describeAutoPool names the workers, and says when the mark is being ignored', () => {
@@ -65,6 +99,15 @@ describe('filterAutoPool (the allowlist rule)', () => {
   it('listWorkerDevices returns only the worker marks', () => {
     const roles = { 'yosemite-s0': 'worker', zion: 'personal' } as const;
     expect(listWorkerDevices({ roles })).toEqual(['yosemite-s0']);
+  });
+
+  it('autoLaunchPreferredSet returns the boosted hosts, normalized', () => {
+    const autoLaunch = { 'mac-mini': { preferred: true }, zion: { enabled: false } };
+    const preferred = autoLaunchPreferredSet(['MAC-MINI', 'zion'], { autoLaunch });
+    expect(preferred.has('mac-mini')).toBe(true);
+    // A disabled-but-not-preferred device is not in the preferred set.
+    expect(preferred.has('zion')).toBe(false);
+    expect(preferred.size).toBe(1);
   });
 });
 
@@ -184,5 +227,34 @@ describe('roles read from the per-device docs', () => {
   it('rejects an auto.pool mode outside the vocabulary', async () => {
     const mod = await freshPool();
     expect(() => mod.setConfigValue('auto.pool', 'some')).toThrow(/workers \| all/);
+  });
+
+  it('`devices disable` (auto-launch.enabled off) drops the box from the pool on the next read', async () => {
+    // The acceptance path: `agents devices disable zion` removes zion from
+    // candidates. `setAutoLaunchEnabled(false)` is exactly what the CLI verb writes.
+    const mod = await freshPool();
+    mod.setAutoLaunchEnabled('zion', false);
+    expect(mod.isAutoLaunchEnabled('zion')).toBe(false);
+    expect(mod.filterAutoPool(FLEET)).toEqual(['yosemite-s0', 'yosemite-s1', 'mac-mini', 'iphone']);
+    // Re-enabling restores it.
+    mod.setAutoLaunchEnabled('zion', true);
+    expect(mod.filterAutoPool(FLEET)).toEqual(FLEET);
+  });
+
+  it('`devices prefer` (auto-launch.preferred on) surfaces in the preferred set, without narrowing the pool', async () => {
+    // `agents devices prefer mac-mini` boosts ranking — it never drops a box.
+    const mod = await freshPool();
+    mod.setAutoLaunchPreferred('mac-mini', true);
+    expect(mod.isAutoLaunchPreferred('mac-mini')).toBe(true);
+    expect(mod.autoLaunchPreferredSet(FLEET).has('mac-mini')).toBe(true);
+    expect(mod.filterAutoPool(FLEET)).toEqual(FLEET);
+  });
+
+  it('a fleet-default disable reaches a doc-less device via the candidate roster', async () => {
+    const mod = await freshPool();
+    mod.setConfigValue('auto-launch.enabled', false, { fleet: true });
+    // No device has a doc; filterAutoPool passes its pool as the roster, so the
+    // fleet-wide disable empties the whole fleet.
+    expect(mod.filterAutoPool(FLEET)).toEqual([]);
   });
 });

--- a/cli/src/lib/devices/pool.ts
+++ b/cli/src/lib/devices/pool.ts
@@ -16,12 +16,27 @@
  * | no device marked | every online device (unchanged behavior) |
  * | some marked `worker` | ONLY those workers |
  * | marked `personal` / `desktop` | never, under either state |
+ * | `auto-launch.enabled` off | never, whatever its role or the mode |
  *
- * `auto.pool all` turns the allowlist off; `personal` and `desktop` stay
+ * `auto.pool all` turns the WORKER allowlist off; `personal` and `desktop` stay
  * excluded, because a box the user sits at (personal) or a headed always-on
  * release/credential box (desktop) is marked precisely so agents stay off it.
+ *
+ * A device the operator turned off with `agents devices disable <name>`
+ * (`auto-launch.enabled` = false) is dropped here too — one operator switch,
+ * one place, so `disable` removes a box from EVERY automatic-placement path
+ * (run/teams/ssh auto), not just one surface. Its sibling
+ * `auto-launch.preferred` does not narrow the pool; it BOOSTS a member in the
+ * ranker ({@link autoLaunchPreferredSet}, applied by `pickBestDevice`).
  */
-import { autoPoolMode, listConfiguredDeviceRoles, type AutoPoolMode, type ConfiguredDeviceRole } from '../device-config.js';
+import {
+  autoPoolMode,
+  listConfiguredDeviceRoles,
+  loadAutoLaunchPreferences,
+  type AutoLaunchPreference,
+  type AutoPoolMode,
+  type ConfiguredDeviceRole,
+} from '../device-config.js';
 import { normalizeHost } from '../machine-id.js';
 
 /**
@@ -46,6 +61,14 @@ export interface AutoPoolOptions {
    * {@link listConfiguredDeviceRoles}.
    */
   roster?: string[];
+  /**
+   * Auto-launch flags by device name; defaults to the fleet-shared block for
+   * the roster (or the pool). A device whose `enabled` is `false` is dropped
+   * from the pool. Inject `{}` in a pure unit test to keep the rule off disk,
+   * exactly as `roles: {}` does for the role rule. See
+   * {@link loadAutoLaunchPreferences}.
+   */
+  autoLaunch?: Record<string, AutoLaunchPreference>;
 }
 
 /**
@@ -60,7 +83,9 @@ export function filterAutoPool(pool: string[], opts: AutoPoolOptions = {}): stri
   const roles = opts.roles ?? listConfiguredDeviceRoles(opts.roster ?? pool);
   const byHost = new Map(Object.entries(roles).map(([name, role]) => [normalizeHost(name), role]));
   const roleOf = (host: string) => byHost.get(normalizeHost(host));
+  const disabled = disabledAutoLaunchSet(pool, opts);
   const eligible = pool.filter((host) => {
+    if (disabled.has(normalizeHost(host))) return false;
     const role = roleOf(host);
     return role === undefined || !NEVER_AUTO.has(role);
   });
@@ -69,6 +94,31 @@ export function filterAutoPool(pool: string[], opts: AutoPoolOptions = {}): stri
   const anyWorkerMarked = [...byHost.values()].some((role) => role === 'worker');
   if (!anyWorkerMarked) return eligible;
   return eligible.filter((host) => roleOf(host) === 'worker');
+}
+
+/** Normalized hosts the operator turned off with `auto-launch.enabled` = false. */
+function disabledAutoLaunchSet(pool: string[], opts: AutoPoolOptions): Set<string> {
+  const prefs = opts.autoLaunch ?? loadAutoLaunchPreferences(opts.roster ?? pool);
+  return new Set(
+    Object.entries(prefs)
+      .filter(([, pref]) => pref.enabled === false)
+      .map(([name]) => normalizeHost(name)),
+  );
+}
+
+/**
+ * Normalized hosts the operator boosted with `auto-launch.preferred` = true —
+ * the set `pickBestDevice` ranks ahead of its peers. Unlike the disable drop,
+ * a preference never removes a device: an eligible non-preferred box is still
+ * picked when no preferred one is available.
+ */
+export function autoLaunchPreferredSet(pool: string[], opts: AutoPoolOptions = {}): Set<string> {
+  const prefs = opts.autoLaunch ?? loadAutoLaunchPreferences(opts.roster ?? pool);
+  return new Set(
+    Object.entries(prefs)
+      .filter(([, pref]) => pref.preferred === true)
+      .map(([name]) => normalizeHost(name)),
+  );
 }
 
 /** True when this host is one automatic placement may pick. */

--- a/cli/src/lib/smart-launch.test.ts
+++ b/cli/src/lib/smart-launch.test.ts
@@ -122,6 +122,18 @@ describe('resolveDeviceAuto', () => {
     expect(plan.pickedDeviceKey).toBe('idle');
   });
 
+  it('ranks a preferred device ahead of a less-loaded one (agents devices prefer)', async () => {
+    // `busy-preferred` is loaded heavier than `idle`, but the operator boosted
+    // it — so it wins. Without the boost `idle` would.
+    const probe = async () => new Map([
+      ['idle', { reachable: true, loadPercent: 5, memPercent: 5, headroom: 'idle', installed: true, signedIn: true }],
+      ['busy-preferred', { reachable: true, loadPercent: 60, memPercent: 30, headroom: 'busy', installed: true, signedIn: true }],
+    ] as const);
+    const base = { localMachine: 'local', eligibleHosts: ['idle', 'busy-preferred'], probe } as const;
+    expect((await resolveDeviceAuto('codex', { ...base })).host).toBe('idle');
+    expect((await resolveDeviceAuto('codex', { ...base, preferred: new Set(['busy-preferred']) })).host).toBe('busy-preferred');
+  });
+
   it('fails loud when live probing cannot evaluate placement', async () => {
     await expect(resolveDeviceAuto('codex', {
       localMachine: 'local',

--- a/cli/src/lib/smart-launch.ts
+++ b/cli/src/lib/smart-launch.ts
@@ -9,7 +9,7 @@
 import { queryAffinityRollup, type AffinityRow } from './session/db.js';
 import { localMachineId } from './session/origin-machine.js';
 import { loadDevicesSync } from './devices/registry.js';
-import { describeAutoPool, filterAutoPool, isAutoPoolMember } from './devices/pool.js';
+import { autoLaunchPreferredSet, describeAutoPool, filterAutoPool, isAutoPoolMember } from './devices/pool.js';
 import { normalizeHost } from './machine-id.js';
 import { probePoolSignals } from './teams/placement-probe.js';
 import { pickBestDevice, type DevicePlacementSignal } from './teams/scheduler.js';
@@ -178,6 +178,12 @@ export async function resolveDeviceAuto(
     /** Route only to devices with a row the interactive account picker can launch. */
     accountPicker?: boolean;
     probe?: (pool: string[], agent?: AgentType) => Promise<Map<string, DevicePlacementSignal>>;
+    /**
+     * Preferred hosts (`auto-launch.preferred`) that get the ranking boost.
+     * Defaults to the stored fleet block resolved over the candidate pool;
+     * injectable so a test pins it without touching disk.
+     */
+    preferred?: ReadonlySet<string>;
   } = {},
 ): Promise<DeviceAutoPlan> {
   const local = normalizeHost(opts.localMachine ?? localMachineId());
@@ -211,7 +217,10 @@ export async function resolveDeviceAuto(
   if (eligiblePool.length === 0) {
     throw new Error(formatNoHealthyDeviceError(pool, signals, agent));
   }
-  const picked = pickBestDevice(eligiblePool, [], { signals, agentLabel: agent });
+  // `agents devices prefer <name>` boosts a device in the ranking — resolved
+  // over the same pool so a fleet default reaches a doc-less box.
+  const preferred = opts.preferred ?? autoLaunchPreferredSet(pool, { roster: pool });
+  const picked = pickBestDevice(eligiblePool, [], { signals, agentLabel: agent, preferred });
   return {
     host: picked === local ? null : picked,
     pickedDeviceKey: picked,

--- a/cli/src/lib/teams/scheduler.test.ts
+++ b/cli/src/lib/teams/scheduler.test.ts
@@ -243,6 +243,36 @@ describe('pickBestDevice — health/harness/load ranking (RUSH-2002)', () => {
     expect(pickBestDevice(['box-a', 'box-b'], [], { signals })).toBe('box-b');
   });
 
+  it('a preferred device outranks a less-loaded non-preferred one', () => {
+    // `agents devices prefer box-a` boosts it above box-b even though box-b is
+    // idle and box-a is busy — the operator boost overrides load-based order.
+    const signals = sig({
+      'box-a': { headroom: 'busy' },
+      'box-b': { headroom: 'idle' },
+    });
+    expect(pickBestDevice(['box-a', 'box-b'], [], { signals })).toBe('box-b');
+    expect(pickBestDevice(['box-a', 'box-b'], [], { signals, preferred: new Set(['box-a']) })).toBe('box-a');
+  });
+
+  it('a signed-out preferred device does NOT jump ahead of a signed-in one', () => {
+    // Preference boosts within the health tier, not over it — a box that can't
+    // run the agent stays behind one that can, boosted or not.
+    const signals = sig({
+      'box-a': { installed: true, signedIn: false, headroom: 'idle' },
+      'box-b': { installed: true, signedIn: true, headroom: 'idle' },
+    });
+    expect(pickBestDevice(['box-a', 'box-b'], [], { signals, preferred: new Set(['box-a']) })).toBe('box-b');
+  });
+
+  it('with two preferred devices the load tiebreak still decides between them', () => {
+    const signals = sig({
+      'box-a': { headroom: 'busy' },
+      'box-b': { headroom: 'idle' },
+    });
+    // Both boosted → the boost cancels and lower load wins.
+    expect(pickBestDevice(['box-a', 'box-b'], [], { signals, preferred: new Set(['box-a', 'box-b']) })).toBe('box-b');
+  });
+
   it('load tier outranks teammate count', () => {
     // box-a is idle but already has a teammate; box-b is busy and empty.
     // Lower load (tier) wins over fewer teammates per the ranking order.

--- a/cli/src/lib/teams/scheduler.ts
+++ b/cli/src/lib/teams/scheduler.ts
@@ -88,6 +88,16 @@ export interface PlacementOptions {
   /** Human label of the requested agent (e.g. `claude@2.1.112`) for the
    * fail-loud message. */
   agentLabel?: string;
+  /**
+   * Normalized hosts boosted with `auto-launch.preferred` (set by
+   * `agents devices prefer <name>`). A preferred device ranks ahead of a
+   * non-preferred one among the eligible survivors — after the signed-in tier
+   * (a preferred box that can't run the agent is still no use) and before load,
+   * so an operator boost overrides load-based ordering without overriding hard
+   * health. Empty/undefined leaves the ranking unchanged. See
+   * {@link autoLaunchPreferredSet}.
+   */
+  preferred?: ReadonlySet<string>;
 }
 
 /** Why a device was excluded from the viable set, for the fail-loud message. */
@@ -362,6 +372,13 @@ export function pickBestDevice(
     // (a) signed-in agent first.
     const signedIn = (sa?.signedIn === true ? 0 : 1) - (sb?.signedIn === true ? 0 : 1);
     if (signedIn !== 0) return signedIn;
+    // (a2) operator-preferred device next — `agents devices prefer <name>`
+    // boosts a box above its load-equal peers, overriding load-based order.
+    const preferred = opts?.preferred;
+    if (preferred && preferred.size > 0) {
+      const pref = (preferred.has(a) ? 0 : 1) - (preferred.has(b) ? 0 : 1);
+      if (pref !== 0) return pref;
+    }
     // (b) lower load — coarse headroom tier, then raw load cost.
     const tier = headroomTier(sa?.headroom) - headroomTier(sb?.headroom);
     if (tier !== 0) return tier;


### PR DESCRIPTION
## PHNX-2092 — per-device auto-launch preferences honored by `--device auto`

**Goal:** let a user control which devices are eligible for automatic host
selection, and make the picker respect it.

### Scoping decision (the ticket's paths were stale)
- **Storage: extend the existing device-config store, NOT a new `auto-launch.json`.**
  The legacy `~/.agents/.history/devices/auto-launch.json` was already migrated
  into the per-device config layer (`devices/<name>/agents.yaml` `config:` block)
  by `config-migration.ts`; recreating the file would fight the migration. The
  config keys `auto-launch.enabled` / `auto-launch.preferred` and their setters
  already existed (from the earlier PHNX-2092 work, before Factory split out).
- **Commands already exist.** `agents devices enable/disable/prefer/unprefer <name>`
  are forwarding spellings for `agents devices config <name> auto-launch.*` (the
  repo deliberately unified per-device settings under `devices config`; the four
  verbs are hidden tombstones that do the write and print a notice). Left as-is —
  resurrecting them as first-class would contradict the unified surface.
- **The real gap was placement.** The flags were stored + fleet-synced but the
  CLI's single placement path never read them, so `disable` didn't remove a box
  and `prefer` gave no boost. This PR wires them into that ONE rule.
- **No ext change required.** AGI EXT (phnx-labs/agi-ext) emits `--device auto`
  and delegates placement to the CLI (`launchTarget.ts`: "The extension does NOT
  score devices"). Its `deviceAutoLaunch.ts` reader is now unused dead code there
  (only its own test imports it) — a follow-up cleanup, not needed for acceptance.
  Fixing the CLI's `--device auto` makes the flags effective for ext launches too.

### What changed (one placement rule, extended — no parallel path)
- `filterAutoPool` (`lib/devices/pool.ts`) drops any device with
  `auto-launch.enabled` = false from **every** automatic-placement path
  (run / teams / ssh auto / AGI EXT), exactly as a `personal`/`desktop` role does.
  New `autoLaunchPreferredSet` exposes the boosted hosts.
- `pickBestDevice` (`lib/teams/scheduler.ts`) gains a `preferred` set and ranks a
  preferred device ahead of its load-equal peers — after the signed-in tier,
  before load, so an operator boost overrides load ordering without overriding
  hard health.
- `resolveDeviceAuto` (`lib/smart-launch.ts`) — the single resolver behind
  `run`/`teams`/routines `--device auto` — feeds the preferred set through. Drop
  and boost are both injectable for hermetic tests.
- Config-key descriptions + `cli/AGENTS.md` devices section updated (the flags now
  govern all automatic placement, not just AGI EXT); CHANGELOG fragment added.

### Acceptance (real run, throwaway HOME)
```
before:             [ "zion", "yosemite-s0", "yosemite-s1", "mac-mini" ]
after disable zion: [ "yosemite-s0", "yosemite-s1", "mac-mini" ]   <-- zion dropped
after prefer mac-mini: preferredSet = [ "mac-mini" ]
pool (prefer never drops): [ "yosemite-s0", "yosemite-s1", "mac-mini" ]
```

### Tests
- `pool.test.ts`: disable drops (incl. a disabled worker, FQDN normalization,
  fleet-default disable), prefer never narrows, `autoLaunchPreferredSet`, plus a
  stored-config path driving the real `setAutoLaunchEnabled/Preferred` helpers.
- `scheduler.test.ts`: preferred outranks a less-loaded box; a signed-out
  preferred box does NOT jump the signed-in tier; two-preferred falls back to load.
- `smart-launch.test.ts`: `resolveDeviceAuto` picks the preferred box over the
  less-loaded one.
- All touched suites green: pool + scheduler + smart-launch + worker-pick +
  menubar snapshot + device-config tombstones/fleet + gen-changelog/command-index.
  `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
