### PR TITLE
fix(traces): strip stray tool-call artifact from PHNX-3472 changelog

### DIFF
--- a/cli/.changelog/next/PHNX-3472.md
+++ b/cli/.changelog/next/PHNX-3472.md
@@ -9,5 +9,3 @@
   unchanged blended `medianMs`/`p90Ms`. Reuses the PHNX-3457 active-time computation
   (span minus idle gaps > 120s); no calendar span reintroduced. Source:
   `cli/src/lib/traces/sync.ts`.
-</content>
-</invoke>


### PR DESCRIPTION
## What

PR #3281 (seg-producer, PHNX-3472) merged with a serialization artifact in its changelog fragment: `cli/.changelog/next/PHNX-3472.md` ended with two literal lines —

```
</content>
</invoke>
```

— leftover tool-call markup that leaked into the committed file. These would render verbatim in the aggregated release notes. This strips them; the changelog prose is unchanged.

## Why it slipped

PR #3281 was self-merged ~5 min after open with **no non-author review posted** (`reviews: []`). CI (`test`, `gitleaks`) was green — the checks don't lint changelog-fragment content, so the artifact rode through. The producer code in `sync.ts` itself is correct and well-tested; only the changelog file was affected.

## Evidence

Artifact on `main` before this fix (via GitHub contents API):

```
  ...no calendar span reintroduced. Source:
  `cli/src/lib/traces/sync.ts`.
</content>          <- stray
</invoke>           <- stray
```

Diff: `1 file changed, 2 deletions(-)` — removes only the two stray lines.

## Scope

Changelog-only; no code, no behavior change. This does not affect the PHNX-3472 producer landing (already merged) or the downstream console segmentation work that consumes the new `agentMedianMs`/`interactiveMedianMs`/`measuredFraction` fields.