### PR TITLE
test(browser): raise real-ffmpeg frame-pipe test ceiling to 120s (PHNX-3465)

### DIFF
--- a/cli/src/lib/browser/service.test.ts
+++ b/cli/src/lib/browser/service.test.ts
@@ -695,7 +695,19 @@ describe('browser recording frame pipe (PHNX-2600)', () => {
     // verification uses ffprobe to assert the exact frame count and duration.
     execFileSync(ffmpeg, ['-v', 'error', '-i', result.path, '-f', 'null', '-']);
     expect(result.bytes).toBeGreaterThan(1000);
-  });
+    // 120s ceiling (below): this test spawns several REAL ffmpeg processes end to
+    // end — resolveFfmpeg (a one-time `-version` probe, or an install), an
+    // execFileSync to synthesize the JPEG frame, the recording ffmpeg behind
+    // recordStart/recordStop, and a final execFileSync decode of the produced
+    // WebM. That is a few seconds on an idle box, but under concurrent CI load
+    // (several PRs running the ~18-min suite on one runner) process spawns balloon
+    // and the default 30s testTimeout was exceeded intermittently — red-CI'ing
+    // unrelated PRs (PHNX-3465). The 120s ceiling sits well above the true cost
+    // (like ChildProcess.doctorTimeout's 180s over a 136s command) so a load
+    // spike can't flake it, while still failing a genuinely hung spawn in bounded
+    // time. Do NOT globally raise testTimeout — only this real-multi-spawn test
+    // needs the headroom.
+  }, 120_000);
 });
 
 describe('BrowserService.stopProfile — composite-key cleanup (#559)', () => {


### PR DESCRIPTION
## PHNX-3465 — `service.test.ts` flakes on a 30s timeout under CI load

One test in `cli/src/lib/browser/service.test.ts` intermittently times out at
`30000ms` and red-CI's **unrelated** PRs (observed 4 consecutive times on PR
#3262, which touches no browser code). Root cause: the test at `service.test.ts:660`
(`catches a frame emitted before startScreencast responds and finalizes a playable
WebM`, PHNX-2600) spawns **several real ffmpeg processes** end to end and inherits
the global 30s `testTimeout`. Under concurrent CI load (several PRs running the
~18-min suite on one runner) those spawns balloon past 30s.

### Diagnosis (why >30s is possible)
The test does real, unavoidable process work — this is the point of the test:
- `resolveFfmpeg()` — a `-version` probe (or a managed install on a fresh box)
- `execFileSync(ffmpeg, …)` — synthesize the source JPEG frame
- `svc.recordStart` / `svc.recordStop` — the **recording ffmpeg** subprocess
- `execFileSync(ffmpeg, …)` — a real **decode** of the produced WebM

There's no avoidable spawn, missing await, or busy poll to remove — the spawns
*are* what the test verifies (frame-race → real WebM → real decode). So this is the
"inherently ~seconds of real-process work, ceiling too tight under contention" case:
raise **this test's** ceiling, per the `ChildProcess.doctorTimeout` precedent
(`menubar/…/ChildProcess.swift`: 180s over a 136s command — a ceiling *above* true
cost, never below). `testTimeout` is **not** globally raised.

### The fix
`service.test.ts:698` — add a `120_000` per-test timeout arg (well above the true
~3s idle cost; still fails a genuinely hung spawn in bounded time). The test body is
unchanged — it still spawns real ffmpeg and asserts a playable WebM via a real decode.

### BEFORE — the failure signature (forced deterministically with a 200ms ceiling on the same real-spawn test)
```
 ❯ src/lib/browser/service.repro.test.ts (77 tests | 1 failed | 76 skipped) 209ms
     × catches a frame emitted before startScreencast responds and finalizes a playable WebM 206ms
 FAIL  … > catches a frame emitted before startScreencast responds and finalizes a playable WebM
Error: Test timed out in 200ms.
   660|   it('catches a frame emitted before startScreencast responds and fina…
 Tests  1 failed | 76 skipped (77)
```
This is the identical `Test timed out in Nms` signature that hits at `30000ms`
under CI load; the ticket documents the real 4× consecutive failures on PR #3262.

### AFTER — with the 120s ceiling (real ffmpeg, real decode)
```
 ✓ src/lib/browser/service.test.ts > browser recording frame pipe (PHNX-2600) > catches a frame emitted before startScreencast responds and finalizes a playable WebM 2946ms
 Test Files  1 passed (1)
      Tests  77 passed (77)
   Duration  5.93s
```
Full-file run: **77 passed (77)**, ~3s for this test on an idle box — 40× under the
new ceiling, with ample headroom for CI contention.

### No regression / scope
- Test still exercises the exact real path (no mocks added, nothing skipped/disabled).
- One-line arg + explanatory comment; no product code touched.
- **CHANGELOG:** none — test-only change, not user-visible.
- **Docs:** none — no flag/command/behavior change.

Fixes PHNX-3465. Do not self-merge — handing off to the orchestrator for a non-author review.
