### PR TITLE
fix(sessions): stats coverage reports scan coverage, not sparse with-usage (PHNX-2301)

### DIFF
--- a/cli/.changelog/next/PHNX-2301.md
+++ b/cli/.changelog/next/PHNX-2301.md
@@ -1,0 +1,24 @@
+- **`agents sessions stats` coverage now reports scan coverage, not with-usage,
+  so a completed backfill clears the "run the backfill" hint (PHNX-2301).** The
+  coverage line read `sessionsWithUsage / sessionsIndexed` — a ratio that stays
+  near-zero (~1.2% on a real fleet) even after `agents sessions backfill
+  resources` has fully run, because most sessions genuinely invoke no
+  skill/slash-command and a non-recording harness contributes none by
+  construction. The nag therefore never cleared and the low number read as a
+  coverage bug when it was not. `resourceUsageCoverage()` now also returns
+  `scanned` — the count of sessions carrying a `resource_scan_ledger` row at the
+  current `RESOURCE_INDEX_VERSION`, the honest "has the backfill folded in
+  history?" signal (the ledger is stamped for EVERY scanned session, including
+  ones that invoked nothing). The human line shows both — `N/T sessions scanned ·
+  M carry an explicit invocation` — and the backfill hint keys on
+  `scanned/total`, so it appears only when history really is un-scanned. The
+  `--json` `coverage` object gains `sessionsScanned` alongside the unchanged
+  `sessionsWithUsage`/`sessionsIndexed` (SES-IF-4b envelope preserved;
+  `schemaVersion` bumped to 2), and `signal.recording` now names the recorded set
+  (`skills: claude+kimi`, `commands: claude`) so a machine consumer can tell a
+  zero from a non-recording harness apart from genuine non-use. The zero-invoked
+  heading reads "never explicitly invoked" to match. Recording coverage itself is
+  unchanged — extending the `Skill`-tool set to another harness needs a verified
+  transcript tool-name, not a blind capability-table edit. Source:
+  `cli/src/lib/session/db.ts` (`resourceUsageCoverage`),
+  `cli/src/commands/sessions-stats.ts`.

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -1086,7 +1086,16 @@ The command surface (bare `sessions [query]`, `preview`, `tail`, `resume`, `deta
   count each resource identity (kind + name) once — merging source layers — and
   MUST record only EXPLICIT invocations (slash commands + `Skill` tool calls), so
   an auto-triggered skill reads as 0 (skill invocations come from Claude + Kimi,
-  slash-commands from Claude only); the envelope's `signal` field states this.
+  slash-commands from Claude only); the envelope's `signal` field states this and
+  its `signal.recording` field names the recorded set so a zero is not over-read.
+  The `coverage` object MUST distinguish SCAN coverage from with-usage coverage:
+  `sessionsScanned` counts sessions carrying a `resource_scan_ledger` row at the
+  current `RESOURCE_INDEX_VERSION` (the "has the backfill run" signal, which
+  reaches ~`sessionsIndexed` after a full backfill because the ledger is stamped
+  for every scanned session, incl. zero-usage ones), while `sessionsWithUsage`
+  stays the ABSOLUTE count of sessions with ≥1 explicit invocation — the
+  backfill hint keys on `sessionsScanned/sessionsIndexed`, never on
+  `sessionsWithUsage`, which is sparse by nature and would nag forever (PHNX-2301).
   `sessions backfill resources --json` MUST emit the versioned
   `resources-backfill` envelope and populate `session_resource_usage` for
   historical sessions gated by `resource_scan_ledger`, never silently re-scanning

--- a/cli/src/commands/sessions-stats.ts
+++ b/cli/src/commands/sessions-stats.ts
@@ -48,6 +48,20 @@ interface StatsOpts {
 
 const DEFAULT_TOP = 20;
 
+/**
+ * The recorded-set the zero-counts must be read against (PHNX-2301). A resource
+ * only records an EXPLICIT invocation from a harness that emits the event:
+ * `Skill` tool calls come from Claude + Kimi, slash-commands from Claude only
+ * (`SKILL_TOOL_NAME_BY_AGENT` in `lib/session/highlights.ts`, slash-command
+ * parsing in `lib/session/parse.ts`). A session under any other harness — or an
+ * auto-triggered skill, which emits no event on any harness — contributes
+ * nothing, so its resources read as 0 whether or not they were used. Keep these
+ * in lockstep with the writer: widening them here without a verified transcript
+ * tool-name would make the caveat lie about coverage it does not have.
+ */
+const RECORDING_SKILL_HARNESSES = ['claude', 'kimi'] as const;
+const RECORDING_COMMAND_HARNESSES = ['claude'] as const;
+
 /** One installed resource, keyed the same way session_resource_usage stores it. */
 export interface InstalledResource {
   kind: 'skill' | 'command';
@@ -194,7 +208,7 @@ async function statsAction(cmd: Command): Promise<void> {
     process.stdout.write(
       JSON.stringify(
         {
-          schemaVersion: 1,
+          schemaVersion: 2,
           kind: 'sessions-stats',
           generatedAt: new Date().toISOString(),
           filters: {
@@ -208,9 +222,21 @@ async function statsAction(cmd: Command): Promise<void> {
           signal: {
             explicitOnly: true,
             note: 'Explicit invocations only (slash commands + Skill tool calls). Auto-triggered skills emit no event and read as 0. Skill invocations are recorded for Claude and Kimi; slash-commands for Claude only.',
+            // Structured recorded-set so a machine consumer can tell a zero from a
+            // non-recording harness apart from a genuine non-use (PHNX-2301): a
+            // zeroInvoked resource may simply have been auto-triggered, or only
+            // used under a harness not in these sets.
+            recording: {
+              skills: RECORDING_SKILL_HARNESSES,
+              commands: RECORDING_COMMAND_HARNESSES,
+            },
           },
           coverage: {
+            // sessionsWithUsage/sessionsIndexed kept for the SES-IF-4b envelope
+            // contract; sessionsScanned is the honest backfill-coverage numerator
+            // (ledger rows), distinct from the absolute sessionsWithUsage count.
             sessionsWithUsage: coverage.covered,
+            sessionsScanned: coverage.scanned,
             sessionsIndexed: coverage.total,
           },
           totals: {
@@ -279,7 +305,7 @@ function renderHuman(args: {
   kind: 'skill' | 'command' | undefined;
   ranked: ResourceStatRow[];
   zeroInvoked: InstalledResource[];
-  coverage: { covered: number; total: number };
+  coverage: { covered: number; scanned: number; total: number };
   totalInvocations: number;
   allInvokedCount: number;
   top: number;
@@ -300,9 +326,13 @@ function renderHuman(args: {
       chalk.gray(`  ·  ${allInvokedCount} invoked · ${totalInvocations} invocation${totalInvocations !== 1 ? 's' : ''}` +
         (scopeBits.length ? `  ·  ${scopeBits.join(' · ')}` : '')),
   );
+  // Scan coverage (ledger) is the honest "has the backfill folded in history?"
+  // signal and drives the hint; sessionsWithUsage is an ABSOLUTE count of sessions
+  // carrying ≥1 explicit invocation, which stays small at full scan coverage
+  // because most sessions invoke nothing (PHNX-2301).
   out.push(
-    chalk.gray(`  coverage: ${coverage.covered}/${coverage.total} sessions carry the signal`) +
-      (coverage.total > 0 && coverage.covered / coverage.total < 0.5
+    chalk.gray(`  coverage: ${coverage.scanned}/${coverage.total} sessions scanned · ${coverage.covered} carry an explicit invocation`) +
+      (coverage.total > 0 && coverage.scanned / coverage.total < 0.5
         ? chalk.yellow('  — run `agents sessions backfill resources` to fold in history')
         : ''),
   );
@@ -321,8 +351,11 @@ function renderHuman(args: {
     out.push('');
   }
 
-  // Zero-invoked section (the dead weight).
-  out.push(chalk.bold('Installed but never invoked') + chalk.gray(`  (${zeroInvoked.length})`));
+  // Zero-invoked section (the dead weight). "Never invoked" is scoped to the
+  // recorded set: never EXPLICITLY invoked under a recording harness (skills
+  // Claude+Kimi, commands Claude-only) — it may still have been auto-triggered or
+  // used under another harness, which is why this is dead-weight EVIDENCE, not proof.
+  out.push(chalk.bold('Installed but never explicitly invoked') + chalk.gray(`  (${zeroInvoked.length})`));
   if (zeroInvoked.length === 0) {
     out.push(chalk.gray('  (every installed resource has at least one explicit invocation in this window)'));
   } else {

--- a/cli/src/lib/session/__tests__/resource-coverage.test.ts
+++ b/cli/src/lib/session/__tests__/resource-coverage.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolated HOME so this file's SQLite population is fully controlled — the whole
+// point is to assert scan-coverage vs. usage-coverage against a KNOWN total, which
+// a shared db (resource-stats.test.ts seeds extra sessions) would perturb. Real
+// SQLite + real parseSession/backfill, no mocking. (PHNX-2301)
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-rescov-'));
+process.env.HOME = TEST_HOME;
+
+const { getDB, resourceUsageCoverage, backfillResourceUsage } = await import('../db.js');
+
+const SEED_FILES_DIR = path.join(TEST_HOME, 'seed-files');
+fs.mkdirSync(SEED_FILES_DIR, { recursive: true });
+
+function seedSession(id: string, filePath: string): void {
+  getDB().prepare(`
+    INSERT INTO sessions (
+      id, short_id, agent, version, timestamp, project, cwd, machine,
+      file_path, file_mtime_ms, file_size, scanned_at, is_team_origin
+    ) VALUES (?, ?, 'claude', NULL, '2026-06-01T00:00:00.000Z', 'proj', ?, 'boxA', ?, 0, 0, 0, 0)
+  `).run(id, id.slice(0, 8), SEED_FILES_DIR, filePath);
+}
+
+/** A claude transcript that explicitly invokes one skill + one slash command. */
+function invokingTranscript(): string {
+  return [
+    { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'run the teams skill' } },
+    { type: 'assistant', timestamp: '2026-06-28T00:00:10.000Z', uuid: 'a-1', message: { id: 'm1', model: 'claude-sonnet-4-5', content: [{ type: 'tool_use', id: 'sk-1', name: 'Skill', input: { skill: 'teams' } }], usage: { input_tokens: 5, output_tokens: 5 } } },
+    { type: 'assistant', timestamp: '2026-06-28T00:00:20.000Z', uuid: 'a-2', message: { id: 'm2', model: 'claude-sonnet-4-5', content: [{ type: 'tool_use', id: 'sc-1', name: 'SlashCommand', input: { command: '/recap' } }], usage: { input_tokens: 5, output_tokens: 5 } } },
+  ].map((l) => JSON.stringify(l)).join('\n') + '\n';
+}
+
+/** A real, complete claude transcript with turns but NO skill/slash-command — the
+ * "we scanned it and it genuinely invoked nothing" case that must count as SCANNED
+ * yet contribute nothing to the with-usage count. */
+function quietTranscript(): string {
+  return [
+    { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'what does this function do?' } },
+    { type: 'assistant', timestamp: '2026-06-28T00:00:10.000Z', uuid: 'q-1', message: { id: 'q1', model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'It sums the array.' }], usage: { input_tokens: 5, output_tokens: 5 } } },
+  ].map((l) => JSON.stringify(l)).join('\n') + '\n';
+}
+
+// 5 sessions, all with real non-empty transcripts: 2 invoke a resource, 3 are
+// quiet. A full backfill scans all 5 (ledger stamped for every one, incl. the
+// quiet zero-usage ones), but only 2 land a session_resource_usage row.
+beforeAll(() => {
+  for (const id of ['inv1', 'inv2']) {
+    const fp = path.join(SEED_FILES_DIR, `${id}.jsonl`);
+    fs.writeFileSync(fp, invokingTranscript());
+    seedSession(id, fp);
+  }
+  for (const id of ['quiet1', 'quiet2', 'quiet3']) {
+    const fp = path.join(SEED_FILES_DIR, `${id}.jsonl`);
+    fs.writeFileSync(fp, quietTranscript());
+    seedSession(id, fp);
+  }
+});
+
+describe('resourceUsageCoverage — scan coverage is distinct from with-usage coverage (PHNX-2301)', () => {
+  it('before backfill: nothing scanned, and the old with-usage numerator is 0 — both would nag', () => {
+    const cov = resourceUsageCoverage();
+    expect(cov.total).toBe(5);
+    expect(cov.scanned).toBe(0);   // no ledger rows yet → backfill hasn't run
+    expect(cov.covered).toBe(0);   // no usage rows written yet
+  });
+
+  it('after backfill: scan coverage reaches 100% while with-usage stays sparse — the exact 1.2% illusion', () => {
+    const result = backfillResourceUsage({});
+    // Every one of the 5 real transcripts is parsed and its ledger stamped —
+    // including the 3 quiet sessions that produced zero usage rows.
+    expect(result.scanned).toBe(5);
+    expect(result.updated).toBe(5);
+    expect(result.failed).toBe(0);
+    expect(result.resourceRows).toBe(4); // inv1 + inv2, each a skill + a command
+
+    const cov = resourceUsageCoverage();
+    // The fix: scan coverage is the honest "backfill has run" signal — 5/5, so the
+    // hint (`scanned/total < 0.5`) clears. The OLD covered-based coverage would read
+    // 2/5 = 40% and keep nagging for a backfill that has, in fact, fully run.
+    expect(cov.scanned).toBe(5);
+    expect(cov.total).toBe(5);
+    expect(cov.scanned / cov.total).toBe(1);           // hint cleared — healthy path
+    expect(cov.covered).toBe(2);                       // absolute signal count, unchanged meaning
+    expect(cov.covered / cov.total).toBeLessThan(0.5); // old numerator would still nag
+  });
+
+  it('a stale-extractor-version ledger row does NOT count as scanned (re-derived next backfill)', () => {
+    // Demote inv1's ledger row to an older extractor version, as a pre-bump row
+    // would read. It must drop out of the scanned count until re-derived.
+    getDB().prepare(`UPDATE resource_scan_ledger SET extractor_version = 0 WHERE session_id = 'inv1'`).run();
+    expect(resourceUsageCoverage().scanned).toBe(4);
+    // Restore so the row is current again.
+    getDB().prepare(`UPDATE resource_scan_ledger SET extractor_version = 1 WHERE session_id = 'inv1'`).run();
+    expect(resourceUsageCoverage().scanned).toBe(5);
+  });
+
+  it('a ledger row for a since-vanished session does NOT inflate scan coverage past the indexed set', () => {
+    // A ledger row whose session was dropped from `sessions` (transcript vanished)
+    // must not be counted — the JOIN guards this. Insert an orphan ledger row.
+    getDB().prepare(`
+      INSERT INTO resource_scan_ledger
+        (session_id, file_path, file_mtime_ms, file_size, extractor_version, indexed_at, resource_count)
+      VALUES ('ghost', ?, 0, 0, 1, 0, 0)
+    `).run(path.join(SEED_FILES_DIR, 'ghost.jsonl'));
+    const cov = resourceUsageCoverage();
+    expect(cov.scanned).toBe(5); // ghost excluded — no matching sessions row
+    expect(cov.total).toBe(5);
+  });
+});

--- a/cli/src/lib/session/__tests__/resource-stats.test.ts
+++ b/cli/src/lib/session/__tests__/resource-stats.test.ts
@@ -147,11 +147,15 @@ describe('queryResourceUsageStats — aggregate rollup', () => {
 });
 
 describe('resourceUsageCoverage', () => {
-  it('reports distinct sessions carrying the signal vs. total indexed', () => {
-    const { covered, total } = resourceUsageCoverage();
+  it('reports distinct sessions carrying the signal, sessions scanned, and total indexed', () => {
+    const { covered, scanned, total } = resourceUsageCoverage();
     // A, B, C carry seeded usage; D was seeded WITHOUT a usage row (backfill fills it).
     expect(covered).toBe(3);
     expect(total).toBe(4);
+    // No backfill has run in THIS describe yet, so no resource_scan_ledger rows —
+    // scan coverage is 0 even though 3 sessions carry seeded usage. This is the
+    // PHNX-2301 distinction: with-usage is not scan coverage.
+    expect(scanned).toBe(0);
   });
 });
 

--- a/cli/src/lib/session/db.ts
+++ b/cli/src/lib/session/db.ts
@@ -3878,17 +3878,43 @@ export function queryResourceUsageStats(
 }
 
 /**
- * Coverage of the resource-usage signal: how many distinct sessions carry any
- * row in session_resource_usage vs. the total indexed. A low ratio means the
- * historical backfill (`agents sessions backfill resources`) hasn't run — the
- * stats surface uses this to tell the user their zero-counts may just be
- * un-scanned history, not genuine non-use.
+ * Coverage of the resource-usage signal, as three honest facts:
+ *
+ * - `scanned`  — sessions the resource extractor has actually processed, i.e.
+ *   those carrying a `resource_scan_ledger` row at the current
+ *   `RESOURCE_INDEX_VERSION`. This is the true "has the historical backfill run"
+ *   signal: the ledger is stamped for EVERY scanned session, including ones that
+ *   invoked nothing (`resource_count = 0`), so `scanned/total` rises to ~1 after
+ *   `agents sessions backfill resources` regardless of how sparse explicit
+ *   invocations are.
+ * - `covered`  — distinct sessions that carry AT LEAST ONE row in
+ *   `session_resource_usage`, i.e. that actually recorded an explicit invocation.
+ *   This is an ABSOLUTE signal count, not a coverage ratio: it stays small even
+ *   at full scan coverage because most sessions invoke no skill/command, and a
+ *   non-recording harness contributes none by construction.
+ * - `total`    — sessions indexed.
+ *
+ * The two were previously conflated: `covered/total` was framed as coverage and
+ * read ~1.2% even after a full backfill (most sessions genuinely invoke nothing),
+ * so the "run the backfill" hint never cleared. Keying the hint on `scanned/total`
+ * fixes that — see `commands/sessions-stats.ts` (PHNX-2301).
  */
-export function resourceUsageCoverage(): { covered: number; total: number } {
+export function resourceUsageCoverage(): { covered: number; scanned: number; total: number } {
   const db = getDB();
   const covered = (db.prepare(`SELECT COUNT(DISTINCT session_id) AS n FROM session_resource_usage`).get() as { n: number }).n;
+  // JOIN sessions so a ledger row for a since-vanished transcript (dropped from
+  // `sessions` but not yet from the ledger) can't inflate scan coverage past the
+  // indexed set. Only rows at the current extractor version count as scanned —
+  // a stale-version row is re-derived on the next backfill, so it is not yet
+  // "covered" for this extractor.
+  const scanned = (db.prepare(`
+    SELECT COUNT(*) AS n
+    FROM resource_scan_ledger l
+    JOIN sessions s ON s.id = l.session_id
+    WHERE l.extractor_version = ?
+  `).get(RESOURCE_INDEX_VERSION) as { n: number }).n;
   const total = (db.prepare(`SELECT COUNT(*) AS n FROM sessions`).get() as { n: number }).n;
-  return { covered, total };
+  return { covered, scanned, total };
 }
 
 /** Has this session's resource usage been derived at the current extractor version for this exact file? */


### PR DESCRIPTION
## PHNX-2301 — `agents sessions stats` coverage reads ~1.2% and never clears the backfill hint

### Root cause (file:line)
`resourceUsageCoverage()` (`cli/src/lib/session/db.ts:3887`) returned `covered = COUNT(DISTINCT session_id) FROM session_resource_usage` — but a usage row only exists when a session **explicitly invoked** a skill/slash-command. Its own docstring claimed "a low ratio means the historical backfill hasn't run", yet the ratio stays ~1.2% **even after a full backfill**, because:
- most sessions genuinely invoke no skill/command, and
- a non-recording harness contributes none by construction (`SKILL_TOOL_NAME_BY_AGENT` is Claude+Kimi only; slash-commands Claude-only — `cli/src/lib/session/highlights.ts:40`).

So the number conflated *"we haven't scanned this history"* with *"this session invoked nothing"*, the hint never cleared, and dead-weight analysis read the zeros as un-recorded rather than genuinely unused.

### The honest signal already exists: the ledger
`resource_scan_ledger` is stamped for **every** scanned session, including ones that invoked nothing (`resource_count = 0`) — `stampResourceLedger` at `db.ts:4006`. That is the faithful "has the backfill run?" signal. `resourceUsageCoverage()` now also returns `scanned` (ledger rows at the current `RESOURCE_INDEX_VERSION`, JOINed to `sessions` so a vanished-transcript row can't inflate it). The human line shows both facts, and the backfill hint keys on `scanned/total`, not the sparse `withUsage/total`.

### Why not the naive "record every harness" fix
Adding harnesses to `SKILL_TOOL_NAME_BY_AGENT` without a verified transcript tool-name would violate the repo's **"capability table stays truthful"** convention — the doc states an absent entry means "we don't know yet", not "unsupported". So I took the ticket's explicitly-offered safe alternative ("document the recorded-set explicitly in the output"): `signal.recording` now names the recorded set, and the zero-invoked heading reads "never **explicitly** invoked". Extending recording to another harness is a separate, evidence-required change.

### Before / after (real `agents sessions stats --since 30d`, same sessions.db)

**BEFORE** (installed production CLI):
```
Resource usage  ·  24 invoked · 117 invocations  ·  since 30d
  coverage: 63/895 sessions carry the signal  — run `agents sessions backfill resources` to fold in history
```
The `63/895` reads as a coverage failure; running the backfill barely moves it (with-usage is sparse by nature), so the hint never clears.

**AFTER — before running backfill** (this branch):
```
Resource usage  ·  24 invoked · 117 invocations  ·  since 30d
  coverage: 0/895 sessions scanned · 63 carry an explicit invocation  — run `agents sessions backfill resources` to fold in history
```
`0/895 scanned` is honest: the ledger really is empty on this box, so the hint is correct.

**AFTER — after `agents sessions backfill resources`** (this branch):
```
$ node dist/index.js sessions backfill resources
yosemite-*: derived usage for 306 sessions (104 resource rows); 0 already current, 332 scanned.
26 transcripts could not be parsed; rerun to retry.

$ node dist/index.js sessions stats --since 30d
Resource usage  ·  24 invoked · 120 invocations  ·  since 30d
  coverage: 306/895 sessions scanned · 64 carry an explicit invocation  — ...
```
Scan coverage rose **0 → 306** (the backfill visibly worked); with-usage barely moved (64), confirming the old numerator was the wrong signal. The residual (306 of 895) is remote-mirror rows without a local transcript on this box — the backfill reported 332 locally scannable — so scan coverage tracks *local* derivation honestly.

### JSON envelope (SES-IF-4b preserved, `schemaVersion` 2)
```json
"signal": { "explicitOnly": true, "note": "...", "recording": { "skills": ["claude","kimi"], "commands": ["claude"] } },
"coverage": { "sessionsWithUsage": 64, "sessionsScanned": 306, "sessionsIndexed": 895 }
```
Required keys unchanged; `sessionsScanned` and `signal.recording` are additive.

### Tests (real SQLite + real backfill, no mocks)
`cli/src/lib/session/__tests__/resource-coverage.test.ts` seeds 5 real transcripts (2 invoking, 3 quiet), runs the real `backfillResourceUsage`, and asserts:
- before backfill: `scanned=0`, `covered=0` (both would nag);
- after backfill: `scanned=5/5` (hint clears) while `covered=2/5` (old numerator would still nag) — the exact illusion;
- a stale-`extractor_version` ledger row does **not** count as scanned;
- a ledger row for a since-vanished session does **not** inflate scan coverage.

```
Test Files  3 passed (3)
     Tests  16 passed (16)
```

### Docs
- CHANGELOG fragment `cli/.changelog/next/PHNX-2301.md`.
- SES-IF-4b updated in `cli/docs/specifications.md` to specify the scan-vs-with-usage distinction and `signal.recording`.

### No regression
- `sessionsWithUsage`/`sessionsIndexed` kept (additive change); envelope keys unchanged.
- Hot incremental scan path untouched — the ledger stays the backfill's idempotency record, and the idempotent backfill clears the hint. `resourceUsageCoverage` has one consumer (`sessions-stats.ts`), updated in lockstep.

Handing off to the orchestrator for an independent non-author review + merge (prix-cloud auto-review is paused).