### PR TITLE
fix(sessions): finish durable Previous backfill (PHNX-3621)

### DIFF
--- a/cli/src/lib/session/discover.opencode-ledger.test.ts
+++ b/cli/src/lib/session/discover.opencode-ledger.test.ts
@@ -396,4 +396,15 @@ describe('OpenCode first-user-message extractor invalidation (PHNX-3621)', () =>
     expect(firstUserMessageOf(target)).toBe('first turn of 0');
     expect(db.getScanStampByPath(`${OPENCODE_DB}#${target}`)?.extractorVersion).toBe(db.CONTENT_INDEX_VERSION);
   });
+
+  it('keeps a first-ever import capped when no container ledger exists', async () => {
+    db.getDB().exec(`DELETE FROM scan_ledger; DELETE FROM sessions;`);
+
+    await scan();
+
+    const imported = db.getDB().prepare(`SELECT COUNT(*) AS n FROM sessions`).get() as { n: number };
+    expect(imported.n).toBe(1_000);
+    expect(firstUserMessageOf('ses_fixture00')).toBeNull();
+    expect(db.getScanStampByPath(OPENCODE_DB)?.extractorVersion).toBe(db.CONTENT_INDEX_VERSION);
+  });
 });

--- a/cli/src/lib/session/discover.opencode-ledger.test.ts
+++ b/cli/src/lib/session/discover.opencode-ledger.test.ts
@@ -367,4 +367,33 @@ describe('OpenCode first-user-message extractor invalidation (PHNX-3621)', () =>
     await scan();
     expect(openCounter.count).toBe(0);
   });
+
+  it('re-extracts an older stale row behind more than 1,000 newer sessions', async () => {
+    const target = 'ses_fixture00';
+    await scan();
+
+    const oc = openFixture();
+    const insertSession = oc.prepare(
+      `INSERT INTO session (id, parent_id, title, directory, version, time_created, time_updated)
+       VALUES (?, NULL, ?, ?, ?, ?, ?)`,
+    );
+    const base = Date.UTC(2026, 7, 1);
+    oc.transaction(() => {
+      for (let i = 0; i < 1_001; i++) {
+        const id = `ses_upgrade_${String(i).padStart(4, '0')}`;
+        const ts = base + i * 1_000;
+        insertSession.run(id, `upgrade ${i}`, path.join(tmpHome, 'proj'), '0.3.0', ts, ts);
+        addMessage(oc, id, `${id}-m0`, ts, `upgrade turn ${i}`);
+      }
+    })();
+    oc.close();
+    bumpDbMtime(base + 2_000_000);
+
+    db.getDB().prepare(`UPDATE scan_ledger SET extractor_version = ?`).run(db.CONTENT_INDEX_VERSION - 1);
+    db.getDB().prepare(`UPDATE sessions SET first_user_message = NULL WHERE id = ?`).run(target);
+    await scan();
+
+    expect(firstUserMessageOf(target)).toBe('first turn of 0');
+    expect(db.getScanStampByPath(`${OPENCODE_DB}#${target}`)?.extractorVersion).toBe(db.CONTENT_INDEX_VERSION);
+  });
 });

--- a/cli/src/lib/session/discover.ts
+++ b/cli/src/lib/session/discover.ts
@@ -2484,7 +2484,7 @@ async function scanOpenCodeIncremental(onProgress?: (p: ScanProgress) => void): 
     fileSize: stat.size,
   };
   const prev = getScanStampByPath(OPENCODE_DB);
-  const extractorUpgrade = prev?.extractorVersion !== CONTENT_INDEX_VERSION;
+  const extractorUpgrade = prev != null && prev.extractorVersion !== CONTENT_INDEX_VERSION;
   // OpenCode has a shared database rather than one transcript file per session,
   // so this container-level gate must honor extractor-version invalidation too.
   if (

--- a/cli/src/lib/session/discover.ts
+++ b/cli/src/lib/session/discover.ts
@@ -2484,6 +2484,7 @@ async function scanOpenCodeIncremental(onProgress?: (p: ScanProgress) => void): 
     fileSize: stat.size,
   };
   const prev = getScanStampByPath(OPENCODE_DB);
+  const extractorUpgrade = prev?.extractorVersion !== CONTENT_INDEX_VERSION;
   // OpenCode has a shared database rather than one transcript file per session,
   // so this container-level gate must honor extractor-version invalidation too.
   if (
@@ -2572,7 +2573,7 @@ async function scanOpenCodeIncremental(onProgress?: (p: ScanProgress) => void): 
       ) stats ON stats.session_id = s.id
       WHERE s.parent_id IS NULL
       ORDER BY time_created DESC
-      LIMIT 1000;
+      ${extractorUpgrade ? '' : 'LIMIT 1000'};
     `.replace(/\n/g, ' ');
 
     const account = getOpenCodeAccount();

--- a/cli/src/lib/session/remote/previous-rows.test.ts
+++ b/cli/src/lib/session/remote/previous-rows.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { SessionMeta } from '../types.js';
+
+const realHome = process.env.HOME;
+const realUserProfile = process.env.USERPROFILE;
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-previous-rows-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+let db: typeof import('../db.js');
+let readPreviousSessionsForWatch: typeof import('./watch.js').readPreviousSessionsForWatch;
+const scope = 'test-device';
+const now = Date.now();
+
+function seed(meta: Partial<SessionMeta> & Pick<SessionMeta, 'id' | 'agent'>, exists: boolean): void {
+  const filePath = path.join(tmpHome, `${meta.id}.jsonl`);
+  if (exists) fs.writeFileSync(filePath, '{}\n');
+  const timestamp = meta.timestamp ?? new Date(now - 2 * 60 * 60 * 1_000).toISOString();
+  db.upsertSession({
+    shortId: meta.id.slice(0, 8),
+    timestamp,
+    lastActivity: meta.lastActivity ?? timestamp,
+    machine: scope,
+    filePath,
+    ...meta,
+  } as SessionMeta, 'fixture', {
+    fileMtimeMs: exists ? fs.statSync(filePath).mtimeMs : now,
+    fileSize: exists ? fs.statSync(filePath).size : 0,
+  });
+}
+
+beforeAll(async () => {
+  db = await import('../db.js');
+  ({ readPreviousSessionsForWatch } = await import('./watch.js'));
+  db.getDB();
+});
+
+afterAll(() => {
+  db.closeDB();
+  process.env.HOME = realHome;
+  process.env.USERPROFILE = realUserProfile;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('readPreviousSessionsForWatch', () => {
+  it('filters newer ineligible rows before applying the 50-row cap', () => {
+    for (let i = 0; i < 60; i++) {
+      const timestamp = new Date(now - i * 1_000).toISOString();
+      seed({ id: `missing-${i}`, agent: 'codex', timestamp, lastActivity: timestamp }, false);
+      seed({ id: `captured-${i}`, agent: 'grok', timestamp, lastActivity: timestamp }, true);
+    }
+    for (let i = 0; i < 50; i++) {
+      const timestamp = new Date(now - 24 * 60 * 60 * 1_000 - i * 1_000).toISOString();
+      seed({ id: `eligible-${i}`, agent: 'codex', timestamp, lastActivity: timestamp }, true);
+    }
+
+    const rows = readPreviousSessionsForWatch(scope);
+    expect(rows).toHaveLength(50);
+    expect(rows.every((row) => row.id.startsWith('eligible-'))).toBe(true);
+    expect(rows.every((row) => row.filePath && fs.existsSync(row.filePath))).toBe(true);
+  });
+});

--- a/cli/src/lib/session/remote/watch.ts
+++ b/cli/src/lib/session/remote/watch.ts
@@ -320,9 +320,12 @@ export function readPreviousSessionsForWatch(scope: string): SessionMeta[] {
   try {
     return querySessions({
       machine: normalizeHost(scope),
-      limit: SESSION_WATCH_PREVIOUS_LIMIT,
+      agents: ['claude', 'codex', 'muse', 'opencode'],
+      sinceMs: Date.now() - 7 * 24 * 60 * 60 * 1000,
       excludeTeamOrigin: true,
-    });
+    })
+      .filter((session) => !session.archived && Boolean(session.filePath))
+      .slice(0, SESSION_WATCH_PREVIOUS_LIMIT);
   } catch {
     return [];
   }


### PR DESCRIPTION
## Outcome

Closes the remaining PHNX-3621 CLI gaps after the core first-message and Previous-stream changes landed on main.

- invalidates unchanged OpenCode rows when the content extractor version advances
- backfills every OpenCode row during an extractor upgrade instead of stopping at 1,000
- filters Previous history to resumable, local, non-archived transcript rows before applying the 50-row cap

## Verification

- `vitest run src/lib/session/discover.opencode-ledger.test.ts src/lib/session/remote/watch.test.ts` — 23 passed
- `bun run build` — passed
- `git diff --check` — passed

Tracking: PHNX-3621