### PR TITLE
fix(devices): --device auto excludes a box logged out for the target harness (PHNX-3466)

### DIFF
--- a/cli/.changelog/next/PHNX-3466.md
+++ b/cli/.changelog/next/PHNX-3466.md
@@ -1,0 +1,19 @@
+- **`agents run --device auto` no longer lands a launch on a fleet box that is logged out for the target harness (PHNX-3466).**
+  The `--device auto` placement gate already excluded a device whose harness reads
+  signed-out — but it judged a REMOTE candidate by `agents view --json`'s display
+  `signedIn`, which is true whenever the box's active/global HOME carries a login even
+  if the per-version home the isolated run actually launches has no credential of its
+  own. The LOCAL candidate, by contrast, used the strict per-version launch truth
+  (`collectRunCandidates` → `isLaunchableSignedIn`). So a worker whose selected harness
+  version home was not launchable passed the remote gate, got picked, and the launch
+  died at spawn — from AGI EXT the dispatched tab exited 1 and vanished. `agents view
+  --json` now emits a per-version `launchable` field (the same `isLaunchableSignedIn`
+  signal the local path uses), and remote placement (`viewAgentAccountEligibility`)
+  gates on it, so both paths agree. A device with no launchable account for the harness
+  is excluded from the `--device auto` candidate set; when that empties the pool the
+  existing fail-loud `no healthy device` error fires instead of a silently-lost launch.
+  An older remote CLI that omits `launchable` falls back to `signedIn`, so a rolling
+  fleet does not regress. No second placement path was added — the single CLI gate is
+  hardened, so both the CLI and AGI EXT (which delegates placement to it) benefit.
+  Source: `cli/src/commands/view.ts`, `cli/src/lib/view-types.ts`,
+  `cli/src/lib/hosts/ready.ts`.

--- a/cli/docs/hosts.md
+++ b/cli/docs/hosts.md
@@ -141,6 +141,16 @@ offer `launch to sign in`. A device whose picker would contain only throttled
 rows remains excluded; ordinary automatic runs still require a healthy,
 signed-in account before placement.
 
+The sign-in a device is judged by is the **strict per-version launch truth**, not
+the display "who is logged in": a box whose selected harness only inherits the
+active/global HOME login but has no credential in the per-version home the
+isolated run launches is **not** a valid `--device auto` target and is excluded,
+because such a launch would die at spawn. This is the same launchability the
+local candidate uses (`isLaunchableSignedIn`), carried to remote candidates by a
+per-version `launchable` field in `agents view --json` (PHNX-3466). A blind
+worker with a real per-version credential but no readable usage snapshot stays
+eligible — unverified usage is not a logout.
+
 **One carve-out: a missing login is not an exhausted account.** When the only
 thing wrong is that an account is signed out (or its token was revoked), a
 terminal run does NOT fail loud — it launches so you can authenticate, because

--- a/cli/src/commands/view.isolated.integration.test.ts
+++ b/cli/src/commands/view.isolated.integration.test.ts
@@ -43,7 +43,7 @@ describe.skipIf(process.platform === 'win32')('agents view — isolated installs
     }).toString('utf-8');
   }
 
-  function viewJson(): { versions: Array<{ version: string; authVerdict: string | null }> } {
+  function viewJson(): { versions: Array<{ version: string; authVerdict: string | null; signedIn: boolean; launchable: boolean }> } {
     return JSON.parse(execFileSync('bun', [path.resolve(process.cwd(), 'src/index.ts'), 'view', 'codex', '--json'], {
       cwd: process.cwd(),
       env: {
@@ -122,5 +122,18 @@ describe.skipIf(process.platform === 'win32')('agents view — isolated installs
       version: '9.9.4',
       authVerdict: 'revoked',
     }));
+  }, 120_000);
+
+  // PHNX-3466: the JSON also carries a per-version `launchable` — the strict
+  // per-version launch truth (`isLaunchableSignedIn`) that remote `--device auto`
+  // placement gates on. This planted version has an empty `.codex` home and no
+  // credential anywhere, so it is not launchable; the field must be present and
+  // false, proving the emission is live (not dead) and matches the signed-out state.
+  it('emits a per-version launchable flag in JSON for remote placement', () => {
+    plantVersion('9.9.4', { isolated: false });
+    const version = viewJson().versions.find((v) => v.version === '9.9.4');
+    expect(version).toBeDefined();
+    expect(version!.signedIn).toBe(false);
+    expect(version!.launchable).toBe(false);
   }, 120_000);
 });

--- a/cli/src/commands/view.ts
+++ b/cli/src/commands/view.ts
@@ -22,6 +22,7 @@ import {
   getAllCliStates,
   getUnmanagedCliState,
   getAccountInfo,
+  credentialPresence,
   resolveAgentName,
   formatAgentError,
   agentLabel,
@@ -81,7 +82,7 @@ import { listNativeAccounts } from '../lib/account-registry.js';
 import { isGitRepo, getGitSyncStatus } from '../lib/git.js';
 import { getCentralRulesFileName } from '../lib/rules/rules.js';
 import { composeRulesFromState, type ComposedSubrule } from '../lib/rules/compose.js';
-import { getConfiguredRunStrategy } from '../lib/accounting/rotate.js';
+import { getConfiguredRunStrategy, isLaunchableSignedIn } from '../lib/accounting/rotate.js';
 import { resolveRunDefaults } from '../lib/run-defaults.js';
 import { resolveConfiguredModel, type ConfiguredModelSource } from '../lib/models.js';
 import type { ResourceItemJson, ResourceSection, SyncState, VersionResourcesJson, ViewJsonAgent, ViewJsonVersion } from '../lib/view-types.js';
@@ -1521,6 +1522,11 @@ export async function collectAgentsJson(
       isolated: isVersionIsolated(agentId, version),
       isIsolatedDefault: getIsolatedDefault(agentId) === version,
       signedIn: info.signedIn,
+      // The strict per-version launch truth (vs the display `signedIn` above,
+      // which inherits the active/global HOME login). The same primitive
+      // `collectRunCandidates` uses locally, so remote `--device auto` placement
+      // is gated on identical launchability (PHNX-3466).
+      launchable: isLaunchableSignedIn(info.signedIn, credentialPresence(agentId, home)),
       authVerdict: authCache[authCacheKey(host, agentId, version)]?.verdict ?? null,
       email: info.email,
       accountId: info.accountId,

--- a/cli/src/lib/hosts/ready.test.ts
+++ b/cli/src/lib/hosts/ready.test.ts
@@ -97,6 +97,87 @@ describe('viewAgentSignedIn', () => {
   });
 });
 
+// PHNX-3466: `--device auto` remote placement must judge a box by the SAME strict
+// per-version launchability the LOCAL candidate uses (`collectRunCandidates` →
+// `isLaunchableSignedIn`), not the display `signedIn` that inherits the global
+// HOME login. The signal rides `agents view --json`'s new per-version `launchable`
+// field; these lock the placement seam (`viewAgentAccountEligibility` reads it,
+// `probeRemoteReadiness` maps it into the signal `resolveDeviceAuto` gates on).
+describe('viewAgentAccountEligibility — launchable gates remote placement (PHNX-3466)', () => {
+  it('EXCLUDES a version signed-in-but-not-launchable (inherits global login, empty version home)', () => {
+    // The exact bug: the version home has no per-version credential, so it only
+    // *inherits* the active/global HOME login. `signedIn` reads true (who is
+    // logged in) but the isolated launch dies at spawn — `launchable` is false.
+    const view = JSON.stringify([{ agent: 'claude', versions: [
+      { signedIn: true, launchable: false, usageStatus: 'available' },
+    ] }]);
+    expect(viewAgentAccountEligibility(view, 'claude')).toEqual({
+      // Not ready → excluded from the non-picker `--device auto` candidate set.
+      signedIn: false,
+      // Still picker-eligible: launching it IS the per-version login flow.
+      pickerEligible: true,
+    });
+  });
+
+  it('keeps a blind-but-launchable worker eligible (per-version credential, no usage snapshot — RUSH-2392)', () => {
+    // A worker box with a real per-version setup-token credential but whose usage
+    // endpoint 403s (no snapshot → usageStatus null). launchable is true, so it
+    // stays a valid placement target — the "unverified stays eligible" rule.
+    const view = JSON.stringify([{ agent: 'claude', versions: [
+      { signedIn: true, launchable: true, usageStatus: null },
+    ] }]);
+    expect(viewAgentAccountEligibility(view, 'claude')).toEqual({
+      signedIn: true,
+      pickerEligible: true,
+    });
+  });
+
+  it('falls back to signedIn on an older remote CLI that omits launchable (no rolling-fleet regression)', () => {
+    // A remote CLI predating the field emits no `launchable`; the gate must read
+    // `signedIn` exactly as it did before — a signed-in version stays eligible.
+    const legacyView = JSON.stringify([{ agent: 'claude', versions: [
+      { signedIn: true, usageStatus: 'available' },
+    ] }]);
+    expect(viewAgentAccountEligibility(legacyView, 'claude')).toEqual({
+      signedIn: true,
+      pickerEligible: true,
+    });
+    // ...and a signed-out legacy version stays excluded-but-picker-eligible.
+    const legacyOut = JSON.stringify([{ agent: 'claude', versions: [{ signedIn: false }] }]);
+    expect(viewAgentAccountEligibility(legacyOut, 'claude')).toEqual({
+      signedIn: false,
+      pickerEligible: true,
+    });
+  });
+
+  it('a box whose only launchable version is throttled is neither ready nor picker-eligible', () => {
+    // launchable:true but rate_limited → not ready, and not picker-eligible
+    // (a login cannot clear a throttle — only a window reset). Matches the
+    // signed-in-but-capped semantics for the launchable signal.
+    const view = JSON.stringify([{ agent: 'claude', versions: [
+      { signedIn: true, launchable: true, usageStatus: 'rate_limited' },
+    ] }]);
+    expect(viewAgentAccountEligibility(view, 'claude')).toEqual({
+      signedIn: false,
+      pickerEligible: false,
+    });
+  });
+
+  it('one launchable version keeps the device eligible even when a sibling only inherits the global login', () => {
+    // Real multi-version box: v1 empty home (launchable:false), v2 real
+    // per-version login (launchable:true). The device can run claude, so it must
+    // stay eligible — the launchable version carries it.
+    const view = JSON.stringify([{ agent: 'claude', versions: [
+      { signedIn: true, launchable: false, usageStatus: 'available' },
+      { signedIn: true, launchable: true, usageStatus: 'available' },
+    ] }]);
+    expect(viewAgentAccountEligibility(view, 'claude')).toEqual({
+      signedIn: true,
+      pickerEligible: true,
+    });
+  });
+});
+
 describe('parseReadyProbe', () => {
   it('parses version + agent listing from one compound probe', () => {
     const stdout = `2.1.170\n${MARK}\nClaude (balanced)\nCodex (balanced)\n`;

--- a/cli/src/lib/hosts/ready.ts
+++ b/cli/src/lib/hosts/ready.ts
@@ -248,6 +248,14 @@ export interface ViewAgentAccountEligibility {
  * --json`. A picker may route to a signed-out version because launching it is
  * the login flow, but it must not route to a device whose every signed-in
  * account is throttled.
+ *
+ * The sign-in gate reads the per-version `launchable` field — the strict
+ * per-version launch truth (`isLaunchableSignedIn`) — so a remote box is judged
+ * by the SAME launchability the local candidate uses (`collectRunCandidates` →
+ * `isLaunchableSignedIn`), not the display `signedIn` that inherits the
+ * active/global HOME login and passes a box that dies at spawn (PHNX-3466). An
+ * older remote CLI omits `launchable`, so it falls back to `signedIn` — the
+ * pre-fix behavior, so a rolling fleet does not regress.
  */
 export function viewAgentAccountEligibility(view: string, agent: string): ViewAgentAccountEligibility {
   try {
@@ -255,6 +263,7 @@ export function viewAgentAccountEligibility(view: string, agent: string): ViewAg
       agent?: string;
       versions?: Array<{
         signedIn?: boolean;
+        launchable?: boolean;
         authVerdict?: AuthVerdict | null;
         usageStatus?: 'available' | 'rate_limited' | 'out_of_credits' | null;
       }>;
@@ -263,12 +272,15 @@ export function viewAgentAccountEligibility(view: string, agent: string): ViewAg
     if (!row) return { signedIn: undefined, pickerEligible: undefined };
     const verdicts = (row.versions ?? []).flatMap((version) => {
       if (typeof version.signedIn !== 'boolean') return [];
+      // Prefer the strict per-version launch signal; fall back to the display
+      // `signedIn` for an older remote CLI that does not emit `launchable`.
+      const launchable = typeof version.launchable === 'boolean' ? version.launchable : version.signedIn;
       const throttled = version.usageStatus === 'rate_limited' || version.usageStatus === 'out_of_credits';
       const authBlocked = version.authVerdict !== null
         && version.authVerdict !== undefined
         && isDeadVerdict(version.authVerdict);
-      const ready = version.signedIn && !authBlocked && !throttled;
-      return [{ ready, pickerEligible: ready || !version.signedIn || authBlocked }];
+      const ready = launchable && !authBlocked && !throttled;
+      return [{ ready, pickerEligible: ready || !launchable || authBlocked }];
     });
     if (verdicts.length === 0) return { signedIn: undefined, pickerEligible: undefined };
     return {

--- a/cli/src/lib/view-types.ts
+++ b/cli/src/lib/view-types.ts
@@ -11,6 +11,18 @@ export interface ViewJsonVersion {
   isolated: boolean;
   isIsolatedDefault: boolean;
   signedIn: boolean;
+  /**
+   * Whether THIS version home can actually spawn a signed-in agent — the strict
+   * per-version launch truth (`isLaunchableSignedIn`), not the display `signedIn`
+   * above. `signedIn` is true when the version *inherits* the active/global HOME
+   * login even with no per-version credential of its own; such a home shows "who
+   * is logged in" but dies at spawn once launch isolates HOME to it. Automatic
+   * `--device auto` placement gates on THIS field so a remote box is judged by
+   * the same launchability the local candidate uses (`collectRunCandidates` →
+   * `isLaunchableSignedIn`), closing the local/remote asymmetry (PHNX-3466).
+   * Absent on an older remote CLI, whose consumers fall back to `signedIn`.
+   */
+  launchable: boolean;
   /** Live cached authentication verdict for this installed version. */
   authVerdict: AuthVerdict | null;
   email: string | null;


### PR DESCRIPTION
## PHNX-3466 — `--device auto` must never land on a box logged out for the target harness

Child of the PHNX-2653 Factory-reliability epic.

### The bug
When AGI EXT dispatches a new agent with `--device auto`, placement could select a fleet box whose selected harness cannot actually launch — the dispatched tab then exited 1 and vanished with no useful signal.

### Root cause (verified)
The `--device auto` gate (`resolveDeviceAuto`, non-picker path) **already excludes** a device whose harness reads signed-out — it requires `signal.signedIn === true`. The failure was an **asymmetry in the signal**, not the gate:

- **Local** candidate: strict per-version launch truth — `collectRunCandidates` → `isLaunchableSignedIn(info.signedIn, credentialPresence(agent, home))` (`placement-probe.ts`). Correctly reports not-launchable for a version home that only *inherits* the active/global HOME login.
- **Remote** candidate: `viewAgentAccountEligibility` (`hosts/ready.ts`) keyed off `agents view --json`'s **display** `signedIn` = `getAccountInfo().signedIn` (`view.ts:1523` → `agents.ts:2292`, `!!email`), which is true whenever the box's global HOME carries a login even if the per-version launch home is empty.

So a worker signed in globally but with no per-version credential for the harness passed the remote gate, was picked, and the isolated launch died at spawn.

### The fix — at the single placement source
- `agents view --json` now emits a per-version **`launchable`** field, computed with the canonical `isLaunchableSignedIn(info.signedIn, credentialPresence(agentId, home))` — the same primitive the local path uses (`view-types.ts`, `view.ts`).
- Remote placement (`viewAgentAccountEligibility`, `hosts/ready.ts`) **prefers `launchable`** and **falls back to `signedIn`** when it is absent, so an older remote CLI on a rolling fleet does not regress.
- No second placement path was added — the one CLI gate is hardened, so both the CLI and AGI EXT (which delegates placement to the CLI) benefit. When exclusion empties the pool, the existing fail-loud `no healthy device` error fires instead of a silently-lost launch.

The "unverified/blind stays eligible" behavior is preserved: a blind worker with a real per-version credential but no usage snapshot has `launchable: true` and remains eligible — unverified usage is not a logout.

### Tests (real path, no mocking)
`cli/src/lib/hosts/ready.test.ts` — the placement seam `probeRemoteReadiness` feeds:
- a version `signedIn:true` but `launchable:false` (inherits global login, empty version home) is **excluded** (`signedIn:false`) yet stays picker-eligible;
- a blind-but-launchable worker (`launchable:true`, no usage snapshot) stays **eligible**;
- an older-CLI view with **no** `launchable` field falls back to `signedIn`;
- a launchable-but-throttled box is neither ready nor picker-eligible; and one launchable version keeps a multi-version box eligible.

`cli/src/commands/view.isolated.integration.test.ts` — drives the **real** `agents view codex --json` against a throwaway HOME and asserts the emitted per-version `launchable` (false for the signed-out planted version), proving the field is wired, not dead.

`tsc --noEmit` clean; `ready.test.ts`, `smart-launch.test.ts`, `placement-probe.test.ts`, and the `view.*` suites pass locally. Full suite runs in CI.

### Docs / changelog
- `cli/docs/hosts.md` — the `--device auto` placement section now states it judges a device by the strict per-version launch truth (carried by `launchable`).
- `cli/.changelog/next/PHNX-3466.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
