### PR TITLE
fix(cli): rush session expiry compares ms against seconds (PHNX-3805)

### DIFF
--- a/cli/src/lib/cloud/rush.test.ts
+++ b/cli/src/lib/cloud/rush.test.ts
@@ -294,16 +294,16 @@ describe('isRushSessionValid', () => {
     expect(isRushSessionValid(p)).toBe(false);
   });
 
-  it('returns false when expires_at is in the past', () => {
-    const expiredAt = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+  it('returns false when expires_at (ms) is in the past', () => {
+    const expiredAt = Date.now() - 3600_000; // 1 hour ago, Unix ms
     const p = writeYaml(tmpDir, {
       session: { access_token: 'tok', expires_at: expiredAt },
     });
     expect(isRushSessionValid(p)).toBe(false);
   });
 
-  it('returns true when expires_at is in the future', () => {
-    const futureAt = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+  it('returns true when expires_at (ms) is in the future', () => {
+    const futureAt = Date.now() + 3600_000; // 1 hour from now, Unix ms
     const p = writeYaml(tmpDir, {
       session: { access_token: 'tok', expires_at: futureAt },
     });
@@ -347,11 +347,22 @@ describe('readToken', () => {
   });
 
   it('throws for a genuinely expired session', () => {
-    const expiredAt = Math.floor(Date.now() / 1000) - 3600;
+    const expiredAt = Date.now() - 3600_000; // 1 hour ago, Unix ms
     const p = writeYaml(tmpDir, {
       session: { access_token: 'tok', expires_at: expiredAt },
     });
     expect(() => readToken(p)).toThrow(/Rush session expired/);
+  });
+
+  // PHNX-3805: the thrown message renders expires_at directly (ms → Date), not
+  // `expires_at * 1000`. Multiplying an already-ms value put the reported expiry
+  // ~57000 years in the future; the ISO date must land in a sane range.
+  it('renders the expiry from ms without an extra *1000 (PHNX-3805)', () => {
+    const expiredAt = Date.now() - 3600_000;
+    const p = writeYaml(tmpDir, {
+      session: { access_token: 'tok', expires_at: expiredAt },
+    });
+    expect(() => readToken(p)).toThrow(new Date(expiredAt).toISOString());
   });
 
 });

--- a/cli/src/lib/cloud/rush.ts
+++ b/cli/src/lib/cloud/rush.ts
@@ -51,7 +51,7 @@ interface Installation {
 
 /**
  * Returns true when ~/.rush/user.yaml exists, carries an access_token, and
- * the token has not passed its expires_at timestamp (Unix seconds). A missing
+ * the token has not passed its expires_at timestamp (Unix milliseconds). A missing
  * expires_at, or `expires_at: 0` (a non-expiring Phoenix `pid_` bearer), is
  * treated as non-expired (see isRushSessionExpired, PHNX-3645). Pass yamlPath
  * to override the default path in tests.
@@ -87,7 +87,7 @@ export function readToken(yamlPath: string = USER_YAML): string {
   }
   const expiresAt = data.session?.expires_at;
   if (isRushSessionExpired(expiresAt)) {
-    const expiredAt = new Date(expiresAt! * 1000).toISOString();
+    const expiredAt = new Date(expiresAt!).toISOString();
     throw new Error(`Rush session expired at ${expiredAt}. Run \`rush login\` to refresh.`);
   }
   return token;

--- a/cli/src/lib/rush-session.test.ts
+++ b/cli/src/lib/rush-session.test.ts
@@ -14,13 +14,35 @@ describe('isRushSessionExpired', () => {
     expect(isRushSessionExpired(undefined)).toBe(false);
   });
 
-  it('is expired when expires_at is in the past', () => {
-    const oneHourAgo = Math.floor(Date.now() / 1000) - 3600;
+  it('is expired when expires_at (ms) is in the past', () => {
+    // expires_at is stored in Unix MILLISECONDS.
+    const oneHourAgo = Date.now() - 3600_000;
     expect(isRushSessionExpired(oneHourAgo)).toBe(true);
   });
 
-  it('is not expired when expires_at is in the future', () => {
-    const oneHourAhead = Math.floor(Date.now() / 1000) + 3600;
+  it('is not expired when expires_at (ms) is in the future', () => {
+    const oneHourAhead = Date.now() + 3600_000;
     expect(isRushSessionExpired(oneHourAhead)).toBe(false);
+  });
+
+  // PHNX-3805 regression: expires_at is stored in MILLISECONDS (e.g.
+  // 1788157222000 = the JWT `exp` 1788157222 seconds × 1000). The check used to
+  // compare it against `Date.now() / 1000` (SECONDS), so a long-past ms value
+  // read as `1.788e12 <= 1.788e9` → always false → never expired. That made
+  // `agents cloud providers` report Rush `available: true` on a dead session.
+  // A real ms-scale timestamp well in the past MUST read as expired.
+  it('is expired for a real ms-scale timestamp already in the past (PHNX-3805)', () => {
+    // A concrete stored value observed on disk: 2026-08-31, already past.
+    const realPastMs = 1788157222000;
+    expect(realPastMs).toBeLessThan(Date.now()); // guard: this fixture is truly past
+    expect(isRushSessionExpired(realPastMs)).toBe(true);
+  });
+
+  it('does not misread a valid future ms timestamp as expired (PHNX-3805)', () => {
+    // A future ms timestamp — the pre-fix seconds comparison would have read
+    // this correctly by luck, but a seconds-scale check breaks in the other
+    // direction; pin the ms contract here too.
+    const farFutureMs = Date.now() + 30 * 24 * 3600_000; // 30 days out
+    expect(isRushSessionExpired(farFutureMs)).toBe(false);
   });
 });

--- a/cli/src/lib/rush-session.ts
+++ b/cli/src/lib/rush-session.ts
@@ -2,8 +2,16 @@
  * Rush session freshness — the ONE judgment shared by every consumer of
  * ~/.rush/user.yaml (cloud dispatch, cloud session source, secrets sync driver).
  *
- * A Rush session stores `expires_at` as Unix seconds. Two values mean "never
- * expires" and MUST NOT be read as an absolute timestamp:
+ * A Rush session stores `expires_at` as Unix MILLISECONDS — the same unit
+ * rush/cli writes and reads it in (`sessionTokenFresh` in auth_reader.go compares
+ * against `time.Now()...UnixMilli()`), and the same unit the JWT `exp` claim maps
+ * to (`exp * 1000`). So freshness must compare it against `Date.now()` (ms), NOT
+ * `Date.now() / 1000` (seconds). Comparing ms against seconds was PHNX-3805: a
+ * long-expired session (e.g. `expires_at: 1788157222000`) read as `1.788e12 <=
+ * 1.788e9` → always false → never expired, so `agents cloud providers` reported
+ * Rush `available: true` on a dead session and every dispatch failed with a 401.
+ *
+ * Two values mean "never expires" and MUST NOT be read as an absolute timestamp:
  *   - `0`         — an opaque Phoenix `pid_` bearer written by `rush login`;
  *                   `0` = non-expiring by contract (mirrors rush/cli's isFresh,
  *                   the same fix RUSH-1310 landed for the daemon-less freshness
@@ -19,5 +27,6 @@
 export function isRushSessionExpired(expiresAt: number | undefined): boolean {
   // `0` (non-expiring pid_ bearer) and a missing value are never expired.
   if (typeof expiresAt !== 'number' || expiresAt === 0) return false;
-  return expiresAt <= Date.now() / 1000;
+  // expires_at is Unix milliseconds — compare ms to ms.
+  return expiresAt <= Date.now();
 }

--- a/cli/src/lib/secrets/drivers/rush.ts
+++ b/cli/src/lib/secrets/drivers/rush.ts
@@ -40,7 +40,7 @@ function readRushToken(): string {
   }
   const expiresAt = data.session?.expires_at;
   if (isRushSessionExpired(expiresAt)) {
-    const expiredAt = new Date(expiresAt! * 1000).toISOString();
+    const expiredAt = new Date(expiresAt!).toISOString();
     throw new Error(`Rush session expired at ${expiredAt}. Run \`rush login\` to refresh.`);
   }
   return token;

--- a/cli/src/lib/session/cloud.ts
+++ b/cli/src/lib/session/cloud.ts
@@ -57,7 +57,7 @@ function readToken(): string {
   }
   const expiresAt = data.session?.expires_at;
   if (isRushSessionExpired(expiresAt)) {
-    const expiredAt = new Date(expiresAt! * 1000).toISOString();
+    const expiredAt = new Date(expiresAt!).toISOString();
     throw new Error(`Rush session expired at ${expiredAt}. Run \`rush login\` to refresh.`);
   }
   return token;


### PR DESCRIPTION
## Root cause

`isRushSessionExpired` in `cli/src/lib/rush-session.ts:22` (pre-fix) compared the stored session `expires_at` against `Date.now() / 1000`:

```ts
return expiresAt <= Date.now() / 1000;
```

But `expires_at` in `~/.rush/user.yaml` is **Unix milliseconds**, not seconds:

- rush/cli writes and reads it in ms — `sessionTokenFresh` in `rush/cli/internal/cli/auth_reader.go:360` compares against `time.Now().Add(buffer).UnixMilli() < expiresAt`.
- It equals the JWT `exp` (seconds) × 1000. Observed on disk: `expires_at: 1788157222000`, whose embedded JWT `exp` is `1788157222`.

So a long-expired session evaluated as `1.788e12 <= 1.788e9` → **always false** → the session never read as expired. Every downstream caller that routes through this predicate — `isRushSessionValid`, `readToken` (`cli/src/lib/cloud/rush.ts`), the secrets Rush driver (`cli/src/lib/secrets/drivers/rush.ts`), and the cloud session source (`cli/src/lib/session/cloud.ts`) — then treated a dead session as live. `agents cloud providers` reported Rush `available: true` (`cli/src/lib/cloud/rush.ts:321`) on an expired session, and each dispatch failed downstream with an HTTP 401.

A second, latent form of the same units bug: the three thrown expiry messages did `new Date(expiresAt! * 1000)`. Multiplying an already-ms value by 1000 put the reported expiry ~57,000 years in the future.

## Fix

- `isRushSessionExpired`: compare ms to ms — `return expiresAt <= Date.now();`
- Three expiry-message sites: `new Date(expiresAt!)` (value is already ms), in `cloud/rush.ts`, `secrets/drivers/rush.ts`, `session/cloud.ts`.
- The `expires_at: 0` / `undefined` non-expiring guard (PHNX-3645, opaque Phoenix `pid_` bearer) is preserved unchanged — one canonical unit, no fallback.
- Left alone: the Kimi and Droid probes in `cli/src/lib/accounting/usage.ts` — those read *different* credentials (Kimi's own cred file; a Droid JWT `exp`) whose values are genuinely Unix seconds. Out of scope for the Rush session.

## Why the bug slipped

The existing `rush-session.test.ts` and `cloud/rush.test.ts` fixtures built `expires_at` in **seconds** (`Math.floor(Date.now() / 1000) ± 3600`), which matched the buggy seconds comparison and passed. This PR converts those fixtures to ms and adds PHNX-3805 regression tests:

- a real ms-scale past timestamp (`1788157222000`) reads as expired,
- `expires_at: 0` stays non-expiring,
- a future ms timestamp stays valid,
- the thrown message renders without the extra `*1000`.

## Test evidence

Reverting **only** the core comparison back to `Date.now() / 1000` (leaving tests) fails 5 tests:

```
 Test Files  2 failed (2)
      Tests  5 failed | 31 passed (36)
```

With the fix, focused + affected suites are green:

```
$ TZ=UTC vitest run src/lib/rush-session.test.ts src/lib/cloud/rush.test.ts \
    src/lib/secrets/drivers/rush.test.ts src/lib/session/cloud.test.ts
 Test Files  3 passed (3)
      Tests  45 passed (45)
```

`tsc --noEmit` → exit 0.

Fixes PHNX-3805