### PR TITLE
test(sessions): fix red main — sessions-stats.cli asserts schemaVersion 1 but code emits 2

### DIFF
--- a/cli/src/commands/__tests__/sessions-stats.cli.test.ts
+++ b/cli/src/commands/__tests__/sessions-stats.cli.test.ts
@@ -70,7 +70,7 @@ describe('agents sessions stats (real CLI parse)', () => {
     const res = run(['sessions', 'backfill', 'resources', '--json']);
     expect(res.status).toBe(0);
     const parsed = JSON.parse(res.stdout) as { schemaVersion: number; kind: string; updated: number };
-    expect(parsed.schemaVersion).toBe(2);
+    expect(parsed.schemaVersion).toBe(1);
     expect(parsed.kind).toBe('resources-backfill');
     expect(typeof parsed.updated).toBe('number');
   });

--- a/cli/src/commands/__tests__/sessions-stats.cli.test.ts
+++ b/cli/src/commands/__tests__/sessions-stats.cli.test.ts
@@ -42,7 +42,7 @@ describe('agents sessions stats (real CLI parse)', () => {
     const res = run(['sessions', 'stats', '--json']);
     expect(res.status).toBe(0);
     const parsed = JSON.parse(res.stdout) as { schemaVersion: number; kind: string; ranked: unknown[] };
-    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.schemaVersion).toBe(2);
     expect(parsed.kind).toBe('sessions-stats');
     expect(Array.isArray(parsed.ranked)).toBe(true);
   });
@@ -70,7 +70,7 @@ describe('agents sessions stats (real CLI parse)', () => {
     const res = run(['sessions', 'backfill', 'resources', '--json']);
     expect(res.status).toBe(0);
     const parsed = JSON.parse(res.stdout) as { schemaVersion: number; kind: string; updated: number };
-    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.schemaVersion).toBe(2);
     expect(parsed.kind).toBe('resources-backfill');
     expect(typeof parsed.updated).toBe('number');
   });


### PR DESCRIPTION
## Fixes red `main`

`main` is currently RED: `src/commands/__tests__/sessions-stats.cli.test.ts` fails **`AssertionError: expected 2 to be 1`** deterministically, which fails the required `test` check on **every** PR (surfaced while landing #3262/pty — an unrelated PR).

## Root cause
PR #3270 (PHNX-2301) bumped the `sessions stats --json` envelope to **schemaVersion 2** — `sessions-stats.ts:211`, the PHNX-2301 changelog fragment ("`schemaVersion` bumped to 2"), and the spec (SES-IF-4b) all agree it's 2. But its test still asserted `schemaVersion === 1`. The test-side update was lost in a merge-rebase when #3270 landed, so code says 2 and the test expects 1 → deterministic failure on `main`.

## Fix (test-only)
Align the two `schemaVersion` assertions (lines 45, 73) to `2`, matching the shipped code + changelog + spec. No source change; no behavior change. Once this merges, `main` is green again and #3262 (+ any other blocked PR) can pass on a rebase.