### PR TITLE
fix(sessions): backfill genuine OpenCode requests (PHNX-3621)

### DIFF
--- a/cli/.changelog/next/PHNX-3621-opencode.md
+++ b/cli/.changelog/next/PHNX-3621-opencode.md
@@ -1,0 +1,1 @@
+Fix OpenCode session history to index and backfill the genuine first user request.

--- a/cli/src/lib/session/db.ts
+++ b/cli/src/lib/session/db.ts
@@ -51,8 +51,11 @@ export const SCHEMA_VERSION = 45;
  * here backfills every existing session's assistant text on its next scan
  * without a `DELETE FROM scan_ledger` (which would also throw away the
  * resumable parser_state/content_text for Claude/Codex).
+ *
+ * v3 (PHNX-3621) invalidates OpenCode rows that merged v2 stamped before its
+ * genuine first-user-turn extractor was added.
  */
-export const CONTENT_INDEX_VERSION = 2;
+export const CONTENT_INDEX_VERSION = 3;
 
 /**
  * Bump to force `agents sessions backfill resources` to re-derive every
@@ -1774,9 +1777,11 @@ export function getDBPath(): string {
 export function getScanStampByPath(filePath: string): ScanStamp | null {
   const db = getDB();
   const row = db
-    .prepare(`SELECT file_mtime_ms, file_size, scanned_at FROM scan_ledger WHERE file_path = ? LIMIT 1`)
-    .get(canonicalLedgerKey(filePath)) as { file_mtime_ms: number; file_size: number; scanned_at: number } | undefined;
-  return row ? { fileMtimeMs: row.file_mtime_ms, fileSize: row.file_size, scannedAt: row.scanned_at } : null;
+    .prepare(`SELECT file_mtime_ms, file_size, scanned_at, extractor_version FROM scan_ledger WHERE file_path = ? LIMIT 1`)
+    .get(canonicalLedgerKey(filePath)) as { file_mtime_ms: number; file_size: number; scanned_at: number; extractor_version: number | null } | undefined;
+  return row
+    ? { fileMtimeMs: row.file_mtime_ms, fileSize: row.file_size, scannedAt: row.scanned_at, extractorVersion: row.extractor_version }
+    : null;
 }
 
 /**

--- a/cli/src/lib/session/discover.opencode-ledger.test.ts
+++ b/cli/src/lib/session/discover.opencode-ledger.test.ts
@@ -331,3 +331,40 @@ describe('OpenCode per-session scan ledger (RUSH-2210)', () => {
     expect(openCounter.count).toBe(0);
   });
 });
+
+describe('OpenCode first-user-message extractor invalidation (PHNX-3621)', () => {
+  function firstUserMessageOf(sessionId: string): string | null {
+    const row = db.getDB()
+      .prepare(`SELECT first_user_message FROM sessions WHERE id = ?`)
+      .get(sessionId) as { first_user_message: string | null } | undefined;
+    return row?.first_user_message ?? null;
+  }
+
+  it('backfills an unchanged merged-v2 session and then returns to the warm short-circuit', async () => {
+    const target = 'ses_fixture09';
+    await scan();
+
+    // Model the real merged-v2 -> fixed-v3 upgrade: #3358 already stamped the
+    // transcript and shared OpenCode DB at v2 without extracting this field.
+    // Nothing on disk changed; only the extractor version advanced.
+    const stale = db.CONTENT_INDEX_VERSION - 1;
+    db.getDB().prepare(`UPDATE scan_ledger SET extractor_version = ?`).run(stale);
+    db.getDB().prepare(`UPDATE sessions SET first_user_message = NULL WHERE id = ?`).run(target);
+    expect(firstUserMessageOf(target)).toBeNull();
+
+    openCounter.match = OPENCODE_DB;
+    openCounter.count = 0;
+    await scan();
+
+    expect(firstUserMessageOf(target)).toBe('first turn of 9');
+    expect(openCounter.count).toBeGreaterThanOrEqual(1);
+    expect(db.getScanStampByPath(OPENCODE_DB)?.extractorVersion).toBe(db.CONTENT_INDEX_VERSION);
+
+    // The successful scan stamps both the container and session rows current;
+    // another unchanged scan must be a zero-open warm no-op again.
+    openCounter.match = OPENCODE_DB;
+    openCounter.count = 0;
+    await scan();
+    expect(openCounter.count).toBe(0);
+  });
+});

--- a/cli/src/lib/session/discover.ts
+++ b/cli/src/lib/session/discover.ts
@@ -2484,7 +2484,14 @@ async function scanOpenCodeIncremental(onProgress?: (p: ScanProgress) => void): 
     fileSize: stat.size,
   };
   const prev = getScanStampByPath(OPENCODE_DB);
-  if (prev && prev.fileMtimeMs === currentScan.fileMtimeMs && prev.fileSize === currentScan.fileSize) {
+  // OpenCode has a shared database rather than one transcript file per session,
+  // so this container-level gate must honor extractor-version invalidation too.
+  if (
+    prev &&
+    prev.fileMtimeMs === currentScan.fileMtimeMs &&
+    prev.fileSize === currentScan.fileSize &&
+    prev.extractorVersion === CONTENT_INDEX_VERSION
+  ) {
     return;
   }
 
@@ -2623,12 +2630,33 @@ async function scanOpenCodeIncremental(onProgress?: (p: ScanProgress) => void): 
       const prevStamp = priorStamps.get(c.filePath);
       return !prevStamp
         || prevStamp.fileMtimeMs !== c.scan.fileMtimeMs
-        || prevStamp.fileSize !== c.scan.fileSize;
+        || prevStamp.fileSize !== c.scan.fileSize
+        || prevStamp.extractorVersion !== CONTENT_INDEX_VERSION;
     });
+
+    // Role lives on the message row and the genuine user text lives on its
+    // ordered text parts. Poisoned JSON is ignored per row, never per database.
+    const firstUserStmt = db.prepare(`
+      SELECT json_extract(p.data, '$.text') AS text
+      FROM part p
+      WHERE p.message_id = (
+        SELECT m.id FROM message m
+        WHERE m.session_id = ?
+          AND json_valid(m.data) AND json_extract(m.data, '$.role') = 'user'
+        ORDER BY m.time_created ASC
+        LIMIT 1
+      )
+      AND json_valid(p.data) AND json_extract(p.data, '$.type') = 'text'
+      ORDER BY p.time_created ASC
+    `);
 
     const entries: ScanEntry[] = [];
     for (const { row, id, filePath, scan } of changed) {
       const title = typeof row.title === 'string' ? row.title : '';
+      const firstUserMessage = (firstUserStmt.all(id) as Array<{ text: unknown }>)
+        .map((part) => (typeof part.text === 'string' ? part.text : ''))
+        .join('')
+        .trim() || undefined;
       const directory = typeof row.directory === 'string' ? row.directory : '';
       const version = typeof row.version === 'string' ? row.version : '';
 
@@ -2685,6 +2713,7 @@ async function scanOpenCodeIncremental(onProgress?: (p: ScanProgress) => void): 
         version: resolveSessionVersion('opencode', OPENCODE_DB, version || undefined, currentVersion),
         account,
         topic,
+        firstUserMessage,
         model,
         costUsd,
         durationMs,


### PR DESCRIPTION
## Outcome

Fast-follow to merged #3358: OpenCode now supplies the genuine first user turn to `firstUserMessage`, including unchanged sessions already stamped by merged extractor v2.

## Canonical data path

- Extracts the earliest user-role OpenCode message's ordered text parts inside the existing session-index scan.
- Advances `CONTENT_INDEX_VERSION` to v3 and makes both the shared `opencode.db` warm gate and per-session ledger gate honor it.
- Persists through the existing sessions index and canonical watch stream; no extension fetch, poll, or transcript side channel.

## Verification

- `bunx vitest run src/lib/session/discover.opencode-ledger.test.ts` — 9 pass, 0 fail
- `bunx tsc --noEmit` — pass
- `git diff --check` — pass
- Real SQLite regression models the unchanged merged-v2 ledger, proves `first_user_message` backfills, then proves the next unchanged scan returns to the zero-open warm path.

Companion delivery: [agi-ext#26](https://github.com/phnx-labs/agi-ext/pull/26), follow-up [agi-ext#27](https://github.com/phnx-labs/agi-ext/pull/27), and merged base CLI stream [agi-cli#3358](https://github.com/phnx-labs/agi-cli/pull/3358).

Exact-head non-author [APPROVE](https://github.com/phnx-labs/agi-cli/pull/3361#issuecomment-5473315023) posted for `f08e9d48`; left open and unmerged for orchestrator handoff.
