### PR TITLE
fix(usage): resolve device pin against the ssh host, not the bare name (PHNX-3505)

### DIFF
--- a/cli/.changelog/next/PHNX-3505.md
+++ b/cli/.changelog/next/PHNX-3505.md
@@ -1,0 +1,10 @@
+- **Fleet usage/auth sync now reaches FQDN-only-pinned workers (PHNX-3505).** The
+  usage-sync and reserved-auth-sync push/pull planners judged a peer "pinned" by its
+  bare device name, but a tailnet-discovered worker's host key is pinned under its
+  FQDN (`yosemite-m6.tail….ts.net`). So every worker not also pinned under its short
+  name was silently skipped — its `claude-usage.json` went days stale and `balanced`
+  routed into weekly-maxed accounts, and its auth token never propagated. The pin
+  check now resolves the same host string the ssh connection dials
+  (`isDevicePinned`), matching either form. Source:
+  `cli/src/lib/devices/known-hosts.ts`, `cli/src/lib/accounting/usage-sync.ts`,
+  `cli/src/lib/secrets/reserved-sync.ts`.

--- a/cli/src/commands/apply.ts
+++ b/cli/src/commands/apply.ts
@@ -16,7 +16,7 @@ import chalk from 'chalk';
 import { setHelpSections } from '../lib/help.js';
 import { machineId } from '../lib/session/sync/config.js';
 import { loadDevices, type DeviceProfile } from '../lib/devices/registry.js';
-import { isHostPinned, managedKnownHostsPath } from '../lib/devices/known-hosts.js';
+import { isHostPinned, isDevicePinned, managedKnownHostsPath } from '../lib/devices/known-hosts.js';
 import { ensureDevicesRegistered } from '../lib/devices/sync.js';
 import { readFleetFile, resolveDesired, emptyTargetsMessage } from '../lib/fleet/manifest.js';
 import { snapshotAuth } from '../lib/fleet/auth-sync.js';
@@ -270,7 +270,14 @@ async function runApply(opts: ApplyOptions): Promise<void> {
     provisionSecrets: opts.provisionSecrets === true,
     forceSecrets: opts.force === true,
     // Portable secret values only ever go to a host whose key is already pinned.
-    isHostPinned: (device) => isHostPinned(device, managedKnownHostsPath()),
+    // Resolve the device to its profile so the pin is checked against the FQDN the
+    // ssh connection dials (isDevicePinned), not the bare name — a tailnet worker
+    // pinned only under its FQDN would otherwise be refused as "not pinned"
+    // (PHNX-3505). A name with no profile falls back to the raw host-string check.
+    isHostPinned: (device) => {
+      const p = nameToProfile.get(device);
+      return p ? isDevicePinned(p) : isHostPinned(device, managedKnownHostsPath());
+    },
   });
 
   // --only filter.

--- a/cli/src/lib/accounting/usage-sync.test.ts
+++ b/cli/src/lib/accounting/usage-sync.test.ts
@@ -122,6 +122,49 @@ describe('syncFleetUsageSnapshots (driver, injected deps)', () => {
     expect(result.pushed).toEqual([]);
     expect(result.skipped.every((s) => /no local usage snapshot/.test(s.reason))).toBe(true);
   });
+
+  it('pushes to a worker pinned only under its FQDN, not its bare name (PHNX-3505)', () => {
+    // The managed known_hosts pins the tailnet FQDN the ssh connection dials, never
+    // the bare device name. The pin check must resolve the same host `sshTargetFor`
+    // dials, or an FQDN-only-pinned worker is wrongly skipped as "not pinned" and
+    // silently starved of usage pushes (its cache goes days stale, balanced then
+    // routes into a weekly-maxed account).
+    const seen: string[] = [];
+    const result = syncFleetUsageSnapshots(baseDeps({
+      listDevices: () => [
+        { name: 'yosemite-m6', address: { dnsName: 'yosemite-m6.tail1a85a1.ts.net' }, tailscale: { online: true } } as DeviceProfile,
+      ],
+      listRoles: () => ({ 'yosemite-m6': 'worker' }),
+      isPinned: (host) => host === 'yosemite-m6.tail1a85a1.ts.net',
+      push: (device) => { seen.push(device.name); return { ok: true }; },
+    }));
+    expect(result.pushed).toEqual(['yosemite-m6']);
+    expect(seen).toEqual(['yosemite-m6']);
+  });
+
+  it('still pushes to a worker pinned only under its bare name', () => {
+    const result = syncFleetUsageSnapshots(baseDeps({
+      listDevices: () => [
+        { name: 'yosemite-s0', address: { dnsName: 'yosemite-s0.tail1a85a1.ts.net' }, tailscale: { online: true } } as DeviceProfile,
+      ],
+      listRoles: () => ({ 'yosemite-s0': 'worker' }),
+      isPinned: (host) => host === 'yosemite-s0',
+      push: () => ({ ok: true }),
+    }));
+    expect(result.pushed).toEqual(['yosemite-s0']);
+  });
+
+  it('skips a worker whose host key is pinned under neither form', () => {
+    const result = syncFleetUsageSnapshots(baseDeps({
+      listDevices: () => [
+        { name: 'yosemite-m6', address: { dnsName: 'yosemite-m6.tail1a85a1.ts.net' }, tailscale: { online: true } } as DeviceProfile,
+      ],
+      listRoles: () => ({ 'yosemite-m6': 'worker' }),
+      isPinned: () => false,
+    }));
+    expect(result.pushed).toEqual([]);
+    expect(result.skipped.some((s) => /not pinned/.test(s.reason))).toBe(true);
+  });
 });
 
 describe('pullUsageFromPrimary', () => {

--- a/cli/src/lib/accounting/usage-sync.ts
+++ b/cli/src/lib/accounting/usage-sync.ts
@@ -29,7 +29,7 @@ import { buildRemoteAgentsInvocation, buildWindowsStdinAgentsCommand, remoteShel
 import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { loadDevicesSync, type DeviceProfile } from '../devices/registry.js';
 import { sshTargetFor } from '../devices/connect.js';
-import { isHostPinned } from '../devices/known-hosts.js';
+import { isHostPinned, isDevicePinned } from '../devices/known-hosts.js';
 import { machineId, normalizeHost } from '../session/sync/config.js';
 import {
   isHeadedDeviceRole,
@@ -230,7 +230,7 @@ export function pullUsageFromPrimary(deps: UsagePullDeps = {}): UsagePullResult 
   const primary = devices
     .filter((device) => roles[device.name] === 'personal')
     .concat(devices.filter((device) => roles[device.name] === 'desktop'))
-    .find((device) => device.tailscale?.online !== false && isPinned(device.name));
+    .find((device) => device.tailscale?.online !== false && isDevicePinned(device, isPinned));
   if (!primary) {
     result.error = 'no reachable, pinned personal or desktop device is configured as the usage primary';
     return result;
@@ -285,7 +285,7 @@ export function syncFleetUsageSnapshots(deps: UsageSyncDeps = {}): UsageSyncResu
       name: d.name,
       role: roles[d.name],
       online: d.tailscale?.online !== false,
-      pinned: isPinned(d.name),
+      pinned: isDevicePinned(d, isPinned),
     }));
 
   const rows = (deps.exportRows ?? exportClaudeUsageCacheRows)();

--- a/cli/src/lib/devices/known-hosts.test.ts
+++ b/cli/src/lib/devices/known-hosts.test.ts
@@ -13,11 +13,13 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   hostKeyCheckingOpts,
+  isDevicePinned,
   isHostPinned,
   isHostPinnedIn,
   newKnownHostsLines,
   recordScannedKeys,
 } from './known-hosts.js';
+import type { DeviceProfile } from './registry.js';
 
 const KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI0000000000000000000000000000000000000000000';
 
@@ -134,5 +136,31 @@ describe('isHostPinned (on-disk store)', () => {
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('isDevicePinned', () => {
+  const dev = (name: string, dnsName?: string): DeviceProfile =>
+    ({ name, ...(dnsName ? { address: { dnsName } } : {}) }) as DeviceProfile;
+
+  it('is pinned when the FQDN the ssh connection dials is pinned, even if the bare name is not (PHNX-3505)', () => {
+    // Tailnet discovery only pins the FQDN — the exact managed-store state that
+    // starved FQDN-only workers of usage/auth fan-out when callers checked the
+    // bare name.
+    const pinned = (host: string) => host === 'yosemite-m6.tail1a85a1.ts.net';
+    expect(isDevicePinned(dev('yosemite-m6', 'yosemite-m6.tail1a85a1.ts.net'), pinned)).toBe(true);
+  });
+
+  it('is pinned when only the bare name is pinned', () => {
+    expect(isDevicePinned(dev('mac-mini', 'mac-mini.tail1a85a1.ts.net'), (h) => h === 'mac-mini')).toBe(true);
+  });
+
+  it('is not pinned when neither the FQDN nor the bare name is pinned', () => {
+    expect(isDevicePinned(dev('yosemite-m6', 'yosemite-m6.tail1a85a1.ts.net'), () => false)).toBe(false);
+  });
+
+  it('falls back to the bare-name check when the device has no address', () => {
+    expect(isDevicePinned(dev('mark-1'), (h) => h === 'mark-1')).toBe(true);
+    expect(isDevicePinned(dev('mark-1'), () => false)).toBe(false);
   });
 });

--- a/cli/src/lib/devices/known-hosts.ts
+++ b/cli/src/lib/devices/known-hosts.ts
@@ -22,6 +22,8 @@ import { spawnSync } from 'child_process';
 import { getCacheDir } from '../state.js';
 import { assertValidSshTarget } from '../ssh-exec.js';
 import { parseKnownHosts } from '../hosts/ssh-config.js';
+import { hostNameFor } from './ssh-config.js';
+import type { DeviceProfile } from './registry.js';
 
 /** Path to the CLI-managed known_hosts store (created lazily, mode 0600). */
 export function managedKnownHostsPath(): string {
@@ -56,6 +58,27 @@ export function isHostPinnedIn(content: string, host: string): boolean {
 /** True if `host` is pinned in the managed store on disk. */
 export function isHostPinned(host: string, file = managedKnownHostsPath()): boolean {
   return isHostPinnedIn(readManagedKnownHosts(file), host);
+}
+
+/**
+ * True if a DEVICE's host key is pinned — checked against the SAME host string
+ * the ssh connection dials (`hostNameFor(device)`: the Tailscale dnsName/IP that
+ * `sshTargetFor` resolves), falling back to the bare device name.
+ *
+ * A device discovered over the tailnet is pinned under its FQDN
+ * (`yosemite-m6.tail….ts.net`), so a caller that checks the bare `device.name`
+ * misses the pin and wrongly treats a reachable, pinned peer as unpinned —
+ * silently excluding it from usage/auth fan-out while ssh to it would have
+ * succeeded (PHNX-3505). Accepting the bare name too keeps a device pinned only
+ * under its short name working. `isPinned` is injectable for tests; it defaults
+ * to the managed on-disk store.
+ */
+export function isDevicePinned(
+  device: DeviceProfile,
+  isPinned: (host: string) => boolean = (host) => isHostPinned(host),
+): boolean {
+  const host = device.address ? hostNameFor(device) : undefined;
+  return (host != null && isPinned(host)) || isPinned(device.name);
 }
 
 /**

--- a/cli/src/lib/secrets/reserved-sync.test.ts
+++ b/cli/src/lib/secrets/reserved-sync.test.ts
@@ -70,6 +70,35 @@ describe('syncReservedAuthBundle', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('pushes to a device pinned only under its FQDN, not its bare name (PHNX-3505)', () => {
+    // A tailnet worker's host key is pinned under its FQDN, not its bare name. The
+    // pin gate must resolve the same host the ssh connection dials, or an
+    // already-pinned worker is refused with a misleading "run `agents ssh` to pin"
+    // — and its reserved auth token never propagates. Fails on the pre-fix
+    // bare-name check (which would see `m6` as unpinned and skip it).
+    const fqdnDevice = {
+      name: 'm6',
+      address: { dnsName: 'm6.tail1a85a1.ts.net' },
+      platform: 'linux',
+      user: 'agent',
+    } as unknown as DeviceProfile;
+    const hosts: string[] = [];
+    const result = syncReservedAuthBundle({
+      inspectLocal: () => ({ exists: true, ok: true }),
+      listDevices: () => [fqdnDevice],
+      localName: 'me',
+      isPinned: (host) => host === 'm6.tail1a85a1.ts.net',
+      probe: () => ({ reachable: true, remoteHasAuth: false }),
+      sshTarget: (d) => (typeof d.address === 'string' ? d.address : d.address?.dnsName) ?? d.name,
+      push: (bundle, host) => {
+        hosts.push(host);
+        return { ok: true, host, bundle, keyCount: 2, message: 'ok' };
+      },
+    });
+    expect(result.pushed).toEqual(['m6']);
+    expect(hosts).toEqual(['m6.tail1a85a1.ts.net']);
+  });
+
   it('records a failed remote decrypt as an error, not success', () => {
     const result = syncReservedAuthBundle({
       inspectLocal: () => ({ exists: true, ok: true }),

--- a/cli/src/lib/secrets/reserved-sync.ts
+++ b/cli/src/lib/secrets/reserved-sync.ts
@@ -17,7 +17,7 @@ import { AUTH_BUNDLE_NAME, inspectReservedAuthBundle } from './bundles.js';
 import { pushBundleToHost, type PushBundleResult } from './push.js';
 import { loadDevicesSync, type DeviceProfile } from '../devices/registry.js';
 import { sshTargetFor } from '../devices/connect.js';
-import { isHostPinned, managedKnownHostsPath } from '../devices/known-hosts.js';
+import { isHostPinned, isDevicePinned, managedKnownHostsPath } from '../devices/known-hosts.js';
 import { machineId, normalizeHost } from '../session/sync/config.js';
 import { probeDevice } from '../fleet/apply.js';
 import type { DeviceProbe } from '../fleet/types.js';
@@ -130,9 +130,9 @@ export function syncReservedAuthBundle(deps: AuthSyncDeps = {}): AuthSyncResult 
       // No live probe until we know a push is even possible: missing local auth
       // skips every device, and an unpinned host is refused before we SSH.
       if (!localOk) {
-        return { name: d.name, reachable: true, pinned: pinned(d.name), remoteHasAuth: false };
+        return { name: d.name, reachable: true, pinned: isDevicePinned(d, pinned), remoteHasAuth: false };
       }
-      const isPinnedDev = pinned(d.name);
+      const isPinnedDev = isDevicePinned(d, pinned);
       if (!isPinnedDev) {
         return { name: d.name, reachable: true, pinned: false, remoteHasAuth: false };
       }


### PR DESCRIPTION
## Problem

Fleet **usage** (and reserved **auth-token**) sync only propagated to a subset of workers. On this fleet, zion (the sole `personal` publisher) was pushing usage to **exactly 3 boxes** — never to m0–m6:

```
$ grep usage-sync ~/.agents/.cache/helpers/daemon/logs.jsonl | tail
usage-sync: pushed usage to mac-mini, yosemite-s0, yosemite-s1     ← always only these 3
```

The unpushed workers served **day-old** usage, so `balanced` routed into weekly-maxed accounts (the PHNX-3505 symptom):

```
$ agents view claude --device yosemite-m6 --json   # a worker never pushed to
muqsitnawaz@icloud.com   captured 2026-08-29 23:41   (~22h stale)
```

## Root cause

The push/pull planners judged a peer "pinned" by its **bare device name** (`isPinned(d.name)`), but the ssh connection dials the Tailscale **FQDN** (`hostNameFor(device)` → `yosemite-m6.tail1a85a1.ts.net`), and that FQDN is what's recorded in the managed `known_hosts`. `isHostPinnedIn` matches the hostname **exactly** (no bare↔FQDN normalization), so a worker discovered over the tailnet — pinned only under its FQDN — reads as "not pinned" and is skipped, even though ssh to it would succeed. Only the 3 boxes that *also* had a bare-name pin passed.

The managed store proves it:
```
mac-mini      AND  mac-mini.tail1a85a1.ts.net      ← both forms → pushed
yosemite-m6   ONLY yosemite-m6.tail1a85a1.ts.net   ← FQDN only  → skipped
```

The sibling `secrets/remote.ts` already does this right (`isHostPinned(hostKeyLookupName(target))`); `usage-sync.ts` and `secrets/reserved-sync.ts` did not.

## Fix

New `isDevicePinned(device, isPinned?)` in `known-hosts.ts` resolves the **same host string the ssh connection dials** (`hostNameFor(device)`) and matches the FQDN **or** the bare name (so the 3 working boxes can't regress, and a device with no address falls back to the bare check). Both push/pull planners in `usage-sync.ts` and both call sites in `reserved-sync.ts` route through it — surface parity across the usage lane *and* the auth-token lane the same bug affected.

## Tests

- `known-hosts.test.ts`: unit tests for `isDevicePinned` — FQDN-only pinned, bare-only pinned, neither, no-address fallback.
- `usage-sync.test.ts`: driver tests — a FQDN-only-pinned worker is now a push target; bare-only still pushes; neither is skipped with `not pinned`.
- All affected suites green: `known-hosts` + `usage-sync` + `reserved-sync` = **42 passed**. `tsc --noEmit` clean.

## Follow-up (not in this PR)
- Operational: keep `mark-1` (a production server) out of the worker fan-out — a config/role change, separate from this code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)