### PR TITLE
test(session): isolate the mirror suite from the host's machine id (PHNX-3850)

### DIFF
--- a/cli/src/lib/session/mirror.test.ts
+++ b/cli/src/lib/session/mirror.test.ts
@@ -9,6 +9,15 @@ const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-mirror-'));
 process.env.HOME = TEST_HOME;
 process.env.USERPROFILE = TEST_HOME;
 
+// Pin this box's device id so the suite is independent of the host it runs on
+// (PHNX-3850). Otherwise machineId() resolves to the real hostname: on a box
+// literally named `yosemite-m6` it collides with the peer this file uses as a
+// remote publisher, and consumeSessionMirrorFromSharedStore skips that peer's
+// digest as "self" — the fold never runs and the placeholder-label overwrite is
+// never exercised. A fixed id that matches no peer keeps self and every peer
+// distinct on every machine.
+process.env.AGENTS_SYNC_MACHINE_ID = 'mirror-test-self';
+
 const { getSessionsDir, getUserAgentsDir } = await import('../state.js');
 fs.mkdirSync(getSessionsDir(), { recursive: true });
 


### PR DESCRIPTION
**test-only** — remove a machine-state coupling that fails the mirror suite on the box literally named `yosemite-m6` (PHNX-3850 release gate).

## What changed
- **`cli/src/lib/session/mirror.test.ts`** — pin `AGENTS_SYNC_MACHINE_ID = 'mirror-test-self'` alongside the existing `HOME` isolation, before importing `state`/`db`/`mirror`. `machineId()` reads that env var at call time, so the suite's `self` is now a fixed id that collides with none of the hardcoded peer hostnames.

## Why
The suite hardcodes fleet hostnames (`yosemite-m5`/`m6`/`s1`) as *remote* peers but left `machineId()` resolving to the real host. On a runner named `yosemite-m6`, `self` equalled the peer the `OVERWRITES a host-dispatch stub's [host/peer] placeholder label` test publishes from, so `consumeSessionMirrorFromSharedStore` skipped that peer's digest via its `normalizeHost(state.device) === self` self-skip. The placeholder-label → synced-topic fold never ran and the assertion failed:

```
AssertionError: expected '[host/yosemite-m6]' to be null
 ❯ src/lib/session/mirror.test.ts:133:23
```

The reconciliation logic itself was already correct — `upsertMirrorSession` does `label = excluded.label` (overwrite, not COALESCE) precisely to clear the `[host/peer]` placeholder. The only defect was the test's dependence on the host's name; no production change is needed, and no assertion is weakened. With `self` decoupled the fold genuinely runs and the label-overwrite path is now exercised on every machine.

## Verification
Focused suite on `yosemite-m6` (the box that reproduced the failure):

```
$ bunx vitest run src/lib/session/mirror.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Before the pin, the same command on this box failed `1 failed | 6 passed`.

Typecheck:
```
$ bunx tsc --noEmit ; echo $?
0
```
