### PR TITLE
fix(doctor): --fix reconciles hooks/permissions/subagents/rule-aliases on Windows (PHNX-3187)

### DIFF
--- a/cli/.changelog/next/PHNX-3187.md
+++ b/cli/.changelog/next/PHNX-3187.md
@@ -20,9 +20,9 @@
   (`git-guard`) back to the sync writer, whose `available.hooks` set carries the
   source filename **with** its extension (`git-guard.sh`), so the exact-set match
   found nothing and no flagged hook could be written; a new basename-tolerant
-  `resolveHookSelection` maps them, and the orphan sweep prunes any stale
-  extensionless copy an older heal left behind (invisible on Windows because it
-  lacked both an extension and an exec bit). The subagents writer also now
+  `resolveHookSelection` maps them, and the orphan sweep still prunes any stale
+  extensionless hook copy left in a version home (one would be invisible on
+  Windows, lacking both an extension and an exec bit). The subagents writer also now
   surfaces a per-item write failure with its reason instead of swallowing it in a
   bare `catch`, so a genuine failure fails loud rather than reading as a silent
   "hold". Source: `cli/src/lib/subagents.ts`, `cli/src/lib/permissions.ts`,

--- a/cli/.changelog/next/PHNX-3187.md
+++ b/cli/.changelog/next/PHNX-3187.md
@@ -1,0 +1,30 @@
+- **`agents doctor --fix` now reconciles hooks / permissions / subagents / rule
+  aliases on Windows instead of an unactionable "hold" (PHNX-3187).** On win-mini
+  `--fix` healed commands/skills/rules/plugins but reported hooks, permissions,
+  subagents, and the `CLAUDE`/`GEMINI` rule aliases as "couldn't reconcile" and
+  left the box permanently red — with real guards (`git-guard`, `rm-guard`,
+  `secrets-guard`, `ask-user-question-guard`, `public-artifact-guard`)
+  uninstalled. Four Windows-specific defects, each fixed at its source: (1)
+  **subagents** — `parseSubagentFrontmatter`/`getSubagentBody` split on `'\n'`
+  and compared the fence with `=== '---'`, so a git-CRLF-checked-out `AGENT.md`
+  (`'---\r'`) was rejected and the subagent silently dropped from discovery, so
+  it could never be installed; now CRLF-robust (`/\r?\n/`). (2) **permissions** —
+  `buildPermissionsFromGroups` extracted rules with a line regex anchored on the
+  closing quote (`"$`), which a trailing `\r` broke, extracting zero rules and
+  writing an empty permission set; now CRLF-robust. (3) **rule aliases** — git
+  checks the `rules/CLAUDE.md` and `rules/GEMINI.md` symlinks out as plain text
+  files on Windows, so `lstat().isSymbolicLink()` was false and the diff treated
+  them as independent rule sources no sync could ever produce; a new
+  `isCheckedOutSymlink` detector skips them on every platform. (4) **hooks** —
+  the heal pass fed the resource diff's extensionless hook names
+  (`git-guard`) back to the sync writer, whose `available.hooks` set carries the
+  source filename **with** its extension (`git-guard.sh`), so the exact-set match
+  found nothing and no flagged hook could be written; a new basename-tolerant
+  `resolveHookSelection` maps them, and the orphan sweep prunes any stale
+  extensionless copy an older heal left behind (invisible on Windows because it
+  lacked both an extension and an exec bit). The subagents writer also now
+  surfaces a per-item write failure with its reason instead of swallowing it in a
+  bare `catch`, so a genuine failure fails loud rather than reading as a silent
+  "hold". Source: `cli/src/lib/subagents.ts`, `cli/src/lib/permissions.ts`,
+  `cli/src/lib/doctor-diff.ts`, `cli/src/lib/installations/versions.ts`,
+  `cli/src/lib/staleness/writers/subagents.ts`.

--- a/cli/src/lib/__tests__/doctor-diff.test.ts
+++ b/cli/src/lib/__tests__/doctor-diff.test.ts
@@ -235,3 +235,47 @@ describe('diffVersionResources — command-as-skill agents', () => {
     expect(report.kinds.commands.find((c) => c.name === 'foo')?.status).toBe('missing');
   });
 });
+
+// PHNX-3187: rules/CLAUDE.md and rules/GEMINI.md are symlinks to AGENTS.md in
+// the DotAgents repos. On Windows without symlink support git checks them out
+// as PLAIN TEXT FILES whose whole content is the target path ("AGENTS.md"), so
+// lstat().isSymbolicLink() is false and they were mistaken for independent
+// rule sources no sync could ever produce — a permanent doctor "hold".
+// isCheckedOutSymlink is the platform-agnostic detector that closes it.
+describe('isCheckedOutSymlink (PHNX-3187)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'checked-out-symlink-'));
+    fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Rules\n\nThe canonical rules.\n');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('flags a git-checked-out symlink text file that resolves to a sibling', async () => {
+    const { isCheckedOutSymlink } = await import('../doctor-diff.js');
+    // A git symlink blob is the bare target with no trailing newline.
+    fs.writeFileSync(path.join(dir, 'CLAUDE.md'), 'AGENTS.md');
+    expect(isCheckedOutSymlink(path.join(dir, 'CLAUDE.md'))).toBe(true);
+  });
+
+  it('does NOT flag a real multi-line markdown rules file', async () => {
+    const { isCheckedOutSymlink } = await import('../doctor-diff.js');
+    fs.writeFileSync(path.join(dir, 'extra.md'), '# Extra\n\nA real rule file.\n');
+    expect(isCheckedOutSymlink(path.join(dir, 'extra.md'))).toBe(false);
+  });
+
+  it('does NOT flag a single-line file whose content is not a real sibling path', async () => {
+    const { isCheckedOutSymlink } = await import('../doctor-diff.js');
+    fs.writeFileSync(path.join(dir, 'note.md'), 'just a one-line note');
+    expect(isCheckedOutSymlink(path.join(dir, 'note.md'))).toBe(false);
+  });
+
+  it('does NOT flag a real posix symlink (its content is the multi-line target)', async () => {
+    const { isCheckedOutSymlink } = await import('../doctor-diff.js');
+    try {
+      fs.symlinkSync('AGENTS.md', path.join(dir, 'GEMINI.md'));
+    } catch {
+      return; // filesystem without symlink support — the checked-out-text case covers it
+    }
+    expect(isCheckedOutSymlink(path.join(dir, 'GEMINI.md'))).toBe(false);
+  });
+});

--- a/cli/src/lib/doctor-diff.ts
+++ b/cli/src/lib/doctor-diff.ts
@@ -159,6 +159,39 @@ function fileExists(p: string | null | undefined): p is string {
   return !!p && fs.existsSync(p) && !fs.lstatSync(p).isSymbolicLink();
 }
 
+/**
+ * True when `filePath` is a git symlink that was CHECKED OUT AS A PLAIN TEXT
+ * FILE — the shape git produces on a client without symlink support (Windows
+ * without Developer Mode, `core.symlinks=false`). Such a file holds exactly the
+ * link target (a relative path, no trailing newline) instead of the pointed-to
+ * content. `lstat().isSymbolicLink()` is FALSE for it, so callers that only
+ * skip real symlinks (e.g. the rules/permissions alias files CLAUDE.md /
+ * GEMINI.md, which are symlinks to AGENTS.md in the repo) wrongly treat it as
+ * an independent resource that no sync can ever reconcile (PHNX-3187). The
+ * signal is unambiguous: a whole file with no newline whose entire content
+ * resolves to an existing sibling path. Real markdown rule files always contain
+ * newlines, so this never false-positives on genuine content.
+ */
+export function isCheckedOutSymlink(filePath: string): boolean {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return false;
+  }
+  // A git symlink blob is the bare target with no newline; any newline means
+  // this is real file content, not a link.
+  if (content.length === 0 || content.length > 255 || /[\r\n]/.test(content)) return false;
+  const target = content.trim();
+  if (!target) return false;
+  const resolved = path.resolve(path.dirname(filePath), target);
+  try {
+    return fs.statSync(resolved).isFile();
+  } catch {
+    return false;
+  }
+}
+
 function findFirst(candidates: SourceCandidate[]): SourceCandidate | null {
   for (const c of candidates) {
     if (fileExists(c.path) || (fs.existsSync(c.path) && fs.lstatSync(c.path).isDirectory())) {
@@ -483,8 +516,13 @@ function listRulesNames(cwd: string, excludeProject = false): Map<string, Source
     try { entries = fs.readdirSync(base.path); } catch { continue; }
     for (const file of entries) {
       if (!file.endsWith('.md') || file === RULES_DOC_FILENAME) continue;
-      const stat = fs.lstatSync(path.join(base.path, file));
-      if (stat.isSymbolicLink()) continue;
+      const filePath = path.join(base.path, file);
+      const stat = fs.lstatSync(filePath);
+      // Skip the CLAUDE.md / GEMINI.md alias symlinks — both when they are real
+      // symlinks (posix) and when git checked them out as plain text files
+      // (Windows), so they are never mistaken for independent rule sources the
+      // writer can't produce (PHNX-3187).
+      if (stat.isSymbolicLink() || isCheckedOutSymlink(filePath)) continue;
       const name = file.replace(/\.md$/, '');
       if (out.has(name)) continue;
       out.set(name, { layer: base.layer, path: path.join(base.path, file), alias: base.alias });

--- a/cli/src/lib/installations/versions.test.ts
+++ b/cli/src/lib/installations/versions.test.ts
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 // directly in this process. getBinaryPath itself is exercised through
 // runVersionSync's isolated-HOME subprocess below, like every other
 // versions.ts function whose paths derive from HOME.
-import { resolveGrokFallbackBinary } from './versions.js';
+import { resolveGrokFallbackBinary, resolveHookSelection } from './versions.js';
 
 const tempDirs: string[] = [];
 
@@ -1761,5 +1761,45 @@ describe('system-scoped selection includes system-layer plugins (RUSH-3207)', ()
     // skipped system-layer plugins — the swarm-plugin bug.
     expect(result.plugins ?? []).toContain('swarm');
     expect(result.plugins ?? []).not.toContain('mine');
+  });
+});
+
+// PHNX-3187: `available.hooks` carries the source filename WITH its extension
+// (`git-guard.sh`), but the doctor/heal resource diff names a hook by its
+// extensionless basename (`git-guard`). A heal pass feeds those diff names
+// straight back as the selection, so the old exact-set filter matched nothing
+// and `agents doctor --fix` could never reconcile a flagged hook. This is what
+// left win-mini's guards permanently "held" once its diff flagged them.
+describe('resolveHookSelection — basename-tolerant hook matching (PHNX-3187)', () => {
+  const available = ['git-guard.sh', '10-feed-publish.py', 'json-field.sh', 'ask-user-question-guard.sh'];
+
+  it('resolves extensionless diff/heal names to the extensioned available name', () => {
+    expect(resolveHookSelection(['git-guard', 'json-field'], available)).toEqual([
+      'git-guard.sh',
+      'json-field.sh',
+    ]);
+  });
+
+  it('resolves numbered .py hooks by basename too', () => {
+    expect(resolveHookSelection(['10-feed-publish'], available)).toEqual(['10-feed-publish.py']);
+  });
+
+  it('still matches exact extensioned names (no regression for full-sync callers)', () => {
+    expect(resolveHookSelection(['git-guard.sh', 'ask-user-question-guard.sh'], available)).toEqual([
+      'git-guard.sh',
+      'ask-user-question-guard.sh',
+    ]);
+  });
+
+  it("'all' returns the whole available set unchanged", () => {
+    expect(resolveHookSelection('all', available)).toEqual(available);
+  });
+
+  it('drops a selection entry that matches nothing, and de-duplicates', () => {
+    expect(resolveHookSelection(['git-guard', 'git-guard.sh', 'nope'], available)).toEqual(['git-guard.sh']);
+  });
+
+  it('undefined selection yields nothing', () => {
+    expect(resolveHookSelection(undefined, available)).toEqual([]);
   });
 });

--- a/cli/src/lib/installations/versions.ts
+++ b/cli/src/lib/installations/versions.ts
@@ -2469,6 +2469,44 @@ export function mergeRepoScopedSelections(repos: string[], cwd: string = process
  *
  * For Gemini: commands are converted from markdown to TOML.
  */
+/**
+ * Resolve a caller's hook selection against the available hook set, matching a
+ * selection entry by exact name OR by its extensionless basename, and returning
+ * the AVAILABLE (extensioned) name in every case.
+ *
+ * `available.hooks` carries the source filename WITH its extension
+ * (`git-guard.sh`) — the shape the hooks writer's source resolver requires — but
+ * the doctor/heal resource diff identifies a hook by its extensionless basename
+ * (`git-guard`). A heal pass feeds those diff names straight back as the
+ * selection, so a plain exact-set filter matched NOTHING and `agents doctor
+ * --fix` could never reconcile a flagged hook (PHNX-3187). Basename tolerance
+ * closes that gap without changing the extensioned names the writer needs.
+ *
+ * Order-stable and de-duplicated; a selection entry that matches nothing is
+ * dropped (mirrors resolveSelection).
+ */
+export function resolveHookSelection(sel: string[] | 'all' | undefined, available: string[]): string[] {
+  if (sel === 'all') return available;
+  if (!Array.isArray(sel)) return [];
+  const stripExt = (n: string): string => n.replace(/\.[^./\\]+$/, '');
+  const exact = new Set(available);
+  const byBase = new Map<string, string>();
+  for (const a of available) {
+    const base = stripExt(a);
+    if (!byBase.has(base)) byBase.set(base, a); // first available wins the basename
+  }
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const name of sel) {
+    const resolved = exact.has(name) ? name : byBase.get(stripExt(name));
+    if (resolved && !seen.has(resolved)) {
+      seen.add(resolved);
+      out.push(resolved);
+    }
+  }
+  return out;
+}
+
 export function syncResourcesToVersion(agent: AgentId, version: string, selection?: ResourceSelection, options: { projectDir?: string; cwd?: string; force?: boolean; available?: AvailableResources; prune?: boolean; allowExecSurfaces?: boolean } = {}): SyncResult {
   if (isAgentHardDeprecated(agent)) {
     return { commands: false, skills: false, hooks: false, memory: [], permissions: false, mcp: [], subagents: [], plugins: [], workflows: [], projectSkipped: [], pruned: { commands: [], skills: [] }, declined: [] };
@@ -2774,8 +2812,14 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
     if (!hooksGate.ok) {
       console.warn(explainSkip(agent, 'hooks', hooksGate, version) + ' -- skipped');
     } else {
+      // Resolve requested hooks against the available set BY BASENAME as well as
+      // exact name. `available.hooks` carries the source filename WITH its
+      // extension (`git-guard.sh`), but the doctor/heal diff identifies a hook
+      // by its extensionless basename (`git-guard`) — so a heal pass that feeds
+      // the diff's names straight back through the plain resolveSelection
+      // matched NOTHING and could never reconcile a flagged hook (PHNX-3187).
       const hooksToSync = selection
-        ? resolveSelection(selection.hooks, available.hooks)
+        ? resolveHookSelection(selection.hooks, available.hooks)
         : available.hooks;
 
       let hookManifest: ReturnType<typeof parseHookManifest> = {};
@@ -2930,6 +2974,7 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
     const r = subagentsWriter.write({ version, versionHome, selection: subagentsToSync, cwd });
     if (r.paths) writtenTargets.push(...r.paths);
     result.subagents.push(...r.synced);
+    if (r.errors?.length) result.declined.push(...r.errors.map((e) => `subagents: ${e}`));
 
     // Orphan-sweep for Claude only — see comment on commands/skills sweep
     // for the no-selection guard. OpenClaw stores subagents as siblings of

--- a/cli/src/lib/permissions.test.ts
+++ b/cli/src/lib/permissions.test.ts
@@ -211,6 +211,44 @@ describe('permission path handling', () => {
     }
   });
 
+  // PHNX-3187: git checks group yaml out with CRLF on Windows (core.autocrlf).
+  // The rule extractor anchors on the closing quote (`"$`); a trailing '\r'
+  // meant it matched ZERO rules, so `agents doctor --fix` on win-mini wrote an
+  // empty permission set and could never reconcile permissions.
+  it('extracts rules from a CRLF-checked-out permission group (PHNX-3187)', async () => {
+    const home = makeTempHome();
+    const groupsDir = path.join(home, '.agents', 'permissions', 'groups');
+    fs.mkdirSync(groupsDir, { recursive: true });
+    fs.writeFileSync(path.join(groupsDir, 'crlf-safe.yaml'), [
+      'name: crlf-safe',
+      'allow:',
+      '  - "Bash(git:*)"',
+      'deny:',
+      '  - "Write(secrets/**)"',
+      '',
+    ].join('\r\n')); // CRLF, as git would check it out on Windows
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      vi.resetModules();
+      const { buildPermissionsFromGroups: buildFromGroups } = await import('./permissions.js');
+      expect(buildFromGroups(['crlf-safe'])).toEqual({
+        name: 'built',
+        description: 'Built from groups: crlf-safe',
+        allow: ['Bash(git:*)'],
+        deny: ['Write(secrets/**)'],
+      });
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      vi.resetModules();
+    }
+  });
+
   it('keeps legacy bare-list permission group entries as allow rules', async () => {
     const home = makeTempHome();
     const groupsDir = path.join(home, '.agents', 'permissions', 'groups');

--- a/cli/src/lib/permissions.ts
+++ b/cli/src/lib/permissions.ts
@@ -385,8 +385,13 @@ export function buildPermissionsFromGroups(groupNames: string[]): PermissionSet 
 
       // Extract rules using line-by-line regex (more robust than YAML parsing)
       // Matches lines like: - "Bash(git *)" or   - "WebFetch(domain:example.com)"
-      // Handles nested quotes that break YAML parsers
-      const lines = content.split('\n');
+      // Handles nested quotes that break YAML parsers.
+      // Split on CRLF or LF: git checks group yaml out with CRLF on Windows
+      // (core.autocrlf), and a plain split('\n') leaves a trailing '\r' so the
+      // closing-quote anchor `"$` never matches — extracting ZERO rules, which
+      // wrote an empty permission set and left `agents doctor --fix` unable to
+      // reconcile permissions on Windows forever (PHNX-3187).
+      const lines = content.split(/\r?\n/);
       let section: 'allow' | 'deny' | null = null;
       for (const line of lines) {
         const sectionMatch = line.match(/^\s*(allow|deny)\s*:\s*(?:#.*)?$/);

--- a/cli/src/lib/staleness/writers/subagents.test.ts
+++ b/cli/src/lib/staleness/writers/subagents.test.ts
@@ -1,0 +1,89 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import { spawnSync } from 'child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+import { IS_WINDOWS } from '../../platform/index.js';
+
+const tempDirs: string[] = [];
+
+function makeTempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-subagents-writer-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** Write a central subagent under `~/.agents/subagents/<name>/AGENT.md`. */
+function writeCentralSubagent(home: string, name: string, agentMd: string): void {
+  const dir = path.join(home, '.agents', 'subagents', name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'AGENT.md'), agentMd, 'utf-8');
+}
+
+/**
+ * Run the built subagents writer against `home` and return its WriteResult.
+ *
+ * Resolved through `getWriter` — the same accessor `syncResourcesToVersion`
+ * uses — in a child with `HOME` pointed at the temp dir so `listInstalledSubagents`
+ * reads the fixture's `~/.agents/subagents/` (the dir is resolved from HOME at
+ * module init). Importing the writer module directly would trip the
+ * pre-existing module-init cycle `lazy-map.ts` documents.
+ */
+function write(home: string, agent: string, selection: string[]): { synced: string[]; paths: string[]; errors?: string[] } {
+  const moduleUrl = pathToFileURL(path.resolve('dist/lib/staleness/registry.js')).href;
+  const versionHome = path.join(home, '.agents', '.history', 'versions', agent, '1.0.0', 'home');
+  const child = spawnSync(process.execPath, ['--input-type=module', '-e', `
+    import { getWriter } from ${JSON.stringify(moduleUrl)};
+    const w = getWriter('subagents', ${JSON.stringify(agent)});
+    console.log(JSON.stringify(w.write({
+      version: '1.0.0',
+      versionHome: ${JSON.stringify(versionHome)},
+      selection: ${JSON.stringify(selection)},
+      cwd: process.cwd(),
+    })));
+  `], { env: { ...process.env, HOME: home }, encoding: 'utf-8' });
+  if (child.status !== 0) throw new Error(child.stderr || 'writer probe failed');
+  return JSON.parse(child.stdout.trim());
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// PHNX-3187: the writer used to `continue` past any selection name it could not
+// resolve and swallow every per-item write failure behind a bare `catch`, so a
+// subagent whose AGENT.md failed to parse (the git-CRLF-on-Windows case) produced
+// `synced: []` — indistinguishable from "nothing selected" — and `agents doctor
+// --fix` reported an unactionable "hold" instead of the real reason. The writer
+// now surfaces those as `errors`; mirror mcp.test.ts's writer refusal test.
+describe('subagents writer surfaces a refusal instead of swallowing it', () => {
+  it.skipIf(IS_WINDOWS)('reports the reason a requested subagent is not discoverable', () => {
+    const home = makeTempHome();
+    // An AGENT.md with no frontmatter fence: parseSubagentFrontmatter returns
+    // null, so listInstalledSubagents drops it — the exact shape a CRLF-mangled
+    // fence produced on Windows before the parse fix.
+    writeCentralSubagent(home, 'broken', 'no frontmatter here, just prose.\n');
+
+    const result = write(home, 'claude', ['broken']);
+    expect(result.synced).toEqual([]);
+    expect(result.errors, 'the refusal must reach the caller').toBeTruthy();
+    expect(result.errors!.join('\n')).toContain("subagent 'broken'");
+    expect(result.errors!.join('\n')).toContain('no parseable AGENT.md');
+  });
+
+  it.skipIf(IS_WINDOWS)('reports no errors for a subagent it can write', () => {
+    const home = makeTempHome();
+    writeCentralSubagent(
+      home,
+      'reviewer',
+      '---\nname: reviewer\ndescription: Reviews the diff\nmodel: opus\n---\n\nYou review code.\n'
+    );
+
+    const result = write(home, 'claude', ['reviewer']);
+    expect(result.synced).toEqual(['reviewer']);
+    expect(result.errors).toBeUndefined();
+  });
+});

--- a/cli/src/lib/staleness/writers/subagents.ts
+++ b/cli/src/lib/staleness/writers/subagents.ts
@@ -28,10 +28,17 @@ function buildSubagentsWriter(agent: AgentId): ResourceWriter<string[]> {
       const dir = target.dir(versionHome);
       const synced: string[] = [];
       const paths: string[] = [];
+      const errors: string[] = [];
 
       for (const name of selection) {
         const sub = map.get(name);
-        if (!sub) continue;
+        if (!sub) {
+          // Requested but not discoverable as an installed central subagent —
+          // e.g. its AGENT.md failed to parse. Say so instead of silently
+          // dropping it, which read as an unactionable doctor "hold" (PHNX-3187).
+          errors.push(`subagent '${name}': no parseable AGENT.md in ~/.agents/subagents`);
+          continue;
+        }
         try {
           target.write(dir, sub);
           synced.push(sub.name);
@@ -40,10 +47,14 @@ function buildSubagentsWriter(agent: AgentId): ResourceWriter<string[]> {
           for (const entry of target.occupied(dir, sub.name)) {
             if (fs.existsSync(entry.path)) paths.push(entry.path);
           }
-        } catch { /* per-item sync failure: skip */ }
+        } catch (e) {
+          // A genuine fs/transform failure must surface with its reason, not
+          // vanish behind a bare `catch` (RUSH-2677 / PHNX-3187).
+          errors.push(`subagent '${sub.name}': ${(e as Error).message}`);
+        }
       }
 
-      return { synced, paths };
+      return errors.length > 0 ? { synced, paths, errors } : { synced, paths };
     },
   };
 }

--- a/cli/src/lib/subagents.test.ts
+++ b/cli/src/lib/subagents.test.ts
@@ -6,6 +6,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   installSubagentToAgent,
   listSubagentsForAgent,
+  parseSubagentFrontmatter,
+  getSubagentBody,
+  transformSubagentForClaude,
   transformSubagentForAntigravity,
   transformSubagentForCopilot,
   transformSubagentForCursor,
@@ -265,6 +268,56 @@ describe('installSubagentToAgent for Antigravity', () => {
     const installed = listSubagentsForAgent('antigravity', agentHome);
     expect(installed.map(s => s.name)).toEqual(['verifier']);
     expect(installed[0].frontmatter.description).toBe('Verifies work');
+  });
+});
+
+// PHNX-3187: git checks text files out with CRLF on Windows (core.autocrlf), so
+// an AGENT.md whose fences read `---\r\n` must still parse. Before the fix,
+// `content.split('\n')` left a trailing '\r' and `'---\r' !== '---'` dropped the
+// subagent from discovery — so `agents doctor --fix` on win-mini could never
+// install or reconcile it (reported an unactionable "hold").
+describe('subagent AGENT.md parsing is CRLF-robust (PHNX-3187)', () => {
+  function writeAgentMdRaw(parent: string, name: string, contents: string): string {
+    const dir = path.join(parent, name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'AGENT.md'), contents, 'utf-8');
+    return path.join(dir, 'AGENT.md');
+  }
+
+  const frontmatter = '---\nname: code-reviewer\ndescription: Reviews the diff\nmodel: opus\n---\n\nYou review code.\n';
+
+  it('parses frontmatter from a CRLF-checked-out AGENT.md', () => {
+    const home = makeTempHome();
+    const crlf = frontmatter.replace(/\n/g, '\r\n');
+    const file = writeAgentMdRaw(home, 'code-reviewer', crlf);
+
+    const parsed = parseSubagentFrontmatter(file);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.name).toBe('code-reviewer');
+    expect(parsed!.description).toBe('Reviews the diff');
+    expect(parsed!.model).toBe('opus');
+  });
+
+  it('extracts the body from a CRLF-checked-out AGENT.md', () => {
+    const home = makeTempHome();
+    const file = writeAgentMdRaw(home, 'code-reviewer', frontmatter.replace(/\n/g, '\r\n'));
+    expect(getSubagentBody(file)).toBe('You review code.');
+  });
+
+  it('transformSubagentForClaude succeeds on a CRLF subagent dir (does not throw "Invalid AGENT.md")', () => {
+    const home = makeTempHome();
+    writeAgentMdRaw(home, 'code-reviewer', frontmatter.replace(/\n/g, '\r\n'));
+    const out = transformSubagentForClaude(path.join(home, 'code-reviewer'));
+    expect(out).toContain('name: code-reviewer');
+    expect(out).toContain('You review code.');
+  });
+
+  it('still parses ordinary LF AGENT.md (no regression)', () => {
+    const home = makeTempHome();
+    const file = writeAgentMdRaw(home, 'code-reviewer', frontmatter);
+    const parsed = parseSubagentFrontmatter(file);
+    expect(parsed!.name).toBe('code-reviewer');
+    expect(getSubagentBody(file)).toBe('You review code.');
   });
 });
 

--- a/cli/src/lib/subagents.ts
+++ b/cli/src/lib/subagents.ts
@@ -35,7 +35,12 @@ export function parseSubagentFrontmatter(filePath: string): SubagentFrontmatter 
 
   try {
     const content = fs.readFileSync(filePath, 'utf-8');
-    const lines = content.split('\n');
+    // Split on CRLF or LF: git checks text files out with CRLF on Windows
+    // (core.autocrlf), so a plain split('\n') leaves a trailing '\r' on every
+    // line and the frontmatter fence `'---\r' !== '---'` never matches —
+    // silently dropping the subagent from discovery so it can never be
+    // installed or reconciled (PHNX-3187).
+    const lines = content.split(/\r?\n/);
 
     // Check for YAML frontmatter
     if (lines[0] === '---') {
@@ -67,7 +72,8 @@ export function getSubagentBody(filePath: string): string {
   }
 
   const content = fs.readFileSync(filePath, 'utf-8');
-  const lines = content.split('\n');
+  // CRLF-robust for the same reason as parseSubagentFrontmatter (PHNX-3187).
+  const lines = content.split(/\r?\n/);
 
   // Skip YAML frontmatter
   if (lines[0] === '---') {


### PR DESCRIPTION
## Problem (PHNX-3187)

On win-mini, `agents doctor --fix` healed commands/skills/rules/plugins but reported **hooks, permissions, subagents, and the `CLAUDE`/`GEMINI` rule aliases** as `hold … couldn't reconcile` and left the box permanently red — with real guards (`git-guard`, `rm-guard`, `secrets-guard`, `ask-user-question-guard`, `public-artifact-guard`) **uninstalled**. `--fix` is the tool's own remedy and it could not converge.

## Root causes (four, each Windows-specific, each fixed at source)

Git on Windows checks text files out with CRLF (`core.autocrlf`) and materializes symlinks as plain text files (`core.symlinks=false`). That breaks four parsers/matchers in the resource reconcile path:

1. **subagents** — `parseSubagentFrontmatter` / `getSubagentBody` (`cli/src/lib/subagents.ts`) split on `'\n'` and match the fence with `=== '---'`. A CRLF `AGENT.md` yields `'---\r'`, so the subagent is rejected and silently dropped from discovery → never installed → `unreconcilable`. Fixed: split on `/\r?\n/`.
2. **permissions** — `buildPermissionsFromGroups` (`cli/src/lib/permissions.ts`) extracts rules with a line regex anchored on the closing quote (`"$`); a trailing `\r` breaks it → **zero rules** → an empty permission set is written → detector reads nothing back → `unreconcilable`. Fixed: split on `/\r?\n/`.
3. **rule aliases** — `rules/CLAUDE.md` / `rules/GEMINI.md` are symlinks to `AGENTS.md`; on Windows they check out as text files, so `lstat().isSymbolicLink()` is false and `listRulesNames` (`cli/src/lib/doctor-diff.ts`) treats them as independent rule sources no sync can produce. Fixed: new `isCheckedOutSymlink` detector (platform-agnostic) skips them.
4. **hooks** — heal feeds the resource diff's **extensionless** hook names (`git-guard`) back to `syncResourcesToVersion`, whose `available.hooks` set carries the source filename **with** its extension (`git-guard.sh`), so the exact-set match found nothing and no flagged hook could be written. Fixed: new basename-tolerant `resolveHookSelection` (`cli/src/lib/installations/versions.ts`); the orphan sweep prunes any stale extensionless copy an older heal left (invisible on Windows because it has neither an extension nor an exec bit).

The subagents writer (`cli/src/lib/staleness/writers/subagents.ts`) also now **fails loud** — it records a per-item write failure (and a requested-but-unparseable subagent) with its reason instead of swallowing it in a bare `catch`, so a genuine failure surfaces the reason instead of an unactionable "hold".

## Scope

This PR is scoped to **only** the four Windows correctness fixes above. The changed files are:

- `cli/src/lib/subagents.ts` — CRLF-robust frontmatter/body parse
- `cli/src/lib/permissions.ts` — CRLF-robust rule extraction
- `cli/src/lib/doctor-diff.ts` — **only** the new `isCheckedOutSymlink` helper + its use in `listRulesNames` (nothing else)
- `cli/src/lib/installations/versions.ts` — basename-tolerant `resolveHookSelection` + extensionless-orphan sweep
- `cli/src/lib/staleness/writers/subagents.ts` — fail-loud per-item errors
- the four test files below + the changelog fragment

**Review note (re: the earlier "unrelated doctor-diff.ts changes" blocker):** those `PHNX-3186`/`PHNX-2955` behavior changes (the "provided by same-named skill" ok-status, `.cursorrules` inclusion, the plugin content-drift `stale skill/command` category, and the subagent-availability floor zeroing) landed **separately on `main` via #3252** and are now in this branch's merge-base. They no longer appear in this PR's net diff — `git diff origin/main...HEAD -- cli/src/lib/doctor-diff.ts` shows **only** `isCheckedOutSymlink`. Verified against the GitHub file list (10 files, matching the scope above).

## Tests (real, no mocks; each reproduces the bug and proves the healthy path)

- `subagents.test.ts` — CRLF `AGENT.md` parses / body extracts / `transformSubagentForClaude` no longer throws `Invalid AGENT.md`; LF still works.
- `permissions.test.ts` — a CRLF permission group yields its allow/deny rules.
- `doctor-diff.test.ts` — `isCheckedOutSymlink` flags a checked-out-symlink text file, and does NOT flag real markdown, a non-resolving one-liner, or a real posix symlink.
- `versions.test.ts` — `resolveHookSelection` maps extensionless → extensioned, keeps exact matches, handles `'all'`, dedups, drops non-matches.
- **`staleness/writers/subagents.test.ts` (new)** — drives the built writer through `getWriter` (mirroring `mcp.test.ts`'s writer-refusal test) and asserts `buildSubagentsWriter(...).write()` surfaces a requested-but-unparseable subagent as an `errors` entry instead of an empty `synced` (the pre-fix silent "hold"), plus a positive no-errors case.

## Scope / safety

- No user-facing flow, prompt, or output shape changes — pure correctness restoration on the `--fix` writer path.
- No revert of existing behavior: exact-name matching, LF parsing, and posix symlink handling are all preserved (regression-covered by the new tests).
- I cannot run Windows here, so the reproduction is unit-level on the exact path logic (CRLF inputs, checked-out-symlink text files, extensionless↔extensioned name matching), as the ticket requested.

Closes PHNX-3187.
