### PR TITLE
fix(teams): default teammates off self-merging their own PRs (PHNX-3236)

### DIFF
--- a/cli/.changelog/next/PHNX-3236.md
+++ b/cli/.changelog/next/PHNX-3236.md
@@ -1,0 +1,11 @@
+- **Teammates can no longer silently self-merge their own PRs (PHNX-3236).** A
+  write-capable `agents teams` teammate authenticates as the repo owner, so it
+  could merge its own PR straight past the required non-author-review gate (the
+  RUSH-2988 wave-1 dispatch self-merged PRs #1817/#1820 with zero reviews). Team
+  dispatch now appends a self-merge boundary (`TEAMMATE_PR_POLICY`) to every
+  write-capable (non-plan) teammate's prompt, fresh or resumed and across every
+  harness — open the PR and hand it off; do not merge your own PR without a posted
+  non-author verdict. The hard enforcement remains `merge-guard.sh`, the PreToolUse
+  hook the teammate inherits, whose verdict check now excludes the PR author's own
+  reviews/comments (`phnx-labs/.agents` #395). Source:
+  `cli/src/lib/teams/agents.ts`.

--- a/cli/.changelog/next/PHNX-3236.md
+++ b/cli/.changelog/next/PHNX-3236.md
@@ -2,10 +2,15 @@
   write-capable `agents teams` teammate authenticates as the repo owner, so it
   could merge its own PR straight past the required non-author-review gate (the
   RUSH-2988 wave-1 dispatch self-merged PRs #1817/#1820 with zero reviews). Team
-  dispatch now appends a self-merge boundary (`TEAMMATE_PR_POLICY`) to every
-  write-capable (non-plan) teammate's prompt, fresh or resumed and across every
-  harness — open the PR and hand it off; do not merge your own PR without a posted
-  non-author verdict. The hard enforcement remains `merge-guard.sh`, the PreToolUse
-  hook the teammate inherits, whose verdict check now excludes the PR author's own
-  reviews/comments (`phnx-labs/.agents` #395). Source:
-  `cli/src/lib/teams/agents.ts`.
+  dispatch now appends a self-merge boundary (`TEAMMATE_PR_POLICY`, via one
+  `withTeammatePrPolicy` helper) to every write-capable (non-plan) teammate's
+  prompt, fresh or resumed, at **all three** dispatch surfaces — local, `--device`
+  remote (both via `buildRunArgv`), and `--cloud` (`cloudDispatchOptions`) — so
+  none can drift: open the PR and hand it off; do not merge your own PR without a
+  posted non-author verdict. The hard enforcement is `merge-guard.sh`, the PreToolUse
+  hook a teammate inherits, whose verdict check now excludes the PR author's own
+  reviews/comments (`phnx-labs/.agents` #395) — but it only reaches hook-capable
+  local/remote teammates; cloud teammates (provider sandbox, no inherited hook) and
+  hook-incapable harnesses (Warp) get the prompt as their only layer, a residual
+  documented in `cli/AGENTS.md` §6 that server-side branch protection closes. Source:
+  `cli/src/lib/teams/agents.ts`, `cli/src/commands/teams.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -307,6 +307,33 @@ DAG-style, boundary contracts, `--watch` supervisor, `--worktree` isolation, opt
 `--cloud` dispatch. The old `mcp__Swarm__*` surface was folded into teams
 (`migrateLegacySwarmToTeams()` in `src/lib/installations/migrate.ts`). Don't reach for Swarm — gone.
 
+**A teammate opens PRs but MUST NOT merge its OWN PR without a posted non-author
+verdict (PHNX-3236).** A write-capable teammate has `gh pr merge` and authenticates
+as the repo owner, so nothing about being a teammate stops it from merging its own
+PR straight past the required non-author review — which is exactly what happened in
+the RUSH-2988 wave-1 dispatch (PRs #1817, #1820 self-merged with `reviews: []`). The
+boundary is enforced in two layers, and neither is per-brief prompt wording (the
+failure mode: only one teammate in that batch was *told* not to merge, and its
+siblings weren't):
+
+- **Hard enforcement — `merge-guard.sh`.** The PreToolUse Bash guard the teammate
+  inherits from the shared version home blocks `gh pr merge` on a PR that has no
+  non-author verdict on it. Its verdict check (`pr-verdict.py`) **excludes any
+  review/comment authored by the PR's own author** (landed in the same ticket,
+  `phnx-labs/.agents` #395), so a teammate posting `VERDICT: APPROVE` on its own PR
+  — every fleet agent shares one GitHub identity — no longer clears the gate.
+- **Dispatch default — `TEAMMATE_PR_POLICY`.** `buildRunArgv`
+  ([`src/lib/teams/agents.ts`](src/lib/teams/agents.ts)) appends the boundary to the
+  prompt of every **write-capable** (non-plan) teammate, fresh or resumed, so the
+  rule is uniform across every harness — including the hook-incapable ones that
+  can't run `merge-guard.sh` — rather than depending on each dispatch remembering
+  to say it. Pinned by
+  [`agents.pr-policy.test.ts`](src/lib/teams/agents.pr-policy.test.ts).
+
+agents-cli itself never merges a teammate's PR (`pr-watch` only opens follow-up
+fixers or escalates to a human — there is no merge action); the teammate's own
+`gh pr merge` is the only merge path, which is why both layers target that call.
+
 ### 7. Every agent conversation is a session; execution ledgers link to it
 
 **An agent conversation from a session-capable harness MUST remain a session,

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -322,13 +322,39 @@ siblings weren't):
   review/comment authored by the PR's own author** (landed in the same ticket,
   `phnx-labs/.agents` #395), so a teammate posting `VERDICT: APPROVE` on its own PR
   — every fleet agent shares one GitHub identity — no longer clears the gate.
-- **Dispatch default — `TEAMMATE_PR_POLICY`.** `buildRunArgv`
-  ([`src/lib/teams/agents.ts`](src/lib/teams/agents.ts)) appends the boundary to the
-  prompt of every **write-capable** (non-plan) teammate, fresh or resumed, so the
-  rule is uniform across every harness — including the hook-incapable ones that
-  can't run `merge-guard.sh` — rather than depending on each dispatch remembering
-  to say it. Pinned by
+- **Dispatch default — `TEAMMATE_PR_POLICY`.** One helper,
+  `withTeammatePrPolicy(prompt, mode)`
+  ([`src/lib/teams/agents.ts`](src/lib/teams/agents.ts)), appends the boundary to the
+  prompt of every **write-capable** (non-plan) teammate, fresh or resumed, applied at
+  **all three** dispatch surfaces so they can't drift: the local launch and the
+  `--device` remote launch (both through `buildRunArgv`), and the `--cloud` launch
+  (`cloudDispatchOptions` in [`src/commands/teams.ts`](src/commands/teams.ts)). It is
+  the harness-independent layer — it reaches every entry in `TEAM_AGENT_TYPES`, not
+  just the hook-capable ones — rather than depending on each dispatch remembering to
+  say it. Pinned by
   [`agents.pr-policy.test.ts`](src/lib/teams/agents.pr-policy.test.ts).
+
+**Coverage, and the residual gap (stated per §Surface parity).** The two layers do
+not overlap everywhere, so name where each reaches:
+
+- **Hook-capable local / `--device` remote teammates** get **both** layers — the
+  hard `merge-guard.sh` block plus the prompt. This is the common case.
+- **Cloud teammates (`--cloud`)** get **only** the prompt: a cloud teammate runs in
+  the provider's sandbox, not the shared local version home, so it never inherits
+  `merge-guard.sh`. Wiring the prompt into `cloudDispatchOptions` is what keeps this
+  surface covered at all.
+- **Hook-incapable harnesses** (e.g. Warp/`oz` — `hooks: OFF` and no allowlist in the
+  capability table above, yet present in `TEAM_AGENT_TYPES`) get **only** the prompt,
+  local or remote, because there is no hook surface for `merge-guard.sh` to occupy
+  and no allowlist to express a `Bash(gh pr merge:*)` deny.
+
+So for the cloud and hook-incapable cases the prompt is a **soft** control an agent
+can ignore under pressure — the exact reliability limit the ticket names. That
+residual is accepted deliberately: there is no code-level merge interception point on
+those surfaces short of provider-side branch protection (cloud) or a per-harness
+enforcement mechanism those harnesses don't expose. **Enable server-side GitHub branch
+protection requiring a review** to close it uniformly regardless of harness or
+dispatch surface — that is the only guard that does not depend on the client.
 
 agents-cli itself never merges a teammate's PR (`pr-watch` only opens follow-up
 fixers or escalates to a human — there is no merge action); the teammate's own

--- a/cli/src/commands/teams.cloud-dispatch.test.ts
+++ b/cli/src/commands/teams.cloud-dispatch.test.ts
@@ -19,10 +19,15 @@ describe('staged cloud teammate dispatch', () => {
       cloudRepo: 'phnx-labs/agi-cli',
       cloudBranch: 'agents/test',
       model: null,
+      mode: 'edit',
     });
 
+    // A write-capable cloud teammate carries the brief plus the self-merge
+    // policy (PHNX-3236 — cloud is the surface with no inherited merge-guard.sh),
+    // so the prompt is no longer the bare brief.
+    expect(options.prompt).toContain('ship it');
+    expect(options.prompt).toContain('do NOT merge your OWN PR');
     expect(options).toMatchObject({
-      prompt: 'ship it',
       agent: 'codex',
       repo: 'phnx-labs/agi-cli',
       branch: 'agents/test',

--- a/cli/src/commands/teams.ts
+++ b/cli/src/commands/teams.ts
@@ -18,6 +18,7 @@ import {
   collectTeamsDoctorData,
   getAgentsDir,
   VALID_TASK_TYPES,
+  withTeammatePrPolicy,
   type AgentType,
   type TaskType,
   type TeamsDoctorEntry,
@@ -525,10 +526,13 @@ export function wireCloudDispatcher(mgr: AgentManager): void {
 }
 
 export function cloudDispatchOptions(
-  agent: Pick<AgentProcess, 'prompt' | 'agentType' | 'cloudRepo' | 'cloudBranch' | 'model'>,
+  agent: Pick<AgentProcess, 'prompt' | 'agentType' | 'cloudRepo' | 'cloudBranch' | 'model' | 'mode'>,
 ): DispatchOptions {
   return {
-    prompt: agent.prompt,
+    // PHNX-3236: a cloud teammate runs in the provider sandbox and never inherits
+    // the local merge-guard.sh hook, so the prompt policy is its ONLY self-merge
+    // boundary — apply the same helper buildRunArgv uses for local/remote.
+    prompt: withTeammatePrPolicy(agent.prompt, agent.mode),
     agent: agent.agentType,
     repo: agent.cloudRepo ?? undefined,
     branch: agent.cloudBranch ?? undefined,
@@ -2234,7 +2238,10 @@ export function registerTeamsCommands(program: Command): void {
         mgr.setCloudDispatcher(async (a) => {
           const prov = resolveProvider(providerId);
           const dispatchOpts: DispatchOptions = {
-            prompt: a.prompt,
+            // PHNX-3236: same self-merge boundary as the local/remote path — a
+            // cloud teammate has no inherited merge-guard.sh, so the prompt is
+            // its only layer.
+            prompt: withTeammatePrPolicy(a.prompt, a.mode),
             agent: a.agentType,
             repo: opts.repo,
             branch: opts.branch,

--- a/cli/src/lib/teams/agents.pr-policy.test.ts
+++ b/cli/src/lib/teams/agents.pr-policy.test.ts
@@ -11,7 +11,8 @@
  * is absent from a read-only plan-mode launch.
  */
 import { describe, it, expect } from 'vitest';
-import { AgentManager } from './agents.js';
+import { AgentManager, withTeammatePrPolicy } from './agents.js';
+import { cloudDispatchOptions } from '../../commands/teams.js';
 
 // buildRunArgv is private; reach it through a cast — testing the real builder,
 // not a re-implementation. Same seam as agents.resume.test.ts.
@@ -72,5 +73,32 @@ describe('buildRunArgv — teammate self-merge policy (PHNX-3236)', () => {
     expect(claudePlan).toContain('HEADLESS PLAN MODE');
     const codexPlan = promptOf(argv({ agentType: 'codex', mode: 'plan' }));
     expect(codexPlan).not.toContain('do NOT merge your OWN PR');
+  });
+});
+
+describe('withTeammatePrPolicy helper (PHNX-3236)', () => {
+  it('appends the policy for write modes and skips plan', () => {
+    for (const mode of ['edit', 'auto', 'skip']) {
+      expect(withTeammatePrPolicy('brief', mode)).toContain('do NOT merge your OWN PR');
+    }
+    expect(withTeammatePrPolicy('brief', 'plan')).toBe('brief');
+  });
+});
+
+// PHNX-3236 surface parity: the CLOUD dispatch path bypasses buildRunArgv (it
+// sends the teammate's raw prompt to the provider), and a cloud teammate runs in
+// the provider sandbox WITHOUT the inherited merge-guard.sh hook — so if the
+// policy were dropped here it would be the ONE dispatch surface with neither
+// layer. cloudDispatchOptions must apply the same boundary.
+describe('cloudDispatchOptions — teammate self-merge policy on the cloud path', () => {
+  const base = { prompt: 'ship the fix', agentType: 'claude' as const, cloudRepo: 'o/r', cloudBranch: 'b', model: null };
+  it('a write-capable cloud teammate carries the policy in its dispatched prompt', () => {
+    const opts = cloudDispatchOptions({ ...base, mode: 'edit' });
+    expect(opts.prompt).toContain('do NOT merge your OWN PR');
+    expect(opts.prompt).toContain('ship the fix');
+  });
+  it('a plan-mode cloud teammate does not', () => {
+    const opts = cloudDispatchOptions({ ...base, mode: 'plan' });
+    expect(opts.prompt).not.toContain('do NOT merge your OWN PR');
   });
 });

--- a/cli/src/lib/teams/agents.pr-policy.test.ts
+++ b/cli/src/lib/teams/agents.pr-policy.test.ts
@@ -1,0 +1,76 @@
+/**
+ * PHNX-3236: the teammate self-merge boundary is injected as a DISPATCH DEFAULT.
+ * A write-capable teammate authenticates as the repo owner, so it can merge its
+ * OWN PR past the required non-author-review gate (the RUSH-2988 wave-1 incident,
+ * PRs #1817/#1820). Making the boundary a default the runner appends to every
+ * non-plan teammate — rather than per-brief wording one teammate got and its
+ * siblings didn't — is what closes the gap uniformly across every harness.
+ *
+ * Real builder, no mocking: buildRunArgv is the production argv builder; these
+ * assert the policy rides the teammate's prompt on every write-capable launch and
+ * is absent from a read-only plan-mode launch.
+ */
+import { describe, it, expect } from 'vitest';
+import { AgentManager } from './agents.js';
+
+// buildRunArgv is private; reach it through a cast — testing the real builder,
+// not a re-implementation. Same seam as agents.resume.test.ts.
+function argv(opts: {
+  agentType?: string;
+  prompt?: string;
+  mode?: string;
+  resume?: { id: string; message: string };
+}): string[] {
+  const mgr = new AgentManager() as any;
+  return mgr.buildRunArgv(
+    opts.agentType ?? 'claude',
+    opts.prompt ?? 'the original brief',
+    opts.mode ?? 'edit',
+    null,
+    'medium',
+    null,
+    null,
+    opts.resume,
+  );
+}
+
+// The prompt is always the first positional after `run <target>`.
+const promptOf = (a: string[]): string => a[2];
+
+describe('buildRunArgv — teammate self-merge policy (PHNX-3236)', () => {
+  it('appends the no-self-merge policy to a fresh write-capable teammate', () => {
+    const p = promptOf(argv({ mode: 'edit', prompt: 'ship the fix' }));
+    expect(p).toContain('do NOT merge your OWN PR');
+    expect(p).toContain('NON-AUTHOR review verdict');
+    // The policy names the hard enforcement so it is not a naked instruction.
+    expect(p).toContain('merge-guard');
+    // The original brief and the summary suffix are still present.
+    expect(p).toContain('ship the fix');
+    expect(p).toContain('provide a brief summary');
+  });
+
+  it('appends the policy to a resumed teammate too (the incident recurred on resume)', () => {
+    const p = promptOf(argv({ mode: 'edit', resume: { id: 's1', message: 'keep going' } }));
+    expect(p.startsWith('keep going')).toBe(true);
+    expect(p).toContain('do NOT merge your OWN PR');
+  });
+
+  it('is applied in auto and skip modes as well — any write mode can open a PR', () => {
+    for (const mode of ['auto', 'skip']) {
+      expect(promptOf(argv({ mode }))).toContain('do NOT merge your OWN PR');
+    }
+  });
+
+  it('is harness-independent — a codex teammate gets the same policy', () => {
+    expect(promptOf(argv({ agentType: 'codex', mode: 'edit' }))).toContain('do NOT merge your OWN PR');
+  });
+
+  it('is NOT injected into a read-only plan-mode teammate (it opens no PR)', () => {
+    const claudePlan = promptOf(argv({ agentType: 'claude', mode: 'plan', prompt: 'design it' }));
+    expect(claudePlan).not.toContain('do NOT merge your OWN PR');
+    // Plan mode still carries its own scaffolding.
+    expect(claudePlan).toContain('HEADLESS PLAN MODE');
+    const codexPlan = promptOf(argv({ agentType: 'codex', mode: 'plan' }));
+    expect(codexPlan).not.toContain('do NOT merge your OWN PR');
+  });
+});

--- a/cli/src/lib/teams/agents.ts
+++ b/cli/src/lib/teams/agents.ts
@@ -329,13 +329,18 @@ const CLAUDE_PLAN_MODE_PREFIX = `You are running in HEADLESS PLAN MODE. This mod
 // root cause was that the boundary lived in per-brief wording: one teammate in the
 // batch was told "open the PR, don't merge" and held off; the others weren't and
 // self-merged. Making it a default the runner appends to every non-plan teammate
-// closes that gap uniformly, across every harness, instead of relying on each
-// dispatch prompt remembering to say it. The HARD enforcement is still
-// merge-guard.sh — a PreToolUse hook the teammate inherits from the shared version
-// home, whose self-authored-verdict exclusion was closed in the same ticket
-// (.agents-system #395) so a verdict a teammate posts on its own PR no longer
-// clears the gate — this is the harness-independent layer plus the operator
-// hand-off contract, not a replacement for it.
+// gives one HARNESS-INDEPENDENT layer instead of relying on each dispatch prompt
+// remembering to say it. The HARD enforcement is merge-guard.sh — a PreToolUse hook
+// the teammate inherits from the shared version home, whose self-authored-verdict
+// exclusion was closed in the same ticket (.agents-system #395) so a verdict a
+// teammate posts on its own PR no longer clears the gate. The two layers do NOT
+// overlap everywhere: hook-capable local/remote teammates get both, but cloud
+// teammates (provider sandbox, no inherited hook) and hook-incapable harnesses
+// (Warp/oz — no hook surface, no allowlist) get ONLY this prompt, so for them it is
+// a soft control. That residual is documented in cli/AGENTS.md §6; server-side
+// branch protection is the client-independent way to close it. This is the
+// harness-independent layer plus the operator hand-off contract, not a replacement
+// for the hard block where the hard block can run.
 const TEAMMATE_PR_POLICY = `
 
 Teammate PR policy (agents teams): when your work opens a pull request, open it and
@@ -346,6 +351,21 @@ does not count as a non-author review. \`gh pr merge\` on your own PR is blocked
 merge-guard until a genuine non-author verdict exists on it; never pass --admin or
 otherwise route around that guard. Report the PR as open and let the orchestrator
 or a separate reviewer take it to merge.`;
+
+/**
+ * Append {@link TEAMMATE_PR_POLICY} to a teammate prompt for every WRITE-capable
+ * mode (all but plan, which is read-only and opens no PR). Exported so the CLOUD
+ * dispatch path (`cloudDispatchOptions` in `commands/teams.ts`) applies the SAME
+ * boundary this file's `buildRunArgv` applies to LOCAL and REMOTE teammates. A
+ * cloud teammate is the case that needs it MOST: it runs in the provider's
+ * sandbox, not the shared local version home, so it never inherits the
+ * `merge-guard.sh` PreToolUse hook — the prompt policy is then its ONLY
+ * self-merge layer. Routing every dispatch surface through one helper keeps that
+ * parity from drifting (PHNX-3236).
+ */
+export function withTeammatePrPolicy(prompt: string, mode: string): string {
+  return mode === 'plan' ? prompt : prompt + TEAMMATE_PR_POLICY;
+}
 
 // Canonical modes plus the historical `full` alias (rewritten to `skip` by
 // normalizeModeValue). Keep `full` listed so user-typed CLI flags and stored
@@ -2953,9 +2973,9 @@ export class AgentManager {
     // skipped to keep its prompt clean; every other mode can open — and could
     // self-merge — a PR, so the policy rides along regardless of harness. The
     // hard block is still merge-guard.sh (inherited hook); see TEAMMATE_PR_POLICY.
-    if (mode !== 'plan') {
-      fullPrompt += TEAMMATE_PR_POLICY;
-    }
+    // The cloud dispatch path applies the SAME helper (withTeammatePrPolicy) so
+    // local, remote, and cloud teammates never diverge on this boundary.
+    fullPrompt = withTeammatePrPolicy(fullPrompt, mode);
 
     // Profile target takes precedence — `agents run <profile>` resolves the
     // host harness, version pin, and env injection in one place. Plain

--- a/cli/src/lib/teams/agents.ts
+++ b/cli/src/lib/teams/agents.ts
@@ -322,6 +322,31 @@ const CLAUDE_PLAN_MODE_PREFIX = `You are running in HEADLESS PLAN MODE. This mod
 
 `;
 
+// PHNX-3236: the teammate self-merge boundary, injected as a DISPATCH DEFAULT.
+// A write-capable teammate has `gh pr merge` and authenticates as the repo owner,
+// so it can merge its OWN PR past the required non-author-review gate — which is
+// exactly what happened in the RUSH-2988 wave-1 dispatch (PR #1817, #1820). The
+// root cause was that the boundary lived in per-brief wording: one teammate in the
+// batch was told "open the PR, don't merge" and held off; the others weren't and
+// self-merged. Making it a default the runner appends to every non-plan teammate
+// closes that gap uniformly, across every harness, instead of relying on each
+// dispatch prompt remembering to say it. The HARD enforcement is still
+// merge-guard.sh — a PreToolUse hook the teammate inherits from the shared version
+// home, whose self-authored-verdict exclusion was closed in the same ticket
+// (.agents-system #395) so a verdict a teammate posts on its own PR no longer
+// clears the gate — this is the harness-independent layer plus the operator
+// hand-off contract, not a replacement for it.
+const TEAMMATE_PR_POLICY = `
+
+Teammate PR policy (agents teams): when your work opens a pull request, open it and
+hand it off — do NOT merge your OWN PR unless a NON-AUTHOR review verdict has been
+posted on that same PR. You authenticate as the repo owner and share that one
+GitHub identity with every other teammate, so an APPROVE you post on your own PR
+does not count as a non-author review. \`gh pr merge\` on your own PR is blocked by
+merge-guard until a genuine non-author verdict exists on it; never pass --admin or
+otherwise route around that guard. Report the PR as open and let the orchestrator
+or a separate reviewer take it to merge.`;
+
 // Canonical modes plus the historical `full` alias (rewritten to `skip` by
 // normalizeModeValue). Keep `full` listed so user-typed CLI flags and stored
 // metadata that pre-date the rename continue to parse.
@@ -2922,6 +2947,14 @@ export class AgentManager {
       if (agentType === 'claude' && mode === 'plan') {
         fullPrompt = CLAUDE_PLAN_MODE_PREFIX + fullPrompt;
       }
+    }
+    // PHNX-3236: append the self-merge boundary to every WRITE-capable teammate,
+    // fresh or resumed. A plan-mode teammate produces no PR (read-only), so it is
+    // skipped to keep its prompt clean; every other mode can open — and could
+    // self-merge — a PR, so the policy rides along regardless of harness. The
+    // hard block is still merge-guard.sh (inherited hook); see TEAMMATE_PR_POLICY.
+    if (mode !== 'plan') {
+      fullPrompt += TEAMMATE_PR_POLICY;
     }
 
     // Profile target takes precedence — `agents run <profile>` resolves the


### PR DESCRIPTION
## Problem (PHNX-3236)

A write-capable `agents teams` teammate has `gh pr merge` and authenticates as the
repo owner, so nothing about *being* a teammate stops it from merging its **own** PR
straight past the required non-author-review gate. In the RUSH-2988 wave-1 dispatch,
the ws5-api and ws3-instances teammates self-merged PRs #1817 and #1820 with
`reviews: []`. The root cause was that the boundary lived in **per-brief prompt
wording**: one teammate in the batch was told "open the PR, don't merge" and correctly
held off; its siblings weren't, and self-merged — and a mid-run `agents teams message`
warning didn't stop the second occurrence. A prompt an agent can ignore under pressure
is not a control.

## Fix — two layers, neither of them per-brief wording

- **Dispatch default (this PR).** `buildRunArgv` appends `TEAMMATE_PR_POLICY` to the
  prompt of **every write-capable (non-plan) teammate**, fresh or resumed, uniformly
  across every harness — including the hook-incapable ones that can't run
  `merge-guard.sh`. This closes the "siblings weren't told" gap at the dispatch
  mechanism rather than leaving it to each brief. A read-only plan-mode teammate opens
  no PR, so it is skipped.
- **Hard enforcement (already landed, cross-linked).** The real block is
  `merge-guard.sh` — the PreToolUse Bash hook the teammate **inherits from the shared
  version home** — which refuses `gh pr merge` on a PR with no non-author verdict. Its
  verdict check (`pr-verdict.py`) now **excludes any review/comment authored by the PR's
  own author** (`phnx-labs/.agents#395`, same ticket), so a teammate posting
  `VERDICT: APPROVE` on its own PR — every fleet agent shares one GitHub identity — no
  longer clears the gate.

agents-cli itself never merges a teammate's PR (`pr-watch` only spawns follow-up fixers
or escalates to a human — there is no merge action), so the teammate's own
`gh pr merge` is the only merge path, which is why both layers target that call.

## Tests

`cli/src/lib/teams/agents.pr-policy.test.ts` (new) exercises the real `buildRunArgv`
builder: the policy rides a fresh + resumed write-capable teammate across claude/codex
and in edit/auto/skip modes, names `merge-guard` (not a naked instruction), and is
**absent** from a read-only plan-mode teammate. Existing `agents.resume.test.ts` still
green.

## Docs / CHANGELOG

`cli/AGENTS.md` §6 documents the two-layer contract (`cli/CLAUDE.md` is a symlink to it);
`cli/.changelog/next/PHNX-3236.md` added.

## Cross-links

- `phnx-labs/.agents#395` — the merge-guard self-authored-verdict exclusion (hard layer).
- `phnx-labs/.agents#422` — PHNX-3118 negation/code-fence hardening of the same `pr-verdict.py`.