### PR TITLE
fix(usage): cap daemon refresh with a global per-provider budget

### DIFF
--- a/cli/.changelog/next/usage-provider-budget.md
+++ b/cli/.changelog/next/usage-provider-budget.md
@@ -1,0 +1,13 @@
+- **Cap the daemon's usage-refresh traffic with a global per-provider budget.** The
+  refresher enforced only a per-account hourly cap, so endpoint load scaled linearly
+  with account count: 8 Claude accounts × 12/hr = ~96 usage calls/hr from one box,
+  against Anthropic's ~100/hr `/api/oauth/usage` ceiling — which 429'd accounts into
+  Retry-After parks (measured on `zion`: 7 of 8 accounts parked, never refreshed in
+  their window, so `agents view` showed `S: unavailable` and balanced routing read
+  stale usage). A new `PROVIDER_HOURLY_BUDGET` (40/hr per network provider, across all
+  its accounts) bounds aggregate endpoint traffic at a fixed rate that no longer grows
+  with account count. The budget is spent stalest-account-first, so no account is
+  starved and each account's effective proactive cadence simply stretches as N grows.
+  The free statusline ingest of a live `agents run` now also suppresses a redundant
+  API refresh of an already-current account. Source: `cli/src/lib/usage-refresh.ts`,
+  `cli/src/lib/daemon-ticks.ts`.

--- a/cli/.changelog/next/usage-provider-budget.md
+++ b/cli/.changelog/next/usage-provider-budget.md
@@ -1,13 +1,20 @@
-- **Cap the daemon's usage-refresh traffic with a global per-provider budget.** The
+- **Cap and smooth the daemon's usage-refresh traffic with a per-provider budget.** The
   refresher enforced only a per-account hourly cap, so endpoint load scaled linearly
   with account count: 8 Claude accounts × 12/hr = ~96 usage calls/hr from one box,
   against Anthropic's ~100/hr `/api/oauth/usage` ceiling — which 429'd accounts into
   Retry-After parks (measured on `zion`: 7 of 8 accounts parked, never refreshed in
   their window, so `agents view` showed `S: unavailable` and balanced routing read
-  stale usage). A new `PROVIDER_HOURLY_BUDGET` (40/hr per network provider, across all
-  its accounts) bounds aggregate endpoint traffic at a fixed rate that no longer grows
-  with account count. The budget is spent stalest-account-first, so no account is
-  starved and each account's effective proactive cadence simply stretches as N grows.
-  The free statusline ingest of a live `agents run` now also suppresses a redundant
-  API refresh of an already-current account. Source: `cli/src/lib/usage-refresh.ts`,
+  stale usage). A per-provider budget (`PROVIDER_HOURLY_BUDGET`, 30/hr across all of a
+  network provider's accounts) now bounds aggregate traffic at a fixed rate that no
+  longer grows with account count, paced smoothly (one fetch per ~2 min, round-robin,
+  stalest account first) so it never bursts-then-stalls. Actively-used accounts stay
+  fresh for free via the statusline ingest, which now also re-derives their headroom
+  and suppresses a redundant API refresh. Source: `cli/src/lib/usage-refresh.ts`,
   `cli/src/lib/daemon-ticks.ts`.
+- **Route-refuse only on genuinely stale usage, not merely budget-paced usage.** Because
+  proactive refreshes are now paced, an idle account is deliberately refreshed on a
+  stretched cadence. Routing keeps its tight 5-min bar for *weighting* an account, but
+  the fail-loud `NO_VERIFIED_USAGE` refusal now fires on a wider 40-min bar
+  (`USAGE_STALE_REFUSAL_MAX_AGE_MS`) — so a budget-paced fleet routes normally while a
+  genuinely broken refresh (hours-old readings) still refuses. Source:
+  `cli/src/lib/accounting/rotate.ts`.

--- a/cli/src/lib/accounting/rotate.test.ts
+++ b/cli/src/lib/accounting/rotate.test.ts
@@ -758,6 +758,31 @@ describe('routing refuses to decide on usage it cannot verify', () => {
     expect(hasStaleUsage(candidate({ version: '1.0.0', usageSnapshot: meterless }), NOW)).toBe(false);
   });
 
+  it('two-tier freshness: a budget-paced idle reading is unverified but NOT refusal-stale', () => {
+    // The daemon paces proactive refreshes under a per-provider budget, so a
+    // healthy IDLE account is deliberately refreshed on a stretched round-robin
+    // cadence. A 25-min-old reading is one of those: too old to WEIGHT on (the
+    // 5-min decision bar), but nowhere near the hours-old broken-refresh staleness
+    // the NO_VERIFIED_USAGE refusal exists to catch (40-min bar).
+    const paced = snapshotAt(new Date(NOW - 25 * 60_000), [{ key: 'week', usedPercent: 30 }]);
+    expect(isUsageVerified(candidate({ version: '1.0.0', usageSnapshot: paced }), NOW)).toBe(false);
+    expect(hasStaleUsage(candidate({ version: '1.0.0', usageSnapshot: paced }), NOW)).toBe(false);
+    // A genuinely broken refresh (past the 40-min refusal bar) IS refusal-stale.
+    const broken = snapshotAt(new Date(NOW - 45 * 60_000), [{ key: 'week', usedPercent: 30 }]);
+    expect(hasStaleUsage(candidate({ version: '1.0.0', usageSnapshot: broken }), NOW)).toBe(true);
+  });
+
+  it('does NOT refuse a pool where every account is merely budget-paced (10–30 min), only genuinely stale ones', () => {
+    // The BLOCKER: budget pacing + a 5-min refusal bar collapsed an all-idle fleet
+    // to NO_VERIFIED_USAGE. With the wider refusal bar, a fleet of paced-but-not-
+    // broken readings still routes (drawing on the floored weights).
+    const pacedA = candidate({ version: '2.1.181', usageSnapshot: snapshotAt(new Date(NOW - 12 * 60_000), [{ key: 'week', usedPercent: 20 }]) });
+    const pacedB = candidate({ version: '2.1.207', usageSnapshot: snapshotAt(new Date(NOW - 28 * 60_000), [{ key: 'week', usedPercent: 40 }]) });
+    const result = pickBalancedCandidate([pacedA, pacedB], NOW)!;
+    expect(result.noVerifiedUsage).toBe(false);
+    expect(['2.1.181', '2.1.207']).toContain(result.picked.version);
+  });
+
   it('a verified MINORITY does not capture every launch — the 429-throttled regime', () => {
     // The 2026-08-20 incident: the usage endpoint 429-throttles a machine, so
     // each refresh cycle confirms exactly one account. Narrowing to verified

--- a/cli/src/lib/accounting/rotate.ts
+++ b/cli/src/lib/accounting/rotate.ts
@@ -251,6 +251,28 @@ function isAvailableEligible(candidate: RotateCandidate): boolean {
 export const USAGE_DECISION_MAX_AGE_MS = 5 * 60 * 1000;
 
 /**
+ * How old a usage snapshot may be before routing REFUSES to run at all
+ * (NO_VERIFIED_USAGE), as opposed to merely declining to *weight* by its number.
+ *
+ * These are two different risks and now two different bars. Weighting on a
+ * slightly-old number is cheap to get wrong (a floored weight, {@link
+ * USAGE_DECISION_MAX_AGE_MS} = 5 min); refusing to launch at all is expensive to
+ * get wrong — it fails the user's `agents run` outright. The daemon's usage
+ * refresher paces proactive fetches under a fixed per-provider budget
+ * (`usage-refresh.ts`, PROVIDER_HOURLY_BUDGET), so on a multi-account fleet an
+ * IDLE account is deliberately refreshed on a stretched round-robin cadence
+ * (bounded at N × spacing — ~16 min at 8 accounts, ~32 min at 16) rather than
+ * every 5 min, which would 429 the endpoint and park it for up to an hour. A
+ * budget-paced idle reading of 10–30 min is NOT the failure this refusal exists
+ * to catch. That failure is the `yosemite-s1` case: a box whose refresh is
+ * genuinely BROKEN, holding readings 26 h – 2.7 d old. 40 min sits comfortably
+ * above the worst-case budget cadence and still an order of magnitude below the
+ * multi-hour staleness of a broken box — and actively-used accounts refresh for
+ * free via the statusline ingest, so a *busy* account is never even this old.
+ */
+export const USAGE_STALE_REFUSAL_MAX_AGE_MS = 40 * 60 * 1000;
+
+/**
  * Whether this candidate's usage number is recent enough to route on. A missing
  * snapshot is unverified by definition — there is no number to trust.
  *
@@ -271,23 +293,29 @@ export function isUsageVerified(candidate: RotateCandidate, nowMs: number = Date
 }
 
 /**
- * Whether this candidate carries a STALE-but-present usage number: a snapshot
- * with windows whose capture time is older than {@link USAGE_DECISION_MAX_AGE_MS}.
+ * Whether this candidate carries a GENUINELY-STALE usage number: a snapshot with
+ * windows whose capture time is older than {@link USAGE_STALE_REFUSAL_MAX_AGE_MS}.
  *
  * This is the misleading case the initial route must refuse — the number reads
  * "48% used" with the same confidence whether captured a minute or three days
- * ago, and a box whose refresh is failing stays wrong indefinitely. It is
- * deliberately NARROWER than "not verified": a BLIND candidate with no snapshot
- * (or a plan-only meterless one with no windows) carries no number to be misled
- * by — a worker box whose usage endpoint 403s (RUSH-2392), or a meterless Grok
- * login — so it is not "stale", and an entirely-blind pool still draws a pick
- * (PHNX-3392) rather than fail loud with NO_VERIFIED_USAGE.
+ * ago, and a box whose refresh is failing stays wrong indefinitely. Two things
+ * make it NARROWER than "not verified":
+ *   1. It uses the wider REFUSAL bar, not the 5-min weighting bar. A merely
+ *      budget-paced idle account (10–30 min old) is not-verified — so it weights
+ *      at the floor, conservatively — but it is NOT "stale" and must not, on its
+ *      own, drive the whole provider to a NO_VERIFIED_USAGE refusal. Only a
+ *      genuinely broken refresh (hours old) trips this.
+ *   2. A BLIND candidate with no snapshot (or a plan-only meterless one with no
+ *      windows) carries no number to be misled by — a worker box whose usage
+ *      endpoint 403s (RUSH-2392), or a meterless Grok login — so it is not
+ *      "stale", and an entirely-blind pool still draws a pick (PHNX-3392) rather
+ *      than fail loud with NO_VERIFIED_USAGE.
  */
 export function hasStaleUsage(candidate: RotateCandidate, nowMs: number = Date.now()): boolean {
   const snapshot = candidate.usageSnapshot;
   const capturedAt = snapshot?.capturedAt;
   if (!capturedAt || !snapshot?.windows.length) return false;
-  return nowMs - capturedAt.getTime() > USAGE_DECISION_MAX_AGE_MS;
+  return nowMs - capturedAt.getTime() > USAGE_STALE_REFUSAL_MAX_AGE_MS;
 }
 
 function hasUsageAvailable(candidate: RotateCandidate): boolean {
@@ -846,7 +874,7 @@ export function formatNoVerifiedUsageError(
         const staleness = age === null ? 'no usage snapshot' : `usage ${age}m old`;
         return `${c.version} (${staleness})`;
       }).join(', ');
-  const maxAgeMin = Math.round(USAGE_DECISION_MAX_AGE_MS / 60_000);
+  const maxAgeMin = Math.round(USAGE_STALE_REFUSAL_MAX_AGE_MS / 60_000);
   return `agents: NO_VERIFIED_USAGE — no signed-in ${agent} account has usage newer than ${maxAgeMin}m under strategy '${strategy}', so routing refuses to guess on a stale number: ${detail}. Refresh usage (agents view ${agent}) or pin the default with --strategy pinned.`;
 }
 

--- a/cli/src/lib/daemon-ticks.test.ts
+++ b/cli/src/lib/daemon-ticks.test.ts
@@ -202,6 +202,6 @@ describe('runUsageRefreshTick — every host is its own publisher (RUSH-3193 #15
     // local refresh, never a cross-host import.
     expect(line).not.toMatch(/imported \d+ account\(s\) from primary host/);
     expect(line).not.toMatch(/published \d+ account\(s\)/);
-    expect(line).toMatch(/refreshed, .* failed, .* not-due, .* backed-off, .* capped; BYOK/);
+    expect(line).toMatch(/refreshed, .* failed, .* not-due, .* backed-off, .* capped, .* over-budget, .* statusline-fresh; BYOK/);
   });
 });

--- a/cli/src/lib/daemon-ticks.ts
+++ b/cli/src/lib/daemon-ticks.ts
@@ -136,18 +136,22 @@ export async function runFleetCacheWarmTick(): Promise<void> {
  */
 export async function runUsageRefreshTick(): Promise<void> {
   const { runUsageRefresh, buildLocalUsageAccounts } = await import('./usage-refresh.js');
-  const { writeClaudeUsageCache } = await import('./accounting/usage.js');
+  const { writeClaudeUsageCache, readClaudeUsageCache } = await import('./accounting/usage.js');
   const { usageRateLimitedUntil } = await import('./usage-backoff.js');
   const r = await runUsageRefresh({
     listAccounts: buildLocalUsageAccounts,
     writeUsageCache: writeClaudeUsageCache,
     backoffUntil: (agentId, usageKey) => usageRateLimitedUntil(agentId, Date.now(), usageKey),
+    // The free statusline ingest of a live `agents run` writes this same cache,
+    // so a recent capture means the account is already fresh at zero API cost —
+    // the provider budget skips re-refreshing it.
+    lastCapturedAt: (usageKey) => readClaudeUsageCache(usageKey)?.capturedAt?.getTime() ?? null,
   });
   const { listProfiles } = await import('./profiles.js');
   const { refreshDueByokUsage } = await import('./byok-usage.js');
   const byok = await refreshDueByokUsage(listProfiles());
   console.log(
-    `usage refresh: ${r.refreshed} refreshed, ${r.failed} failed, ${r.skippedNotDue} not-due, ${r.skippedBackoff} backed-off, ${r.skippedCap} capped; BYOK ${byok.refreshed} refreshed, ${byok.skipped} not-due`,
+    `usage refresh: ${r.refreshed} refreshed, ${r.failed} failed, ${r.skippedNotDue} not-due, ${r.skippedBackoff} backed-off, ${r.skippedCap} capped, ${r.skippedBudget} over-budget, ${r.skippedFresh} statusline-fresh; BYOK ${byok.refreshed} refreshed, ${byok.skipped} not-due`,
   );
 }
 

--- a/cli/src/lib/daemon-ticks.ts
+++ b/cli/src/lib/daemon-ticks.ts
@@ -144,8 +144,8 @@ export async function runUsageRefreshTick(): Promise<void> {
     backoffUntil: (agentId, usageKey) => usageRateLimitedUntil(agentId, Date.now(), usageKey),
     // The free statusline ingest of a live `agents run` writes this same cache,
     // so a recent capture means the account is already fresh at zero API cost —
-    // the provider budget skips re-refreshing it.
-    lastCapturedAt: (usageKey) => readClaudeUsageCache(usageKey)?.capturedAt?.getTime() ?? null,
+    // the refresher re-derives headroom from it and skips the API fetch.
+    readCachedSnapshot: (usageKey) => readClaudeUsageCache(usageKey),
   });
   const { listProfiles } = await import('./profiles.js');
   const { refreshDueByokUsage } = await import('./byok-usage.js');

--- a/cli/src/lib/usage-refresh.test.ts
+++ b/cli/src/lib/usage-refresh.test.ts
@@ -9,6 +9,8 @@ import {
   REFRESH_MAX_MS,
   REFRESH_BURN_DIVISOR,
   HOURLY_CALL_CAP,
+  PROVIDER_HOURLY_BUDGET,
+  STATUSLINE_FRESH_MS,
   USAGE_REFRESH_TICK_MS,
   FAILURE_QUARANTINE_MS,
   FAILURE_QUARANTINE_THRESHOLD,
@@ -17,6 +19,7 @@ import {
   shouldRefreshAccount,
   nextHeadroomEntry,
   orderUsageAccounts,
+  providerRecentCalls,
   runUsageRefresh,
   readHeadroomEntry,
   writeHeadroomEntries,
@@ -26,6 +29,17 @@ import {
 import { setClaudeUsageCachePathForTest, writeClaudeUsageCache, readClaudeUsageCache, type UsageSnapshot } from './accounting/usage.js';
 
 const NOW = 1_800_000_000_000;
+
+/** A minimal cached headroom entry the new budget/ordering tests clone and tweak. */
+const baseEntry: HeadroomEntry = {
+  status: 'available',
+  minutesToLimit: 10,
+  sessionUsedPercent: 50,
+  capturedAt: NOW - 60_000,
+  nextRefreshAt: NOW - 1,
+  callTimestamps: [],
+  computedAt: NOW - 60_000,
+};
 
 const sessionSnap = (usedPercent: number, capturedAtMs: number): UsageSnapshot => ({
   source: 'live',
@@ -285,5 +299,202 @@ describe('runUsageRefresh — refreshes only due, uncapped, un-backed-off local 
     writeClaudeUsageCache('claude:org=b', sessionSnap(20, NOW));
     expect(readClaudeUsageCache('claude:org=a')?.windows[0]?.usedPercent).toBe(10);
     expect(readClaudeUsageCache('claude:org=b')?.windows[0]?.usedPercent).toBe(20);
+  });
+});
+
+describe('orderUsageAccounts — stalest account first', () => {
+  it('orders cached accounts oldest-capture first, cold accounts lead', () => {
+    const accounts = ['fresh', 'stalest', 'mid', 'cold'].map((k) => ({
+      usageKey: `claude:org=${k}`,
+      agentId: 'claude' as const,
+      fetch: async () => ({ snapshot: sessionSnap(10, NOW), error: null }),
+    }));
+    const cache: Record<string, HeadroomEntry> = {
+      'claude:org=fresh': { ...baseEntry, capturedAt: NOW - 60_000 },
+      'claude:org=stalest': { ...baseEntry, capturedAt: NOW - 40 * 60_000 },
+      'claude:org=mid': { ...baseEntry, capturedAt: NOW - 10 * 60_000 },
+      // 'cold' has no entry → maximally stale, leads the pass.
+    };
+    const ordered = orderUsageAccounts(accounts, cache, 0).map((a) => a.usageKey);
+    expect(ordered).toEqual([
+      'claude:org=cold',
+      'claude:org=stalest',
+      'claude:org=mid',
+      'claude:org=fresh',
+    ]);
+  });
+
+  it('treats a null capturedAt as maximally stale among cached accounts', () => {
+    const accounts = ['hasCapture', 'nullCapture'].map((k) => ({
+      usageKey: `claude:org=${k}`,
+      agentId: 'claude' as const,
+      fetch: async () => ({ snapshot: sessionSnap(10, NOW), error: null }),
+    }));
+    const cache: Record<string, HeadroomEntry> = {
+      'claude:org=hasCapture': { ...baseEntry, capturedAt: NOW - 5 * 60_000 },
+      'claude:org=nullCapture': { ...baseEntry, capturedAt: null },
+    };
+    const ordered = orderUsageAccounts(accounts, cache, 0).map((a) => a.usageKey);
+    expect(ordered).toEqual(['claude:org=nullCapture', 'claude:org=hasCapture']);
+  });
+});
+
+describe('providerRecentCalls — aggregate rolling-hour spend per network provider', () => {
+  it('sums only network providers, only calls inside the trailing hour', () => {
+    const accounts = [
+      { usageKey: 'claude:org=a', agentId: 'claude' as const, fetch: async () => ({ snapshot: null, error: null }) },
+      { usageKey: 'claude:org=b', agentId: 'claude' as const, fetch: async () => ({ snapshot: null, error: null }) },
+      // grok is network:false — no rate-limited endpoint, excluded from the budget.
+      { usageKey: 'grok:user=g', agentId: 'grok' as const, fetch: async () => ({ snapshot: null, error: null }) },
+    ];
+    const cache: Record<string, HeadroomEntry> = {
+      'claude:org=a': { ...baseEntry, callTimestamps: [NOW - 10 * 60_000, NOW - 90 * 60_000, NOW - 1_000] },
+      'claude:org=b': { ...baseEntry, callTimestamps: [NOW - 5 * 60_000] },
+      'grok:user=g': { ...baseEntry, callTimestamps: [NOW - 1_000, NOW - 2_000] },
+    };
+    const counts = providerRecentCalls(accounts, cache, NOW);
+    // claude: 2 recent from a (the 90-min-old one is pruned) + 1 from b = 3.
+    expect(counts.get('claude')).toBe(3);
+    expect(counts.has('grok')).toBe(false);
+  });
+});
+
+describe('provider budget — aggregate endpoint pressure does not scale with N', () => {
+  let cacheDir: string;
+  let prevHeadroom: string | null;
+  let prevUsage: string | null;
+
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-budget-'));
+    prevHeadroom = setHeadroomCachePathForTest(path.join(cacheDir, '.usage-headroom.json'));
+    prevUsage = setClaudeUsageCachePathForTest(path.join(cacheDir, 'claude-usage.json'));
+  });
+
+  afterEach(() => {
+    setHeadroomCachePathForTest(prevHeadroom);
+    setClaudeUsageCachePathForTest(prevUsage);
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it('caps one tick at PROVIDER_HOURLY_BUDGET fetches even with far more due accounts', async () => {
+    const n = PROVIDER_HOURLY_BUDGET + 12; // 8+ accounts is the real case; go well over.
+    let fetches = 0;
+    const accounts = Array.from({ length: n }, (_, i) => ({
+      usageKey: `claude:org=acct-${i}`,
+      agentId: 'claude' as const,
+      fetch: async () => { fetches += 1; return { snapshot: sessionSnap(10, NOW), error: null }; },
+    }));
+    const result = await runUsageRefresh({
+      now: NOW,
+      listAccounts: async () => accounts,
+      writeUsageCache: writeClaudeUsageCache,
+      backoffUntil: () => null,
+    });
+    expect(result.refreshed).toBe(PROVIDER_HOURLY_BUDGET);
+    expect(result.skippedBudget).toBe(n - PROVIDER_HOURLY_BUDGET);
+    expect(fetches).toBe(PROVIDER_HOURLY_BUDGET);
+  });
+
+  it('holds the aggregate under the budget across multiple ticks in one hour', async () => {
+    const n = PROVIDER_HOURLY_BUDGET + 12;
+    let fetches = 0;
+    const accounts = Array.from({ length: n }, (_, i) => ({
+      usageKey: `claude:org=acct-${i}`,
+      agentId: 'claude' as const,
+      fetch: async () => { fetches += 1; return { snapshot: sessionSnap(10, NOW), error: null }; },
+    }));
+    // Three ticks 60s apart — all inside one rolling hour. Budget-skipped accounts
+    // stay due and compete again, but the rolling-hour aggregate must not exceed
+    // the budget (the endpoint would 429 otherwise).
+    for (let tick = 0; tick < 3; tick += 1) {
+      await runUsageRefresh({
+        now: NOW + tick * USAGE_REFRESH_TICK_MS,
+        listAccounts: async () => accounts,
+        writeUsageCache: writeClaudeUsageCache,
+        backoffUntil: () => null,
+      });
+    }
+    expect(fetches).toBe(PROVIDER_HOURLY_BUDGET);
+  });
+
+  it('spends the budget on the STALEST accounts, deferring the freshest', async () => {
+    const n = PROVIDER_HOURLY_BUDGET + 1; // exactly one account must be deferred.
+    const fetched = new Set<string>();
+    const accounts = Array.from({ length: n }, (_, i) => ({
+      usageKey: `claude:org=acct-${i}`,
+      agentId: 'claude' as const,
+      fetch: async () => { fetched.add(`claude:org=acct-${i}`); return { snapshot: sessionSnap(10, NOW), error: null }; },
+    }));
+    // Seed staggered capture times: acct-0 freshest (NOW-1m), acct-n stalest.
+    const seed: Record<string, HeadroomEntry> = {};
+    accounts.forEach((a, i) => {
+      seed[a.usageKey] = { ...baseEntry, capturedAt: NOW - (i + 1) * 60_000, nextRefreshAt: NOW - 1 };
+    });
+    writeHeadroomEntries(seed);
+
+    const result = await runUsageRefresh({
+      now: NOW,
+      listAccounts: async () => accounts,
+      writeUsageCache: writeClaudeUsageCache,
+      backoffUntil: () => null,
+    });
+    expect(result.refreshed).toBe(PROVIDER_HOURLY_BUDGET);
+    expect(result.skippedBudget).toBe(1);
+    // The single deferred account is the FRESHEST one (acct-0, captured 1m ago).
+    expect(fetched.has('claude:org=acct-0')).toBe(false);
+  });
+
+  it('never calls a parked (backed-off) account, and it does not consume budget', async () => {
+    let parkedCalled = false;
+    let liveCalled = false;
+    const result = await runUsageRefresh({
+      now: NOW,
+      listAccounts: async () => [
+        { usageKey: 'claude:org=parked', agentId: 'claude', fetch: async () => { parkedCalled = true; return { snapshot: sessionSnap(10, NOW), error: null }; } },
+        { usageKey: 'claude:org=live', agentId: 'claude', fetch: async () => { liveCalled = true; return { snapshot: sessionSnap(10, NOW), error: null }; } },
+      ],
+      writeUsageCache: writeClaudeUsageCache,
+      backoffUntil: (_agent, usageKey) => (usageKey === 'claude:org=parked' ? NOW + 30 * 60_000 : null),
+    });
+    expect(parkedCalled).toBe(false);
+    expect(liveCalled).toBe(true);
+    expect(result.skippedBackoff).toBe(1);
+    expect(result.refreshed).toBe(1);
+  });
+
+  it('does not API-refresh an account a statusline ingest just captured for free', async () => {
+    let fetched = false;
+    const key = 'claude:org=statusline-fresh';
+    const result = await runUsageRefresh({
+      now: NOW,
+      listAccounts: async () => [
+        { usageKey: key, agentId: 'claude', fetch: async () => { fetched = true; return { snapshot: sessionSnap(10, NOW), error: null }; } },
+      ],
+      writeUsageCache: writeClaudeUsageCache,
+      backoffUntil: () => null,
+      // Captured 1 minute ago by the free statusline ingest (< STATUSLINE_FRESH_MS).
+      lastCapturedAt: () => NOW - 60_000,
+    });
+    expect(fetched).toBe(false);
+    expect(result.skippedFresh).toBe(1);
+    expect(result.refreshed).toBe(0);
+    // Rescheduled one interval past the free capture, not re-attempted every tick.
+    expect(readHeadroomEntry(key)?.nextRefreshAt).toBe(NOW - 60_000 + STATUSLINE_FRESH_MS);
+  });
+
+  it('DOES API-refresh an account whose statusline capture has aged past the window', async () => {
+    let fetched = false;
+    const result = await runUsageRefresh({
+      now: NOW,
+      listAccounts: async () => [
+        { usageKey: 'claude:org=stale-statusline', agentId: 'claude', fetch: async () => { fetched = true; return { snapshot: sessionSnap(10, NOW), error: null }; } },
+      ],
+      writeUsageCache: writeClaudeUsageCache,
+      backoffUntil: () => null,
+      lastCapturedAt: () => NOW - (STATUSLINE_FRESH_MS + 60_000), // older than the window
+    });
+    expect(fetched).toBe(true);
+    expect(result.refreshed).toBe(1);
+    expect(result.skippedFresh).toBe(0);
   });
 });

--- a/cli/src/lib/usage-refresh.test.ts
+++ b/cli/src/lib/usage-refresh.test.ts
@@ -10,6 +10,8 @@ import {
   REFRESH_BURN_DIVISOR,
   HOURLY_CALL_CAP,
   PROVIDER_HOURLY_BUDGET,
+  PROVIDER_MIN_REFRESH_SPACING_MS,
+  PROVIDER_CATCHUP_MAX,
   STATUSLINE_FRESH_MS,
   USAGE_REFRESH_TICK_MS,
   FAILURE_QUARANTINE_MS,
@@ -20,6 +22,8 @@ import {
   nextHeadroomEntry,
   orderUsageAccounts,
   providerRecentCalls,
+  providerLastCall,
+  providerSpacingTokens,
   runUsageRefresh,
   readHeadroomEntry,
   writeHeadroomEntries,
@@ -27,6 +31,13 @@ import {
   type HeadroomEntry,
 } from './usage-refresh.js';
 import { setClaudeUsageCachePathForTest, writeClaudeUsageCache, readClaudeUsageCache, type UsageSnapshot } from './accounting/usage.js';
+import {
+  isUsageVerified,
+  hasStaleUsage,
+  USAGE_DECISION_MAX_AGE_MS,
+  USAGE_STALE_REFUSAL_MAX_AGE_MS,
+  type RotateCandidate,
+} from './accounting/rotate.js';
 
 const NOW = 1_800_000_000_000;
 
@@ -359,6 +370,46 @@ describe('providerRecentCalls — aggregate rolling-hour spend per network provi
   });
 });
 
+describe('providerSpacingTokens — smooth per-provider pacing', () => {
+  it('grants a cold provider the catch-up ceiling (warms a couple of accounts, not a burst)', () => {
+    expect(providerSpacingTokens(0, NOW)).toBe(PROVIDER_CATCHUP_MAX);
+  });
+
+  it('grants none until a full spacing has elapsed, then one', () => {
+    const last = NOW - PROVIDER_MIN_REFRESH_SPACING_MS + 1;
+    expect(providerSpacingTokens(last, NOW)).toBe(0);
+    expect(providerSpacingTokens(NOW - PROVIDER_MIN_REFRESH_SPACING_MS, NOW)).toBe(1);
+  });
+
+  it('clamps catch-up after a long idle gap so it cannot re-burst', () => {
+    const longAgo = NOW - 10 * PROVIDER_MIN_REFRESH_SPACING_MS;
+    expect(providerSpacingTokens(longAgo, NOW)).toBe(PROVIDER_CATCHUP_MAX);
+  });
+
+  it('is consistent with the hourly budget (HOUR / spacing)', () => {
+    expect(PROVIDER_HOURLY_BUDGET).toBe(60 * 60 * 1000 / PROVIDER_MIN_REFRESH_SPACING_MS);
+    expect(PROVIDER_MIN_REFRESH_SPACING_MS).toBe(2 * USAGE_REFRESH_TICK_MS);
+  });
+});
+
+describe('providerLastCall — most-recent live fetch per network provider', () => {
+  it('takes the max timestamp across a provider, and ignores non-network providers', () => {
+    const accounts = [
+      { usageKey: 'claude:org=a', agentId: 'claude' as const, fetch: async () => ({ snapshot: null, error: null }) },
+      { usageKey: 'claude:org=b', agentId: 'claude' as const, fetch: async () => ({ snapshot: null, error: null }) },
+      { usageKey: 'grok:user=g', agentId: 'grok' as const, fetch: async () => ({ snapshot: null, error: null }) },
+    ];
+    const cache: Record<string, HeadroomEntry> = {
+      'claude:org=a': { ...baseEntry, callTimestamps: [NOW - 500, NOW - 5_000] },
+      'claude:org=b': { ...baseEntry, callTimestamps: [NOW - 200] },
+      'grok:user=g': { ...baseEntry, callTimestamps: [NOW - 1] },
+    };
+    const last = providerLastCall(accounts, cache);
+    expect(last.get('claude')).toBe(NOW - 200);
+    expect(last.has('grok')).toBe(false);
+  });
+});
+
 describe('provider budget — aggregate endpoint pressure does not scale with N', () => {
   let cacheDir: string;
   let prevHeadroom: string | null;
@@ -376,59 +427,60 @@ describe('provider budget — aggregate endpoint pressure does not scale with N'
     fs.rmSync(cacheDir, { recursive: true, force: true });
   });
 
-  it('caps one tick at PROVIDER_HOURLY_BUDGET fetches even with far more due accounts', async () => {
-    const n = PROVIDER_HOURLY_BUDGET + 12; // 8+ accounts is the real case; go well over.
-    let fetches = 0;
-    const accounts = Array.from({ length: n }, (_, i) => ({
-      usageKey: `claude:org=acct-${i}`,
-      agentId: 'claude' as const,
-      fetch: async () => { fetches += 1; return { snapshot: sessionSnap(10, NOW), error: null }; },
-    }));
+  const claudeAccounts = (n: number, fetchImpl?: (key: string, now: number) => void) =>
+    Array.from({ length: n }, (_, i) => {
+      const usageKey = `claude:org=acct-${i}`;
+      return {
+        usageKey,
+        agentId: 'claude' as const,
+        fetch: async () => { fetchImpl?.(usageKey, NOW); return { snapshot: sessionSnap(10, NOW), error: null }; },
+      };
+    });
+
+  it('paces a cold provider to the catch-up ceiling, not the whole due set at once', async () => {
+    const accounts = claudeAccounts(PROVIDER_HOURLY_BUDGET + 12);
     const result = await runUsageRefresh({
       now: NOW,
       listAccounts: async () => accounts,
       writeUsageCache: writeClaudeUsageCache,
       backoffUntil: () => null,
     });
-    expect(result.refreshed).toBe(PROVIDER_HOURLY_BUDGET);
-    expect(result.skippedBudget).toBe(n - PROVIDER_HOURLY_BUDGET);
-    expect(fetches).toBe(PROVIDER_HOURLY_BUDGET);
+    // Spacing caps a single tick at the catch-up ceiling — never the full due set.
+    expect(result.refreshed).toBe(PROVIDER_CATCHUP_MAX);
+    expect(result.skippedBudget).toBe(accounts.length - PROVIDER_CATCHUP_MAX);
   });
 
-  it('holds the aggregate under the budget across multiple ticks in one hour', async () => {
-    const n = PROVIDER_HOURLY_BUDGET + 12;
+  it('holds the aggregate at the hourly budget across a full hour of ticks', async () => {
+    const accounts = claudeAccounts(PROVIDER_HOURLY_BUDGET + 12);
     let fetches = 0;
-    const accounts = Array.from({ length: n }, (_, i) => ({
-      usageKey: `claude:org=acct-${i}`,
-      agentId: 'claude' as const,
-      fetch: async () => { fetches += 1; return { snapshot: sessionSnap(10, NOW), error: null }; },
-    }));
-    // Three ticks 60s apart — all inside one rolling hour. Budget-skipped accounts
-    // stay due and compete again, but the rolling-hour aggregate must not exceed
-    // the budget (the endpoint would 429 otherwise).
-    for (let tick = 0; tick < 3; tick += 1) {
-      await runUsageRefresh({
+    const ticksPerHour = (60 * 60 * 1000) / USAGE_REFRESH_TICK_MS; // 60
+    for (let tick = 0; tick < ticksPerHour; tick += 1) {
+      const r = await runUsageRefresh({
         now: NOW + tick * USAGE_REFRESH_TICK_MS,
         listAccounts: async () => accounts,
         writeUsageCache: writeClaudeUsageCache,
         backoffUntil: () => null,
       });
+      fetches += r.refreshed;
     }
+    // Smooth pacing lands exactly on the budget — one fetch every other tick.
     expect(fetches).toBe(PROVIDER_HOURLY_BUDGET);
   });
 
-  it('spends the budget on the STALEST accounts, deferring the freshest', async () => {
-    const n = PROVIDER_HOURLY_BUDGET + 1; // exactly one account must be deferred.
-    const fetched = new Set<string>();
-    const accounts = Array.from({ length: n }, (_, i) => ({
-      usageKey: `claude:org=acct-${i}`,
-      agentId: 'claude' as const,
-      fetch: async () => { fetched.add(`claude:org=acct-${i}`); return { snapshot: sessionSnap(10, NOW), error: null }; },
-    }));
-    // Seed staggered capture times: acct-0 freshest (NOW-1m), acct-n stalest.
+  it('serves the STALEST account first when spacing frees a token', async () => {
+    const fetched: string[] = [];
+    const accounts = claudeAccounts(4, (key) => fetched.push(key));
+    // Seed staggered capture times: acct-3 stalest, acct-0 freshest. All due.
+    // A recent provider call means spacing grants no token this tick...
     const seed: Record<string, HeadroomEntry> = {};
     accounts.forEach((a, i) => {
-      seed[a.usageKey] = { ...baseEntry, capturedAt: NOW - (i + 1) * 60_000, nextRefreshAt: NOW - 1 };
+      seed[a.usageKey] = {
+        ...baseEntry,
+        capturedAt: NOW - (i + 1) * 60_000,
+        nextRefreshAt: NOW - 1,
+        // last provider call one full spacing ago ⇒ exactly one token this tick.
+        callTimestamps: i === 0 ? [NOW - PROVIDER_MIN_REFRESH_SPACING_MS] : [],
+      };
     });
     writeHeadroomEntries(seed);
 
@@ -438,10 +490,9 @@ describe('provider budget — aggregate endpoint pressure does not scale with N'
       writeUsageCache: writeClaudeUsageCache,
       backoffUntil: () => null,
     });
-    expect(result.refreshed).toBe(PROVIDER_HOURLY_BUDGET);
-    expect(result.skippedBudget).toBe(1);
-    // The single deferred account is the FRESHEST one (acct-0, captured 1m ago).
-    expect(fetched.has('claude:org=acct-0')).toBe(false);
+    expect(result.refreshed).toBe(1);
+    // The one token went to the stalest account (acct-3), not the freshest.
+    expect(fetched).toEqual(['claude:org=acct-3']);
   });
 
   it('never calls a parked (backed-off) account, and it does not consume budget', async () => {
@@ -462,27 +513,41 @@ describe('provider budget — aggregate endpoint pressure does not scale with N'
     expect(result.refreshed).toBe(1);
   });
 
-  it('does not API-refresh an account a statusline ingest just captured for free', async () => {
+  it('does not API-refresh an account a statusline ingest just captured, and re-derives its headroom', async () => {
     let fetched = false;
     const key = 'claude:org=statusline-fresh';
+    // Prior sample so the burn projection has something to compute minutesToLimit from.
+    writeHeadroomEntries({
+      [key]: { ...baseEntry, capturedAt: NOW - 10 * 60_000, sessionUsedPercent: 50, nextRefreshAt: NOW - 1, callTimestamps: [] },
+    });
+    // The statusline wrote a fresh row 1 minute ago: 70% used (up from 50%).
+    const fresh = { ...sessionSnap(70, NOW - 60_000) };
     const result = await runUsageRefresh({
       now: NOW,
       listAccounts: async () => [
-        { usageKey: key, agentId: 'claude', fetch: async () => { fetched = true; return { snapshot: sessionSnap(10, NOW), error: null }; } },
+        { usageKey: key, agentId: 'claude', fetch: async () => { fetched = true; return { snapshot: sessionSnap(99, NOW), error: null }; } },
       ],
       writeUsageCache: writeClaudeUsageCache,
       backoffUntil: () => null,
-      // Captured 1 minute ago by the free statusline ingest (< STATUSLINE_FRESH_MS).
-      lastCapturedAt: () => NOW - 60_000,
+      readCachedSnapshot: () => fresh,
     });
     expect(fetched).toBe(false);
     expect(result.skippedFresh).toBe(1);
     expect(result.refreshed).toBe(0);
-    // Rescheduled one interval past the free capture, not re-attempted every tick.
-    expect(readHeadroomEntry(key)?.nextRefreshAt).toBe(NOW - 60_000 + STATUSLINE_FRESH_MS);
+    const entry = readHeadroomEntry(key);
+    // Headroom is RE-DERIVED from the fresh statusline row, not frozen at the old sample.
+    expect(entry?.sessionUsedPercent).toBe(70);
+    expect(entry?.status).not.toBeNull();
+    // Prev sample (50% @ NOW-10m) → fresh (70% @ NOW-1m): 20% over 9 min = 2.22%/min,
+    // 30% left ⇒ 13.5 min to cap — computed from the REAL fresh capture time, not frozen.
+    expect(entry?.minutesToLimit).toBeCloseTo(13.5, 5);
+    // No API call recorded (statusline is free) ⇒ no call timestamp consumed budget.
+    expect(entry?.callTimestamps).toEqual([]);
+    // Rescheduled one interval past the free capture.
+    expect(entry?.nextRefreshAt).toBe(NOW - 60_000 + STATUSLINE_FRESH_MS);
   });
 
-  it('DOES API-refresh an account whose statusline capture has aged past the window', async () => {
+  it('DOES API-refresh an account whose cached row aged past the statusline-fresh window', async () => {
     let fetched = false;
     const result = await runUsageRefresh({
       now: NOW,
@@ -491,10 +556,121 @@ describe('provider budget — aggregate endpoint pressure does not scale with N'
       ],
       writeUsageCache: writeClaudeUsageCache,
       backoffUntil: () => null,
-      lastCapturedAt: () => NOW - (STATUSLINE_FRESH_MS + 60_000), // older than the window
+      readCachedSnapshot: () => sessionSnap(10, NOW - (STATUSLINE_FRESH_MS + 60_000)),
     });
     expect(fetched).toBe(true);
     expect(result.refreshed).toBe(1);
     expect(result.skippedFresh).toBe(0);
+  });
+
+  it('does NOT apply the statusline-fresh skip to a network:false provider (grok refreshes)', async () => {
+    let fetched = false;
+    // grok's cache is always its own last local-log write, so a "recent" capture
+    // must NOT suppress its refresh — only network providers get the skip.
+    const result = await runUsageRefresh({
+      now: NOW,
+      listAccounts: async () => [
+        { usageKey: 'grok:user=g', agentId: 'grok', fetch: async () => { fetched = true; return { snapshot: sessionSnap(10, NOW), error: null }; } },
+      ],
+      writeUsageCache: writeClaudeUsageCache,
+      backoffUntil: () => null,
+      readCachedSnapshot: () => sessionSnap(10, NOW - 1_000), // 1s ago
+    });
+    expect(fetched).toBe(true);
+    expect(result.refreshed).toBe(1);
+    expect(result.skippedFresh).toBe(0);
+  });
+});
+
+describe('BLOCKER reconciliation — a budget-paced fleet never collapses to NO_VERIFIED_USAGE', () => {
+  let cacheDir: string;
+  let prevHeadroom: string | null;
+  let prevUsage: string | null;
+
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-sim-'));
+    prevHeadroom = setHeadroomCachePathForTest(path.join(cacheDir, '.usage-headroom.json'));
+    prevUsage = setClaudeUsageCachePathForTest(path.join(cacheDir, 'claude-usage.json'));
+  });
+
+  afterEach(() => {
+    setHeadroomCachePathForTest(prevHeadroom);
+    setClaudeUsageCachePathForTest(prevUsage);
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  // Build the router's freshness view of a provider straight from the usage cache
+  // the daemon just wrote, then apply the REAL rotate gates. This is the seam the
+  // reviewer's blocker lives on: budget-paced cadence vs the routing window.
+  const noVerifiedUsage = (keys: string[], now: number): { refuse: boolean; maxAgeMs: number; verified: number } => {
+    const pool = keys.map((usageKey) => {
+      const snap = readClaudeUsageCache(usageKey);
+      return { usageSnapshot: snap } as unknown as RotateCandidate;
+    });
+    const verified = pool.filter((c) => isUsageVerified(c, now)).length;
+    const refuse = verified === 0 && pool.some((c) => hasStaleUsage(c, now));
+    const maxAgeMs = Math.max(
+      0,
+      ...keys.map((k) => {
+        const cap = readClaudeUsageCache(k)?.capturedAt?.getTime();
+        return cap ? now - cap : 0;
+      }),
+    );
+    return { refuse, maxAgeMs, verified };
+  };
+
+  const runFleet = async (n: number, hours: number) => {
+    const keys = Array.from({ length: n }, (_, i) => `claude:org=acct-${i}`);
+    const accounts = keys.map((usageKey) => ({
+      usageKey,
+      agentId: 'claude' as const,
+      fetch: async () => ({ snapshot: sessionSnap(10, NOW), error: null }),
+    }));
+    const ticks = (hours * 60 * 60 * 1000) / USAGE_REFRESH_TICK_MS;
+    let totalFetches = 0;
+    let everRefused = false;
+    let worstAgeMs = 0;
+    let allWarm = false;
+    for (let tick = 0; tick < ticks; tick += 1) {
+      const now = NOW + tick * USAGE_REFRESH_TICK_MS;
+      const r = await runUsageRefresh({
+        now,
+        listAccounts: async () => accounts.map((a) => ({
+          ...a,
+          fetch: async () => ({ snapshot: sessionSnap(10, now), error: null }),
+        })),
+        writeUsageCache: writeClaudeUsageCache,
+        backoffUntil: () => null,
+      });
+      totalFetches += r.refreshed;
+      // Once every account has a snapshot, the fleet is warm; from then on the
+      // refusal must NEVER fire.
+      if (!allWarm) allWarm = keys.every((k) => readClaudeUsageCache(k) !== null);
+      if (allWarm) {
+        const v = noVerifiedUsage(keys, now);
+        if (v.refuse) everRefused = true;
+        worstAgeMs = Math.max(worstAgeMs, v.maxAgeMs);
+      }
+    }
+    return { totalFetches, everRefused, worstAgeMs, ticks };
+  };
+
+  it('8-account idle fleet: refusal never fires, every account stays under the routing window, load ~budget/hr', async () => {
+    const { totalFetches, everRefused, worstAgeMs, ticks } = await runFleet(8, 3);
+    expect(everRefused).toBe(false);
+    // No account ever reads as genuinely stale (the refusal bar)...
+    expect(worstAgeMs).toBeLessThan(USAGE_STALE_REFUSAL_MAX_AGE_MS);
+    // ...and the worst-case cadence tracks round-robin N × spacing (~16 min for 8
+    // accounts), not the unbounded 40-min stall a plain rolling cap produced.
+    expect(worstAgeMs).toBeLessThan(9 * PROVIDER_MIN_REFRESH_SPACING_MS);
+    // Aggregate endpoint load holds at ~budget/hr (NOT 8×12=96/hr).
+    const perHour = totalFetches / (ticks / ((60 * 60 * 1000) / USAGE_REFRESH_TICK_MS));
+    expect(perHour).toBeLessThanOrEqual(PROVIDER_HOURLY_BUDGET + PROVIDER_CATCHUP_MAX);
+  });
+
+  it('16-account idle fleet (realistic max): still no refusal, cadence still under the window', async () => {
+    const { everRefused, worstAgeMs } = await runFleet(16, 3);
+    expect(everRefused).toBe(false);
+    expect(worstAgeMs).toBeLessThan(USAGE_STALE_REFUSAL_MAX_AGE_MS);
   });
 });

--- a/cli/src/lib/usage-refresh.ts
+++ b/cli/src/lib/usage-refresh.ts
@@ -82,9 +82,24 @@ export const REFRESH_MAX_MS = REFRESH_INTERVAL_MS;
 export const REFRESH_BURN_DIVISOR = 4;
 /** At most this many live fetches per account per rolling hour (5m cadence ⇒ 12). */
 export const HOURLY_CALL_CAP = 12;
+/** How often the daemon wakes to *consider* a refresh pass (due accounts only). */
+export const USAGE_REFRESH_TICK_MS = 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+/**
+ * Minimum wall-clock spacing between two live usage fetches to ONE network
+ * provider, across all of its accounts. This is the pacing primitive: refreshes
+ * are issued round-robin (stalest account first) no faster than one per spacing,
+ * so aggregate endpoint load is a smooth, fixed rate — never the synchronized
+ * burst-then-stall a plain rolling-hour cap produces when every account falls
+ * due on the same tick. Set to two daemon ticks so the floor-based pacing lands
+ * on exact tick boundaries (no drift): one refresh every other tick ⇒ 30/hr.
+ */
+export const PROVIDER_MIN_REFRESH_SPACING_MS = 2 * USAGE_REFRESH_TICK_MS;
 /**
  * Aggregate live fetches this daemon may spend on ONE network provider's usage
- * endpoint per rolling hour, across ALL of that provider's local accounts.
+ * endpoint per rolling hour, across ALL of that provider's local accounts —
+ * derived from {@link PROVIDER_MIN_REFRESH_SPACING_MS} so the two are always
+ * consistent (HOUR / 120s = 30).
  *
  * The per-account {@link HOURLY_CALL_CAP} alone scales linearly with account
  * count — 8 Claude accounts × 12/hr = ~96 usage calls/hr from one box — and
@@ -95,16 +110,24 @@ export const HOURLY_CALL_CAP = 12;
  * `agents view` showed `S: unavailable` and balanced routing read stale/absent
  * usage. It got WORSE with every account added.
  *
- * This budget caps the daemon's usage traffic at a fixed rate that does NOT grow
- * with account count. 40/hr leaves real headroom under the ~100/hr ceiling for
- * the auth probe (which rides the same endpoint at ~3/hr/account, RUSH-2998) and
- * for foreground `agents view` bursts. The consequence — each account's
- * effective proactive cadence stretches as N grows (roughly one refresh every
- * ceil(N / (budget·tick-share)) — is correct: a slightly older-but-present
- * reading beats a 45-minute 429 park. Applies only to `network:true` providers;
+ * 30/hr is a fixed rate that does NOT grow with account count, and leaves ample
+ * headroom under the ~100/hr ceiling for the auth probe (same endpoint, ~3/hr
+ * per account, RUSH-2998) and foreground `agents view` bursts. Because refreshes
+ * are paced round-robin (stalest first), each account's worst-case proactive
+ * cadence is bounded at N × spacing (8 accounts ⇒ 16 min; 16 ⇒ 32 min) — kept
+ * deliberately under the {@link USAGE_STALE_REFUSAL_MAX_AGE_MS} routing window so
+ * a budget-paced account never reads as "genuinely stale". A slightly
+ * older-but-present reading beats a 45-minute 429 park. Network providers only;
  * grok/codex read local logs and have no rate-limited endpoint.
  */
-export const PROVIDER_HOURLY_BUDGET = 40;
+export const PROVIDER_HOURLY_BUDGET = HOUR_MS / PROVIDER_MIN_REFRESH_SPACING_MS;
+/**
+ * Most refreshes a single tick may catch up after the daemon has been idle/down
+ * (elapsed ≫ spacing). Without this clamp a long gap would grant many tokens at
+ * once and re-synchronize every account into the very burst the spacing exists
+ * to prevent. A small catch-up keeps the load smooth even after a restart.
+ */
+export const PROVIDER_CATCHUP_MAX = 2;
 /**
  * A usage row this recently captured (by the free statusline ingest of a live
  * `agents run`, or any writer) is already fresh — do not spend an API call to
@@ -112,15 +135,12 @@ export const PROVIDER_HOURLY_BUDGET = 40;
  * the proactive budget is reserved for genuinely idle accounts.
  */
 export const STATUSLINE_FRESH_MS = REFRESH_INTERVAL_MS;
-/** How often the daemon wakes to *consider* a refresh pass (due accounts only). */
-export const USAGE_REFRESH_TICK_MS = 60 * 1000;
 /** Consecutive failed live reads before one broken account is quarantined. */
 export const FAILURE_QUARANTINE_THRESHOLD = 3;
 /** A chronic offender waits this long while healthy siblings keep their cadence. */
 export const FAILURE_QUARANTINE_MS = 30 * 60 * 1000;
 const SKIP_JITTER_MIN_MS = 2_000;
 const SKIP_JITTER_RANGE_MS = 3_001;
-const HOUR_MS = 60 * 60 * 1000;
 
 /**
  * One account's refresh state + published headroom. `sessionUsedPercent` /
@@ -293,25 +313,77 @@ function skippedHeadroomEntry(
 
 /**
  * Reschedule an account we skipped because a free statusline ingest already
- * captured it inside {@link STATUSLINE_FRESH_MS}. Carry the prior projection
- * forward and push the next proactive attempt to one interval past that free
- * capture, so the budget is not spent re-refreshing an already-current row.
+ * captured it inside {@link STATUSLINE_FRESH_MS}. The statusline row IS a real,
+ * live sample, so RE-DERIVE headroom (status / minutesToLimit) from it against
+ * the prior sample — otherwise `status`/`minutesToLimit` would freeze at their
+ * last API-refresh value forever for exactly the actively-used accounts that
+ * stay statusline-fresh, and `capacityWeight` reads `minutesToLimit`. No call
+ * timestamp is recorded (this cost zero API budget); the next proactive attempt
+ * is pushed to one interval past the free capture.
  */
 function freshHeadroomEntry(
   prev: HeadroomEntry | null,
+  snapshot: UsageSnapshot,
   now: number,
-  lastCapturedAt: number,
+  capturedAtMs: number,
 ): HeadroomEntry {
+  const headroom = deriveUsageHeadroom(
+    snapshot,
+    prev && prev.capturedAt !== null && prev.sessionUsedPercent !== null
+      ? { capturedAt: prev.capturedAt, usedPercent: prev.sessionUsedPercent }
+      : null,
+  );
+  const session = snapshot.windows.find((window) => window.key === 'session') ?? null;
   return {
-    status: prev?.status ?? null,
-    minutesToLimit: prev?.minutesToLimit ?? null,
-    sessionUsedPercent: prev?.sessionUsedPercent ?? null,
-    capturedAt: prev?.capturedAt ?? null,
-    nextRefreshAt: lastCapturedAt + REFRESH_INTERVAL_MS,
+    status: headroom.status,
+    minutesToLimit: headroom.minutesToLimit,
+    sessionUsedPercent: session?.usedPercent ?? prev?.sessionUsedPercent ?? null,
+    capturedAt: snapshot.capturedAt?.getTime() ?? prev?.capturedAt ?? null,
+    nextRefreshAt: capturedAtMs + REFRESH_INTERVAL_MS,
+    // Not an API call — do NOT record a timestamp (would wrongly spend budget).
     callTimestamps: pruneCallTimestamps(prev?.callTimestamps ?? [], now),
     computedAt: now,
-    consecutiveFailures: prev?.consecutiveFailures ?? 0,
+    consecutiveFailures: 0,
   };
+}
+
+/**
+ * Most-recent live-fetch time per network provider (the max call timestamp
+ * across its accounts, 0 when none), which the smooth per-provider pacing spaces
+ * the next refresh from. Non-network providers are omitted — they have no
+ * rate-limited endpoint to pace.
+ */
+export function providerLastCall(
+  accounts: LocalUsageAccount[],
+  cache: Record<string, HeadroomEntry>,
+): Map<AgentId, number> {
+  const last = new Map<AgentId, number>();
+  for (const account of accounts) {
+    if (!agentUsesNetworkUsage(account.agentId)) continue;
+    if (!last.has(account.agentId)) last.set(account.agentId, 0);
+    for (const ts of cache[account.usageKey]?.callTimestamps ?? []) {
+      if (ts > (last.get(account.agentId) ?? 0)) last.set(account.agentId, ts);
+    }
+  }
+  return last;
+}
+
+/**
+ * How many live fetches the smooth pacing permits a provider THIS tick: one per
+ * elapsed {@link PROVIDER_MIN_REFRESH_SPACING_MS} since its last fetch, clamped
+ * to {@link PROVIDER_CATCHUP_MAX} so a long idle gap (or a cold provider with no
+ * prior fetch) cannot re-burst the whole due set at once. At the daemon's 60 s
+ * tick this yields at most one fetch every other tick in steady state (⇒ the
+ * hourly budget), while a small fleet whose total demand fits under budget is
+ * never throttled — the {@link PROVIDER_HOURLY_BUDGET} rolling cap is the only
+ * gate that binds it.
+ */
+export function providerSpacingTokens(lastCallMs: number, now: number): number {
+  // A cold provider (never fetched) is treated as maximally idle: grant the
+  // catch-up ceiling so a couple of accounts warm immediately without bursting.
+  const elapsed = lastCallMs <= 0 ? Infinity : now - lastCallMs;
+  if (elapsed < PROVIDER_MIN_REFRESH_SPACING_MS) return 0;
+  return Math.min(PROVIDER_CATCHUP_MAX, Math.floor(elapsed / PROVIDER_MIN_REFRESH_SPACING_MS));
 }
 
 function failedHeadroomEntry(prev: HeadroomEntry | null, now: number): HeadroomEntry {
@@ -444,12 +516,13 @@ export interface UsageRefreshDeps {
    */
   backoffUntil: (agentId: AgentId, usageKey?: string) => number | null;
   /**
-   * Epoch ms this account's usage row was last captured in the shared usage
-   * cache (the row the routing hot path reads), or null when absent. Lets the
-   * refresher see the FREE statusline ingest of a live `agents run` and skip a
-   * redundant API refresh of an already-current account (RUSH: provider budget).
+   * The account's current usage row from the shared cache (the row the routing
+   * hot path reads), or null when absent. Lets the refresher see the FREE
+   * statusline ingest of a live `agents run` and, when that row is recent, skip a
+   * redundant API refresh while still re-deriving headroom from it — instead of
+   * spending scarce provider budget re-fetching an already-current account.
    */
-  lastCapturedAt?: (usageKey: string) => number | null;
+  readCachedSnapshot?: (usageKey: string) => UsageSnapshot | null;
 }
 
 export interface UsageRefreshResult {
@@ -488,16 +561,25 @@ export async function runUsageRefresh(deps: UsageRefreshDeps): Promise<UsageRefr
     cache,
     Math.floor(now / USAGE_REFRESH_TICK_MS),
   );
-  // Per-provider rolling-hour budget counter, seeded with calls already spent in
-  // the trailing hour so PROVIDER_HOURLY_BUDGET bounds the true hourly total.
-  // Because accounts are ordered stalest-first, the budget is consumed by the
-  // accounts most in need; fresher ones defer to a later tick (their entry is
-  // left untouched, so they stay due and compete again next tick).
+  // Per-provider pacing. Two gates keep aggregate endpoint load smooth and bounded:
+  //  - a rolling-hour ceiling (PROVIDER_HOURLY_BUDGET) — the hard cap, seeded
+  //    with calls already spent in the trailing hour;
+  //  - a min-spacing token count (PROVIDER_MIN_REFRESH_SPACING_MS) — the smoother,
+  //    which issues refreshes round-robin at a fixed rate instead of the
+  //    synchronized burst-then-stall a plain rolling cap produces when every
+  //    account falls due on the same tick.
+  // Both are per-provider and network-only; accounts are ordered stalest-first, so
+  // the scarce budget always serves the account most in need and none is starved.
   const budgetSpent = providerRecentCalls(accounts, cache, now);
+  const lastCall = providerLastCall(accounts, cache);
+  const spacingTokens = new Map<AgentId, number>();
+  for (const [agent, last] of lastCall) spacingTokens.set(agent, providerSpacingTokens(last, now));
+  const spacingUsed = new Map<AgentId, number>();
   const updates: Record<string, HeadroomEntry> = {};
 
   for (const [index, account] of accounts.entries()) {
     const entry = cache[account.usageKey] ?? null;
+    const network = agentUsesNetworkUsage(account.agentId);
 
     // A penalized account/provider is off-limits — poking it re-arms the
     // penalty (the whole reason usage-backoff exists).
@@ -513,27 +595,33 @@ export async function runUsageRefresh(deps: UsageRefreshDeps): Promise<UsageRefr
     }
 
     // A live `agents run` already refreshed this account's usage row for free via
-    // the statusline ingest — don't spend a scarce API call re-refreshing it.
-    const lastCapturedAt = deps.lastCapturedAt?.(account.usageKey) ?? null;
-    if (lastCapturedAt !== null && now - lastCapturedAt < STATUSLINE_FRESH_MS) {
-      updates[account.usageKey] = freshHeadroomEntry(entry, now, lastCapturedAt);
-      result.skippedFresh += 1;
-      continue;
+    // the statusline ingest — re-derive headroom from that row and skip the API
+    // call. Network providers only: a local-log provider's cache is always its
+    // own last write, so this must not suppress its refresh (grok/codex).
+    if (network) {
+      const cached = deps.readCachedSnapshot?.(account.usageKey) ?? null;
+      const capturedAtMs = cached?.capturedAt?.getTime() ?? null;
+      if (cached && capturedAtMs !== null && now - capturedAtMs < STATUSLINE_FRESH_MS) {
+        updates[account.usageKey] = freshHeadroomEntry(entry, cached, now, capturedAtMs);
+        result.skippedFresh += 1;
+        continue;
+      }
     }
 
     // Global per-provider budget: cap aggregate endpoint traffic so it does not
-    // scale linearly with account count and trip the ~100/hr rate limit. Only
-    // network providers ride a rate-limited endpoint; local-log providers don't.
-    if (agentUsesNetworkUsage(account.agentId)
-      && (budgetSpent.get(account.agentId) ?? 0) >= PROVIDER_HOURLY_BUDGET) {
-      // Leave the entry untouched so this still-due account competes again next
-      // tick, when the rolling window has freed budget — never starved.
-      result.skippedBudget += 1;
-      continue;
-    }
-
-    if (agentUsesNetworkUsage(account.agentId)) {
+    // scale linearly with account count and trip the ~100/hr rate limit, and pace
+    // it smoothly. Non-network providers (local logs) have no endpoint to protect.
+    if (network) {
+      const overHourly = (budgetSpent.get(account.agentId) ?? 0) >= PROVIDER_HOURLY_BUDGET;
+      const overSpacing = (spacingUsed.get(account.agentId) ?? 0) >= (spacingTokens.get(account.agentId) ?? 0);
+      if (overHourly || overSpacing) {
+        // Leave the entry untouched so this still-due account competes again next
+        // tick, when budget/spacing frees — never starved (stalest-first serves it).
+        result.skippedBudget += 1;
+        continue;
+      }
       budgetSpent.set(account.agentId, (budgetSpent.get(account.agentId) ?? 0) + 1);
+      spacingUsed.set(account.agentId, (spacingUsed.get(account.agentId) ?? 0) + 1);
     }
 
     try {

--- a/cli/src/lib/usage-refresh.ts
+++ b/cli/src/lib/usage-refresh.ts
@@ -55,6 +55,7 @@ import {
   deriveUsageHeadroom,
   getUsageInfo,
   buildCanonicalUsageContext,
+  agentUsesNetworkUsage,
   USAGE_SOURCE_AGENT_IDS,
   type UsageHeadroom,
   type UsageSnapshot,
@@ -81,6 +82,36 @@ export const REFRESH_MAX_MS = REFRESH_INTERVAL_MS;
 export const REFRESH_BURN_DIVISOR = 4;
 /** At most this many live fetches per account per rolling hour (5m cadence ⇒ 12). */
 export const HOURLY_CALL_CAP = 12;
+/**
+ * Aggregate live fetches this daemon may spend on ONE network provider's usage
+ * endpoint per rolling hour, across ALL of that provider's local accounts.
+ *
+ * The per-account {@link HOURLY_CALL_CAP} alone scales linearly with account
+ * count — 8 Claude accounts × 12/hr = ~96 usage calls/hr from one box — and
+ * Anthropic's `/api/oauth/usage` rate-limits around ~100/hr (see the
+ * `usage-backoff.ts` header). That tripped the endpoint into per-account 429s
+ * with Retry-After penalties up to an hour: measured live on `zion`, 7 of 8
+ * Claude accounts sat parked, never refreshed inside their 5h window, so
+ * `agents view` showed `S: unavailable` and balanced routing read stale/absent
+ * usage. It got WORSE with every account added.
+ *
+ * This budget caps the daemon's usage traffic at a fixed rate that does NOT grow
+ * with account count. 40/hr leaves real headroom under the ~100/hr ceiling for
+ * the auth probe (which rides the same endpoint at ~3/hr/account, RUSH-2998) and
+ * for foreground `agents view` bursts. The consequence — each account's
+ * effective proactive cadence stretches as N grows (roughly one refresh every
+ * ceil(N / (budget·tick-share)) — is correct: a slightly older-but-present
+ * reading beats a 45-minute 429 park. Applies only to `network:true` providers;
+ * grok/codex read local logs and have no rate-limited endpoint.
+ */
+export const PROVIDER_HOURLY_BUDGET = 40;
+/**
+ * A usage row this recently captured (by the free statusline ingest of a live
+ * `agents run`, or any writer) is already fresh — do not spend an API call to
+ * re-refresh it. Actively-used accounts stay current at zero endpoint cost, so
+ * the proactive budget is reserved for genuinely idle accounts.
+ */
+export const STATUSLINE_FRESH_MS = REFRESH_INTERVAL_MS;
 /** How often the daemon wakes to *consider* a refresh pass (due accounts only). */
 export const USAGE_REFRESH_TICK_MS = 60 * 1000;
 /** Consecutive failed live reads before one broken account is quarantined. */
@@ -260,6 +291,29 @@ function skippedHeadroomEntry(
   };
 }
 
+/**
+ * Reschedule an account we skipped because a free statusline ingest already
+ * captured it inside {@link STATUSLINE_FRESH_MS}. Carry the prior projection
+ * forward and push the next proactive attempt to one interval past that free
+ * capture, so the budget is not spent re-refreshing an already-current row.
+ */
+function freshHeadroomEntry(
+  prev: HeadroomEntry | null,
+  now: number,
+  lastCapturedAt: number,
+): HeadroomEntry {
+  return {
+    status: prev?.status ?? null,
+    minutesToLimit: prev?.minutesToLimit ?? null,
+    sessionUsedPercent: prev?.sessionUsedPercent ?? null,
+    capturedAt: prev?.capturedAt ?? null,
+    nextRefreshAt: lastCapturedAt + REFRESH_INTERVAL_MS,
+    callTimestamps: pruneCallTimestamps(prev?.callTimestamps ?? [], now),
+    computedAt: now,
+    consecutiveFailures: prev?.consecutiveFailures ?? 0,
+  };
+}
+
 function failedHeadroomEntry(prev: HeadroomEntry | null, now: number): HeadroomEntry {
   const next = nextHeadroomEntry(prev, null, now);
   if ((next.consecutiveFailures ?? 0) >= FAILURE_QUARANTINE_THRESHOLD) {
@@ -276,7 +330,18 @@ export interface LocalUsageAccount {
   fetch: () => Promise<UsageInfo>;
 }
 
-/** Cold accounts lead each pass; both cold and cached groups rotate every tick. */
+/**
+ * Order a pass STALEST-FIRST so a scarce per-provider budget
+ * ({@link PROVIDER_HOURLY_BUDGET}) is always spent on the accounts most in need
+ * of a fresh reading, and no account is starved indefinitely.
+ *
+ *  - **Cold accounts** (never refreshed → no cache entry) are maximally stale
+ *    and lead the pass. They rotate by `tick` so, when the budget can't cover
+ *    them all in one tick, a different cold account leads each tick.
+ *  - **Cached accounts** follow, oldest `capturedAt` first (a null capture time
+ *    counts as maximally stale). As accounts refresh their `capturedAt` advances,
+ *    so the next pass naturally rotates to whoever is now most out of date.
+ */
 export function orderUsageAccounts(
   accounts: LocalUsageAccount[],
   cache: Record<string, HeadroomEntry>,
@@ -289,7 +354,30 @@ export function orderUsageAccounts(
   };
   const cold = accounts.filter((account) => cache[account.usageKey] == null);
   const cached = accounts.filter((account) => cache[account.usageKey] != null);
-  return [...rotate(cold), ...rotate(cached)];
+  const staleness = (account: LocalUsageAccount): number => cache[account.usageKey]?.capturedAt ?? 0;
+  const byStalest = [...cached].sort((a, b) => staleness(a) - staleness(b));
+  return [...rotate(cold), ...byStalest];
+}
+
+/**
+ * Aggregate live calls a network provider has already spent in the trailing hour,
+ * summed across the accounts in this pass. Seeds the per-provider budget counter
+ * so {@link PROVIDER_HOURLY_BUDGET} bounds the rolling-hour total, not just this
+ * one tick. Non-network providers (grok/codex, local logs) are excluded — they
+ * have no rate-limited endpoint to budget.
+ */
+export function providerRecentCalls(
+  accounts: LocalUsageAccount[],
+  cache: Record<string, HeadroomEntry>,
+  now: number,
+): Map<AgentId, number> {
+  const counts = new Map<AgentId, number>();
+  for (const account of accounts) {
+    if (!agentUsesNetworkUsage(account.agentId)) continue;
+    const recent = pruneCallTimestamps(cache[account.usageKey]?.callTimestamps ?? [], now);
+    counts.set(account.agentId, (counts.get(account.agentId) ?? 0) + recent.length);
+  }
+  return counts;
 }
 
 /**
@@ -355,6 +443,13 @@ export interface UsageRefreshDeps {
    * this loop's fixed iteration order.
    */
   backoffUntil: (agentId: AgentId, usageKey?: string) => number | null;
+  /**
+   * Epoch ms this account's usage row was last captured in the shared usage
+   * cache (the row the routing hot path reads), or null when absent. Lets the
+   * refresher see the FREE statusline ingest of a live `agents run` and skip a
+   * redundant API refresh of an already-current account (RUSH: provider budget).
+   */
+  lastCapturedAt?: (usageKey: string) => number | null;
 }
 
 export interface UsageRefreshResult {
@@ -362,6 +457,10 @@ export interface UsageRefreshResult {
   skippedNotDue: number;
   skippedBackoff: number;
   skippedCap: number;
+  /** Skipped because the provider's rolling-hour budget was already spent. */
+  skippedBudget: number;
+  /** Skipped because a free statusline ingest already captured it recently. */
+  skippedFresh: number;
   failed: number;
 }
 
@@ -378,6 +477,8 @@ export async function runUsageRefresh(deps: UsageRefreshDeps): Promise<UsageRefr
     skippedNotDue: 0,
     skippedBackoff: 0,
     skippedCap: 0,
+    skippedBudget: 0,
+    skippedFresh: 0,
     failed: 0,
   };
 
@@ -387,6 +488,12 @@ export async function runUsageRefresh(deps: UsageRefreshDeps): Promise<UsageRefr
     cache,
     Math.floor(now / USAGE_REFRESH_TICK_MS),
   );
+  // Per-provider rolling-hour budget counter, seeded with calls already spent in
+  // the trailing hour so PROVIDER_HOURLY_BUDGET bounds the true hourly total.
+  // Because accounts are ordered stalest-first, the budget is consumed by the
+  // accounts most in need; fresher ones defer to a later tick (their entry is
+  // left untouched, so they stay due and compete again next tick).
+  const budgetSpent = providerRecentCalls(accounts, cache, now);
   const updates: Record<string, HeadroomEntry> = {};
 
   for (const [index, account] of accounts.entries()) {
@@ -403,6 +510,30 @@ export async function runUsageRefresh(deps: UsageRefreshDeps): Promise<UsageRefr
       if (entry && now < entry.nextRefreshAt) result.skippedNotDue += 1;
       else result.skippedCap += 1;
       continue;
+    }
+
+    // A live `agents run` already refreshed this account's usage row for free via
+    // the statusline ingest — don't spend a scarce API call re-refreshing it.
+    const lastCapturedAt = deps.lastCapturedAt?.(account.usageKey) ?? null;
+    if (lastCapturedAt !== null && now - lastCapturedAt < STATUSLINE_FRESH_MS) {
+      updates[account.usageKey] = freshHeadroomEntry(entry, now, lastCapturedAt);
+      result.skippedFresh += 1;
+      continue;
+    }
+
+    // Global per-provider budget: cap aggregate endpoint traffic so it does not
+    // scale linearly with account count and trip the ~100/hr rate limit. Only
+    // network providers ride a rate-limited endpoint; local-log providers don't.
+    if (agentUsesNetworkUsage(account.agentId)
+      && (budgetSpent.get(account.agentId) ?? 0) >= PROVIDER_HOURLY_BUDGET) {
+      // Leave the entry untouched so this still-due account competes again next
+      // tick, when the rolling window has freed budget — never starved.
+      result.skippedBudget += 1;
+      continue;
+    }
+
+    if (agentUsesNetworkUsage(account.agentId)) {
+      budgetSpent.set(account.agentId, (budgetSpent.get(account.agentId) ?? 0) + 1);
     }
 
     try {


### PR DESCRIPTION
## The problem — grounded in live data on `zion`

The daemon's usage refresher (`cli/src/lib/usage-refresh.ts`, driven by `runUsageRefreshTick` in `cli/src/lib/daemon-ticks.ts`) enforced only a **per-account** hourly cap (`HOURLY_CALL_CAP = 12`/account/hr, at `REFRESH_INTERVAL_MS = 5min` cadence). There was **no global per-provider cap** — the cap was purely per-account, so aggregate endpoint load scaled **linearly with account count**:

> 8 Claude accounts × 12/hr = **~96 usage calls/hr** from one machine, and Anthropic's `/api/oauth/usage` endpoint rate-limits around **~100/hr** (documented in `usage-backoff.ts`).

Confirmed live on `zion`: `~/.agents/.cache/usage-backoff/` held **7 of 8 accounts parked**, deadlines staggered 16–51 min out; the daemon log showed `7 backed-off` / `8 backed-off` every tick. Each 429 issues a Retry-After penalty up to `MAX_BACKOFF_MS = 60min`. So ~7/8 accounts were **perpetually parked** → never refreshed within their 5-hour session window → `agents view` showed `S: unavailable`, and balanced routing saw stale/absent usage and landed on maxed/bad accounts. **It scaled worse with every added account.** This is the core disease behind the "usage is broken / balanced picks bad accounts" complaint.

Diagnosis confirmed against the code: the cap was per-account only; there was no aggregate/global provider budget anywhere in the refresh path.

## The fix — a global per-provider token budget, spent stalest-first

1. **`PROVIDER_HOURLY_BUDGET = 40`** — aggregate live fetches this daemon may spend on ONE network provider's usage endpoint per rolling hour, across **all** of that provider's local accounts. Seeded from the accounts' existing `callTimestamps` (no new state file) so it bounds the true rolling-hour total, not just one tick. This is a **fixed rate that does not grow with account count**: 8 accounts → 40/hr aggregate (was 96); 16 accounts → still 40/hr. 40 leaves real headroom under the ~100/hr ceiling for the auth probe (same endpoint, ~3/hr/account, RUSH-2998) and foreground `agents view` bursts.

2. **Stalest-account-first ordering** (`orderUsageAccounts`): cold accounts (never refreshed) lead, then cached accounts oldest-`capturedAt` first. The scarce budget is always spent on the accounts most in need; fresher ones defer to a later tick (their entry is left untouched, so they stay due and compete again — never starved). Each account's effective proactive cadence simply stretches as N grows, which is correct: a slightly older-but-present reading beats a 45-minute 429 park.

3. **Lean on the free signal:** every real `agents run` already refreshes its own account at zero API cost via `ingestClaudeStatusLineUsage`. The refresher now reads the usage cache's `capturedAt` (`lastCapturedAt` dep) and **skips a redundant API refresh** of an account captured within `STATUSLINE_FRESH_MS` (5min). Active accounts stay fresh for free; the budget is reserved for idle accounts.

4. **Scope:** the budget applies only to `network:true` providers (`agentUsesNetworkUsage`). grok/codex read local logs, have no rate-limited endpoint, and are excluded. Existing per-account cap, `Retry-After` backoff, and per-account backoff scoping are all preserved and never re-armed — a parked account is never called and never consumes budget.

## Tests (drive real code paths)

- one tick caps at `PROVIDER_HOURLY_BUDGET` fetches even with far more due accounts;
- aggregate stays under the budget across multiple ticks in one rolling hour;
- the budget is spent on the **stalest** accounts, deferring the freshest;
- a parked (backed-off) account is never called and does not consume budget;
- an account a statusline ingest just captured is **not** API-refreshed; one whose capture aged past the window **is**;
- `orderUsageAccounts` stalest-first ordering and `providerRecentCalls` aggregation (network-only, trailing-hour) unit-tested.

`tsc --noEmit` clean; `usage-refresh` / `usage-backoff` / `daemon-ticks` vitest green (59 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4R1kiAVVZTtZXs9SYs79