### PR TITLE
docs(auth): canonical non-reversible provisioning model (owner requirement)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,8 +148,13 @@ and [`architecture.md`](cli/docs/architecture.md).
   authenticates with the durable, identity-blind long-term setup-token synced from
   the account bundle. A headed device MUST NOT fall back to the setup-token when its
   native login dies — the fix for that is re-running the native OAuth flow, never the
-  token. This is a standing, non-negotiable owner requirement; the full statement and
-  rationale is [`cli/docs/credential-management.md` invariant 7](cli/docs/credential-management.md#the-invariants-non-negotiable).
+  token. Provisioning follows one non-reversible flow: mint every interactive login
+  on the laptop; for a token-bearing harness (claude/codex/gemini/grok/opencode/droid)
+  copy the durable credential out to workers where it auto-injects; a token-less
+  harness (kimi, antigravity) is logged in per box. This is a standing, non-negotiable
+  owner requirement; the full statement is
+  [`cli/docs/credential-management.md` invariant 7](cli/docs/credential-management.md#the-invariants-non-negotiable)
+  + [§Provisioning model](cli/docs/credential-management.md#provisioning-model--the-canonical-non-reversible-flow-owner-requirement).
 
 ## CLI surface conventions
 

--- a/cli/docs/credential-management.md
+++ b/cli/docs/credential-management.md
@@ -130,6 +130,45 @@ Both come from the same mistake: **agents-cli touching the interactive login.**
      remedy for a logged-out personal home is `claude` → `/login` (or `agents
      accounts mint claude`), which restores a real identity-bearing native login.
 
+## Provisioning model — the canonical, non-reversible flow (owner requirement)
+
+This is how every harness account is set up across the fleet. It is a standing
+owner requirement: **do not redesign or reverse it.** It follows directly from
+invariant 7 (device role decides the credential) and the per-harness capability
+map below.
+
+**The interactive laptop (the `personal` device) is the single origin of every
+interactive OAuth flow.** All native, identity-bearing logins are minted there, by
+a human, in a browser. Worker/desktop boxes NEVER run an interactive login flow.
+
+From that one origin, a harness is provisioned to the rest of the fleet by exactly
+one of two paths, chosen by whether the harness exposes a **portable long-term
+credential** (see the per-harness map):
+
+1. **Token-bearing harnesses → mint-once-on-laptop, then copy + auto-inject.**
+   For a harness that has a durable, non-rotating credential — `claude`
+   (`setup-token`, 1yr), `codex`/`gemini`/`grok`/`opencode` (provider API key),
+   `droid` (`FACTORY_API_KEY`) — obtain the credential on the laptop (run the auth /
+   `agents accounts mint` flow once), store it as a policy-`never` account bundle,
+   and propagate it to the other devices with `agents accounts sync`, where it is
+   **auto-injected** into that harness's home at run time (worker devices only —
+   the laptop keeps its own native login per invariant 7). Making that
+   save + propagate + inject fully automatic (no manual 1Password round-trip) is
+   [PHNX-3728](https://linear.app/getrush/issue/PHNX-3728).
+
+2. **Token-less harnesses → log in per box (cannot be copied).** `kimi` (no env
+   auth, `config.toml` only) and `antigravity` (opaque keychain login, no working
+   portable key) expose no shareable credential, so each box that runs them must
+   hold its own login — `agents fleet login` (per-box device-code over SSH, writes
+   the credential locally, never transports it). This is a harness limitation, not
+   a bug, and it is why the fleet holds e.g. two separate antigravity subs on two
+   boxes rather than one copied everywhere.
+
+**Forbidden (the reverse of the above):** running an interactive OAuth flow on a
+worker; treating a copied long-term token as a headed device's own runtime
+credential; or copying a rotating native OAuth session between devices
+(invariant 2). Any of these is a regression.
+
 ## One account namespace: provider credentials and named native logins (RUSH-2527)
 
 An **account** is one authorization identity, and it comes in two kinds that share

--- a/cli/docs/credential-management.md
+++ b/cli/docs/credential-management.md
@@ -137,9 +137,13 @@ owner requirement: **do not redesign or reverse it.** It follows directly from
 invariant 7 (device role decides the credential) and the per-harness capability
 map below.
 
-**The interactive laptop (the `personal` device) is the single origin of every
-interactive OAuth flow.** All native, identity-bearing logins are minted there, by
-a human, in a browser. Worker/desktop boxes NEVER run an interactive login flow.
+**Headed devices (`personal` and `desktop`) each authenticate with their own
+native interactive OAuth login** (invariant 7) — minted by a human, in a browser,
+on that box; never a copied token. The **`personal` laptop is additionally the
+canonical origin where durable tokens are minted for DISTRIBUTION** to workers
+(step 1 below) — it is the interactive seat the owner works at. **`worker` boxes
+NEVER run an interactive login flow;** they authenticate only from a distributed
+durable credential.
 
 From that one origin, a harness is provisioned to the rest of the fleet by exactly
 one of two paths, chosen by whether the harness exposes a **portable long-term
@@ -151,8 +155,8 @@ credential** (see the per-harness map):
    `droid` (`FACTORY_API_KEY`) — obtain the credential on the laptop (run the auth /
    `agents accounts mint` flow once), store it as a policy-`never` account bundle,
    and propagate it to the other devices with `agents accounts sync`, where it is
-   **auto-injected** into that harness's home at run time (worker devices only —
-   the laptop keeps its own native login per invariant 7). Making that
+   **auto-injected** into that harness's home at run time (worker devices only;
+   headed devices keep their own native login per invariant 7). Making that
    save + propagate + inject fully automatic (no manual 1Password round-trip) is
    [PHNX-3728](https://linear.app/getrush/issue/PHNX-3728).
 


### PR DESCRIPTION
## What

Cements the fleet auth **provisioning model** as a canonical, non-reversible owner requirement, extending the device-role rule from #3401 (invariant 7) into the full flow. Docs-only.

## The model (new `## Provisioning model` section in `credential-management.md`)

- **The interactive laptop (`personal` device) is the single origin of every interactive OAuth flow.** All native, identity-bearing logins are minted there, by a human. Workers never run an interactive login.
- **Token-bearing harnesses → mint-once-on-laptop, copy, auto-inject.** For claude (`setup-token`), codex/gemini/grok/opencode (API key), droid (`FACTORY_API_KEY`): obtain on the laptop, store as a policy-`never` bundle, `agents accounts sync` to workers, auto-inject at run time (worker-only — the laptop keeps its own native login per invariant 7). Full automation = PHNX-3728.
- **Token-less harnesses → per-box login.** kimi (config.toml only) and antigravity (opaque keychain, no working portable key) expose no shareable credential, so each box logs in itself (`agents fleet login`). Harness limitation, not a bug — this is why the fleet holds two separate antigravity subs rather than one copied everywhere.
- **Forbidden (the reverse):** a worker running OAuth; a headed device using a copied long-term token as its runtime credential; copying a rotating native session (invariant 2).

## Conflict sweep

Sept the top-level `AGENTS.md`, `cli/AGENTS.md`, and `specifications.md` for instructions that contradict this (worker interactive login, headed-uses-token, copy-native-session). None found — the device-role text landed by #3401 is already consistent; this makes the end-to-end flow explicit and marks it non-reversible.

## Files

- `cli/docs/credential-management.md` — new `## Provisioning model` section
- `AGENTS.md` (root; mirrors to `CLAUDE.md`/`GEMINI.md`) — credential bullet extended to link it

Verified against live fleet state this session: claude/codex/grok/kimi/droid/antigravity(×2 subs)/cursor/muse/opencode all authenticate on the workers; deepseek was repointed to its OpenRouter key; grok s0/s1 is a 402 billing issue (not auth).
