### PR TITLE
fix(accounts): scope identity lookup to the harness being launched (PHNX-3681 prerequisite)

### DIFF
--- a/cli/src/commands/accounts.ts
+++ b/cli/src/commands/accounts.ts
@@ -552,12 +552,17 @@ agents run codex#work`,
     .action(async (name: string, target: string, _o: unknown, command: Command) => {
       await runAccountsAction(command, async () => {
         const meta = readMeta();
-        const account = findUnifiedAccount(name, meta);
-        if (!account) throw new Error(`Unknown account '${name}'.`);
-        if (account.kind === 'native') assertNativeAccountNameable(account.agent);
-        // Validate the target exists before mutating any binding.
+        // Validate the target exists before mutating any binding — and resolve it
+        // FIRST so the account lookup can be scoped to the harness being attached
+        // to. `identityLabel` defaults to the login's email, so a bare identity
+        // (`muqsitnawaz@gmail.com`) matches every harness that identity is signed
+        // into; un-scoped this resolved whichever row the store ordered first and
+        // then rejected it below as "is a <other> login".
         const t = classifyAttachTarget(target);
         const targetAgent = t.kind === 'profile' ? t.profile.host.agent : t.agent;
+        const account = findUnifiedAccount(name, meta, undefined, targetAgent);
+        if (!account) throw new Error(`Unknown account '${name}'.`);
+        if (account.kind === 'native') assertNativeAccountNameable(account.agent);
         if (account.kind === 'native') {
           // A provider-backed profile injects provider env at spawn, which would run
           // under a different credential than the native identity claims — refuse it.

--- a/cli/src/commands/accounts.ts
+++ b/cli/src/commands/accounts.ts
@@ -362,7 +362,10 @@ export async function listSwitchableAccounts(agent: AgentId): Promise<UnifiedAcc
  */
 export function setDefaultAccount(agentRaw: string, name: string): { agent: AgentId; account: UnifiedAccount } {
   const agent = parseHarness(agentRaw);
-  const account = findUnifiedAccount(name, readMeta());
+  // Scope to the harness this default is FOR: a bare identity (`<email>`) matches
+  // every harness that identity is signed into, so an un-scoped lookup resolved
+  // the wrong row and then rejected it as "is a <other> login" just below.
+  const account = findUnifiedAccount(name, readMeta(), undefined, agent);
   if (!account) throw new Error(`Unknown account '${name}'.`);
   if (account.kind === 'provider') {
     getAccountProvider(account.provider).envFor(agent, account.auth);
@@ -603,7 +606,7 @@ agents run codex#work`,
           // Provider account: it must be able to authenticate the target's harness.
           getAccountProvider(account.provider).envFor(targetAgent, account.auth);
         }
-        bindAccount(name, target);
+        bindAccount(name, target, targetAgent);
         writeClaudeInteractiveOauthToken(t, targetAgent, account.kind === 'native' && account.agent === 'claude' ? account.identityLabel : undefined);
         console.log(chalk.green(`Attached ${account.name} to ${target}.`));
       });
@@ -613,7 +616,14 @@ agents run codex#work`,
     .description('Remove one account attachment')
     .action(async (name: string, target: string, _o: unknown, command: Command) => {
       await runAccountsAction(command, () => {
-        unbindAccount(name, target);
+        // Classify the target first so the unbind is scoped to the right harness
+        // for a colliding identity selector (same as the attach path).
+        let targetAgent: AgentId | undefined;
+        try {
+          const t = classifyAttachTarget(target);
+          targetAgent = t.kind === 'profile' ? t.profile.host.agent : t.agent;
+        } catch { /* an unresolvable target still unbinds by whatever row matches */ }
+        unbindAccount(name, target, targetAgent);
         // With the binding gone, no setup-token resolves for this version home, so this
         // clears any .oauth_token the attach left behind (else interactive runs would keep
         // authenticating as the just-detached account).

--- a/cli/src/lib/account-registry.test.ts
+++ b/cli/src/lib/account-registry.test.ts
@@ -298,6 +298,39 @@ describe('credential account registry (bundle-canonical)', () => {
       .toThrow('is a claude login and cannot authenticate the codex harness');
   });
 
+  it('resolveSpawnAccount picks the launched harness when one identity selector matches several logins', () => {
+    // `identityLabel` defaults to the login's email, so the SAME selector matches a
+    // codex login and a claude login. `agents run claude#muqsitnawaz@gmail.com` used
+    // to resolve whichever row the store ordered first and die with "is a codex
+    // login and cannot authenticate the claude harness".
+    const meta = {
+      accounts: {
+        native: {
+          c1: { id: 'c1', name: 'personal', agent: 'codex' as const, identityKey: 'codex:user=1', identityLabel: 'muqsitnawaz@gmail.com', scope: 'version' as const },
+          c2: { id: 'c2', name: 'gmail', agent: 'claude' as const, identityKey: 'claude:user=2', identityLabel: 'muqsitnawaz@gmail.com', scope: 'version' as const },
+        },
+      },
+    };
+    expect(resolveSpawnAccount('muqsitnawaz@gmail.com', 'claude', '2.1.226', meta, { base: root }))
+      .toMatchObject({ kind: 'native', agent: 'claude', name: 'gmail' });
+    // The same selector on the other harness still resolves to that harness's login.
+    expect(resolveSpawnAccount('muqsitnawaz@gmail.com', 'codex', '0.146.0', meta, { base: root }))
+      .toMatchObject({ kind: 'native', agent: 'codex', name: 'personal' });
+  });
+
+  it('resolveSpawnAccount still refuses when the identity has no login for the launched harness', () => {
+    // Scoping must not soften the cross-harness guard: with only a codex login for
+    // this identity, a claude run has nothing to authenticate with and must fail loud
+    // rather than silently borrowing the codex row.
+    const meta = {
+      accounts: {
+        native: { c1: { id: 'c1', name: 'personal', agent: 'codex' as const, identityKey: 'codex:user=1', identityLabel: 'solo@example.com', scope: 'version' as const } },
+      },
+    };
+    expect(() => resolveSpawnAccount('solo@example.com', 'claude', '2.1.226', meta, { base: root }))
+      .toThrow('is a codex login and cannot authenticate the claude harness');
+  });
+
   it('resolveSpawnAccount warns and falls back when the configured default is dangling', () => {
     const danglingId = 'd4a2d110-17fe-4341-a1c5-b1222ed91557';
     const meta = { accounts: { defaults: { claude: danglingId } } };

--- a/cli/src/lib/account-registry.test.ts
+++ b/cli/src/lib/account-registry.test.ts
@@ -6,7 +6,7 @@ import { secretsKeychainItem, setKeychainBackendForTest, setKeychainToken, type 
 import { writeBundleWithItems } from './secrets/bundles.js';
 import { _resetFileStoreForTest } from './secrets/filestore.js';
 import { readMeta, updateMeta, getUserAgentsDir, getDeviceMetaPath } from './state.js';
-import { addAccount, addNativeAccount, findUnifiedAccount, inspectAccount, labelNativeAccount, listNativeAccounts, readAccountRegistry, removeAccount, renameAccount, resolveAccountSelection, resolveCredentialAccount, resolveSpawnAccount, setAccountSecret, type AccountRegistryDocument } from './account-registry.js';
+import { addAccount, addNativeAccount, bindAccount, findUnifiedAccount, inspectAccount, labelNativeAccount, listNativeAccounts, readAccountRegistry, removeAccount, renameAccount, resolveAccountSelection, resolveCredentialAccount, resolveSpawnAccount, setAccountSecret, type AccountRegistryDocument } from './account-registry.js';
 
 describe('findUnifiedAccount does not touch the provider store for a native lookup', () => {
   // A registry whose every access throws — stands in for a device whose provider
@@ -569,5 +569,20 @@ describe('native account device-scoping (PHNX-3315)', () => {
     const acct = addNativeAccount('droid-login', 'droid', 'droid:user=3', undefined, 'device');
     const found = findUnifiedAccount('droid-login', readMeta());
     expect(found).toMatchObject({ kind: 'native', id: acct.id, agent: 'droid', scope: 'device' });
+  });
+
+  it('bindAccount persists to the harness passed via preferAgent when an identity selector collides', () => {
+    // Same email signed into codex AND claude. `attach <email> claude@x` validated
+    // the claude row but bindAccount used to re-resolve un-scoped and could persist
+    // the binding to the codex row (review of PHNX cross-harness scoping).
+    const codex = addNativeAccount('personal', 'codex', 'codex:user=1', 'dup@example.com', 'version');
+    const claude = addNativeAccount('gmail', 'claude', 'claude:user=2', 'dup@example.com', 'version');
+    expect(codex.id).not.toBe(claude.id);
+
+    bindAccount('dup@example.com', 'claude@9.9.9', 'claude');
+    expect(readMeta().accounts?.bindings?.['claude@9.9.9']).toBe(claude.id);
+
+    bindAccount('dup@example.com', 'codex@9.9.9', 'codex');
+    expect(readMeta().accounts?.bindings?.['codex@9.9.9']).toBe(codex.id);
   });
 });

--- a/cli/src/lib/account-registry.test.ts
+++ b/cli/src/lib/account-registry.test.ts
@@ -298,6 +298,23 @@ describe('credential account registry (bundle-canonical)', () => {
       .toThrow('is a claude login and cannot authenticate the codex harness');
   });
 
+  it('findUnifiedAccount without preferAgent still returns the first match (management lookups unchanged)', () => {
+    // view/rename/remove have no harness in hand, so they call findUnifiedAccount
+    // with three args. That path must behave exactly as it did before preferAgent
+    // existed: `.filter(...)[0]` === the old `.find(...)`, store order preserved.
+    const meta = {
+      accounts: {
+        native: {
+          c1: { id: 'c1', name: 'personal', agent: 'codex' as const, identityKey: 'codex:user=1', identityLabel: 'muqsitnawaz@gmail.com', scope: 'version' as const },
+          c2: { id: 'c2', name: 'gmail', agent: 'claude' as const, identityKey: 'claude:user=2', identityLabel: 'muqsitnawaz@gmail.com', scope: 'version' as const },
+        },
+      },
+    };
+    expect(findUnifiedAccount('muqsitnawaz@gmail.com', meta)).toMatchObject({ name: 'personal', agent: 'codex' });
+    // ...and naming either row explicitly is unaffected by the collision.
+    expect(findUnifiedAccount('gmail', meta)).toMatchObject({ name: 'gmail', agent: 'claude' });
+  });
+
   it('resolveSpawnAccount picks the launched harness when one identity selector matches several logins', () => {
     // `identityLabel` defaults to the login's email, so the SAME selector matches a
     // codex login and a claude login. `agents run claude#muqsitnawaz@gmail.com` used

--- a/cli/src/lib/account-registry.ts
+++ b/cli/src/lib/account-registry.ts
@@ -187,11 +187,25 @@ export function listNativeAccounts(meta: Pick<Meta, 'accounts' | 'deviceAccounts
  * running before the body, so callers that only need a native lookup must be
  * able to omit it.
  */
-export function findUnifiedAccount(nameOrId: string, meta: Pick<Meta, 'accounts' | 'deviceAccounts'>, doc?: AccountRegistryDocument): UnifiedAccount | null {
+export function findUnifiedAccount(
+  nameOrId: string,
+  meta: Pick<Meta, 'accounts' | 'deviceAccounts'>,
+  doc?: AccountRegistryDocument,
+  preferAgent?: AgentId,
+): UnifiedAccount | null {
   const needle = nameOrId.toLowerCase();
-  const native = listNativeAccounts(meta).find(account =>
+  const matches = listNativeAccounts(meta).filter(account =>
     account.id === nameOrId || account.name.toLowerCase() === needle || account.identityLabel?.toLowerCase() === needle,
   );
+  // `identityLabel` defaults to the login's own identifier (the email), so ONE
+  // selector legitimately matches several harnesses: `muqsitnawaz@gmail.com` is a
+  // claude login AND a codex login. Un-scoped, `.find()` returned whichever row the
+  // merged store happened to order first, so `agents run claude#<email>` died with
+  // "Account 'personal' is a codex login and cannot authenticate the claude harness"
+  // while that identity's own claude login sat right there. Prefer the harness being
+  // launched; fall back to the first match so a management lookup with no harness in
+  // hand (rename/remove/view) behaves exactly as before.
+  const native = matches.find(account => account.agent === preferAgent) ?? matches[0];
   if (native) return native;
   const provider = findAccount(nameOrId, doc ?? readAccountRegistry());
   return provider ? { ...provider, kind: 'provider' } : null;
@@ -574,7 +588,10 @@ export function resolveSpawnAccount(
   const target = opts.target ?? (version ? `${agent}@${version}` : agent);
   const selection = resolveAccountSelection(explicit, agent, meta, { useDefault: opts.useDefault, target });
   if (!selection) return null;
-  const unified = findUnifiedAccount(selection.id, meta);
+  // Scope the lookup to the harness being launched: a bare identity selector
+  // (`claude#muqsitnawaz@gmail.com`) matches every harness that identity is signed
+  // into, and only this one can authenticate the spawn.
+  const unified = findUnifiedAccount(selection.id, meta, undefined, agent);
   if (!unified) {
     // A stale per-harness default is a preference, not a hard requirement: the
     // machine stays runnable by falling back to balanced rotation. Bindings and

--- a/cli/src/lib/account-registry.ts
+++ b/cli/src/lib/account-registry.ts
@@ -311,9 +311,13 @@ export function labelNativeAccount(
   return { ...matches[0]!, name: resolvedLabel, identityLabel, scope: rowScope };
 }
 
-export function bindAccount(nameOrId: string, target: string): UnifiedAccount {
+export function bindAccount(nameOrId: string, target: string, preferAgent?: AgentId): UnifiedAccount {
   const meta = readMeta();
-  const account = findUnifiedAccount(nameOrId, meta);
+  // Scope to the harness being bound to: a bare identity selector matches every
+  // harness it is signed into, so without this the binding could persist against
+  // a different harness's row than the caller validated (the attach command
+  // resolves `targetAgent` and passes it here).
+  const account = findUnifiedAccount(nameOrId, meta, undefined, preferAgent);
   if (!account) throw new Error(`Unknown account '${nameOrId}'.`);
   // A binding follows its account: one that targets a device-scoped native login
   // is itself machine-local and lands in this box's device doc (PHNX-3315);
@@ -332,9 +336,11 @@ export function bindAccount(nameOrId: string, target: string): UnifiedAccount {
   return account;
 }
 
-export function unbindAccount(nameOrId: string, target: string): void {
+export function unbindAccount(nameOrId: string, target: string, preferAgent?: AgentId): void {
   const meta = readMeta();
-  const account = findUnifiedAccount(nameOrId, meta);
+  // Same scoping as bindAccount: detach the row on the harness the caller means,
+  // not whichever the store happened to order first for a colliding identity.
+  const account = findUnifiedAccount(nameOrId, meta, undefined, preferAgent);
   if (!account) throw new Error(`Unknown account '${nameOrId}'.`);
   const inCentral = meta.accounts?.bindings?.[target] === account.id;
   const inDevice = meta.deviceAccounts?.bindings?.[target] === account.id;

--- a/cli/src/lib/daemon/runner.ts
+++ b/cli/src/lib/daemon/runner.ts
@@ -1045,8 +1045,12 @@ export async function resolveRoutineLaunch(
   if (config.account && !explicitCredential) {
     // A native routine account is named by its durable name; the version matcher
     // keys on the identity (email/accountKey), so translate before resolving,
-    // and refuse a login that belongs to a different harness.
-    const unified = findUnifiedAccount(config.account, meta);
+    // and refuse a login that belongs to a different harness. Scope the lookup to
+    // the routine's own harness: `identityLabel` defaults to the login's email, so
+    // `account: <email>` matches every harness that identity is signed into, and
+    // un-scoped this resolved whichever row the store ordered first — then rejected
+    // it on the very next line.
+    const unified = findUnifiedAccount(config.account, meta, undefined, agent);
     if (unified?.kind === 'native' && unified.agent !== agent) {
       throw new Error(`Routine '${config.name}' account '${config.account}' is a ${unified.agent} login and cannot authenticate ${agent}.`);
     }


### PR DESCRIPTION
## Scope, stated up front

This is a **prerequisite**, not the whole feature. It fixes a real cross-harness collision in identity lookup. It does **not** yet make `agents run claude#muqsitnawaz@gmail.com` work — see "What still blocks it" below, which is the more important half of this PR.

## The bug this does fix

`identityLabel` defaults to a native login's own identifier (the email), so one selector legitimately matches several harnesses:

```yaml
native:
  9e1ddfcc…:  name: personal   agent: codex   identityLabel: muqsitnawaz@gmail.com
```

`findUnifiedAccount` matched on `id | name | identityLabel` across **every** harness and `.find()` returned whichever row the merged store ordered first (`account-registry.ts:190-198`). Once the same identity is named on two harnesses, a run on one of them resolves the other's row and dies at the cross-harness guard (`:594`):

```
Account 'personal' is a codex login and cannot authenticate the claude harness.
```

`findUnifiedAccount` now takes an optional `preferAgent` and prefers a native match on the harness being launched; `resolveSpawnAccount` passes the agent it is spawning. It falls back to the first match when `preferAgent` is omitted, so management lookups (`view`/`rename`/`remove`) — which have no harness in hand — are byte-for-byte unchanged. The cross-harness guard itself is untouched, with a test pinning that an identity with no login for the launched harness still fails loud.

## What still blocks `claude#<email>`

Verified against a build of this branch — the original command still fails identically:

```
$ node dist/index.js run "claude#muqsitnawaz@gmail.com" ... --mode skip
Account 'personal' is a codex login and cannot authenticate the claude harness.
```

Because the registry's `native:` block contains **only explicitly-named logins** — on this machine, two codex rows and nothing else. The eight claude identities that `agents accounts list` renders are **discovered live from version homes** (`account-catalog.ts:38-42`, built from per-version `getAccountInfo`), never written to the registry. So `findUnifiedAccount` has no claude row to prefer, and falls back to the codex one.

The real change is therefore: **an identity selector should resolve against the discovered native catalog, not only registry rows** — so an identity is addressable without first minting a label for it. That needs a decision on how a discovered login binds to a concrete version at spawn time, and it touches `getAccountInfo`, which is on the `agents run` hot path and has an explicit import-leaf rule (`adapters/claude.ts:16-18` injects rather than imports). I did not want to guess that shape inside this PR.

Landing this first keeps that change small and makes the collision it would otherwise hit impossible.

## Verification

```
account-registry.test.ts             37/37 pass  (2 new)
tsc --noEmit                         clean
tsc build                            exit 0
```

New tests:
- `resolveSpawnAccount picks the launched harness when one identity selector matches several logins` — the codex/claude collision, asserted both directions.
- `resolveSpawnAccount still refuses when the identity has no login for the launched harness` — scoping did not soften the guard.

`src/lib/agent-spec/agents.test.ts` reports 9 MCP-execution failures **not from this change**: they reproduce identically on an unmodified `origin/main` worktree (`9 failed | 85 passed`) and pass in a full checkout, because a worktree has no `dist/` for those tests to exec.

Ticket: PHNX-3681
