### PR TITLE
test: pin suite to TZ=UTC (fixes SING-15 flake that wedges the release attestation on non-UTC boxes)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -53,7 +53,7 @@
     "gen:index": "bun scripts/gen-command-index.ts",
     "verify:index": "bash scripts/verify-command-index.sh",
     "start": "node dist/index.js",
-    "test": "node ./node_modules/vitest/vitest.mjs run",
+    "test": "TZ=UTC node ./node_modules/vitest/vitest.mjs run",
     "bench": "node ./node_modules/vitest/vitest.mjs bench --run",
     "typecheck:bench": "tsc --noEmit --ignoreConfig --skipLibCheck --module esnext --moduleResolution bundler --target es2022 --strict --esModuleInterop --lib es2022 --types node src/lib/*.bench.ts src/lib/**/*.bench.ts",
     "test:remote": "scripts/sandbox.sh test",


### PR DESCRIPTION
## Problem
`release.sh --apply` wedges at the release-tree attestation because the suite goes RED on a non-UTC worker. Root cause: TZ-flaky tests.

Several tests assert **UTC-aligned** schedule boundaries (daemon single-fire slots — `src/lib/daemon/runner.fire.test.ts` SING-15). A `Cron` with no configured timezone fires in the machine's **local** zone, so `0 3 * * *` = 03:00 UTC on a UTC box but 03:00 **PDT** (10:00 UTC) on a `America/Los_Angeles` box — and the test's `new Date('…T03:00:00Z')` boundary never aligns. GitHub CI runners are UTC, so CI is green and never sees it; a **non-UTC release/attestation worker** makes the identical suite red and blocks every release (the exact wedge behind R2 / PHNX-3696 on non-UTC boxes).

## Fix
One line: pin `TZ=UTC` in the `test` launch env (`cli/package.json`). Node reads TZ once at process start, so every vitest fork inherits UTC. No test logic and no production code touched.

## Verified
On a PDT box: `SING-15` **fails without** TZ=UTC, **passes with** it. The attestation runs `bun run test`, so this reaches it.

Unblocks: agents-cli release 1.22.69 (PR #3370) and every future release on a non-UTC worker.