### PR TITLE
docs(traces): note device=all is a synthesized cross-device merge (PHNX-3483)

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -117,6 +117,13 @@ segmentation (`headless`/`interactive`) so a mode-split median over the MEASURED
 rows reproduces `stats.agentMedianMs`/`interactiveMedianMs` — the segmented stats
 skip null-duration rows, which the roster still carries at `durationMs: 0`; utility
 rows are excluded, so the roster length equals `stats.sessionsImported`.
+
+**`device=all` is synthesized, not stored:** each device syncs its own shard, and the
+worker merges them on read (`worker-template.ts`). That merge re-projects field by
+field — so a new per-device shard field reaches the default console view only if it is
+also added to the merge, else it silently vanishes from `/all` while still present
+per-device.
+
 Group-by dimensions for the console insight bar are pure functions in
 [`src/lib/traces/segments.ts`](src/lib/traces/segments.ts): `deriveAgent`
 (model × harness), `classifyTaskType`, `failureTiming`, and `computeLatency`


### PR DESCRIPTION
One durable, high-level line in cli/AGENTS.md (mirrored to CLAUDE.md/GEMINI.md): the default `device=all` console view is **merged on read** by the worker, and that merge re-projects field by field — so a new per-device shard field reaches `/all` only if it's also added to the merge, else it silently vanishes from the default view while still present per-device.

This is the exact architectural gap that hid the `sessions` roster from every multi-device user's default view until the /all merge was fixed (PHNX-3516). Docs-only; kept deliberately concise (no field lists / ticket-specifics that would rot).