### PR TITLE
docs(changelog): add PHNX-3798 fragment for the phoenixId feed field

### DIFF
--- a/cli/.changelog/next/PHNX-3798.md
+++ b/cli/.changelog/next/PHNX-3798.md
@@ -1,0 +1,13 @@
+- **`agents sessions --json` now carries the initiator's Phoenix ID (PHNX-3798).**
+  The actor resolver already mapped a run's tailnet identity to a `phoenixId`
+  (the stable internal work identity) and rode it through the exec env, but it was
+  never persisted per session, so a durable listing couldn't attribute a session
+  to a person's work identity. The `phoenixId` now flows the same path the
+  `actor`/`initiatedBy` fields already take — stamped into the durable actor
+  sidecar at launch, joined into a new write-once `phoenix_id` column via a v47
+  schema migration, and emitted by the sessions feed. Best-effort throughout: a
+  session with no mapped Phoenix ID (the common case) simply omits the field
+  rather than emitting a null/empty sentinel. This is the persistence half of the
+  ownership work whose resolver landed in PHNX-3798's first PR. Source:
+  `src/lib/session/actor-sidecar.ts`, `src/lib/session/db.ts`,
+  `src/lib/session/types.ts`, `src/lib/exec.ts`.


### PR DESCRIPTION
Follow-up to #3424 (merged), which added `phoenixId` to `agents sessions --json` but landed without the `.changelog/next/` fragment the repo requires for user-visible PRs (flagged in #3424's non-author review as a blocker that the self-merge missed). This adds only that fragment — the code already merged. Diff is one doc file.