### PR TITLE
fix(traces): carry per-session roster through the /all worker merge (PHNX-3483)

### DIFF
--- a/cli/src/lib/traces/worker-template.test.ts
+++ b/cli/src/lib/traces/worker-template.test.ts
@@ -251,6 +251,7 @@ describe('traces worker — /all cross-device aggregation (PHNX-3397)', () => {
     latency: { firstToolMs: { p50: 100, p90: 900, p99: 5000, max: 9000 } },
     bucketHistory: [],
     driftSignals: [],
+    sessions: [{ id: `sess-${device}`, title: 't', harness: 'claude', model: 'm', repo: 'r', mode: 'headless', projectType: 'code', startedAt: 1, durationMs: 100, toolCount: 5, errorCount: 0, needsAttention: false }],
     ...over,
   });
 
@@ -269,6 +270,9 @@ describe('traces worker — /all cross-device aggregation (PHNX-3397)', () => {
     expect(body.wastedMsTotal).toBe(120000);
     expect(body.failurePatterns).toHaveLength(1);
     expect(body.latency.firstToolMs.p50).toBe(100);
+    // Roster passes through so the single-device "all" view can filter/re-aggregate.
+    expect(body.sessions).toHaveLength(1);
+    expect(body.sessions[0].id).toBe('sess-zion');
   });
 
   it('two devices → summed counts, concatenated lists, summed wasted time', async () => {
@@ -298,6 +302,13 @@ describe('traces worker — /all cross-device aggregation (PHNX-3397)', () => {
     expect(p.sessions).toBe(6);
     expect(p.occurrences).toBe(10);
     expect(p.exampleSessionIds).toEqual(expect.arrayContaining(['ex-zion', 'ex-mac']));
+    // Rosters concat across devices so the "all" view sees every session's raw row
+    // (PHNX-3483). Without this the merged shard drops `sessions` and the console
+    // degrades to the pre-rolled stats with no filtering.
+    expect(body.sessions).toHaveLength(2);
+    expect(body.sessions.map((s: { id: string }) => s.id)).toEqual(
+      expect.arrayContaining(['sess-zion', 'sess-mac']),
+    );
   });
 
   it('all/sessions/<id> → served from whichever device owns it', async () => {

--- a/cli/src/lib/traces/worker-template.ts
+++ b/cli/src/lib/traces/worker-template.ts
@@ -226,6 +226,11 @@ function mergeIndexShards(shards, owner) {
     failurePatterns: Array.from(patternById.values())
       .sort((a, b) => (b.wastedMs || 0) - (a.wastedMs || 0)).slice(0, 25),
     wastedMsTotal: sorted.reduce((n, s) => n + (s.wastedMsTotal || 0), 0),
+    // Per-session roster (PHNX-3483): concat every device's rows so the "all"
+    // view can filter + re-aggregate client-side exactly like a single device.
+    // Devices still on a pre-roster CLI contribute none (|| []) and degrade to
+    // the pre-rolled stats, so coverage grows as devices update — never crashes.
+    sessions: sorted.flatMap((s) => s.sessions || []),
     latency: latencies.length ? {
       firstToolMs: {
         p50: Math.round(wsum((s) => s.latency && s.latency.firstToolMs && s.latency.firstToolMs.p50)),


### PR DESCRIPTION
## Why
The prix/web filterable Insights console reads `index.sessions` (the per-session roster) and re-aggregates it client-side. The producer now emits that roster per device (#3307), but the **worker's `/all` cross-device merge dropped it** — `mergeIndexShards` folded stats/topics/failures/latency and never copied `sessions`. Result: a user with >1 device sees the default `device=all` console degrade to the pre-rolled stats with no filtering (verified live on prix.dev).

## What
- `mergeIndexShards`: `sessions: sorted.flatMap((s) => s.sessions || [])` — concat every device's roster; devices on a pre-roster CLI contribute none and degrade gracefully. Single-device passthrough already carried it via the object spread.
- Tests: passthrough keeps the roster (single device); two devices concatenate both rosters.

## Evidence
```
vitest run src/lib/traces/worker-template.test.ts
 Tests  19 passed (19)
```

## Deploy note
This ships in the CLI-rendered worker template. The **managed traces.agents-cli.sh worker must be redeployed** with this template for the `/all` view to surface the roster. PHNX-3483.