### PR TITLE
fix(feed): forward Rush sinks to a Mac peer

### DIFF
--- a/cli/.changelog/next/PHNX-3572-rush-peer.md
+++ b/cli/.changelog/next/PHNX-3572-rush-peer.md
@@ -1,0 +1,1 @@
+- Fixed Rush-backed feed channel sinks failing on Linux workers by handing delivery to a reachable macOS fleet peer with the Keychain-bound transport.

--- a/cli/src/lib/feed-broadcast.test.ts
+++ b/cli/src/lib/feed-broadcast.test.ts
@@ -504,6 +504,22 @@ describe.skipIf(process.platform === 'win32')('feed owner sink forwards over SSH
     expect(log).toContain('send');
   });
 
+  it('forwards an explicit Slack sink to the macOS peer', async () => {
+    const meta = { config: { interactiveHost: 'mac-test' } } as Meta;
+    const planned = planFeedBroadcast(
+      { engineering: { channel: 'slack', to: 'CENGINEERING' } },
+      ctx({ level: 'important' }),
+    );
+    const outcomes = await runFeedBroadcast(planned, meta);
+
+    expect(outcomes).toEqual([{ name: 'engineering', ok: true }]);
+    const log = fs.readFileSync(sshRecord, 'utf-8');
+    expect(log).toContain('mac-test.example');
+    expect(log).toContain('slack');
+    expect(log).toContain('CENGINEERING');
+    expect(log).toContain('AGENTS_OWNER_NO_FORWARD');
+  });
+
   it('keeps the clean local failure when no capable peer exists', async () => {
     fs.writeFileSync(path.join(process.env.AGENTS_DEVICES_DIR!, 'registry.json'), JSON.stringify({}));
     const meta = { notify: { owner: { channel: 'imessage', to: '+18055551234' } } } as Meta;

--- a/cli/src/lib/feed-broadcast.ts
+++ b/cli/src/lib/feed-broadcast.ts
@@ -39,6 +39,7 @@ import { isOwnerAlias, readOwnerDest, resolveSendEnvelope, deliverEnvelope } fro
 import { lookupTransport } from './channels/resolve.js';
 import { registerBuiltinProviders } from './channels/providers/index.js';
 import { sendToOwner } from './notify.js';
+import { forwardOwnerNotifyToPeer } from './channels/owner-forward.js';
 
 /** How loudly a post asks to be heard. Ordered — `important` implies milestone. */
 export type FeedPostLevel = 'milestone' | 'important';
@@ -618,6 +619,19 @@ async function runChannelSink(sink: PlannedSink, meta: Meta): Promise<SinkOutcom
 
   const result = await deliverEnvelope(resolved.envelope, meta);
   if (result.ok) return { name, ok: true };
+
+  // Explicit rush-backed channel sinks need the same cross-device handoff as
+  // the owner alias. Linux workers do not carry the macOS Keychain-bound Rush
+  // transport, but feed posts originate on those workers routinely. Keep the
+  // destination explicit so the peer delivers exactly this sink once instead
+  // of expanding the owner's multi-channel policy.
+  const forwarded = await forwardOwnerNotifyToPeer(
+    resolved.envelope.text,
+    resolved.envelope.channel,
+    resolved.envelope.to,
+    meta,
+  );
+  if (forwarded?.ok) return { name, ok: true };
 
   return { name, ok: false, error: result.error };
 }


### PR DESCRIPTION
## What
- forward explicit Rush-backed feed channel sinks to a reachable macOS fleet peer when local delivery fails
- preserve the explicit channel and destination so owner policy is not expanded
- cover the real absent-Rush + SSH handoff path

## Why
PHNX-3572 was published, but a live Linux-worker post selected the engineering Slack sink and failed with `rush CLI not found on PATH`. The Rush transport is Keychain-bound on macOS, so explicit feed sinks need the same fleet handoff already used by owner notifications.

## Verification
- `bun run vitest run src/lib/feed-broadcast.test.ts` (45/45)
- `bun run build`
- `git diff --check`

Ticket: PHNX-3572