### PR TITLE
fix(monitors): default system built-ins enabled, add scope, fleet-wide list (PHNX-2506)

### DIFF
--- a/cli/.changelog/next/PHNX-2506.md
+++ b/cli/.changelog/next/PHNX-2506.md
@@ -1,0 +1,8 @@
+- **`agents monitors list` is fleet-wide and honest about built-ins (PHNX-2506).**
+  A shipped system built-in now defaults to **enabled** like any user monitor, so the
+  operator sees what the daemon is actually watching instead of a built-in silently
+  parked as disabled. `monitors list` marks each built-in `(built-in)`, adds `scope`
+  (`user`/`system`) to the `--json` payload, and fans out fleet-wide — every peer's
+  monitors are listed too, each tagged with the box it lives on (reusing the same
+  cross-machine fan-out the add duplicate-guard uses). Source:
+  `cli/src/lib/monitors/config.ts`, `cli/src/commands/monitors.ts`.

--- a/cli/docs/monitors.md
+++ b/cli/docs/monitors.md
@@ -42,9 +42,12 @@ built-in shipped with the CLI, `~/.agents/.system/monitors/` (the system layer,
 from `gh:phnx-labs/.agents-system`). `listMonitors()`/`readMonitor()` union the
 two — the user layer shadows a system built-in of the same name, exactly like
 routines' project/user/system resolution. A system built-in with no `enabled:`
-field is **opt-in**: it stays disabled until you enable it, which materializes a
-user copy (enable/edit/delete always write the user dir; the system mirror is
-pull-only). The same background daemon that runs routines
+field defaults to **enabled**, exactly like a user monitor: a shipped built-in is
+visible and active by default so the operator sees what the daemon is watching
+(edit/delete still write the user dir — the system mirror is pull-only). Each
+monitor carries a read-time `scope` (`user` or `system`) — `monitors list` marks a
+system built-in with `(built-in)` and reports `scope` in `--json`. The same
+background daemon that runs routines
 (`agents routines start`) hosts a **monitor engine** beside the cron scheduler. On each tick it evaluates every enabled, device-owned monitor that
 is due, applies the condition through the native state-diff store, and on a fire
 dispatches the action through the exact `executeJobDetached` path cron and webhook
@@ -167,7 +170,7 @@ agents monitors add cert-issued \
   --poll-http 'https://secure.ssl.com/team/.../co-ec1l5dgjofa' 8h \
   --match issued --notify telegram --device zion
 
-agents monitors list                  # all monitors, source, action, owner, liveness (checked Nx / never polled / STALLED / fired)
+agents monitors list                  # every monitor fleet-wide (local + peers, each tagged with its box), source, action, owner, liveness (checked Nx / never polled / STALLED / fired)
 agents monitors view <name>           # full config + liveness + current watched-state + recent fires
 agents monitors test <name>           # DRY-RUN: evaluate once, print event + would-fire (no action)
 agents monitors edit <name>           # $EDITOR on the YAML

--- a/cli/src/commands/monitors.test.ts
+++ b/cli/src/commands/monitors.test.ts
@@ -12,6 +12,8 @@ import * as os from 'os';
 import * as path from 'path';
 import * as yaml from 'yaml';
 import { fileURLToPath } from 'url';
+import { formatFleetMonitorLines } from './monitors.js';
+import { parseRemoteMonitors } from '../lib/monitors/remote.js';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -150,6 +152,51 @@ describe('monitors inspection JSON and stderr', () => {
     const payload = JSON.parse(run(home, ['list', '--json']).stdout);
     expect(payload[0].lastActionStatus).toBe('failed');
     expect(payload[0].lastActionFailed).toBe(true);
+  });
+
+  it('list --json reports scope and a system built-in lists enabled by default (PHNX-2506)', () => {
+    const home = makeHome();
+    // A built-in with no explicit `enabled:` field.
+    writeSystemMonitor(home, {
+      name: 'ci-built-in',
+      source: { type: 'poll', command: 'echo hi', interval: '30s' },
+      condition: { mode: 'on-change' },
+      action: { type: 'notify', notifyChannel: 'telegram' },
+    });
+    writeMonitor(home, {
+      name: 'mine',
+      enabled: true,
+      source: { type: 'poll', command: 'echo fail', interval: '30s' },
+      condition: { mode: 'match', match: 'fail' },
+      action: { type: 'notify', notifyChannel: 'telegram' },
+    });
+
+    // AGENTS_MONITORS_LOCAL keeps the run from fanning out to a real fleet.
+    const res = run(home, ['list', '--json'], { AGENTS_MONITORS_LOCAL: '1' });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toBe('');
+    const payload = JSON.parse(res.stdout);
+    const builtin = payload.find((m: any) => m.name === 'ci-built-in');
+    const mine = payload.find((m: any) => m.name === 'mine');
+    expect(builtin.scope).toBe('system');
+    // No explicit `enabled:` on the built-in now defaults ON, like a user monitor.
+    expect(builtin.enabled).toBe(true);
+    expect(mine.scope).toBe('user');
+  });
+
+  it('list marks a system built-in as (built-in) in the text view (PHNX-2506)', () => {
+    const home = makeHome();
+    writeSystemMonitor(home, {
+      name: 'ci-built-in',
+      source: { type: 'poll', command: 'echo hi', interval: '30s' },
+      condition: { mode: 'on-change' },
+      action: { type: 'notify', notifyChannel: 'telegram' },
+    });
+
+    const res = run(home, ['list'], { AGENTS_MONITORS_LOCAL: '1' });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('ci-built-in');
+    expect(res.stdout).toContain('(built-in)');
   });
 
   it('test --json evaluates once, prints the dry-run decision as JSON, and writes no state', () => {
@@ -325,6 +372,39 @@ describe('monitors inspection JSON and stderr', () => {
       expect(fs.readFileSync(sysFile, 'utf-8')).toBe(sysBefore);
     },
   );
+});
+
+/**
+ * PHNX-2506: `monitors list` fans out fleet-wide and tags each peer's monitors
+ * with the box they live on. `formatFleetMonitorLines` is the pure renderer, so
+ * the tagging is exercised against the real `parseRemoteMonitors` projection —
+ * the same helper the add duplicate-guard consumes — without an SSH fleet.
+ */
+describe('formatFleetMonitorLines (fleet-wide list, PHNX-2506)', () => {
+  it("tags a remote box's monitors with its box name", () => {
+    const remote = parseRemoteMonitors(
+      JSON.stringify([
+        {
+          name: 'land-2517',
+          enabled: true,
+          scope: 'user',
+          source: { type: 'poll', command: 'gh pr view 2517', interval: '2m' },
+          condition: { mode: 'on-change' },
+          action: { type: 'run', agent: 'claude', prompt: 'merge it' },
+        },
+      ]),
+      'zion',
+    );
+    const rendered = formatFleetMonitorLines(remote).join('\n');
+    expect(rendered).toContain('Elsewhere on the fleet');
+    expect(rendered).toContain('land-2517');
+    // Tagged with the owning box.
+    expect(rendered).toContain('zion');
+  });
+
+  it('renders nothing when no peer reported a monitor', () => {
+    expect(formatFleetMonitorLines([])).toEqual([]);
+  });
 });
 
 /**

--- a/cli/src/commands/monitors.ts
+++ b/cli/src/commands/monitors.ts
@@ -20,7 +20,7 @@ import {
   startDaemon,
 } from '../lib/daemon/daemon.js';
 import { findDuplicateMonitor, monitorFingerprint } from '../lib/monitors/fingerprint.js';
-import { gatherFleetMonitors, NO_MONITOR_FANOUT_ENV } from '../lib/monitors/remote.js';
+import { gatherFleetMonitors, NO_MONITOR_FANOUT_ENV, type RemoteMonitor } from '../lib/monitors/remote.js';
 import {
   listMonitors,
   readMonitor,
@@ -126,6 +126,23 @@ function ownerLabel(monitor: MonitorConfig): string {
   if (monitor.device) return monitor.device;
   if (monitor.devices && monitor.devices.length > 0) return monitor.devices.join(',');
   return 'all';
+}
+
+/**
+ * Render the fleet-wide section of `monitors list`: every monitor a peer
+ * reported, each tagged with the box it lives on. Pure so the tagging is
+ * unit-testable against real `parseRemoteMonitors` output without an SSH fleet.
+ * Returns [] when no peer reported a monitor, so the caller prints nothing.
+ */
+export function formatFleetMonitorLines(remote: RemoteMonitor[]): string[] {
+  if (remote.length === 0) return [];
+  const lines = [chalk.bold('Elsewhere on the fleet')];
+  for (const r of remote) {
+    lines.push(
+      `  ${chalk.cyan(r.monitor.name.padEnd(22))} ${sourceLabel(r.monitor.source)} → ${actionLabel(r.monitor.action)}  ${chalk.gray(`on ${r.machine}`)}`,
+    );
+  }
+  return lines;
 }
 
 /** A monitor's evaluation cadence in ms (falls back to the engine default). */
@@ -690,7 +707,7 @@ export function registerMonitorsCommands(program: Command): void {
     .command('list')
     .description('See all monitors: source, condition, action, owner, and last fire.')
     .option('--json', 'Emit machine-readable JSON')
-    .action((options: { json?: boolean }) => {
+    .action(async (options: { json?: boolean }) => {
       const monitors = listMonitors();
       if (options.json) {
         const payload = monitors.map((m) => {
@@ -701,6 +718,9 @@ export function registerMonitorsCommands(program: Command): void {
           return {
             name: m.name,
             enabled: m.enabled,
+            // `user` or `system` (a shipped built-in) — the layer this monitor
+            // resolved from, so a machine consumer can tell a built-in apart.
+            scope: m.scope ?? 'user',
             source: m.source,
             condition: m.condition,
             // Full action, not just `type`: the cross-machine duplicate guard
@@ -726,7 +746,15 @@ export function registerMonitorsCommands(program: Command): void {
         stdoutJson(payload);
         return;
       }
-      if (monitors.length === 0) {
+      // Fan out to peers so `monitors list` shows every monitor fleet-wide,
+      // each tagged with its owning box — the same cross-machine fan-out the
+      // add duplicate-guard uses. Skipped when this process is itself a peer
+      // answering the fan-out (recursion guard), so a peer only reports local.
+      const fleet = process.env[NO_MONITOR_FANOUT_ENV]
+        ? { monitors: [] as RemoteMonitor[], skipped: [] as string[], discoveryFailed: false }
+        : await gatherFleetMonitors();
+
+      if (monitors.length === 0 && fleet.monitors.length === 0) {
         console.log(chalk.gray('No monitors configured'));
         console.log(chalk.gray('  Add one: agents monitors add <name> --poll "<cmd>" 30s --match fail --run claude --prompt "..."'));
         return;
@@ -738,10 +766,25 @@ export function registerMonitorsCommands(program: Command): void {
         const enabled = m.enabled ? chalk.green('on') : chalk.gray('off');
         const here = monitorRunsOnThisDevice(m);
         const owner = here ? ownerLabel(m) : chalk.gray(ownerLabel(m));
-        console.log(`  ${chalk.cyan(m.name.padEnd(22))} ${enabled.padEnd(3)} ${sourceLabel(m.source)}`);
+        // A shipped system built-in is marked so the operator can tell it from
+        // one they authored; a user monitor gets no tag.
+        const builtIn = m.scope === 'system' ? ` ${chalk.gray('(built-in)')}` : '';
+        console.log(`  ${chalk.cyan(m.name.padEnd(22))} ${enabled.padEnd(3)} ${sourceLabel(m.source)}${builtIn}`);
         console.log(`  ${' '.repeat(22)}     ${chalk.gray(`[${m.condition.mode}]`)} → ${actionLabel(m.action)}  ${chalk.gray(`owner: ${owner}`)}  ${livenessLabel(m, state, liveness)}`);
       }
       console.log();
+
+      const fleetLines = formatFleetMonitorLines(fleet.monitors);
+      if (fleetLines.length > 0) {
+        for (const line of fleetLines) console.log(line);
+        console.log();
+      }
+      // Never let "we couldn't ask the fleet" read as "nothing runs elsewhere".
+      if (fleet.discoveryFailed) {
+        console.log(chalk.yellow('  Note: could not reach the device registry — the fleet was not listed.'));
+      } else if (fleet.skipped.length > 0) {
+        console.log(chalk.yellow(`  Note: could not reach ${fleet.skipped.join(', ')} — their monitors are not shown.`));
+      }
     });
 
   // ─── view ──────────────────────────────────────────────────────────────────

--- a/cli/src/lib/monitors/config.test.ts
+++ b/cli/src/lib/monitors/config.test.ts
@@ -271,20 +271,28 @@ describe('system-layer monitors (built-ins from ~/.agents/.system/monitors/)', (
     expect(getMonitorPath('dupe')).toBe(path.join(userDir, 'dupe.yml'));
   });
 
-  it('(c) a system built-in with no enabled: field is opt-in (disabled until toggled)', () => {
-    fs.writeFileSync(path.join(sysDir, 'optin.yml'), monitorYaml('name: optin\n'));
+  it('(c) a system built-in with no enabled: field defaults to enabled, like a user monitor (PHNX-2506)', () => {
+    fs.writeFileSync(path.join(sysDir, 'builtin.yml'), monitorYaml('name: builtin\n'));
 
-    // Read straight from the system layer — opt-in, so disabled.
-    expect(readMonitor('optin')?.enabled).toBe(false);
-    expect(listMonitors().find((m) => m.name === 'optin')?.enabled).toBe(false);
+    // Read straight from the system layer — no explicit enabled:, so ON, and
+    // tagged with its resolving layer.
+    const fromSystem = readMonitor('builtin');
+    expect(fromSystem?.enabled).toBe(true);
+    expect(fromSystem?.scope).toBe('system');
+    expect(listMonitors().find((m) => m.name === 'builtin')?.enabled).toBe(true);
 
-    // A user monitor with no enabled: field, by contrast, defaults to enabled.
+    // A user monitor with no enabled: field also defaults to enabled, and is
+    // tagged `user`.
     fs.writeFileSync(path.join(userDir, 'userdefault.yml'), monitorYaml('name: userdefault\n'));
-    expect(readMonitor('userdefault')?.enabled).toBe(true);
+    const fromUser = readMonitor('userdefault');
+    expect(fromUser?.enabled).toBe(true);
+    expect(fromUser?.scope).toBe('user');
   });
 
-  it('(d) enabling a system built-in writes into the USER dir, never the system dir', () => {
-    fs.writeFileSync(path.join(sysDir, 'optin.yml'), monitorYaml('name: optin\n'));
+  it('(d) toggling a system built-in writes into the USER dir, never the system dir', () => {
+    // Explicitly disabled in the mirror so there is a state to flip; the write
+    // must land a user copy rather than rewriting the pull-only system file.
+    fs.writeFileSync(path.join(sysDir, 'optin.yml'), monitorYaml('name: optin\nenabled: false\n'));
     expect(readMonitor('optin')?.enabled).toBe(false);
 
     setMonitorEnabled('optin', true);
@@ -293,6 +301,8 @@ describe('system-layer monitors (built-ins from ~/.agents/.system/monitors/)', (
     expect(fs.existsSync(path.join(userDir, 'optin.yml'))).toBe(true);
     const sysBody = fs.readFileSync(path.join(sysDir, 'optin.yml'), 'utf-8');
     expect(sysBody).not.toContain('enabled: true');
+    // The read-time `scope` annotation is never persisted into the user copy.
+    expect(fs.readFileSync(path.join(userDir, 'optin.yml'), 'utf-8')).not.toContain('scope:');
     // The user copy now wins and reads enabled.
     expect(readMonitor('optin')?.enabled).toBe(true);
     expect(getMonitorPath('optin')).toBe(path.join(userDir, 'optin.yml'));

--- a/cli/src/lib/monitors/config.ts
+++ b/cli/src/lib/monitors/config.ts
@@ -159,6 +159,14 @@ export interface MonitorConfig {
   variables?: Record<string, string>;
   /** Pin the agent version for `run` actions (omit to use the run strategy). */
   version?: string;
+  /**
+   * Which layer this monitor was resolved from — `user` (~/.agents/monitors/)
+   * or `system` (the npm-shipped built-in mirror). Computed at read time by
+   * {@link readMonitorFile}, never persisted to the YAML (writeMonitor strips
+   * it). Lets `monitors list` mark a built-in and keep the `--json` payload
+   * honest about a monitor's origin.
+   */
+  scope?: 'user' | 'system';
 }
 
 /**
@@ -449,11 +457,11 @@ export function validateMonitor(config: Partial<MonitorConfig>): string[] {
 }
 
 /**
- * Read and normalize a monitor file. `scope` decides the enabled default when
- * the YAML has no explicit `enabled:` field: a `user` monitor defaults to
- * enabled (MONITOR_DEFAULTS), while a `system` built-in stays opt-in (disabled)
- * until the user enables it — mirroring how routines treat a fresh built-in
- * (lib/routines.ts readJobFile).
+ * Read and normalize a monitor file. A monitor with no explicit `enabled:`
+ * field defaults to enabled (MONITOR_DEFAULTS) regardless of `scope`: a system
+ * built-in is visible and active like any user monitor, so the operator sees
+ * what the daemon is watching. `scope` is stamped onto the returned config so
+ * `monitors list` can mark a built-in and report the origin in `--json`.
  */
 function readMonitorFile(filePath: string, scope: 'user' | 'system' = 'user'): MonitorConfig | null {
   try {
@@ -465,9 +473,10 @@ function readMonitorFile(filePath: string, scope: 'user' | 'system' = 'user'): M
       ...MONITOR_DEFAULTS,
       ...parsed,
       name: parsed.name || path.basename(filePath).replace(/\.ya?ml$/, ''),
-      // A system built-in with no explicit `enabled:` is opt-in until enabled;
-      // a user monitor keeps the enabled-by-default behavior.
-      enabled: hasEnabled ? parsed.enabled !== false : scope === 'system' ? false : (MONITOR_DEFAULTS.enabled ?? true),
+      // No explicit `enabled:` → enabled by default for both scopes. A system
+      // built-in is not opt-in; it defaults on like a user monitor.
+      enabled: hasEnabled ? parsed.enabled !== false : (MONITOR_DEFAULTS.enabled ?? true),
+      scope,
     } as MonitorConfig;
   } catch {
     return null;
@@ -551,6 +560,9 @@ export function writeMonitor(config: MonitorConfig): void {
 
   const output: Record<string, unknown> = { ...config };
   if (output.enabled === true) delete output.enabled;
+  // `scope` is a read-time annotation (user vs system layer), not config —
+  // persisting it would write a meaningless field into the user's YAML.
+  delete output.scope;
   const devArr = output.devices as string[] | undefined;
   if (!devArr || devArr.length === 0) delete output.devices;
 


### PR DESCRIPTION
## PHNX-2506 — monitors visibility

Three sub-fixes, one PR. Built on top of the recent PHNX-3023 (`--watch-pid`) work on main — nothing reverted.

### 1. System built-ins default ENABLED
`readMonitorFile` (`cli/src/lib/monitors/config.ts`) dropped the `scope === 'system' ? false : …` opt-in special case. A system built-in with no explicit `enabled:` now falls through to `MONITOR_DEFAULTS.enabled` (true), exactly like a user monitor — so the operator sees what the daemon is actually watching instead of a built-in silently parked disabled.

### 2. `scope` on MonitorConfig, surfaced in list
- `MonitorConfig` gains `scope?: 'user' | 'system'`, stamped at read time in `readMonitorFile` and **stripped in `writeMonitor`** so it never leaks into the user's YAML.
- `monitors list` marks a system built-in `(built-in)` in the text view and includes `scope` in the `--json` payload.

### 3. `monitors list` is fleet-wide
The `list` action fans out reusing `gatherFleetMonitors` / `parseRemoteMonitors` from `cli/src/lib/monitors/remote.ts` — the same cross-machine helper the `add` duplicate-guard uses — so every peer's monitors are listed, each tagged with its owning box. Skipped when the process is itself a peer answering the fan-out (recursion guard via `AGENTS_MONITORS_LOCAL`); `--json` stays a bare local array to preserve the fan-out RPC contract.

### Not doing (rejected in ticket)
enable/disable verb; git-tracking definitions. Did not touch `cloud/rush.ts`.

### Tests (real path)
```
 Test Files  3 passed (3)
      Tests  58 passed (58)
```
- `config.test.ts` (c): a system built-in with no `enabled:` now lists **enabled**, and both scopes are tagged (`scope: 'system'` / `'user'`).
- `monitors.test.ts`: `list --json` reports `scope` and the built-in reads enabled; text view shows `(built-in)`; `formatFleetMonitorLines` tags a remote box's monitors with its box name via the real `parseRemoteMonitors` projection.
- `tsc --noEmit` clean.