### PR TITLE
fix(skills): correct GitHub repo path to agi-cli + wire plugin test into CI impact gate (PHNX-3337 review)

### DIFF
--- a/--files
+++ b/--files
@@ -1,9 +1,0 @@
-cli=false
-cli_docs=false
-session_tracker=false
-windows=false
-unmapped=false
-reused=false
-suite=selected
-tree=
-policy_digest=sha256:cf3cfbfe1d28d0f1436547126af6b83110ba926895883cb3b5ed6a743c7e6e02

--- a/--files
+++ b/--files
@@ -1,0 +1,9 @@
+cli=false
+cli_docs=false
+session_tracker=false
+windows=false
+unmapped=false
+reused=false
+suite=selected
+tree=
+policy_digest=sha256:cf3cfbfe1d28d0f1436547126af6b83110ba926895883cb3b5ed6a743c7e6e02

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agents-cli",
   "owner": {
     "name": "Phoenix Labs",
-    "url": "https://github.com/phnx-labs/agents-cli"
+    "url": "https://github.com/phnx-labs/agi-cli"
   },
   "metadata": {
     "description": "The agents CLI — one control plane for every AI coding-agent harness. Install the skill so any coding agent surfaces `agents` when you ask how to run multiple agents in parallel, manage multiple accounts, survive a usage limit, resume a session on another machine, or pin the CLI version.",
@@ -16,7 +16,7 @@
       "version": "1.0.0",
       "author": {
         "name": "Phoenix Labs",
-        "url": "https://github.com/phnx-labs/agents-cli"
+        "url": "https://github.com/phnx-labs/agi-cli"
       }
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "author": {
     "name": "Phoenix Labs",
-    "url": "https://github.com/phnx-labs/agents-cli"
+    "url": "https://github.com/phnx-labs/agi-cli"
   }
 }

--- a/README.md
+++ b/README.md
@@ -918,11 +918,11 @@ This repo is itself a Claude plugin marketplace and a [skills.sh](https://skills
 
 ```bash
 # Claude Code — add this repo as a marketplace, then install the plugin
-claude plugin marketplace add phnx-labs/agents-cli
+claude plugin marketplace add phnx-labs/agi-cli
 claude plugin install agents-cli@agents-cli
 
 # skills.sh — install the skill directly from the repo
-npx skills add phnx-labs/agents-cli
+npx skills add phnx-labs/agi-cli
 ```
 
 The manifest is `.claude-plugin/marketplace.json` (validate with `claude plugin validate .`); the skill source is [`skills/agents-cli/SKILL.md`](skills/agents-cli/SKILL.md). Its `description` carries the exact intents the runtime matches against — *run multiple coding agents in parallel*, *manage multiple Claude Code accounts*, *I hit my usage limit*, *resume a session on another machine*, *pin the agent CLI version* — each with a verified command recipe.

--- a/cli/.changelog/next/PHNX-3337.md
+++ b/cli/.changelog/next/PHNX-3337.md
@@ -6,8 +6,8 @@
   verified `agents` command recipe (`teams`, `accounts`, `run --fallback`/`-b`/`auto`,
   `sessions resume`, `add`/`use`). A repo-root `.claude-plugin/marketplace.json` +
   `.claude-plugin/plugin.json` make the repo installable via
-  `claude plugin marketplace add phnx-labs/agents-cli` and `npx skills add
-  phnx-labs/agents-cli`; the plugin's `source: "./"` bundles the discovery skill
+  `claude plugin marketplace add phnx-labs/agi-cli` and `npx skills add
+  phnx-labs/agi-cli`; the plugin's `source: "./"` bundles the discovery skill
   plus the existing per-command skills. Harness parity is registry-driven, not
   per-harness copies: the one SKILL.md is authored once and the existing
   capability-gated skill sync (`supports(agent, 'skills', …)`) fans it into every

--- a/cli/ci/test-ownership.yaml
+++ b/cli/ci/test-ownership.yaml
@@ -98,6 +98,18 @@ groups:
     tests:
       - cli/scripts/gen-changelog.test.ts
 
+  # The repo-root Claude plugin marketplace manifest and the agents-cli discovery
+  # skill (PHNX-3337) are declarative, but their parse/validate/trigger-intent
+  # contract IS executable — agents-cli-plugin.test.ts reads marketplace.json,
+  # plugin.json and SKILL.md directly. Select that test from the files it guards
+  # so a manifest/skill edit is caught on the PR, not at release time.
+  - id: agents-cli-plugin
+    when:
+      - .claude-plugin/**
+      - skills/agents-cli/**
+    tests:
+      - cli/src/lib/plugins/agents-cli-plugin.test.ts
+
   # 180s, not the default 85s. Any edit to sessions.ts — a two-line subcommand
   # registration included — selects the whole sessions* suite: 24 files, 92s of
   # vitest inside a 122s run (PR #2771, run 32032566960), before the group's own
@@ -298,11 +310,11 @@ testless:
   - .agents/**
   - assets/**
   - demo/**
+  # Other skills carry no companion test; the `agents-cli` discovery skill is
+  # the exception — skills/agents-cli/** is mapped to the agents-cli-plugin
+  # group above so its SKILL.md selects that test. (.claude-plugin/** is mapped
+  # there too, so it is deliberately NOT listed here.)
   - skills/**
-  # Repo-root Claude plugin marketplace manifest (PHNX-3337): declarative JSON
-  # consumed by `claude plugin marketplace add`, not executable source. Its
-  # parse/validate contract is covered by cli/src/lib/plugins/agents-cli-plugin.test.ts.
-  - .claude-plugin/**
   - openspec/**
   - native/**
   - apps/ios/**

--- a/cli/src/lib/plugins/agents-cli-plugin.test.ts
+++ b/cli/src/lib/plugins/agents-cli-plugin.test.ts
@@ -1,8 +1,8 @@
 /**
  * PHNX-3337 — the cross-harness `agents-cli` discovery skill + the repo-root
  * Claude plugin marketplace are a distribution contract: an outside agent runs
- * `claude plugin marketplace add phnx-labs/agents-cli` (reads
- * `.claude-plugin/marketplace.json`) or `npx skills add phnx-labs/agents-cli`
+ * `claude plugin marketplace add phnx-labs/agi-cli` (reads
+ * `.claude-plugin/marketplace.json`) or `npx skills add phnx-labs/agi-cli`
  * (reads `skills/**\/SKILL.md`). Both break silently if the committed files drift
  * from the schema Claude Code / skills.sh parse, or if the SKILL.md description
  * loses a trigger intent — the string the runtime matches an operator's question

--- a/skills/agents-cli/SKILL.md
+++ b/skills/agents-cli/SKILL.md
@@ -2,7 +2,7 @@
 name: agents-cli
 description: "Run and manage many AI coding agents (Claude Code, Codex, Cursor, Gemini/Antigravity, Grok, Kimi, OpenCode, Droid, …) from one CLI — the `agents` command. Use this to run multiple coding agents in parallel, manage multiple Claude Code accounts, keep working when I hit my usage limit, resume a session on another machine, or pin the agent CLI version. Triggers on: run multiple coding agents in parallel, manage multiple Claude Code accounts, I hit my usage limit, resume a session on another machine, pin the agent CLI version."
 argument-hint: "[teams|accounts|run|sessions|use]"
-allowed-tools: Bash(agents*)
+allowed-tools: Bash(agents teams*), Bash(agents run*), Bash(agents accounts*), Bash(agents sessions*), Bash(agents view*), Bash(agents add*), Bash(agents use*), Bash(agents devices*), Bash(agents mcp*), Bash(agents browser*), Bash(agents secrets*), Bash(agents routines*), Bash(agents sync*)
 user-invocable: true
 ---
 
@@ -162,5 +162,5 @@ releases.
 | Schedule recurring agent jobs | `agents routines` |
 | Sync skills/commands/rules across the fleet | `agents sync` |
 
-Full docs: <https://github.com/phnx-labs/agents-cli>. Every group teaches its own
+Full docs: <https://github.com/phnx-labs/agi-cli>. Every group teaches its own
 workflow — start with `agents <group> --help`.


### PR DESCRIPTION
Fix-forward for the non-author REQUEST-CHANGES review on #3282 (which was rebase-merged before the review's two blockers were addressed). Both blockers fixed, plus the SHOULD.

## Blocker 1 — wrong GitHub repo path in install commands
The install commands and repo URLs hardcoded `phnx-labs/agents-cli`, which resolves today **only** via GitHub's rename redirect (the repo is `phnx-labs/agi-cli`; `gh api repos/phnx-labs/agents-cli` returns `full_name: phnx-labs/agi-cli`). If the old name is ever reclaimed, `claude plugin marketplace add` / `npx skills add` break. Every repo-path/URL occurrence now points at `phnx-labs/agi-cli`, matching the README badge two lines away.

- `README.md:921` `claude plugin marketplace add phnx-labs/agi-cli`
- `README.md:925` `npx skills add phnx-labs/agi-cli`
- `.claude-plugin/marketplace.json:5,19` owner + author `url` → `…/agi-cli`
- `.claude-plugin/plugin.json:7` author `url` → `…/agi-cli`
- `skills/agents-cli/SKILL.md:165` `Full docs: <https://github.com/phnx-labs/agi-cli>`

The npm package (`@phnx-labs/agents-cli`) and binary (`agents`) are **unchanged** — this is only the GitHub repo path.

## Blocker 2 — test invisible to the CI impact gate
`cli/ci/test-ownership.yaml` filed `.claude-plugin/**` under `testless` (paths that select **no** tests) with a comment claiming coverage — the opposite of what `testless` means, so a plugin/skill edit never ran its guarding test. Following the `changelog-sources` pattern, a new `agents-cli-plugin` group maps `.claude-plugin/**` and `skills/agents-cli/**` to `cli/src/lib/plugins/agents-cli-plugin.test.ts`, and `.claude-plugin/**` is removed from `testless`.

Verified with `bun scripts/ci-scope.ts`:
```
.claude-plugin/marketplace.json  agents-cli-plugin.test.ts  owner:agents-cli-plugin
.claude-plugin/plugin.json       agents-cli-plugin.test.ts  owner:agents-cli-plugin
skills/agents-cli/SKILL.md       agents-cli-plugin.test.ts  owner:agents-cli-plugin
```
`bun scripts/ci-scope.ts --validate-manifest` → `ownership manifest covers 2889 tracked files`.

## SHOULD — scope allowed-tools
`skills/agents-cli/SKILL.md` `allowed-tools` narrowed from blanket `Bash(agents*)` to the specific command families the recipes use (`teams`, `run`, `accounts`, `sessions`, `view`, `add`, `use`, `devices`, `mcp`, `browser`, `secrets`, `routines`, `sync`), matching the sibling skills' pattern.

## Test
`bunx vitest run src/lib/plugins/agents-cli-plugin.test.ts` → **4 passed**.
