### PR TITLE
feat(feed): template channel messages (PHNX-3572)

### DIFF
--- a/cli/.changelog/next/PHNX-3572.md
+++ b/cli/.changelog/next/PHNX-3572.md
@@ -1,0 +1,1 @@
+- Let feed channel sinks customize their delivered body with existing post placeholders, including fail-closed `{ticket}` routing for clickable tracker links in team channels.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -97,6 +97,14 @@ the peer never re-expands the owner policy and duplicates another channel.
 Legacy `notify.owner` and a humans file without `policy.normal` retain the
 historical single-destination behavior.
 
+Feed channel sinks may override their outbound body with a `message:` template
+using the same placeholders as command sinks (`{message}`, `{ticket}`, `{project}`,
+and the rest in `feed-broadcast.ts`). Placeholder resolution is fail-closed: if
+the post lacks a referenced value, that sink is skipped. This is the semantic
+routing primitive for destinations such as an engineering Slack channel: a
+template that includes `{ticket}` receives ticket-backed posts without leaking
+unrelated owner alerts into the team channel.
+
 **`gh` is overloaded so the fleet's trained `gh pr checks` escapes the shared
 GraphQL rate limit (PHNX-3501).** The whole fleet shares one GitHub token, and
 `gh pr checks/view/list` are all GraphQL-backed, so the fleet drains GitHub's

--- a/cli/docs/observability.md
+++ b/cli/docs/observability.md
@@ -19,6 +19,41 @@ block clears, preventing stale session reads from resurrecting answered asks. Th
 publishes one versioned stream; thin clients replace state on reset and apply monotonic
 increments.
 
+## Feed broadcast routing
+
+`agents feed post` records the complete event first, then mirrors it through the
+named sinks under `feed.broadcast` in `agents.yaml`. A sink is either a direct
+argv template (`command:`) or an in-process provider delivery (`channel:`). Both
+shapes use post context rather than asking the agent to repeat domain facts: the
+session index supplies `{ticket}`, while `{message}` is the compact human-facing
+title, body, provenance, and first attached URL.
+
+Channel sinks may set `message:` to customize their outbound body. It supports
+the same placeholders as command sinks. If any referenced value is absent, the
+sink is skipped instead of delivering a malformed message. That makes the
+template itself a routing declaration:
+
+```yaml
+feed:
+  broadcast:
+    owner:
+      channel: owner
+      minLevel: important
+    engineering:
+      channel: slack
+      to: C01234567
+      minLevel: important
+      message: |-
+        {message}
+        https://linear.app/example/issue/{ticket}
+```
+
+The engineering sink above fires only for important posts whose session carries
+a ticket. Posts without ticket context remain in the feed and may still reach
+the private owner sink; they do not enter the team channel. Tracker-specific URL
+shape and Slack destination remain operator configuration, not compiled product
+assumptions.
+
 ## Performance latency warehouse
 
 Performance is a disposable SQLite warehouse at `~/.agents/.cache/perf/perf.db`

--- a/cli/src/commands/feed.ts
+++ b/cli/src/commands/feed.ts
@@ -135,7 +135,8 @@ PRs) are not CLI flags - the ticket is joined from the session index at post
 time. No em-dashes in title/body - they are scrubbed on the way out.
 
 Configure where a post is mirrored under feed.broadcast in agents.yaml - see
-docs/observability.md. A milestone is always recorded, but it does not text
+docs/observability.md. A channel sink may set message: with placeholders such
+as {message} and {ticket}; a missing placeholder skips that sink. A milestone is always recorded, but it does not text
 the owner when the sink has minLevel: important. Add --level important for a
 phone-worthy successful update. Use --blocked only when work cannot continue.
 The owner destination comes from humans.yaml; do not duplicate it in agents.yaml.

--- a/cli/src/lib/feed-broadcast.test.ts
+++ b/cli/src/lib/feed-broadcast.test.ts
@@ -10,6 +10,7 @@ import {
   parseFeedPostLevel,
   planFeedBroadcast,
   renderSinkArgv,
+  renderSinkMessage,
   runFeedBroadcast,
   withDesktopNotify,
   DESKTOP_NOTIFY_SINK,
@@ -68,6 +69,19 @@ describe('sink argv rendering', () => {
   it('keeps post text as one argv element, never shell syntax', () => {
     const argv = renderSinkArgv(['echo', '{text}'], ctx({ text: 'done; rm -rf / && echo pwned' }));
     expect(argv).toEqual(['echo', 'done; rm -rf / && echo pwned']);
+  });
+});
+
+describe('channel message rendering', () => {
+  it('renders ticket-aware channel copy from the same placeholder context', () => {
+    expect(renderSinkMessage(
+      '{message}\nhttps://linear.app/getrush/issue/{ticket}',
+      ctx({ ticket: 'PHNX-3572' }),
+    )).toContain('https://linear.app/getrush/issue/PHNX-3572');
+  });
+
+  it('skips a channel template when required ticket context is absent', () => {
+    expect(renderSinkMessage('{message}\nTicket: {ticket}', ctx())).toBeUndefined();
   });
 });
 
@@ -258,6 +272,29 @@ describe('channel sink planning', () => {
     expect(planned).toEqual([
       { name: 'tg', channel: 'telegram', to: '12345', text: composeBroadcastMessage(ctx()) },
     ]);
+  });
+
+  it('uses a custom channel message and gates it on ticket context', () => {
+    const config: FeedBroadcastConfig = {
+      engineering: {
+        channel: 'slack',
+        to: 'C01234567',
+        minLevel: 'important',
+        message: '{message}\nhttps://linear.app/getrush/issue/{ticket}',
+      },
+    };
+    expect(planFeedBroadcast(config, ctx({ level: 'important' }))).toEqual([]);
+
+    const [planned] = planFeedBroadcast(
+      config,
+      ctx({ level: 'important', ticket: 'PHNX-3572' }),
+    );
+    expect(planned).toMatchObject({
+      name: 'engineering',
+      channel: 'slack',
+      to: 'C01234567',
+    });
+    expect(planned.text).toContain('https://linear.app/getrush/issue/PHNX-3572');
   });
 
   it('gates a channel sink by minLevel exactly like a command sink', () => {

--- a/cli/src/lib/feed-broadcast.ts
+++ b/cli/src/lib/feed-broadcast.ts
@@ -71,6 +71,13 @@ export interface FeedSinkConfig {
   channel?: string;
   /** Recipient for a `channel` sink. Required unless `channel` is the `owner` alias. */
   to?: string;
+  /**
+   * Optional channel body template. Uses the same placeholders as `command`
+   * argv (`{message}`, `{ticket}`, `{project}`, ...). Defaults to `{message}`.
+   * A missing placeholder skips the sink, which lets a `{ticket}` template
+   * declare that only ticket-backed posts belong in that destination.
+   */
+  message?: string;
   /** Lowest post level that reaches this sink. Defaults to `milestone` (all posts). */
   minLevel?: FeedPostLevel;
 }
@@ -425,6 +432,26 @@ export function renderSinkArgv(
   return argv.length > 0 ? argv : undefined;
 }
 
+/** Render one channel-message template with the same fail-closed placeholder contract as argv. */
+export function renderSinkMessage(
+  template: string,
+  ctx: FeedBroadcastContext,
+): string | undefined {
+  const vars = templateVars(ctx);
+  let missing = false;
+  const rendered = template.replace(PLACEHOLDER, (whole, key: string) => {
+    const value = vars[key];
+    if (value === undefined || value === '') {
+      missing = true;
+      return whole;
+    }
+    return value;
+  });
+  if (missing) return undefined;
+  const text = rendered.trim();
+  return text || undefined;
+}
+
 /**
  * Which sinks this post reaches, in config order. Pure — the dry-run listing and
  * the real fan-out plan through here, so what `--dry-run` shows is what runs.
@@ -451,11 +478,13 @@ export function planFeedBroadcast(
       // sink can never fire with a hole in it (same contract as a missing argv
       // placeholder below).
       if (!isOwnerAlias(channel) && !sink.to?.trim()) continue;
+      const text = renderSinkMessage(sink.message ?? '{message}', ctx);
+      if (!text) continue;
       planned.push({
         name,
         channel,
         to: isOwnerAlias(channel) ? undefined : sink.to!.trim(),
-        text: composeBroadcastMessage(ctx),
+        text,
       });
       continue;
     }

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -994,7 +994,9 @@ export interface Meta {
   /**
    * `agents feed post` fan-out. `broadcast` maps a sink name to either an argv
    * template (`command:`, run for each post) or an in-process channel delivery
-   * (`channel:`, the same registry `agents send`/`agents notify` use), so
+   * (`channel:`, the same registry `agents send`/`agents notify` use). Channel
+   * sinks may set `message:` with feed placeholders; a missing placeholder
+   * skips that sink, so `{ticket}` cleanly gates a tracker-specific channel. Thus
    * mirroring to a tracker, a messaging CLI, or a channel provider is the
    * operator's config rather than an integration compiled into this CLI. When
    * this is unset/empty, an important-level post falls back to `notify.owner`


### PR DESCRIPTION
## Outcome

Lets a feed channel sink customize its outbound body with the existing feed placeholders. A missing placeholder skips that sink, enabling ticket-gated team routing without compiling Linear or Slack assumptions into agents-cli.

## Behavior

```yaml
engineering:
  channel: slack
  to: C01234567
  minLevel: important
  message: |-
    {message}
    https://linear.app/example/issue/{ticket}
```

Posts with ticket context receive a clickable issue URL. Posts without a ticket do not enter the engineering sink. Private owner delivery remains independent.

## Verification

- `bun run vitest run src/lib/feed-broadcast.test.ts src/commands/feed.test.ts` — 2 files, 70 tests passed.
- `bun run build` — TypeScript clean.
- `git diff --check` — clean.

## Tracking

PHNX-3572

## Companion audit

The private user configuration needs a companion PR adding the existing Slack engineering destination. It will remain unmerged until this behavior is released, because older clients ignore `message:` and would over-broadcast.