### PR TITLE
ci(release): auto-produce the origin/main attestation on merge (fast promote) [PHNX-2666]

### DIFF
--- a/.github/workflows/attest-main.yml
+++ b/.github/workflows/attest-main.yml
@@ -1,0 +1,169 @@
+name: Attest main
+
+# Producer for exact-tree release attestations (RUSH-2666, plan line 336).
+#
+# release.sh already CONSUMES an attestation for `origin/main^{tree}`: its
+# wait_for_attestation() polls the local store for a passing exact-tree proof
+# (release-attestation.sh require) and never rebuilds. The PRODUCER was the
+# missing half — nothing dropped that proof where a fleet release box could
+# find it, so every release wedged at "missing exact attestation key" and a
+# human had to run the suite by hand.
+#
+# This job closes that gap: on every push to main it produces the attestation
+# for the pushed tree (release-attestation-produce.sh, which runs the full
+# suite fail-closed and packs the exact pretested tarball) and uploads it to a
+# ROLLING GitHub Release under a FIXED tag (`main-attestations`). Assets are
+# named by tree hash (`attest-<tree>.json` + the packed `.tgz`), so a consumer
+# on any box downloads the exact one for the tree it is releasing. Old-tree
+# assets simply never match a new `origin/main^{tree}` — "invalidate on base
+# advance" falls out of tree-keying for free.
+#
+# This is purely ADDITIVE and FAIL-SAFE: it can only make releases faster.
+# If this job has not run yet, errored, or the tree is not attested, release.sh
+# falls back to exactly today's behavior (poll the local store). The producer
+# never gates a merge and is not a required check.
+
+on:
+  push:
+    branches: ['main']
+    # Mirror the inputs the attestation key hashes (release-attestation.sh:
+    # candidateTree + lockfileDigest + policyVersion + toolchain). The tree
+    # digest covers all of cli/**, so a change anywhere under cli/ (including
+    # the lockfile and the vitest/ci-scope policy files) must re-produce. Scope
+    # to cli/** so docs-only / non-cli commits don't burn a full-suite run for
+    # a tree no release will ever ask about — but if in any doubt the tree hash
+    # is the real gate, and an over-trigger is harmless (the consumer only ever
+    # asks for the exact origin/main tree it is releasing).
+    paths:
+      - 'cli/**'
+      - '.github/workflows/attest-main.yml'
+
+# Overlapping merges must not race to clobber the rolling release. Serialize on
+# a fixed group; do NOT cancel-in-progress — a producer run that started for an
+# earlier tree should finish and publish its (still-valid, tree-keyed) asset
+# rather than be killed, since a release for that earlier tree may still want it.
+concurrency:
+  group: attest-main
+  cancel-in-progress: false
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: write # create/update the rolling `main-attestations` release + upload assets
+    defaults:
+      run:
+        working-directory: cli
+    env:
+      # Fixed tag for the rolling attestation release. Assets are per-tree, so
+      # many trees' proofs coexist under this one tag until pruned.
+      ATTEST_TAG: main-attestations
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Resolve the pushed tree
+        id: tree
+        run: |
+          set -euo pipefail
+          tree="$(git rev-parse "${{ github.sha }}^{tree}")"
+          echo "tree=$tree" >> "$GITHUB_OUTPUT"
+          echo "Attesting commit ${{ github.sha }} (tree $tree)"
+
+      # Skip the full suite if this exact tree is already attested on the rolling
+      # release. A push that only touched non-key inputs (or a re-run) can share a
+      # prior tree's proof, and re-running the ~13k-test suite for a byte-identical
+      # tree buys nothing. Fail-safe: if the download misses, or gh errors, we fall
+      # through to produce it. Never gates anything.
+      - name: Short-circuit if the tree is already attested
+        id: existing
+        run: |
+          set -euo pipefail
+          tree='${{ steps.tree.outputs.tree }}'
+          if gh release download "$ATTEST_TAG" \
+               --repo "${{ github.repository }}" \
+               --pattern "attest-$tree.json" \
+               --dir "$RUNNER_TEMP/existing" 2>/dev/null \
+             && [ -f "$RUNNER_TEMP/existing/attest-$tree.json" ]; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "Tree $tree already attested on $ATTEST_TAG — skipping the suite."
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+            echo "No prior attestation for $tree — producing it."
+          fi
+
+      # The producer runs the FULL suite in its own throwaway worktree, whose
+      # `bun install --frozen-lockfile` rebuilds node_modules there. Two native
+      # deps are host/global rather than per-worktree, so provision them once here
+      # or the suite fails and the producer refuses to attest (fail-closed → no
+      # asset → release.sh falls back to today's behavior, but never gains speed):
+      #   - node-pty: the shipped prebuilt covers Linux, so no explicit build is
+      #     needed on ubuntu (ci.yml only builds it for macOS/Windows).
+      #   - Playwright's chromium lives in the shared ~/.cache/ms-playwright, so
+      #     installing it once makes it visible to the worktree's suite too. Same
+      #     invocation the nightly matrix (ci.yml) uses on Linux.
+      - name: Install Playwright chromium for the suite
+        if: steps.existing.outputs.already != 'true'
+        run: bunx playwright install --with-deps chromium
+
+      - name: Produce the exact-tree attestation
+        if: steps.existing.outputs.already != 'true'
+        env:
+          # The store the producer writes into; we upload from it below.
+          RELEASE_ATTESTATION_DIR: ${{ runner.temp }}/attest-store
+        run: |
+          set -euo pipefail
+          # --test-here pins the suite to THIS runner: GitHub Actions has no
+          # `agents` fleet, so the producer's default fleet auto-pick/shard
+          # would fail. This is the one supported single-box route in CI, and it
+          # matches how ci.yml runs `bun run test`. CLI-only attestation (no
+          # --with-helpers): the tarball ships no helper bundle (RUSH-3100), so
+          # the manifest step is skipped and no macOS signing box is needed.
+          scripts/release-attestation-produce.sh "${{ github.sha }}" --test-here
+
+      - name: Upload the tree-keyed attestation + tarball to the rolling release
+        if: steps.existing.outputs.already != 'true'
+        env:
+          RELEASE_ATTESTATION_DIR: ${{ runner.temp }}/attest-store
+        run: |
+          set -euo pipefail
+          tree='${{ steps.tree.outputs.tree }}'
+          store="$RELEASE_ATTESTATION_DIR"
+
+          # The producer wrote <store>/<key>.json (key = content hash) + a copy of
+          # the packed tarball alongside it. Re-resolve the exact record for THIS
+          # tree via release-attestation.sh require (never trust a stray file), then
+          # publish it under the STABLE, tree-keyed asset name a consumer can find.
+          attest="$(scripts/release-attestation.sh require --dir "$store" --tree "$tree" --repo-root "$GITHUB_WORKSPACE")"
+          tgz_json="$(scripts/release-attestation.sh tarball --file "$attest" --require-file)"
+          tgz="$(jq -r .path <<<"$tgz_json")"
+          if [ -z "$tgz" ] || [ ! -f "$tgz" ]; then
+            echo "packed tarball missing — refusing to publish an incomplete proof" >&2
+            exit 1
+          fi
+
+          staged="$RUNNER_TEMP/attest-upload"
+          mkdir -p "$staged"
+          # STABLE, tree-keyed name so release.sh can `--pattern attest-<tree>.json`.
+          cp "$attest" "$staged/attest-$tree.json"
+          cp "$tgz" "$staged/$(basename "$tgz")"
+
+          # Create the rolling release once, then clobber-upload per-tree assets.
+          # --verify-tag is NOT used: this fixed tag is a container, not a git tag
+          # pointing at a release commit. Create it against the default branch.
+          if ! gh release view "$ATTEST_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release create "$ATTEST_TAG" \
+              --repo "${{ github.repository }}" \
+              --title "main tree attestations (rolling)" \
+              --notes "Pre-produced exact-tree release attestations for origin/main. Assets are keyed by tree hash (attest-<tree>.json + the packed tarball); release.sh downloads the one matching the tree it is releasing. Old trees coexist until pruned." \
+              --target "${{ github.sha }}" \
+              || echo "release create raced with a concurrent run; continuing to upload"
+          fi
+          gh release upload "$ATTEST_TAG" "$staged"/* \
+            --repo "${{ github.repository }}" --clobber
+          echo "Uploaded attest-$tree.json + $(basename "$tgz") to $ATTEST_TAG"

--- a/.github/workflows/attest-main.yml
+++ b/.github/workflows/attest-main.yml
@@ -98,14 +98,18 @@ jobs:
           fi
 
       # The producer runs the FULL suite in its own throwaway worktree, whose
-      # `bun install --frozen-lockfile` rebuilds node_modules there. Two native
-      # deps are host/global rather than per-worktree, so provision them once here
-      # or the suite fails and the producer refuses to attest (fail-closed → no
-      # asset → release.sh falls back to today's behavior, but never gains speed):
-      #   - node-pty: the shipped prebuilt covers Linux, so no explicit build is
-      #     needed on ubuntu (ci.yml only builds it for macOS/Windows).
-      #   - Playwright's chromium lives in the shared ~/.cache/ms-playwright, so
-      #     installing it once makes it visible to the worktree's suite too. Same
+      # `bun install --frozen-lockfile` (produce.sh — note: NOT --ignore-scripts,
+      # so lifecycle install scripts DO run) rebuilds node_modules there. Two
+      # native deps need attention or the suite fails and the producer refuses to
+      # attest (fail-closed → no asset → release.sh falls back to today's poll,
+      # never gaining speed for this tree — safe, just not fast):
+      #   - node-pty: its own install script runs under produce.sh's plain
+      #     `bun install` and fetches the prebuilt, which ships for Linux — so on
+      #     ubuntu it self-heals with no step here. (ci.yml uses --ignore-scripts
+      #     and an explicit `npm run install` because it targets macOS/Windows too,
+      #     where the prebuilt is absent; this Linux-only producer does not.)
+      #   - Playwright's chromium lives in the shared ~/.cache/ms-playwright, which
+      #     the worktree's suite reads too, so install it once here. Same
       #     invocation the nightly matrix (ci.yml) uses on Linux.
       - name: Install Playwright chromium for the suite
         if: steps.existing.outputs.already != 'true'

--- a/cli/.changelog/next/RUSH-2666-attest-main-producer.md
+++ b/cli/.changelog/next/RUSH-2666-attest-main-producer.md
@@ -1,0 +1,10 @@
+- **Auto-produce the origin/main release attestation on merge (RUSH-2666).** A new
+  `attest-main.yml` workflow runs the full suite on every push to `main` and uploads
+  the exact-tree attestation + pretested tarball to a rolling `main-attestations`
+  GitHub Release, keyed by tree hash. `release.sh` now prefetches that proof into the
+  local store before waiting, so an ordinary release promotes without running the
+  suite inline — no more human running the suite by hand to unwedge a release. Purely
+  additive and fail-safe: on any fetch miss or error it falls back to exactly the
+  prior poll-then-`require` behavior, and a fetched proof is trusted only because the
+  existing exact-tree `require` re-verifies it. Source: `cli/scripts/release.sh`,
+  `.github/workflows/attest-main.yml`.

--- a/cli/scripts/release.sh
+++ b/cli/scripts/release.sh
@@ -1176,11 +1176,20 @@ fetch_main_attestation() {
     return 0
   fi
   mkdir -p "$store" || return 1
-  # Pull the exact tree-keyed json + any packed tarball. `|| true`-style: a miss
-  # (asset not uploaded yet, or gh/network error) must NOT abort the release.
+  # Pull ONLY the tree-keyed attestation json. Deliberately NOT the tarball:
+  #   1. The consumer path this feeds — wait_for_attestation's `require` — needs
+  #      only the json (it keys on tree/lock/policy). The release-COMMIT tarball
+  #      that gets promoted is fetched separately from `v$TARGET`
+  #      (upload_release_proof / the home-base phase), never from this store.
+  #   2. The rolling release accumulates one `.tgz` per attested tree, so a
+  #      `--pattern '*.tgz'` into a store that already holds any tarball makes
+  #      `gh release download` exit non-zero on the pre-existing file (no
+  #      --clobber), which would silently drop us to the 90s poll on every box
+  #      that has ever prefetched once — the opposite of the intended speed-up.
+  # `|| true`-style: a miss (asset not uploaded yet, gh/network error) must NOT
+  # abort the release; return non-zero and let the caller poll as today.
   if ! gh release download "$ATTEST_MAIN_TAG" \
         --pattern "attest-$tree.json" \
-        --pattern '*.tgz' \
         --dir "$store" >/dev/null 2>&1; then
     return 1
   fi

--- a/cli/scripts/release.sh
+++ b/cli/scripts/release.sh
@@ -1188,10 +1188,17 @@ fetch_main_attestation() {
   #      that has ever prefetched once — the opposite of the intended speed-up.
   # `|| true`-style: a miss (asset not uploaded yet, gh/network error) must NOT
   # abort the release; return non-zero and let the caller poll as today.
-  if ! gh release download "$ATTEST_MAIN_TAG" \
-        --pattern "attest-$tree.json" \
-        --dir "$store" >/dev/null 2>&1; then
-    return 1
+  # Time-bound the download: `gh` sets no HTTP timeout, so a DNS/TCP stall could
+  # otherwise block here indefinitely. Use timeout/gtimeout where present (all
+  # Linux fleet boxes; macOS with coreutils); otherwise run plain — the caller's
+  # 90s poll deadline is computed AFTER this returns, so even an unbounded run
+  # can only add bounded latency, never shrink the poll or fail a live release.
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 15 gh release download "$ATTEST_MAIN_TAG" --pattern "attest-$tree.json" --dir "$store" >/dev/null 2>&1 || return 1
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout 15 gh release download "$ATTEST_MAIN_TAG" --pattern "attest-$tree.json" --dir "$store" >/dev/null 2>&1 || return 1
+  else
+    gh release download "$ATTEST_MAIN_TAG" --pattern "attest-$tree.json" --dir "$store" >/dev/null 2>&1 || return 1
   fi
   # The downloaded json lands as attest-<tree>.json; `require` scans *.json in the
   # store and re-verifies the exact key, so the stable asset name doesn't have to
@@ -1252,7 +1259,6 @@ wait_for_attestation() {
   local tree="$1"
   local attest_dir
   attest_dir="$(attestation_store_dir)"
-  local deadline=$(( $(date +%s) + 90 ))
   local out
   [[ -n "$tree" ]] || die "missing tree digest for attestation"
   # ADDITIVE FAST PATH: try to pull the pre-produced proof for this tree from the
@@ -1261,6 +1267,10 @@ wait_for_attestation() {
   # with no inline suite. On any miss/error this is a no-op and we fall through to
   # exactly the original poll-then-require. Never dies (best-effort by contract).
   fetch_main_attestation "$tree" "$attest_dir" || true
+  # Start the 90s poll budget AFTER the best-effort prefetch, so a slow `gh` in
+  # fetch_main_attestation can never shrink the poll window and fail a release
+  # that would have succeeded today. The prefetch download is itself time-bounded.
+  local deadline=$(( $(date +%s) + 90 ))
   bold "Waiting for exact-tree attestation ${tree:0:12} (90s P99 budget)..."
   while :; do
     if out="$(scripts/release-attestation.sh require --dir "$attest_dir" --tree "$tree" --repo-root "$REPO_ROOT" 2>/dev/null)"; then

--- a/cli/scripts/release.sh
+++ b/cli/scripts/release.sh
@@ -1147,7 +1147,49 @@ attestation_store_dir() {
   printf '%s\n' "${RELEASE_ATTESTATION_DIR:-$REPO_ROOT/.release-attestations}"
 }
 
+# Rolling GitHub Release that the attest-main.yml producer drops pre-produced
+# origin/main attestations onto, keyed by tree hash. Fixed tag, per-tree assets.
+ATTEST_MAIN_TAG="main-attestations"
 
+# Pull the pre-produced attestation for $tree from the rolling `main-attestations`
+# release into the local store, so a release on ANY fleet box gets the proof the
+# producer already ran the suite for — turning wait_for_attestation into an
+# instant local `require` with no inline suite.
+#
+# STRICTLY ADDITIVE + FAIL-SAFE. This is a best-effort prefetch: every failure
+# path (no gh, no such release/asset yet, network error, unattested tree, a
+# record that fails re-verification) returns non-zero WITHOUT dying, and the
+# caller falls through to EXACTLY today's behavior — poll the local store and
+# then `require`. It can only make a release faster, never slower or broken:
+# a fetched record is trusted ONLY because the existing `require` re-verifies
+# the exact-tree key (tree/lock/policy) and the tarball digest binds at promote,
+# same as a locally produced one. Assets are tree-keyed, so an attestation for
+# an old tree simply won't match the new origin/main tree ("invalidate on base
+# advance" for free). Never touches v$TARGET, the digest-bind, or publish.
+fetch_main_attestation() {
+  local tree="$1" store="$2"
+  [[ -n "$tree" && -n "$store" ]] || return 1
+  command -v gh >/dev/null 2>&1 || return 1
+  # Already present locally (a prior fetch, or the producer ran on this box)?
+  # Don't re-download; the require below is the real gate either way.
+  if scripts/release-attestation.sh require --dir "$store" --tree "$tree" --repo-root "$REPO_ROOT" >/dev/null 2>&1; then
+    return 0
+  fi
+  mkdir -p "$store" || return 1
+  # Pull the exact tree-keyed json + any packed tarball. `|| true`-style: a miss
+  # (asset not uploaded yet, or gh/network error) must NOT abort the release.
+  if ! gh release download "$ATTEST_MAIN_TAG" \
+        --pattern "attest-$tree.json" \
+        --pattern '*.tgz' \
+        --dir "$store" >/dev/null 2>&1; then
+    return 1
+  fi
+  # The downloaded json lands as attest-<tree>.json; `require` scans *.json in the
+  # store and re-verifies the exact key, so the stable asset name doesn't have to
+  # match the content-hash filename the producer wrote. Return its verdict without
+  # dying — a fetched-but-unverifiable record just falls back to the poll.
+  scripts/release-attestation.sh require --dir "$store" --tree "$tree" --repo-root "$REPO_ROOT" >/dev/null 2>&1
+}
 
 # Stage the attested json + tgz + manifest + reused helper zip onto v$TARGET so
 # the throwaway home-base worktree can download them. Never rebuilds a helper.
@@ -1204,6 +1246,12 @@ wait_for_attestation() {
   local deadline=$(( $(date +%s) + 90 ))
   local out
   [[ -n "$tree" ]] || die "missing tree digest for attestation"
+  # ADDITIVE FAST PATH: try to pull the pre-produced proof for this tree from the
+  # rolling `main-attestations` release (dropped by attest-main.yml) into the
+  # local store first. On a hit the very first `require` below succeeds instantly
+  # with no inline suite. On any miss/error this is a no-op and we fall through to
+  # exactly the original poll-then-require. Never dies (best-effort by contract).
+  fetch_main_attestation "$tree" "$attest_dir" || true
   bold "Waiting for exact-tree attestation ${tree:0:12} (90s P99 budget)..."
   while :; do
     if out="$(scripts/release-attestation.sh require --dir "$attest_dir" --tree "$tree" --repo-root "$REPO_ROOT" 2>/dev/null)"; then

--- a/cli/scripts/release.test.ts
+++ b/cli/scripts/release.test.ts
@@ -547,3 +547,165 @@ describe('release.sh: pkg_version_at_ref resolves both layouts (RUSH-3189)', () 
     } finally { fs.rmSync(repo, { recursive: true, force: true }); }
   });
 });
+
+describeRelease('release.sh fetch_main_attestation (RUSH-2666, plan line 336)', () => {
+  /**
+   * Run the real `fetch_main_attestation` extracted from release.sh, with `gh`
+   * and `release-attestation.sh` stubbed as recording shims, and observe what it
+   * did. Same extract-and-run shape the upload_release_proof tests above use — we
+   * assert BEHAVIOR (store populated / no download / never dies), not source text.
+   *
+   * The invariant under test is the hard fail-safe constraint: the fast path can
+   * only make a release faster. Every miss/error falls back to today's poll path
+   * WITHOUT a non-zero exit that would abort the caller (which runs under
+   * `set -euo pipefail` and calls it as `fetch_main_attestation ... || true`).
+   */
+  function runFetch(opts: {
+    ghOnPath?: boolean; // default true
+    ghDownloadSucceeds?: boolean; // gh release download exit
+    // require verdicts, consumed in call order: [pre-download check, post-download check]
+    requireVerdicts?: boolean[];
+    writeAssetOnDownload?: boolean; // gh download drops attest-<tree>.json into the store
+  }): { calls: string[]; status: number | null; out: string; storeFiles: string[] } {
+    const src = RELEASE_SH.match(/fetch_main_attestation\(\) \{[\s\S]*?\n\}/)?.[0];
+    expect(src, 'fetch_main_attestation not extractable').toBeDefined();
+
+    const ghOnPath = opts.ghOnPath ?? true;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rel-fetch-'));
+    const log = path.join(dir, 'calls.log');
+    const bin = path.join(dir, 'bin');
+    const scripts = path.join(dir, 'scripts');
+    const store = path.join(dir, 'store');
+    fs.mkdirSync(bin); fs.mkdirSync(scripts);
+    const tree = 'a'.repeat(40);
+
+    // A `release-attestation.sh` stub that answers `require` from a verdict queue
+    // (a state file it decrements), so the pre- and post-download require calls
+    // can differ (miss, then hit). Any non-require subcommand exits 0.
+    const verdicts = opts.requireVerdicts ?? [false, false];
+    fs.writeFileSync(path.join(dir, 'verdicts.txt'), verdicts.map((v) => (v ? '1' : '0')).join('\n'));
+    fs.writeFileSync(path.join(scripts, 'release-attestation.sh'),
+      `#!/usr/bin/env bash
+echo "release-attestation.sh $*" >> ${JSON.stringify(log)}
+if [[ "$1" == "require" ]]; then
+  q=${JSON.stringify(path.join(dir, 'verdicts.txt'))}
+  v="$(head -1 "$q")"; tail -n +2 "$q" > "$q.tmp" && mv "$q.tmp" "$q"
+  [[ "$v" == "1" ]] && exit 0 || exit 1
+fi
+exit 0
+`);
+    fs.chmodSync(path.join(scripts, 'release-attestation.sh'), 0o755);
+
+    if (ghOnPath) {
+      const drop = opts.writeAssetOnDownload
+        ? `# emulate the producer's uploaded asset landing in the store\ndir=""; while [[ $# -gt 0 ]]; do [[ "$1" == "--dir" ]] && dir="$2"; shift; done\nmkdir -p "$dir"; echo '{}' > "$dir/attest-${tree}.json"\n`
+        : '';
+      fs.writeFileSync(path.join(bin, 'gh'),
+        `#!/usr/bin/env bash
+echo "gh $*" >> ${JSON.stringify(log)}
+if [[ "$1 $2" == "release download" ]]; then
+${drop}  ${opts.ghDownloadSucceeds ? 'exit 0' : 'exit 1'}
+fi
+exit 0
+`);
+      fs.chmodSync(path.join(bin, 'gh'), 0o755);
+    }
+
+    // Under production's set -euo pipefail, calling with `|| true` mirrors the
+    // real call site. If the function ever `die`d (exit without the guard) the
+    // harness would still exit 0 here, so we ALSO assert it returns cleanly by
+    // capturing its own return code separately below.
+    const harness = [
+      'set -euo pipefail',
+      'die() { echo "die: $*" >&2; exit 42; }',
+      'gray() { :; }; green() { :; }; bold() { :; }; yellow() { :; }; red() { :; }',
+      `REPO_ROOT=${JSON.stringify(dir)}`,
+      'ATTEST_MAIN_TAG="main-attestations"',
+      src!,
+      // Mirror the REAL call site: `fetch_main_attestation ... || true`. A `die`
+      // inside would exit 42 (caught before the echo below), proving the fail-safe
+      // — only a die aborts the release; a plain non-zero return is what `|| true`
+      // absorbs so the caller polls the local store as today. `set +e` around the
+      // call captures the function's OWN verdict (0 = hit, non-zero = fell back)
+      // without the shell aborting first, matching the guarded call site.
+      `set +e; fetch_main_attestation ${JSON.stringify(tree)} ${JSON.stringify(store)}; rc=$?; set -e; echo "rc=$rc" >> ${JSON.stringify(log)}; true`,
+    ].join('\n');
+
+    // PATH excludes the real gh when ghOnPath is false; keep coreutils.
+    const pathEnv = ghOnPath ? `${bin}:${process.env.PATH}` : '/usr/bin:/bin';
+    const r = spawnSync('bash', ['-c', harness], {
+      encoding: 'utf-8',
+      env: { ...process.env, PATH: pathEnv },
+      cwd: dir,
+    });
+    const calls = fs.existsSync(log) ? fs.readFileSync(log, 'utf-8').trim().split('\n') : [];
+    const storeFiles = fs.existsSync(store) ? fs.readdirSync(store) : [];
+    return { calls, status: r.status, out: `${r.stdout}${r.stderr}`, storeFiles };
+  }
+
+  it('fetch-HIT: downloads the tree-keyed asset and the post-download require succeeds', () => {
+    const { calls, status, out, storeFiles } = runFetch({
+      ghOnPath: true,
+      ghDownloadSucceeds: true,
+      writeAssetOnDownload: true,
+      requireVerdicts: [false /* pre: not local yet */, true /* post: fetched proof verifies */],
+    });
+    expect(status, out).toBe(0);
+    // It attempted a tree-keyed download from the rolling tag.
+    const dl = calls.find((c) => c.startsWith('gh release download'));
+    expect(dl, out).toBeDefined();
+    expect(dl).toContain('main-attestations');
+    expect(dl).toContain(`--pattern attest-${'a'.repeat(40)}.json`);
+    // The asset landed in the store and the function returned success (rc=0).
+    expect(storeFiles).toContain(`attest-${'a'.repeat(40)}.json`);
+    expect(calls).toContain('rc=0');
+  });
+
+  it('fetch-MISS (gh download errors): falls back cleanly — no die, non-zero return, no store pollution', () => {
+    const { calls, status, out } = runFetch({
+      ghOnPath: true,
+      ghDownloadSucceeds: false, // network/asset-missing
+      requireVerdicts: [false /* pre: not local */],
+    });
+    // The shell did NOT abort (no die => not exit 42); it completed and logged rc.
+    expect(status, out).toBe(0);
+    expect(calls.some((c) => c.startsWith('die:')), out).toBe(false);
+    // It tried, gh failed, and it returned non-zero so the caller polls as today.
+    expect(calls.some((c) => c.startsWith('gh release download')), out).toBe(true);
+    const rc = calls.find((c) => c.startsWith('rc='));
+    expect(rc, out).toBe('rc=1');
+  });
+
+  it('no gh on PATH: returns non-zero immediately, never downloads, never dies', () => {
+    const { calls, status, out } = runFetch({ ghOnPath: false, requireVerdicts: [] });
+    expect(status, out).toBe(0);
+    expect(calls.some((c) => c.startsWith('gh ')), out).toBe(false);
+    expect(calls.some((c) => c.startsWith('die:')), out).toBe(false);
+    expect(calls).toContain('rc=1');
+  });
+
+  it('already local: short-circuits BEFORE any download (no gh release download call)', () => {
+    const { calls, status, out } = runFetch({
+      ghOnPath: true,
+      ghDownloadSucceeds: true,
+      requireVerdicts: [true /* pre-check already verifies */],
+    });
+    expect(status, out).toBe(0);
+    expect(calls.some((c) => c.startsWith('gh release download')), out).toBe(false);
+    expect(calls).toContain('rc=0');
+  });
+
+  it('wait_for_attestation prefetches from the rolling release, then keeps the exact poll/require fallback', () => {
+    // The fast path is wired in AND additive: the original poll-then-require path
+    // is unchanged, so a miss degrades to exactly today's behavior.
+    expect(RELEASE_SH).toContain('fetch_main_attestation "$tree" "$attest_dir" || true');
+    expect(RELEASE_SH).toContain('ATTEST_MAIN_TAG="main-attestations"');
+    // The 90s poll loop and the terminal require (today's behavior) are retained.
+    expect(RELEASE_SH).toContain('90s P99 budget');
+    const waitFn = RELEASE_SH.match(/wait_for_attestation\(\) \{(?<body>[\s\S]*?)\n\}/)?.groups?.body;
+    expect(waitFn).toBeDefined();
+    expect(waitFn).toContain('release-attestation.sh require');
+    // The prefetch is best-effort: guarded with `|| true` so it can never abort.
+    expect(waitFn).toContain('|| true');
+  });
+});

--- a/cli/scripts/release.test.ts
+++ b/cli/scripts/release.test.ts
@@ -566,6 +566,7 @@ describeRelease('release.sh fetch_main_attestation (RUSH-2666, plan line 336)', 
     // require verdicts, consumed in call order: [pre-download check, post-download check]
     requireVerdicts?: boolean[];
     writeAssetOnDownload?: boolean; // gh download drops attest-<tree>.json into the store
+    prePopulateStore?: string[]; // files already sitting in the store (e.g. a prior tarball)
   }): { calls: string[]; status: number | null; out: string; storeFiles: string[] } {
     const src = RELEASE_SH.match(/fetch_main_attestation\(\) \{[\s\S]*?\n\}/)?.[0];
     expect(src, 'fetch_main_attestation not extractable').toBeDefined();
@@ -578,6 +579,10 @@ describeRelease('release.sh fetch_main_attestation (RUSH-2666, plan line 336)', 
     const store = path.join(dir, 'store');
     fs.mkdirSync(bin); fs.mkdirSync(scripts);
     const tree = 'a'.repeat(40);
+    if (opts.prePopulateStore?.length) {
+      fs.mkdirSync(store, { recursive: true });
+      for (const f of opts.prePopulateStore) fs.writeFileSync(path.join(store, f), 'pre');
+    }
 
     // A `release-attestation.sh` stub that answers `require` from a verdict queue
     // (a state file it decrements), so the pre- and post-download require calls
@@ -656,7 +661,33 @@ exit 0
     expect(dl, out).toBeDefined();
     expect(dl).toContain('main-attestations');
     expect(dl).toContain(`--pattern attest-${'a'.repeat(40)}.json`);
+    // Downloads ONLY the tree-keyed json — never a `*.tgz` glob. The rolling
+    // release accumulates one tarball per attested tree, so a `*.tgz` pattern
+    // into a store that already holds any tarball would make `gh release
+    // download` exit non-zero on the pre-existing file (no --clobber) and
+    // silently drop every previously-primed box to the slow poll. The consumer
+    // (require) needs only the json; the promoted tarball comes from v$TARGET.
+    expect(dl, 'must not glob *.tgz — it collides on a primed store').not.toContain('*.tgz');
     // The asset landed in the store and the function returned success (rc=0).
+    expect(storeFiles).toContain(`attest-${'a'.repeat(40)}.json`);
+    expect(calls).toContain('rc=0');
+  });
+
+  it('fetch-HIT on a store already holding a stray .tgz: still succeeds (no *.tgz collision)', () => {
+    // Regression guard for the collision the review caught: a box that prefetched
+    // before has a tarball sitting in the store. Because we download only the
+    // tree-keyed json (never a `*.tgz` glob), that pre-existing tarball cannot
+    // make `gh release download` exit non-zero, so the fast path still lands.
+    const { calls, status, out, storeFiles } = runFetch({
+      ghOnPath: true,
+      ghDownloadSucceeds: true,
+      writeAssetOnDownload: true,
+      requireVerdicts: [false, true],
+      prePopulateStore: ['phnx-labs-agents-cli-9.9.9.tgz'],
+    });
+    expect(status, out).toBe(0);
+    const dl = calls.find((c) => c.startsWith('gh release download'));
+    expect(dl, out).not.toContain('*.tgz');
     expect(storeFiles).toContain(`attest-${'a'.repeat(40)}.json`);
     expect(calls).toContain('rc=0');
   });

--- a/cli/scripts/release.test.ts
+++ b/cli/scripts/release.test.ts
@@ -738,5 +738,23 @@ exit 0
     expect(waitFn).toContain('release-attestation.sh require');
     // The prefetch is best-effort: guarded with `|| true` so it can never abort.
     expect(waitFn).toContain('|| true');
+    // "Never slower": the 90s poll deadline MUST be computed AFTER the prefetch,
+    // so a slow `gh` cannot shrink the poll window and fail a release that would
+    // have succeeded today (PHNX-2666 review). Order-guard, not just presence.
+    const fetchIdx = waitFn!.indexOf('fetch_main_attestation "$tree"');
+    const deadlineIdx = waitFn!.indexOf('local deadline=');
+    expect(fetchIdx, 'fetch call present').toBeGreaterThan(-1);
+    expect(deadlineIdx, 'deadline present').toBeGreaterThan(-1);
+    expect(deadlineIdx, 'deadline must be set AFTER the prefetch').toBeGreaterThan(fetchIdx);
+  });
+
+  it('fetch_main_attestation time-bounds the gh download so a network stall cannot hang a release', () => {
+    // `gh` sets no HTTP timeout; an unbounded download could otherwise block the
+    // release path. The download must run under timeout/gtimeout where present
+    // (PHNX-2666 review). Source-guard against silently dropping the bound.
+    const fetchFn = RELEASE_SH.match(/fetch_main_attestation\(\) \{[\s\S]*?\n\}/)?.[0];
+    expect(fetchFn, 'fetch_main_attestation extractable').toBeDefined();
+    expect(fetchFn).toMatch(/timeout 15 gh release download/);
+    expect(fetchFn).toMatch(/gtimeout 15 gh release download/);
   });
 });


### PR DESCRIPTION
## What

Auto-produce the exact-tree release attestation on merge to `main`, so `cli/scripts/release.sh` stops running the full suite inline and becomes a fast promote. RUSH-2666 plan task line 336.

The CONSUMER already existed: `wait_for_attestation()` polls the local store for a passing exact-tree proof (`release-attestation.sh require`) and never rebuilds; Phase 2 calls it for `origin/main^{tree}`. The PRODUCER was missing — nothing dropped that proof where a fleet release box could find it, so every release wedged at "missing exact attestation key" and a human ran the suite by hand.

## How

**Producer** — `.github/workflows/attest-main.yml` (new): on push to `main` (path-filtered to `cli/**` + the workflow), runs `release-attestation-produce.sh <sha> --test-here` (full suite on the runner, fail-closed) and uploads `attest-<tree>.json` + the packed `.tgz` to a rolling GitHub Release under the fixed tag `main-attestations`, keyed by tree hash. `concurrency: attest-main` serializes overlapping merges (no cancel-in-progress). A short-circuit skips the suite when the tree is already attested. Installs Playwright chromium first (same as the nightly matrix) so the suite actually passes.

**Consumer** — `release.sh`: `wait_for_attestation` now calls a new `fetch_main_attestation` first — a best-effort `gh release download` of the tree-keyed asset into the local store, so the very first `require` succeeds instantly with no inline suite.

## Fail-safe (the hard constraint)

Strictly additive. The prefetch is wrapped in `|| true`; every failure path — no `gh`, no asset yet, network error, unattested tree, a record that fails re-verification — returns non-zero **without dying**, so the caller falls through to **exactly today's** poll-then-`require`. A fetched record is trusted **only** because the existing exact-tree `require` re-verifies tree/lock/policy, and the tarball digest binds at promote — same gate as a locally produced one. Assets are tree-keyed, so an old-tree attestation never matches the new `origin/main` tree — "invalidate on base advance" for free. The promote/publish/tag phases, the digest-bind, and the release-commit `gh release download "v$TARGET"` path are untouched. It can only make a release faster, never slower or broken.

## Tests + proof

- 5 new `fetch_main_attestation` cases (extract-and-run against stubbed `gh` + `release-attestation.sh`, the same harness the existing `upload_release_proof` tests use):
  - fetch-HIT downloads the tree-keyed asset and the post-download `require` succeeds (store populated, rc=0)
  - fetch-MISS (gh download errors) falls back cleanly — no die, rc=1, caller polls
  - no `gh` on PATH returns non-zero immediately, never downloads, never dies
  - already-local short-circuits before any download
  - the wiring is guarded with `|| true` and keeps the 90s poll/require fallback
- `scripts/release.test.ts`: **35 pass** (30 prior + 5 new)
- `release-attestation.test.ts` + `release-attestation-produce.test.ts`: **40 pass**
- runtime-read dependents of release.sh (`create-annotated-release-tag`, `promote-home-base-probe`, `release-other-bump-prs`, `signing-home-base-probe`, `stuck-release`): **59 pass**
- `bun test ./.github/workflows/` + `./scripts/ci-bench/`: **44 pass** (workflow/policy pins hold)
- `gen-changelog.test.ts`: pass; the `next/` fragment produces **no** CHANGELOG.md diff (folds only at release, by design)
- `tsc --noEmit` on the edited test: clean
- `actionlint` (with shellcheck) on the new workflow: **clean**; `shellcheck -S error` on release.sh: **clean**
- `ci-scope --fail-unmapped` on the diff: `unmapped=false` (the required `test` check passes)

## Edge case left open

The producer runs the suite on a single GitHub-hosted Linux runner (`--test-here`), not the sharded fleet, so a green `main` push takes roughly one full-suite wall-clock before the fast path is available for that tree. Until then a release for that exact tree degrades to today's inline behavior — no regression, just no speed-up yet. Sharding this in CI is a future optimization, not a correctness gap.

PHNX-2666
