### PR TITLE
fix(plugins): reconcile a shadow plugin left by a marketplace move (PHNX-2618)

### DIFF
--- a/cli/.changelog/next/PHNX-2618.md
+++ b/cli/.changelog/next/PHNX-2618.md
@@ -1,0 +1,22 @@
+- **A version-home plugin left behind by a marketplace move is now reconciled
+  away instead of shadowing the current copy (PHNX-2618).** Plugin orphan
+  detection keyed on plugin **name** alone, but a version home installs plugins
+  per **marketplace** (`marketplaces/<name>/plugins/<plugin>`). When a plugin
+  moved marketplaces — e.g. `code` once shipped from the user repo (the
+  `agents-cli` marketplace) and later from the system repo (`agents-system`) —
+  the stale `agents-cli` copy was never cleaned, because the name `code` was
+  still active via `agents-system`. Fleet boxes then carried **two** `code`
+  plugins: the current one, plus a shadow serving skills the repo deleted on
+  purpose (`code:quality` / `code:ship` / `code:verify`), and resolution order
+  decided which `code:review` an agent got. `cleanOrphanedPluginSkills` /
+  `diffVersionPlugins` now key on the `(marketplace, name)` pair: an installed
+  copy whose marketplace source repo is present but no longer ships that plugin
+  is trashed (soft-deleted to `~/.agents/.trash/plugins/`), even when another
+  marketplace still ships the same name — so a plain `agents sync` reconciles the
+  shadow away. When a marketplace's source repo is **absent** (a project we're
+  not in, a removed extra repo) the original name-only test is kept, so an
+  unrelated sync from another cwd never trashes a plugin whose source simply is
+  not reachable right now. Source: `cli/src/lib/plugins/plugins.ts`
+  (`cleanOrphanedPluginSkills`, `diffVersionPlugins`, `isOrphanMarketplacePlugin`),
+  `cli/src/lib/staleness/writers/plugins.ts`,
+  `cli/src/lib/installations/versions.ts`.

--- a/cli/docs/resource-sync.md
+++ b/cli/docs/resource-sync.md
@@ -518,11 +518,21 @@ Behavior rules, per `src/lib/plugins.ts:379` and `src/lib/plugin-marketplace.ts`
    converted to skills prefixed with `<plugin>-<command>`
    (`plugins.ts:444-453`) so they remain reachable as `$<plugin>-<command>`.
 
-7. **Source delete ≠ destination clean — but skills get swept.**
-   `cleanOrphanedPluginSkills()` (`plugins.ts:866`) runs every sync and
-   removes plugin-owned skill dirs whose parent plugin no longer exists in
-   `~/.agents/plugins/`. The marketplace copy itself isn't pruned until
-   `agents plugins remove <name>` runs explicitly.
+7. **Source delete ≠ destination clean — but stale marketplace copies get
+   swept.** `cleanOrphanedPluginSkills()` (`plugins.ts`) runs every sync and
+   trashes a version-home marketplace-plugin install once no active source
+   plugin matches its **`(marketplace, name)` pair**. Keying on the pair — not
+   the plugin name alone — is what removes a *shadow*: a plugin that moved
+   marketplaces (e.g. `code` shipping from the user `agents-cli` marketplace and
+   later from the system `agents-system` marketplace) leaves a stale
+   `agents-cli` copy that a name-only sweep kept alive because the name was still
+   active via `agents-system` (PHNX-2618). A copy is trashed when its
+   marketplace's **source repo is present** but no longer ships that plugin;
+   when the source repo is **absent** (a project we're not in, a removed extra
+   repo) the sweep falls back to the name-only test so an unrelated sync never
+   trashes a plugin whose source simply is not reachable in this context. Trashed
+   copies soft-delete to `~/.agents/.trash/plugins/`; `diffVersionPlugins()`
+   surfaces the same orphans for `agents prune`.
 
 ## Key Functions
 

--- a/cli/src/lib/installations/versions.ts
+++ b/cli/src/lib/installations/versions.ts
@@ -2956,7 +2956,10 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   if (pluginsToSync.length > 0 && pluginsWriter) {
     if (options.allowExecSurfaces) {
       const allPlugins = discoverPlugins();
-      cleanOrphanedPluginSkills(agent, versionHome, new Set(allPlugins.map(p => p.name)));
+      // Pass the discovered plugins (with marketplace provenance) so a stale
+      // install under one marketplace is trashed even when another marketplace
+      // still ships that name — the PHNX-2618 shadow `code` plugin.
+      cleanOrphanedPluginSkills(agent, versionHome, allPlugins);
       const pluginMap = new Map(allPlugins.map(p => [p.name, p]));
       for (const name of pluginsToSync) {
         const plugin = pluginMap.get(name);

--- a/cli/src/lib/plugins/plugins.test.ts
+++ b/cli/src/lib/plugins/plugins.test.ts
@@ -2129,3 +2129,179 @@ describePlugins('updatePlugin exec-surface consent gate', () => {
     expect(fs.readFileSync(path.join(pluginRoot, 'hooks', 'existing.json'), 'utf-8')).toContain('"v":2');
   });
 });
+
+// ─── cleanOrphanedPluginSkills: cross-marketplace shadow (PHNX-2618) ───────────
+//
+// A `code` plugin used to live in the user repo (→ the "agents-cli" marketplace)
+// and later moved to the system repo (→ "agents-system"). The stale agents-cli
+// install was never reconciled, so every fleet box served BOTH — the shadow
+// copy answering `/code:quality` / `/code:ship` from skills the repo deleted.
+// Orphan detection keyed on plugin NAME kept the shadow alive because `code`
+// was still active (via agents-system). These tests reproduce the shadow end to
+// end through the real sync + cleanup path (no mocks) and prove the healthy
+// multi-marketplace case is untouched.
+
+describePlugins('cleanOrphanedPluginSkills across marketplaces (PHNX-2618 shadow)', () => {
+  let tmpDir: string;
+  let userDir: string;
+  let systemDir: string;
+  let extraRepo: string;
+  let versionHome: string;
+  let trashDir: string;
+
+  // A plugin that ships one skill, so a stale copy is visibly serving a skill.
+  function writePlugin(pluginsDir: string, name: string, skill = `${name}-skill`): string {
+    const root = path.join(pluginsDir, name);
+    fs.mkdirSync(path.join(root, '.claude-plugin'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name, version: '1.0.0', description: `${name} plugin` })
+    );
+    const skillDir = path.join(root, 'skills', skill);
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `# ${name}:${skill}`);
+    return root;
+  }
+
+  function installedPluginDir(marketplace: string, name: string): string {
+    return path.join(versionHome, '.claude', 'plugins', 'marketplaces', marketplace, 'plugins', name);
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-shadow-'));
+    userDir = path.join(tmpDir, 'user', 'plugins');
+    systemDir = path.join(tmpDir, 'system', 'plugins');
+    extraRepo = path.join(tmpDir, 'agents-extras'); // ~/.agents-extras/ for alias "extras"
+    versionHome = path.join(tmpDir, 'version-home');
+    trashDir = path.join(tmpDir, 'trash', 'plugins');
+    fs.mkdirSync(userDir, { recursive: true });
+    fs.mkdirSync(systemDir, { recursive: true });
+    fs.mkdirSync(path.join(extraRepo, 'plugins'), { recursive: true });
+    fs.mkdirSync(versionHome, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../state.js');
+    vi.resetModules();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function withState(
+    overrides: Partial<typeof import('../state.js')>,
+    fn: (mod: typeof import('./plugins.js')) => Promise<void> | void
+  ) {
+    vi.resetModules();
+    vi.doMock('../state.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../state.js')>();
+      return {
+        ...actual,
+        getPluginsDir: () => userDir,
+        getSystemPluginsDir: () => systemDir,
+        getEnabledExtraRepos: () => [],
+        getProjectPluginsDir: () => null,
+        getExtraPluginsDir: (alias: string) =>
+          alias === 'extras' ? path.join(extraRepo, 'plugins') : path.join(tmpDir, `agents-${alias}`, 'plugins'),
+        getTrashPluginsDir: () => trashDir,
+        ...overrides,
+      };
+    });
+    try {
+      const mod = await import('./plugins.js');
+      await fn(mod);
+    } finally {
+      vi.doUnmock('../state.js');
+      vi.resetModules();
+    }
+  }
+
+  it('trashes the stale agents-cli `code` after it moved to agents-system, keeping the current copy', async () => {
+    // Lineage: `code` was in the user repo AND the system repo. Install both.
+    writePlugin(userDir, 'code');
+    writePlugin(systemDir, 'code');
+
+    await withState({}, ({ discoverPlugins, syncPluginToVersion, cleanOrphanedPluginSkills }) => {
+      for (const p of discoverPlugins()) {
+        expect(syncPluginToVersion(p, 'claude', versionHome, { version: '1.0.0' }).success).toBe(true);
+      }
+      // Both marketplaces installed the plugin.
+      expect(fs.existsSync(installedPluginDir('agents-cli', 'code'))).toBe(true);
+      expect(fs.existsSync(installedPluginDir('agents-system', 'code'))).toBe(true);
+
+      // `code` moves out of the user repo entirely — now only agents-system ships it.
+      fs.rmSync(path.join(userDir, 'code'), { recursive: true, force: true });
+      const active = discoverPlugins();
+      expect(active.filter((p) => p.name === 'code').map((p) => p.marketplace)).toEqual(['agents-system']);
+
+      const removed = cleanOrphanedPluginSkills('claude', versionHome, active, '1.0.0');
+
+      // The shadow is gone; the current copy survives.
+      expect(removed).toContain('code');
+      expect(fs.existsSync(installedPluginDir('agents-cli', 'code'))).toBe(false);
+      expect(fs.existsSync(installedPluginDir('agents-system', 'code'))).toBe(true);
+    });
+  });
+
+  it('keeps BOTH copies while the same name is a live source in each marketplace (healthy path)', async () => {
+    writePlugin(userDir, 'code');
+    writePlugin(systemDir, 'code');
+
+    await withState({}, ({ discoverPlugins, syncPluginToVersion, cleanOrphanedPluginSkills }) => {
+      for (const p of discoverPlugins()) {
+        expect(syncPluginToVersion(p, 'claude', versionHome, { version: '1.0.0' }).success).toBe(true);
+      }
+      // Both sources still present — nothing is stale.
+      const removed = cleanOrphanedPluginSkills('claude', versionHome, discoverPlugins(), '1.0.0');
+
+      expect(removed).toEqual([]);
+      expect(fs.existsSync(installedPluginDir('agents-cli', 'code'))).toBe(true);
+      expect(fs.existsSync(installedPluginDir('agents-system', 'code'))).toBe(true);
+    });
+  });
+
+  it('keeps a still-present user plugin while trashing the moved one in the same pass', async () => {
+    writePlugin(userDir, 'code');
+    writePlugin(systemDir, 'code');
+    writePlugin(userDir, 'keeper');
+
+    await withState({}, ({ discoverPlugins, syncPluginToVersion, cleanOrphanedPluginSkills }) => {
+      for (const p of discoverPlugins()) {
+        expect(syncPluginToVersion(p, 'claude', versionHome, { version: '1.0.0' }).success).toBe(true);
+      }
+      fs.rmSync(path.join(userDir, 'code'), { recursive: true, force: true });
+
+      const removed = cleanOrphanedPluginSkills('claude', versionHome, discoverPlugins(), '1.0.0');
+
+      expect(removed).toEqual(['code']);
+      expect(fs.existsSync(installedPluginDir('agents-cli', 'code'))).toBe(false);
+      expect(fs.existsSync(installedPluginDir('agents-cli', 'keeper'))).toBe(true);
+    });
+  });
+
+  it('lenient fallback: does not trash an install whose source marketplace is unreachable', async () => {
+    // `code` lives in the user repo and an extra repo; install both. Then the
+    // extra repo is DISABLED (its source vanishes from discovery). Because that
+    // marketplace's source repo is no longer on disk, the extra install must be
+    // kept — an unrelated sync must not trash a plugin whose source simply is
+    // not reachable right now (only a present, authoritative source cleans).
+    writePlugin(userDir, 'code');
+    writePlugin(path.join(extraRepo, 'plugins'), 'code');
+
+    await withState(
+      { getEnabledExtraRepos: () => [{ alias: 'extras', dir: extraRepo, url: '' }] },
+      ({ discoverPlugins, syncPluginToVersion }) => {
+        for (const p of discoverPlugins()) {
+          expect(syncPluginToVersion(p, 'claude', versionHome, { version: '1.0.0' }).success).toBe(true);
+        }
+        expect(fs.existsSync(installedPluginDir('agents-extras', 'code'))).toBe(true);
+      }
+    );
+
+    // Re-run with the extra repo disabled AND its source directory removed.
+    fs.rmSync(extraRepo, { recursive: true, force: true });
+    await withState({}, ({ discoverPlugins, cleanOrphanedPluginSkills }) => {
+      const removed = cleanOrphanedPluginSkills('claude', versionHome, discoverPlugins(), '1.0.0');
+      expect(removed).not.toContain('code');
+      expect(fs.existsSync(installedPluginDir('agents-extras', 'code'))).toBe(true);
+    });
+  });
+});

--- a/cli/src/lib/plugins/plugins.ts
+++ b/cli/src/lib/plugins/plugins.ts
@@ -1595,17 +1595,113 @@ function cleanLegacyFlatLayout(
 // ─── Orphan cleanup ───────────────────────────────────────────────────────────
 
 /**
- * Remove orphaned plugin entries from a version home. An entry is "orphan" if
- * its plugin name is not in the active plugin set. Soft-deletes the affected
+ * The active plugin set, either as bare names (legacy callers / the dual-dash
+ * sweep, which has no marketplace to key on) or as the discovered plugins
+ * themselves (which carry marketplace provenance, enabling per-marketplace
+ * orphan detection — the PHNX-2618 shadow case below).
+ */
+export type ActivePluginsInput = Set<string> | Array<{ name: string; marketplace?: string }>;
+
+interface ActivePluginIndex {
+  /** Every active plugin name across all marketplaces. */
+  names: Set<string>;
+  /** `${marketplace} ${name}` for each active plugin, or null when the
+   * caller passed bare names (marketplace-aware detection disabled). */
+  pairs: Set<string> | null;
+}
+
+function pairKey(marketplace: string, name: string): string {
+  return `${marketplace} ${name}`;
+}
+
+function indexActivePlugins(input: ActivePluginsInput): ActivePluginIndex {
+  if (input instanceof Set) return { names: input, pairs: null };
+  const names = new Set<string>();
+  const pairs = new Set<string>();
+  for (const p of input) {
+    names.add(p.name);
+    // A discovered plugin always carries provenance; the type allows undefined,
+    // so mirror discovery's own default (a marketplace-less plugin is the user
+    // "agents-cli" marketplace — see discoverPlugins / buildDiscoveredPlugin).
+    pairs.add(pairKey(p.marketplace ?? MARKETPLACE_NAME, p.name));
+  }
+  return { names, pairs };
+}
+
+/**
+ * Does the SOURCE repo backing a synthesized marketplace exist on disk? A
+ * marketplace's version-home install is only authoritative-cleanable when its
+ * source repo is present: a present repo missing a plugin means that plugin was
+ * genuinely removed, while an absent repo (a project we're not in, a removed
+ * extra repo) is merely unreachable and must not be mistaken for deletion.
+ *
+ * We check the REPO root, not the plugins/ subdir: the user repo (~/.agents/)
+ * always exists but its plugins/ dir may not, and "user repo present, no `code`
+ * plugin in it" is exactly what makes an `agents-cli` `code` shadow a real
+ * orphan (PHNX-2618).
+ */
+function marketplaceSourceRepoExists(marketplaceName: string, cwd: string): boolean {
+  const spec = marketplaceSpecForName(marketplaceName, cwd);
+  switch (spec.kind) {
+    case 'user': return fs.existsSync(path.dirname(getPluginsDir()));
+    case 'system': return fs.existsSync(path.dirname(getSystemPluginsDir()));
+    case 'extra': return fs.existsSync(path.dirname(getExtraPluginsDir(spec.alias)));
+    case 'project': {
+      const root = getProjectPluginsDir(cwd);
+      return root != null && fs.existsSync(path.dirname(root));
+    }
+  }
+}
+
+/**
+ * Is a version-home marketplace-plugin install an orphan (safe to trash)?
+ *
+ * A version-home plugin is keyed by (marketplace, name), not name alone — the
+ * bug PHNX-2618 exposed. When the same plugin name lives in two marketplaces
+ * (e.g. a legacy `code` under `agents-cli` and the current `code` under
+ * `agents-system`), a name-only test keeps BOTH alive because the name is active
+ * somewhere, so the stale copy never gets cleaned and serves deleted skills.
+ *
+ *   - Pair still active → keep.
+ *   - Pair gone, but the marketplace's source repo is present (authoritative) →
+ *     orphan. Trash it even though another marketplace still ships that name.
+ *   - Pair gone AND the source repo is absent (unreachable) → fall back to the
+ *     original name-only test so an unrelated sync can't trash a plugin whose
+ *     source simply isn't on this box / in this cwd right now.
+ *
+ * When `pairs` is null (a legacy bare-name caller), this reduces to the original
+ * name-only behavior unchanged.
+ */
+function isOrphanMarketplacePlugin(
+  marketplaceName: string,
+  pluginName: string,
+  active: ActivePluginIndex,
+  cwd: string,
+): boolean {
+  if (active.pairs === null) return !active.names.has(pluginName);
+  if (active.pairs.has(pairKey(marketplaceName, pluginName))) return false;
+  if (marketplaceSourceRepoExists(marketplaceName, cwd)) return true;
+  return !active.names.has(pluginName);
+}
+
+/**
+ * Remove orphaned plugin entries from a version home. A marketplace-plugin
+ * install is "orphan" when no active source plugin matches its (marketplace,
+ * name) pair (see isOrphanMarketplacePlugin). Soft-deletes the affected
  * marketplace plugin dir to ~/.agents/.trash/plugins/. Also cleans up any
  * legacy dual-dash skills/ directories from older agents-cli versions.
+ *
+ * Pass the discovered plugins (`discoverPlugins()`) for marketplace-aware
+ * detection; a bare `Set<string>` of names keeps the original name-only behavior.
  */
 export function cleanOrphanedPluginSkills(
   agent: AgentId,
   versionHome: string,
-  activePluginNames: Set<string>,
+  activePlugins: ActivePluginsInput,
   version?: string
 ): string[] {
+  const active = indexActivePlugins(activePlugins);
+  const cwd = process.cwd();
   const removed: string[] = [];
 
   // 1. Walk every marketplace's install dir and trash entries no longer active.
@@ -1616,7 +1712,7 @@ export function cleanOrphanedPluginSkills(
     let trashedHere = false;
     for (const entry of fs.readdirSync(mktPluginsDir, { withFileTypes: true })) {
       if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
-      if (activePluginNames.has(entry.name)) continue;
+      if (!isOrphanMarketplacePlugin(name, entry.name, active, cwd)) continue;
       try {
         const stamp = new Date().toISOString().replace(/[:.]/g, '-');
         const trashDir = path.join(getTrashPluginsDir(), agent, version || 'unknown', entry.name);
@@ -1652,7 +1748,7 @@ export function cleanOrphanedPluginSkills(
       const dashIdx = entry.name.indexOf('--');
       if (dashIdx === -1) continue;
       const pluginName = entry.name.slice(0, dashIdx);
-      if (activePluginNames.has(pluginName)) continue;
+      if (active.names.has(pluginName)) continue;
       try {
         const stamp = new Date().toISOString().replace(/[:.]/g, '-');
         const trashDir = path.join(getTrashPluginsDir(), agent, version || 'unknown', entry.name);
@@ -1677,7 +1773,8 @@ export interface VersionPluginDiff {
 
 export function diffVersionPlugins(agent: AgentId, version: string): VersionPluginDiff {
   const versionHome = getVersionHomePath(agent, version);
-  const activePlugins = new Set(discoverPlugins().map(p => p.name));
+  const active = indexActivePlugins(discoverPlugins());
+  const cwd = process.cwd();
   const orphans: string[] = [];
 
   for (const name of listVersionMarketplaceNames(agent, versionHome)) {
@@ -1685,7 +1782,7 @@ export function diffVersionPlugins(agent: AgentId, version: string): VersionPlug
     if (!fs.existsSync(mktPluginsDir)) continue;
     for (const entry of fs.readdirSync(mktPluginsDir, { withFileTypes: true })) {
       if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
-      if (!activePlugins.has(entry.name)) {
+      if (isOrphanMarketplacePlugin(name, entry.name, active, cwd)) {
         orphans.push(entry.name);
       }
     }
@@ -1699,7 +1796,7 @@ export function diffVersionPlugins(agent: AgentId, version: string): VersionPlug
       const dashIdx = entry.name.indexOf('--');
       if (dashIdx === -1) continue;
       const pluginName = entry.name.slice(0, dashIdx);
-      if (!activePlugins.has(pluginName)) {
+      if (!active.names.has(pluginName)) {
         orphans.push(entry.name);
       }
     }

--- a/cli/src/lib/staleness/writers/plugins.ts
+++ b/cli/src/lib/staleness/writers/plugins.ts
@@ -16,8 +16,11 @@ function buildPluginsWriter(agent: AgentId): ResourceWriter<string[]> {
       const all = discoverPlugins();
       const map = new Map(all.map(p => [p.name, p]));
 
-      // Clean orphan plugin-skills from plugins that no longer exist.
-      cleanOrphanedPluginSkills(agent, versionHome, new Set(all.map(p => p.name)));
+      // Clean orphan plugin-skills from plugins that no longer exist. Pass the
+      // discovered plugins (not just names) so a stale install under one
+      // marketplace is trashed even when another marketplace still ships that
+      // name — the PHNX-2618 shadow `code` plugin.
+      cleanOrphanedPluginSkills(agent, versionHome, all);
 
       const synced: string[] = [];
       for (const name of selection) {


### PR DESCRIPTION
## PHNX-2618 — Fleet boxes carry a shadow `code` plugin from an old marketplace

### Root cause
A version home installs plugins **per marketplace** (`marketplaces/<name>/plugins/<plugin>`), but plugin orphan detection (`cleanOrphanedPluginSkills`, `diffVersionPlugins`) keyed on plugin **name** alone. When a plugin moved marketplaces — `code` once shipped from the user repo (the `agents-cli` marketplace) and later from the system repo (`agents-system`) — the stale `agents-cli` copy was never cleaned, because the name `code` was still active via `agents-system`.

Result: every fleet box carried **two** `code` plugins — the current one plus a shadow serving skills the repo deleted on purpose (`code:quality` / `code:ship` / `code:verify`), and resolution order decided which `code:review` an agent got.

### Fix
Orphan detection now keys on the **`(marketplace, name)` pair** via a shared `isOrphanMarketplacePlugin`:

- Pair still active → keep.
- Pair gone, **marketplace source repo present** (authoritative) → trash, even when another marketplace still ships that name. This is the shadow case — a plain `agents sync` reconciles it away.
- Pair gone, **marketplace source repo absent** (a project we're not in, a removed extra repo) → fall back to the original name-only test, so an unrelated sync from another cwd never trashes a plugin whose source simply isn't reachable right now.

The two production callers (`staleness/writers/plugins.ts`, `installations/versions.ts`) now pass the discovered plugins (with marketplace provenance) instead of a bare name set. The legacy `Set<string>` signature is preserved for the dual-dash sweep and existing tests (name-only behavior unchanged when passed a Set).

No revert, no behavior removed — the lenient path that existing code relied on is kept intact for unreachable sources; only the authoritative-source shadow is newly cleaned.

### Before / after evidence
Real sync + cleanup path, identical scenario (`code` installed from both marketplaces, then removed from the user repo so only `agents-system` ships it):

```
BEFORE (name-only Set):     removed = []        | agents-cli/code exists = true
AFTER  (marketplace-aware): removed = ["code"]  | agents-cli/code exists = false | agents-system/code exists = true
```

BEFORE = the exact call the old code paths made (`new Set(all.map(p => p.name))`). AFTER = the fixed callers. The shadow survives under name-only keying and is cleaned under marketplace-aware keying, while the current copy is kept.

### Tests (real, no mocks)
New block in `src/lib/plugins/plugins.test.ts` drives the real `discoverPlugins` → `syncPluginToVersion` → `cleanOrphanedPluginSkills` path against temp marketplaces:

- Trashes the stale `agents-cli` `code` after it moves to `agents-system`, keeping the current copy.
- Keeps **both** copies while the same name is a live source in each marketplace (healthy path — no over-cleaning).
- Keeps a still-present user plugin while trashing the moved one in the same pass.
- Lenient fallback: does **not** trash an install whose source marketplace is unreachable.

```
node_modules/.bin/vitest run src/lib/plugins/ src/lib/__tests__/plugins-prune.test.ts src/lib/staleness/ src/commands/prune.test.ts
Test Files  22 passed (22)
      Tests  329 passed (329)
```

`tsc --noEmit` clean. CHANGELOG (`.changelog/next/PHNX-2618.md`) + docs (`docs/resource-sync.md` §7) updated in this PR.

### Scope
Only `cli/src/lib/plugins/**` + the two reconcile callers + docs/changelog. The repo-pull hook path (a separate track) is untouched.

Closes PHNX-2618.
