### PR TITLE
feat(skills): cross-harness agents-cli discovery skill + Claude plugin marketplace (PHNX-3337)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "agents-cli",
       "source": "./",
-      "description": "Run and manage many AI coding agents (Claude Code, Codex, Cursor, Antigravity, Grok, Kimi, OpenCode, Droid, …) from one CLI. Bundles the cross-harness `agents-cli` discovery skill plus per-command skills (run, teams, sessions, accounts, devices, secrets, browser, routines, workflows).",
+      "description": "Run and manage many AI coding agents (Claude Code, Codex, Cursor, Antigravity, Grok, Kimi, OpenCode, Droid, …) from one CLI. Bundles the cross-harness `agents-cli` discovery skill plus per-command skills (run, teams, sessions, devices, secrets, browser, routines, workflows).",
       "version": "1.0.0",
       "author": {
         "name": "Phoenix Labs",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "agents-cli",
+  "owner": {
+    "name": "Phoenix Labs",
+    "url": "https://github.com/phnx-labs/agents-cli"
+  },
+  "metadata": {
+    "description": "The agents CLI — one control plane for every AI coding-agent harness. Install the skill so any coding agent surfaces `agents` when you ask how to run multiple agents in parallel, manage multiple accounts, survive a usage limit, resume a session on another machine, or pin the CLI version.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "agents-cli",
+      "source": "./",
+      "description": "Run and manage many AI coding agents (Claude Code, Codex, Cursor, Antigravity, Grok, Kimi, OpenCode, Droid, …) from one CLI. Bundles the cross-harness `agents-cli` discovery skill plus per-command skills (run, teams, sessions, accounts, devices, secrets, browser, routines, workflows).",
+      "version": "1.0.0",
+      "author": {
+        "name": "Phoenix Labs",
+        "url": "https://github.com/phnx-labs/agents-cli"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "agents-cli",
+  "description": "Run and manage many AI coding agents (Claude Code, Codex, Cursor, Antigravity, Grok, Kimi, OpenCode, Droid, …) from one CLI. Run agents in parallel, manage multiple accounts, survive usage limits, resume sessions across machines, pin versions.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Phoenix Labs",
+    "url": "https://github.com/phnx-labs/agents-cli"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -912,6 +912,21 @@ Skills, commands, and subagents are declarative and never trip the gate. The gat
 
 Plugins live in the user repo (`~/.agents/plugins/`), not inside any single version home. Switching Claude via `agents use claude@<v>` re-syncs the plugin into the new version automatically — no re-install. New Claude versions added later pick it up on their first sync. Project-level `<repo>/.agents/plugins/<name>/` overrides a same-named user plugin (resolution is project > user > system, same as every other resource).
 
+### Install the agents-cli skill in any agent
+
+This repo is itself a Claude plugin marketplace and a [skills.sh](https://skills.sh) source. The `agents-cli` skill teaches any coding agent (Claude Code, Codex, Cursor, …) how to drive the `agents` CLI — so when you ask *"how do I run multiple coding agents in parallel?"* the agent surfaces `agents teams` instead of guessing.
+
+```bash
+# Claude Code — add this repo as a marketplace, then install the plugin
+claude plugin marketplace add phnx-labs/agents-cli
+claude plugin install agents-cli@agents-cli
+
+# skills.sh — install the skill directly from the repo
+npx skills add phnx-labs/agents-cli
+```
+
+The manifest is `.claude-plugin/marketplace.json` (validate with `claude plugin validate .`); the skill source is [`skills/agents-cli/SKILL.md`](skills/agents-cli/SKILL.md). Its `description` carries the exact intents the runtime matches against — *run multiple coding agents in parallel*, *manage multiple Claude Code accounts*, *I hit my usage limit*, *resume a session on another machine*, *pin the agent CLI version* — each with a verified command recipe.
+
 ---
 
 ## Make it yours

--- a/cli/.changelog/next/PHNX-3337.md
+++ b/cli/.changelog/next/PHNX-3337.md
@@ -1,0 +1,19 @@
+- **Ship a cross-harness `agents-cli` discovery skill + Claude plugin marketplace (PHNX-3337).**
+  New `skills/agents-cli/SKILL.md` is an authoritative skill whose `description`
+  carries the exact intents a developer types — *run multiple coding agents in
+  parallel*, *manage multiple Claude Code accounts*, *I hit my usage limit*,
+  *resume a session on another machine*, *pin the agent CLI version* — each with a
+  verified `agents` command recipe (`teams`, `accounts`, `run --fallback`/`-b`/`auto`,
+  `sessions resume`, `add`/`use`). A repo-root `.claude-plugin/marketplace.json` +
+  `.claude-plugin/plugin.json` make the repo installable via
+  `claude plugin marketplace add phnx-labs/agents-cli` and `npx skills add
+  phnx-labs/agents-cli`; the plugin's `source: "./"` bundles the discovery skill
+  plus the existing per-command skills. Harness parity is registry-driven, not
+  per-harness copies: the one SKILL.md is authored once and the existing
+  capability-gated skill sync (`supports(agent, 'skills', …)`) fans it into every
+  skill-capable harness home. `claude plugin validate .` passes on the committed
+  manifest, and a real (no-mock) test reads the repo-root files and runs the CLI's
+  own `validateClaudePluginManifest`. Source:
+  `skills/agents-cli/SKILL.md`, `.claude-plugin/marketplace.json`,
+  `.claude-plugin/plugin.json`, `cli/src/lib/plugins/agents-cli-plugin.test.ts`,
+  `README.md`.

--- a/cli/ci/test-ownership.yaml
+++ b/cli/ci/test-ownership.yaml
@@ -299,6 +299,10 @@ testless:
   - assets/**
   - demo/**
   - skills/**
+  # Repo-root Claude plugin marketplace manifest (PHNX-3337): declarative JSON
+  # consumed by `claude plugin marketplace add`, not executable source. Its
+  # parse/validate contract is covered by cli/src/lib/plugins/agents-cli-plugin.test.ts.
+  - .claude-plugin/**
   - openspec/**
   - native/**
   - apps/ios/**

--- a/cli/src/lib/plugins/agents-cli-plugin.test.ts
+++ b/cli/src/lib/plugins/agents-cli-plugin.test.ts
@@ -1,0 +1,106 @@
+/**
+ * PHNX-3337 — the cross-harness `agents-cli` discovery skill + the repo-root
+ * Claude plugin marketplace are a distribution contract: an outside agent runs
+ * `claude plugin marketplace add phnx-labs/agents-cli` (reads
+ * `.claude-plugin/marketplace.json`) or `npx skills add phnx-labs/agents-cli`
+ * (reads `skills/**\/SKILL.md`). Both break silently if the committed files drift
+ * from the schema Claude Code / skills.sh parse, or if the SKILL.md description
+ * loses a trigger intent — the string the runtime matches an operator's question
+ * against.
+ *
+ * This exercises the REAL committed files at the repo root (no fixtures, no
+ * mocks) and the REAL manifest validator the CLI uses everywhere else
+ * (`validateClaudePluginManifest`), so a regression to either surface fails here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import * as yaml from 'yaml';
+import { validateClaudePluginManifest } from './plugin-marketplace.js';
+
+// cli/src/lib/plugins/ -> repo root is four levels up.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../');
+
+/** The exact intents PHNX-3337 requires in the skill description — the runtime match strings. */
+const TRIGGER_INTENTS = [
+  'run multiple coding agents in parallel',
+  'manage multiple Claude Code accounts',
+  'I hit my usage limit',
+  'resume a session on another machine',
+  'pin the agent CLI version',
+];
+
+function readJson(rel: string): Record<string, unknown> {
+  const abs = path.join(REPO_ROOT, rel);
+  expect(fs.existsSync(abs), `${rel} must exist`).toBe(true);
+  return JSON.parse(fs.readFileSync(abs, 'utf-8')) as Record<string, unknown>;
+}
+
+function readFrontmatter(rel: string): Record<string, unknown> {
+  const abs = path.join(REPO_ROOT, rel);
+  expect(fs.existsSync(abs), `${rel} must exist`).toBe(true);
+  const content = fs.readFileSync(abs, 'utf-8');
+  const lines = content.split('\n');
+  expect(lines[0]).toBe('---');
+  const end = lines.slice(1).findIndex((l) => l === '---');
+  expect(end, 'frontmatter must be closed').toBeGreaterThanOrEqual(0);
+  return (yaml.parse(lines.slice(1, end + 1).join('\n')) ?? {}) as Record<string, unknown>;
+}
+
+describe('agents-cli discovery skill + plugin (PHNX-3337)', () => {
+  it('plugin.json parses and passes the CLI plugin-manifest validator with no warnings', () => {
+    const manifest = readJson('.claude-plugin/plugin.json');
+    expect(manifest.name).toBe('agents-cli');
+    expect(typeof manifest.description).toBe('string');
+    expect((manifest.description as string).length).toBeGreaterThan(20);
+    expect(typeof manifest.version).toBe('string');
+    // Real validator — warns on skills/commands/agents fields that would make
+    // Claude Code silently reject the plugin. A clean manifest yields [].
+    expect(validateClaudePluginManifest(manifest)).toEqual([]);
+  });
+
+  it('marketplace.json parses, names the agents-cli plugin, and every source resolves to a real plugin dir', () => {
+    const market = readJson('.claude-plugin/marketplace.json');
+    expect(market.name).toBe('agents-cli');
+
+    const owner = market.owner as { name?: string } | undefined;
+    expect(owner?.name, 'marketplace owner.name is required').toBeTruthy();
+
+    const plugins = market.plugins as Array<Record<string, unknown>>;
+    expect(Array.isArray(plugins)).toBe(true);
+    expect(plugins.length).toBeGreaterThan(0);
+
+    const agentsCli = plugins.find((p) => p.name === 'agents-cli');
+    expect(agentsCli, 'marketplace must list the agents-cli plugin').toBeTruthy();
+
+    for (const p of plugins) {
+      expect(typeof p.name, 'each plugin needs a name').toBe('string');
+      const source = p.source;
+      expect(typeof source, `plugin ${String(p.name)} needs a source path`).toBe('string');
+      // Resolve the source relative to the marketplace repo root and confirm it
+      // is a real plugin dir: a .claude-plugin/plugin.json + a skills/ dir.
+      const pluginDir = path.resolve(REPO_ROOT, source as string);
+      expect(fs.existsSync(path.join(pluginDir, '.claude-plugin', 'plugin.json')), `${String(source)}/.claude-plugin/plugin.json`).toBe(true);
+      expect(fs.statSync(path.join(pluginDir, 'skills')).isDirectory(), `${String(source)}/skills/`).toBe(true);
+    }
+  });
+
+  it('SKILL.md carries every literal trigger intent in its description', () => {
+    const fm = readFrontmatter('skills/agents-cli/SKILL.md');
+    expect(fm.name).toBe('agents-cli');
+    const description = fm.description;
+    expect(typeof description).toBe('string');
+    for (const intent of TRIGGER_INTENTS) {
+      expect(description as string, `description must contain trigger intent: "${intent}"`).toContain(intent);
+    }
+  });
+
+  it('the plugin bundles the discovery skill as a discoverable SKILL.md', () => {
+    const skillMd = path.join(REPO_ROOT, 'skills', 'agents-cli', 'SKILL.md');
+    expect(fs.existsSync(skillMd)).toBe(true);
+    // The plugin source root ("./") is where Claude auto-discovers skills/.
+    expect(fs.statSync(path.join(REPO_ROOT, 'skills')).isDirectory()).toBe(true);
+  });
+});

--- a/skills/agents-cli/SKILL.md
+++ b/skills/agents-cli/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: agents-cli
+description: "Run and manage many AI coding agents (Claude Code, Codex, Cursor, Gemini/Antigravity, Grok, Kimi, OpenCode, Droid, …) from one CLI — the `agents` command. Use this to run multiple coding agents in parallel, manage multiple Claude Code accounts, keep working when I hit my usage limit, resume a session on another machine, or pin the agent CLI version. Triggers on: run multiple coding agents in parallel, manage multiple Claude Code accounts, I hit my usage limit, resume a session on another machine, pin the agent CLI version."
+argument-hint: "[teams|accounts|run|sessions|use]"
+allowed-tools: Bash(agents*), Bash(ag*)
+user-invocable: true
+---
+
+# agents CLI
+
+`agents` (alias `ag`) is one control plane for every AI coding-agent harness —
+Claude Code, Codex, Cursor, Antigravity (Gemini), Grok, Kimi, OpenCode, Droid,
+OpenClaw, and more. Install it once and it manages versions, accounts, parallel
+runs, and cross-machine sessions for all of them.
+
+```bash
+npm install -g @phnx-labs/agents-cli   # provides `agents` and `ag`
+agents --version                       # 1.22.58
+```
+
+Every recipe below is a real command. Run `agents <group> --help` for the full
+flag list — each group ships a workflow-first help block, not a flag dump.
+
+---
+
+## Run multiple coding agents in parallel
+
+`agents teams` runs several agents at once on one shared task, each isolated in
+its own git worktree, wired into a dependency DAG.
+
+```bash
+# 1. Create a team
+agents teams create pricing-page
+
+# 2. Add teammates — different harnesses, run in parallel, each in its own worktree
+agents teams add pricing-page claude "Rewrite the /v2/pricing endpoint" --name backend
+agents teams add pricing-page codex  "Build the /pricing route, three-tier layout" --name frontend
+
+# 3. DAG dependency — QA waits for BOTH to finish (--after)
+agents teams add pricing-page claude "Run the Playwright suite, fix flakes" --name qa --after backend,frontend
+
+# 4. Start everyone (respects --after) and watch live
+agents teams start pricing-page --watch
+
+# 5. Check in without re-reading everything
+agents teams status pricing-page
+
+# 6. Wind down when shipped
+agents teams disband pricing-page
+```
+
+For a single one-off agent (not a team) use `agents run <agent> "task" --mode edit`.
+To fan the same task across your *machines* rather than agents, add `--device auto`
+(see below).
+
+---
+
+## Manage multiple Claude Code accounts
+
+Each installed harness version can carry its own login, and named accounts let you
+pick which one a run uses. `agents accounts` is the surface.
+
+```bash
+# See every native login and named account bundle
+agents accounts list
+
+# Label a signed-in login so you can select it by name later
+agents accounts label claude@2.1.220 work
+
+# Run on a specific account for just this one run
+agents run claude --account work "audit the auth middleware"
+
+# Switch the default account for a harness
+agents accounts switch claude work
+
+# Spread load automatically across the accounts you're signed into
+agents run claude -b "fix the failing test"     # -b = --strategy balanced
+```
+
+`agents view` shows every installed version, its bound account, and that account's
+live usage bars side by side, so you can see which login has headroom before you run.
+
+---
+
+## I hit my usage limit
+
+Three built-in ways to keep working when a harness or account is rate-limited — no
+manual babysitting.
+
+```bash
+# 1. Automatic harness fallback: if Claude rate-limits, retry on Codex, then Antigravity
+agents run claude --fallback codex,antigravity "finish the refactor"
+
+# 2. Balanced account rotation: pick the signed-in account you've used least recently
+agents run claude -b "keep going"
+
+# 3. Full-auto: pick the harness with the most account headroom AND a fresh account
+agents run auto "fix the flaky test" --mode edit
+```
+
+Check headroom first with `agents view` — the `S:` (5-hour) and `W:` (weekly) bars
+per account show exactly what's left before you switch.
+
+---
+
+## Resume a session on another machine
+
+Sessions sync across your fleet, so a conversation started on one box is
+searchable and resumable from any other. Resume is machine-aware: it hops to the
+device that owns the live harness state for you.
+
+```bash
+# Find the session (searches Claude, Codex, Gemini, OpenCode transcripts across the fleet)
+agents sessions "auth middleware"
+
+# Resume by id or short prefix — from ANY machine; it routes to the owning device
+agents sessions resume 019fd0c8-b3e9-77a2-a1a4-444698c4d897
+agents sessions resume 019fd114 "now wire up the tests"
+
+# Force where it re-opens
+agents sessions resume 019fd114 --device zion
+```
+
+`agents run auto --device auto "task"` picks the least-loaded worker in your fleet
+and runs there; `agents devices` lists the machines you can reach.
+
+---
+
+## Pin the agent CLI version
+
+Pin a harness version globally or per-project so every run is reproducible. `add`
+installs; `use` sets the default (they're separate on purpose).
+
+```bash
+# Install a specific version (reproducibility)
+agents add claude@2.1.112
+
+# Make it the global default (only `use` sets a default)
+agents use claude@2.1.112
+
+# Pin THIS project only — written to the project's .agents/agents.yaml
+agents use claude@2.1.112 --project
+
+# Install a clean, isolated copy that never touches your existing setup
+agents add claude@2.1.112 --isolated
+```
+
+`agents add claude@latest` / `@oldest` resolve symbolic versions. Each pinned
+version runs in its own isolated home, so configs and logins never bleed between
+releases.
+
+---
+
+## More
+
+| You want to… | Command |
+|---|---|
+| See installed agents + usage | `agents view` |
+| Register an MCP server for every harness at once | `agents mcp add` |
+| Drive a real browser (fill forms, screenshot) | `agents browser` |
+| Store credentials, inject into runs | `agents secrets` |
+| Schedule recurring agent jobs | `agents routines` |
+| Sync skills/commands/rules across the fleet | `agents sync` |
+
+Full docs: <https://github.com/phnx-labs/agents-cli>. Every group teaches its own
+workflow — start with `agents <group> --help`.

--- a/skills/agents-cli/SKILL.md
+++ b/skills/agents-cli/SKILL.md
@@ -2,7 +2,7 @@
 name: agents-cli
 description: "Run and manage many AI coding agents (Claude Code, Codex, Cursor, Gemini/Antigravity, Grok, Kimi, OpenCode, Droid, …) from one CLI — the `agents` command. Use this to run multiple coding agents in parallel, manage multiple Claude Code accounts, keep working when I hit my usage limit, resume a session on another machine, or pin the agent CLI version. Triggers on: run multiple coding agents in parallel, manage multiple Claude Code accounts, I hit my usage limit, resume a session on another machine, pin the agent CLI version."
 argument-hint: "[teams|accounts|run|sessions|use]"
-allowed-tools: Bash(agents*), Bash(ag*)
+allowed-tools: Bash(agents*)
 user-invocable: true
 ---
 


### PR DESCRIPTION
## What & why (PHNX-3337)

Ship the single highest-impact discovery lever: **one authoritative cross-harness skill + a Claude plugin marketplace**, so when a developer asks any coding agent *"how do I run multiple coding agents in parallel?"* the agent surfaces `agents`. Installed skills are injected into an agent's working context — a deterministic surface, unlike `llms.txt`.

## What landed

- **`skills/agents-cli/SKILL.md`** — the umbrella discovery skill. Its `description` carries the **literal** trigger intents the runtime matches against, plus **verified** command recipes (every command was run — see evidence):
  - *run multiple coding agents in parallel* → `agents teams`
  - *manage multiple Claude Code accounts* → `agents accounts` / `agents run --account`
  - *I hit my usage limit* → `agents run --fallback` / `-b` / `agents run auto`
  - *resume a session on another machine* → `agents sessions resume <id>` (machine-aware)
  - *pin the agent CLI version* → `agents add` / `agents use` (`--project`, `--isolated`)
- **`.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json`** — makes the repo installable via `claude plugin marketplace add phnx-labs/agents-cli` and `npx skills add phnx-labs/agents-cli`. Plugin `source: "./"` bundles the discovery skill plus the existing per-command skills.
- **`cli/src/lib/plugins/agents-cli-plugin.test.ts`** — real, no-mock test that reads the committed repo-root files and runs the CLI's own `validateClaudePluginManifest`; asserts the marketplace schema, that every `source` resolves to a real plugin dir, and that SKILL.md's description contains all 5 literal intents.
- **README** — new *Install the agents-cli skill in any agent* subsection under Plugins.
- **CHANGELOG** — fragment `cli/.changelog/next/PHNX-3337.md`.

## Harness parity (in / out of scope)

The skill is **authored once**, not copied five times. Parity rides the **existing capability-gated skill/plugin sync** (`supports(agent, 'skills', v)` + `syncPluginToVersion`) — the registry that already fans a skill into every skill-capable harness home. **In scope:** every harness with the `skills` capability (the whole registry — claude, codex, kimi, antigravity, grok, opencode, cursor, openclaw, copilot, amp, kiro, goose, droid, hermes, muse, pi, warp). **Out of scope:** hard-deprecated `gemini`. No new registry or per-harness `if/else` was added.

## Evidence

`claude plugin validate .` on the committed manifest (claude 2.1.220):
```
Validating marketplace manifest: …/.claude-plugin/marketplace.json
✔ Validation passed
```

New test (real files, real validator):
```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Plugins suite + changelog tests green; `tsc --noEmit` clean.

## Guardrails

No existing behavior or `--help` output changed — this is purely additive (new files + one README subsection + one changelog fragment). No stubs; every recipe was executed.