### PR TITLE
feat(feed): tap-to-view console link for the posting session in phone broadcasts

### DIFF
--- a/cli/src/lib/feed-broadcast.test.ts
+++ b/cli/src/lib/feed-broadcast.test.ts
@@ -129,9 +129,15 @@ describe('message composition', () => {
     expect(msg).toContain('https://prix.dev/console/sessions/c854ae60-0bde-4049-bc8a-0b9674aeabd0');
   });
 
-  it('omits the console link when the session id is absent or not a full uuid', () => {
+  it('adds the console link for a native non-uuid session id (e.g. OpenCode ses_…)', () => {
+    const msg = composeBroadcastMessage(ctx({ session: 'ses_fields0000000000000000', links: undefined }));
+    expect(msg).toContain('https://prix.dev/console/sessions/ses_fields0000000000000000');
+  });
+
+  it('omits the console link when the session id is absent, the bare 8-char footer crumb, or path-unsafe', () => {
     expect(composeBroadcastMessage(ctx({ session: undefined, links: undefined }))).not.toContain('/console/sessions/');
     expect(composeBroadcastMessage(ctx({ session: 'c854ae60', links: undefined }))).not.toContain('/console/sessions/');
+    expect(composeBroadcastMessage(ctx({ session: 'a/b/../c', links: undefined }))).not.toContain('/console/sessions/');
   });
 
   it('scrubs em-dashes from title and body', () => {

--- a/cli/src/lib/feed-broadcast.test.ts
+++ b/cli/src/lib/feed-broadcast.test.ts
@@ -111,7 +111,7 @@ describe('message composition', () => {
     expect(message.match(new RegExp(url, 'g'))).toHaveLength(1);
   });
 
-  it('title, blank line, body, Sent from footer, then link', () => {
+  it('title, blank line, body, Sent from footer, then session link, then attached link', () => {
     expect(composeBroadcastMessage(ctx({ links: ['https://github.com/phnx-labs/agents-cli/pull/1690'] })))
       .toBe(
         'CI green, merging\n' +
@@ -119,8 +119,19 @@ describe('message composition', () => {
           'PR #1690 open, waiting on prix-cloud\n' +
           '\n' +
           'Sent from claude/c854ae60 on yosemite-s1\n' +
+          'https://prix.dev/console/sessions/c854ae60-0bde-4049-bc8a-0b9674aeabd0\n' +
           'https://github.com/phnx-labs/agents-cli/pull/1690',
       );
+  });
+
+  it('adds a tap-to-view console link for the posting session', () => {
+    const msg = composeBroadcastMessage(ctx({ links: undefined }));
+    expect(msg).toContain('https://prix.dev/console/sessions/c854ae60-0bde-4049-bc8a-0b9674aeabd0');
+  });
+
+  it('omits the console link when the session id is absent or not a full uuid', () => {
+    expect(composeBroadcastMessage(ctx({ session: undefined, links: undefined }))).not.toContain('/console/sessions/');
+    expect(composeBroadcastMessage(ctx({ session: 'c854ae60', links: undefined }))).not.toContain('/console/sessions/');
   });
 
   it('scrubs em-dashes from title and body', () => {
@@ -168,6 +179,7 @@ describe('message composition', () => {
         'PR #1690 open, waiting on prix-cloud\n' +
         '\n' +
         'Sent from claude/c854ae60 on yosemite-s1\n' +
+        'https://prix.dev/console/sessions/c854ae60-0bde-4049-bc8a-0b9674aeabd0\n' +
         'https://example.com/p',
     );
     expect(msg).not.toContain('agents focus');

--- a/cli/src/lib/feed-broadcast.ts
+++ b/cli/src/lib/feed-broadcast.ts
@@ -40,6 +40,7 @@ import { lookupTransport } from './channels/resolve.js';
 import { registerBuiltinProviders } from './channels/providers/index.js';
 import { sendToOwner } from './notify.js';
 import { linearIssueUrl } from './session/linear.js';
+import { isValidMailboxId } from './mailbox.js';
 import { forwardOwnerNotifyToPeer } from './channels/owner-forward.js';
 
 /** How loudly a post asks to be heard. Ordered — `important` implies milestone. */
@@ -257,14 +258,19 @@ export function shortSessionChunk(session: string | undefined): string | undefin
  * ({@link https://prix.dev/console/sessions/<id>}, prix/web). The footer already
  * carries a short session crumb for disambiguation; this rides the link trail so
  * the owner can open the full transcript straight from an iMessage broadcast
- * instead of hunting for it in the console. Only a UUID-shaped id qualifies — a
- * partial/placeholder crumb would just 404.
+ * instead of hunting for it in the console.
+ *
+ * Accepts any real, path-safe session id — a Claude/Codex UUID *and* a native
+ * `ses_…` id from OpenCode or another harness. The console shard uploader
+ * (`traces/sync.ts`) syncs sessions with no harness filter, so all of them are
+ * addressable; a UUID-only gate would silently drop the link for every non-Claude
+ * harness (the whole point of the link). Reject only an id that could not resolve:
+ * one with a path separator (URL-unsafe, via {@link isValidMailboxId}) or the bare
+ * 8-char footer crumb (a truncated id that would 404).
  */
 export function sessionConsoleUrl(session: string | undefined): string | undefined {
   const id = session?.trim();
-  if (!id || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
-    return undefined;
-  }
+  if (!id || !isValidMailboxId(id) || /^[0-9a-f]{8}$/i.test(id)) return undefined;
   return `https://prix.dev/console/sessions/${id}`;
 }
 

--- a/cli/src/lib/feed-broadcast.ts
+++ b/cli/src/lib/feed-broadcast.ts
@@ -253,6 +253,22 @@ export function shortSessionChunk(session: string | undefined): string | undefin
 }
 
 /**
+ * Tap-to-view link for the session behind a post: the addressable console page
+ * ({@link https://prix.dev/console/sessions/<id>}, prix/web). The footer already
+ * carries a short session crumb for disambiguation; this rides the link trail so
+ * the owner can open the full transcript straight from an iMessage broadcast
+ * instead of hunting for it in the console. Only a UUID-shaped id qualifies — a
+ * partial/placeholder crumb would just 404.
+ */
+export function sessionConsoleUrl(session: string | undefined): string | undefined {
+  const id = session?.trim();
+  if (!id || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
+    return undefined;
+  }
+  return `https://prix.dev/console/sessions/${id}`;
+}
+
+/**
  * Scrub em/en dashes from outbound phone copy (house rule + iMessage readability).
  * Collapses whitespace; does not invent meaning.
  */
@@ -348,7 +364,7 @@ export function composeBroadcastMessage(ctx: FeedBroadcastContext): string {
   const head = title || body;
   const mid = title && body && title !== body ? body : undefined;
   const footer = composeBroadcastFooter(ctx);
-  const links = [ctx.ticketUrl, ...(ctx.links ?? [])]
+  const links = [ctx.ticketUrl, sessionConsoleUrl(ctx.session), ...(ctx.links ?? [])]
     .filter((l): l is string => !!l && /^https?:\/\//i.test(l))
     .filter((l, i, all) => all.indexOf(l) === i);
 


### PR DESCRIPTION
## What
Feed phone broadcasts (milestone / `--level important` / `--blocked`) already carry a **"Sent from agent/session on host"** footer with a short session crumb — but no way to actually open that session. The full session id is already in `FeedBroadcastContext`, and prix/web now ships an addressable single-session page (`/console/sessions/[id]`). This adds `https://prix.dev/console/sessions/<id>` to the broadcast link trail so an owner can **tap straight from an iMessage into the session's transcript**.

## Why
Real report from the field: a `--blocked` post arrived on the owner's phone reading *"Sent from claude/160fcd8b on yosemite-m6"* with a GitHub PR preview but **no link to view that session**. The id is right there in the footer crumb; this makes it actionable.

## Change (`cli/src/lib/feed-broadcast.ts`)
- New `sessionConsoleUrl(session)` helper — emits the console URL only for a **full UUID** id (a partial footer crumb would 404).
- `composeBroadcastMessage()` — the session URL joins the existing deduped, https-validated link trail, right after the "Sent from" footer and alongside the ticket / PR links.

## Behavior
```
CI green, merging

PR #1690 open, waiting on prix-cloud

Sent from claude/c854ae60 on yosemite-s1
https://prix.dev/console/sessions/c854ae60-0bde-4049-bc8a-0b9674aeabd0   ← new
https://github.com/phnx-labs/agents-cli/pull/1690
```

## Tests
`bunx vitest run` across `feed-broadcast` / `feed-blocked` / `feed` — **93 passing**. Updated the two exact-match cases; added coverage for present / absent / partial-id.

## Notes
- Console domain hardcoded (`prix.dev`), mirroring how `ticketUrl` hardcodes the Linear domain.
- Not all sessions are synced to the console (traces auto-sync is opt-in, PHNX-3636) — a link to an unsynced session 404s. Acceptable for v1; a sync-aware gate can follow.
- Complements PHNX-3621 (sessions-view UX) rather than overlapping it — this is the feed→session entry point, not the view itself.
