### PR TITLE
revert(guard): remove operator-PII email/home-path checks (undoes #3309)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,15 +311,7 @@ models, revenue/ARR/MRR/churn figures, launch venues, GitHub stars playbooks, or
 intelligence belong in `.agents/artifacts/private/` or a private repo — never in the
 committed `.agents/artifacts/<yyyy-mm-dd>/` tree. The required Linux PR check runs
 `scripts/guard-artifacts-confidential.ts` and fails loud with the offending paths and the
-right home if one is staged. The same guard also flags un-anonymized operator **PII** in a
-public artifact — an **absolute home path**, or a **personal email** at a curated set of
-consumer/company mail domains (`gmail.com`, `outlook.com`, the operator's own domain, …; see
-`PERSONAL_EMAIL_DOMAINS` in the guard) — pointing you at a placeholder (`you@example.com`,
-`<home>`/`~`). The email check is a domain **denylist** on purpose, so `user@host` ssh/git-remote
-idioms never false-fire; the trade-off is that an email at an *unlisted* domain is a conservative
-miss (add the domain to the set to guard it). Device names and bare UUIDs are intentionally
-**not** flagged (device names already appear openly in this README/AGENTS.md, and UUIDs are
-common in legitimate fixtures), so anonymize those by hand per the list above.
+right home if one is staged.
 
 ## Conventions (repo-wide)
 

--- a/scripts/guard-artifacts-confidential.test.ts
+++ b/scripts/guard-artifacts-confidential.test.ts
@@ -10,7 +10,6 @@ import { dirname, join } from 'node:path';
 import {
   checkContent,
   checkFilename,
-  checkPii,
   formatError,
   inspectFiles,
   isUnderPublicArtifacts,
@@ -112,76 +111,6 @@ describe('checkContent', () => {
   });
 });
 
-describe('checkPii', () => {
-  test('flags a real email address', () => {
-    expect(checkPii('Reach the owner at muqsit@getrush.ai for access.')).toMatch(/email/);
-    expect(checkPii('Signed-in as someone@gmail.com in the browser profile.')).toMatch(/email/);
-  });
-
-  test('does not flag placeholder / reserved emails', () => {
-    expect(checkPii('Use you@example.com as the sender.')).toBeNull();
-    expect(checkPii('Co-Authored-By: noreply@anthropic.com')).toBeNull();
-    expect(checkPii('git configured user@example.invalid for the test.')).toBeNull();
-  });
-
-  test('does not flag user@host git-remote / ssh syntax (reviewer #3309)', () => {
-    // SCP / git-remote — colon+path after the host
-    expect(checkPii('clone via git@github.com:phnx-labs/agents-cli.git')).toBeNull();
-    expect(checkPii('git remote add origin git@gitlab.com:org/repo.git')).toBeNull();
-    // bare code-host domain mention
-    expect(checkPii('the git@github.com identity is the deploy key')).toBeNull();
-    // ssh/scp host reference (no colon)
-    expect(checkPii('ssh deploy@build-host.io for the release')).toBeNull();
-    expect(checkPii('scp -r report.html deploy@build-host.io')).toBeNull();
-    // ...but a real personal email in the same file still flags
-    expect(checkPii('owner muqsit@getrush.ai; clone git@github.com:o/r.git')).toMatch(/email/);
-  });
-
-  test('still flags a real email even when the line mentions ssh in prose (#3309 re-review)', () => {
-    // "ssh" here is a NOUN, not a command governing the email — must still flag.
-    expect(checkPii('ssh notes: contact muqsit@getrush.ai for prod access')).toMatch(/email/);
-    // a colon that is prose punctuation (not a scp path) must not skip the email
-    expect(checkPii('escalation email muqsit@getrush.ai: reach out on call')).toMatch(/email/);
-    // ssh mentioned, then a separate clause with a real email
-    expect(checkPii('run the ssh setup, then email someone@gmail.com about it')).toMatch(/email/);
-    // a real ssh host arg AND a real personal email on the same line: the personal
-    // one must still flag (the denylist keys on the domain, not proximity to ssh).
-    expect(checkPii('ssh deploy@build-host.io then tell muqsit@getrush.ai it is done')).toMatch(/email/);
-  });
-
-  test('domain denylist: personal/company domains flag; hostnames and unlisted domains pass', () => {
-    // personal + company mailboxes flag regardless of context
-    for (const d of ['gmail.com', 'outlook.com', 'icloud.com', 'proton.me', 'getrush.ai']) {
-      expect(checkPii(`reach a.person@${d} for details`)).toMatch(/email/);
-    }
-    // raw hostnames used as ssh/scp/git targets are never on the denylist -> pass
-    for (const h of ['build-host.io', 'github.com', 'ec2-1-2-3-4.compute.amazonaws.com']) {
-      expect(checkPii(`deploy@${h} is the target`)).toBeNull();
-    }
-    // deliberate conservative miss: an email at an unlisted custom domain passes
-    // (better a rare miss than the false-positive churn of scanning every @host).
-    expect(checkPii('mail admin@some-random-startup.io about it')).toBeNull();
-  });
-
-  test('flags an absolute home path with a real username', () => {
-    expect(checkPii('cd /home/muqsit/src/github.com/foo && bun test')).toMatch(/home path/);
-    expect(checkPii('opened /Users/bisma/Desktop/report.html')).toMatch(/home path/);
-  });
-
-  test('does not flag placeholder or CI home paths', () => {
-    expect(checkPii('the tree lives at /home/runner/work/repo on CI')).toBeNull();
-    expect(checkPii('put it under <home>/rescued or ~/rescued instead')).toBeNull();
-    expect(checkPii('a repo at <repo-root>/.agents/artifacts')).toBeNull();
-  });
-
-  test('does NOT flag device names or bare UUIDs (deliberate scope)', () => {
-    // device names are documented openly in the public README/AGENTS.md
-    expect(checkPii('verified on yosemite-s0/s1 and mac-mini; host: zion')).toBeNull();
-    // bare UUIDs are common in legit fixtures
-    expect(checkPii('session 10e70c98-8047-4d3a-b8cb-51c4d4b26eb6 resumed')).toBeNull();
-  });
-});
-
 describe('inspectFiles', () => {
   let tmp: string;
 
@@ -231,22 +160,6 @@ describe('inspectFiles', () => {
   test('sensitive file under private/ passes', () => {
     const files = ['.agents/artifacts/private/2026-08-27/gtm-strategy.md'];
     writeFixture(tmp, files[0]!, '# Secret GTM strategy\n\n$1.2M ARR target.');
-    const violations = inspectFiles(tmp, files);
-    expect(violations).toHaveLength(0);
-  });
-
-  test('reproduces the PHNX-3033 follow-up: operator PII in a public artifact fails', () => {
-    const files = ['.agents/artifacts/2026-08-27/plan-fleet-reconnect.md'];
-    // an otherwise-fine engineering plan that leaks a real home path
-    writeFixture(tmp, files[0]!, '# Reconnect plan\n\nRan on /home/muqsit/src/github.com/foo/agents-cli.');
-    const violations = inspectFiles(tmp, files);
-    expect(violations).toHaveLength(1);
-    expect(violations[0]!.reason).toBe('pii');
-  });
-
-  test('same plan with the home path anonymized passes', () => {
-    const files = ['.agents/artifacts/2026-08-27/plan-fleet-reconnect.md'];
-    writeFixture(tmp, files[0]!, '# Reconnect plan\n\nRan on <repo-root> (see ~/agents-cli).');
     const violations = inspectFiles(tmp, files);
     expect(violations).toHaveLength(0);
   });

--- a/scripts/guard-artifacts-confidential.ts
+++ b/scripts/guard-artifacts-confidential.ts
@@ -9,12 +9,9 @@
  *
  * The guard inspects added/modified files under `.agents/artifacts/` (excluding
  * the private subtree) and fails loud if a filename or content matches
- * sensitive-strategy signals OR carries operator PII (a real email address or an
- * absolute home path — see `checkPii`). It is intentionally conservative: an
- * ambiguous file is rejected with an actionable error that points the author to
- * the private dir or a private repo. Device names and bare UUIDs are deliberately
- * NOT flagged (device names appear openly in the public README/AGENTS.md; UUIDs
- * are too common in legitimate fixtures) — see `checkPii` for the rationale.
+ * sensitive-strategy signals. It is intentionally conservative: an ambiguous
+ * file is rejected with an actionable error that points the author to the
+ * private dir or a private repo.
  *
  * Usage in CI:
  *   bun scripts/guard-artifacts-confidential.ts --base <sha> --head <sha>
@@ -34,7 +31,7 @@ export interface GuardOptions {
 
 export interface Violation {
   file: string;
-  reason: 'filename' | 'content' | 'pii';
+  reason: 'filename' | 'content';
   detail: string;
 }
 
@@ -92,53 +89,6 @@ const STRATEGY_CONTEXT_RES: RegExp[] = [
 ];
 
 const DOLLAR_FIGURE_RE = /\$\d[\d,]*\.?\d*\s*[KMBkmb]?/;
-
-// ── Operator PII signals (PHNX-3033 follow-up) ───────────────────────────────
-// The GTM signals above catch confidential *strategy*; these catch personal /
-// operator data that must never land in a PUBLIC artifact even when it is not
-// strategy: a personal email address (matched by a curated domain DENYLIST — see
-// PERSONAL_EMAIL_DOMAINS, which is precise so `user@host` ssh/git-remote idioms
-// never false-fire) and an absolute home path. Deliberately NOT covered: fleet
-// *device names* (already documented openly in the public README + AGENTS.md, so
-// flagging them would fight the repo's own docs) and bare UUIDs (too common in
-// legitimate test/plan fixtures to flag without noise). The convention (AGENTS.md
-// "The `.agents/` workspace") says to anonymize these before landing; use a
-// placeholder (`you@example.com`, `<home>`, `~`) instead.
-
-const EMAIL_RE = /\b[A-Za-z0-9._%+-]+@([A-Za-z0-9.-]+\.[A-Za-z]{2,})\b/g;
-// A curated DENYLIST of domains that indicate a real personal / company mailbox.
-// This is deliberately the inverse of an "allow everything, exempt host-refs"
-// scan: a bare host reference (`git@github.com`, `ssh user@build-host.io`, an scp
-// destination) is NEVER on this list, so those idioms can't false-fire — while
-// the operator's own domain and common consumer providers always flag, whatever
-// the surrounding prose. Add a domain here when a new real mailbox needs guarding.
-const PERSONAL_EMAIL_DOMAINS = new Set([
-  'getrush.ai',
-  'gmail.com', 'googlemail.com', 'outlook.com', 'hotmail.com', 'live.com', 'msn.com',
-  'yahoo.com', 'ymail.com', 'icloud.com', 'me.com', 'mac.com',
-  'proton.me', 'protonmail.com', 'pm.me', 'aol.com', 'fastmail.com', 'hey.com', 'zoho.com',
-]);
-
-// Absolute home paths. `runner` is the GitHub-hosted CI user and appears in
-// legitimate public CI logs/paths, so it is allowlisted; a real operator
-// username is not.
-const SAFE_HOME_USERS = new Set(['runner', 'user', 'username', 'youruser', 'me']);
-const HOME_PATH_RE = /\/(?:home|Users)\/([A-Za-z_][\w.-]*)(?=[/\s"'`)\]]|$)/g;
-
-export function checkPii(text: string): string | null {
-  for (const m of text.matchAll(EMAIL_RE)) {
-    const domain = (m[1] ?? '').toLowerCase();
-    if (PERSONAL_EMAIL_DOMAINS.has(domain)) {
-      return `content contains a personal email address: "${m[0]}" (anonymize it, e.g. you@example.com)`;
-    }
-  }
-  for (const m of text.matchAll(HOME_PATH_RE)) {
-    const user = (m[1] ?? '').toLowerCase();
-    if (SAFE_HOME_USERS.has(user)) continue;
-    return `content contains an absolute home path: "${m[0]}" (use <home> or ~ instead)`;
-  }
-  return null;
-}
 
 export function posix(file: string): string {
   return file.split(sep).join('/');
@@ -243,11 +193,6 @@ export function inspectFile(repoRoot: string, file: string): Violation | null {
     return { file, reason: 'content', detail: contentHit };
   }
 
-  const piiHit = checkPii(text);
-  if (piiHit) {
-    return { file, reason: 'pii', detail: piiHit };
-  }
-
   return null;
 }
 
@@ -265,10 +210,9 @@ export function changedArtifactFiles(options: GuardOptions): string[] {
 const ERROR_LEAD = `\nCONFIDENTIAL-CONTENT GUARD FAILED (PHNX-3033)
 
 The following file(s) under the PUBLIC \`.agents/artifacts/\` tree look like confidential
-GTM/monetization/pricing/revenue/competitor strategy material, or personal/operator data
-(a real email address or an absolute home path). Everything committed to
-\`.agents/artifacts/<yyyy-mm-dd>/\` is public by design; it must not contain strategy intel,
-financial figures, launch planning, or un-anonymized personal data.
+GTM, monetization, pricing, revenue, or competitor strategy material. Everything committed
+to \`.agents/artifacts/<yyyy-mm-dd>/\` is public by design; it must not contain strategy
+intel, financial figures, or launch planning.
 `;
 
 const ERROR_TAIL = `


### PR DESCRIPTION
Reverts the PII additions from #3309 to `scripts/guard-artifacts-confidential.ts`. The operator didn't want a new/extended guard — it's just hardcoded regex + a domain list (no real intelligence), and it runs against the standing rule not to encode judgment into rigid guards. Restores the guard to its GTM-only state; the three touched files (`guard-artifacts-confidential.ts`, its test, `AGENTS.md`) go back to their pre-#3309 content. The actual public-repo leak was already fixed by reverting the leaked artifacts (#3304) — no mechanism was needed.