### PR TITLE
test(daemon): synchronize successor race after SIGTERM (PHNX-3607)

### DIFF
--- a/cli/src/lib/daemon/daemon.stop.test.ts
+++ b/cli/src/lib/daemon/daemon.stop.test.ts
@@ -208,6 +208,7 @@ describe('agents daemon stop — asserts its postcondition (RUSH-2355)', () => {
       const daemonDir = path.join(home, '.agents', '.cache', 'helpers', 'daemon');
       const instancesDir = path.join(daemonDir, 'instances');
       const browserSock = path.join(home, '.agents', '.cache', 'helpers', 'browser', 'browser.sock');
+      const incumbentSignaled = path.join(home, 'incumbent-signaled');
       fs.mkdirSync(instancesDir, { recursive: true });
       fs.mkdirSync(path.dirname(browserSock), { recursive: true });
 
@@ -217,10 +218,10 @@ describe('agents daemon stop — asserts its postcondition (RUSH-2355)', () => {
         "const sock = process.argv[1];",
         "try { fs.unlinkSync(sock); } catch {}",
         "net.createServer(() => {}).listen(sock);",
-        "process.on('SIGTERM', () => {});",
+        "process.on('SIGTERM', () => { if (process.argv[2]) fs.writeFileSync(process.argv[2], 'received'); });",
         "setInterval(() => {}, 1000);",
       ].join(' ');
-      const incumbent = spawn(process.execPath, ['-e', socketDaemonScript, browserSock, '__daemon-run'], { stdio: 'ignore' });
+      const incumbent = spawn(process.execPath, ['-e', socketDaemonScript, browserSock, incumbentSignaled, '__daemon-run'], { stdio: 'ignore' });
       let successor: ReturnType<typeof spawn> | null = null;
       let stopper: ReturnType<typeof spawn> | null = null;
       try {
@@ -238,12 +239,13 @@ describe('agents daemon stop — asserts its postcondition (RUSH-2355)', () => {
         stopper.stdout!.on('data', (chunk) => { stdout += chunk.toString(); });
         stopper.stderr!.on('data', (chunk) => { stderr += chunk.toString(); });
         expect(await waitFor(() => fs.existsSync(path.join(daemonDir, 'daemon.lock')), 5_000)).toBe(true);
+        expect(await waitFor(() => fs.existsSync(incumbentSignaled), 5_000)).toBe(true);
 
         // A non-cooperating fresh daemon replaces both shared artifacts while
         // stop is inside its real SIGTERM grace window. The lock excludes every
         // production start; the replacement also proves cleanup is ownership-
         // checked rather than merely relying on cooperation.
-        successor = spawn(process.execPath, ['-e', socketDaemonScript, browserSock, '__daemon-run'], { stdio: 'ignore' });
+        successor = spawn(process.execPath, ['-e', socketDaemonScript, browserSock, '', '__daemon-run'], { stdio: 'ignore' });
         expect(successor.pid).toBeTruthy();
         expect(await waitFor(() => {
           try { return fs.lstatSync(browserSock).ino !== incumbentSocket.ino; } catch { return false; }


### PR DESCRIPTION
## Summary

- wait until the real incumbent receives SIGTERM before injecting the successor pid/socket
- remove a scheduler-load race where observing daemon.lock alone could precede the stop transaction
- keep the regression fully real-path: actual child processes, signals, pid files, and Unix sockets; no mocks

The PHNX-3607 implementation landed separately in #3350 while recovery verification was still running. This follow-up contains only the deterministic synchronization found necessary by the recovered fleet run.

## Run evidence

cd cli && scripts/test.sh --device auto -- src/lib/daemon/daemon.stop.test.ts --retry=2
worker=yosemite-m5
Test Files  1 passed (1)
Tests       11 passed (11)
Duration    29.95s

The full PHNX-3607 suite evidence and green required check are retained on #3350.

## CI

- Tests: success
- Secret Scan: success
- CodeQL: success (actions, C#, JavaScript/TypeScript, Python, Swift)

## Final full-suite evidence

cd cli && scripts/test.sh --device auto
worker=yosemite-m6
Test Files  1017 passed | 7 skipped (1024)
Tests       14638 passed | 112 skipped (14750)
Duration    318.35s