### PR TITLE
docs(conventions): gh pr merge/create/comment are GraphQL, not REST — correct #3405's imprecise line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,10 +433,15 @@ right home if one is staged.
   `gh pr list --json …statusCheckRollup`, the exact GraphQL pattern this rule bans
   (migrating it onto `rest.ts` is part of PHNX-3557). NEVER poll in a tight loop —
   arm a daemon monitor (`agents monitors add`, 10-min cadence) or a single spaced
-  check; on a rate-limit error, back off, do not retry. The mutation path
-  (`gh pr merge`, `gh pr create`) is one REST call and is fine. Making the `gh`
-  overload auto-route `pr view/list`/`pr checks` to REST so no agent has to remember
-  this is [PHNX-3557](https://linear.app/getrush/issue/PHNX-3557).
+  check; on a rate-limit error, back off, do not retry. Mutations
+  (`gh pr merge`, `gh pr create`, and `gh pr comment`) also resolve through GraphQL,
+  not REST — but each is a single call, so it does not *drain* the budget the way a
+  poll loop does. It will still *fail* once the shared GraphQL budget is already
+  exhausted, so when the budget is tight prefer the REST equivalent — e.g. post a PR
+  comment with `gh api repos/{owner}/{repo}/issues/{n}/comments -f body='…'` rather
+  than `gh pr comment`. Making the `gh` overload auto-route `pr view/list`/`pr checks`
+  to REST so no agent has to remember this is
+  [PHNX-3557](https://linear.app/getrush/issue/PHNX-3557).
 - **The `swarm-ext://` URI authority is the extension id `swarmify.swarm-ext`.**
   The extension itself lives in [phnx-labs/agi-ext](https://github.com/phnx-labs/agi-ext)
   (its frozen publish identity is documented there), but the CLI emits into that


### PR DESCRIPTION
## What

Correct the imprecise mutation line in the fleet-shared **REST-not-GraphQL** rule that #3405 landed in `AGENTS.md`.

## Why

#3405 said:
> The mutation path (`gh pr merge`, `gh pr create`) is one REST call and is fine.

That is wrong in two ways, and it bit us live last session:

1. Those subcommands resolve through **GraphQL**, not REST — as does **`gh pr comment`**, which the line omitted entirely.
2. Because `gh pr comment` is GraphQL, it **failed** once the shared GraphQL budget was already exhausted; the comment only went through after being reposted via `gh api repos/{o}/{r}/issues/{n}/comments` (REST). "is one REST call and is fine" told an agent the opposite of what happened.

The single-call point is still true and worth keeping — a mutation doesn't *drain* the budget the way a status-poll loop does. The fix keeps that nuance but states it accurately.

## The corrected rule

Mutations (`gh pr merge`, `gh pr create`, `gh pr comment`) route through GraphQL; each is a single call so it does not *drain* the budget, but it will *fail* once the budget is exhausted. When the budget is tight, prefer the REST equivalent — e.g. `gh api repos/{owner}/{repo}/issues/{n}/comments -f body='…'` instead of `gh pr comment`.

Docs-only. `AGENTS.md` (`CLAUDE.md`/`GEMINI.md` are symlinks). Follow-up flagged in the handoff of session 34c1ac33; the durable auto-route fix remains PHNX-3557.
