### PR TITLE
feat(sessions): mirror remote-host session previews fleet-wide, render inline without per-row SSH (PHNX-3792)

### DIFF
--- a/cli/.changelog/next/PHNX-3792.md
+++ b/cli/.changelog/next/PHNX-3792.md
@@ -1,0 +1,15 @@
+- **Remote-host session previews render inline, no per-row SSH (PHNX-3792).** On
+  the interactive device, a session that originated on another box used to show
+  as a bare `[host/<peer>]` row with no topic, and its preview pane fetched the
+  peer's digest live over SSH — slow, and blank when the peer was asleep. Each
+  box now mirrors its own sessions' lightweight preview/metadata (topic, first
+  user message, last activity, agent+version, cwd, ticket, PR) into its
+  conflict-free `devices/<device>/daemon-state.json`, which the daemon's existing
+  bounded Git transport already delivers fleet-wide. The picker, `agents sessions`
+  list, and `focus` read the local mirror, so a peer session shows its real
+  topic/preview inline — even while the peer is offline (last-synced). The live
+  SSH digest fetch remains the fallback for a never-synced session, and `space`
+  still reads the full transcript live. No transcript leaves the worker; the
+  mirror is bounded and pruned by age. Source: `src/lib/session/mirror.ts`,
+  `src/lib/fleet-shared-state.ts`, `src/lib/session/db.ts`,
+  `src/lib/daemon/usage-sync-service.ts`, `src/commands/sessions-picker.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -841,6 +841,23 @@ bare-remote test proves the automatic Git delivery
 peers and retain real-file / real-CLI coverage. A synced row reads as `last_seen`
 (cached), never a live fetch, so a worker's bar is honest about being propagated.
 
+**The same shared-state tick carries the session mirror (PHNX-3792).** So there
+is exactly one committer of `daemon-state.json`, the `usage-sync` service also
+publishes EVERY box's lightweight per-session preview/metadata into the
+`sessions` field of its owned file, and every box except a marked `worker` folds
+peers' digests into its local `sessions` index as mirror rows. Only topic/label,
+a first-user-message snippet, last-activity, agent+version, cwd, ticket, and PR
+ride — never a transcript — and the mirror is bounded (200 recent sessions per
+box) and pruned by age (14 days). This is what lets the picker / `agents sessions`
+/ `focus` render a remote-host row's topic and preview INLINE (no per-row SSH),
+and keep showing the last-synced preview when the peer is offline. Publish/consume
++ prune live in [`src/lib/session/mirror.ts`](src/lib/session/mirror.ts), the DB
+mirror writer/pruner in [`src/lib/session/db.ts`](src/lib/session/db.ts)
+(`upsertMirrorSession` / `pruneMirrorSessions`, guarded so a mirror never
+overwrites a genuine local transcript row), and the inline render in
+`buildPreview` ([`src/commands/sessions-picker.ts`](src/commands/sessions-picker.ts)),
+which still falls back to the live SSH digest fetch for a never-synced session.
+
 ### 11. Session recovery is one decision on the origin device
 
 `resolveSessionRecovery` in `src/lib/session/recovery.ts` is the only place that
@@ -1195,7 +1212,11 @@ skills, plugins, hooks, links, dirs, repos).
 ID-shaped selectors go through the indexed fleet resolver, remote cards render on
 their owning peer, and the normalized digest is cached in SQLite against the
 transcript's actual mtime + size. Live status is deliberately outside that durable
-digest and expires after 15 seconds through `session-cache.ts`.
+digest and expires after 15 seconds through `session-cache.ts`. A remote-host row
+whose lightweight digest was fleet-synced (a `mirrorSyncedAt` row — see §10 the
+session mirror, PHNX-3792) renders its topic + first-user preview INLINE from that
+local mirror with no per-row SSH; only a never-synced remote row still triggers the
+live `sessions preview <id> --local --json` fetch over SSH.
 
 Indexing is lazy — only `discoverSessions` writes the index — so a session THIS
 box just started is "running" in `--active` before it is indexed. The id resolver

--- a/cli/src/commands/sessions-picker.test.ts
+++ b/cli/src/commands/sessions-picker.test.ts
@@ -101,6 +101,43 @@ describe('transcriptOnPeerOf (PHNX-3481)', () => {
   });
 });
 
+describe('buildPreview — fleet-synced mirror renders inline, no per-row SSH (PHNX-3792)', () => {
+  afterEach(() => {
+    setPeerDigestFetcherForTest(undefined);
+    clearRemoteDigestCacheForTest();
+    clearPreviewMemoryCacheForTest();
+  });
+
+  it('renders a synced peer row inline (topic + first-user) and never dials the peer', () => {
+    const fetcher = vi.fn(async () => undefined);
+    setPeerDigestFetcherForTest(fetcher);
+    const preview = stripVTControlCharacters(buildPreview(mk({
+      machine: 'yosemite-m5',
+      _remote: true,
+      mirrorSyncedAt: Date.now(),
+      topic: 'refactor the exec engine',
+      firstUserMessage: 'Refactor buildExecEnv so every dispatch path shares one env builder.',
+    })));
+    expect(preview).toContain('yosemite-m5');
+    expect(preview).toContain('synced from the fleet');
+    expect(preview).toContain('Refactor buildExecEnv');
+    expect(preview).not.toContain('fetching preview');
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('still falls back to the live SSH digest fetch for a never-synced remote row', () => {
+    const fetcher = vi.fn(async () => undefined);
+    setPeerDigestFetcherForTest(fetcher);
+    const preview = stripVTControlCharacters(buildPreview(mk({
+      machine: 'yosemite-m5',
+      _remote: true,
+      // No topic / firstUser / mirrorSyncedAt: nothing local to render.
+    })));
+    expect(preview).toContain('yosemite-m5');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('formatTodoCompact (RUSH-2045)', () => {
   it('renders ✓done/total · activeForm', () => {
     expect(formatTodoCompact({ done: 6, total: 8, activeForm: 'A5 wiring runner' })).toBe(

--- a/cli/src/commands/sessions-picker.ts
+++ b/cli/src/commands/sessions-picker.ts
@@ -361,6 +361,7 @@ function previewCacheKey(session: SessionMeta, remote: string | undefined): stri
     session.topic, session.ticketId, session.prUrl, session.messageCount,
     session.tokenCount, session.model, session.todos, session.plan,
     session.recentDirectoriesTouched, session.skillsUsed,
+    session.firstUserMessage, session.mirrorSyncedAt,
   ]);
 }
 
@@ -424,12 +425,38 @@ export function buildPreview(session: SessionMeta): string {
   const safe = sanitizeMeta(session);
 
   // Remote session: the transcript is on the peer's disk, so there is nothing to
-  // parse here. Fetch the peer's already-computed digest over SSH (kicked off on
-  // first render; the pane repaints when it lands) and render the same compact
-  // preview a local row gets. Until it arrives — or when the peer can't answer —
-  // show the metadata header (agent, cwd, msgs, tokens — all carried over in the
-  // fan-out) plus where it lives and how to open it.
+  // parse here. The common case is now a fleet-synced MIRROR row (PHNX-3792): its
+  // topic + first-user snippet + metadata are already local, so the compact card
+  // renders INLINE with no per-row SSH. The live SSH digest fetch stays as the
+  // fallback for a never-synced row (or a peer whose digest was already fetched
+  // this session), and `space` still reads the full transcript live over SSH.
   if (remote) {
+    // A fleet-synced MIRROR row is the explicit signal that this box already
+    // holds the peer session's topic + first-user snippet locally (PHNX-3792):
+    // render inline with NO per-row SSH. An ordinary remote row (a live fan-out
+    // row, or a never-synced host-dispatch stub) is NOT treated as synced — it
+    // keeps the live digest fetch below, so this change is scoped to mirror rows.
+    const fetched = remoteDigestCache.get(remoteDigestKey(session.id, remote));
+    if (fetched?.state === 'ready') {
+      // A richer live digest already landed this session (changed files, tool
+      // mix) — prefer it over the lightweight mirror card.
+      const note = '  ' + chalk.gray(`on `) + chalk.bold.white(remote)
+        + chalk.gray(` — enter to resume there`);
+      const body = formatCompactPreview(fetched.digest, safe);
+      const output = [formatHeader(safe, []), '', note, body].filter(Boolean).join('\n');
+      previewCache.set(cacheKey, output);
+      return output;
+    }
+    if (safe.mirrorSyncedAt !== undefined) {
+      const note = '  ' + chalk.gray(`on `) + chalk.bold.white(remote)
+        + chalk.gray(` — synced from the fleet; enter to resume there, or space to read it live over SSH`);
+      const metaBody = formatMetaOnlyBody(safe);
+      const output = [formatHeader(safe, []), '', note, metaBody].filter(Boolean).join('\n');
+      previewCache.set(cacheKey, output);
+      return output;
+    }
+    // Not a mirror row: fall back to the live SSH digest fetch (kicked off on
+    // first render; the pane repaints when it lands).
     const note = '  ' + chalk.gray(`on `) + chalk.bold.white(remote)
       + chalk.gray(` — enter to resume there, or space then enter to read it over SSH`);
     const entry = remoteDigestForPreview(session, remote);
@@ -626,8 +653,12 @@ function formatMetaOnlyBody(session: SessionMeta): string {
   const valueWidth = termWidth - VERB_GUTTER - 5;
 
   // Same verb-led rows as the digest body (RUSH-2757), from SessionMeta alone.
-  if (session.topic) {
-    lines.push(verbLabel('Asked') + chalk.white(`"${truncate(session.topic.trim(), valueWidth)}"`));
+  // Prefer the fuller first genuine user turn over the one-line topic when the
+  // row carries it (a fleet-synced mirror row does — PHNX-3792) so the inline
+  // card reads like the originating prompt, not just its title.
+  const asked = session.firstUserMessage?.trim() || session.topic?.trim();
+  if (asked) {
+    lines.push(verbLabel('Asked') + chalk.white(`"${truncate(asked, valueWidth)}"`));
   }
   const compact = formatTodoCompact(session.todos);
   const teamLine = formatTeamLineage(session);

--- a/cli/src/lib/daemon/usage-sync-service.ts
+++ b/cli/src/lib/daemon/usage-sync-service.ts
@@ -1,10 +1,17 @@
 /**
- * Fleet usage-snapshot sync as a `PeriodicService` (PHNX-3392 usage-sync).
+ * Fleet shared-state sync as a `PeriodicService` (PHNX-3392 usage-sync,
+ * PHNX-3792 session mirror).
  *
- * A headed box publishes its local identity-keyed Claude usage rows into its
- * owned file in the fleet-synced user repo. The tick then runs one serialized,
- * timeout-bounded git exchange; a worker reads the delivered peer snapshots
- * and merges newest-wins. No tick opens a device-to-device SSH mesh.
+ * This is the one tick that owns the bounded Git exchange over the fleet-synced
+ * user repo, so every non-secret daemon-state field rides it rather than opening
+ * a second committer. Each tick: (1) publishes this box's own fields into its
+ * conflict-free `devices/<device>/daemon-state.json` — a headed box's Claude
+ * usage snapshot, and EVERY box's lightweight session digests (PHNX-3792);
+ * (2) runs one serialized, timeout-bounded commit/rebase/push; (3) consumes the
+ * peer fields the exchange delivered — a worker merges usage newest-wins, and
+ * every non-worker box folds peers' session digests into its local index so the
+ * picker renders remote-host previews inline. No tick opens a device-to-device
+ * SSH mesh.
  */
 import { BasePeriodicService, type DaemonContext } from './service.js';
 import type { DaemonServiceId } from '../daemon-services.js';
@@ -29,9 +36,14 @@ export class UsageSyncService extends BasePeriodicService {
 
   protected async onTick(ctx: DaemonContext): Promise<void> {
     const { consumeUsageSnapshotsFromSharedStore, publishUsageSnapshotToSharedStore } = await import('../accounting/usage-sync.js');
+    const { consumeSessionMirrorFromSharedStore, publishSessionMirrorToSharedStore } = await import('../session/mirror.js');
+    // Publish every owned field BEFORE the single git exchange so they ride one commit.
     const published = await publishUsageSnapshotToSharedStore();
     if (published.changed) ctx.log('INFO', `usage-sync: published usage snapshot to ${published.path}`);
     if (published.error) ctx.log('WARN', `usage-sync: publish: ${published.error}`);
+    const mirrored = await publishSessionMirrorToSharedStore();
+    if (mirrored.changed) ctx.log('INFO', `session-mirror: published ${mirrored.count} session digest(s)`);
+    if (mirrored.error) ctx.log('WARN', `session-mirror: publish: ${mirrored.error}`);
     const { syncFleetSharedStateRepo } = await import('../fleet-shared-repo-sync.js');
     const transport = await syncFleetSharedStateRepo();
     if (transport.skipped) ctx.log('WARN', `usage-sync: ${transport.skipped}`);
@@ -42,5 +54,11 @@ export class UsageSyncService extends BasePeriodicService {
       ctx.log('INFO', `usage-sync: merged ${consumed.merged} row(s) from ${consumed.sources.join(', ')}`);
     }
     for (const err of consumed.errors) ctx.log('WARN', `usage-sync: ${err.device}: ${err.message}`);
+    const foldedIn = consumeSessionMirrorFromSharedStore();
+    if (foldedIn.merged > 0) {
+      ctx.log('INFO', `session-mirror: folded ${foldedIn.merged} session(s) from ${foldedIn.sources.join(', ')}`);
+    }
+    if (foldedIn.pruned > 0) ctx.log('INFO', `session-mirror: pruned ${foldedIn.pruned} stale mirror row(s)`);
+    for (const err of foldedIn.errors) ctx.log('WARN', `session-mirror: ${err.device}: ${err.message}`);
   }
 }

--- a/cli/src/lib/fleet-shared-state.test.ts
+++ b/cli/src/lib/fleet-shared-state.test.ts
@@ -40,6 +40,44 @@ describe('fleet shared daemon state (real files)', () => {
     expect(read.states).toEqual([{ version: 1, device: 'zion', usage, auth: { status: 'ready' } }]);
   });
 
+  it('carries the session mirror alongside usage/auth without losing a field (PHNX-3792)', () => {
+    const root = tempStore();
+    const sessions = {
+      rows: [{
+        id: 'aaaaaaaa-1111-2222-3333-444444444444',
+        shortId: 'aaaaaaaa',
+        agent: 'claude',
+        machine: 'yosemite-m5',
+        topic: 'refactor exec',
+        firstUser: 'Refactor buildExecEnv.',
+        lastActivity: '2026-09-01T12:00:00.000Z',
+        timestamp: '2026-09-01T11:00:00.000Z',
+        capturedAt: 1_756_000_000_000,
+      }],
+    };
+    expect(updateFleetSharedDeviceState('yosemite-m5', { auth: { status: 'ready' } }, root).changed).toBe(true);
+    expect(updateFleetSharedDeviceState('yosemite-m5', { sessions }, root).changed).toBe(true);
+    const read = readFleetSharedDeviceStates(root);
+    expect(read.errors).toEqual([]);
+    expect(read.states).toEqual([{ version: 1, device: 'yosemite-m5', auth: { status: 'ready' }, sessions }]);
+    // An unchanged re-publish of the same mirror does not dirty the repo.
+    expect(updateFleetSharedDeviceState('yosemite-m5', { sessions }, root).changed).toBe(false);
+  });
+
+  it('rejects a session mirror whose envelope is not {rows: [...]}', () => {
+    const root = tempStore();
+    const dir = path.join(root, 'devices', 'yosemite-m6');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, FLEET_SHARED_STATE_FILE),
+      JSON.stringify({ version: 1, device: 'yosemite-m6', sessions: { rows: 'nope' } }),
+      'utf-8',
+    );
+    const read = readFleetSharedDeviceStates(root);
+    expect(read.states).toEqual([]);
+    expect(read.errors).toEqual([{ device: 'yosemite-m6', message: expect.stringContaining('session mirror') }]);
+  });
+
   it('does not rewrite an unchanged state and isolates a malformed peer', () => {
     const root = tempStore();
     updateFleetSharedDeviceState('worker-a', { auth: { status: 'missing' } }, root);

--- a/cli/src/lib/fleet-shared-state.ts
+++ b/cli/src/lib/fleet-shared-state.ts
@@ -21,6 +21,33 @@ export const FLEET_SHARED_STATE_FILE = 'daemon-state.json';
 
 export type SharedAuthStatus = 'ready' | 'missing' | 'invalid';
 
+/**
+ * One session's lightweight preview/metadata, mirrored to the fleet so the
+ * interactive device renders a remote-host row's topic/preview INLINE instead of
+ * fetching the peer's digest live over SSH per row (PHNX-3792). Deliberately
+ * NOT a full transcript: only the fields a list row and a compact preview card
+ * need. `machine` is the EXECUTION host the publisher recorded (so an offloaded
+ * session's mirror row matches the same `machine:id` key the live fan-out uses,
+ * never double-counting), `firstUser` is a bounded first-user-message snippet,
+ * and `capturedAt` stamps publish time for the staleness marker.
+ */
+export interface SessionMirrorRow {
+  id: string;
+  shortId: string;
+  agent: string;
+  version?: string;
+  machine: string;
+  cwd?: string;
+  topic?: string;
+  label?: string;
+  firstUser?: string;
+  lastActivity?: string;
+  timestamp: string;
+  ticketId?: string;
+  prUrl?: string;
+  capturedAt: number;
+}
+
 export interface FleetSharedDeviceState {
   version: typeof FLEET_SHARED_STATE_VERSION;
   device: string;
@@ -30,11 +57,15 @@ export interface FleetSharedDeviceState {
   auth?: {
     status: SharedAuthStatus;
   };
+  sessions?: {
+    rows: SessionMirrorRow[];
+  };
 }
 
 export interface FleetSharedStatePatch {
   usage?: FleetSharedDeviceState['usage'];
   auth?: FleetSharedDeviceState['auth'];
+  sessions?: FleetSharedDeviceState['sessions'];
 }
 
 export interface FleetSharedStateReadResult {
@@ -71,6 +102,10 @@ function parseFleetSharedDeviceState(raw: string, owner: string): FleetSharedDev
   ) {
     throw new Error('unrecognized auth verdict');
   }
+  const sessions = parsed.sessions;
+  if (sessions !== undefined && (!isRecord(sessions) || !Array.isArray(sessions.rows))) {
+    throw new Error('unrecognized session mirror');
+  }
   return parsed as unknown as FleetSharedDeviceState;
 }
 
@@ -91,6 +126,7 @@ function mergeFleetState(currentRaw: string, device: string, patch: FleetSharedS
     ...current,
     ...(patch.usage !== undefined ? { usage: patch.usage } : {}),
     ...(patch.auth !== undefined ? { auth: patch.auth } : {}),
+    ...(patch.sessions !== undefined ? { sessions: patch.sessions } : {}),
     version: FLEET_SHARED_STATE_VERSION,
     device,
   };

--- a/cli/src/lib/session/db.migrate-v46.test.ts
+++ b/cli/src/lib/session/db.migrate-v46.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-migv46-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const { getSessionsDir, getSessionsDbPath } = await import('../state.js');
+fs.mkdirSync(getSessionsDir(), { recursive: true });
+
+const Database = (await import('../sqlite.js')).default;
+
+{
+  const seed = new Database(getSessionsDbPath());
+  // Authentic v45 shape: first_user_message exists (added in v45), but the
+  // PHNX-3792 mirror provenance columns are deliberately absent so getDB must
+  // add them through migrateSchema(45).
+  seed.exec(`
+    CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, short_id TEXT NOT NULL, agent TEXT NOT NULL, harness TEXT,
+      origin TEXT DEFAULT 'cli', routine_name TEXT, routine_run_id TEXT, version TEXT,
+      account TEXT, account_key TEXT, account_org TEXT, mode TEXT, timestamp TEXT NOT NULL,
+      last_activity TEXT, project TEXT, cwd TEXT, git_branch TEXT, topic TEXT,
+      first_user_message TEXT, label TEXT,
+      message_count INTEGER, token_count INTEGER, output_tokens INTEGER, input_tokens INTEGER,
+      cache_read_tokens INTEGER, cache_write_tokens INTEGER, cost_usd REAL, cost_usd_nocache REAL,
+      duration_ms INTEGER, model TEXT, tool_call_count INTEGER, file_path TEXT NOT NULL,
+      file_mtime_ms INTEGER, file_size INTEGER, scanned_at INTEGER, is_team_origin INTEGER DEFAULT 0,
+      pr_url TEXT, pr_number INTEGER, worktree_slug TEXT, ticket_id TEXT, spawned_team TEXT,
+      sub_agent_count INTEGER, background_shell_count INTEGER, plan TEXT, machine TEXT, todos TEXT,
+      recent_directories_touched TEXT, linear_project TEXT, linear_project_url TEXT, actor TEXT,
+      initiated_by TEXT, used_browser INTEGER, used_computer INTEGER, archived_at INTEGER
+    );
+    INSERT INTO sessions (id, short_id, agent, timestamp, file_path)
+      VALUES ('legacy', 'legacy', 'codex', '2026-08-30T10:00:00.000Z', '/s/legacy.jsonl');
+    INSERT INTO meta(key, value) VALUES ('schema_version', '45');
+  `);
+  seed.close();
+}
+
+const { getDB, SCHEMA_VERSION } = await import('./db.js');
+
+describe('schema migration v45 -> v46 (session mirror provenance, PHNX-3792)', () => {
+  it('adds nullable mirror_synced_at + mirror_source columns without damaging legacy rows', () => {
+    const columns = (getDB().prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map((c) => c.name);
+    expect(columns).toContain('mirror_synced_at');
+    expect(columns).toContain('mirror_source');
+    const row = getDB()
+      .prepare(`SELECT mirror_synced_at, mirror_source, file_path FROM sessions WHERE id = 'legacy'`)
+      .get() as { mirror_synced_at: number | null; mirror_source: string | null; file_path: string };
+    // A genuine legacy local row is NOT a mirror row: both provenance columns NULL.
+    expect(row.mirror_synced_at).toBeNull();
+    expect(row.mirror_source).toBeNull();
+    expect(row.file_path).toBe('/s/legacy.jsonl');
+  });
+
+  it('builds the mirror-prune scan index and stamps the new schema version', () => {
+    const indexes = (getDB().prepare(`PRAGMA index_list(sessions)`).all() as Array<{ name: string }>).map((i) => i.name);
+    expect(indexes).toContain('idx_sessions_mirror_synced');
+    const row = getDB().prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
+    expect(row.value).toBe(String(SCHEMA_VERSION));
+  });
+});

--- a/cli/src/lib/session/db.ts
+++ b/cli/src/lib/session/db.ts
@@ -39,7 +39,7 @@ const DB_PATH = getSessionsDbPath();
 /** Current schema version; bumped when migrations are added. Exported so tests
  * assert against the constant instead of hardcoding a number that every bump
  * then has to chase (docs/sessions.md calls the constant the source of truth). */
-export const SCHEMA_VERSION = 45;
+export const SCHEMA_VERSION = 46;
 
 /**
  * Bump to force the content extractor (assistant-answer text, alongside the
@@ -157,7 +157,14 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- DB and flagged, instead of being dropped when the file vanishes. A row whose
   -- file is missing but which has NO cached content is a phantom (a stale/moved
   -- file_path), never stamped, still suppressed — see querySessions.
-  archived_at INTEGER
+  archived_at INTEGER,
+  -- Epoch ms this row was last written from a PEER's synced session mirror
+  -- (PHNX-3792), NULL for a genuine local/host-dispatch row. Non-NULL marks a
+  -- row created/enriched purely from a fleet-synced digest so it can be pruned
+  -- by age without touching real rows; mirror_source names the publishing
+  -- device. A row keeps a NULL mirror_synced_at once it gains a real transcript.
+  mirror_synced_at INTEGER,
+  mirror_source TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_timestamp ON sessions(timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_cwd ON sessions(cwd);
@@ -165,7 +172,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_agent ON sessions(agent);
 CREATE INDEX IF NOT EXISTS idx_sessions_file_path ON sessions(file_path);
 CREATE INDEX IF NOT EXISTS idx_sessions_short_id ON sessions(short_id);
 -- idx_sessions_machine_ts / idx_sessions_agent_ts are created after migration
--- v17 guarantees the machine column exists (same pattern as last_activity).
+-- v17 guarantees the machine column exists (same pattern as last_activity);
+-- idx_sessions_mirror_synced likewise waits for migration v46's column add.
 
 CREATE VIRTUAL TABLE IF NOT EXISTS session_text USING fts5(
   session_id UNINDEXED,
@@ -561,6 +569,9 @@ interface SessionRow {
    * preserves the sticky stamp; it is written only by querySessions.
    */
   archived_at?: number | null;
+  /** Epoch ms last written from a peer's fleet session mirror (PHNX-3792); NULL for a local row. */
+  mirror_synced_at?: number | null;
+  mirror_source?: string | null;
 }
 
 /** File stat snapshot used to detect changes between scan runs. */
@@ -1412,6 +1423,20 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     if (!cols.has('first_user_message')) db.exec(`ALTER TABLE sessions ADD COLUMN first_user_message TEXT`);
   }
 
+  if (fromVersion < 46) {
+    // v45 -> v46: mirror provenance for fleet-synced peer session digests
+    // (PHNX-3792). Additive columns, no ledger wipe: they are written only by the
+    // session-mirror consume path (never a transcript scan), so re-parsing every
+    // indexed transcript would be pure churn — a genuine local row keeps them NULL.
+    const cols = new Set(
+      (db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map((c) => c.name),
+    );
+    if (!cols.has('mirror_synced_at')) db.exec(`ALTER TABLE sessions ADD COLUMN mirror_synced_at INTEGER`);
+    if (!cols.has('mirror_source')) db.exec(`ALTER TABLE sessions ADD COLUMN mirror_source TEXT`);
+    // The idx_sessions_mirror_synced index is created unconditionally after this
+    // block (fresh DBs skip migrations), alongside idx_sessions_last_activity.
+  }
+
 }
 
 /**
@@ -1496,6 +1521,10 @@ export function getDB(): Database.Database {
   // DB would fail the index build on a column it doesn't have yet.
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions(last_activity DESC)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_origin ON sessions(origin)`);
+  // Same fresh-vs-migrated rule: the column is guaranteed above (fresh from
+  // CREATE TABLE, existing from migration v46), so index the mirror pruner's
+  // scan column here rather than in SCHEMA (PHNX-3792).
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_mirror_synced ON sessions(mirror_synced_at)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_routine_run_id ON sessions(routine_run_id)`);
   // Account attribution repair. Two ways a Claude row ends up wrong even at v33:
   // an older CLI (whose INSERT does not name the column) writes NULL, and a DB
@@ -2984,6 +3013,8 @@ function rowToMeta(row: SessionRow): SessionMeta {
     // flagged, never dropped (RUSH-2436). NULL leaves both undefined (live row).
     archivedAt: row.archived_at ?? undefined,
     archived: row.archived_at != null ? true : undefined,
+    mirrorSyncedAt: row.mirror_synced_at ?? undefined,
+    mirrorSource: row.mirror_source ?? undefined,
   };
 }
 
@@ -3722,6 +3753,170 @@ export function readArchivedSessionPreview<T>(id: string): T | undefined {
   } catch {
     return undefined;
   }
+}
+
+/** A local-origin session, projected to the compact fields the fleet mirror publishes. */
+export interface LocalMirrorSource {
+  id: string;
+  shortId: string;
+  agent: string;
+  version: string | null;
+  machine: string | null;
+  cwd: string | null;
+  topic: string | null;
+  firstUserMessage: string | null;
+  label: string | null;
+  lastActivity: string | null;
+  timestamp: string;
+  ticketId: string | null;
+  prUrl: string | null;
+}
+
+/**
+ * The most-recently-active sessions whose transcript is genuinely local to this
+ * box — a real `file_path`, not a peer mirror — for publishing to the fleet
+ * session mirror (PHNX-3792). Bounded and team-origin-excluded so the published
+ * payload stays the size a picker would show. Never returns a row this box is
+ * itself mirroring from a peer (`mirror_synced_at IS NULL`).
+ */
+export function queryLocalOriginSessionsForMirror(self: string, limit: number): LocalMirrorSource[] {
+  const rows = getDB().prepare(`
+    SELECT id, short_id, agent, version, machine, cwd, topic, first_user_message,
+           label, last_activity, timestamp, ticket_id, pr_url
+    FROM sessions
+    WHERE mirror_synced_at IS NULL
+      AND file_path IS NOT NULL AND file_path <> ''
+      AND machine = ?
+      AND is_team_origin = 0
+      AND (topic IS NOT NULL OR first_user_message IS NOT NULL OR label IS NOT NULL)
+    ORDER BY last_activity DESC, timestamp DESC
+    LIMIT ?
+  `).all(self, limit) as Array<{
+    id: string; short_id: string; agent: string; version: string | null; machine: string | null;
+    cwd: string | null; topic: string | null; first_user_message: string | null; label: string | null;
+    last_activity: string | null; timestamp: string; ticket_id: string | null; pr_url: string | null;
+  }>;
+  return rows.map((r) => ({
+    id: r.id, shortId: r.short_id, agent: r.agent, version: r.version, machine: r.machine,
+    cwd: r.cwd, topic: r.topic, firstUserMessage: r.first_user_message, label: r.label,
+    lastActivity: r.last_activity, timestamp: r.timestamp, ticketId: r.ticket_id, prUrl: r.pr_url,
+  }));
+}
+
+/** One peer session digest to write into this box's local mirror. */
+export interface MirrorSessionUpsert {
+  id: string;
+  shortId: string;
+  agent: string;
+  version?: string | null;
+  machine: string;
+  cwd?: string | null;
+  topic?: string | null;
+  firstUser?: string | null;
+  label?: string | null;
+  lastActivity?: string | null;
+  timestamp: string;
+  ticketId?: string | null;
+  prUrl?: string | null;
+}
+
+/**
+ * Write one peer session's digest into the local `sessions` index as a mirror
+ * row (PHNX-3792), so the picker/list/focus render its topic/preview inline
+ * with no per-row SSH. The upsert is GUARDED: it never overwrites a genuine
+ * local transcript row (`file_path` non-empty and not itself a mirror), so a
+ * mirror can only create a new peer-only row or enrich an existing empty-file
+ * host-dispatch stub / older mirror. Returns true when a row was written (the
+ * caller then persists the matching preview digest); false when a real row was
+ * protected. `machine` carries the publisher's recorded execution host so the
+ * row collapses with the live fan-out row under the same `machine:id` key.
+ */
+export function upsertMirrorSession(row: MirrorSessionUpsert, source: string, syncedAt: number): boolean {
+  const db = getDB();
+  const lastActivity = row.lastActivity ?? row.timestamp;
+  const result = db.prepare(`
+    INSERT INTO sessions (
+      id, short_id, agent, origin, version, timestamp, last_activity, cwd,
+      topic, first_user_message, label, message_count, file_path, scanned_at,
+      is_team_origin, ticket_id, pr_url, machine, mirror_synced_at, mirror_source
+    ) VALUES (
+      @id, @short_id, @agent, 'cli', @version, @timestamp, @last_activity, @cwd,
+      @topic, @first_user, @label, NULL, '', @scanned_at,
+      0, @ticket_id, @pr_url, @machine, @synced_at, @source
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      short_id = excluded.short_id,
+      agent = excluded.agent,
+      version = COALESCE(excluded.version, sessions.version),
+      timestamp = excluded.timestamp,
+      last_activity = excluded.last_activity,
+      cwd = COALESCE(excluded.cwd, sessions.cwd),
+      topic = COALESCE(excluded.topic, sessions.topic),
+      first_user_message = COALESCE(excluded.first_user_message, sessions.first_user_message),
+      -- The peer is authoritative for the session's real name, so OVERWRITE (not
+      -- COALESCE) the label: a host-dispatch stub carries the [host/peer]
+      -- placeholder, and coalescing would keep it forever — the exact bare-row
+      -- symptom this feature fixes. A null peer label clears it so the list falls
+      -- back to the synced topic.
+      label = excluded.label,
+      ticket_id = COALESCE(excluded.ticket_id, sessions.ticket_id),
+      pr_url = COALESCE(excluded.pr_url, sessions.pr_url),
+      machine = excluded.machine,
+      mirror_synced_at = excluded.mirror_synced_at,
+      mirror_source = excluded.mirror_source
+    WHERE sessions.file_path IS NULL OR sessions.file_path = '' OR sessions.mirror_synced_at IS NOT NULL
+  `).run({
+    id: row.id,
+    short_id: row.shortId,
+    agent: row.agent,
+    version: row.version ?? null,
+    timestamp: row.timestamp,
+    last_activity: lastActivity,
+    cwd: row.cwd ?? null,
+    topic: row.topic ?? null,
+    first_user: row.firstUser ?? null,
+    label: row.label ?? null,
+    ticket_id: row.ticketId ?? null,
+    pr_url: row.prUrl ?? null,
+    machine: row.machine,
+    scanned_at: syncedAt,
+    synced_at: syncedAt,
+    source,
+  });
+  if (result.changes === 0) return false;
+  // Keep the mirror row searchable by topic + first user turn, like a local row.
+  db.prepare(`DELETE FROM session_text WHERE session_id = ?`).run(row.id);
+  db.prepare(`
+    INSERT INTO session_text (session_id, label, topic, project, content, assistant)
+    VALUES (?, ?, ?, '', ?, '')
+  `).run(row.id, row.label ?? '', row.topic ?? '', row.firstUser ?? '');
+  return true;
+}
+
+/**
+ * Drop peer mirror rows (and their cached digests) whose last sync predates the
+ * cutoff — the size ceiling / staleness pruner for the fleet session mirror
+ * (PHNX-3792). Only ever touches mirror rows (`mirror_synced_at IS NOT NULL`),
+ * never a genuine local or host-dispatch row. Returns the number of rows pruned.
+ */
+export function pruneMirrorSessions(cutoffMs: number): number {
+  const db = getDB();
+  const stale = db.prepare(
+    `SELECT id FROM sessions WHERE mirror_synced_at IS NOT NULL AND mirror_synced_at < ?`,
+  ).all(cutoffMs) as Array<{ id: string }>;
+  if (stale.length === 0) return 0;
+  const delRow = db.prepare(`DELETE FROM sessions WHERE id = ?`);
+  const delText = db.prepare(`DELETE FROM session_text WHERE session_id = ?`);
+  const delPreview = db.prepare(`DELETE FROM session_preview_cache WHERE session_id = ?`);
+  const txn = db.transaction(() => {
+    for (const { id } of stale) {
+      delRow.run(id);
+      delText.run(id);
+      delPreview.run(id);
+    }
+  });
+  txn();
+  return stale.length;
 }
 
 /** Plugin provenance already indexed for resources used by one session. */

--- a/cli/src/lib/session/db.ts
+++ b/cli/src/lib/session/db.ts
@@ -2162,7 +2162,24 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     -- the actor sidecar landed — once the sidecar-join finally provides one. Plain
     -- exclusion locked those rows to NULL forever (RUSH-2018/2019 fix).
     actor = COALESCE(sessions.actor, excluded.actor),
-    initiated_by = COALESCE(sessions.initiated_by, excluded.initiated_by)
+    initiated_by = COALESCE(sessions.initiated_by, excluded.initiated_by),
+    -- A genuine local transcript write (the scanner always carries a non-empty
+    -- file_path) reclaims a row that was first seeded as a peer mirror: clear the
+    -- mirror provenance so pruneMirrorSessions (which deletes mirror_synced_at IS
+    -- NOT NULL rows past the age cutoff) can never delete real local content, and
+    -- so queryLocalOriginSessionsForMirror (mirror_synced_at IS NULL) re-publishes
+    -- it. Without this the stamp set by upsertMirrorSession survived a later real
+    -- scan, since an omitted column keeps its prior value on upsert (PHNX-3792).
+    -- An empty-file write (a host-dispatch stub) is NOT a real transcript, so it
+    -- leaves the stamp intact — matching the mirror guard's own file_path test.
+    mirror_synced_at = CASE
+      WHEN excluded.file_path IS NOT NULL AND excluded.file_path <> '' THEN NULL
+      ELSE sessions.mirror_synced_at
+    END,
+    mirror_source = CASE
+      WHEN excluded.file_path IS NOT NULL AND excluded.file_path <> '' THEN NULL
+      ELSE sessions.mirror_source
+    END
 `);
 
 /**

--- a/cli/src/lib/session/mirror.test.ts
+++ b/cli/src/lib/session/mirror.test.ts
@@ -174,3 +174,38 @@ describe('session mirror (real DB + real shared-state files)', () => {
     expect(rawRow('ffffffff-0000-0000-0000-000000000006')).toBeTruthy();
   });
 });
+
+describe('a mirror row reclaimed by a real local transcript (PHNX-3792 blocker fix)', () => {
+  const ID = '33333333-0000-0000-0000-000000000009';
+
+  it('clears the mirror stamp on a genuine local write, so prune cannot delete it and it re-publishes', () => {
+    // 1. Seed the id as a peer mirror row (empty file_path, mirror_synced_at set).
+    const staleSync = Date.now() - mirror.SESSION_MIRROR_MAX_AGE_MS - 60_000;
+    db.upsertMirrorSession(
+      { id: ID, shortId: '33333333', agent: 'claude', machine: 'peer-b', timestamp: '2026-09-01T00:00:00.000Z', topic: 'from peer' },
+      'peer-b',
+      staleSync,
+    );
+    const asMirror = rawRow(ID);
+    expect(asMirror.mirror_synced_at).toBe(staleSync);
+    expect(asMirror.file_path === '' || asMirror.file_path == null).toBe(true);
+
+    // 2. The same id then gains a genuine LOCAL transcript via the ordinary scan path.
+    seedLocalSession({ id: ID, topic: 'now local', firstUserMessage: 'real transcript content' });
+    const asLocal = rawRow(ID);
+    expect(asLocal.mirror_synced_at).toBeNull();   // stamp cleared by the real write
+    expect(asLocal.mirror_source).toBeNull();
+    expect(asLocal.file_path).toBeTruthy();
+
+    // 3. (a) Prune with a cutoff PAST the original stale stamp — the reclaimed row
+    // survives because its stamp is now NULL, not because it is fresh. (The prune
+    // count is not asserted: this file shares one DB, so other tests' mirror rows
+    // also fall in the cutoff — what matters is that THIS real local row is spared.)
+    db.pruneMirrorSessions(Date.now());
+    expect(rawRow(ID)).toBeTruthy();
+
+    // 4. (b) It is re-publishable as a genuine local-origin row again.
+    const publishable = db.queryLocalOriginSessionsForMirror(self, 200).map((r) => r.id);
+    expect(publishable).toContain(ID);
+  });
+});

--- a/cli/src/lib/session/mirror.test.ts
+++ b/cli/src/lib/session/mirror.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate a fresh HOME BEFORE importing state/db — db.ts captures DB_PATH at
+// module load (same pattern as the migration tests in this directory).
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-mirror-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const { getSessionsDir, getUserAgentsDir } = await import('../state.js');
+fs.mkdirSync(getSessionsDir(), { recursive: true });
+
+const db = await import('./db.js');
+const mirror = await import('./mirror.js');
+const { readFleetSharedDeviceStates, updateFleetSharedDeviceState } = await import('../fleet-shared-state.js');
+const { machineId } = await import('./sync/config.js');
+const Database = (await import('../sqlite.js')).default;
+
+const self = machineId();
+
+function seedLocalSession(over: Partial<Parameters<typeof db.upsertSession>[0]> & { id: string }): void {
+  const meta: any = {
+    id: over.id,
+    shortId: over.id.slice(0, 8),
+    agent: 'claude',
+    timestamp: '2026-09-01T10:00:00.000Z',
+    lastActivity: '2026-09-01T10:30:00.000Z',
+    filePath: `/tmp/${over.id}.jsonl`,
+    machine: self,
+    topic: 'do the thing',
+    firstUserMessage: 'Please do the thing end to end and open a PR.',
+    ...over,
+  };
+  db.upsertSession(meta, meta.firstUserMessage ?? '');
+}
+
+function rawRow(id: string): any {
+  const d = new Database(path.join(getSessionsDir(), 'sessions.db'));
+  try {
+    return d.prepare('SELECT * FROM sessions WHERE id = ?').get(id);
+  } finally {
+    d.close();
+  }
+}
+
+describe('session mirror (real DB + real shared-state files)', () => {
+  it('publishes this box\'s local sessions into its owned shared-state file', async () => {
+    seedLocalSession({ id: 'aaaaaaaa-0000-0000-0000-000000000001' });
+    const root = getUserAgentsDir();
+    const res = await mirror.publishSessionMirrorToSharedStore({ userAgentsDir: root });
+    expect(res.published).toBe(true);
+    expect(res.count).toBeGreaterThanOrEqual(1);
+
+    const read = readFleetSharedDeviceStates(root);
+    const mine = read.states.find((s) => s.device === self);
+    expect(mine?.sessions?.rows?.length).toBeGreaterThanOrEqual(1);
+    const row = mine!.sessions!.rows.find((r) => r.id === 'aaaaaaaa-0000-0000-0000-000000000001')!;
+    expect(row.topic).toBe('do the thing');
+    expect(row.firstUser).toContain('do the thing end to end');
+    expect(row.machine).toBe(self);
+  });
+
+  it('folds a PEER\'s published digests into the local index as mirror rows and previews them inline', () => {
+    const root = getUserAgentsDir();
+    // A peer publishes a session that never existed on this box.
+    updateFleetSharedDeviceState('yosemite-m5', {
+      sessions: {
+        rows: [{
+          id: 'bbbbbbbb-0000-0000-0000-000000000002',
+          shortId: 'bbbbbbbb',
+          agent: 'claude',
+          machine: 'yosemite-m5',
+          topic: 'refactor the exec engine',
+          firstUser: 'Refactor buildExecEnv so every dispatch path shares one env builder.',
+          label: 'exec refactor',
+          lastActivity: '2026-09-01T12:00:00.000Z',
+          timestamp: '2026-09-01T11:00:00.000Z',
+          ticketId: 'PHNX-9999',
+          capturedAt: Date.now(),
+        }],
+      },
+    }, root);
+
+    const res = mirror.consumeSessionMirrorFromSharedStore({ userAgentsDir: root, device: self, role: 'personal' });
+    expect(res.merged).toBe(1);
+    expect(res.sources).toContain('yosemite-m5');
+
+    const row = rawRow('bbbbbbbb-0000-0000-0000-000000000002');
+    expect(row).toBeTruthy();
+    expect(row.machine).toBe('yosemite-m5');
+    expect(row.file_path).toBe('');
+    expect(row.topic).toBe('refactor the exec engine');
+    expect(row.label).toBe('exec refactor');
+    expect(row.ticket_id).toBe('PHNX-9999');
+    expect(row.mirror_synced_at).toBeGreaterThan(0);
+    expect(row.mirror_source).toBe('yosemite-m5');
+  });
+
+  it('OVERWRITES a host-dispatch stub\'s [host/peer] placeholder label with the synced topic', () => {
+    const root = getUserAgentsDir();
+    // A local host-dispatch stub: peer machine, empty file, placeholder label, no topic.
+    db.upsertSession({
+      id: 'cccccccc-0000-0000-0000-000000000003',
+      shortId: 'cccccccc',
+      agent: 'claude',
+      timestamp: '2026-09-01T09:00:00.000Z',
+      filePath: '',
+      machine: 'yosemite-m6',
+      label: '[host/yosemite-m6]',
+    } as any, '');
+
+    updateFleetSharedDeviceState('yosemite-m6', {
+      sessions: {
+        rows: [{
+          id: 'cccccccc-0000-0000-0000-000000000003',
+          shortId: 'cccccccc',
+          agent: 'claude',
+          machine: 'yosemite-m6',
+          topic: 'land the traces insight engine',
+          firstUser: 'Ship the cross-session failure clustering.',
+          lastActivity: '2026-09-01T09:30:00.000Z',
+          timestamp: '2026-09-01T09:00:00.000Z',
+          capturedAt: Date.now(),
+        }],
+      },
+    }, root);
+
+    mirror.consumeSessionMirrorFromSharedStore({ userAgentsDir: root, device: self, role: 'personal' });
+    const row = rawRow('cccccccc-0000-0000-0000-000000000003');
+    // The bare [host/peer] placeholder is gone; the list now renders the topic.
+    expect(row.label).toBeNull();
+    expect(row.topic).toBe('land the traces insight engine');
+  });
+
+  it('NEVER overwrites a genuine local transcript row', () => {
+    const root = getUserAgentsDir();
+    seedLocalSession({ id: 'dddddddd-0000-0000-0000-000000000004', topic: 'real local work' });
+    // A peer claims the same id (shouldn't happen with UUIDs, but the guard must hold).
+    const wrote = db.upsertMirrorSession(
+      { id: 'dddddddd-0000-0000-0000-000000000004', shortId: 'dddddddd', agent: 'claude', machine: 'evil-peer', timestamp: '2026-09-01T00:00:00.000Z', topic: 'hijacked' },
+      'evil-peer',
+      Date.now(),
+    );
+    expect(wrote).toBe(false);
+    const row = rawRow('dddddddd-0000-0000-0000-000000000004');
+    expect(row.machine).toBe(self);
+    expect(row.topic).toBe('real local work');
+    expect(row.mirror_synced_at).toBeNull();
+  });
+
+  it('a worker skips the consume (the mirror feeds an interactive picker)', () => {
+    const root = getUserAgentsDir();
+    updateFleetSharedDeviceState('yosemite-s1', {
+      sessions: { rows: [{ id: 'eeeeeeee-0000-0000-0000-000000000005', shortId: 'eeeeeeee', agent: 'claude', machine: 'yosemite-s1', topic: 'x', timestamp: '2026-09-01T00:00:00.000Z', capturedAt: Date.now() }] },
+    }, root);
+    const res = mirror.consumeSessionMirrorFromSharedStore({ userAgentsDir: root, device: self, role: 'worker' });
+    expect(res.skipped).toMatch(/worker/);
+    expect(res.merged).toBe(0);
+    expect(rawRow('eeeeeeee-0000-0000-0000-000000000005')).toBeFalsy();
+  });
+
+  it('prunes only stale mirror rows, never a real or fresh one', () => {
+    const now = Date.now();
+    seedLocalSession({ id: 'ffffffff-0000-0000-0000-000000000006', topic: 'keep me local' });
+    db.upsertMirrorSession({ id: '11111111-0000-0000-0000-000000000007', shortId: '11111111', agent: 'claude', machine: 'peer-a', timestamp: '2026-09-01T00:00:00.000Z', topic: 'stale' }, 'peer-a', now - mirror.SESSION_MIRROR_MAX_AGE_MS - 60_000);
+    db.upsertMirrorSession({ id: '22222222-0000-0000-0000-000000000008', shortId: '22222222', agent: 'claude', machine: 'peer-a', timestamp: '2026-09-01T00:00:00.000Z', topic: 'fresh' }, 'peer-a', now);
+
+    const pruned = db.pruneMirrorSessions(now - mirror.SESSION_MIRROR_MAX_AGE_MS);
+    expect(pruned).toBe(1);
+    expect(rawRow('11111111-0000-0000-0000-000000000007')).toBeFalsy();
+    expect(rawRow('22222222-0000-0000-0000-000000000008')).toBeTruthy();
+    expect(rawRow('ffffffff-0000-0000-0000-000000000006')).toBeTruthy();
+  });
+});

--- a/cli/src/lib/session/mirror.ts
+++ b/cli/src/lib/session/mirror.ts
@@ -1,0 +1,201 @@
+/**
+ * Fleet distribution of lightweight per-session preview/metadata (PHNX-3792).
+ *
+ * On the interactive/personal device, a session that originated on another host
+ * used to render as a bare `[host/<peer>]` row with no topic, and its preview
+ * pane fetched the peer's digest LIVE over SSH per row — slow, and blank when
+ * the peer is asleep. This module mirrors each box's own session digests into
+ * its conflict-free `~/.agents/devices/<device>/daemon-state.json`, which the
+ * daemon's existing bounded Git transport (`fleet-shared-repo-sync.ts`) already
+ * delivers fleet-wide with no operator step. The consuming device folds peer
+ * digests into its local `sessions` index as mirror rows, so the picker/list/
+ * focus read a LOCAL row instead of dialing the peer. No transcript is shipped —
+ * only topic/label, a first-user-message snippet, last-activity, agent+version,
+ * cwd, ticket, and PR — and the mirror is bounded and pruned by age.
+ *
+ * Direction is deliberately the inverse of usage-sync: EVERY box publishes its
+ * own local sessions (workers are exactly where the remote sessions the personal
+ * box lacks previews for are created), and every box EXCEPT a marked worker folds
+ * peers' digests in (the picker is an interactive surface). A worker skips the
+ * consume so its DB is not written with rows it never renders.
+ */
+import { selfConfiguredDeviceRole, type ConfiguredDeviceRole } from '../device-config.js';
+import {
+  readFleetSharedDeviceStates,
+  updateFleetSharedDeviceStateAsync,
+  type SessionMirrorRow,
+} from '../fleet-shared-state.js';
+import { getUserAgentsDir } from '../state.js';
+import { machineId, normalizeHost } from './sync/config.js';
+import {
+  pruneMirrorSessions,
+  queryLocalOriginSessionsForMirror,
+  upsertMirrorSession,
+} from './db.js';
+
+/** Cap on sessions published per device — the payload stays what a picker shows. */
+export const SESSION_MIRROR_MAX_ROWS = 200;
+/** First-user-message snippet ceiling; the full turn stays on the owning box. */
+export const SESSION_MIRROR_SNIPPET_MAX = 280;
+/** Mirror rows older than this since their last sync are pruned (staleness/size ceiling). */
+export const SESSION_MIRROR_MAX_AGE_MS = 14 * 24 * 60 * 60_000;
+
+export interface PublishSessionMirrorOptions {
+  userAgentsDir?: string;
+  device?: string;
+  limit?: number;
+}
+
+export interface PublishSessionMirrorResult {
+  published: boolean;
+  changed: boolean;
+  count: number;
+  skipped: string | null;
+  error: string | null;
+  path: string | null;
+}
+
+function snippet(value: string | null | undefined, max = SESSION_MIRROR_SNIPPET_MAX): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+}
+
+/** Publish this device's most-recent local sessions into its owned shared-state file. */
+export async function publishSessionMirrorToSharedStore(
+  options: PublishSessionMirrorOptions = {},
+): Promise<PublishSessionMirrorResult> {
+  const result: PublishSessionMirrorResult = {
+    published: false, changed: false, count: 0, skipped: null, error: null, path: null,
+  };
+  const device = options.device ?? machineId();
+  const self = normalizeHost(device);
+  const limit = options.limit ?? SESSION_MIRROR_MAX_ROWS;
+  const capturedAt = Date.now();
+  const sources = queryLocalOriginSessionsForMirror(self, limit);
+  const rows: SessionMirrorRow[] = sources.map((s) => ({
+    id: s.id,
+    shortId: s.shortId,
+    agent: s.agent,
+    ...(s.version ? { version: s.version } : {}),
+    machine: s.machine?.trim() || self,
+    ...(s.cwd ? { cwd: s.cwd } : {}),
+    ...(snippet(s.topic, 200) ? { topic: snippet(s.topic, 200) } : {}),
+    ...(s.label ? { label: s.label } : {}),
+    ...(snippet(s.firstUserMessage) ? { firstUser: snippet(s.firstUserMessage) } : {}),
+    ...(s.lastActivity ? { lastActivity: s.lastActivity } : {}),
+    timestamp: s.timestamp,
+    ...(s.ticketId ? { ticketId: s.ticketId } : {}),
+    ...(s.prUrl ? { prUrl: s.prUrl } : {}),
+    capturedAt,
+  }));
+  try {
+    const write = await updateFleetSharedDeviceStateAsync(
+      device,
+      { sessions: { rows } },
+      options.userAgentsDir ?? getUserAgentsDir(),
+    );
+    result.published = true;
+    result.changed = write.changed;
+    result.count = rows.length;
+    result.path = write.path;
+  } catch (err) {
+    result.error = (err as Error).message;
+  }
+  return result;
+}
+
+export interface ConsumeSessionMirrorOptions {
+  userAgentsDir?: string;
+  device?: string;
+  role?: ConfiguredDeviceRole;
+  now?: number;
+  maxAgeMs?: number;
+}
+
+export interface ConsumeSessionMirrorResult {
+  sources: string[];
+  merged: number;
+  pruned: number;
+  skipped: string | null;
+  errors: Array<{ device: string; message: string }>;
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0;
+}
+
+/**
+ * Validate one untrusted peer-supplied row into a DB upsert (or null when it is
+ * missing a load-bearing field). Terminal-escape scrubbing is NOT done here —
+ * the render path (`sanitizeMeta` in sessions-picker) scrubs every meta string
+ * before it reaches a TTY, exactly as it does for live fan-out rows — this only
+ * enforces shape and bounds so a malformed/hostile peer can't poison the index.
+ */
+function toUpsert(raw: unknown): {
+  id: string; shortId: string; agent: string; version?: string; machine: string;
+  cwd?: string; topic?: string; firstUser?: string; label?: string;
+  lastActivity?: string; timestamp: string; ticketId?: string; prUrl?: string;
+} | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const r = raw as Record<string, unknown>;
+  if (!isString(r.id) || !isString(r.agent) || !isString(r.machine)) return null;
+  const timestamp = isString(r.timestamp) ? r.timestamp : (isString(r.lastActivity) ? r.lastActivity : null);
+  if (!timestamp) return null;
+  const shortId = isString(r.shortId) ? r.shortId : r.id.slice(0, 8);
+  const cap = (v: unknown, max: number): string | undefined =>
+    isString(v) ? (v.length > max ? v.slice(0, max) : v) : undefined;
+  return {
+    id: r.id,
+    shortId,
+    agent: r.agent,
+    version: cap(r.version, 64),
+    machine: r.machine,
+    cwd: cap(r.cwd, 1024),
+    topic: cap(r.topic, 400),
+    firstUser: cap(r.firstUser, SESSION_MIRROR_SNIPPET_MAX),
+    label: cap(r.label, 400),
+    lastActivity: isString(r.lastActivity) ? r.lastActivity : undefined,
+    timestamp,
+    ticketId: cap(r.ticketId, 64),
+    prUrl: cap(r.prUrl, 512),
+  };
+}
+
+/**
+ * Fold peers' published session digests into this box's local `sessions` index
+ * as mirror rows, then prune stale ones. Reads only the local user-repo checkout
+ * (the daemon's Git transport already delivered peers' files) — no network. A
+ * marked worker skips: the mirror feeds an interactive picker it never renders.
+ */
+export function consumeSessionMirrorFromSharedStore(
+  options: ConsumeSessionMirrorOptions = {},
+): ConsumeSessionMirrorResult {
+  const result: ConsumeSessionMirrorResult = { sources: [], merged: 0, pruned: 0, skipped: null, errors: [] };
+  const role = options.role ?? selfConfiguredDeviceRole();
+  if (role === 'worker') {
+    result.skipped = 'this device is a worker; the session mirror feeds the interactive picker';
+    return result;
+  }
+  const now = options.now ?? Date.now();
+  const read = readFleetSharedDeviceStates(options.userAgentsDir ?? getUserAgentsDir());
+  result.errors.push(...read.errors);
+  const self = normalizeHost(options.device ?? machineId());
+  for (const state of read.states) {
+    if (normalizeHost(state.device) === self || !state.sessions?.rows) continue;
+    let mergedForDevice = 0;
+    for (const raw of state.sessions.rows) {
+      const row = toUpsert(raw);
+      if (!row) continue;
+      if (upsertMirrorSession(row, state.device, now)) mergedForDevice++;
+    }
+    if (mergedForDevice > 0) {
+      result.sources.push(state.device);
+      result.merged += mergedForDevice;
+    }
+  }
+  result.sources.sort();
+  result.pruned = pruneMirrorSessions(now - (options.maxAgeMs ?? SESSION_MIRROR_MAX_AGE_MS));
+  return result;
+}

--- a/cli/src/lib/session/mirror.ts
+++ b/cli/src/lib/session/mirror.ts
@@ -174,11 +174,17 @@ export function consumeSessionMirrorFromSharedStore(
 ): ConsumeSessionMirrorResult {
   const result: ConsumeSessionMirrorResult = { sources: [], merged: 0, pruned: 0, skipped: null, errors: [] };
   const role = options.role ?? selfConfiguredDeviceRole();
+  const now = options.now ?? Date.now();
   if (role === 'worker') {
+    // A worker never renders the picker, so it does not consume peers' digests.
+    // But if this box was previously a non-worker it may still hold mirror rows,
+    // which it will never refresh or render — prune them all now (cutoff = now
+    // drops every row synced before this tick) rather than leave a demoted box's
+    // index permanently bloated with stale peer rows (PHNX-3792).
+    result.pruned = pruneMirrorSessions(now);
     result.skipped = 'this device is a worker; the session mirror feeds the interactive picker';
     return result;
   }
-  const now = options.now ?? Date.now();
   const read = readFleetSharedDeviceStates(options.userAgentsDir ?? getUserAgentsDir());
   result.errors.push(...read.errors);
   const self = normalizeHost(options.device ?? machineId());

--- a/cli/src/lib/session/types.ts
+++ b/cli/src/lib/session/types.ts
@@ -390,6 +390,15 @@ export interface SessionMeta {
    */
   _remote?: boolean;
   /**
+   * Epoch ms this row was last written from a PEER's fleet-synced session mirror
+   * (PHNX-3792); absent for a genuine local or host-dispatch row. When set, the
+   * picker renders the peer session's topic/preview INLINE from this mirror
+   * (no per-row SSH) and stamps a "synced <ago>" / stale marker. `mirrorSource`
+   * names the publishing device. Backed by the `mirror_synced_at` column.
+   */
+  mirrorSyncedAt?: number;
+  mirrorSource?: string;
+  /**
    * True when the transcript file is gone from disk but the session's user turns
    * still live in the local DB (session_text), so the row is served and rendered
    * from the DB instead of vanishing (RUSH-2436). Absent for a live session whose


### PR DESCRIPTION
Closes PHNX-3792.

## Problem

On the interactive/personal device, a session that originated on another host rendered as a bare `[host/<peer>]` row with no topic, and its preview pane fetched the peer's digest **live over SSH** — slow, and blank when the peer was asleep. Local sessions render rich preview inline; remote-host ones didn't.

## Design

Reuses the **existing** daemon shared-state Git transport rather than a new path (the abandoned `backup/sessions-sync` CRDT-over-R2 branch was deliberately not revived). The `usage-sync` service — already the single committer of `devices/<device>/daemon-state.json` — now also publishes each box's lightweight per-session digest into a `sessions` field of its own file. Every box **except** a marked `worker` folds peers' digests into its local session index as mirror rows, guarded so a mirror never overwrites a genuine local transcript row.

- **Only lightweight fields ride:** topic/label, first-user-message snippet, last-activity, agent+version, cwd, ticket, PR. **No transcript leaves the worker.** Bounded to 200 recent sessions/box, pruned by age (14d) — respects the zero-data-retention posture.
- The picker, `agents sessions` list, and `focus` read the local mirror, so a remote-host row shows its real topic/preview **inline, no per-row SSH** — and keeps showing the last-synced preview when the peer is offline.
- The live SSH digest fetch remains the fallback for a never-synced session; `space` still reads the full transcript live.

## Acceptance criteria (from PHNX-3792)

- [x] Remote-host row shows real topic/preview inline in picker / `sessions` / `focus`, no per-row SSH
- [x] Offline peer still shows last-synced preview instead of blank `[host/<peer>]`
- [x] Live SSH fetch retained as fallback for cache-miss/never-synced
- [x] Bounded; no full transcripts shipped off the worker
- [x] Guarded against overwriting a genuine local transcript row

## Files

`src/lib/session/mirror.ts` (+ test), `src/lib/session/db.ts` (`upsertMirrorSession`/`pruneMirrorSessions`), `src/lib/fleet-shared-state.ts` (+ test), `src/lib/daemon/usage-sync-service.ts`, `src/commands/sessions-picker.ts` (+ test), `src/lib/session/types.ts`, `cli/AGENTS.md` (§10/§11), changelog fragment.

Authored by a dispatched agent (PHNX-3792) on yosemite-m3; opened + driven to review/merge from the orchestrating session.
