### PR TITLE
fix(sessions): pull peer-owned preview transcripts (PHNX-3481)

### DIFF
--- a/cli/.changelog/next/PHNX-3481.md
+++ b/cli/.changelog/next/PHNX-3481.md
@@ -1,0 +1,15 @@
+- **`agents sessions preview <id>` now pulls the transcript digest from the
+  owning device for host-dispatched sessions (PHNX-3481).** A host dispatch
+  leaves a synthetic local index row with `machine = <peer>` and an empty
+  `filePath`, but that row does not carry the live fan-out's `_remote` marker.
+  Full-UUID preview resolved the local row and then treated it as a local live
+  session, rendering "full transcript not indexed here" without making any SSH
+  hop. Transcript reads now follow one file-aware predicate: an explicit remote
+  row still reads on its peer; a row naming another machine also reads there
+  when no transcript exists on this disk; and a synced mirror with a real local
+  file still renders locally. The direct preview, `sessions <id>`, picker view,
+  and picker/browser digest pane all share that rule. Live-registry metadata now
+  also stamps `_remote` when its execution machine differs from this box, and an
+  unreachable owner remains a loud error instead of a local placeholder.
+  Source: `cli/src/commands/sessions-picker.ts`, `cli/src/commands/sessions.ts`,
+  `cli/src/lib/session/live-metadata.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -936,13 +936,17 @@ for the non-empty-preview invariant (SES-8).
 ### Resume is machine-bound — check the owner before you start a harness
 
 **Reading and resuming follow different machines, and conflating them is the bug.**
-Reading follows the FILE — a synced mirror is on this disk, so only a live fan-out
-row (`_remote`) must be read on the peer (`transcriptOnPeerOf` in
-`sessions-picker.ts`). Resuming follows the HARNESS STATE, which is on the owning
-machine whatever the transcript's location. A mirror is therefore readable and NOT
-resumable, and that is the trap: nothing fails until the agent is asked to continue
-a conversation it has never seen, and `sessions-resume.ts`'s `fs.existsSync(cwd)`
-fallback then quietly resumed in `process.cwd()` (RUSH-2022).
+Reading follows the FILE — a synced mirror with a readable `filePath` is on this
+disk and previews locally, even when `machine` names its owner. Otherwise, a row
+whose `machine` names another box must be read on that peer. `_remote` is one
+explicit signal, not the gate: host-dispatch index rows and live-registry rows can
+name a peer without carrying it. `transcriptOnPeerOf` in `sessions-picker.ts` is
+the one predicate used by picker previews, direct `preview <id>`, and `sessions
+<id>`. Resuming follows the HARNESS STATE, which is on the owning machine whatever
+the transcript's location. A mirror is therefore readable and NOT resumable, and
+that is the trap: nothing fails until the agent is asked to continue a conversation
+it has never seen, and `sessions-resume.ts`'s `fs.existsSync(cwd)` fallback then
+quietly resumed in `process.cwd()` (RUSH-2022, PHNX-3481).
 
 `sessionOwnerDevice`
 ([`src/lib/session/resume-owner.ts`](src/lib/session/resume-owner.ts)) is the one

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,20 +2,6 @@
 
 ## 1.22.59
 
-- **`agents sessions preview <id>` now pulls the transcript digest from the
-  owning device for host-dispatched sessions (PHNX-3481).** A host dispatch
-  leaves a synthetic local index row with `machine = <peer>` and an empty
-  `filePath`, but that row does not carry the live fan-out's `_remote` marker.
-  Full-UUID preview resolved the local row and then treated it as a local live
-  session, rendering "full transcript not indexed here" without making any SSH
-  hop. Transcript reads now follow one file-aware predicate: an explicit remote
-  row still reads on its peer; a row naming another machine also reads there
-  when no transcript exists on this disk; and a synced mirror with a real local
-  file still renders locally. The direct preview, `sessions <id>`, picker view,
-  and picker/browser digest pane all share that rule. Live-registry metadata now
-  also stamps `_remote` when its execution machine differs from this box, and an
-  unreachable owner remains a loud error instead of a local placeholder.
-
 - **`agents devices disable/prefer` now actually change `--device auto` placement (PHNX-2092).**
   The per-device `auto-launch.enabled` / `auto-launch.preferred` flags (written by
   `agents devices disable/enable` and `prefer/unprefer`, and by `agents devices config

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 1.22.59
 
+- **`agents sessions preview <id>` now pulls the transcript digest from the
+  owning device for host-dispatched sessions (PHNX-3481).** A host dispatch
+  leaves a synthetic local index row with `machine = <peer>` and an empty
+  `filePath`, but that row does not carry the live fan-out's `_remote` marker.
+  Full-UUID preview resolved the local row and then treated it as a local live
+  session, rendering "full transcript not indexed here" without making any SSH
+  hop. Transcript reads now follow one file-aware predicate: an explicit remote
+  row still reads on its peer; a row naming another machine also reads there
+  when no transcript exists on this disk; and a synced mirror with a real local
+  file still renders locally. The direct preview, `sessions <id>`, picker view,
+  and picker/browser digest pane all share that rule. Live-registry metadata now
+  also stamps `_remote` when its execution machine differs from this box, and an
+  unreachable owner remains a loud error instead of a local placeholder.
+
 - **`agents devices disable/prefer` now actually change `--device auto` placement (PHNX-2092).**
   The per-device `auto-launch.enabled` / `auto-launch.preferred` flags (written by
   `agents devices disable/enable` and `prefer/unprefer`, and by `agents devices config

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -574,9 +574,16 @@ SSH access (§7); rendering sessions that no harness produced.
     boundary (`lib/session/remote-active.ts`), where an `offloadedFrom` row keeps
     its own `machine` and every other row takes the dialed device name; the guard
     in `foldExecutionMachine` is the same rule stated locally.
-  - Consequence for SES-8: an offloaded row is then `_remote`, so
-    `liveSessionToMeta` → `buildPreview` renders the "on `<peer>`" affordance
-    instead of the empty "full transcript not indexed here" branch.
+  - **Transcript reads follow the file (PHNX-3481).** `_remote` is sufficient but
+    not required to read from a peer. `transcriptOnPeerOf` MUST also return
+    `machine` when it names another box and `filePath` is empty or absent on this
+    disk. This covers the synthetic empty-file row from `registerHostSession` and
+    the live-registry bridge used by full-UUID `preview <id>` without making a
+    genuinely local unindexed live row remote. A synced mirror whose `filePath`
+    exists MUST still preview locally even when `machine` names the owner.
+    `buildPreview`, direct `preview <id>`, and `sessions <id>` MUST all use this
+    predicate, so they fetch/hop to the peer rather than render "full transcript
+    not indexed here". An unreachable owner MUST remain a loud `no-target` error.
   - **`machine` is not "where the process is".** For an offloaded run the shim
     process, its tmux pane, and its terminal window remain on the dispatcher.
     Any caller reaching for a LOCAL pid/pane/window MUST ask

--- a/cli/src/commands/sessions-picker.test.ts
+++ b/cli/src/commands/sessions-picker.test.ts
@@ -25,11 +25,15 @@ import {
   sanitizeRemoteDigest,
   setPeerDigestFetcherForTest,
   setRemotePreviewRepaint,
+  transcriptOnPeerOf,
 } from './sessions-picker.js';
 import { stringWidth } from '../lib/session/width.js';
 import { limitPreviewHeight, pickerPageSize, PREVIEW_MIN_ROWS } from '../lib/picker.js';
 import { _resetLinearWorkspaceCache } from '../lib/session/linear.js';
+import { machineId } from '../lib/session/sync/config.js';
 import type { SessionEvent, SessionMeta, TodoProgress } from '../lib/session/types.js';
+import { hostSessionMeta } from '../lib/hosts/session-index.js';
+import type { HostTask } from '../lib/hosts/tasks.js';
 
 function mk(overrides: Partial<SessionMeta>): SessionMeta {
   return {
@@ -41,6 +45,61 @@ function mk(overrides: Partial<SessionMeta>): SessionMeta {
     ...overrides,
   } as SessionMeta;
 }
+
+function hostDispatchedMeta(): SessionMeta {
+  const task = {
+    id: 'phnx3481-host-task',
+    host: 'peer-box',
+    target: 'user@peer-box',
+    agent: 'claude',
+    prompt: 'Pull the peer transcript digest',
+    sessionId: '34810000-1111-2222-3333-444444444444',
+    remoteLog: '/remote/session.log',
+    remoteExit: '/remote/session.exit',
+    status: 'running',
+    createdAt: '2026-08-29T00:00:00.000Z',
+  } as HostTask;
+  const meta = hostSessionMeta(task, { cwd: '/home/me/project', prompt: task.prompt });
+  if (!meta) throw new Error('host-dispatch fixture did not produce session metadata');
+  return meta;
+}
+
+describe('transcriptOnPeerOf (PHNX-3481)', () => {
+  it('routes a host-dispatch index row to the peer even without _remote', () => {
+    const session = hostDispatchedMeta();
+    expect(session.filePath).toBe('');
+    expect(session._remote).toBeUndefined();
+    expect(transcriptOnPeerOf(session)).toBe('peer-box');
+  });
+
+  it('keeps a genuinely local unindexed live row local', () => {
+    expect(transcriptOnPeerOf(mk({ filePath: '', machine: machineId() }))).toBeUndefined();
+  });
+
+  it('keeps a synced local transcript local even when machine names a peer', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-preview-peer-predicate-'));
+    try {
+      const filePath = path.join(dir, 'session.jsonl');
+      fs.writeFileSync(filePath, '{}\n');
+      expect(transcriptOnPeerOf(mk({ filePath, machine: 'peer-box' }))).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('makes the host-dispatch picker preview fetch from the peer, not show the local live-note dead end', () => {
+    setPeerDigestFetcherForTest(async () => undefined);
+    try {
+      const preview = stripVTControlCharacters(buildPreview(hostDispatchedMeta()));
+      expect(preview).toContain('peer-box');
+      expect(preview).not.toContain('full transcript not indexed here');
+    } finally {
+      setPeerDigestFetcherForTest(undefined);
+      clearRemoteDigestCacheForTest();
+      clearPreviewMemoryCacheForTest();
+    }
+  });
+});
 
 describe('formatTodoCompact (RUSH-2045)', () => {
   it('renders ✓done/total · activeForm', () => {

--- a/cli/src/commands/sessions-picker.ts
+++ b/cli/src/commands/sessions-picker.ts
@@ -37,19 +37,29 @@ import {
   isSubAgentTool,
 } from '../lib/session/highlights.js';
 import { getSessionPlugins, readSessionPreviewCache, writeSessionPreviewCache, readSessionContent, readArchivedSessionPreview } from '../lib/session/db.js';
-/** A session whose transcript FILE is on another machine (folded in over the
- * live cross-machine fan-out): its `filePath` is on that peer's disk, so the
- * preview can't parse it locally — it fetches the peer's digest over SSH and
- * shows metadata + a "resume there" note until that lands. Keys off `_remote`,
- * not the machine tag, so locally-readable synced mirrors still parse their
- * file normally.
+import { machineId } from '../lib/session/sync/config.js';
+/** A session whose transcript FILE is on another machine: its `filePath` is on
+ * that peer's disk, so the preview can't parse it locally — it fetches the
+ * peer's digest over SSH and shows metadata + a "resume there" note until that
+ * lands. `_remote` is an explicit signal; a peer `machine` plus no readable
+ * local file covers host-dispatch index rows and live-registry rows that were
+ * synthesized outside the fan-out. A locally-readable synced mirror stays
+ * local even when its recorded owner is another machine.
  *
  * This is the READ rule and only the read rule. Whether a session may be
  * RESUMED here is a different question with a different answer — a mirror is
  * readable but not resumable — and `sessionOwnerDevice`
  * (lib/session/resume-owner.ts) is the single place that answers it (RUSH-2022). */
-function transcriptOnPeerOf(session: SessionMeta): string | undefined {
-  return session._remote ? session.machine : undefined;
+export function transcriptOnPeerOf(session: SessionMeta): string | undefined {
+  if (session._remote) return session.machine;
+  if (
+    session.machine
+    && session.machine !== machineId()
+    && (!session.filePath || !fs.existsSync(session.filePath))
+  ) {
+    return session.machine;
+  }
+  return undefined;
 }
 
 /**
@@ -147,8 +157,8 @@ const previewCache = createMemoryCache<string, string>({
 });
 
 /**
- * Peer preview digests for `_remote` rows. A remote row's transcript is on the
- * peer's disk, so the pane fetches its already-computed digest over SSH (the
+ * Peer preview digests for rows whose transcript is remote. The pane fetches
+ * its already-computed digest over SSH (the
  * peer's `sessions preview <id> --local --json`) the first time the row is
  * previewed, and renders the full compact preview once it lands. `pending`
  * marks an in-flight fetch; `failed` marks a peer that couldn't answer, retried

--- a/cli/src/commands/sessions.ts
+++ b/cli/src/commands/sessions.ts
@@ -72,6 +72,7 @@ import {
   sessionPicker,
   buildPreview,
   loadSessionPreviewDigest,
+  transcriptOnPeerOf,
   formatTodoCompact,
   githubRepoUrlFromCwd,
   type PickedSession,
@@ -2333,12 +2334,13 @@ export async function renderSessionPreview(
   }
 
   const session = outcome.session;
-  if (session._remote && session.machine && session.machine !== machineId()) {
+  const transcriptPeer = transcriptOnPeerOf(session);
+  if (transcriptPeer) {
     const args = ['sessions', 'preview', session.id, '--local'];
     if (scope.json) args.push('--json');
-    const rendered = await runOnPeer(args, session.machine);
+    const rendered = await runOnPeer(args, transcriptPeer);
     if (rendered === 'no-target') {
-      console.error(chalk.red(`Session ${session.id} is on ${session.machine}, but that device is not reachable.`));
+      console.error(chalk.red(`Session ${session.id} is on ${transcriptPeer}, but that device is not reachable.`));
       process.exitCode = 1;
     }
     return;
@@ -4431,11 +4433,11 @@ export async function handlePickedSession(picked: PickedSession): Promise<void> 
   }
   // Reading and resuming are on DIFFERENT machines' terms, and conflating them
   // is what RUSH-2022 was. Reading follows the FILE: a synced mirror sits on
-  // this disk, so only a live fan-out row (`_remote`) has to be read on the
-  // peer. Resuming follows the HARNESS STATE, which is on the owning machine
-  // whatever the transcript's location — a mirror included.
+  // this disk, so a peer-owned row with no readable local transcript has to be
+  // read on the peer. Resuming follows the HARNESS STATE, which is on the
+  // owning machine whatever the transcript's location — a mirror included.
   if (picked.action === 'view') {
-    const readFrom = picked.session._remote ? picked.session.machine : undefined;
+    const readFrom = transcriptOnPeerOf(picked.session);
     if (readFrom) {
       const rc = await runOnPeer(['sessions', picked.session.shortId, '--markdown'], readFrom);
       if (rc === 'no-target') warnNoPeerTarget(readFrom, picked.session);
@@ -5146,20 +5148,21 @@ async function renderOneSession(
 
     if (outcome.kind === 'resolved') {
       const resolved = outcome.session;
-      if (resolved._remote && resolved.machine && resolved.machine !== machineId()) {
-      const args = ['sessions', resolved.id, '--local'];
-      const flag = modeFlag(mode);
-      if (flag) args.push(flag);
-      if (scope.filter.include?.length) args.push('--include', scope.filter.include.join(','));
-      if (scope.filter.exclude?.length) args.push('--exclude', scope.filter.exclude.join(','));
-      if (scope.filter.first !== undefined) args.push('--first', String(scope.filter.first));
-      if (scope.filter.last !== undefined) args.push('--last', String(scope.filter.last));
-      if (scope.redact === false) args.push('--no-redact');
-      const rendered = await runOnPeer(args, resolved.machine);
-      if (rendered === 'no-target') {
-        console.error(chalk.red(`Session ${resolved.id} is on ${resolved.machine}, but that device is not reachable.`));
-        process.exit(1);
-      }
+      const transcriptPeer = transcriptOnPeerOf(resolved);
+      if (transcriptPeer) {
+        const args = ['sessions', resolved.id, '--local'];
+        const flag = modeFlag(mode);
+        if (flag) args.push(flag);
+        if (scope.filter.include?.length) args.push('--include', scope.filter.include.join(','));
+        if (scope.filter.exclude?.length) args.push('--exclude', scope.filter.exclude.join(','));
+        if (scope.filter.first !== undefined) args.push('--first', String(scope.filter.first));
+        if (scope.filter.last !== undefined) args.push('--last', String(scope.filter.last));
+        if (scope.redact === false) args.push('--no-redact');
+        const rendered = await runOnPeer(args, transcriptPeer);
+        if (rendered === 'no-target') {
+          console.error(chalk.red(`Session ${resolved.id} is on ${transcriptPeer}, but that device is not reachable.`));
+          process.exit(1);
+        }
         return;
       }
 

--- a/cli/src/lib/session/live-metadata.test.ts
+++ b/cli/src/lib/session/live-metadata.test.ts
@@ -55,6 +55,7 @@ describe('activeSessionToSessionMeta', () => {
     expect(meta!.label).toBe('do the thing');
     expect(meta!.version).toBe('2.1.226');
     expect(meta!.machine).toBe(self);
+    expect(meta!._remote).toBe(false);
     expect(meta!.ticketId).toBe('RUSH-2682');
     expect(meta!.prUrl).toBe('https://github.com/o/r/pull/9');
     expect(meta!.prNumber).toBe(9);
@@ -94,6 +95,7 @@ describe('activeSessionToSessionMeta', () => {
       now,
     );
     expect(meta!.machine).toBe('peer-box');
+    expect(meta!._remote).toBe(true);
   });
 
   it('drops a row with no session id — nothing durable to resolve', () => {

--- a/cli/src/lib/session/live-metadata.ts
+++ b/cli/src/lib/session/live-metadata.ts
@@ -15,7 +15,8 @@
 // exist. It parses no transcript and renders nothing — it only reshapes process
 // state the live registry already computed. When the transcript IS on disk, the
 // synthesized row carries its path, so the downstream `buildPreview` renders the
-// real digest; otherwise it renders the header + a "not indexed here" note.
+// real digest. Without a path, a peer-owned row fetches its digest from that peer;
+// a genuinely local row renders the header + a "not indexed here" note.
 
 import { deriveShortId } from '../text/short-id.js';
 import { isSessionTrackedAgent, type SessionMeta } from './types.js';
@@ -57,9 +58,8 @@ export function activeSessionToSessionMeta(
     topic: active.topic,
     version: active.version,
     messageCount: undefined,
-    // The row runs HERE — the local live registry is machine-local, so a match
-    // resolves without an SSH hop back to a peer.
     machine: active.machine ?? self,
+    _remote: (active.machine ?? self) !== self,
     ticketId: active.ticket?.id,
     prUrl: active.pr?.url,
     prNumber: active.pr?.number,


### PR DESCRIPTION
## Summary

- make transcript reads follow the local file through one `transcriptOnPeerOf` predicate
- hop direct preview, `sessions UUID`, and picker view to the owner when a peer-named row has no local transcript
- stamp live-registry metadata `_remote` truthfully and keep synced mirrors local
- update SES-23a, CLI architecture notes, and the 1.22.59 changelog

## Reproduction

A real host-dispatch index fixture from `hostSessionMeta` has `filePath: ""`, `machine: "peer-box"`, label `[host/peer-box]`, and no `_remote`. Before this change:

```text
transcriptOnPeerOf returned undefined
Live session — full transcript not indexed here.
```

Regression-first run on the old predicate:

```text
Test Files  2 failed (2)
Tests       4 failed | 63 passed (67)
```

The four failures covered the host-index hop, picker dead-end card, and local/remote live-metadata stamps.

## Verification

```text
Test Files  5 passed (5)
Tests       85 passed (85)
Duration    5.79s
```

Command:

```text
bun run test -- src/commands/sessions-picker.test.ts src/lib/session/live-metadata.test.ts src/commands/__tests__/sessions-offload-preview.test.ts src/lib/hosts/session-index.test.ts src/commands/sessions.local-live-index.test.ts
```

`bun run build` passed and `git diff --check` is clean.

The `phnx-labs/.agents` audit found only callers teaching the unchanged `agents sessions preview UUID` syntax; no companion guidance change is required.

Ticket: PHNX-3481