### PR TITLE
fix(accounts): attach bootstraps a keychain-less worker home (PHNX-3502)

### DIFF
--- a/cli/.changelog/next/PHNX-3502.md
+++ b/cli/.changelog/next/PHNX-3502.md
@@ -1,0 +1,9 @@
+- **`agents accounts attach` bootstraps a keychain-less Linux worker (PHNX-3502).**
+  Attaching a Claude account to a version home on a headless worker now seeds the
+  home's identity and writes its `.oauth_token` from the account's non-rotating
+  setup-token already synced in the `auth` bundle, instead of refusing because the
+  home was never interactively signed in. This is what lets all accounts show as
+  logged in — and interactive worker runs authenticate (the shim's Linux
+  `.oauth_token` fallback) instead of dropping to the login screen. No rotating
+  OAuth credential is ever copied. Source: `apps/cli/src/commands/accounts.ts`,
+  `apps/cli/src/lib/claude-account-token.ts`.

--- a/cli/src/commands/accounts.test.ts
+++ b/cli/src/commands/accounts.test.ts
@@ -6,7 +6,7 @@ import * as yaml from 'yaml';
 import { Command } from 'commander';
 import { password } from '@inquirer/prompts';
 import { classifyAttachTarget, groupLabelIdentities, listSwitchableAccounts, nativeIdentityFromSource, parseBundleKey, registerAccountsCommand, resolveLabelIdentity, runAccountsLabel, setDefaultAccount, writeClaudeInteractiveOauthToken } from './accounts.js';
-import { claudeAccountTokenKey } from '../lib/claude-account-token.js';
+import { claudeAccountTokenKey, readClaudeAccountEmail, resolveClaudeSetupTokenForEmail, seedClaudeWorkerHomeIdentity } from '../lib/claude-account-token.js';
 import { getVersionHomePath } from '../lib/installations/versions.js';
 import { addAccount, addNativeAccount, listNativeAccounts, removeAccount } from '../lib/account-registry.js';
 import type { RotateCandidate } from '../lib/accounting/rotate.js';
@@ -458,6 +458,32 @@ describe('writeClaudeInteractiveOauthToken', () => {
   it('no-ops for a non-installation target (device-scoped attach)', () => {
     writeClaudeInteractiveOauthToken({ kind: 'device-agent', agent: 'claude' }, 'claude');
     expect(fs.existsSync(oauthTokenPath())).toBe(false);
+  });
+
+  // Regression for the review BLOCKER on PR #3331: a native claude account's email
+  // lives in `identityLabel`, NOT `identityKey` (which is the synthetic composite
+  // `claude:account=<uuid>:org=<uuid>`). The bootstrap must key the setup-token off
+  // the email; keying off `identityKey` resolves nothing and the fix silently no-ops.
+  linuxOnly('bootstraps a signed-out worker home off the account email in identityLabel, not identityKey', () => {
+    // A signed-out worker home: drop the identity the beforeEach seeded.
+    const workerHome = getVersionHomePath('claude', VERSION);
+    fs.rmSync(path.join(workerHome, '.claude', '.claude.json'), { force: true });
+    writeAuthToken(EMAIL, TOKEN);
+    // A realistic native claude account: composite identityKey, email in identityLabel.
+    const account = addNativeAccount('claude-worker', 'claude', 'claude:account=abc:org=xyz', EMAIL, 'version');
+    expect(account.identityKey).not.toContain('@');
+    expect(account.identityLabel).toBe(EMAIL);
+    // The bug: keying the token off identityKey resolves nothing.
+    expect(resolveClaudeSetupTokenForEmail(account.identityKey)).toBeNull();
+    // The fix: keying off identityLabel (the email) resolves the fleet-synced token.
+    expect(resolveClaudeSetupTokenForEmail(account.identityLabel!)).toBe(TOKEN);
+    // End to end, the bootstrap path attach takes: seed identity, then write .oauth_token.
+    expect(readClaudeAccountEmail(workerHome)).toBeNull();
+    seedClaudeWorkerHomeIdentity(workerHome, account.identityLabel!);
+    writeClaudeInteractiveOauthToken({ kind: 'installation', agent: 'claude', version: VERSION }, 'claude', account.identityLabel);
+    expect(readClaudeAccountEmail(workerHome)).toBe(EMAIL);
+    expect(fs.readFileSync(oauthTokenPath(), 'utf8')).toBe(TOKEN);
+    expect(fs.statSync(oauthTokenPath()).mode & 0o777).toBe(0o600);
   });
 });
 

--- a/cli/src/commands/accounts.ts
+++ b/cli/src/commands/accounts.ts
@@ -569,6 +569,11 @@ agents run codex#work`,
           } else {
             if (t.kind !== 'installation') throw new Error(`${account.agent} authentication is per-version. Attach '${account.name}' to a specific ${account.agent}@<version>.`);
             const versionHome = getVersionHomePath(t.agent, t.version);
+            // The literal email keys the account's `auth`-bundle setup-token. It lives
+            // in `identityLabel` — `identityKey` is a synthetic composite
+            // (`claude:account=<uuid>:org=<uuid>`, agents.ts nativeIdentityKey), never
+            // the address, so it must NOT be used to derive the token key.
+            const accountEmail = account.identityLabel;
             // Headless-worker bootstrap: a keychain-less Linux worker home never had
             // an interactive login, so its `.claude.json` carries no identity and
             // `nativeIdentityFromSource` would reject the attach — yet the account's
@@ -578,10 +583,11 @@ agents run codex#work`,
             if (
               process.platform === 'linux' &&
               account.agent === 'claude' &&
+              accountEmail &&
               !readClaudeAccountEmail(versionHome) &&
-              resolveClaudeSetupTokenForEmail(account.identityKey)
+              resolveClaudeSetupTokenForEmail(accountEmail)
             ) {
-              seedClaudeWorkerHomeIdentity(versionHome, account.identityKey);
+              seedClaudeWorkerHomeIdentity(versionHome, accountEmail);
             } else {
               const identity = await nativeIdentityFromSource(target);
               if (identity.identityKey !== account.identityKey) throw new Error(`'${target}' is signed in to a different identity than account '${account.name}'.`);
@@ -592,7 +598,7 @@ agents run codex#work`,
           getAccountProvider(account.provider).envFor(targetAgent, account.auth);
         }
         bindAccount(name, target);
-        writeClaudeInteractiveOauthToken(t, targetAgent, account.kind === 'native' && account.agent === 'claude' ? account.identityKey : undefined);
+        writeClaudeInteractiveOauthToken(t, targetAgent, account.kind === 'native' && account.agent === 'claude' ? account.identityLabel : undefined);
         console.log(chalk.green(`Attached ${account.name} to ${target}.`));
       });
     });

--- a/cli/src/commands/accounts.ts
+++ b/cli/src/commands/accounts.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import chalk from 'chalk';
 import { password, select } from '@inquirer/prompts';
-import { resolveClaudeSetupToken } from '../lib/claude-account-token.js';
+import { readClaudeAccountEmail, resolveClaudeSetupToken, resolveClaudeSetupTokenForEmail, seedClaudeWorkerHomeIdentity } from '../lib/claude-account-token.js';
 import { setHelpSections } from '../lib/help.js';
 import { readMeta, updateMeta } from '../lib/state.js';
 import type { AgentId } from '../lib/types.js';
@@ -93,11 +93,16 @@ export function classifyAttachTarget(target: string): AttachTarget {
  * the credential in the keychain, so `resolveClaudeSetupToken` returns null there and this
  * is a no-op off Linux.
  */
-export function writeClaudeInteractiveOauthToken(target: AttachTarget, targetAgent: AgentId): void {
+export function writeClaudeInteractiveOauthToken(target: AttachTarget, targetAgent: AgentId, email?: string): void {
   if (process.platform !== 'linux' || targetAgent !== 'claude' || target.kind !== 'installation') return;
   const versionHome = getVersionHomePath('claude', target.version);
   const tokenPath = path.join(versionHome, '.claude', '.oauth_token');
-  const token = resolveClaudeSetupToken(versionHome);
+  // Resolve by the attached account's email when known (a freshly-seeded worker
+  // home the `.claude.json` read below could not key on yet), else by the home's
+  // own recorded identity for a re-point/detach.
+  const token = email
+    ? resolveClaudeSetupTokenForEmail(email, versionHome)
+    : resolveClaudeSetupToken(versionHome);
   // A re-point (attach B over A, or a detach) can leave no setup-token resolving for
   // this version — B's may not be minted yet. A leftover file from the previous binding
   // would silently authenticate interactive runs as the OLD account (the shim's Linux
@@ -563,15 +568,31 @@ agents run codex#work`,
             if (t.kind !== 'device-agent') throw new Error(`${account.agent} authentication is device-scoped. Attach it with 'agents accounts attach ${account.name} ${account.agent}'.`);
           } else {
             if (t.kind !== 'installation') throw new Error(`${account.agent} authentication is per-version. Attach '${account.name}' to a specific ${account.agent}@<version>.`);
-            const identity = await nativeIdentityFromSource(target);
-            if (identity.identityKey !== account.identityKey) throw new Error(`'${target}' is signed in to a different identity than account '${account.name}'.`);
+            const versionHome = getVersionHomePath(t.agent, t.version);
+            // Headless-worker bootstrap: a keychain-less Linux worker home never had
+            // an interactive login, so its `.claude.json` carries no identity and
+            // `nativeIdentityFromSource` would reject the attach — yet the account's
+            // non-rotating setup-token is already fleet-synced in the `auth` bundle.
+            // Seed the identity (email only, no rotating credential) so the token
+            // resolves; `writeClaudeInteractiveOauthToken` then writes `.oauth_token`.
+            if (
+              process.platform === 'linux' &&
+              account.agent === 'claude' &&
+              !readClaudeAccountEmail(versionHome) &&
+              resolveClaudeSetupTokenForEmail(account.identityKey)
+            ) {
+              seedClaudeWorkerHomeIdentity(versionHome, account.identityKey);
+            } else {
+              const identity = await nativeIdentityFromSource(target);
+              if (identity.identityKey !== account.identityKey) throw new Error(`'${target}' is signed in to a different identity than account '${account.name}'.`);
+            }
           }
         } else {
           // Provider account: it must be able to authenticate the target's harness.
           getAccountProvider(account.provider).envFor(targetAgent, account.auth);
         }
         bindAccount(name, target);
-        writeClaudeInteractiveOauthToken(t, targetAgent);
+        writeClaudeInteractiveOauthToken(t, targetAgent, account.kind === 'native' && account.agent === 'claude' ? account.identityKey : undefined);
         console.log(chalk.green(`Attached ${account.name} to ${target}.`));
       });
     });

--- a/cli/src/lib/claude-account-token.test.ts
+++ b/cli/src/lib/claude-account-token.test.ts
@@ -6,7 +6,10 @@ import * as path from 'path';
 import {
   claudeAccountTokenKey,
   isValidClaudeSetupToken,
+  readClaudeAccountEmail,
   resolveClaudeSetupToken,
+  resolveClaudeSetupTokenForEmail,
+  seedClaudeWorkerHomeIdentity,
 } from './claude-account-token.js';
 import { buildExecEnv } from './exec.js';
 import {
@@ -337,5 +340,40 @@ describe('isValidClaudeSetupToken', () => {
     expect(isValidClaudeSetupToken('sk-ant-api03-abc')).toBe(false);
     expect(isValidClaudeSetupToken('sk-ant-oat01-')).toBe(false);
     expect(isValidClaudeSetupToken('')).toBe(false);
+  });
+});
+
+describe('resolveClaudeSetupTokenForEmail + seedClaudeWorkerHomeIdentity (worker bootstrap)', () => {
+  it('resolves a setup-token by explicit email with no version-home identity', () => {
+    writeAuthBundle({ [claudeAccountTokenKey('social@swarmify.co')]: 'sk-ant-oat01-social' });
+    expect(resolveClaudeSetupTokenForEmail('social@swarmify.co')).toBe('sk-ant-oat01-social');
+    // An account with no token in the bundle resolves to null, never another account's.
+    expect(resolveClaudeSetupTokenForEmail('nobody@nowhere.dev')).toBeNull();
+    expect(resolveClaudeSetupTokenForEmail('')).toBeNull();
+  });
+
+  it('seeds a signed-out worker home so its account then resolves end to end', () => {
+    writeAuthBundle({ [claudeAccountTokenKey('dev@getrush.ai')]: 'sk-ant-oat01-dev' });
+    const home = makeHome(); // no oauthAccount → reads as signed out
+    expect(readClaudeAccountEmail(home)).toBeNull();
+    expect(resolveClaudeSetupToken(home)).toBeNull();
+    seedClaudeWorkerHomeIdentity(home, 'dev@getrush.ai');
+    expect(readClaudeAccountEmail(home)).toBe('dev@getrush.ai');
+    expect(resolveClaudeSetupToken(home)).toBe('sk-ant-oat01-dev');
+  });
+
+  it('preserves existing .claude.json fields when seeding the identity', () => {
+    const home = makeHome();
+    const cfg = path.join(home, '.claude', '.claude.json');
+    fs.mkdirSync(path.dirname(cfg), { recursive: true });
+    fs.writeFileSync(cfg, JSON.stringify({ numStartups: 7, tipsHistory: { a: 1 }, oauthAccount: { displayName: 'Keep' } }));
+    seedClaudeWorkerHomeIdentity(home, 'tech@prix.dev');
+    const doc = JSON.parse(fs.readFileSync(cfg, 'utf-8')) as {
+      numStartups: number; tipsHistory: Record<string, number>; oauthAccount: { emailAddress: string; displayName: string };
+    };
+    expect(doc.numStartups).toBe(7);
+    expect(doc.tipsHistory).toEqual({ a: 1 });
+    expect(doc.oauthAccount.displayName).toBe('Keep');
+    expect(doc.oauthAccount.emailAddress).toBe('tech@prix.dev');
   });
 });

--- a/cli/src/lib/claude-account-token.ts
+++ b/cli/src/lib/claude-account-token.ts
@@ -96,12 +96,32 @@ export function readClaudeAccountEmail(home?: string): string | null {
  * authenticate with the shareable setup-token, not the ACL-bound login item.
  */
 export function resolveClaudeSetupToken(home?: string): string | null {
+  // Require a known account (email) up front: without it we cannot key a
+  // per-account token, and we must NOT fall back to a bare shared key that
+  // would misapply one account's setup-token to another.
+  const email = readClaudeAccountEmail(home);
+  if (!email) return null;
+  return resolveClaudeSetupTokenForEmail(email, home ?? os.homedir());
+}
+
+/**
+ * Resolve a long-lived setup-token for an EXPLICIT account email, independent of
+ * any version home's `.claude.json`. This is what lets `agents accounts attach`
+ * provision a headless worker home that has never had an interactive login: the
+ * account's non-rotating setup-token is already fleet-synced in the file-based
+ * `auth` bundle, keyed by email ({@link claudeAccountTokenKey}), so we can write
+ * the home's `.oauth_token` from it without the circular
+ * "read the home's email to resolve the home's token" dependency that
+ * {@link resolveClaudeSetupToken} has. Same file-backed-only, fail-closed,
+ * fingerprint-stable read as the home-keyed path — it is the shared core.
+ *
+ * `cacheKey` scopes the process-local token cache; callers pass a version home
+ * so a home-keyed and email-keyed read of the same account share nothing stale.
+ */
+export function resolveClaudeSetupTokenForEmail(email: string, cacheKey?: string): string | null {
   try {
-    // Require a known account (email) up front: without it we cannot key a
-    // per-account token, and we must NOT fall back to a bare shared key that
-    // would misapply one account's setup-token to another.
-    const email = readClaudeAccountEmail(home);
-    if (!email) return null;
+    const trimmed = email.trim();
+    if (!trimmed) return null;
     if (!bundleExists(AUTH_BUNDLE)) return null;
     const backend = bundleBackend(AUTH_BUNDLE);
     if (backend !== 'file') {
@@ -110,25 +130,26 @@ export function resolveClaudeSetupToken(home?: string): string | null {
       // hint that the seeded setup-token was being ignored.
       throw new ReservedBundleWrongBackendError(AUTH_BUNDLE, backend);
     }
-    const cacheKey = home ?? os.homedir();
-    const item = secretsKeychainItem(AUTH_BUNDLE, claudeAccountTokenKey(email));
+    const key = claudeAccountTokenKey(trimmed);
+    const ck = cacheKey ?? `email:${trimmed}`;
+    const item = secretsKeychainItem(AUTH_BUNDLE, key);
     const credentialPath = fileStoreItemPath(item);
     for (let attempt = 0; attempt < 2; attempt++) {
       const before = credentialFingerprint(credentialPath);
-      const cached = setupTokenCache.get(cacheKey);
+      const cached = setupTokenCache.get(ck);
       if (cached?.credentialPath === credentialPath && cached.fingerprint === before) {
         return cached.token;
       }
       if (before === 'missing') {
-        setupTokenCache.set(cacheKey, { credentialPath, fingerprint: before, token: null });
+        setupTokenCache.set(ck, { credentialPath, fingerprint: before, token: null });
         return null;
       }
       const { env } = readAndResolveBundleEnv(AUTH_BUNDLE, { caller: 'usage', agentOnly: true });
-      const v = (env[claudeAccountTokenKey(email)] ?? '').trim();
+      const v = (env[key] ?? '').trim();
       const token = v.length > 0 && isValidClaudeSetupToken(v) ? v : null;
       const after = credentialFingerprint(credentialPath);
       if (before === after) {
-        setupTokenCache.set(cacheKey, { credentialPath, fingerprint: after, token });
+        setupTokenCache.set(ck, { credentialPath, fingerprint: after, token });
         return token;
       }
     }
@@ -138,5 +159,37 @@ export function resolveClaudeSetupToken(home?: string): string | null {
   } catch (err) {
     if (err instanceof ReservedBundleWrongBackendError) throw err;
     return null;
+  }
+}
+
+/**
+ * Seed a keychain-less Linux worker's Claude version-home identity so an account's
+ * fleet-synced setup-token resolves for it. A worker home never had an interactive
+ * browser login, so its `.claude.json` carries no `oauthAccount.emailAddress` and
+ * the account reads "signed out" even though its non-rotating setup-token is present
+ * in the `auth` bundle. This writes ONLY the descriptive identity (the email), merged
+ * into both `.claude.json` locations Claude Code reads, preserving every other field.
+ * It never copies a rotating OAuth credential (`.credentials.json`) — the setup-token
+ * stays the credential of record.
+ */
+export function seedClaudeWorkerHomeIdentity(versionHome: string, email: string): void {
+  const trimmed = email.trim();
+  if (!trimmed) return;
+  for (const p of [
+    path.join(versionHome, '.claude', '.claude.json'),
+    path.join(versionHome, '.claude.json'),
+  ]) {
+    let doc: Record<string, unknown> = {};
+    try {
+      doc = JSON.parse(fs.readFileSync(p, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      // Missing or unreadable at this location — write a fresh minimal document.
+    }
+    const existing = (doc.oauthAccount && typeof doc.oauthAccount === 'object'
+      ? (doc.oauthAccount as Record<string, unknown>)
+      : {});
+    doc.oauthAccount = { ...existing, emailAddress: trimmed };
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify(doc));
   }
 }


### PR DESCRIPTION
## Problem

`agents run claude --interactive` on a worker (e.g. `yosemite-m3`) drops to the Claude Code **login screen**, and most Claude accounts read **"signed out"** on the m* workers (`agents devices accounts`) even though their long-term setup-tokens are synced to every box.

### Root cause (verified live)

The credentials are fine — the **binding** is missing.

- Every worker's `auth` bundle already carries all 8 accounts' non-rotating setup-tokens (1Password "Employee" vault → imported → fleet-synced). Verified: `yosemite-m3`'s bundle is byte-identical to the source, and a headless `agents run claude --account <x>` on m3 authenticates.
- But an account only reads "logged in" (and `balanced`/interactive work without an explicit `--account`) when a **version home is bound** to it: `.claude.json` `oauthAccount.emailAddress` + a `.oauth_token`.
- On a **headless worker**, that binding never happens: the home never had an interactive browser login, so `agents accounts attach` — which resolves the token via the home's *own* email (`resolveClaudeSetupToken`) — finds no email, writes nothing, and `nativeIdentityFromSource` rejects the attach. Circular: the token write needs the email, the email needs a login the worker can't do.

s0/s1 were seeded once out-of-band; m0–m6 never were, and nothing reconciles it.

## Fix

Let `attach` **bootstrap** an unbound Linux worker home instead of refusing it:

1. `resolveClaudeSetupTokenForEmail(email)` — the email-keyed core of `resolveClaudeSetupToken`, so a token resolves from the `auth` bundle **without** the circular "read the home's email first" dependency.
2. `seedClaudeWorkerHomeIdentity(home, email)` — writes **only** the descriptive identity (`oauthAccount.emailAddress`) into the home's `.claude.json`, merged/preserving other fields. **No rotating OAuth credential (`.credentials.json`) is ever copied.**
3. `attach` seeds the identity when the target is a signed-out Linux worker claude home *and* the account's setup-token is present in the bundle; `writeClaudeInteractiveOauthToken` then writes `.oauth_token` from the attached account's email.

Because the shim's Linux fallback (`claudeAdapter.shimConfigEnvBash`) reads exactly that `.oauth_token`, this **also fixes the interactive-login drop** (PHNX-3502) — one change, both outcomes.

## Verification

Real file-store, no mocks — `src/lib/claude-account-token.test.ts`:

```
$ bunx vitest run src/lib/claude-account-token.test.ts
 Test Files  1 passed (1)
      Tests  20 passed (20)   # 3 new: email-keyed resolve, end-to-end seed→resolve, field-preserving seed
$ bunx tsc --noEmit           # clean
```

New tests cover: resolving a token by explicit email with no home identity; seeding a signed-out home so `resolveClaudeSetupToken` then returns its token end-to-end; and preserving existing `.claude.json` fields when seeding.

## Follow-up (not in this PR)

Post-merge + release, provision the fleet: `agents accounts attach <account> claude@<version>` across the Yosemite workers to reach 8/8 logged-in. A `--device` targeting flag and an `accounts provision` fleet sweep are natural next steps.