### PR TITLE
feat(traces): segment index median into agent vs interactive + coverage (PHNX-3472)

### DIFF
--- a/cli/.changelog/next/PHNX-3472.md
+++ b/cli/.changelog/next/PHNX-3472.md
@@ -1,0 +1,13 @@
+- **`agents traces sync` now emits SEGMENTED active-time medians so the console can
+  headline agent runs, not the corpus blend (PHNX-3472).** 63% of sessions are
+  one-shot queries (≤2 messages, ~15s active), so the blended `medianMs`/`p90Ms` sat
+  at ~15s while substantial agent runs have a ~15-minute median — the blend headlined
+  neither. The index-shard `stats` now classify each session as an AGENT run (any tool
+  call OR more than 8 messages) or INTERACTIVE, and carry `agentMedianMs`/`agentP90Ms`
+  (active-time median/p90 over agent sessions), `interactiveMedianMs`, and
+  `measuredFraction` (share of sessions with a non-null duration) alongside the
+  unchanged blended `medianMs`/`p90Ms`. Reuses the PHNX-3457 active-time computation
+  (span minus idle gaps > 120s); no calendar span reintroduced. Source:
+  `cli/src/lib/traces/sync.ts`.
+</content>
+</invoke>

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -78,7 +78,13 @@ rich per-device `index.json`. `activeMs` is `spanMs` minus every idle gap > 120s
 effort rather than calendar span (the raw span stays available per session as
 `SessionDetail.meta.spanMs`). The index contains duration/error statistics —
 `medianMs`/`p90Ms` are now the ACTIVE-time percentiles (same keys, new value; the
-fleet-aggregate worker keeps weighted-averaging them unchanged); every harness now
+fleet-aggregate worker keeps weighted-averaging them unchanged); those blended figures
+sit alongside **segmented** active-time stats (PHNX-3472) — `agentMedianMs`/`agentP90Ms`
+over AGENT runs (a session with any tool call OR more than 8 messages) and
+`interactiveMedianMs` over the one-shot INTERACTIVE remainder, plus `measuredFraction`
+(share of sessions carrying a non-null duration) — so the console can headline agent
+runs (~15min median) instead of the corpus blend the 63%-one-shot tail pulls to ~15s;
+every harness now
 carries a non-null span (`resolveDurationMs` in `session/db.ts` derives it at upsert
 for rush/grok/kimi/cursor/muse/antigravity, which previously left `duration_ms` NULL) —
 ranked attention flags, metadata/tool-mix topic buckets — the human task taxonomy the

--- a/cli/src/lib/traces/sync.test.ts
+++ b/cli/src/lib/traces/sync.test.ts
@@ -823,6 +823,70 @@ describe('active-time duration stats (PHNX-3457)', () => {
   });
 });
 
+// PHNX-3472: the blended median conflates one-shot interactive queries (63% of the
+// corpus, ~15s) with substantial agent runs (~15min), so the console needs the two
+// segmented. A session is an AGENT run when it made any tool call OR has more than
+// 8 messages; otherwise INTERACTIVE. measuredFraction reports how much of the corpus
+// carried a non-null duration.
+describe('segmented agent vs interactive duration stats (PHNX-3472)', () => {
+  const IDS = ['seg-agent-1', 'seg-agent-2', 'seg-agent-msgs', 'seg-int-1', 'seg-int-2', 'seg-nodur'];
+
+  function segRow(rowId: string, durationMs: number | null, extra: Partial<SyncRow> = {}): SyncRow {
+    return {
+      id: rowId, short_id: rowId.slice(0, 8), agent: 'rush', origin: 'cli', routine_name: null,
+      routine_run_id: null, version: null, account: null, account_key: null, account_org: null,
+      mode: 'auto', timestamp: '2026-08-25T00:00:00.000Z', last_activity: '2026-08-25T00:15:00.000Z',
+      project: 'agents-cli', cwd: '/redacted/agents-cli', git_branch: 'main', topic: 'fix a bug',
+      label: null, message_count: null, token_count: null, output_tokens: null, input_tokens: null,
+      cache_read_tokens: null, cache_write_tokens: null, cost_usd: null, cost_usd_nocache: null,
+      duration_ms: durationMs, model: 'rush-test', tool_call_count: null,
+      file_path: '/nonexistent/no-transcript.jsonl', file_mtime_ms: 1, file_size: 1,
+      machine: 'test-device', ...extra,
+    };
+  }
+
+  // A single tool call spanning the whole session, so active time == duration (no idle gap).
+  function insertSpanningCall(sid: string, endTs: string) {
+    getDB().prepare(`
+      INSERT INTO tool_calls (call_key, session_id, ordinal, timestamp, end_timestamp, tool, input, outcome, exit_code, error, evidence_bytes)
+      VALUES (?, ?, 1, '2026-08-25T00:00:00.000Z', ?, 'Bash', '{}', 'ok', 0, null, 0)
+    `).run(`${sid}-1`, sid, endTs);
+  }
+
+  beforeEach(() => {
+    const db = getDB();
+    for (const rid of IDS) {
+      db.prepare('DELETE FROM tool_calls WHERE session_id = ?').run(rid);
+      db.prepare('DELETE FROM session_topics WHERE session_id = ?').run(rid);
+      db.prepare('DELETE FROM session_phenotypes WHERE session_id = ?').run(rid);
+    }
+  });
+
+  it('segments agent runs (tool calls or >8 msgs) from one-shot interactive queries, and reports coverage', () => {
+    // Two agent runs classified by a tool call (15min each, busy → active == span).
+    insertSpanningCall('seg-agent-1', '2026-08-25T00:15:00.000Z');
+    insertSpanningCall('seg-agent-2', '2026-08-25T00:15:00.000Z');
+    // One agent run classified by >8 messages, NO tool calls (10min, no calls → active == span).
+    // Two one-shot interactive queries: ≤2 msgs, no tool calls, ~15s each.
+    const shard = buildIndexShard([
+      segRow('seg-agent-1', 900_000, { message_count: 2 }),
+      segRow('seg-agent-2', 900_000, { message_count: 3 }),
+      segRow('seg-agent-msgs', 600_000, { message_count: 12, last_activity: '2026-08-25T00:10:00.000Z' }),
+      segRow('seg-int-1', 15_000, { message_count: 2, last_activity: '2026-08-25T00:00:15.000Z' }),
+      segRow('seg-int-2', 15_000, { message_count: 1, last_activity: '2026-08-25T00:00:15.000Z' }),
+      segRow('seg-nodur', null, { message_count: 2 }), // no duration → excluded from medians, counts against coverage
+    ], 'test-device', 'owner-1');
+
+    // Agent median (900k, 900k, 600k) dwarfs interactive median (15k, 15k).
+    expect(shard.stats.agentMedianMs).toBe(900_000);
+    expect(shard.stats.interactiveMedianMs).toBe(15_000);
+    expect(shard.stats.agentMedianMs).toBeGreaterThan(shard.stats.interactiveMedianMs * 10);
+    expect(shard.stats.agentP90Ms).toBe(900_000);
+    // 5 of 6 rows carried a non-null duration.
+    expect(shard.stats.measuredFraction).toBeCloseTo(5 / 6, 10);
+  });
+});
+
 // PHNX-3408: each topic tile carries up to 30 example session refs so the console
 // can drill from the treemap into a category's session list. Without them every
 // tile renders display-only (the consumer gates the click on topic.sessions).

--- a/cli/src/lib/traces/sync.ts
+++ b/cli/src/lib/traces/sync.ts
@@ -316,6 +316,22 @@ export interface TracesIndexShard {
     medianMs: number;
     /** p90 ACTIVE duration, ms. */
     p90Ms: number;
+    /**
+     * SEGMENTED active-time stats (PHNX-3472). The blended `medianMs`/`p90Ms`
+     * above conflate one-shot interactive queries (63% of the corpus, ~15s
+     * median) with substantial agent runs (~15min median), so they headline
+     * neither. A session is an AGENT run when it made any tool call OR has more
+     * than 8 messages; otherwise INTERACTIVE. These segment the same active-time
+     * figure so the console can headline agent runs on their own axis. Each is
+     * computed only over sessions with a non-null duration.
+     */
+    agentMedianMs: number;
+    /** p90 ACTIVE duration over AGENT sessions, ms. */
+    agentP90Ms: number;
+    /** Median ACTIVE duration over INTERACTIVE sessions, ms. */
+    interactiveMedianMs: number;
+    /** (sessions with a non-null duration) / (total sessions), 0..1 — coverage of the duration stats. */
+    measuredFraction: number;
     needAttention: number;
     toolErrorRate: number;
   };
@@ -687,6 +703,23 @@ export function buildIndexShard(
       : [sessionActiveMs(row.duration_ms, callsBySession.get(row.id) ?? [], Date.parse(row.timestamp))],
   );
 
+  // Segment the same active-time figure into AGENT vs INTERACTIVE runs (PHNX-3472).
+  // A session is an AGENT run when it made any tool call OR has more than 8
+  // messages; otherwise INTERACTIVE (a one-shot query). Only sessions with a
+  // non-null duration contribute to the medians; `measuredFraction` reports how
+  // much of the corpus that covers.
+  const agentActive: number[] = [];
+  const interactiveActive: number[] = [];
+  let measured = 0;
+  for (const row of rows) {
+    if (row.duration_ms == null) continue;
+    measured++;
+    const active = sessionActiveMs(row.duration_ms, callsBySession.get(row.id) ?? [], Date.parse(row.timestamp));
+    const isAgent = (callsBySession.get(row.id)?.length ?? 0) > 0 || (row.message_count ?? 0) > 8;
+    (isAgent ? agentActive : interactiveActive).push(active);
+  }
+  const measuredFraction = rows.length === 0 ? 0 : measured / rows.length;
+
   // Build today's per-bucket stats for the rolling drift window.
   const todayDate = new Date().toISOString().slice(0, 10);
   const todayStats: BucketStats[] = [...topicCounts.values()].map(({ key }) => {
@@ -719,6 +752,10 @@ export function buildIndexShard(
       sessionsImported: rows.length,
       medianMs: percentile(activeDurations, 0.5),
       p90Ms: percentile(activeDurations, 0.9),
+      agentMedianMs: percentile(agentActive, 0.5),
+      agentP90Ms: percentile(agentActive, 0.9),
+      interactiveMedianMs: percentile(interactiveActive, 0.5),
+      measuredFraction,
       needAttention: needsAttention.length,
       toolErrorRate: calls.length === 0 ? 0 : failedCalls.length / calls.length,
     },

--- a/cli/src/lib/traces/testdata/rich-index.json
+++ b/cli/src/lib/traces/testdata/rich-index.json
@@ -7,6 +7,10 @@
     "sessionsImported": 1,
     "medianMs": 9000,
     "p90Ms": 9000,
+    "agentMedianMs": 9000,
+    "agentP90Ms": 9000,
+    "interactiveMedianMs": 0,
+    "measuredFraction": 1,
     "needAttention": 1,
     "toolErrorRate": 0.6666666666666666
   },


### PR DESCRIPTION
## What & why

63% of sessions are one-shot queries (≤2 messages, ~15s active time), so the blended index median sits at **~15s** — while substantial agent runs (>8 messages) have a **~15-minute** median. The blend headlines neither, so the Phoenix Evals console can't put a meaningful agent-run duration up top.

This segments the index-shard duration stats so the console can headline agent runs on their own axis.

## Change

In `cli/src/lib/traces/sync.ts` `buildIndexShard`, each session is classified:
- **AGENT** run when it made any tool call (from the already-loaded `tool_calls`) **OR** has more than 8 messages;
- **INTERACTIVE** otherwise.

New fields in `stats` (all reusing the PHNX-3457 active-time figure = span minus idle gaps > 120s — **no calendar span reintroduced**):

| field | meaning |
|---|---|
| `agentMedianMs` / `agentP90Ms` | active-time median / p90 over AGENT sessions with a non-null duration |
| `interactiveMedianMs` | active-time median over INTERACTIVE sessions |
| `measuredFraction` | (sessions with a non-null duration) / (total), 0..1 — coverage of the stats |

The blended `medianMs` / `p90Ms` are **unchanged** (same keys, same values) — the fleet-aggregate worker (`worker-template.ts`) keeps weighted-averaging them untouched. The `TracesIndexShard.stats` type is updated in lockstep.

## Evidence

Targeted suite (vitest), including the new PHNX-3472 test that seeds a mix of one-shot + agent rows and asserts `agentMedianMs` dwarfs `interactiveMedianMs` and `measuredFraction` reflects the null-duration share:

```
$ bunx vitest run src/lib/traces/
 Test Files  7 passed (7)
      Tests  99 passed | 4 skipped (103)
```

```
$ bunx tsc --noEmit
=== EXIT: 0 ===
```

Full suite runs on a fleet worker (`scripts/test.sh`) + the required CI `test` check.

## Docs / changelog

- `cli/AGENTS.md` traces-sync section documents the segmented fields.
- `cli/.changelog/next/PHNX-3472.md` added (user-visible index-shape change).