### PR TITLE
fix(hosts): isolate actor-provenance dispatch test from machine tailnet state (PHNX-3850)

### DIFF
--- a/cli/src/lib/actor.ts
+++ b/cli/src/lib/actor.ts
@@ -225,14 +225,28 @@ export function computeActor(
 }
 
 let cached: ResolvedActor | undefined;
+let resolverOverride: ActorResolvers | undefined;
 
 /**
  * Resolve the actor for the current process, cached for the process lifetime
  * (the SSH `whois` shell-out runs at most once).
  */
 export function resolveActor(): ResolvedActor {
-  if (!cached) cached = computeActor(process.env);
+  if (!cached) cached = computeActor(process.env, resolverOverride ?? defaultResolvers);
   return cached;
+}
+
+/**
+ * Test-only: pin the tailscale resolvers `resolveActor()` uses, so a test that
+ * exercises the cached production entrypoint (e.g. `withActorEnv()`) is isolated
+ * from whether the box running it is on the tailnet. `computeActor` already takes
+ * injected resolvers for its unit tests; this extends the same seam to the cached
+ * path. Pass `undefined` to restore the real tailscale resolvers. Resets the
+ * cache so the next `resolveActor()` recomputes under the new resolvers.
+ */
+export function setActorResolvers(resolvers: ActorResolvers | undefined): void {
+  resolverOverride = resolvers;
+  cached = undefined;
 }
 
 /** Clear the per-process cache. For tests, and for env changes within a run. */

--- a/cli/src/lib/hosts/dispatch.test.ts
+++ b/cli/src/lib/hosts/dispatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -19,7 +19,7 @@ import {
   remoteRunShellPrelude,
 } from './dispatch.js';
 import { buildRemoteAgentsInvocation, posixEnvExports } from './remote-cmd.js';
-import { resetActorCache } from '../actor.js';
+import { resetActorCache, setActorResolvers } from '../actor.js';
 import type { HostTask } from './tasks.js';
 
 const LOCAL_HOME = process.env.HOME ?? os.homedir();
@@ -536,9 +536,20 @@ describe('withActorEnv — forward actor provenance across the SSH hop (RUSH-202
     Object.assign(process.env, env);
     resetActorCache();
   }
+  // Pin the tailscale resolvers to "names no one" for every test in this block,
+  // so an UNRESOLVED case is genuinely unresolvable regardless of whether the box
+  // running the suite is on the tailnet. Without this the local-run self-credit
+  // (`tailscaleSelf`) returns the CI/dev box's own tailnet owner and the
+  // UNRESOLVED assertion below sees that ambient account instead. The
+  // inherited-actor tests short-circuit before any resolver, so this doesn't
+  // change their behavior.
+  beforeEach(() => {
+    setActorResolvers({ whois: () => undefined, self: () => undefined });
+  });
   afterEach(() => {
     for (const k of Object.keys(process.env)) if (!(k in SAVE)) delete process.env[k];
     Object.assign(process.env, SAVE);
+    setActorResolvers(undefined);
     resetActorCache();
   });
 


### PR DESCRIPTION
**Test-only isolation fix (one small test-only production seam) — PHNX-3850 release gate, actor-provenance lane.**

The required suite fails on any tailnet-connected box because one dispatch test depended on machine state.

## What changed

- **`cli/src/lib/hosts/dispatch.test.ts`** — the `withActorEnv` block (`an UNRESOLVED origin stamps its own id …`) reached tailscale through `withActorEnv() → resolveActor()` with the real resolvers. On a box that is on the tailnet, `tailscaleSelf()` **correctly** credits the device owner for a local run, so the test saw that ambient account (`muqsitnawaz@gmail.com`) instead of `UNRESOLVED@<host>`. Now a `beforeEach` pins "names no one" resolvers for the whole block, so an UNRESOLVED case is genuinely unresolvable regardless of the box; `afterEach` restores the real ones. The inherited-actor tests short-circuit before any resolver, so they're unaffected.
- **`cli/src/lib/actor.ts`** — added `setActorResolvers()`. `computeActor` already accepts injected resolvers for its own unit tests (`actor.test.ts` uses `{ whois: () => undefined, self: () => undefined }`), but the cached `resolveActor()` — the path `withActorEnv` uses — had no injection point. This extends the same existing seam to the cached entrypoint; production keeps `defaultResolvers`.

**Root cause is test isolation, not production semantics.** Crediting a local run to the box's tailnet owner via `tailscaleSelf()` is intended behavior (`actor.ts` docblock + `computeActor`). The assertion is unchanged and not weakened — it still requires `UNRESOLVED@`; the fix makes the precondition ("genuinely unresolvable") actually hold in the test.

## Verification

Before (on this tailnet box):
```
× an UNRESOLVED origin stamps its own id …
AssertionError: expected 'muqsitnawaz@gmail.com' to match /^UNRESOLVED@/
```
After:
```
$ bunx vitest run src/lib/hosts/dispatch.test.ts
 Test Files  1 passed (1)
      Tests  58 passed | 1 skipped (59)

$ bunx vitest run src/lib/actor.test.ts
 Test Files  1 passed (1)
      Tests  21 passed (21)

$ bun run build   # tsc typecheck
build ok
```
