### PR TITLE
feat(actor): resolve the local device owner + carry a Phoenix ID (PHNX-3798)

### DIFF
--- a/cli/src/lib/actor.test.ts
+++ b/cli/src/lib/actor.test.ts
@@ -28,16 +28,41 @@ describe('computeActor', () => {
     expect(actor.kind).toBe('agent');
   });
 
-  it('falls back to UNRESOLVED@<host> for a local (non-SSH) run', () => {
-    const actor = computeActor({});
+  const noTailscale = { whois: () => undefined, self: () => undefined };
+
+  it('falls back to UNRESOLVED@<host> for a local run when tailscale names no owner', () => {
+    const actor = computeActor({}, noTailscale);
     expect(actor.id).toMatch(/^UNRESOLVED@/);
     expect(actor.kind).toBe('human');
     expect(actor.email).toBeUndefined();
     expect(actor.name).toBeUndefined();
   });
 
-  it('does not shell out when SSH_CONNECTION is malformed (no client ip)', () => {
-    const actor = computeActor({ SSH_CONNECTION: 'garbage' });
+  it('credits the device`s own tailnet owner for a local (non-SSH) run', () => {
+    const actor = computeActor({}, {
+      whois: () => undefined,
+      self: () => ({ login: 'muqsitnawaz@gmail.com', displayName: 'Muqsit' }),
+    });
+    expect(actor.id).toBe('muqsitnawaz@gmail.com');
+    expect(actor.name).toBe('Muqsit');
+    expect(actor.email).toBe('muqsitnawaz@gmail.com');
+  });
+
+  it('does not self-credit an SSH run whose whois fails (no misattribution to the box owner)', () => {
+    const actor = computeActor(
+      { SSH_CONNECTION: '100.64.0.9 51000 100.64.0.1 22' },
+      { whois: () => undefined, self: () => ({ login: 'boxowner@example.com' }) },
+    );
+    expect(actor.id).toMatch(/^UNRESOLVED@/);
+  });
+
+  it('does not shell out (whois or self) when SSH_CONNECTION is present but malformed', () => {
+    // SSH_CONNECTION is set, so this is an SSH session, not a local run: the self
+    // fallback must stay off even though the connection string is unparseable.
+    const actor = computeActor(
+      { SSH_CONNECTION: 'garbage' },
+      { whois: () => ({ login: 'x' }), self: () => ({ login: 'boxowner@example.com' }) },
+    );
     expect(actor.id).toMatch(/^UNRESOLVED@/);
   });
 });
@@ -77,6 +102,17 @@ describe('actorFromIdentity (the SSH-resolved enrich/override path)', () => {
     const actors = { b: { email: 'bisma@example.com', github: 'bee' } };
     const actor = actorFromIdentity({ login: 'bisma@example.com' }, 'h', actors);
     expect(actor.github).toBe('bee');
+  });
+
+  it('carries the phoenixId from a matched actors entry (personal login -> work identity)', () => {
+    const actors = { 'muqsitnawaz@gmail.com': { email: 'muqsit@getrush.ai', phoenixId: 'muqsit' } };
+    const actor = actorFromIdentity(whoMuqsit, 'h', actors);
+    expect(actor.phoenixId).toBe('muqsit');
+    expect(actor.id).toBe('muqsitnawaz@gmail.com'); // id stays the tailnet login
+  });
+
+  it('leaves phoenixId undefined for a login with no actors entry', () => {
+    expect(actorFromIdentity(whoMuqsit, 'h', {}).phoenixId).toBeUndefined();
   });
 
   it('honors a kind: agent override (so an agent identity gets no personal git credit)', () => {
@@ -128,6 +164,20 @@ describe('actorEnv', () => {
     expect(env.AGENTS_ACTOR_KIND).toBe('agent');
     expect(env.GIT_AUTHOR_NAME).toBeUndefined();
     expect(env.GIT_AUTHOR_EMAIL).toBeUndefined();
+  });
+
+  it('propagates phoenixId and round-trips it back through inheritance', () => {
+    const actor: ResolvedActor = {
+      id: 'muqsitnawaz@gmail.com',
+      kind: 'human',
+      name: 'Muqsit',
+      email: 'muqsit@getrush.ai',
+      phoenixId: 'muqsit',
+    };
+    const env = actorEnv(actor);
+    expect(env.AGENTS_ACTOR_PHOENIX_ID).toBe('muqsit');
+    // Inheritance wins before any tailscale shell-out, so no resolvers needed.
+    expect(computeActor(env)).toEqual(actor);
   });
 
   it('round-trips through the env: actorEnv output re-inherits to the same actor', () => {

--- a/cli/src/lib/actor.ts
+++ b/cli/src/lib/actor.ts
@@ -7,8 +7,10 @@
  *
  *   - Over SSH (the shared-fleet case): `tailscale whois` the SSH client IP to
  *     the connecting tailnet identity -- a real name + login email.
- *   - Locally (non-SSH): we can't honestly say who is at the box, so the id is
- *     `UNRESOLVED@<host>` and no personal git identity is claimed.
+ *   - Locally (non-SSH): the run belongs to whoever owns this device on the
+ *     tailnet, so we read that owner from `tailscale status` (`.Self.UserID` ->
+ *     `.User[]`). Only if tailscale can't name the device owner either do we fall
+ *     back to the honest `UNRESOLVED@<host>` with no personal git identity claimed.
  *   - Inherited: a child spawn trusts the `AGENTS_ACTOR*` env its parent
  *     stamped rather than re-resolving, so the whole spawn tree shares one actor.
  *
@@ -41,6 +43,13 @@ export interface ResolvedActor {
   email?: string;
   /** GitHub handle, when the actors map records one. */
   github?: string;
+  /**
+   * Phoenix (work) identity id for this human, when the actors map records one.
+   * Bridges a personal tailnet login (e.g. a personal gmail) to the stable
+   * internal work identity, so attribution survives whichever email a person
+   * happens to be signed into tailscale with.
+   */
+  phoenixId?: string;
 }
 
 /** Result of `tailscale whois --json <ip>` we care about. */
@@ -73,6 +82,38 @@ function tailscaleWhois(ip: string): WhoisIdentity | undefined {
     const up = data.UserProfile;
     if (!up) return undefined;
     return { login: up.LoginName, displayName: up.DisplayName };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve this device's own tailnet owner via `tailscale status --json`:
+ * `.Self.UserID` indexes into the `.User` map for the owner's login + display
+ * name. Used for a LOCAL run, where there is no SSH client to whois — the run
+ * belongs to whoever owns the box on the tailnet. Same graceful-undefined +
+ * timeout discipline as `tailscaleWhois`: tailscale absent, a wedged daemon, a
+ * tagged (owner-less) device, or a parse failure all yield undefined, never an
+ * error and never a hang on the spawn hot path.
+ */
+function tailscaleSelf(): WhoisIdentity | undefined {
+  try {
+    const res = spawnSync('tailscale', ['status', '--json'], {
+      encoding: 'utf-8',
+      windowsHide: true,
+      timeout: WHOIS_TIMEOUT_MS,
+    });
+    if (res.status !== 0 || !res.stdout) return undefined;
+    const data = JSON.parse(res.stdout) as {
+      Self?: { UserID?: number };
+      User?: Record<string, { LoginName?: string; DisplayName?: string }>;
+    };
+    const uid = data.Self?.UserID;
+    if (uid == null) return undefined;
+    // The User map is keyed by the UserID rendered as a string.
+    const u = data.User?.[String(uid)];
+    if (!u?.LoginName) return undefined;
+    return { login: u.LoginName, displayName: u.DisplayName };
   } catch {
     return undefined;
   }
@@ -124,6 +165,7 @@ export function actorFromIdentity(
     name: cfg?.name ?? who?.displayName,
     email: cfg?.email ?? emailFromLogin,
     github: cfg?.github,
+    phoenixId: cfg?.phoenixId,
   };
 }
 
@@ -137,20 +179,48 @@ function inheritedActor(env: NodeJS.ProcessEnv): ResolvedActor | undefined {
     name: env.AGENTS_ACTOR_NAME || undefined,
     email: env.AGENTS_ACTOR_EMAIL || undefined,
     github: env.AGENTS_ACTOR_GITHUB || undefined,
+    phoenixId: env.AGENTS_ACTOR_PHOENIX_ID || undefined,
   };
 }
 
 /**
- * Compute the actor for a given environment. Pure with respect to `env` (the
- * only impurity is the `tailscale whois` / config read on the fresh-SSH path),
- * so tests can drive every branch by passing an env explicitly.
+ * Injectable tailscale resolvers, so tests can drive the SSH-whois and
+ * local-self branches deterministically without a real tailscale on the box
+ * (a dev machine that *is* on the tailnet would otherwise make the local path
+ * non-deterministic). Production callers use the defaults.
  */
-export function computeActor(env: NodeJS.ProcessEnv = process.env): ResolvedActor {
+export interface ActorResolvers {
+  whois: (ip: string) => WhoisIdentity | undefined;
+  self: () => WhoisIdentity | undefined;
+}
+
+const defaultResolvers: ActorResolvers = { whois: tailscaleWhois, self: tailscaleSelf };
+
+/**
+ * Compute the actor for a given environment. The only impurity is the tailscale
+ * shell-out (injectable via `resolvers`), so tests drive every branch explicitly.
+ *
+ * Resolution order: an inherited env actor wins; otherwise an SSH run whois-es
+ * its client IP; a local run (no SSH) credits the device's own tailnet owner;
+ * and anything unresolvable degrades to `UNRESOLVED@<host>`. Note the self
+ * fallback fires ONLY for a truly local run — an SSH run whose whois fails must
+ * NOT be credited to the box owner (that would misattribute a remote human to
+ * whoever owns the machine).
+ */
+export function computeActor(
+  env: NodeJS.ProcessEnv = process.env,
+  resolvers: ActorResolvers = defaultResolvers,
+): ResolvedActor {
   const inherited = inheritedActor(env);
   if (inherited) return inherited;
 
-  const ssh = env.SSH_CONNECTION ? parseSshConnection(env.SSH_CONNECTION) : undefined;
-  const who = ssh?.clientIp ? tailscaleWhois(ssh.clientIp) : undefined;
+  const sshRaw = env.SSH_CONNECTION;
+  const ssh = sshRaw ? parseSshConnection(sshRaw) : undefined;
+  let who = ssh?.clientIp ? resolvers.whois(ssh.clientIp) : undefined;
+  // Self-credit only for a genuinely LOCAL run (no SSH_CONNECTION at all). An
+  // SSH session whose connection is unparseable or unresolvable stays
+  // UNRESOLVED rather than being misattributed to the box's owner.
+  if (!who && !sshRaw) who = resolvers.self();
   return actorFromIdentity(who, machineId(), readActors());
 }
 
@@ -185,6 +255,7 @@ export function actorEnv(actor: ResolvedActor): Record<string, string> {
   if (actor.name) env.AGENTS_ACTOR_NAME = actor.name;
   if (actor.email) env.AGENTS_ACTOR_EMAIL = actor.email;
   if (actor.github) env.AGENTS_ACTOR_GITHUB = actor.github;
+  if (actor.phoenixId) env.AGENTS_ACTOR_PHOENIX_ID = actor.phoenixId;
 
   if (actor.kind === 'human' && actor.name && actor.email) {
     env.GIT_AUTHOR_NAME = actor.name;

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -878,6 +878,12 @@ export interface ActorConfig {
   github?: string;
   /** Tailnet login-name this entry matches. Defaults to the map key. */
   login?: string;
+  /**
+   * Phoenix (work) identity id — bridges this person's tailnet login (often a
+   * personal email) to their stable internal work identity, so session/commit
+   * attribution survives whichever email they are signed into tailscale with.
+   */
+  phoenixId?: string;
 }
 
 /** Top-level structure of ~/.agents/.system/agents.yaml -- the CLI's persistent state. */


### PR DESCRIPTION
## What

Closes the first, centralized piece of **PHNX-3798** (session ownership → who started a run). All resolution stays in the one place, `cli/src/lib/actor.ts`; nothing re-implements tailscale.

### 1. Local runs resolve the human (kills `UNRESOLVED@<host>`)
`computeActor()` previously only resolved over SSH (whois the client IP). A run started *locally* on a box had no `SSH_CONNECTION` and degraded to `UNRESOLVED@<host>` — the `UNRESOLVED@zion` we see on fleet rows. It now falls back to the **device's own tailnet owner** via `tailscale status --json` (`.Self.UserID` → `.User[]`).

Guardrail: the self-credit fires **only for a genuinely local run** (no `SSH_CONNECTION` at all). An SSH session whose whois fails stays `UNRESOLVED` — never misattributed to whoever owns the box.

### 2. `phoenixId` on the actor
`ActorConfig` + `ResolvedActor` gain `phoenixId`, propagated through `actorEnv()` (`AGENTS_ACTOR_PHOENIX_ID`) and re-inherited by child spawns. It bridges a personal tailnet login (often a personal gmail) to the stable internal work identity, sourced from the existing hand-authored `actors:` map — **no second source of truth.**

### Testability
The tailscale shell-outs (`whois`, `self`) are now injectable into `computeActor()`, so every branch is deterministic in tests without a real tailnet.

## Evidence (live, on zion)
```
LOCAL (empty env):  {"id":"muqsitnawaz@gmail.com","kind":"human","name":"Muqsit","email":"muqsitnawaz@gmail.com"}
SSH, unresolvable:  {"id":"UNRESOLVED@zion","kind":"human"}
```
`vitest run src/lib/actor.test.ts` → **21 passed** · `tsc --noEmit` clean.

## Follow-ups (same ticket)
- Persist `phoenixId` through the actor sidecar → sessions DB → `sessions --json` feed.
- agi-ext: render the resolved owner + Phoenix badge; filter/group by owner.