### PR TITLE
fix(feed): include ticket links in every broadcast

### DIFF
--- a/cli/.changelog/next/PHNX-3572-owner-ticket-link.md
+++ b/cli/.changelog/next/PHNX-3572-owner-ticket-link.md
@@ -1,0 +1,1 @@
+- **Include clickable ticket links in every feed broadcast (PHNX-3572).** Ticket-backed posts now put the canonical Linear URL in the shared message delivered to private owner destinations and configured Slack channel sinks; repeated URL lines are deduplicated. Source: `cli/src/lib/feed-broadcast.ts`, `cli/src/commands/feed.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -98,12 +98,15 @@ Legacy `notify.owner` and a humans file without `policy.normal` retain the
 historical single-destination behavior.
 
 Feed channel sinks may override their outbound body with a `message:` template
-using the same placeholders as command sinks (`{message}`, `{ticket}`, `{project}`,
+using the same placeholders as command sinks (`{message}`, `{ticket}`, `{ticket_url}`, `{project}`,
 and the rest in `feed-broadcast.ts`). Placeholder resolution is fail-closed: if
 the post lacks a referenced value, that sink is skipped. This is the semantic
 routing primitive for destinations such as an engineering Slack channel: a
 template that includes `{ticket}` receives ticket-backed posts without leaking
 unrelated owner alerts into the team channel.
+The shared `{message}` also includes the canonical tracker URL whenever the
+session has a resolvable Linear ticket, so every selected sink (including the
+private owner destination) receives a clickable ticket link.
 
 **`gh` is overloaded so the fleet's trained `gh pr checks` escapes the shared
 GraphQL rate limit (PHNX-3501).** The whole fleet shares one GitHub token, and

--- a/cli/docs/observability.md
+++ b/cli/docs/observability.md
@@ -25,8 +25,9 @@ increments.
 named sinks under `feed.broadcast` in `agents.yaml`. A sink is either a direct
 argv template (`command:`) or an in-process provider delivery (`channel:`). Both
 shapes use post context rather than asking the agent to repeat domain facts: the
-session index supplies `{ticket}`, while `{message}` is the compact human-facing
-title, body, provenance, and first attached URL.
+session index supplies `{ticket}` and `{ticket_url}`, while `{message}` is the
+compact human-facing title, body, provenance, canonical Linear ticket URL (when
+available), and attached URLs.
 
 Channel sinks may set `message:` to customize their outbound body. It supports
 the same placeholders as command sinks. If any referenced value is absent, the
@@ -43,16 +44,14 @@ feed:
       channel: slack
       to: C01234567
       minLevel: important
-      message: |-
-        {message}
-        https://linear.app/example/issue/{ticket}
+      message: "{message}"
 ```
 
-The engineering sink above fires only for important posts whose session carries
-a ticket. Posts without ticket context remain in the feed and may still reach
-the private owner sink; they do not enter the team channel. Tracker-specific URL
-shape and Slack destination remain operator configuration, not compiled product
-assumptions.
+To restrict the engineering sink to ticket-backed posts, set its template to
+`"{ticket_url}"` or otherwise reference `{ticket}` / `{ticket_url}`; fail-closed
+placeholder rendering skips ticketless posts. Canonical Linear URL construction
+is shared product behavior, while the Slack destination remains operator
+configuration.
 
 ## Performance latency warehouse
 

--- a/cli/src/commands/feed.ts
+++ b/cli/src/commands/feed.ts
@@ -39,6 +39,7 @@ import {
 } from '../lib/feed/activity.js';
 import { projectKeyFromCwd } from '../lib/project-key.js';
 import { postFeedStatus } from '../lib/feed-post.js';
+import { linearIssueUrl } from '../lib/session/linear.js';
 import {
   parseFeedPostLevel,
   planFeedBroadcast,
@@ -855,6 +856,7 @@ async function broadcastPostedEvent(
     text: event.detail ?? '',
     level,
     ticket,
+    ticketUrl: linearIssueUrl(ticket),
     project: event.project,
     agent: event.agent,
     host: event.host,

--- a/cli/src/lib/feed-broadcast.test.ts
+++ b/cli/src/lib/feed-broadcast.test.ts
@@ -74,18 +74,43 @@ describe('sink argv rendering', () => {
 
 describe('channel message rendering', () => {
   it('renders ticket-aware channel copy from the same placeholder context', () => {
-    expect(renderSinkMessage(
+    const rendered = renderSinkMessage(
       '{message}\nhttps://linear.app/getrush/issue/{ticket}',
-      ctx({ ticket: 'PHNX-3572' }),
-    )).toContain('https://linear.app/getrush/issue/PHNX-3572');
+      ctx({
+        ticket: 'PHNX-3572',
+        ticketUrl: 'https://linear.app/getrush/issue/PHNX-3572',
+      }),
+    );
+    expect(rendered).toContain('https://linear.app/getrush/issue/PHNX-3572');
+    expect(rendered?.match(/https:\/\/linear\.app\/getrush\/issue\/PHNX-3572/g)).toHaveLength(1);
   });
 
   it('skips a channel template when required ticket context is absent', () => {
     expect(renderSinkMessage('{message}\nTicket: {ticket}', ctx())).toBeUndefined();
   });
+
+  it('exposes the canonical tracker URL as a template variable', () => {
+    expect(renderSinkMessage(
+      '{ticket_url}',
+      ctx({ ticket: 'PHNX-3572', ticketUrl: 'https://linear.app/getrush/issue/PHNX-3572' }),
+    )).toBe('https://linear.app/getrush/issue/PHNX-3572');
+  });
 });
 
 describe('message composition', () => {
+  it('puts the canonical ticket URL in the shared message sent to every sink', () => {
+    expect(composeBroadcastMessage(ctx({
+      ticket: 'PHNX-3572',
+      ticketUrl: 'https://linear.app/getrush/issue/PHNX-3572',
+    }))).toContain('https://linear.app/getrush/issue/PHNX-3572');
+  });
+
+  it('does not repeat the ticket URL when it is also attached to the post', () => {
+    const url = 'https://linear.app/getrush/issue/PHNX-3572';
+    const message = composeBroadcastMessage(ctx({ ticket: 'PHNX-3572', ticketUrl: url, links: [url] }));
+    expect(message.match(new RegExp(url, 'g'))).toHaveLength(1);
+  });
+
   it('title, blank line, body, Sent from footer, then link', () => {
     expect(composeBroadcastMessage(ctx({ links: ['https://github.com/phnx-labs/agents-cli/pull/1690'] })))
       .toBe(

--- a/cli/src/lib/feed-broadcast.ts
+++ b/cli/src/lib/feed-broadcast.ts
@@ -39,6 +39,7 @@ import { isOwnerAlias, readOwnerDest, resolveSendEnvelope, deliverEnvelope } fro
 import { lookupTransport } from './channels/resolve.js';
 import { registerBuiltinProviders } from './channels/providers/index.js';
 import { sendToOwner } from './notify.js';
+import { linearIssueUrl } from './session/linear.js';
 import { forwardOwnerNotifyToPeer } from './channels/owner-forward.js';
 
 /** How loudly a post asks to be heard. Ordered — `important` implies milestone. */
@@ -95,6 +96,8 @@ export interface FeedBroadcastContext {
   level: FeedPostLevel;
   /** Tracker id for the work, e.g. `RUSH-2081`. */
   ticket?: string;
+  /** Canonical clickable tracker URL for `ticket`, when the tracker can resolve it. */
+  ticketUrl?: string;
   /** Repo/project the post came from. */
   project?: string;
   agent?: string;
@@ -161,6 +164,7 @@ export function blockBroadcastContext(
     text,
     level: 'important',
     ticket: block.ticket,
+    ticketUrl: linearIssueUrl(block.ticket),
     project: extras.project,
     agent: extras.agent,
     host: block.host,
@@ -224,7 +228,7 @@ export interface SinkOutcome {
   error?: string;
 }
 
-const PLACEHOLDER = /\{([a-z]+)\}/g;
+const PLACEHOLDER = /\{([a-z_]+)\}/g;
 
 /**
  * Short host label for a phone line — strip user@ and domain so
@@ -344,7 +348,9 @@ export function composeBroadcastMessage(ctx: FeedBroadcastContext): string {
   const head = title || body;
   const mid = title && body && title !== body ? body : undefined;
   const footer = composeBroadcastFooter(ctx);
-  const link = ctx.links?.find((l) => /^https?:\/\//i.test(l));
+  const links = [ctx.ticketUrl, ...(ctx.links ?? [])]
+    .filter((l): l is string => !!l && /^https?:\/\//i.test(l))
+    .filter((l, i, all) => all.indexOf(l) === i);
 
   // The action block: the one thing the operator can act on from a phone. Show the
   // choices, then what happens if they do not answer. Deliberately NOT a CLI command
@@ -361,7 +367,7 @@ export function composeBroadcastMessage(ctx: FeedBroadcastContext): string {
   const action = [choices, fallback].filter(Boolean).join('\n') || undefined;
 
   // Link trail after the "Sent from" footer so the human sentence stays at the top.
-  const trail = [footer, link].filter(Boolean) as string[];
+  const trail = [footer, ...links].filter(Boolean) as string[];
 
   const parts: string[] = [];
   if (head) parts.push(head);
@@ -389,6 +395,7 @@ function templateVars(ctx: FeedBroadcastContext): Record<string, string | undefi
     title: ctx.title,
     text: ctx.text,
     ticket: ctx.ticket,
+    ticket_url: ctx.ticketUrl,
     project: ctx.project,
     agent: ctx.agent,
     host: ctx.host,
@@ -449,7 +456,18 @@ export function renderSinkMessage(
     return value;
   });
   if (missing) return undefined;
-  const text = rendered.trim();
+  const seenUrls = new Set<string>();
+  const text = rendered
+    .trim()
+    .split('\n')
+    .filter((line) => {
+      const value = line.trim();
+      if (!/^https?:\/\/\S+$/i.test(value)) return true;
+      if (seenUrls.has(value)) return false;
+      seenUrls.add(value);
+      return true;
+    })
+    .join('\n');
   return text || undefined;
 }
 


### PR DESCRIPTION
Closes PHNX-3572

## What changed
- construct the canonical Linear URL from session ticket context
- include it in the shared `{message}` so owner/Rush and Slack sinks both receive it
- expose `{ticket_url}` for fail-closed routing and deduplicate matching attachments

## Verification
- TypeScript build passed via `cli/scripts/test.sh --device yosemite-m0`
- focused feed suites: 74/74 passed after the final placeholder fix
- full suite reached the changed feed tests green; one pre-existing `self-update.test.ts` symlink repair test fails on yosemite-m0