### PR TITLE
feat(menubar): favorite & pin devices below the current Mac (PHNX-2376)

### DIFF
--- a/cli/.changelog/next/PHNX-2376.md
+++ b/cli/.changelog/next/PHNX-2376.md
@@ -1,0 +1,11 @@
+- **Menu bar: favorite (pin) devices below the current Mac (PHNX-2376).** Each
+  device's submenu in the menu bar's DEVICES section now has a **★ Favorite /
+  Unfavorite** toggle. A favorited device renders with a ★ and sorts immediately
+  below the current machine (`<name> (this Mac)`), above all other devices, with a
+  divider between the favorites and the rest. "Favorite" reuses the EXISTING
+  per-device `auto-launch.preferred` config that automatic placement already
+  honors (PHNX-2092) — the toggle writes `agents devices config <name>
+  auto-launch.preferred on|off`, not a new store — so a box favorited from the
+  menu bar is also boosted in `--device auto` placement, and vice-versa. Source:
+  `cli/menubar/Sources/MenubarHelper/StatusItemController.swift`,
+  `cli/menubar/Sources/MenubarHelper/AgentsCLI.swift`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -705,7 +705,11 @@ keys living in `devices/<name>/agents.yaml` `config.autoLaunch{Enabled,Preferred
 sync with `agents repo push/pull`. The four verbs are task-shaped forwarding
 spellings for `agents devices config <name> auto-launch.{enabled,preferred}
 <on|off>` — the one canonical per-device settings surface — so they print a
-deprecation-style "running that for you" notice and defer to it.
+deprecation-style "running that for you" notice and defer to it. The **menu bar**
+surfaces `auto-launch.preferred` as a per-device **★ Favorite / Unfavorite**
+toggle (writing that same canonical `devices config … auto-launch.preferred
+on|off`, no separate store): a favorited device shows a ★ and sorts directly below
+the current machine, above the rest, in the DEVICES section (PHNX-2376).
 
 `devices.<name>.description` (stored as `description`) is the free-text sibling
 of `role`: one line saying what the box is FOR — "gpu box — cuda 12.4", "release

--- a/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -189,6 +189,18 @@ enum AgentsCLI {
     static func deviceRegister(_ name: String) { runDetached(argv(["devices", "register", name])) }
     static func deviceIgnore(_ name: String) { runDetached(argv(["devices", "ignore", name])) }
 
+    // Favorite a device: set its `auto-launch.preferred` flag on (unfavorite = off).
+    // This is the SAME per-device config the auto-launch ranker honors — not a
+    // separate favorites store — written through the one canonical settings surface
+    // (`devices config <name> auto-launch.preferred <on|off>`, cli/CLAUDE.md). The
+    // next snapshot poll re-reads it, so the ★ and re-sort follow. TS owns the truth.
+    static func devicePrefer(_ name: String) {
+        runDetached(argv(["devices", "config", name, "auto-launch.preferred", "on"]))
+    }
+    static func deviceUnprefer(_ name: String) {
+        runDetached(argv(["devices", "config", name, "auto-launch.preferred", "off"]))
+    }
+
     /// Take the operator to a blocked session: attach its terminal, or open a new
     /// tab and resume it (`agents focus` decides, and handles a remote host).
     ///

--- a/cli/menubar/Sources/MenubarHelper/DeviceSelfTest.swift
+++ b/cli/menubar/Sources/MenubarHelper/DeviceSelfTest.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+// Device-favorites self-test (PHNX-2376): decode the `preferred` flag off a real
+// `menubar snapshot --json` devices payload and exercise the pure ordering
+// (`StatusItemController.planDeviceRows`) that puts this Mac first, favorited
+// (auto-launch.preferred) devices with a ★ next, then the rest, with a divider
+// between favorites and the rest. Gated by MENUBAR_DEVICE_TEST=1 (main.swift); no
+// GUI, no Accessibility grant. Mirrors LoadedDeviceSelfTest / RoutineSelfTest.
+enum DeviceSelfTest {
+    // Compact readout of a plan: device names get a leading ★ when preferred and a
+    // trailing * when local; a divider is `|`.
+    private static func describe(_ plan: [StatusItemController.DeviceRowEntry]) -> [String] {
+        plan.map { entry in
+            switch entry {
+            case .divider: return "|"
+            case .device(let d):
+                return "\(d.isPreferred ? "★" : "")\(d.name)\(d.isLocal ? "*" : "")"
+            }
+        }
+    }
+
+    static func run() -> Never {
+        var pass = true
+        func check(_ name: String, _ cond: Bool) {
+            print("\(cond ? "PASS" : "FAIL") — \(name)")
+            if !cond { pass = false }
+        }
+
+        // 1. An older snapshot with NO `preferred` field still decodes, reading as
+        //    not-favorited (version skew between the helper and the on-PATH CLI).
+        let legacyJSON = #"{"name":"box","platform":"linux","interactive":false,"isLocal":false}"#
+        let legacy = try? JSONDecoder().decode(Device.self, from: Data(legacyJSON.utf8))
+        check("device with no `preferred` field decodes", legacy != nil)
+        check("missing `preferred` reads as not favorited", legacy?.isPreferred == false)
+
+        // 2. The `preferred` flag decodes off the real snapshot shape.
+        let payload = #"""
+        [
+          {"name":"zion","platform":"macos","interactive":true,"isLocal":true,"preferred":false},
+          {"name":"yosemite-m2","platform":"linux","interactive":false,"isLocal":false,"preferred":true},
+          {"name":"mac-mini","platform":"macos","interactive":false,"isLocal":false,"preferred":false},
+          {"name":"ci-runner","platform":"linux","interactive":false,"isLocal":false,"preferred":true},
+          {"name":"win-mini","platform":"windows","interactive":false,"isLocal":false,"preferred":false}
+        ]
+        """#
+        guard let devices = try? JSONDecoder().decode([Device].self, from: Data(payload.utf8)) else {
+            print("FAIL — devices payload decode")
+            print("SOME FAILED")
+            exit(1)
+        }
+        check("preferred flag decodes true", devices.first { $0.name == "ci-runner" }?.isPreferred == true)
+        check("preferred flag decodes false", devices.first { $0.name == "mac-mini" }?.isPreferred == false)
+
+        // 3. Order: this Mac first, favorites (alpha) next, divider, then the rest (alpha).
+        let plan = StatusItemController.planDeviceRows(devices)
+        check("ordered: this Mac, favorites, |, rest",
+              describe(plan) == ["zion*", "★ci-runner", "★yosemite-m2", "|", "mac-mini", "win-mini"])
+        check("this Mac is always the first row", {
+            if case .device(let d) = plan.first { return d.isLocal }
+            return false
+        }())
+
+        // 4. No favorites → order unchanged from a flat list, and NO divider.
+        let noneFav = devices.map {
+            Device(name: $0.name, platform: $0.platform, interactive: $0.interactive,
+                   isLocal: $0.isLocal, preferred: false)
+        }
+        let flatPlan = StatusItemController.planDeviceRows(noneFav)
+        check("no favorites → no divider", !flatPlan.contains(.divider))
+        check("no favorites → this Mac first then alphabetical",
+              describe(flatPlan) == ["zion*", "ci-runner", "mac-mini", "win-mini", "yosemite-m2"])
+
+        // 5. All non-local devices favorited → still no dangling divider (empty rest).
+        let allFav = devices.map {
+            Device(name: $0.name, platform: $0.platform, interactive: $0.interactive,
+                   isLocal: $0.isLocal, preferred: !$0.isLocal)
+        }
+        let allFavPlan = StatusItemController.planDeviceRows(allFav)
+        check("all favorited → no dangling divider", !allFavPlan.contains(.divider))
+
+        // 6. A preferred LOCAL device is still first, with its ★, and does not by
+        //    itself force a divider when there are no non-local favorites.
+        let localFav = [
+            Device(name: "zion", platform: "macos", interactive: true, isLocal: true, preferred: true),
+            Device(name: "mac-mini", platform: "macos", interactive: false, isLocal: false, preferred: false),
+        ]
+        check("preferred local Mac is first with ★, no divider",
+              describe(StatusItemController.planDeviceRows(localFav)) == ["★zion*", "mac-mini"])
+
+        print(pass ? "ALL PASS" : "SOME FAILED")
+        exit(pass ? 0 : 1)
+    }
+}

--- a/cli/menubar/Sources/MenubarHelper/Models.swift
+++ b/cli/menubar/Sources/MenubarHelper/Models.swift
@@ -234,11 +234,20 @@ struct WatchdogCounts: Decodable {
 // at render time from the daemon-warmed .fleet-stats.json (LocalState.deviceLoads);
 // online/offline is deliberately NOT carried (the registry's tailscale flag is
 // stale in both directions), so the menu never claims a status it can't back.
-struct Device: Decodable {
+struct Device: Decodable, Equatable {
     let name: String
     let platform: String
     let interactive: Bool
     let isLocal: Bool
+    // The device's `auto-launch.preferred` flag (a "favorite"): the same
+    // per-device config that boosts a box in AGI EXT's auto-launch ranking
+    // (cli/CLAUDE.md → auto-launch.preferred). Optional so a snapshot from an
+    // older installed `agents` CLI that predates the field still decodes —
+    // version skew between the helper and the on-PATH CLI is real.
+    let preferred: Bool?
+
+    // Nil (an older snapshot with no field) reads as not-favorited.
+    var isPreferred: Bool { preferred ?? false }
 }
 
 // `agents menubar snapshot --json` — the single repeating CLI read owned by

--- a/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -760,25 +760,53 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         menu.update()
     }
 
-    /// One row per device: this Mac first, then alphabetical. Load% is shown only
+    /// One ordered menu entry in the DEVICES block — a device row or a divider.
+    /// Pure data so `planDeviceRows` is testable without AppKit (MENUBAR_DEVICE_TEST).
+    enum DeviceRowEntry: Equatable {
+        case device(Device)
+        case divider
+    }
+
+    /// The DEVICES-block order, as pure data: **this Mac first** (the "you are
+    /// here" anchor, whatever its own preferred flag), then **favorited
+    /// (auto-launch.preferred) devices**, then the rest — each block alphabetical.
+    /// A single divider sets the favorites off from the rest, emitted ONLY when
+    /// there is both a favorites block and a rest block (no dangling separator; a
+    /// list with no non-local favorites is ordered exactly as before).
+    static func planDeviceRows(_ devices: [Device]) -> [DeviceRowEntry] {
+        let local = devices.filter { $0.isLocal }.sorted { $0.name < $1.name }
+        let favorites = devices.filter { !$0.isLocal && $0.isPreferred }.sorted { $0.name < $1.name }
+        let rest = devices.filter { !$0.isLocal && !$0.isPreferred }.sorted { $0.name < $1.name }
+        var entries: [DeviceRowEntry] = (local + favorites).map { .device($0) }
+        if !favorites.isEmpty, !rest.isEmpty { entries.append(.divider) }
+        entries += rest.map { .device($0) }
+        return entries
+    }
+
+    /// One row per device, rendered from `planDeviceRows`. Load% is shown only
     /// where the warm fleet cache has a fresh reading — its absence is never
     /// rendered as "offline" (the roster carries no probed online/offline state).
     private func deviceRows(_ devices: [Device]) -> [NSMenuItem] {
         let loads = LocalState.deviceLoads()
-        let ordered = devices.sorted { a, b in
-            if a.isLocal != b.isLocal { return a.isLocal }
-            return a.name < b.name
-        }
-        return ordered.map { d in
+        let makeRow: (Device) -> NSMenuItem = { d in
             let load = loads[ActiveDisplay.normalizeHost(d.name)]
             var line = d.isLocal ? "\(d.name) (this Mac)" : d.name
             line += " · \(d.platform)"
             if let l = load { line += " · \(Int(l.load.rounded()))%" }
-            // ◉ marks the configured interactive host, ○ otherwise. Deliberately no
-            // color-coded status dot — the roster does not know online/offline.
-            let row = statusRow(d.interactive ? "◉" : "○", idleC, line)
-            row.submenu = deviceSubmenu(d, load: load)
+            // ★ prefixes a favorited (auto-launch.preferred) device; the ◉/○ glyph
+            // stays the interactive-host marker (◉ = configured interactive host).
+            // Deliberately no color-coded status dot — the roster does not know
+            // online/offline.
+            if d.isPreferred { line = "★ \(line)" }
+            let row = self.statusRow(d.interactive ? "◉" : "○", self.idleC, line)
+            row.submenu = self.deviceSubmenu(d, load: load)
             return row
+        }
+        return Self.planDeviceRows(devices).map { entry in
+            switch entry {
+            case .device(let d): return makeRow(d)
+            case .divider: return .separator()
+            }
         }
     }
 
@@ -791,6 +819,20 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
         if d.interactive { sub.addItem(disabled("interactive host")) }
         if !sub.items.isEmpty { sub.addItem(.separator()) }
+        // Favorite toggle — writes the SAME per-device `auto-launch.preferred`
+        // config the auto-launch ranker already honors (no separate favorites
+        // store). The next snapshot poll reflects the ★ and the re-sort; TS owns
+        // the truth (see AgentsCLI.devicePrefer / deviceUnprefer).
+        let fav: NSMenuItem
+        if d.isPreferred {
+            fav = NSMenuItem(title: "Unfavorite", action: #selector(onUnfavoriteDevice(_:)), keyEquivalent: "")
+        } else {
+            fav = NSMenuItem(title: "★  Favorite", action: #selector(onFavoriteDevice(_:)), keyEquivalent: "")
+        }
+        fav.target = self
+        fav.representedObject = d.name
+        sub.addItem(fav)
+        sub.addItem(.separator())
         let ssh = "agents ssh \(d.name)"
         let copy = NSMenuItem(title: "⧉  Copy  \(ssh)", action: #selector(onCopyText(_:)), keyEquivalent: "")
         copy.target = self
@@ -1734,6 +1776,33 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             refreshBadge()
         }
     }
+    // Favorite / unfavorite a device — toggles its `auto-launch.preferred` config
+    // through the CLI (TS owns the truth). Optimistically flip the cached flag so a
+    // reopened menu re-sorts and re-stars immediately, and clear the snapshot
+    // freshness stamp so the next poll reconciles against real config.
+    @objc private func onFavoriteDevice(_ sender: NSMenuItem) {
+        withName(sender) { name in
+            AgentsCLI.devicePrefer(name)
+            setCachedDevicePreferred(name, true)
+        }
+    }
+    @objc private func onUnfavoriteDevice(_ sender: NSMenuItem) {
+        withName(sender) { name in
+            AgentsCLI.deviceUnprefer(name)
+            setCachedDevicePreferred(name, false)
+        }
+    }
+
+    private func setCachedDevicePreferred(_ name: String, _ preferred: Bool) {
+        cachedDevices = cachedDevices.map { d in
+            d.name == name
+                ? Device(name: d.name, platform: d.platform, interactive: d.interactive,
+                         isLocal: d.isLocal, preferred: preferred)
+                : d
+        }
+        snapshotFetchedAt = nil // let the next poll re-read the real config
+    }
+
     @objc private func onStopScheduler() { AgentsCLI.stopDaemon() }
     @objc private func onQuit() { AgentsCLI.menubarDisable(); NSApp.terminate(nil) }
 

--- a/cli/menubar/Sources/MenubarHelper/main.swift
+++ b/cli/menubar/Sources/MenubarHelper/main.swift
@@ -85,6 +85,13 @@ if ProcessInfo.processInfo.environment["MENUBAR_ROUTINE_TEST"] == "1" {
     RoutineSelfTest.run()
 }
 
+// Device-favorites self-test (PHNX-2376): decode the `preferred` flag off a real
+// `menubar snapshot --json` devices payload and exercise the pure DEVICES-block
+// ordering (this Mac → ★ favorites → divider → rest). See DeviceSelfTest.swift.
+if ProcessInfo.processInfo.environment["MENUBAR_DEVICE_TEST"] == "1" {
+    DeviceSelfTest.run()
+}
+
 // Doctor overview self-test (RUSH-2382): decode the additive fleet findings
 // contract and exercise the bounded, doctor-ordered health presentation without
 // constructing an AppKit menu. See DoctorSelfTest.swift.

--- a/cli/menubar/scripts/test-menubar.sh
+++ b/cli/menubar/scripts/test-menubar.sh
@@ -3,7 +3,8 @@
 # Runs every HEADLESS "AGI Menu" (menubar helper) self-test and fails on any FAIL.
 #
 # The helper's self-tests (SingleInstanceSelfTest, ChildProcessSelfTest,
-# GuardsSelfTest, IssueSelfTest, ActiveSessionSelfTest, RoutineSelfTest) are
+# GuardsSelfTest, IssueSelfTest, ActiveSessionSelfTest, RoutineSelfTest,
+# DoctorSelfTest, DeviceSelfTest) are
 # env-gated modes of the binary that exit
 # BEFORE the GUI/AppKit path (Guards.enforceForInteractiveLaunch in main.swift),
 # so they run headless — no display, no signing, no bundle. Until this script
@@ -36,7 +37,7 @@ if [ ! -x "$BIN" ]; then
 fi
 
 fail=0
-for mode in MENUBAR_GUARD_TEST MENUBAR_ISSUE_TEST MENUBAR_SINGLE_TEST MENUBAR_CHILD_TEST MENUBAR_ACTIVE_TEST MENUBAR_ROUTINE_TEST MENUBAR_DOCTOR_TEST; do
+for mode in MENUBAR_GUARD_TEST MENUBAR_ISSUE_TEST MENUBAR_SINGLE_TEST MENUBAR_CHILD_TEST MENUBAR_ACTIVE_TEST MENUBAR_ROUTINE_TEST MENUBAR_DOCTOR_TEST MENUBAR_DEVICE_TEST; do
   echo "=== $mode ==="
   if ! env "$mode=1" "$BIN"; then
     echo "  $mode FAILED" >&2


### PR DESCRIPTION
## PHNX-2376 — Menu bar: favorite & pin devices below the current Mac

Adds a per-device **★ Favorite / Unfavorite** toggle to each device's submenu in the menu bar's **DEVICES** section. A favorited device renders with a ★ and sorts **immediately below the current machine** (`<name> (this Mac)`), above all other devices, with a **divider** between the favorites and the rest.

### "Favorite" = the existing `auto-launch.preferred` config (no new store)
Per the approved design, this reuses the per-device `auto-launch.preferred` flag that automatic placement already honors (landed in **PHNX-2092**). The toggle writes the one canonical settings surface — `agents devices config <name> auto-launch.preferred on|off` — so a box favorited from the menu bar is **also** boosted in `--device auto` placement, and vice-versa. There is no separate favorites store.

The snapshot JSON already emitted `preferred` per device (`src/lib/menubar/snapshot.ts`, PHNX-2092 groundwork); the Swift `Device` struct now **decodes** it (optional, so an older on-PATH CLI's snapshot still decodes under helper/CLI version skew).

### Ordering (pure, headless-testable)
`StatusItemController.planDeviceRows` returns the DEVICES-block order as pure data: **this Mac first** (the "you are here" anchor, whatever its own flag) → **favorites** (alpha, with ★) → **divider** → **rest** (alpha). The divider is emitted only when both a favorites block and a rest block exist, so a list with no non-local favorites is ordered exactly as before (no dangling separator).

### Files
- `cli/menubar/Sources/MenubarHelper/Models.swift` — decode `preferred` (optional) + `isPreferred`, `Equatable`.
- `cli/menubar/Sources/MenubarHelper/StatusItemController.swift` — `planDeviceRows` (pure), ★ in the row, divider, submenu Favorite/Unfavorite toggle + handlers (optimistic cache flip).
- `cli/menubar/Sources/MenubarHelper/AgentsCLI.swift` — `devicePrefer` / `deviceUnprefer` → `devices config … auto-launch.preferred on|off`.
- `cli/menubar/Sources/MenubarHelper/DeviceSelfTest.swift` + `main.swift` + `scripts/test-menubar.sh` — new `MENUBAR_DEVICE_TEST` self-test, wired into the build gate.
- `cli/.changelog/next/PHNX-2376.md`, `cli/AGENTS.md` — CHANGELOG + doc (ties the menu-bar toggle to the existing config key).

### Verification
Swift can't build on the Linux PR runner, so this was built + tested on a real Mac fleet box (mac-mini, Swift 6.2):

```
[33/35] Linking AGI Menu
Build complete! (26.38s)

=== MENUBAR_DEVICE_TEST ===   (all 10 PASS)
PASS — device with no `preferred` field decodes
PASS — missing `preferred` reads as not favorited
PASS — preferred flag decodes true / false
PASS — ordered: this Mac, favorites, |, rest
PASS — this Mac is always the first row
PASS — no favorites → no divider
PASS — all favorited → no dangling divider
PASS — preferred local Mac is first with ★, no divider
...
menubar self-tests: all passed   (full gate: SUITE_EXIT=0)
```

TS snapshot test (`preferred` propagation) green: `vitest run src/lib/menubar/snapshot.test.ts` → 6 passed.

### Not shipped by this PR
Merged ≠ shipped: the menu-bar helper reaches users only via a signed+notarized helper release (`menubar/v<x.y.z>` tag + floor bump). This PR lands the code; the helper cut is a separate follow-up.
