### PR TITLE
feat(traces): classify session kind + exclude utility calls from the eval corpus (PHNX-3474)

### DIFF
--- a/cli/.changelog/next/PHNX-3474.md
+++ b/cli/.changelog/next/PHNX-3474.md
@@ -1,0 +1,17 @@
+- **`agents traces sync` classifies session kind and EXCLUDES internal utility calls
+  from the Evals corpus (PHNX-3474).** ~68% of the raw corpus is machine plumbing —
+  single-shot calls (no tool call AND ≤2 messages) plus known internal-prompt
+  signatures (title generation, watchdog ticks, commit-message writes, factory
+  workers), all spawned under the `claude` harness by the Rush app — and it poisoned
+  every console statistic (count, median, need-attention, tool-error-rate). Each
+  session now carries a `kind` (`utility` vs `agent`, `classifySessionKind` in
+  `traces/sync.ts`) and every index statistic is computed over the AGENT set ONLY:
+  `sessionsImported` is the real agent count (not the raw row count), and the
+  medians / `needAttention` / `toolErrorRate` / topic-bucket counts all exclude
+  utility. A new top-level `utilityCount` reports how many were dropped. Each session
+  ref (topic-tile `sessions[]` and `needsAttention`) also emits `kind` and `harness`
+  so the console can filter by both. Pure reclassification — utility rows are tagged
+  and excluded at shard-build time, never deleted from `sessions.db`. Source:
+  `cli/src/lib/traces/sync.ts`.
+</content>
+</invoke>

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -76,7 +76,19 @@ spanMs/**activeMs**/turns/tools/errorCount/tokens/cost/outcome/repo — plus a p
 rich per-device `index.json`. `activeMs` is `spanMs` minus every idle gap > 120s
 (PHNX-3457) so a session resumed after hours, or left idle mid-turn, reads as
 effort rather than calendar span (the raw span stays available per session as
-`SessionDetail.meta.spanMs`). The index contains duration/error statistics —
+`SessionDetail.meta.spanMs`). **Every index statistic is computed over the AGENT
+corpus ONLY (PHNX-3474):** each session is classified `kind` = `utility` when it is
+internal machine plumbing — no tool call AND ≤2 messages (a single-shot call), or its
+topic/label matches a known internal-prompt signature (title generation, watchdog,
+commit-message writer, factory worker; `classifySessionKind` /
+`UTILITY_PROMPT_SIGNATURES` in `traces/sync.ts`) — otherwise `agent`. Utility rows
+(~68% of the raw corpus: title-gen, watchdog ticks, commit-message writes, factory
+workers, all spawned under the `claude` harness by the Rush app) are **tagged and
+excluded, never deleted** from `sessions.db`, so `sessionsImported` is the real agent
+count, and the medians / needs-attention / tool-error-rate / topic-bucket counts all
+measure agent work; a top-level **`utilityCount`** reports how many were dropped. Each
+session ref (topic-tile `sessions[]`, `needsAttention`) carries `kind` and `harness`
+(the producing agent) so the console can filter by both. The index contains duration/error statistics —
 `medianMs`/`p90Ms` are now the ACTIVE-time percentiles (same keys, new value; the
 fleet-aggregate worker keeps weighted-averaging them unchanged); those blended figures
 sit alongside **segmented** active-time stats (PHNX-3472) — `agentMedianMs`/`agentP90Ms`
@@ -91,7 +103,7 @@ ranked attention flags, metadata/tool-mix topic buckets — the human task taxon
 console treemap renders (Feature work · Bug fixes · Refactor · Debugging · Code review ·
 Release · Blog & docs · Fleet / ops), an ordered rules table in `classify.ts`'s
 `classifyTopic`, keyed within the five stable `TraceTopicGroup` groups, **each bucket
-carrying up to 30 example `sessions` refs (`{id,title}`) so a treemap tile is
+carrying up to 30 example `sessions` refs (`{id,title,kind,harness}`) so a treemap tile is
 drillable into its session list (PHNX-3408)** — and structured tool
 failure cause buckets (`real`, `guard`, `hook`), and a **rolling drift signal**.
 Group-by dimensions for the console insight bar are pure functions in

--- a/cli/src/lib/traces/sync.test.ts
+++ b/cli/src/lib/traces/sync.test.ts
@@ -7,7 +7,7 @@ import { getDB, readSessionTopics, INSIGHTS_EXTRACTOR_VERSION } from '../session
 import * as sessionDb from '../session/db.js';
 import { getRuntimeStateDir } from '../state.js';
 import type { ClassifiedTopic } from './classify.js';
-import { buildIndexShard, buildSessionDetail, readSyncLedger, syncTraces, type SyncRow } from './sync.js';
+import { buildIndexShard, buildSessionDetail, classifySessionKind, readSyncLedger, syncTraces, type SyncRow } from './sync.js';
 
 const id = 'trace-rich-fixture';
 const transcript = path.join(import.meta.dirname, '../session/testdata/codex-fixture.jsonl');
@@ -867,14 +867,17 @@ describe('segmented agent vs interactive duration stats (PHNX-3472)', () => {
     insertSpanningCall('seg-agent-1', '2026-08-25T00:15:00.000Z');
     insertSpanningCall('seg-agent-2', '2026-08-25T00:15:00.000Z');
     // One agent run classified by >8 messages, NO tool calls (10min, no calls → active == span).
-    // Two one-shot interactive queries: ≤2 msgs, no tool calls, ~15s each.
+    // Two INTERACTIVE queries: no tool calls, 3–8 msgs (above the ≤2-msg utility floor
+    // — PHNX-3474 — so they stay in the corpus rather than being excluded), ~15s each.
     const shard = buildIndexShard([
       segRow('seg-agent-1', 900_000, { message_count: 2 }),
       segRow('seg-agent-2', 900_000, { message_count: 3 }),
       segRow('seg-agent-msgs', 600_000, { message_count: 12, last_activity: '2026-08-25T00:10:00.000Z' }),
-      segRow('seg-int-1', 15_000, { message_count: 2, last_activity: '2026-08-25T00:00:15.000Z' }),
-      segRow('seg-int-2', 15_000, { message_count: 1, last_activity: '2026-08-25T00:00:15.000Z' }),
-      segRow('seg-nodur', null, { message_count: 2 }), // no duration → excluded from medians, counts against coverage
+      segRow('seg-int-1', 15_000, { message_count: 4, last_activity: '2026-08-25T00:00:15.000Z' }),
+      segRow('seg-int-2', 15_000, { message_count: 5, last_activity: '2026-08-25T00:00:15.000Z' }),
+      // No duration → excluded from medians but counts against coverage. message_count 12
+      // keeps it an AGENT row (not utility), so it stays in the denominator (PHNX-3474).
+      segRow('seg-nodur', null, { message_count: 12 }),
     ], 'test-device', 'owner-1');
 
     // Agent median (900k, 900k, 600k) dwarfs interactive median (15k, 15k).
@@ -899,7 +902,9 @@ describe('topic session refs for treemap drill-down (PHNX-3408)', () => {
       project: 'agents-cli', cwd: '/redacted/agents-cli', git_branch: 'fix/bug', topic: 'fix the bug',
       label, message_count: null, token_count: null, output_tokens: null, input_tokens: null,
       cache_read_tokens: null, cache_write_tokens: null, cost_usd: null, cost_usd_nocache: null,
-      duration_ms: 1000, model: 'rush-test', tool_call_count: null,
+      // A non-null tool_call_count keeps the row out of the utility class (PHNX-3474),
+      // so it stays in the agent corpus and reaches a topic bucket.
+      duration_ms: 1000, model: 'rush-test', tool_call_count: 2,
       file_path: '/nonexistent/no-transcript.jsonl', file_mtime_ms: 1, file_size: 1,
       machine: 'test-device',
     };
@@ -924,8 +929,8 @@ describe('topic session refs for treemap drill-down (PHNX-3408)', () => {
     expect(withRefs).toBeDefined();
     expect(withRefs!.count).toBe(2);
     expect(withRefs!.sessions).toEqual([
-      { id: 'topic-b', title: 'Newer fix' }, // most-recent first
-      { id: 'topic-a', title: 'Older fix' },
+      { id: 'topic-b', title: 'Newer fix', kind: 'agent', harness: 'rush' }, // most-recent first
+      { id: 'topic-a', title: 'Older fix', kind: 'agent', harness: 'rush' },
     ]);
   });
 
@@ -943,5 +948,87 @@ describe('topic session refs for treemap drill-down (PHNX-3408)', () => {
     expect(bucket.count).toBe(45);          // true total unchanged
     expect(bucket.sessions).toHaveLength(30); // capped
     expect(bucket.sessions[0].id).toBe('topic-44'); // most recent kept
+  });
+});
+
+// PHNX-3474: internal utility plumbing — single-shot calls (no tool AND ≤2 msgs) and
+// known internal-prompt signatures (title-gen, watchdog, commit-message, factory
+// worker) — poisons every console stat. They are tagged `utility` and excluded from
+// the corpus: sessionsImported becomes the real agent count, the medians/topic buckets
+// exclude them, and a top-level utilityCount reports how many were dropped. Real agent
+// rows carry kind='agent' + harness so the console can filter by both.
+describe('utility-call classification excludes internal plumbing (PHNX-3474)', () => {
+  const IDS = ['u-title', 'u-watch', 'u-commit', 'u-shape', 'a-real'];
+
+  function kindRow(rowId: string, agent: string, extra: Partial<SyncRow>): SyncRow {
+    return {
+      id: rowId, short_id: rowId.slice(0, 8), agent, origin: 'cli', routine_name: null,
+      routine_run_id: null, version: null, account: null, account_key: null, account_org: null,
+      mode: 'auto', timestamp: '2026-08-25T00:00:00.000Z', last_activity: '2026-08-25T00:10:00.000Z',
+      project: 'agents-cli', cwd: '/redacted/agents-cli', git_branch: 'main', topic: null,
+      label: null, message_count: null, token_count: null, output_tokens: null, input_tokens: null,
+      cache_read_tokens: null, cache_write_tokens: null, cost_usd: null, cost_usd_nocache: null,
+      duration_ms: 5_000, model: 'test-model', tool_call_count: null,
+      file_path: '/nonexistent/no-transcript.jsonl', file_mtime_ms: 1, file_size: 1,
+      machine: 'test-device', ...extra,
+    };
+  }
+
+  beforeEach(() => {
+    const db = getDB();
+    for (const rid of IDS) {
+      db.prepare('DELETE FROM tool_calls WHERE session_id = ?').run(rid);
+      db.prepare('DELETE FROM session_topics WHERE session_id = ?').run(rid);
+      db.prepare('DELETE FROM session_phenotypes WHERE session_id = ?').run(rid);
+      db.prepare('DELETE FROM session_insights WHERE session_id = ?').run(rid);
+    }
+  });
+
+  it('classifies the single-shot and signature rows utility, and the tool-using row agent', () => {
+    // no tool call, message_count/tool_call_count is the shape's fallback — assert the
+    // pure classifier directly (the authoritative loaded-call count is passed as 0).
+    expect(classifySessionKind({ topic: 'Generate a 3-4 word title for this chat', label: null, message_count: 2, tool_call_count: null }, 0)).toBe('utility');
+    expect(classifySessionKind({ topic: null, label: 'You are a watchdog monitoring agent sessions', message_count: 1, tool_call_count: null }, 0)).toBe('utility');
+    expect(classifySessionKind({ topic: 'Write a conventional-commit message', label: null, message_count: 1, tool_call_count: null }, 0)).toBe('utility');
+    // the single-shot shape rule: no tool call AND ≤2 messages, no signature.
+    expect(classifySessionKind({ topic: 'quick question', label: null, message_count: 2, tool_call_count: null }, 0)).toBe('utility');
+    // a signature match wins even when the row otherwise looks like an agent run.
+    expect(classifySessionKind({ topic: 'FACTORY WORKER: build the widget', label: null, message_count: 40, tool_call_count: 12 }, 12)).toBe('utility');
+    // a real multi-turn tool-using session is agent.
+    expect(classifySessionKind({ topic: 'fix the bug', label: null, message_count: 20, tool_call_count: 3 }, 3)).toBe('agent');
+    // 3–8 messages with no tool call clears the utility floor → agent (interactive).
+    expect(classifySessionKind({ topic: 'discuss the design', label: null, message_count: 4, tool_call_count: null }, 0)).toBe('agent');
+  });
+
+  it('excludes utility rows from sessionsImported, the medians, and the topic buckets; reports utilityCount', () => {
+    const db = getDB();
+    // One real agent session: a single tool call spanning its whole 10-min duration so
+    // active time == span, plus a topic that lands it in a bucket.
+    db.prepare(`
+      INSERT INTO tool_calls (call_key, session_id, ordinal, timestamp, end_timestamp, tool, input, outcome, exit_code, error, evidence_bytes)
+      VALUES (?, ?, 1, '2026-08-25T00:00:00.000Z', '2026-08-25T00:10:00.000Z', 'Bash', '{}', 'ok', 0, null, 0)
+    `).run('a-real-1', 'a-real');
+
+    const shard = buildIndexShard([
+      kindRow('u-title', 'claude', { topic: 'Generate a 3-4 word title for this conversation', message_count: 2 }),
+      kindRow('u-watch', 'claude', { label: 'You are a watchdog monitoring stalled agents', message_count: 1 }),
+      kindRow('u-commit', 'claude', { topic: 'Draft a conventional-commit subject line', message_count: 1 }),
+      kindRow('u-shape', 'claude', { topic: 'single-shot machine call', message_count: 2 }), // no tool, ≤2 msgs
+      kindRow('a-real', 'codex', { topic: 'fix the bug', git_branch: 'fix/bug', message_count: 20, tool_call_count: 3, duration_ms: 600_000 }),
+    ], 'test-device', 'owner-1');
+
+    // Only the one real agent session is imported; the four utility rows are dropped.
+    expect(shard.stats.sessionsImported).toBe(1);
+    expect(shard.utilityCount).toBe(4);
+    // The median is the agent session's active time (600s), not diluted by the ~5s
+    // utility rows that would otherwise pull it toward zero.
+    expect(shard.stats.medianMs).toBe(600_000);
+    expect(shard.stats.agentMedianMs).toBe(600_000);
+    expect(shard.stats.measuredFraction).toBe(1); // the one agent row carried a duration
+
+    // The topic bucket carries only the agent session, tagged kind+harness.
+    const bucket = shard.topics.find((t) => t.sessions.length > 0)!;
+    expect(bucket.sessions).toEqual([{ id: 'a-real', title: 'fix the bug', kind: 'agent', harness: 'codex' }]);
+    expect(shard.topics.flatMap((t) => t.sessions.map((s) => s.id))).not.toContain('u-title');
   });
 });

--- a/cli/src/lib/traces/sync.ts
+++ b/cli/src/lib/traces/sync.ts
@@ -335,6 +335,15 @@ export interface TracesIndexShard {
     needAttention: number;
     toolErrorRate: number;
   };
+  /**
+   * Sessions excluded from the eval corpus as internal utility plumbing (PHNX-3474):
+   * single-shot machine calls (no tool call AND ≤2 messages) or a known
+   * internal-prompt signature (title generation, watchdog, commit-message, factory
+   * worker). Every `stats` figure above, `topics` counts, and `needsAttention` are
+   * computed over the AGENT set ONLY — `sessionsImported` is the real agent count,
+   * not the raw row count. This is the number that was dropped.
+   */
+  utilityCount: number;
   needsAttention: IndexedSession[];
   topics: TopicItem[];
   failures: {
@@ -358,16 +367,72 @@ export interface IndexedSession {
   title: string;
   repo: string;
   device: string;
+  /** The harness that produced the session (claude/codex/rush/grok/…). Same as `harness`. */
   agent: string;
   model: string;
+  /** Corpus classification (PHNX-3474). Always `'agent'` here — utility rows are excluded. */
+  kind: SessionKind;
   severity: number;
   flags: string[];
 }
 
-/** One example session under a topic tile — the shape the console drill-down consumes. */
+/**
+ * One example session under a topic tile — the shape the console drill-down consumes.
+ * Carries `kind` + `harness` (PHNX-3474) so the console can filter a tile's session
+ * list by corpus class and by harness. Refs on a topic tile are always `'agent'`
+ * (utility rows never reach a bucket), but the field is explicit for the consumer.
+ */
 export interface TopicSessionRef {
   id: string;
   title: string;
+  kind: SessionKind;
+  harness: string;
+}
+
+/**
+ * Corpus class of a session (PHNX-3474). `utility` is internal machine plumbing —
+ * a single-shot call with no tool use and ≤2 messages, or one whose topic/label
+ * matches a known internal-prompt signature (title generation, watchdog,
+ * commit-message writer, factory worker). Everything else is `agent`: real agent
+ * work the Evals console counts and scores. Utility rows are tagged, never deleted,
+ * and excluded from every index statistic.
+ */
+export type SessionKind = 'utility' | 'agent';
+
+/**
+ * Topic/label substrings that identify an internal-prompt session regardless of its
+ * message/tool shape. These are the harness-spawned utility prompts the Rush app
+ * fires (they run under the `claude` harness): title generation writes the 3–4 word
+ * session title, the watchdog polls for stalled agents, the commit-message writer
+ * drafts a conventional commit, and factory workers are dispatched sub-agents. The
+ * title-generation prompt lives in the `topic` column, the rest can land in either
+ * `topic` or `label`, so both are matched.
+ */
+const UTILITY_PROMPT_SIGNATURES: RegExp[] = [
+  /generate a 3-4 word title/i, // title generation
+  /you are a watchdog|watchdog monitoring/i, // watchdog tick
+  /conventional[- ]commit/i, // commit-message writer
+  /factory worker/i, // dispatched factory worker
+];
+
+/**
+ * Classify a session as internal `utility` plumbing vs real `agent` work (PHNX-3474).
+ * `toolCallCount` is the AUTHORITATIVE per-session tool-call count from the loaded
+ * `tool_calls` rows (the row's own `tool_call_count` column is a fallback for a row
+ * whose calls weren't loaded). A session is `utility` when a known internal-prompt
+ * signature matches its topic/label, OR it made no tool call AND has ≤2 messages —
+ * the single-shot machine-call shape. Otherwise it is `agent`.
+ */
+export function classifySessionKind(
+  row: Pick<SyncRow, 'topic' | 'label' | 'message_count' | 'tool_call_count'>,
+  toolCallCount: number,
+): SessionKind {
+  const haystack = `${row.topic ?? ''}\n${row.label ?? ''}`;
+  if (UTILITY_PROMPT_SIGNATURES.some((re) => re.test(haystack))) return 'utility';
+  const hasToolCalls = toolCallCount > 0 || (row.tool_call_count ?? 0) > 0;
+  const messages = row.message_count ?? 0;
+  if (!hasToolCalls && messages <= 2) return 'utility';
+  return 'agent';
 }
 
 /**
@@ -563,8 +628,24 @@ export function buildIndexShard(
     if (list) list.push(call); else callsBySession.set(call.session_id, [call]);
   }
 
-  const topics = readSessionTopics<ClassifiedTopic>(ids);
-  const missingTopics = rows.filter((row) => !topics.has(row.id)).map((row) => {
+  // Classify every row as real `agent` work or internal `utility` plumbing, then run
+  // the ENTIRE rest of the shard build over the agent set ONLY (PHNX-3474). Utility
+  // rows — title-gen / watchdog / commit-message / factory-worker calls, ~68% of the
+  // corpus — are tagged and excluded here, never deleted from sessions.db, so the
+  // console counts and scores real agent work: `sessionsImported`, the medians,
+  // needs-attention, tool-error-rate, and the topic buckets all measure `agentRows`.
+  const kindOf = new Map<string, SessionKind>(
+    rows.map((row) => [row.id, classifySessionKind(row, callsBySession.get(row.id)?.length ?? 0)]),
+  );
+  const agentRows = rows.filter((row) => kindOf.get(row.id) === 'agent');
+  const agentIds = agentRows.map((row) => row.id);
+  const utilityCount = rows.length - agentRows.length;
+  // Tool calls belonging to utility rows never contribute to the failure/latency
+  // stats or the tool-error rate — filter them out at the source alongside the rows.
+  const agentCalls = calls.filter((call) => kindOf.get(call.session_id) === 'agent');
+
+  const topics = readSessionTopics<ClassifiedTopic>(agentIds);
+  const missingTopics = agentRows.filter((row) => !topics.has(row.id)).map((row) => {
     const topic = classifyTopic({
       cwd: row.cwd,
       gitBranch: row.git_branch,
@@ -586,8 +667,8 @@ export function buildIndexShard(
   // from an identically-signatured session synced this run purely by *when* each
   // was first seen (PHNX-3327). A cache-miss row is parsed at most once here even
   // when both derivations are missing.
-  const insights = readSessionInsights<InsightFacets>(ids);
-  const phenotypes = readSessionPhenotypes<FailurePhenotype | null>(ids);
+  const insights = readSessionInsights<InsightFacets>(agentIds);
+  const phenotypes = readSessionPhenotypes<FailurePhenotype | null>(agentIds);
   const missingInsights: Array<{
     id: string;
     fileMtimeMs: number | null;
@@ -600,7 +681,7 @@ export function buildIndexShard(
     fileSize: number | null;
     phenotype: FailurePhenotype | null;
   }> = [];
-  for (const row of rows) {
+  for (const row of agentRows) {
     const needInsights = !insights.has(row.id);
     const needPhenotype = !phenotypes.has(row.id);
     if (!needInsights && !needPhenotype) continue;
@@ -629,7 +710,7 @@ export function buildIndexShard(
   persistDerivedCache('session-insights', () => writeSessionInsights(missingInsights));
   persistDerivedCache('session-phenotypes', () => writeSessionPhenotypes(missingPhenotypes));
 
-  const needsAttention = rows.flatMap((row): IndexedSession[] => {
+  const needsAttention = agentRows.flatMap((row): IndexedSession[] => {
     const facets = insights.get(row.id);
     const errorCount = errorCounts.get(row.id) ?? 0;
     const flags = attentionFlags(errorCount, facets);
@@ -646,6 +727,7 @@ export function buildIndexShard(
       device,
       agent: row.agent,
       model: row.model ?? 'unknown',
+      kind: 'agent',
       severity: errorCount * 2 + friction * 3 + corrections * 2,
       flags,
     }];
@@ -663,10 +745,10 @@ export function buildIndexShard(
     label: string;
     count: number;
     group: TraceTopicGroup;
-    refs: Array<{ id: string; title: string; recencyMs: number }>;
+    refs: Array<{ id: string; title: string; harness: string; recencyMs: number }>;
   };
   const topicCounts = new Map<string, TopicBucket>();
-  for (const row of rows) {
+  for (const row of agentRows) {
     const topic = topics.get(row.id);
     if (!topic) continue;
     const bucket = topicCounts.get(topic.key)
@@ -675,12 +757,13 @@ export function buildIndexShard(
     bucket.refs.push({
       id: row.id,
       title: redactSecrets(row.label ?? row.topic ?? topic.label ?? 'Untitled session', knownSecrets),
+      harness: row.agent,
       recencyMs: Date.parse(row.last_activity ?? row.timestamp) || 0,
     });
     topicCounts.set(topic.key, bucket);
   }
 
-  const failedCalls = calls.filter((call) => call.outcome === 'error');
+  const failedCalls = agentCalls.filter((call) => call.outcome === 'error');
   const byCause: Record<TraceFailureCause, number> = { real: 0, guard: 0, hook: 0 };
   const failureCounts = new Map<string, { tool: string; desc: string; cause: TraceFailureCause; count: number }>();
   for (const call of failedCalls) {
@@ -697,7 +780,7 @@ export function buildIndexShard(
   // session resumed after hours, or left idle mid-turn, otherwise inflates the
   // median/p90 with wall-clock the agent did no work in (real corpus max span:
   // 345h). The raw span stays available per session on `SessionDetail.meta.spanMs`.
-  const activeDurations = rows.flatMap((row) =>
+  const activeDurations = agentRows.flatMap((row) =>
     row.duration_ms == null
       ? []
       : [sessionActiveMs(row.duration_ms, callsBySession.get(row.id) ?? [], Date.parse(row.timestamp))],
@@ -711,14 +794,14 @@ export function buildIndexShard(
   const agentActive: number[] = [];
   const interactiveActive: number[] = [];
   let measured = 0;
-  for (const row of rows) {
+  for (const row of agentRows) {
     if (row.duration_ms == null) continue;
     measured++;
     const active = sessionActiveMs(row.duration_ms, callsBySession.get(row.id) ?? [], Date.parse(row.timestamp));
     const isAgent = (callsBySession.get(row.id)?.length ?? 0) > 0 || (row.message_count ?? 0) > 8;
     (isAgent ? agentActive : interactiveActive).push(active);
   }
-  const measuredFraction = rows.length === 0 ? 0 : measured / rows.length;
+  const measuredFraction = agentRows.length === 0 ? 0 : measured / agentRows.length;
 
   // Build today's per-bucket stats for the rolling drift window.
   const todayDate = new Date().toISOString().slice(0, 10);
@@ -726,7 +809,7 @@ export function buildIndexShard(
     const sessionsInBucket = [...topics.entries()]
       .filter(([, t]) => t.key === key)
       .map(([id]) => id);
-    const bucketCalls = calls.filter((c) => sessionsInBucket.includes(c.session_id));
+    const bucketCalls = agentCalls.filter((c) => sessionsInBucket.includes(c.session_id));
     const bucketErrors = bucketCalls.filter((c) => c.outcome === 'error').length;
     const errorRate = bucketCalls.length === 0 ? 0 : bucketErrors / bucketCalls.length;
     const stallCount = sessionsInBucket.filter((id) => {
@@ -741,7 +824,7 @@ export function buildIndexShard(
   const prevHistory = prevShard?.bucketHistory ?? [];
   const bucketHistory = [...prevHistory, todayStats].slice(-14);
   const driftSignals = computeDriftSignal(prevHistory, todayStats);
-  const patternInsights = computeInsights(rows, calls, prevShard, phenotypes);
+  const patternInsights = computeInsights(agentRows, agentCalls, prevShard, phenotypes);
 
   return {
     schema: 1,
@@ -749,7 +832,7 @@ export function buildIndexShard(
     syncedAt: Date.now(),
     owner,
     stats: {
-      sessionsImported: rows.length,
+      sessionsImported: agentRows.length,
       medianMs: percentile(activeDurations, 0.5),
       p90Ms: percentile(activeDurations, 0.9),
       agentMedianMs: percentile(agentActive, 0.5),
@@ -757,8 +840,9 @@ export function buildIndexShard(
       interactiveMedianMs: percentile(interactiveActive, 0.5),
       measuredFraction,
       needAttention: needsAttention.length,
-      toolErrorRate: calls.length === 0 ? 0 : failedCalls.length / calls.length,
+      toolErrorRate: agentCalls.length === 0 ? 0 : failedCalls.length / agentCalls.length,
     },
+    utilityCount,
     needsAttention,
     topics: [...topicCounts.values()]
       .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key))
@@ -776,7 +860,7 @@ export function buildIndexShard(
         sessions: bucket.refs
           .sort((a, b) => b.recencyMs - a.recencyMs)
           .slice(0, TOPIC_SESSION_CAP)
-          .map(({ id, title }) => ({ id, title })),
+          .map(({ id, title, harness }): TopicSessionRef => ({ id, title, kind: 'agent', harness })),
       })),
     failures: {
       byToolError: [...failureCounts.values()].sort((a, b) => b.count - a.count || a.tool.localeCompare(b.tool)),

--- a/cli/src/lib/traces/testdata/rich-index.json
+++ b/cli/src/lib/traces/testdata/rich-index.json
@@ -14,6 +14,7 @@
     "needAttention": 1,
     "toolErrorRate": 0.6666666666666666
   },
+  "utilityCount": 0,
   "needsAttention": [
     {
       "id": "trace-rich-fixture",
@@ -22,12 +23,13 @@
       "device": "test-device",
       "agent": "codex",
       "model": "gpt-test",
+      "kind": "agent",
       "severity": 7,
       "flags": ["2 errors", "retry loop"]
     }
   ],
   "topics": [
-    { "key": "bugfix", "label": "Bug fixes", "count": 1, "group": "code", "sessions": [{ "id": "trace-rich-fixture", "title": "Fix trace sync" }] }
+    { "key": "bugfix", "label": "Bug fixes", "count": 1, "group": "code", "sessions": [{ "id": "trace-rich-fixture", "title": "Fix trace sync", "kind": "agent", "harness": "codex" }] }
   ],
   "failures": {
     "byToolError": [


### PR DESCRIPTION
## Why

On the live `sessions.db` (18,922 rows) only **5,991 are real agent work**. The other **12,931 (68%)** are single-shot internal utility calls — title generation, watchdog ticks, commit-message writes, factory workers — spawned under the `claude` harness by the Rush app. They poison every console statistic: count, median, need-attention, and tool-error-rate.

## What

`buildIndexShard` (`cli/src/lib/traces/sync.ts`) now classifies each session and excludes utility plumbing from the eval corpus:

- **Per-session `kind`** (`classifySessionKind`): `utility` when a session has no tool call AND ≤2 messages (the single-shot machine-call shape), OR its topic/label matches a known internal-prompt signature (`UTILITY_PROMPT_SIGNATURES`: `Generate a 3-4 word title`, `you are a watchdog` / `watchdog monitoring`, `conventional-commit`, `factory worker`). Both `topic` and `label` are matched (the title-gen prompt lives in `topic`). Otherwise `agent`.
- **Every index statistic is computed over `kind='agent'` only:** `sessionsImported` is now the real agent count (~5,991, not 18,922); `medianMs`/`p90Ms`/`agentMedianMs`/`agentP90Ms`/`interactiveMedianMs`/`measuredFraction`/`needAttention`/`toolErrorRate` and the topic-bucket counts all exclude utility.
- **New top-level `utilityCount`** reports how many were dropped (~12,931).
- Each session ref (`TopicSessionRef` on topic tiles, `IndexedSession` in `needsAttention`) now carries **`kind`** and **`harness`** so the console can filter by both.
- Pure reclassification — utility rows are **tagged and excluded at shard-build time, never deleted** from `sessions.db`.

## Tests

Extended `cli/src/lib/traces/sync.test.ts` with a PHNX-3474 block seeding a mix (title-gen no-tool 2-msg row, watchdog row, commit-message row, single-shot-shape row, and a real tool-using multi-turn agent row) and asserting utility rows classify utility + are excluded from `sessionsImported`/medians/topic buckets, `utilityCount` reflects them, and agent rows carry `kind='agent'` + `harness`. Updated the PHNX-3408/PHNX-3472 fixtures and `rich-index.json` for the new fields.

```
 ✓ utility-call classification excludes internal plumbing (PHNX-3474) > classifies the single-shot and signature rows utility, and the tool-using row agent
 ✓ utility-call classification excludes internal plumbing (PHNX-3474) > excludes utility rows from sessionsImported, the medians, and the topic buckets; reports utilityCount

 Test Files  7 passed (7)
      Tests  101 passed | 4 skipped (105)   [full traces suite]
```

`tsc --noEmit` clean. Docs (`cli/AGENTS.md`) and a CHANGELOG fragment (`.changelog/next/PHNX-3474.md`) updated.
