### PR TITLE
docs(auth): codify the device-role credential rule (headed never uses the setup-token)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,15 @@ and [`architecture.md`](cli/docs/architecture.md).
   racing the daemon, spawning resume-tabs every 120s into exhausted accounts) is the
   canonical example; the consolidation (PR #1914) is the canonical fix. The normative
   contract is [§Scheduling & execution singularity](cli/docs/specifications.md#scheduling--execution-singularity).
+- **Credentials are keyed on device role, and the two roles never cross (owner
+  rule).** A **personal/desktop (headed)** device — the machine a human works on,
+  e.g. `zion` — authenticates ONLY with the harness's normal interactive OAuth
+  (native) login, and is where the durable token is minted. A **worker** device
+  authenticates with the durable, identity-blind long-term setup-token synced from
+  the account bundle. A headed device MUST NOT fall back to the setup-token when its
+  native login dies — the fix for that is re-running the native OAuth flow, never the
+  token. This is a standing, non-negotiable owner requirement; the full statement and
+  rationale is [`cli/docs/credential-management.md` invariant 7](cli/docs/credential-management.md#the-invariants-non-negotiable).
 
 ## CLI surface conventions
 

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -982,6 +982,7 @@ native login on a headed box is fixed by re-running the native OAuth flow
 (`claude` → `/login`, or `agents accounts mint claude`), NOT by falling back to
 the injected setup-token. Do not add a "native login expired, use the token
 instead" fallback on a headed device — that inverts the rule.
+
 The one display consequence:
 because a `personal` box is by definition the interactive seat, `agents devices
 list` folds the `★ interactive` star INTO the `personal` role rather than

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -973,6 +973,15 @@ credential, minted via `agents auth mint claude`), while a headed box uses its n
 `--interactive --device` → login screen, the setup-token sitting unused) / RUSH-2395
 (headless laptop run → hijacked the human's login) bug pair. Full model:
 [`cli/docs/credential-management.md` §Which credential a run injects](docs/credential-management.md).
+
+**Owner rule — never regress (credential-management.md invariant 7).** A headed
+box (`personal`/`desktop`, e.g. `zion`) authenticates ONLY with its native
+interactive OAuth login, never the long-term setup-token — the token is
+identity-blind, and the headed box is where the token is minted. A dead/expired
+native login on a headed box is fixed by re-running the native OAuth flow
+(`claude` → `/login`, or `agents accounts mint claude`), NOT by falling back to
+the injected setup-token. Do not add a "native login expired, use the token
+instead" fallback on a headed device — that inverts the rule.
 The one display consequence:
 because a `personal` box is by definition the interactive seat, `agents devices
 list` folds the `★ interactive` star INTO the `personal` role rather than

--- a/cli/docs/credential-management.md
+++ b/cli/docs/credential-management.md
@@ -94,6 +94,40 @@ Both come from the same mistake: **agents-cli touching the interactive login.**
    harness**, including the hard ones (Droid, Kimi). Solution decided per credential
    *type*, not per agent name.
 
+7. **Device role decides the credential source, and the two roles never cross
+   (owner rule — do not regress).** This is an explicit, standing requirement from
+   the fleet owner; treat it as non-negotiable and never "optimize" it away.
+
+   - **Personal / desktop devices (headed — e.g. `zion`) authenticate with the
+     harness's NORMAL interactive OAuth login (the native login), minted on that
+     device.** A headed device MUST NOT authenticate from the injected long-term
+     setup-token. Two reasons: (a) the setup-token is identity-blind — it surfaces
+     no email / account, so a machine a human works on must carry a real,
+     inspectable native login; (b) the personal device is the machine that *mints*
+     the durable token (below), so it is the one place the interactive login must
+     live. This is the headed-device branch in
+     `src/lib/harness/adapters/claude.ts` (`isHeadedDeviceRole`): it defers to the
+     native login and drops any inherited setup-token (RUSH-2395).
+
+   - **Worker devices authenticate with the durable long-term setup-token**,
+     synced from the account bundle. Workers hold no interactive login.
+
+   - **Minting flow (must be automatic).** The durable `claude setup-token` is
+     obtained by running the setup-token flow ON a personal device (`zion`); the
+     minted token must be saved into the account store automatically and propagated
+     to worker devices via `agents accounts sync` / the reserved `auth` bundle — it
+     must NOT require the owner to hand-copy the token through 1Password and have an
+     agent re-inject it. `agents accounts mint claude` is the intended one-shot for
+     mint + seed.
+
+   - **A dead login on a headed device is fixed by re-running the native OAuth
+     flow on that device — NEVER by falling back to the injected setup-token.** Any
+     change that makes a personal/desktop device consume the long-term token
+     (including a well-meant "the native login expired, so use the token instead"
+     fallback) is a REGRESSION of this rule and must not be added. The correct
+     remedy for a logged-out personal home is `claude` → `/login` (or `agents
+     accounts mint claude`), which restores a real identity-bearing native login.
+
 ## One account namespace: provider credentials and named native logins (RUSH-2527)
 
 An **account** is one authorization identity, and it comes in two kinds that share

--- a/cli/docs/credential-management.md
+++ b/cli/docs/credential-management.md
@@ -107,7 +107,9 @@ Both come from the same mistake: **agents-cli touching the interactive login.**
      the durable token (below), so it is the one place the interactive login must
      live. This is the headed-device branch in
      `src/lib/harness/adapters/claude.ts` (`isHeadedDeviceRole`): it defers to the
-     native login and drops any inherited setup-token (RUSH-2395).
+     native login and drops an inherited copy of *that account's* setup-token
+     (matched by value; the broader "strip any inherited token" is the still-open
+     RUSH-2360 follow-up) (RUSH-2395).
 
    - **Worker devices authenticate with the durable long-term setup-token**,
      synced from the account bundle. Workers hold no interactive login.

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -2399,6 +2399,17 @@ schema (`--json` passes through each agent's native stream format).
   Note this MUST NOT be read as "a login-deferring run never carries a token": no
   requirement yet strips an ambient value on that path when NO per-account token
   resolves, tracked as RUSH-2360.
+- **EXEC-2a-role — a headed device MUST NOT fall back to the setup-token when its
+  native login is dead (owner rule, non-negotiable).** The setup-token is a WORKER
+  credential and is identity-blind; a `personal`/`desktop` box MUST authenticate
+  from its native interactive OAuth login for every run, and a dead/expired/blank
+  native login on such a box MUST be remedied by re-running the native OAuth flow
+  (`claude` → `/login`, or `agents accounts mint claude`), NEVER by injecting the
+  long-term setup-token. A change that injects `CLAUDE_CODE_OAUTH_TOKEN` on a headed
+  device on the grounds that the native login expired/blanked is a REGRESSION and
+  MUST be rejected in review. The durable token is minted ON the headed device and
+  synced OUT to workers; it never flows back in as that device's own runtime
+  credential. Full statement: [`credential-management.md` invariant 7](credential-management.md#the-invariants-non-negotiable).
 - **EXEC-2b — usage-read credential (MUST), the same role gate as EXEC-2a.** A
   Claude *usage read* (`getClaudeUsageInfo` → `loadClaudeOauth` with
   `accessTokenCache: true`, `lib/accounting/usage.ts`) selects its credential by an

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -2399,17 +2399,6 @@ schema (`--json` passes through each agent's native stream format).
   Note this MUST NOT be read as "a login-deferring run never carries a token": no
   requirement yet strips an ambient value on that path when NO per-account token
   resolves, tracked as RUSH-2360.
-- **EXEC-2a-role — a headed device MUST NOT fall back to the setup-token when its
-  native login is dead (owner rule, non-negotiable).** The setup-token is a WORKER
-  credential and is identity-blind; a `personal`/`desktop` box MUST authenticate
-  from its native interactive OAuth login for every run, and a dead/expired/blank
-  native login on such a box MUST be remedied by re-running the native OAuth flow
-  (`claude` → `/login`, or `agents accounts mint claude`), NEVER by injecting the
-  long-term setup-token. A change that injects `CLAUDE_CODE_OAUTH_TOKEN` on a headed
-  device on the grounds that the native login expired/blanked is a REGRESSION and
-  MUST be rejected in review. The durable token is minted ON the headed device and
-  synced OUT to workers; it never flows back in as that device's own runtime
-  credential. Full statement: [`credential-management.md` invariant 7](credential-management.md#the-invariants-non-negotiable).
 - **EXEC-2b — usage-read credential (MUST), the same role gate as EXEC-2a.** A
   Claude *usage read* (`getClaudeUsageInfo` → `loadClaudeOauth` with
   `accessTokenCache: true`, `lib/accounting/usage.ts`) selects its credential by an
@@ -2439,6 +2428,17 @@ schema (`--json` passes through each agent's native stream format).
     (`isCachedUsageWindowFresh`: session 300 min, week 10080 min) is unchanged — this
     contract only restores the credential that lets `--refresh` recapture an expired
     session window on a personal device.
+- **EXEC-2c — a headed device MUST NOT fall back to the setup-token when its
+  native login is dead (owner rule, non-negotiable).** The setup-token is a WORKER
+  credential and is identity-blind; a `personal`/`desktop` box MUST authenticate
+  from its native interactive OAuth login for every run, and a dead/expired/blank
+  native login on such a box MUST be remedied by re-running the native OAuth flow
+  (`claude` → `/login`, or `agents accounts mint claude`), NEVER by injecting the
+  long-term setup-token. A change that injects `CLAUDE_CODE_OAUTH_TOKEN` on a headed
+  device on the grounds that the native login expired/blanked is a REGRESSION and
+  MUST be rejected in review. The durable token is minted ON the headed device and
+  synced OUT to workers; it never flows back in as that device's own runtime
+  credential. Full statement: [`credential-management.md` invariant 7](credential-management.md#the-invariants-non-negotiable).
 - **EXEC-3 (MUST).** `buildExecEnv` MUST set `AGENTS_MAILBOX_DIR` +
   `AGENT_SESSION_ID` + `AGENTS_SESSION_ID` when a valid session id is present
   (`lib/exec.ts:572-575`), `AGENTS_RUNTIME` to `terminal`/`headless` from


### PR DESCRIPTION
## What

Codifies a standing **owner rule** for fleet auth so no agent regresses it — because one nearly did (this session almost shipped a "headed device falls back to the setup-token when its native login is dead" change, which is the exact inversion of the rule).

## The rule

- **Personal / desktop (headed) devices — e.g. `zion` — authenticate ONLY with the harness's normal interactive OAuth (native) login.** They MUST NOT use the injected long-term setup-token. The token is identity-blind (surfaces no email/account), so a machine a human works on must carry a real, inspectable native login — and the headed device is where the durable token is *minted*.
- **Worker devices authenticate with the durable long-term setup-token**, synced from the account bundle.
- **A dead native login on a headed device is fixed by re-running the native OAuth flow** (`claude` → `/login`, or `agents accounts mint claude`) — **never** by falling back to the setup-token. Any such fallback is a regression and must be rejected in review.
- **The mint flow runs on the headed device and must save + propagate automatically** — not the manual "paste into 1Password, agent re-injects to workers" dance.

This matches what the code already does (`isHeadedDeviceRole` in `applyExecConfigEnv`, RUSH-2395/PHNX-3502) — it was just never written down as non-negotiable, which is how it nearly got inverted.

## Where it's documented

| File | What |
| --- | --- |
| `cli/docs/credential-management.md` | **invariant 7** — full rule + rationale + mint flow + regression guard |
| `cli/docs/specifications.md` | **EXEC-2a-role** — normative MUST, reviewer-enforceable |
| `cli/AGENTS.md` | device-role section reinforced with the owner rule + no-fallback guard |
| `AGENTS.md` (root; symlinks → `CLAUDE.md`/`GEMINI.md`) | Core-concepts bullet + link |

Docs-only. No code change.

## Not in this PR (follow-ups)

- The **auto-save-and-propagate mint flow** (so minting on zion doesn't need a manual 1Password round-trip) is a real feature gap — worth its own ticket.
- On a headed device, the router can still *pick* a home whose native login is dead (it reads as "available" from stale usage) → logout. The correct fix is fail-closed / mark-unavailable, **not** a token fallback (per this rule). Separate issue.
