### PR TITLE
fix(cli): close remaining symlink-destination gaps in the materializer (PHNX-3838)

### DIFF
--- a/cli/src/lib/agent-spec/materialize.test.ts
+++ b/cli/src/lib/agent-spec/materialize.test.ts
@@ -6,6 +6,8 @@ import type { AgentId } from '../types.js';
 import { AgentPackageError } from './package-types.js';
 import { resolveAgentPackage } from './package-resolve.js';
 import { materializeAgentPackage } from './materialize.js';
+import { getMcpConfigPathForHome } from './agents.js';
+import { hookRegistrationTargets } from '../hooks/install.js';
 
 const FIXTURE = path.join(import.meta.dirname, 'testdata', 'rabbit-hole');
 
@@ -158,6 +160,71 @@ describe('materializeAgentPackage — refuses to write through a symlink out of 
     // The live marker is untouched — nothing was written through the symlink.
     expect(fs.readFileSync(marker, 'utf-8')).toBe('LIVE-MARKER-DO-NOT-TOUCH');
   });
+});
+
+describe('materializeAgentPackage — refuses a preplanted symlink at each final leaf (PHNX-3838)', () => {
+  // Every concrete file the materializer writes/chmods, keyed to the leaf a
+  // preplanted symlink could redirect. `.claude` leaves for the claude harness
+  // (2.1.0). `dangling` = the link's target does not exist yet — the subtle case
+  // realpath-of-existing-prefix misses (it reads the leaf as a contained
+  // to-be-created file), which copyFileSync/writeFileSync/chmod then FOLLOW.
+  const leaves: { name: string; leaf: (home: string) => string }[] = [
+    { name: 'instructions', leaf: (h) => path.join(h, '.claude', 'CLAUDE.md') },
+    { name: 'mcp config', leaf: (h) => getMcpConfigPathForHome('claude', h) },
+    { name: 'subagent file', leaf: (h) => path.join(h, '.claude', 'agents', 'source-finder.md') },
+    { name: 'hook script', leaf: (h) => path.join(h, '.claude', 'hooks', 'capture.sh') },
+    { name: 'hook settings.json', leaf: (h) => path.join(h, '.claude', 'settings.json') },
+    { name: 'materialization receipt', leaf: (h) => path.join(h, 'materialization-receipt.json') },
+  ];
+
+  for (const dangling of [true, false]) {
+    for (const c of leaves) {
+      it(`refuses a ${dangling ? 'dangling' : 'live'} symlink at the ${c.name} leaf`, () => {
+        const resolved = resolveAgentPackage(FIXTURE);
+        const outputHome = tempHome();
+        const victimDir = tempHome();
+        const victim = path.join(victimDir, 'pwned.txt');
+        if (!dangling) fs.writeFileSync(victim, 'LIVE-VICTIM');
+        const leaf = c.leaf(outputHome);
+        fs.mkdirSync(path.dirname(leaf), { recursive: true });
+        fs.symlinkSync(victim, leaf);
+
+        expect(() =>
+          materializeAgentPackage(resolved, { harness: 'claude', harnessVersion: '2.1.0', outputHome }),
+        ).toThrow(/symlink|outside the output home/);
+
+        if (dangling) {
+          expect(fs.existsSync(victim), `${c.name}: nothing created through a dangling symlink`).toBe(false);
+        } else {
+          expect(fs.readFileSync(victim, 'utf-8'), `${c.name}: live victim untouched`).toBe('LIVE-VICTIM');
+        }
+      });
+    }
+  }
+});
+
+describe('hookRegistrationTargets — the settings leaf the materializer guards, per portable harness (PHNX-3838)', () => {
+  it('names the real registrar file(s) each harness writes', () => {
+    const h = '/x';
+    expect(hookRegistrationTargets('claude', h)).toEqual([path.join(h, '.claude', 'settings.json')]);
+    expect(hookRegistrationTargets('codex', h)).toEqual([path.join(h, '.codex', 'hooks.json'), path.join(h, '.codex', 'config.toml')]);
+    expect(hookRegistrationTargets('opencode', h)).toEqual([path.join(h, '.config', 'opencode', 'plugins', 'agents-cli-hooks.ts')]);
+  });
+
+  for (const harness of ['claude', 'codex', 'opencode'] as AgentId[]) {
+    it(`refuses a symlink at ${harness}'s hook settings leaf`, () => {
+      const resolved = resolveAgentPackage(FIXTURE);
+      const outputHome = tempHome();
+      const victim = path.join(tempHome(), 'pwned.txt');
+      const leaf = hookRegistrationTargets(harness, outputHome)[0];
+      fs.mkdirSync(path.dirname(leaf), { recursive: true });
+      fs.symlinkSync(victim, leaf); // dangling
+      expect(() =>
+        materializeAgentPackage(resolved, { harness, harnessVersion: HARNESS_VERSIONS[harness], outputHome }),
+      ).toThrow(/symlink|outside the output home/);
+      expect(fs.existsSync(victim)).toBe(false);
+    });
+  }
 });
 
 describe('materializeAgentPackage — stale-prune never deletes outside the output home', () => {

--- a/cli/src/lib/agent-spec/materialize.ts
+++ b/cli/src/lib/agent-spec/materialize.ts
@@ -27,7 +27,7 @@ import type { AgentId, ManifestHook } from '../types.js';
 import { supports } from '../capabilities.js';
 import { AGENTS, agentConfigDirName, getMcpConfigPathForHome } from './agents.js';
 import { getHooksDirInHome } from '../hooks/install.js';
-import { registerHooksToSettings } from '../hooks/install.js';
+import { registerHooksToSettings, hookRegistrationTargets } from '../hooks/install.js';
 import { writeMcpConfig } from '../mcp.js';
 import type { WritableMcpServer } from '../mcp.js';
 import { subagentTarget } from '../subagents-registry.js';
@@ -137,6 +137,29 @@ function assertTargetContained(realOutputHome: string, target: string, label: st
   }
 }
 
+/**
+ * The final-leaf guard, stricter than {@link assertTargetContained}: it also
+ * refuses a symlink planted AT the leaf itself. `assertTargetContained` resolves
+ * an existing leaf symlink and catches it only when the target is outside — but a
+ * DANGLING leaf symlink (its target does not exist yet) resolves via the leaf's
+ * real parent, reads as contained, and then `copyFileSync`/`writeFileSync`/
+ * `chmodSync` FOLLOWS it and creates/overwrites the file at the link's
+ * destination. So `lstat` the leaf and reject any symlink outright. Called
+ * immediately before each write/chmod of a concrete destination file.
+ */
+function assertLeafSafe(realOutputHome: string, leaf: string, label: string): void {
+  assertTargetContained(realOutputHome, leaf, label);
+  let lst: fs.Stats | undefined;
+  try {
+    lst = fs.lstatSync(leaf);
+  } catch {
+    return; // leaf does not exist — nothing planted
+  }
+  if (lst.isSymbolicLink()) {
+    throw new AgentPackageError(`${label}: refusing to write through a symlink at '${leaf}'`, 'path-escape');
+  }
+}
+
 function materializeInstructions(resource: ResolvedResource, harness: AgentId, outputHome: string, realOutputHome: string): string {
   const cap = AGENTS[harness].capabilities.rules;
   if (cap === false) {
@@ -144,8 +167,12 @@ function materializeInstructions(resource: ResolvedResource, harness: AgentId, o
   }
   const agentDir = path.join(outputHome, agentConfigDirName(harness));
   const destFile = path.join(agentDir, cap.file);
+  // Ancestor guard BEFORE mkdir (else `mkdir -p` traverses a symlinked config
+  // dir into the live home); leaf guard AFTER mkdir (a symlink planted at the
+  // file itself, e.g. on a re-run into a reused home).
   assertTargetContained(realOutputHome, destFile, `${harness} instructions`);
   fs.mkdirSync(path.dirname(destFile), { recursive: true });
+  assertLeafSafe(realOutputHome, destFile, `${harness} instructions`);
   fs.copyFileSync(resource.sourcePath, destFile);
   return path.relative(outputHome, destFile);
 }
@@ -165,9 +192,14 @@ function materializeSubagent(resource: ResolvedResource, harness: AgentId, outpu
     throw new AgentPackageError(`${harness} has no subagent target registered`, 'unsupported-capability');
   }
   const dir = target.dir(outputHome);
+  // Ancestor guard BEFORE the write's `mkdir -p` (a symlinked `.claude/agents`
+  // would otherwise be traversed); leaf guard on the concrete subagent file the
+  // writer forms itself, so a preplanted symlink AT that leaf can't redirect it.
   assertTargetContained(realOutputHome, dir, `${harness} subagent '${resource.name}'`);
-  target.write(dir, { name: resource.name, path: resource.sourcePath });
+  fs.mkdirSync(dir, { recursive: true });
   const occupied = target.occupied(dir, resource.name)[0];
+  assertLeafSafe(realOutputHome, occupied.path, `${harness} subagent '${resource.name}'`);
+  target.write(dir, { name: resource.name, path: resource.sourcePath });
   return path.relative(outputHome, occupied.path);
 }
 
@@ -198,6 +230,10 @@ function materializeMcp(resources: ResolvedResource[], harness: AgentId, outputH
     headers: r.mcp!.headers,
   }));
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  // The shared config is a regular file the materializer (and, later, the harness
+  // itself) rewrites in place; a SYMLINK at that leaf is never something we wrote,
+  // so refuse it before writeMcpConfig follows it out of the output home.
+  assertLeafSafe(realOutputHome, configPath, `${harness} mcp config`);
   try {
     writeMcpConfig(harness, configPath, servers, 'overwrite', { allowEmpty: true });
   } catch (err) {
@@ -216,6 +252,14 @@ function materializeHooks(resources: ResolvedResource[], harness: AgentId, outpu
   // agent-config-dir ancestor, so a symlink there is caught before either write.
   assertTargetContained(realOutputHome, hooksDir, `${harness} hooks dir`);
   fs.mkdirSync(hooksDir, { recursive: true });
+  // The hooks-dir guard catches a symlinked ANCESTOR, but registerHooksToSettings
+  // (called below) writes a per-harness settings/registrar leaf under that dir's
+  // sibling config root — settings.json, codex hooks.json/config.toml, the
+  // opencode plugin. A symlink planted AT one of those leaves would redirect that
+  // write; fail loud here, before any hook script is copied.
+  for (const settingsLeaf of hookRegistrationTargets(harness, outputHome)) {
+    assertLeafSafe(realOutputHome, settingsLeaf, `${harness} hook settings`);
+  }
   const manifest: Record<string, ManifestHook> = {};
   for (const r of resources) {
     const { def, scriptPath } = r.hook!;
@@ -232,6 +276,10 @@ function materializeHooks(resources: ResolvedResource[], harness: AgentId, outpu
     if (!destScript.startsWith(hooksDirResolved + path.sep)) {
       throw new AgentPackageError(`${harness}: hook '${r.name}' resolves outside the hooks directory`, 'invalid-resource');
     }
+    // The check above is textual (name-traversal); this one refuses a preplanted
+    // symlink AT the script leaf, which both copyFileSync AND chmodSync would
+    // otherwise follow — chmod +x on a file outside the output home.
+    assertLeafSafe(realOutputHome, destScript, `${harness} hook '${r.name}'`);
     fs.copyFileSync(scriptPath, destScript);
     fs.chmodSync(destScript, 0o755);
     manifest[r.name] = { script: destScript, events: def.events, matcher: def.matcher, timeout: def.timeout };
@@ -292,9 +340,18 @@ function isValidReceipt(value: unknown): value is MaterializationReceipt {
 }
 
 function readPriorReceipt(outputHome: string): MaterializationReceipt | null {
+  const receiptPath = path.join(outputHome, RECEIPT_FILE);
+  // A preplanted SYMLINK at the receipt is untrusted: reading through it slurps
+  // an arbitrary outside file as the "prior receipt". Treat it as no prior
+  // receipt (the write path refuses to follow it too — see assertLeafSafe below).
+  try {
+    if (fs.lstatSync(receiptPath).isSymbolicLink()) return null;
+  } catch {
+    return null; // no receipt yet
+  }
   let parsed: unknown;
   try {
-    parsed = JSON.parse(fs.readFileSync(path.join(outputHome, RECEIPT_FILE), 'utf-8'));
+    parsed = JSON.parse(fs.readFileSync(receiptPath, 'utf-8'));
   } catch {
     return null;
   }
@@ -361,7 +418,11 @@ export function materializeAgentPackage(resolved: ResolvedAgentPackage, options:
     resources: entries,
     warnings: [],
   };
-  fs.writeFileSync(path.join(outputHome, RECEIPT_FILE), JSON.stringify(receipt, null, 2) + '\n');
+  const receiptPath = path.join(outputHome, RECEIPT_FILE);
+  // Final leaf guard: a symlink planted at the receipt (dangling or live) would
+  // redirect this write out of the output home; refuse it.
+  assertLeafSafe(realOutputHome, receiptPath, 'materialization receipt');
+  fs.writeFileSync(receiptPath, JSON.stringify(receipt, null, 2) + '\n');
   return receipt;
 }
 

--- a/cli/src/lib/hooks/install.ts
+++ b/cli/src/lib/hooks/install.ts
@@ -2146,6 +2146,48 @@ export function registerHooksToSettings(
   return { registered: [], errors: [] };
 }
 
+/**
+ * The concrete config file(s) `registerHooksToSettings` writes for `agentId` in
+ * `home` — the settings/registrar leaves, NOT the per-hook script copies. A
+ * caller materializing into an UNTRUSTED home (the portable-agent materializer)
+ * uses this to verify none of those leaves is a preplanted symlink before the
+ * registrar follows it and overwrites a file outside the home.
+ *
+ * This MUST mirror the `registerHooksToSettings` dispatch above — each arm's
+ * write target is reproduced here, so a new registrar branch adds its leaf here
+ * too. It intentionally returns only the primary settings/registrar file(s); the
+ * per-event/script files a registrar also writes live under the hooks dir the
+ * caller already guards. An agent with no hooks registrar returns `[]`.
+ */
+export function hookRegistrationTargets(agentId: AgentId, home: string): string[] {
+  switch (agentId) {
+    case 'claude':
+    case 'droid':
+    case 'muse':
+      return [path.join(home, agentConfigDirName(agentId), 'settings.json')];
+    case 'codex':
+      return [path.join(home, '.codex', 'hooks.json'), path.join(home, '.codex', 'config.toml')];
+    case 'antigravity':
+      return [path.join(home, '.gemini', 'antigravity-cli', 'settings.json')];
+    case 'grok':
+      return [path.join(home, '.grok', 'hooks', 'hooks.json')];
+    case 'kimi':
+      return [path.join(home, '.kimi-code', 'config.toml')];
+    case 'copilot':
+      return [path.join(home, '.copilot', 'hooks', COPILOT_MANAGED_HOOKS_FILE)];
+    case 'goose':
+      return [path.join(home, '.agents', 'plugins', GOOSE_MANAGED_PLUGIN_NAME, 'hooks', 'hooks.json')];
+    case 'cursor':
+      return [path.join(home, '.cursor', 'hooks.json')];
+    case 'hermes':
+      return [path.join(home, '.hermes', 'config.yaml')];
+    case 'opencode':
+      return [path.join(home, '.config', 'opencode', 'plugins', 'agents-cli-hooks.ts')];
+    default:
+      return [];
+  }
+}
+
 const OPENCODE_DIRECT_EVENT_MAP: Record<string, string> = {
   PreToolUse: 'tool.execute.before',
   PostToolUse: 'tool.execute.after',

--- a/cli/src/lib/packages/output-home.test.ts
+++ b/cli/src/lib/packages/output-home.test.ts
@@ -92,6 +92,22 @@ describe('resolveOutputHome', () => {
     expect(() => resolveOutputHome(escaped, process.cwd(), home)).toThrow(/live \.claude directory/);
   });
 
+  it('refuses the live ~/.claude even when ~/.claude ITSELF is a symlink (PHNX-3838)', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'mat-guard-livelink-'));
+    tempDirs.push(home);
+    const realClaude = fs.mkdtempSync(path.join(os.tmpdir(), 'mat-guard-realclaude-'));
+    tempDirs.push(realClaude);
+    // ~/.claude is a symlink pointing at the operator's real claude config dir.
+    fs.symlinkSync(realClaude, path.join(home, '.claude'));
+
+    // The symlink's real target IS the live home — must be refused.
+    expect(() => resolveOutputHome(realClaude, process.cwd(), home)).toThrow(/live \.claude directory/);
+    // Passing ~/.claude (the symlink) itself resolves to the same real target.
+    expect(() => resolveOutputHome(path.join(home, '.claude'), process.cwd(), home)).toThrow(/live \.claude directory/);
+    // A path inside the real target too.
+    expect(() => resolveOutputHome(path.join(realClaude, 'nested'), process.cwd(), home)).toThrow(/live \.claude directory/);
+  });
+
   it('still allows a non-live directory reached through a benign symlink', () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'mat-guard-benign-'));
     tempDirs.push(home);

--- a/cli/src/lib/packages/output-home.ts
+++ b/cli/src/lib/packages/output-home.ts
@@ -70,8 +70,15 @@ export function outputHomeHasDotDot(raw: string): boolean {
   return raw.split(/[\\/]/).includes('..');
 }
 
-function liveHarnessHomes(home: string): string[] {
-  return PORTABLE_HARNESSES.map((name) => path.join(home, `.${name}`));
+/**
+ * The canonical live harness homes. Each `~/.<harness>` is itself realpath'd:
+ * if `~/.claude` is a SYMLINK to some real dir, the live home to compare against
+ * is that real dir — otherwise `--output-home ~/.claude` (a literal live home
+ * that happens to be a symlink) would canonicalize to the link target and fail
+ * to match the un-resolved `~/.claude` string, sailing past the guard.
+ */
+function liveHarnessHomes(realHome: string): string[] {
+  return PORTABLE_HARNESSES.map((name) => realpathExistingPrefix(path.join(realHome, `.${name}`)));
 }
 
 /**
@@ -110,10 +117,12 @@ export function resolveOutputHome(raw: string, cwd = process.cwd(), home = os.ho
   if (canonical === realHome) {
     throw new MaterializeGuardError('Path escape: output home must not be the live home directory');
   }
-  for (const live of liveHarnessHomes(realHome)) {
+  const liveHomes = liveHarnessHomes(realHome);
+  for (let i = 0; i < liveHomes.length; i++) {
+    const live = liveHomes[i];
     if (canonical === live || canonical.startsWith(live + path.sep)) {
       throw new MaterializeGuardError(
-        `Path escape: output home must not target the live ${path.basename(live)} directory`,
+        `Path escape: output home must not target the live .${PORTABLE_HARNESSES[i]} directory`,
       );
     }
   }


### PR DESCRIPTION
**What + type:** bug-fix (security hardening) — follow-up to #3430, PHNX-3838.

An independent review after #3430 merged found containment gaps that the front-door
guard and the per-target realpath check did not cover. This closes them at the shared
materializer choke point.

## What changed

- **`cli/src/lib/packages/output-home.ts`** — `liveHarnessHomes` now realpath's each
  `~/.<harness>` before comparison. Before, it compared the un-resolved
  `~/.claude` string, so when `~/.claude` is *itself a symlink*, an `--output-home`
  pointing at the symlink's real target (or the symlink itself) canonicalized to the
  link target and slipped past the live-home refusal.
- **`cli/src/lib/agent-spec/materialize.ts`** — new `assertLeafSafe(realOutputHome,
  leaf, label)` lstat-rejects a symlink planted **at the final leaf** immediately
  before each concrete write/chmod. The existing realpath-of-existing-prefix check
  reads a **dangling** leaf symlink (target not yet created) as a contained
  to-be-created file, which `copyFileSync`/`writeFileSync`/`chmodSync` then *follow*
  out of the output home. Wired for: instructions, mcp config, subagent file, hook
  script (guards the `chmod +x` too), hook `settings.json`/registrar file, and the
  materialization receipt. `readPriorReceipt` also ignores a symlinked prior receipt
  rather than reading through it.
- **`cli/src/lib/hooks/install.ts`** — new `hookRegistrationTargets(agentId, home)`
  exposes the concrete per-harness settings/registrar leaf(s) `registerHooksToSettings`
  writes, so the materializer can guard the write it *delegates* (settings.json for
  claude; `.codex/hooks.json` + `config.toml`; the opencode plugin; …). Mirrors the
  registrar dispatch; an agent with no registrar returns `[]`.
- **Tests** — `materialize.test.ts` + `output-home.test.ts`: real-filesystem
  regressions for every case — dangling **and** live leaf symlinks at all six leaves,
  the symlinked-live-home refusal, and an accuracy test pinning
  `hookRegistrationTargets` for all three portable harnesses.

## Verification

- `tsc --noEmit`: clean.
- Focused suites (real filesystem, no mocks): `output-home.test.ts` + `materialize.test.ts` → **49 passed**; `hooks/install.test.ts` → **24 passed**.
- Proved the dangling-symlink gap is real: pre-fix `realpathExistingPrefix` reports a dangling `.claude/CLAUDE.md → /outside/pwned` symlink as *inside* the home, and `copyFileSync` then creates the victim outside. `assertLeafSafe` (lstat-reject) closes it.

Linked: PHNX-3838.