### PR TITLE
fix(traces): classify Codex tool outcomes so error rate stops reporting 0% (PHNX-3761)

### DIFF
--- a/cli/src/lib/session/tool-calls.test.ts
+++ b/cli/src/lib/session/tool-calls.test.ts
@@ -9,6 +9,7 @@ import {
   collectCodexToolCalls,
   toolCallsFromEvents,
   sanitizeToolEvidenceText,
+  structuredToolResult,
 } from './tool-calls.js';
 
 describe('ToolCallCollector', () => {
@@ -287,5 +288,46 @@ describe('ToolCallCollector', () => {
     expect(calls[0].errorCode).not.toContain(credential);
     expect(calls[0].errorCode).not.toContain('\x1b');
     expect(Buffer.byteLength(calls[0].errorCode ?? '')).toBeLessThanOrEqual(512);
+  });
+});
+
+// PHNX-3761: Codex exec/apply_patch results are a string or input_text[], never
+// an object, so before this they always classified 'unknown' and the console
+// error rate read 0%. The only signal is the leading "Script failed"/"Script
+// completed" marker. Shapes below are copied from real ~/.codex/sessions rows.
+describe('structuredToolResult — Codex output shapes', () => {
+  it('classifies a leading "Script failed" string as an error', () => {
+    expect(structuredToolResult('Script failed\nWall time 0.1 seconds\nOutput:\n').outcome).toBe('error');
+  });
+
+  it('classifies a leading "Script completed" string as ok', () => {
+    expect(structuredToolResult('Script completed\nWall time 0.0 seconds\nOutput:\n').outcome).toBe('ok');
+  });
+
+  it('reads the marker from the first block of an input_text[] result and joins the text', () => {
+    const result = structuredToolResult([
+      { type: 'input_text', text: 'Script failed\nWall time 0.3 seconds\nOutput:\n' },
+      { type: 'input_text', text: 'error: apply_patch verification failed: Failed to find expected lines' },
+    ]);
+    expect(result.outcome).toBe('error');
+    expect(result.text).toContain('Script failed');
+    expect(result.text).toContain('apply_patch verification failed');
+  });
+
+  it('classifies a completed input_text[] result as ok', () => {
+    expect(structuredToolResult([
+      { type: 'input_text', text: 'Script completed\nWall time 9.6 seconds\nOutput:\n' },
+      { type: 'input_text', text: '{"chunk_id":"b7deb4","exit_code":0}' },
+    ]).outcome).toBe('ok');
+  });
+
+  it('leaves an async "Script running" cell unknown (no outcome yet)', () => {
+    expect(structuredToolResult('Script running with cell ID 25\nWall time 11.0 seconds\nOutput:\n').outcome).toBe('unknown');
+  });
+
+  it('still honours the object success/is_error path (Claude)', () => {
+    expect(structuredToolResult({ is_error: true, content: 'CONFLICT' }).outcome).toBe('error');
+    expect(structuredToolResult({ success: true, exit_code: 0 }).outcome).toBe('ok');
+    expect(structuredToolResult({ success: false, exit_code: 1 })).toMatchObject({ outcome: 'error', exitCode: 1 });
   });
 });

--- a/cli/src/lib/session/tool-calls.ts
+++ b/cli/src/lib/session/tool-calls.ts
@@ -14,10 +14,12 @@ export const TOOL_CHANGED_MAX_CALLS = 10_000;
 export const TOOL_INDEX_LIMIT_ORDINAL = Number.MAX_SAFE_INTEGER;
 export const TOOL_TEXT_PROCESSING_MAX_BYTES = 64 * 1024;
 export const TOOL_SHELL_PARSE_MAX_BYTES = 64 * 1024;
-// Bumped to 8 for the per-call end timestamp (PHNX-3437): the extractor now
-// records when a call's result arrived, so a re-index re-derives it for rows
-// stored by an older extractor.
-export const TOOL_INDEX_VERSION = 8;
+// Bumped to 9 for Codex tool-outcome classification (PHNX-3761): Codex results
+// arrive as a string or input_text[] rather than an object, so every one used to
+// store as 'unknown' and error rates read 0%. A re-index re-derives outcome for
+// rows stored by an older extractor.
+// (8 added the per-call end timestamp, PHNX-3437.)
+export const TOOL_INDEX_VERSION = 9;
 
 const BASE64_BLOCK = /(?:[A-Za-z0-9+/]{256,}={0,2})/g;
 const SECRET_FIELD = /(?:token|secret|password|authorization|cookie|api[_-]?key|private[_-]?key)$/i;
@@ -294,8 +296,35 @@ function structuredString(source: Record<string, unknown> | undefined, name: str
   return typeof value === 'string' ? value : undefined;
 }
 
+// Codex tool results arrive as a plain string or an array of {type:'input_text',
+// text} blocks (never a plain object), so the text lives across the blocks and
+// the only outcome signal is the leading "Script completed"/"Script failed"
+// marker the exec harness prefixes onto the first block.
+function textSegments(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) {
+    return value
+      .map((block) =>
+        block && typeof block === 'object' && typeof (block as Record<string, unknown>).text === 'string'
+          ? (block as Record<string, unknown>).text as string
+          : '',
+      )
+      .filter((text) => text.length > 0);
+  }
+  return [];
+}
+
+function codexScriptOutcome(value: unknown): ToolCallOutcome | undefined {
+  const lead = textSegments(value)[0]?.trimStart();
+  if (!lead) return undefined;
+  if (lead.startsWith('Script failed')) return 'error';
+  if (lead.startsWith('Script completed')) return 'ok';
+  return undefined;
+}
+
 function resultText(value: unknown): string {
   if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return textSegments(value).join('\n');
   const object = resultObject(value);
   if (object) {
     for (const key of ['output', 'stdout', 'content', 'text', 'message']) {
@@ -320,9 +349,14 @@ export function structuredToolResult(value: unknown): {
   const structured = resultObject(value);
   const success = structuredField(structured, 'success');
   const isError = success === false || structuredField(structured, 'is_error') === true;
+  const outcome: ToolCallOutcome = isError
+    ? 'error'
+    : success === true
+      ? 'ok'
+      : codexScriptOutcome(value) ?? 'unknown';
   return {
     text: resultText(value),
-    outcome: isError ? 'error' : success === true ? 'ok' : 'unknown',
+    outcome,
     exitCode: structuredNumber(structured, 'exit_code'),
     statusCode: structuredNumber(structured, 'status_code'),
     errorCode: structuredString(structured, 'error_code'),


### PR DESCRIPTION
## What
Fix Codex tool-call outcome classification in the traces producer so the console's error rate stops reporting 0% for Codex sessions. **bug-fix** (root cause at source, no consumer band-aid).

## Root cause
`structuredToolResult` (`cli/src/lib/session/tool-calls.ts`) only read `success`/`is_error`/`exit_code` off a plain **object**. But Codex `function_call_output` / `custom_tool_call_output` payloads (`parse.ts:744`, `parse.ts:802`) arrive as either a **string** or an **array of `{type:'input_text',text}` blocks** — never an object. So `resultObject()` returned `undefined`, `outcome` fell to `'unknown'` for every Codex tool call, `traces/sync.ts:695-696` counted 0 errors, and `errorCount` (`sync.ts:931`) was 0 for every Codex session. Consumer formula (`prix/web` `insights.ts:98` `errRate = sum(errorCount)/sum(toolCount)`) was already correct.

## Fix
- Classify outcome on the leading `Script completed` / `Script failed` marker the exec harness prefixes onto the first text segment (string, or first `input_text` block).
- Join `input_text[]` blocks for the stored result text (previously stringified to garbage for arrays).
- Bump `TOOL_INDEX_VERSION` 8 -> 9 so the ~29k already-stored `unknown` rows re-derive on re-index.
- Object path (Claude and other harnesses) unchanged.

## Run evidence

Passing unit-test run (asset): https://share.agents-cli.sh/bisma/tool-calls-test-run
On-disk logs (fleet-local, pinnacles): `~/.agents/scratch/phnx-3761-evidence/tool-calls-test-run.txt`, `~/.agents/scratch/phnx-3761-evidence/before-after.txt`

Captured `tool-calls.test.ts` run:
```
 Test Files  1 passed (1)
      Tests  28 passed (28)
   Duration  366ms
```

Deterministic before/after over the three REAL codex shapes (captured run):
```
shape                                  PRE-FIX -> POST-FIX
string Script failed                   unknown -> error
string Script completed                unknown -> ok
input_text[] leading Script failed     unknown -> error
```

Measured over real `~/.codex/sessions` (11,899 tool results): output shape is **9,207 arrays + 2,692 strings, 0 objects** (why the old object-only path always yielded `unknown`); leading-marker split `Script completed` 8,982 / `Script failed` **224** / other 2,693 (async + orchestration, correctly left `unknown`). Codex tool-error rate moves from a structural **0%** to a real **~1.9%** (224/11,899).

- 6 new unit tests in `tool-calls.test.ts` cover every real shape + the unchanged object path; `tool-calls.test.ts` 28/28.
- Full session parser suite 1,730 pass (one unrelated file, `discover.first-user-message.test.ts`, hit a vitest worker-pool timeout under parallel load; passes 6/6 in isolation, no reference to changed code).

## Not verified
The `Script completed`/`Script failed` prefixes are an observed exec-harness convention (measured across 195 real sessions), not a documented Codex spec.

Ticket: PHNX-3761
