### PR TITLE
feat(sessions): persist actor phoenixId end-to-end so `sessions --json` exposes it (PHNX-3798)

### DIFF
--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -1403,6 +1403,7 @@ export async function execShimPassthrough(
           sessionId: passthroughSessionId,
           actor: resolveActor().id,
           initiatedBy: resolveActor().kind,
+          phoenixId: resolveActor().phoenixId,
           startedAtMs: Date.now(),
         });
       }
@@ -1885,6 +1886,7 @@ async function runInTmux(options: ExecOptions, executable: string, args: string[
         sessionId: options.sessionId,
         actor: resolveActor().id,
         initiatedBy: resolveActor().kind,
+        phoenixId: resolveActor().phoenixId,
         harness: customHarnessName(options),
         startedAtMs: Date.now(),
       });
@@ -2279,6 +2281,7 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
         sessionId: options.sessionId,
         actor: resolveActor().id,
         initiatedBy: resolveActor().kind,
+        phoenixId: resolveActor().phoenixId,
         harness: customHarnessName(options),
         startedAtMs: Date.now(),
       });

--- a/cli/src/lib/session/__tests__/db-actor.test.ts
+++ b/cli/src/lib/session/__tests__/db-actor.test.ts
@@ -44,24 +44,26 @@ describe('sessions DB actor provenance (RUSH-2018)', () => {
     fs.rmSync(TEST_HOME, { recursive: true, force: true });
   });
 
-  it('persists actor + initiatedBy on insert and maps them back through rowToMeta', () => {
-    upsert({ id: 'sess-actor-1', actor: 'ada@example.com', initiatedBy: 'human' });
+  it('persists actor + initiatedBy + phoenixId on insert and maps them back through rowToMeta', () => {
+    upsert({ id: 'sess-actor-1', actor: 'ada@example.com', initiatedBy: 'human', phoenixId: 'phx_ada' });
     const meta = getSessionById('sess-actor-1');
     expect(meta?.actor).toBe('ada@example.com');
     expect(meta?.initiatedBy).toBe('human');
+    expect(meta?.phoenixId).toBe('phx_ada');
   });
 
   it('stores the raw columns on the row', () => {
     const db = getDB();
     const row = db
-      .prepare(`SELECT actor, initiated_by FROM sessions WHERE id = ?`)
-      .get('sess-actor-1') as { actor: string; initiated_by: string };
+      .prepare(`SELECT actor, initiated_by, phoenix_id FROM sessions WHERE id = ?`)
+      .get('sess-actor-1') as { actor: string; initiated_by: string; phoenix_id: string };
     expect(row.actor).toBe('ada@example.com');
     expect(row.initiated_by).toBe('human');
+    expect(row.phoenix_id).toBe('phx_ada');
   });
 
-  it('preserves the original actor on a content rescan (ON CONFLICT excludes it)', () => {
-    upsert({ id: 'sess-actor-2', actor: 'grace@example.com', initiatedBy: 'human' });
+  it('preserves the original actor + phoenixId on a content rescan (ON CONFLICT excludes it)', () => {
+    upsert({ id: 'sess-actor-2', actor: 'grace@example.com', initiatedBy: 'human', phoenixId: 'phx_grace' });
     // A rescan re-upserts the same id with NO actor (the scanner can't know it).
     upsert({ id: 'sess-actor-2', topic: 'rescanned' });
     const meta = getSessionById('sess-actor-2');
@@ -69,12 +71,14 @@ describe('sessions DB actor provenance (RUSH-2018)', () => {
     expect(meta?.topic).toBe('rescanned');
     expect(meta?.actor).toBe('grace@example.com');
     expect(meta?.initiatedBy).toBe('human');
+    expect(meta?.phoenixId).toBe('phx_grace');
   });
 
-  it('leaves actor/initiatedBy undefined when never stamped (pre-actor rows)', () => {
+  it('leaves actor/initiatedBy/phoenixId undefined when never stamped (pre-actor rows)', () => {
     upsert({ id: 'sess-actor-3' });
     const meta = getSessionById('sess-actor-3');
     expect(meta?.actor).toBeUndefined();
     expect(meta?.initiatedBy).toBeUndefined();
+    expect(meta?.phoenixId).toBeUndefined();
   });
 });

--- a/cli/src/lib/session/actor-sidecar.test.ts
+++ b/cli/src/lib/session/actor-sidecar.test.ts
@@ -7,7 +7,7 @@ const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-sidecar-'));
 process.env.HOME = TEST_HOME;
 
 const { writeSessionActorRecord, writeSessionAliasRecord, readSessionActorRecord, loadSessionActorIndex, resolveSessionAlias } = await import('./actor-sidecar.js');
-const { resolveOwner } = await import('./active.js');
+const { resolveOwner, serializeSessionsJson } = await import('./active.js');
 const { getDB, closeDB, upsertSession, upsertSessionsBatch, getSessionById } = await import('./db.js');
 type SessionMeta = import('./types.js').SessionMeta;
 
@@ -23,10 +23,11 @@ fs.mkdirSync(FILES, { recursive: true });
  */
 describe('session actor sidecar (RUSH-2019)', () => {
   it('round-trips a written record and skips one with no session id', () => {
-    writeSessionActorRecord({ sessionId: 'sid-1', actor: 'ada@example.com', initiatedBy: 'human', startedAtMs: 1 });
+    writeSessionActorRecord({ sessionId: 'sid-1', actor: 'ada@example.com', initiatedBy: 'human', phoenixId: 'phx_ada', startedAtMs: 1 });
     const got = readSessionActorRecord('sid-1');
     expect(got?.actor).toBe('ada@example.com');
     expect(got?.initiatedBy).toBe('human');
+    expect(got?.phoenixId).toBe('phx_ada');
     // No id -> no file written, and a read of an absent id is undefined.
     writeSessionActorRecord({ sessionId: '', actor: 'x', initiatedBy: 'human', startedAtMs: 1 });
     expect(readSessionActorRecord('missing')).toBeUndefined();
@@ -53,10 +54,11 @@ describe('session actor sidecar (RUSH-2019)', () => {
   });
 
   it('persists a tmux alias without discarding actor or mode metadata', () => {
-    writeSessionActorRecord({ sessionId: 'alias-actor', actor: 'ada@example.com', initiatedBy: 'human', mode: 'edit', startedAtMs: 1 });
+    writeSessionActorRecord({ sessionId: 'alias-actor', actor: 'ada@example.com', initiatedBy: 'human', phoenixId: 'phx_ada', mode: 'edit', startedAtMs: 1 });
     writeSessionAliasRecord('alias-actor', 'ag-codex-d4e5f607');
     const record = readSessionActorRecord('alias-actor');
     expect(record?.actor).toBe('ada@example.com');
+    expect(record?.phoenixId).toBe('phx_ada');
     expect(record?.mode).toBe('edit');
     expect(record?.aliases).toContain('ag-codex-d4e5f607');
   });
@@ -140,13 +142,51 @@ describe('upsertSession joins the actor sidecar (RUSH-2019)', () => {
     expect(getSessionById('joined-version')?.version).toBe('0.146.0');
   });
 
-  it('fills actor/initiatedBy from the sidecar when the scanned meta has none', () => {
-    writeSessionActorRecord({ sessionId: 'joined-1', actor: 'grace@example.com', initiatedBy: 'human', mode: 'edit', startedAtMs: 1 });
+  it('fills actor/initiatedBy/phoenixId from the sidecar when the scanned meta has none', () => {
+    writeSessionActorRecord({ sessionId: 'joined-1', actor: 'grace@example.com', initiatedBy: 'human', phoenixId: 'phx_grace', mode: 'edit', startedAtMs: 1 });
     upsertSession(scanMeta('joined-1'), '');
     const meta = getSessionById('joined-1');
     expect(meta?.actor).toBe('grace@example.com');
     expect(meta?.initiatedBy).toBe('human');
+    expect(meta?.phoenixId).toBe('phx_grace');
     expect(meta?.mode).toBe('edit');
+  });
+
+  it('round-trips phoenixId from a sidecar record all the way to the sessions --json output (PHNX-3798)', () => {
+    // The acceptance path: a human whose `actors:` entry carries a phoenixId
+    // launches a session -> the sidecar records it -> the scan-join fills the
+    // write-once phoenix_id column -> `agents sessions --json` surfaces it.
+    writeSessionActorRecord({ sessionId: 'phx-1', actor: 'linus@example.com', initiatedBy: 'human', phoenixId: 'phx_linus', startedAtMs: 1 });
+    upsertSession(scanMeta('phx-1'), '');
+    const meta = getSessionById('phx-1');
+    expect(meta).toBeTruthy();
+    expect(meta?.phoenixId).toBe('phx_linus');
+    // serializeSessionsJson is the single seam the `--json` listing emits through.
+    const json = JSON.parse(serializeSessionsJson([meta!])) as Array<{ id: string; phoenixId?: string }>;
+    expect(json[0].id).toBe('phx-1');
+    expect(json[0].phoenixId).toBe('phx_linus');
+  });
+
+  it('BACKFILLS a null-first phoenix_id once the sidecar lands, and preserves it across a phoenixId-less rescan', () => {
+    upsertSession(scanMeta('phx-backfill'), ''); // null-first: no sidecar yet
+    expect(getSessionById('phx-backfill')?.phoenixId).toBeUndefined();
+    writeSessionActorRecord({ sessionId: 'phx-backfill', actor: 'ada@example.com', initiatedBy: 'human', phoenixId: 'phx_ada', startedAtMs: 1 });
+    upsertSession(scanMeta('phx-backfill'), '');
+    expect(getSessionById('phx-backfill')?.phoenixId).toBe('phx_ada');
+    // Sidecar gone + a rescan carrying no phoenixId must NOT erase the recorded id.
+    fs.rmSync(path.join(TEST_HOME, '.agents', '.history', 'by-session', 'phx-backfill.json'), { force: true });
+    upsertSession({ ...scanMeta('phx-backfill'), topic: 'rescanned' }, '');
+    expect(getSessionById('phx-backfill')?.phoenixId).toBe('phx_ada');
+  });
+
+  it('leaves phoenixId undefined when the sidecar record carries none (honest absent field)', () => {
+    writeSessionActorRecord({ sessionId: 'phx-none', actor: 'grace@example.com', initiatedBy: 'human', startedAtMs: 1 });
+    upsertSession(scanMeta('phx-none'), '');
+    const meta = getSessionById('phx-none');
+    expect(meta?.actor).toBe('grace@example.com');
+    expect(meta?.phoenixId).toBeUndefined();
+    const json = JSON.parse(serializeSessionsJson([meta!])) as Array<Record<string, unknown>>;
+    expect('phoenixId' in json[0]).toBe(false);
   });
 
   it('updates the persisted mode when a later native resume uses an explicit override', () => {

--- a/cli/src/lib/session/actor-sidecar.ts
+++ b/cli/src/lib/session/actor-sidecar.ts
@@ -25,6 +25,13 @@ export interface SessionActorRecord {
   actor?: string;
   /** Actor kind (`resolveActor().kind`). */
   initiatedBy?: 'human' | 'agent';
+  /**
+   * Phoenix id of the responsible actor (`resolveActor().phoenixId`) — the
+   * tailnet human's stable Phoenix identity, resolved from the `actors:` map at
+   * spawn (PHNX-3798). Pairs with {@link actor}: joined onto the session index at
+   * scan time so a durable listing can surface the Phoenix id, not just the email.
+   */
+  phoenixId?: string;
   /** Effective permissions mode used by the launcher. */
   mode?: SessionRunMode;
   /**
@@ -76,6 +83,7 @@ function isSafeAlias(alias: string): boolean {
 
 function hasRecordData(record: SessionActorRecord): boolean {
   return typeof record.actor === 'string'
+    || typeof record.phoenixId === 'string'
     || typeof record.mode === 'string'
     || typeof record.version === 'string'
     || typeof record.harness === 'string'
@@ -121,6 +129,7 @@ export function writeSessionAliasRecord(sessionId: string, alias: string): void 
       sessionId,
       actor: previous?.actor,
       initiatedBy: previous?.initiatedBy,
+      phoenixId: previous?.phoenixId,
       mode: previous?.mode,
       version: previous?.version,
       harness: previous?.harness,

--- a/cli/src/lib/session/db.migrate-v47.test.ts
+++ b/cli/src/lib/session/db.migrate-v47.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-migv47-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const { getSessionsDir, getSessionsDbPath } = await import('../state.js');
+fs.mkdirSync(getSessionsDir(), { recursive: true });
+
+const Database = (await import('../sqlite.js')).default;
+
+{
+  const seed = new Database(getSessionsDbPath());
+  // Authentic v46 shape: the PHNX-3792 mirror provenance columns exist, but the
+  // PHNX-3798 phoenix_id column is deliberately absent so getDB must add it
+  // through migrateSchema(46).
+  seed.exec(`
+    CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, short_id TEXT NOT NULL, agent TEXT NOT NULL, harness TEXT,
+      origin TEXT DEFAULT 'cli', routine_name TEXT, routine_run_id TEXT, version TEXT,
+      account TEXT, account_key TEXT, account_org TEXT, mode TEXT, timestamp TEXT NOT NULL,
+      last_activity TEXT, project TEXT, cwd TEXT, git_branch TEXT, topic TEXT,
+      first_user_message TEXT, label TEXT,
+      message_count INTEGER, token_count INTEGER, output_tokens INTEGER, input_tokens INTEGER,
+      cache_read_tokens INTEGER, cache_write_tokens INTEGER, cost_usd REAL, cost_usd_nocache REAL,
+      duration_ms INTEGER, model TEXT, tool_call_count INTEGER, file_path TEXT NOT NULL,
+      file_mtime_ms INTEGER, file_size INTEGER, scanned_at INTEGER, is_team_origin INTEGER DEFAULT 0,
+      pr_url TEXT, pr_number INTEGER, worktree_slug TEXT, ticket_id TEXT, spawned_team TEXT,
+      sub_agent_count INTEGER, background_shell_count INTEGER, plan TEXT, machine TEXT, todos TEXT,
+      recent_directories_touched TEXT, linear_project TEXT, linear_project_url TEXT, actor TEXT,
+      initiated_by TEXT, used_browser INTEGER, used_computer INTEGER, archived_at INTEGER,
+      mirror_synced_at INTEGER, mirror_source TEXT
+    );
+    INSERT INTO sessions (id, short_id, agent, timestamp, file_path, actor, initiated_by)
+      VALUES ('legacy', 'legacy', 'codex', '2026-08-30T10:00:00.000Z', '/s/legacy.jsonl', 'ada@example.com', 'human');
+    INSERT INTO meta(key, value) VALUES ('schema_version', '46');
+  `);
+  seed.close();
+}
+
+const { getDB, SCHEMA_VERSION } = await import('./db.js');
+
+describe('schema migration v46 -> v47 (actor Phoenix id, PHNX-3798)', () => {
+  it('adds a nullable phoenix_id column without damaging legacy rows', () => {
+    const columns = (getDB().prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map((c) => c.name);
+    expect(columns).toContain('phoenix_id');
+    const row = getDB()
+      .prepare(`SELECT phoenix_id, actor, file_path FROM sessions WHERE id = 'legacy'`)
+      .get() as { phoenix_id: string | null; actor: string | null; file_path: string };
+    // A legacy row indexed before Phoenix-id stamping stays NULL; its actor and
+    // content are untouched by the additive migration.
+    expect(row.phoenix_id).toBeNull();
+    expect(row.actor).toBe('ada@example.com');
+    expect(row.file_path).toBe('/s/legacy.jsonl');
+  });
+
+  it('stamps the new schema version', () => {
+    const row = getDB().prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
+    expect(row.value).toBe(String(SCHEMA_VERSION));
+  });
+});

--- a/cli/src/lib/session/db.ts
+++ b/cli/src/lib/session/db.ts
@@ -39,7 +39,7 @@ const DB_PATH = getSessionsDbPath();
 /** Current schema version; bumped when migrations are added. Exported so tests
  * assert against the constant instead of hardcoding a number that every bump
  * then has to chase (docs/sessions.md calls the constant the source of truth). */
-export const SCHEMA_VERSION = 46;
+export const SCHEMA_VERSION = 47;
 
 /**
  * Bump to force the content extractor (assistant-answer text, alongside the
@@ -149,6 +149,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   linear_project_url TEXT,
   actor TEXT,
   initiated_by TEXT,
+  phoenix_id TEXT,
   used_browser INTEGER,
   used_computer INTEGER,
   -- Epoch ms of the first time a previously-scanned transcript was confirmed
@@ -559,6 +560,8 @@ interface SessionRow {
   linear_project_url: string | null;
   actor: string | null;
   initiated_by: string | null;
+  /** Phoenix id of the actor, joined write-once from the actor sidecar (PHNX-3798). */
+  phoenix_id: string | null;
   /** NULL means "not yet computed" (a row scanned before this field existed) — see rowToMeta. */
   used_browser: number | null;
   used_computer: number | null;
@@ -1437,6 +1440,18 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     // block (fresh DBs skip migrations), alongside idx_sessions_last_activity.
   }
 
+  if (fromVersion < 47) {
+    // v46 -> v47: carry the actor's Phoenix id (PHNX-3798). Additive, write-once
+    // launch metadata joined from the actor sidecar — never transcript-derived,
+    // exactly like actor/initiated_by (v19) — so there is no ledger wipe: a rescan
+    // can't backfill it and forcing a full re-parse would be pure churn. Existing
+    // rows stay NULL until the sidecar-join fills them (the ON CONFLICT COALESCEs).
+    const cols = new Set(
+      (db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map((c) => c.name),
+    );
+    if (!cols.has('phoenix_id')) db.exec(`ALTER TABLE sessions ADD COLUMN phoenix_id TEXT`);
+  }
+
 }
 
 /**
@@ -2067,7 +2082,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     pr_url, pr_number, worktree_slug, ticket_id, spawned_team,
     sub_agent_count, background_shell_count, plan, todos,
     recent_directories_touched, linear_project, linear_project_url, machine,
-    actor, initiated_by, used_browser, used_computer
+    actor, initiated_by, phoenix_id, used_browser, used_computer
   ) VALUES (
     @id, @short_id, @agent, @harness, @origin, @routine_name, @routine_run_id,
     @version, @account, @account_key, @account_org, @mode, @timestamp, @last_activity,
@@ -2078,7 +2093,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     @pr_url, @pr_number, @worktree_slug, @ticket_id, @spawned_team,
     @sub_agent_count, @background_shell_count, @plan, @todos,
     @recent_directories_touched, @linear_project, @linear_project_url, @machine,
-    @actor, @initiated_by, @used_browser, @used_computer
+    @actor, @initiated_by, @phoenix_id, @used_browser, @used_computer
   )
   ON CONFLICT(id) DO UPDATE SET
     short_id = excluded.short_id,
@@ -2163,6 +2178,10 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     -- exclusion locked those rows to NULL forever (RUSH-2018/2019 fix).
     actor = COALESCE(sessions.actor, excluded.actor),
     initiated_by = COALESCE(sessions.initiated_by, excluded.initiated_by),
+    -- Phoenix id rides the same write-once join as actor/initiated_by: a rescan
+    -- carries none (excluded.phoenix_id is NULL -> stored value wins), but a row
+    -- indexed NULL-first backfills once the sidecar-join finally provides one.
+    phoenix_id = COALESCE(sessions.phoenix_id, excluded.phoenix_id),
     -- A genuine local transcript write (the scanner always carries a non-empty
     -- file_path) reclaims a row that was first seeded as a peer mirror: clear the
     -- mirror provenance so pruneMirrorSessions (which deletes mirror_synced_at IS
@@ -2491,6 +2510,7 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     machine: resolveMachine(meta),
     actor: meta.actor ?? actorRec?.actor ?? null,
     initiated_by: meta.initiatedBy ?? actorRec?.initiatedBy ?? null,
+    phoenix_id: meta.phoenixId ?? actorRec?.phoenixId ?? null,
     used_browser: toolUsage.usedBrowser ? 1 : 0,
     used_computer: toolUsage.usedComputer ? 1 : 0,
   };
@@ -2768,6 +2788,7 @@ export function upsertSessionsBatch(
     machine: resolveMachine(meta),
         actor: meta.actor ?? actorIndex.get(meta.id)?.actor ?? null,
         initiated_by: meta.initiatedBy ?? actorIndex.get(meta.id)?.initiatedBy ?? null,
+        phoenix_id: meta.phoenixId ?? actorIndex.get(meta.id)?.phoenixId ?? null,
         used_browser: toolUsage.usedBrowser ? 1 : 0,
         used_computer: toolUsage.usedComputer ? 1 : 0,
       };
@@ -3020,6 +3041,7 @@ function rowToMeta(row: SessionRow): SessionMeta {
     // Narrow the free-text column to the known kinds; an unexpected value maps
     // to undefined rather than being asserted as a valid kind.
     initiatedBy: row.initiated_by === 'human' || row.initiated_by === 'agent' ? row.initiated_by : undefined,
+    phoenixId: row.phoenix_id ?? undefined,
     // NULL = never computed by this scanner (legacy row) — leave undefined so
     // the sessions picker knows to fall back to the transcript-regex detection
     // instead of trusting a false "never used browser/computer".

--- a/cli/src/lib/session/types.ts
+++ b/cli/src/lib/session/types.ts
@@ -381,6 +381,15 @@ export interface SessionMeta {
    */
   initiatedBy?: 'human' | 'agent';
   /**
+   * Phoenix id of the actor who initiated this session (`resolveActor().phoenixId`)
+   * — the tailnet human's stable Phoenix identity, resolved from the `actors:` map
+   * at spawn. Pairs with {@link actor}, persisted write-once at session creation
+   * and joined from the actor sidecar at scan time (kept out of the DB upsert's
+   * ON CONFLICT set), so `agents sessions --json` can surface the Phoenix id.
+   * Undefined for rows created before Phoenix-id stamping. PHNX-3798.
+   */
+  phoenixId?: string;
+  /**
    * True only for rows pulled from another machine over the live cross-machine
    * fan-out (`remote-list.ts`) — their transcript is on that peer's disk, so
    * reading/resuming has to hop back over SSH. Distinct from `machine`, which is


### PR DESCRIPTION
## PHNX-3798 — feed-wiring half

The resolver half ([PR #3421](https://github.com/phnx-labs/agi-cli/pull/3421)) resolves a local human's Phoenix identity onto `ResolvedActor.phoenixId` and propagates it through `actorEnv()` as `AGENTS_ACTOR_PHOENIX_ID`, but that value only rode the exec env — it was never **persisted per-session** or surfaced in the sessions feed.

This PR wires `phoenixId` through by **mirroring exactly how the sibling fields `actor` and `initiatedBy` already flow**, at every hop they touch:

1. **Sidecar** (`session/actor-sidecar.ts`) — `SessionActorRecord.phoenixId`, written at launch from `resolveActor().phoenixId` at the 3 `writeSessionActorRecord` sites in `exec.ts`, preserved by `writeSessionAliasRecord`, and counted by `hasRecordData`.
2. **Scanner / session index** (`session/db.ts`) — additive write-once `phoenix_id` column with a **v46 → v47 forward migration** mirroring the actor-column (v19) pattern (no ledger wipe: launch metadata, never transcript-derivable). Joined from the sidecar in both the single-row (`upsertSession`) and batch (`upsertSessionsBatch`) scan paths, `COALESCE`'d in `ON CONFLICT` (backfills a NULL-first row; a rescan carrying none keeps the stored id), and mapped back in `rowToMeta`.
3. **Feed** — `SessionMeta.phoenixId` flows through `serializeSessionsJson`'s field spread, **exactly like `actor`/`initiatedBy`**, so `agents sessions --json` emits it with no serializer change.

**Best-effort throughout**, like the rest of the sidecar: a missing `phoenixId` degrades to an absent field, never throws.

### Acceptance
A session launched by a human whose `actors:` entry has a `phoenixId` shows that `phoenixId` in `agents sessions --json`. Proven by a round-trip test: a sidecar record → scan-join → `serializeSessionsJson` output.

### Tests
Extended `actor-sidecar.test.ts` (round-trip, scan-join fill, **feed-serialization round-trip**, NULL-first backfill, honest-absent) and `db-actor.test.ts` (raw column + write-once preserve + unstamped), plus a new `db.migrate-v47.test.ts`.

```
$ ./node_modules/.bin/tsc --noEmit
TSC_EXIT=0

$ vitest run src/lib/session/actor-sidecar.test.ts src/lib/session/__tests__/db-actor.test.ts src/lib/session/db.migrate-v47.test.ts
 Test Files  3 passed (3)
      Tests  26 passed (26)

$ vitest run src/lib/session/         # full session suite, schema-bump regression check
 Test Files  167 passed | 1 skipped (168)
      Tests  1748 passed | 7 skipped (1755)

$ vitest run src/lib/exec-launchid.test.ts src/lib/exec.test.ts
 Test Files  2 passed (2)
      Tests  142 passed (142)
```

### Out of scope (separate follow-ups)
- agi-ext UI display of the Phoenix id.
- Populating the `actors:` map config (ops task).