### PR TITLE
fix(skills): correct discovery-skill repo path + CI test mapping (PHNX-3337 review follow-up)

### DIFF
--- a/--files
+++ b/--files
@@ -1,9 +1,0 @@
-cli=false
-cli_docs=false
-session_tracker=false
-windows=false
-unmapped=false
-reused=false
-suite=selected
-tree=
-policy_digest=sha256:8d9f8cd5cc499fd877651f8599a5f9ee1b70c29b74ea78cabc191e788845b06a

--- a/--files
+++ b/--files
@@ -1,0 +1,9 @@
+cli=false
+cli_docs=false
+session_tracker=false
+windows=false
+unmapped=false
+reused=false
+suite=selected
+tree=
+policy_digest=sha256:8d9f8cd5cc499fd877651f8599a5f9ee1b70c29b74ea78cabc191e788845b06a

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agents-cli",
   "owner": {
     "name": "Phoenix Labs",
-    "url": "https://github.com/phnx-labs/agents-cli"
+    "url": "https://github.com/phnx-labs/agi-cli"
   },
   "metadata": {
     "description": "The agents CLI — one control plane for every AI coding-agent harness. Install the skill so any coding agent surfaces `agents` when you ask how to run multiple agents in parallel, manage multiple accounts, survive a usage limit, resume a session on another machine, or pin the CLI version.",
@@ -16,7 +16,7 @@
       "version": "1.0.0",
       "author": {
         "name": "Phoenix Labs",
-        "url": "https://github.com/phnx-labs/agents-cli"
+        "url": "https://github.com/phnx-labs/agi-cli"
       }
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "author": {
     "name": "Phoenix Labs",
-    "url": "https://github.com/phnx-labs/agents-cli"
+    "url": "https://github.com/phnx-labs/agi-cli"
   }
 }

--- a/README.md
+++ b/README.md
@@ -918,11 +918,11 @@ This repo is itself a Claude plugin marketplace and a [skills.sh](https://skills
 
 ```bash
 # Claude Code — add this repo as a marketplace, then install the plugin
-claude plugin marketplace add phnx-labs/agents-cli
+claude plugin marketplace add phnx-labs/agi-cli
 claude plugin install agents-cli@agents-cli
 
 # skills.sh — install the skill directly from the repo
-npx skills add phnx-labs/agents-cli
+npx skills add phnx-labs/agi-cli
 ```
 
 The manifest is `.claude-plugin/marketplace.json` (validate with `claude plugin validate .`); the skill source is [`skills/agents-cli/SKILL.md`](skills/agents-cli/SKILL.md). Its `description` carries the exact intents the runtime matches against — *run multiple coding agents in parallel*, *manage multiple Claude Code accounts*, *I hit my usage limit*, *resume a session on another machine*, *pin the agent CLI version* — each with a verified command recipe.

--- a/cli/.changelog/next/PHNX-3337-review.md
+++ b/cli/.changelog/next/PHNX-3337-review.md
@@ -1,0 +1,5 @@
+- Fix the `agents-cli` discovery skill/plugin install commands to use the real GitHub
+  repo path `phnx-labs/agi-cli` (they pointed at `phnx-labs/agents-cli`, which only
+  resolved via GitHub's rename redirect). The npm package stays `@phnx-labs/agents-cli`.
+  Also maps the plugin manifests + skill to `agents-cli-plugin.test.ts` in CI impact
+  analysis so a manifest/skill edit runs its test on the PR. (PHNX-3337 review follow-up)

--- a/cli/ci/test-ownership.yaml
+++ b/cli/ci/test-ownership.yaml
@@ -98,6 +98,18 @@ groups:
     tests:
       - cli/scripts/gen-changelog.test.ts
 
+  # The repo-root Claude plugin marketplace manifest and the agents-cli discovery
+  # skill (PHNX-3337) are declarative, but their parse/validate/trigger-intent
+  # contract IS executable — agents-cli-plugin.test.ts reads marketplace.json,
+  # plugin.json and SKILL.md directly. Select that test from the files it guards
+  # so a manifest/skill edit is caught on the PR, not at release time.
+  - id: agents-cli-plugin
+    when:
+      - .claude-plugin/**
+      - skills/agents-cli/**
+    tests:
+      - cli/src/lib/plugins/agents-cli-plugin.test.ts
+
   # 180s, not the default 85s. Any edit to sessions.ts — a two-line subcommand
   # registration included — selects the whole sessions* suite: 24 files, 92s of
   # vitest inside a 122s run (PR #2771, run 32032566960), before the group's own
@@ -299,10 +311,6 @@ testless:
   - assets/**
   - demo/**
   - skills/**
-  # Repo-root Claude plugin marketplace manifest (PHNX-3337): declarative JSON
-  # consumed by `claude plugin marketplace add`, not executable source. Its
-  # parse/validate contract is covered by cli/src/lib/plugins/agents-cli-plugin.test.ts.
-  - .claude-plugin/**
   - openspec/**
   - native/**
   - apps/ios/**

--- a/skills/agents-cli/SKILL.md
+++ b/skills/agents-cli/SKILL.md
@@ -162,5 +162,5 @@ releases.
 | Schedule recurring agent jobs | `agents routines` |
 | Sync skills/commands/rules across the fleet | `agents sync` |
 
-Full docs: <https://github.com/phnx-labs/agents-cli>. Every group teaches its own
+Full docs: <https://github.com/phnx-labs/agi-cli>. Every group teaches its own
 workflow — start with `agents <group> --help`.


### PR DESCRIPTION
## Why

#3282 (PHNX-3337, the cross-harness discovery skill + plugin) **merged before its non-author review completed**, so the review's two blockers landed on main. This fixes them forward.

## Fixes

1. **Wrong GitHub repo path in install commands.** `marketplace.json`, `plugin.json`, `README.md`, and `SKILL.md` told users to run `claude plugin marketplace add phnx-labs/agents-cli` / `npx skills add phnx-labs/agents-cli`. The GitHub repo is **`phnx-labs/agi-cli`** — `gh api repos/phnx-labs/agents-cli` resolves to `full_name: phnx-labs/agi-cli`. The old path only worked via GitHub's rename redirect (breaks if the old name is reclaimed), and these are the exact commands PHNX-3337's acceptance criteria depend on. The README badge two lines away already used `agi-cli`. **The npm package stays `@phnx-labs/agents-cli`** — only the GitHub repo path changed.

2. **New test invisible to the CI impact gate.** `cli/ci/test-ownership.yaml` filed `.claude-plugin/**` under `testless` (paths that select *no* test) with a comment claiming coverage — the opposite of covered. Now maps `.claude-plugin/**` + `skills/agents-cli/**` → `cli/src/lib/plugins/agents-cli-plugin.test.ts` (mirrors the `changelog-sources` pattern), so a manifest/skill edit runs its test on the PR instead of only at release time.

## Verification

- `bun scripts/ci-scope.ts --validate-manifest` → ownership manifest covers 2889 tracked files
- Impact analysis over the changed set → `unmapped=false`; `.claude-plugin/*` and `skills/agents-cli/*` select `agents-cli-plugin.test.ts`
- No leftover bare `phnx-labs/agents-cli` repo path; `@phnx-labs/agents-cli` npm refs intact

Follow-up to #3282 · PHNX-3337