### PR TITLE
fix(acp): inject the exec env on ACP launches so workers use the setup-token (PHNX-3681)

### DIFF
--- a/cli/src/lib/acp/client.test.ts
+++ b/cli/src/lib/acp/client.test.ts
@@ -1,0 +1,54 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock child_process.spawn so runAcp never launches a real harness; we only
+// assert what env it is handed. The spawned "child" is a stub that never speaks
+// ACP, so runAcp will reject at the protocol handshake — which is fine, the
+// spawn call (and its env) has already happened by then.
+const spawnMock = vi.fn();
+vi.mock('child_process', () => ({ spawn: spawnMock }));
+
+// buildExecEnv is the canonical env-builder that injects the per-account
+// setup-token on a worker. Stub it to a sentinel so we can prove runAcp routes
+// through it instead of handing the harness a raw process.env.
+const buildExecEnvMock = vi.fn(() => ({ SENTINEL_INJECTED_ENV: '1', CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat-test' } as NodeJS.ProcessEnv));
+vi.mock('../exec.js', () => ({ buildExecEnv: buildExecEnvMock }));
+
+function makeFakeChild(): EventEmitter & { stdin: unknown; stdout: unknown } {
+  const child = new EventEmitter() as EventEmitter & { stdin: unknown; stdout: unknown };
+  // Minimal duplex-ish stubs; the ndjson stream wraps these but no bytes flow.
+  const { Readable, Writable } = require('node:stream');
+  child.stdin = new Writable({ write(_c: unknown, _e: unknown, cb: () => void) { cb(); } });
+  child.stdout = new Readable({ read() { /* never emits */ } });
+  return child;
+}
+
+describe('runAcp injects the built exec env (PHNX-3681)', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+    buildExecEnvMock.mockClear();
+    spawnMock.mockImplementation(() => makeFakeChild());
+  });
+  afterEach(() => vi.clearAllTimers());
+
+  it('spawns the harness with buildExecEnv output, not a raw process.env', async () => {
+    const { runAcp } = await import('./client.js');
+    // The handshake will never complete against the fake child; race it against a
+    // short timer so the test does not hang, then inspect the spawn call.
+    await Promise.race([
+      runAcp({ agent: 'claude', prompt: 'hi', cwd: '/tmp', mode: 'edit' }).catch(() => undefined),
+      new Promise(resolve => setTimeout(resolve, 150)),
+    ]);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(buildExecEnvMock).toHaveBeenCalledTimes(1);
+    // The agent/cwd/mode flow into the env-builder so device-role gating applies.
+    expect(buildExecEnvMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: 'claude', cwd: '/tmp', mode: 'edit', interactive: true }),
+    );
+    const passedEnv = spawnMock.mock.calls[0]![2].env;
+    expect(passedEnv.SENTINEL_INJECTED_ENV).toBe('1');
+    expect(passedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat-test');
+    expect(passedEnv).not.toBe(process.env);
+  });
+});

--- a/cli/src/lib/acp/client.ts
+++ b/cli/src/lib/acp/client.ts
@@ -34,7 +34,7 @@ import {
 } from '@zed-industries/agent-client-protocol';
 import { getAcpSpec, supportsAcp } from './harnesses.js';
 import type { AgentId } from '../types.js';
-import type { ExecMode } from '../exec.js';
+import { buildExecEnv, type ExecMode } from '../exec.js';
 
 const PROTOCOL_VERSION = 1;
 
@@ -62,10 +62,20 @@ export async function runAcp(opts: AcpRunOptions): Promise<AcpRunResult> {
   }
   const spec = getAcpSpec(opts.agent)!;
 
+  // Build the harness's exec env the SAME way `agents run` does, instead of
+  // handing it a raw process.env. buildExecEnv is what injects the per-account
+  // `CLAUDE_CODE_OAUTH_TOKEN` on a worker device (gated by device role: a
+  // headed/personal box still defers to its native login). Without this, an ACP
+  // launch inherited no setup-token and fell through to the version home's
+  // copied native `.credentials.json` — which expires in ~15h and 401s once its
+  // refresh chain dies, exactly the "logged out on a worker" report (PHNX-3681).
+  // A verified precedence test shows the env token wins over a present
+  // `.credentials.json`, so injecting here is sufficient — the stale file no
+  // longer decides the session.
   const child: ChildProcess = spawn(spec.command, spec.args, {
     cwd: opts.cwd,
     stdio: ['pipe', 'pipe', 'inherit'],
-    env: process.env,
+    env: buildExecEnv({ agent: opts.agent, cwd: opts.cwd, mode: opts.mode, effort: 'auto', interactive: true }),
   });
 
   const stream = ndJsonStream(


### PR DESCRIPTION
## The bug

"I'm on a worker node with a 1-year token — how am I getting logged out?" The session dies with `401 OAuth access token has expired · run /login`.

## Root cause (pinned by live tests, not theory)

Three facts, each verified on the fleet:

1. **A setup-token never writes a `.credentials.json`** (clean-room: injected token + empty config dir → authenticates, `none written`). So the `.credentials.json` sitting in a worker version home is a copied **native** login — ~15h lifetime — that 401s once its refresh chain dies.
2. **The injected `CLAUDE_CODE_OAUTH_TOKEN` beats a present `.credentials.json`** on both the `--print` and the stream-json interactive paths. Verified on yosemite-s1: with a *valid* native file for account A and the env token set to a *weekly-limited* account B, the run returned B's limit message — the env token won. So injection alone fixes it; the stale file does not get to decide.
3. **`runAcp` never injected.** `cli/src/lib/acp/client.ts` spawned the harness with `env: process.env` — it never called `buildExecEnv`, the function that injects the per-account setup-token. `agents run` builds the env and works; the ACP / editor-extension path skipped it, so those sessions inherited no token and fell through to the dying native file.

## The fix

`runAcp` now builds its child env with `buildExecEnv` — the same canonical builder `agents run` uses. That injects the setup-token **gated by device role**: a worker gets the token; a headed/personal box (zion) still defers to its own native login, which is correct there.

```diff
-    env: process.env,
+    env: buildExecEnv({ agent: opts.agent, cwd: opts.cwd, mode: opts.mode, effort: 'auto', interactive: true }),
```

No new mechanism — it routes the existing injector through the one launch path that bypassed it.

## Verification

```
new regression test (client.test.ts)   pass — pins runAcp routes through buildExecEnv, child env carries the token, never raw process.env
acp/ + exec __tests__                   227 passed
tsc --noEmit                            clean
```

## Honest scope / follow-up

This closes the ACP gap **inside agents-cli**. I could not catch a live ACP child process to prove the VS Codium extension spawns through `runAcp` specifically — if the extension uses its own launcher, the same `buildExecEnv` call must be applied there too. Flagged on PHNX-3681 for follow-up. Either way this fix is correct for every agents-cli ACP launch and cannot regress `agents run` (untouched).

This does **not** touch the separate m3 "unprovisioned default home → onboarding" failure (that's the attach-doesn't-provision bug, tracked separately) or droid's unprovisioned `FACTORY_API_KEY`.

Ticket: PHNX-3681
