### PR TITLE
fix(sessions): read a dispatched session on its owner, not the launcher box (PHNX-3890)

### DIFF
--- a/cli/.changelog/next/PHNX-3890.md
+++ b/cli/.changelog/next/PHNX-3890.md
@@ -1,0 +1,13 @@
+- **`sessions preview` of a remote session no longer dead-ends on the dispatcher
+  (PHNX-3890).** A box that launched a session running on another device kept a
+  transcript-less live row for it whose machine defaulted to itself, so
+  `agents sessions preview <full-uuid>` — and the interactive browser's preview
+  pane — rendered `Live session — full transcript not indexed here.` instead of
+  fetching the owning peer's digest. A passive peer rendered the same session
+  fine. The launcher shim is now reconciled against the fleet's own view of which
+  device runs the session, and a full-UUID hit only skips the fleet fan-out when
+  this box can actually answer for it (a transcript on disk, or a row that already
+  names another device). Remote previews fill in asynchronously over SSH; a
+  locally readable transcript or synced mirror still renders with no hop, and an
+  unreachable owner still fails loud. Source: `cli/src/commands/sessions.ts`,
+  `cli/src/lib/session/live-metadata.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1229,6 +1229,20 @@ repair waits for a concurrent scan rather than returning a stale read
 (`discoverSessions({ waitForScan })` — SES-9c). This is why a running session no
 longer reads "No session matching" during the index-lag window (RUSH-2682).
 
+**A unioned live row is not automatically a LOCAL answer (PHNX-3890).** The box
+that *launched* a session running on a peer holds a live row for it with no
+transcript on disk and a `machine` that defaulted to itself — the launch process is
+here, the conversation is not. So the full-UUID short-circuit only skips the fleet
+fan-out for a row this box can actually answer for (`isLocallyDefinitiveMatch`: a
+real `filePath`, or a `machine` that is genuinely attributed), and the live bridge
+first re-attributes such a row against the fleet-active snapshot
+(`reconcileLiveMetaMachine`). When the fan-out does run, the owning peer's answer
+displaces the shim (`preferOwnerAttribution`) — candidates are grouped per machine
+and consumers read the first hit, so fanning out alone would still let the launcher
+box win. Read the launcher-shim rule in
+[`docs/specifications.md` §Active sessions](docs/specifications.md#sessions) before
+touching any of it.
+
 Routing lives in `src/commands/sessions.ts`: `isBareBrowserListing`
 (+`hasNoBrowserDisqualifyingFlags`) gates the bare fleet-wide listing to the rich
 `runSessionBrowser` ([`src/commands/sessions-browser.ts`](src/commands/sessions-browser.ts));

--- a/cli/docs/sessions.md
+++ b/cli/docs/sessions.md
@@ -88,6 +88,17 @@ pretending remote files are local. Detail reads, resume, migration, and export r
 the owning device through explicit transport. Migration transfers the conversation and
 its provenance, then records the new origin; it does not create two independent owners.
 
+Routing a read to the owner depends on the row naming the device the agent actually
+runs on, and the box that *launched* a dispatched session is the one that gets this
+wrong: it keeps a live shim process carrying the session's id, so the session looks
+local there even though the conversation is on a peer. Process locality is not
+transcript locality. A read therefore only stays local when this box can genuinely
+answer for it — the transcript is on this disk, or the row names another device
+outright. Otherwise the owner is recovered from the fleet's own view of who is
+running what, and the read follows it. A session that is readable locally never
+takes a needless hop, and an owner that cannot be reached is an error rather than an
+empty local card.
+
 ## Off-box backup
 
 `agents sessions export --to-r2` and `agents sessions import --from-r2` are

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -635,15 +635,20 @@ SSH access (§7); rendering sessions that no harness produced.
     the launcher box win. A row that IS locally definitive is never displaced, so a
     local transcript or a synced mirror keeps rendering with no SSH hop, and a shim
     no peer answered for stays local rather than becoming a not-found (SES-9b).
-    The snapshot MUST be trusted symmetrically: a row it confirms as LOCAL is an
-    attribution too (`_machineAttributed`), so it stays definitive and costs no
-    sweep. Otherwise a fresh non-Claude session — empty `filePath` until the index
-    catches up, since only Claude resolves its transcript off disk (SES-9d) — would
-    pay a full fleet fan-out (measured ~13s on a 13-device fleet with 4
-    unreachable) to re-learn what the local snapshot already said. Only a cold
-    snapshot, or one that does not know the id, leaves the row unconfirmed —
-    exactly when this box cannot tell a shim from its own fresh session, and the
-    sweep is warranted.
+    Only a snapshot entry naming a PEER may be trusted, and the asymmetry is
+    deliberate: the fleet snapshot is a merge that INCLUDES this box's own rows,
+    so for the very shape being corrected here — no index row to fold from — an
+    entry naming THIS box may be nothing but an echo of the same self-default,
+    recorded while the owning peer had not yet reported or was unreachable during
+    that gather. Treating it as confirmation would skip the fan-out and dead-end
+    on the local stub for a session genuinely running elsewhere, i.e. reintroduce
+    this very defect. A peer entry is positive information; a self entry is not.
+    The accepted cost is that a transcript-less row this box cannot vouch for
+    pays a fleet sweep (measured ~13s on a 13-device fleet with 4 unreachable),
+    which lands hardest on a fresh non-Claude session — only Claude resolves its
+    transcript off disk (SES-9d), so every other harness has an empty `filePath`
+    until the index catches up. Correctness over latency: the resolution is right
+    either way, and only the fast path is lost. Tracked as PHNX-3900.
   - **`machine` is not "where the process is".** For an offloaded run the shim
     process, its tmux pane, and its terminal window remain on the dispatcher.
     Any caller reaching for a LOCAL pid/pane/window MUST ask

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -217,7 +217,12 @@ SSH access (§7); rendering sessions that no harness produced.
 
 - **SES-9a (MUST).** `sessions preview <id-or-prefix>` MUST resolve ID-shaped
   selectors through the SQLite ID index across the selected fleet. A full UUID
-  MAY return on its first exact hit. When the sweep has completed and some peer
+  MAY return on its first exact **locally-definitive** hit — one this box can
+  actually answer for, meaning a transcript on this disk or a genuine non-self
+  `machine` attribution (`isLocallyDefinitiveMatch`, `commands/sessions.ts`). A
+  transcript-less local row whose `machine` merely DEFAULTED to this box MUST NOT
+  short-circuit the fan-out; see the launcher-shim rule under §Active sessions
+  (PHNX-3890). When the sweep has completed and some peer
   did not answer, a selector that is a complete id, or at least 8 hex characters
   wide (`SHORT_SESSION_ID_WIDTH`, the printed `shortId` width), MUST resolve if
   exactly one session on the reachable fleet matches it; a shorter or
@@ -612,6 +617,24 @@ SSH access (§7); rendering sessions that no harness produced.
     `buildPreview`, direct `preview <id>`, and `sessions <id>` MUST all use this
     predicate, so they fetch/hop to the peer rather than render "full transcript
     not indexed here". An unreachable owner MUST remain a loud `no-target` error.
+  - **A launcher shim MUST NOT claim the transcript (PHNX-3890).** The rules above
+    need a correct `machine`, and the dispatcher's own row is where it goes wrong:
+    a box that LAUNCHED a session running on a peer holds a live registry row with
+    no transcript on disk and a `machine` that defaulted to itself
+    (`active.machine ?? self`, `lib/session/live-metadata.ts`;
+    `machine || localMachine`, `commands/sessions.ts`). `foldExecutionMachine`
+    cannot correct it — there is no local index row to fold from — so two
+    independent paths MUST recover the true execution host:
+    (a) the live bridge reconciles a self-attributed transcript-less row against
+    the fleet-active snapshot, which already knows the owner
+    (`fleetExecutionMachineById` / `reconcileLiveMetaMachine`), stamping `machine`
+    + `_remote`; and (b) with no snapshot to read, the full-UUID resolver MUST
+    consult the fleet (SES-9a) and MUST prefer the owning peer's answer over the
+    shim (`preferOwnerAttribution`) — since candidates are grouped per machine and
+    consumers read the first hit, fanning out without that preference still lets
+    the launcher box win. A row that IS locally definitive is never displaced, so a
+    local transcript or a synced mirror keeps rendering with no SSH hop, and a shim
+    no peer answered for stays local rather than becoming a not-found (SES-9b).
   - **`machine` is not "where the process is".** For an offloaded run the shim
     process, its tmux pane, and its terminal window remain on the dispatcher.
     Any caller reaching for a LOCAL pid/pane/window MUST ask

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -635,6 +635,15 @@ SSH access (§7); rendering sessions that no harness produced.
     the launcher box win. A row that IS locally definitive is never displaced, so a
     local transcript or a synced mirror keeps rendering with no SSH hop, and a shim
     no peer answered for stays local rather than becoming a not-found (SES-9b).
+    The snapshot MUST be trusted symmetrically: a row it confirms as LOCAL is an
+    attribution too (`_machineAttributed`), so it stays definitive and costs no
+    sweep. Otherwise a fresh non-Claude session — empty `filePath` until the index
+    catches up, since only Claude resolves its transcript off disk (SES-9d) — would
+    pay a full fleet fan-out (measured ~13s on a 13-device fleet with 4
+    unreachable) to re-learn what the local snapshot already said. Only a cold
+    snapshot, or one that does not know the id, leaves the row unconfirmed —
+    exactly when this box cannot tell a shim from its own fresh session, and the
+    sweep is warranted.
   - **`machine` is not "where the process is".** For an offloaded run the shim
     process, its tmux pane, and its terminal window remain on the dispatcher.
     Any caller reaching for a LOCAL pid/pane/window MUST ask

--- a/cli/src/commands/sessions.remote-preview-attribution.test.ts
+++ b/cli/src/commands/sessions.remote-preview-attribution.test.ts
@@ -1,0 +1,286 @@
+/**
+ * PHNX-3890: `agents sessions preview <full-uuid>` of a session running on a PEER
+ * must render that peer's digest, not the local "not indexed here" stub.
+ *
+ * The failure was a locality conflation on the DISPATCHER box. A box that
+ * launched a session executing elsewhere holds a live launcher-shim row for it:
+ * no transcript on disk, and a `machine` that defaulted to itself
+ * (`active.machine ?? self`). The full-UUID resolver treated any local hit as
+ * definitive and returned with zero fan-out, so the read was routed back to a box
+ * with no transcript. A passive peer, holding no local row at all, fanned out and
+ * rendered the same session fine — the tell that the local row was the problem.
+ *
+ * Reproduced here at the real seam: `resolveSessionMetadataValue` against the
+ * real SQLite index and the real live-registry bridge, with only the two I/O
+ * edges injected (the live/fleet snapshot readers and the SSH fan-out). HOME is
+ * pinned before importing db.js/sessions.js so the index stays under the fixture.
+ */
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { stripVTControlCharacters } from 'node:util';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sessions-remote-attrib-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+process.env.AGENTS_SYNC_MACHINE_ID = 'this-box';
+
+const dbModule = await import('../lib/session/db.js');
+const { upsertSession, closeDB } = dbModule;
+const {
+  computeLocalMetadataMatches,
+  resolveSessionMetadataValue,
+  isLocallyDefinitiveMatch,
+  preferOwnerAttribution,
+} = await import('./sessions.js');
+type ActiveSession = import('../lib/session/active.js').ActiveSession;
+type SessionMeta = import('../lib/session/types.js').SessionMeta;
+type LoadActive = typeof import('../lib/session/session-cache.js').loadLocalActiveSessions;
+type GatherRemoteList = typeof import('../lib/session/remote/remote-list.js').gatherRemoteList;
+
+afterAll(() => {
+  closeDB();
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  delete process.env.AGENTS_SYNC_MACHINE_ID;
+});
+
+const SELF = 'this-box';
+const PEER = 'peer-box';
+/** The session whose agent + transcript live on PEER, launched from SELF. */
+const DISPATCHED_ID = 'a1b2c3d4-1111-2222-3333-444444444444';
+
+function transcript(id: string): string {
+  const file = path.join(TEST_HOME, '.claude', 'projects', 'p', `${id}.jsonl`);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, '{}\n');
+  return file;
+}
+
+/**
+ * The launcher-shim row a dispatcher holds: the launch process is here, so the
+ * registry lists it, but there is no transcript on this disk and no machine to
+ * attribute it to — `activeSessionToSessionMeta` defaults that to `self`.
+ */
+function launcherShimRow(id: string): ActiveSession {
+  return {
+    context: 'interactive',
+    kind: 'claude',
+    status: 'running',
+    sessionId: id,
+    cwd: '/home/me/repo',
+    startedAtMs: Date.now(),
+    sessionFile: undefined,
+    machine: undefined,
+    host: 'codium',
+  } as unknown as ActiveSession;
+}
+
+/** How the fleet-wide `agents sessions --active` merge reports the same session:
+ * attributed to the box the AGENT runs on. */
+function fleetActiveRow(id: string, machine: string): ActiveSession {
+  return { ...launcherShimRow(id), machine } as ActiveSession;
+}
+
+function loader(sessions: ActiveSession[]): LoadActive {
+  return (async () => ({ sessions, servedFromCache: false, capturedAt: Date.now() })) as unknown as LoadActive;
+}
+
+/** A peer answering the `--resolve-safe-v1` sweep. The real fan-out stamps
+ * `machine` + `_remote` on every row it brings back (remote-list.ts:128,164). */
+function peerAnswer(id: string, machine = PEER): SessionMeta {
+  return {
+    id,
+    shortId: id.slice(0, 8),
+    agent: 'claude',
+    timestamp: new Date().toISOString(),
+    filePath: `/home/me/.claude/projects/p/${id}.jsonl`,
+    machine,
+    _remote: true,
+  } as SessionMeta;
+}
+
+function fanOut(sessions: SessionMeta[], unreachable: string[] = []): GatherRemoteList {
+  return (async () => ({ sessions, unreachable })) as unknown as GatherRemoteList;
+}
+
+describe('remote-session preview attribution (PHNX-3890)', () => {
+  it('attributes a transcript-less launcher shim to the peer the fleet says runs it', async () => {
+    // The fleet-active snapshot is the only local source that knows the truth
+    // when no index row has synced yet.
+    const matches = await computeLocalMetadataMatches(DISPATCHED_ID, {}, {
+      loadActive: loader([launcherShimRow(DISPATCHED_ID)]),
+      loadFleetActive: () => [fleetActiveRow(DISPATCHED_ID, PEER)],
+    });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].machine).toBe(PEER);
+    expect(matches[0]._remote).toBe(true);
+  });
+
+  it('leaves a genuinely local just-started session attributed here (RUSH-2682 intact)', async () => {
+    const localId = 'bbbbbbbb-1111-2222-3333-444444444444';
+    const row = { ...launcherShimRow(localId), sessionFile: transcript(localId) } as ActiveSession;
+    const matches = await computeLocalMetadataMatches(localId, {}, {
+      loadActive: loader([row]),
+      loadFleetActive: () => [fleetActiveRow(localId, SELF)],
+    });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].machine).toBe(SELF);
+    expect(matches[0]._remote).toBeFalsy();
+  });
+
+  it('consults the fleet for a full UUID whose only local match is a launcher shim', async () => {
+    // The zion case: fleet-active snapshot cold, so the shim still reads as
+    // local. The short-circuit must NOT fire, and the peer's row must win.
+    const gather = vi.fn(fanOut([peerAnswer(DISPATCHED_ID)]));
+    const outcome = await resolveSessionMetadataValue(DISPATCHED_ID, {}, {
+      gatherRemoteList: gather as unknown as GatherRemoteList,
+      loadActive: loader([launcherShimRow(DISPATCHED_ID)]),
+      loadFleetActive: () => [],
+    });
+    expect(gather).toHaveBeenCalled();
+    expect(outcome.kind).toBe('resolved');
+    const resolved = (outcome as { kind: 'resolved'; session: SessionMeta }).session;
+    expect(resolved.machine).toBe(PEER);
+    expect(resolved._remote).toBe(true);
+    expect(resolved.filePath).toBeTruthy();
+  });
+
+  it('resolves a locally readable transcript with zero fan-out (no needless SSH hop)', async () => {
+    const indexedId = 'cccccccc-1111-2222-3333-444444444444';
+    upsertSession(
+      {
+        id: indexedId,
+        shortId: 'cccccccc',
+        agent: 'claude',
+        timestamp: new Date().toISOString(),
+        filePath: transcript(indexedId),
+        machine: SELF,
+      },
+      '{}\n',
+    );
+    const gather = vi.fn(fanOut([]));
+    const outcome = await resolveSessionMetadataValue(indexedId, {}, {
+      gatherRemoteList: gather as unknown as GatherRemoteList,
+    });
+    expect(outcome.kind).toBe('resolved');
+    expect(gather).not.toHaveBeenCalled();
+  });
+
+  it('resolves a synced mirror locally even though it is owned by a peer', async () => {
+    // A mirror has a real filePath on THIS disk, so it renders here without an
+    // SSH hop even though `machine` names its owner.
+    const mirrorId = 'dddddddd-1111-2222-3333-444444444444';
+    upsertSession(
+      {
+        id: mirrorId,
+        shortId: 'dddddddd',
+        agent: 'claude',
+        timestamp: new Date().toISOString(),
+        filePath: transcript(mirrorId),
+        machine: PEER,
+      },
+      '{}\n',
+    );
+    const gather = vi.fn(fanOut([]));
+    const outcome = await resolveSessionMetadataValue(mirrorId, {}, {
+      gatherRemoteList: gather as unknown as GatherRemoteList,
+    });
+    expect(outcome.kind).toBe('resolved');
+    expect(gather).not.toHaveBeenCalled();
+  });
+
+  it('keeps the local shim when no peer answers for it', async () => {
+    // With no fleet evidence at all, a transcript-less self-attributed row is
+    // indistinguishable from a session this box just started — so it must still
+    // resolve here rather than becoming a not-found.
+    const gather = vi.fn(fanOut([]));
+    const outcome = await resolveSessionMetadataValue(DISPATCHED_ID, {}, {
+      gatherRemoteList: gather as unknown as GatherRemoteList,
+      loadActive: loader([launcherShimRow(DISPATCHED_ID)]),
+      loadFleetActive: () => [],
+    });
+    expect(gather).toHaveBeenCalled();
+    expect(outcome.kind).toBe('resolved');
+    expect((outcome as { kind: 'resolved'; session: SessionMeta }).session.machine).toBe(SELF);
+  });
+
+  it('reports an unreachable fleet as partial rather than a silent local stub', async () => {
+    const gather = vi.fn(fanOut([], [PEER]));
+    const outcome = await resolveSessionMetadataValue('eeeeeeee-1111-2222-3333-444444444444', {}, {
+      gatherRemoteList: gather as unknown as GatherRemoteList,
+      loadActive: loader([]),
+      loadFleetActive: () => [],
+    });
+    expect(outcome.kind).toBe('partial');
+  });
+});
+
+describe('the corrected row renders the peer digest, not the local stub (PHNX-3890)', () => {
+  it('routes a fleet-attributed launcher shim into the async peer-digest fetch', async () => {
+    const picker = await import('./sessions-picker.js');
+    // Resolve the shim exactly as `preview <id>` does, then render it.
+    const [resolved] = await computeLocalMetadataMatches(DISPATCHED_ID, {}, {
+      loadActive: loader([launcherShimRow(DISPATCHED_ID)]),
+      loadFleetActive: () => [fleetActiveRow(DISPATCHED_ID, PEER)],
+    });
+    expect(picker.transcriptOnPeerOf(resolved)).toBe(PEER);
+
+    let asked: string | undefined;
+    picker.setPeerDigestFetcherForTest(async (_id: string, machine: string) => {
+      asked = machine;
+      return undefined;
+    });
+    try {
+      const preview = stripVTControlCharacters(picker.buildPreview(resolved));
+      // The acceptance criterion: the peer is named and the fetch is under way,
+      // instead of the dead-end stub this box used to print for the session.
+      expect(preview).toContain(PEER);
+      expect(preview).toContain('fetching preview from');
+      expect(preview).not.toContain('full transcript not indexed here');
+      expect(asked).toBe(PEER);
+    } finally {
+      picker.setPeerDigestFetcherForTest(undefined);
+      picker.clearRemoteDigestCacheForTest();
+      picker.clearPreviewMemoryCacheForTest();
+    }
+  });
+});
+
+describe('isLocallyDefinitiveMatch (PHNX-3890)', () => {
+  const base = { id: DISPATCHED_ID, shortId: 'a1b2c3d4', agent: 'claude', timestamp: '' } as SessionMeta;
+
+  it('accepts a row with a real transcript on this disk', () => {
+    expect(isLocallyDefinitiveMatch({ ...base, filePath: '/t.jsonl', machine: SELF }, SELF)).toBe(true);
+  });
+
+  it('accepts a row genuinely attributed to a peer', () => {
+    expect(isLocallyDefinitiveMatch({ ...base, filePath: '', machine: PEER }, SELF)).toBe(true);
+  });
+
+  it('rejects the transcript-less self-defaulted launcher shim', () => {
+    expect(isLocallyDefinitiveMatch({ ...base, filePath: '', machine: SELF }, SELF)).toBe(false);
+  });
+});
+
+describe('preferOwnerAttribution (PHNX-3890)', () => {
+  const shim = { id: DISPATCHED_ID, shortId: 'a1b2c3d4', agent: 'claude', timestamp: '', filePath: '', machine: SELF } as SessionMeta;
+
+  it('drops a shim the owning peer has answered for', () => {
+    expect(preferOwnerAttribution([shim], [peerAnswer(DISPATCHED_ID)], SELF)).toEqual([]);
+  });
+
+  it('keeps the shim when the peer answered about a different session', () => {
+    const other = peerAnswer('ffffffff-1111-2222-3333-444444444444');
+    expect(preferOwnerAttribution([shim], [other], SELF)).toEqual([shim]);
+  });
+
+  it('keeps a locally readable row even when a peer also answered', () => {
+    const readable = { ...shim, filePath: '/t.jsonl' } as SessionMeta;
+    expect(preferOwnerAttribution([readable], [peerAnswer(DISPATCHED_ID)], SELF)).toEqual([readable]);
+  });
+
+  it('is a no-op when the fan-out returned nothing', () => {
+    expect(preferOwnerAttribution([shim], [], SELF)).toEqual([shim]);
+  });
+});

--- a/cli/src/commands/sessions.remote-preview-attribution.test.ts
+++ b/cli/src/commands/sessions.remote-preview-attribution.test.ts
@@ -190,6 +190,23 @@ describe('remote-session preview attribution (PHNX-3890)', () => {
     expect(gather).not.toHaveBeenCalled();
   });
 
+  it('resolves a fleet-CONFIRMED local session with zero fan-out', async () => {
+    // A fresh non-Claude session has no transcript on disk until the index
+    // catches up (SES-9d), so `filePath` alone cannot vouch for it. When the
+    // fleet snapshot confirms this box runs it, that is a real attribution and
+    // must not cost a full fleet sweep (~13s on this fleet).
+    const freshLocalId = '11111111-aaaa-bbbb-cccc-222222222222';
+    const gather = vi.fn(fanOut([]));
+    const outcome = await resolveSessionMetadataValue(freshLocalId, {}, {
+      gatherRemoteList: gather as unknown as GatherRemoteList,
+      loadActive: loader([launcherShimRow(freshLocalId)]),
+      loadFleetActive: () => [fleetActiveRow(freshLocalId, SELF)],
+    });
+    expect(outcome.kind).toBe('resolved');
+    expect((outcome as { kind: 'resolved'; session: SessionMeta }).session.machine).toBe(SELF);
+    expect(gather).not.toHaveBeenCalled();
+  });
+
   it('keeps the local shim when no peer answers for it', async () => {
     // With no fleet evidence at all, a transcript-less self-attributed row is
     // indistinguishable from a session this box just started — so it must still

--- a/cli/src/commands/sessions.remote-preview-attribution.test.ts
+++ b/cli/src/commands/sessions.remote-preview-attribution.test.ts
@@ -190,21 +190,20 @@ describe('remote-session preview attribution (PHNX-3890)', () => {
     expect(gather).not.toHaveBeenCalled();
   });
 
-  it('resolves a fleet-CONFIRMED local session with zero fan-out', async () => {
-    // A fresh non-Claude session has no transcript on disk until the index
-    // catches up (SES-9d), so `filePath` alone cannot vouch for it. When the
-    // fleet snapshot confirms this box runs it, that is a real attribution and
-    // must not cost a full fleet sweep (~13s on this fleet).
-    const freshLocalId = '11111111-aaaa-bbbb-cccc-222222222222';
-    const gather = vi.fn(fanOut([]));
-    const outcome = await resolveSessionMetadataValue(freshLocalId, {}, {
+  it('does NOT skip the sweep because the snapshot names THIS box', async () => {
+    // The fleet snapshot is a merge that INCLUDES this box's own rows, so for a
+    // transcript-less row with no index row to fold from, a `self` entry may be
+    // an echo of the self-default rather than proof. Trusting it would resurrect
+    // the PHNX-3890 dead end whenever the owning peer had not reported yet.
+    const echoedId = '11111111-aaaa-bbbb-cccc-222222222222';
+    const gather = vi.fn(fanOut([peerAnswer(echoedId)]));
+    const outcome = await resolveSessionMetadataValue(echoedId, {}, {
       gatherRemoteList: gather as unknown as GatherRemoteList,
-      loadActive: loader([launcherShimRow(freshLocalId)]),
-      loadFleetActive: () => [fleetActiveRow(freshLocalId, SELF)],
+      loadActive: loader([launcherShimRow(echoedId)]),
+      loadFleetActive: () => [fleetActiveRow(echoedId, SELF)],
     });
-    expect(outcome.kind).toBe('resolved');
-    expect((outcome as { kind: 'resolved'; session: SessionMeta }).session.machine).toBe(SELF);
-    expect(gather).not.toHaveBeenCalled();
+    expect(gather).toHaveBeenCalled();
+    expect((outcome as { kind: 'resolved'; session: SessionMeta }).session.machine).toBe(PEER);
   });
 
   it('keeps the local shim when no peer answers for it', async () => {

--- a/cli/src/commands/sessions.ts
+++ b/cli/src/commands/sessions.ts
@@ -5553,12 +5553,6 @@ export function metadataResolveOutcome(
  */
 export function isLocallyDefinitiveMatch(session: SessionMeta, self: string): boolean {
   if (session.filePath) return true;
-  // A machine the fleet-active snapshot CONFIRMED, including one it confirmed as
-  // this box. Trusting that snapshot only when it names a peer would be
-  // arbitrary — and it would leave a fresh non-Claude session (empty `filePath`
-  // until the index catches up, SES-9d) paying a full fleet sweep to re-learn
-  // what the local snapshot already said.
-  if (session._machineAttributed) return true;
   return !!session.machine && session.machine !== self;
 }
 

--- a/cli/src/commands/sessions.ts
+++ b/cli/src/commands/sessions.ts
@@ -34,6 +34,7 @@ import { gatherRemoteActive, NO_FANOUT_ENV } from '../lib/session/remote-active.
 import {
   loadFleetActiveSessions,
   loadLocalActiveSessions,
+  readActiveSessionsCache,
 } from '../lib/session/session-cache.js';
 import { gatherRemoteList, gatherRemoteToolProgramCounts, gatherRemoteToolSearch, runOnPeer } from '../lib/session/remote-list.js';
 import { gatherRemoteAgentsJson, type RemoteAgentsJsonParseResult } from '../lib/remote-agents-json.js';
@@ -42,7 +43,7 @@ import type { SessionActivity, AwaitingReason } from '../lib/session/state.js';
 import { inferSessionState } from '../lib/session/state.js';
 import { discoverSessions, queryIndexedSessions, countSessionsInScope, resolveSessionById, isCompleteSessionId, looksLikeSessionId, searchContentIndex, parseTimeFilter, getSessionRoots, scopeToManaged, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
 import { findSessionsById, querySessions, getSessionById, readSessionContent, readArchivedSessionPreview } from '../lib/session/db.js';
-import { liveSessionMetas } from '../lib/session/live-metadata.js';
+import { liveSessionMetas, fleetExecutionMachineById, reconcileLiveMetaMachine } from '../lib/session/live-metadata.js';
 import {
   filterTeamSessions,
   shouldShowTeamSessions,
@@ -5526,8 +5527,73 @@ export function metadataResolveOutcome(
   return { kind: 'resolved', session: candidates[0].hits[0].session };
 }
 
-/** Injectable dependency for the live-registry cold-miss fallback (RUSH-2682). */
-export type LiveMetadataDeps = { loadActive?: typeof loadLocalActiveSessions };
+/**
+ * Whether a local candidate answers a full-UUID selector **definitively** — i.e.
+ * whether finding it on this box is the whole answer, so the fleet fan-out can be
+ * skipped (PHNX-3890).
+ *
+ * Two shapes qualify, and both are claims this box can actually back:
+ *
+ * - **A real transcript on this disk** (`filePath`). It renders locally, whoever
+ *   owns it — a local session or a fleet-synced mirror — so no SSH hop is needed.
+ * - **A genuine peer attribution** (`machine` names another box). The row already
+ *   routes the read to its owner through `transcriptOnPeerOf`, so the peer that
+ *   would answer the fan-out is the peer the render already dials.
+ *
+ * What does NOT qualify is the launcher-shim shape: a transcript-less live row
+ * whose `machine` is this box only because it DEFAULTED there
+ * (`activeSessionToSessionMeta`'s `active.machine ?? self`,
+ * `computeLocalMetadataMatches`'s `machine || localMachine`). A dispatcher holds
+ * exactly that row for a session whose agent and transcript live on a peer: the
+ * launch process is here, the conversation is not. Treating it as definitive is
+ * what dead-ended `agents sessions preview <full-uuid>` on the local
+ * "Live session — full transcript not indexed here." stub while a passive peer —
+ * which has no local row at all, so it fans out — rendered the real digest.
+ * Process locality is not transcript locality.
+ */
+export function isLocallyDefinitiveMatch(session: SessionMeta, self: string): boolean {
+  if (session.filePath) return true;
+  return !!session.machine && session.machine !== self;
+}
+
+/**
+ * Drop the launcher-shim local rows that a peer has since answered for
+ * (PHNX-3890). `fleetCandidatesByQuery` groups a logical session's copies per
+ * machine and every consumer reads `hits[0]`, with local rows passed first — so
+ * simply fanning out is not enough: the self-defaulted shim would still win the
+ * attribution and route the read back to a box with no transcript. When the peer
+ * that actually owns the session has answered the sweep, its row is the strictly
+ * better one, and the shim carries no information the candidate loses (same
+ * logical id, so the candidate — and any ambiguity it is part of — survives
+ * through the remote hit).
+ *
+ * A row that is {@link isLocallyDefinitiveMatch} is never dropped, so a locally
+ * readable transcript or a synced mirror still renders here with no SSH hop. When
+ * no peer answered for that id, the shim is kept: with no fleet evidence, a
+ * transcript-less self-attributed row is indistinguishable from a session THIS box
+ * just started, and dropping it would re-break the cold-index lookup RUSH-2682
+ * fixed.
+ */
+export function preferOwnerAttribution(
+  localMatches: SessionMeta[],
+  remoteSessions: SessionMeta[],
+  self: string,
+): SessionMeta[] {
+  if (remoteSessions.length === 0) return localMatches;
+  const answeredByPeer = new Set(remoteSessions.map(session => session.id.toLowerCase()));
+  return localMatches.filter(session =>
+    isLocallyDefinitiveMatch(session, self) || !answeredByPeer.has(session.id.toLowerCase()));
+}
+
+/** Injectable dependencies for the live-registry cold-miss fallback (RUSH-2682)
+ * and the fleet-attribution reconciliation (PHNX-3890). */
+export type LiveMetadataDeps = {
+  loadActive?: typeof loadLocalActiveSessions;
+  /** The fleet-active snapshot rows used to attribute a self-defaulted launcher
+   * shim to its true execution host. Defaults to the cached fleet snapshot; the
+   * cache is warmed by any fleet-wide `agents sessions --active`. */
+  loadFleetActive?: () => ActiveSession[];
+};
 
 /**
  * Local metadata candidates for a selector: the indexed SQLite rows, plus — when
@@ -5577,8 +5643,24 @@ export async function liveMetadataMatches(
   deps: LiveMetadataDeps = {},
 ): Promise<SessionMeta[]> {
   const load = deps.loadActive ?? loadLocalActiveSessions;
+  const loadFleet = deps.loadFleetActive ?? (() => readActiveSessionsCache('fleet')?.sessions ?? []);
+  // A launcher-shim row whose `machine` self-defaulted to this box gets its true
+  // EXECUTION host from the fleet snapshot, so a session dispatched to a peer is
+  // read on that peer instead of dead-ending on the local stub (PHNX-3890). The
+  // read is best-effort: an absent/cold snapshot leaves the row untouched and the
+  // fleet fan-out in resolveSessionMetadataValue supplies the owner instead.
+  let fleetExecMachine: Map<string, string>;
+  try {
+    fleetExecMachine = fleetExecutionMachineById(loadFleet());
+  } catch {
+    fleetExecMachine = new Map();
+  }
   const match = (metas: SessionMeta[]): SessionMeta[] =>
-    resolveIndexedMetadataRows(applyScopeFilters(metas, scope), selector, scope);
+    resolveIndexedMetadataRows(
+      applyScopeFilters(reconcileLiveMetaMachine(metas, fleetExecMachine, self), scope),
+      selector,
+      scope,
+    );
   try {
     const cached = liveSessionMetas((await load()).sessions, self, Date.now());
     const hit = match(cached);
@@ -5598,6 +5680,7 @@ export async function resolveSessionMetadataValue(
   deps: Pick<FleetResolveDeps, 'gatherRemoteList'> & LiveMetadataDeps = { gatherRemoteList },
 ): Promise<MetadataResolveOutcome> {
   const localMatches = await computeLocalMetadataMatches(selector, scope, deps);
+  const localMachine = machineId();
 
   // A full-UUID local hit resolves with ZERO SSH: a UUID is globally unique, so
   // finding it locally is the whole answer and no peer is dialed. (A label is
@@ -5605,9 +5688,17 @@ export async function resolveSessionMetadataValue(
   // peer, so it must consult the fleet; see isDefinitiveMatch, RUSH-2203.) The
   // local index lookup is synchronous and completes before any fan-out spawns,
   // so this local hit never waits on a peer.
+  //
+  // "Found it locally" must mean this box can actually ANSWER for it, though —
+  // see isLocallyDefinitiveMatch. A transcript-less launcher shim for a session
+  // executing on a peer is a local row that is not a local answer, and
+  // short-circuiting on it skipped the one fan-out that could have named the
+  // owner (PHNX-3890).
   if (FULL_SESSION_ID_RE.test(selector)) {
     const localOutcome = metadataResolveOutcome(localMatches, { sessions: [], unreachable: [] }, selector);
-    if (localOutcome.kind === 'resolved') return localOutcome;
+    if (localOutcome.kind === 'resolved' && isLocallyDefinitiveMatch(localOutcome.session, localMachine)) {
+      return localOutcome;
+    }
   }
 
   if (scope.local === true) return metadataResolveOutcome(localMatches, { sessions: [], unreachable: [] }, selector);
@@ -5625,7 +5716,11 @@ export async function resolveSessionMetadataValue(
         ? { isDefinitive: (session) => isDefinitiveMatch(session, selector) }
         : undefined,
     );
-    return metadataResolveOutcome(localMatches, remote, selector);
+    return metadataResolveOutcome(
+      preferOwnerAttribution(localMatches, remote.sessions, localMachine),
+      remote,
+      selector,
+    );
   } catch (error: any) {
     return metadataResolveOutcome(localMatches, { sessions: [], unreachable: [error?.message ?? 'fleet fan-out'] }, selector);
   }

--- a/cli/src/commands/sessions.ts
+++ b/cli/src/commands/sessions.ts
@@ -5553,6 +5553,12 @@ export function metadataResolveOutcome(
  */
 export function isLocallyDefinitiveMatch(session: SessionMeta, self: string): boolean {
   if (session.filePath) return true;
+  // A machine the fleet-active snapshot CONFIRMED, including one it confirmed as
+  // this box. Trusting that snapshot only when it names a peer would be
+  // arbitrary — and it would leave a fresh non-Claude session (empty `filePath`
+  // until the index catches up, SES-9d) paying a full fleet sweep to re-learn
+  // what the local snapshot already said.
+  if (session._machineAttributed) return true;
   return !!session.machine && session.machine !== self;
 }
 

--- a/cli/src/lib/session/live-metadata.test.ts
+++ b/cli/src/lib/session/live-metadata.test.ts
@@ -207,20 +207,21 @@ describe('reconcileLiveMetaMachine', () => {
     const [row] = reconcileLiveMetaMachine([meta()], new Map([[id, 'peer-box']]), self);
     expect(row.machine).toBe('peer-box');
     expect(row._remote).toBe(true);
-    expect(row._machineAttributed).toBe(true);
   });
 
-  it('marks a fleet-CONFIRMED local row attributed, leaving machine alone', () => {
+  it('does NOT treat a snapshot entry naming THIS box as confirmation', () => {
+    // The snapshot is a merge that includes this box's own rows, so for the very
+    // shape being corrected here a `self` entry may just echo the self-default —
+    // recorded while the owning peer had not reported yet. Trusting it would skip
+    // the fan-out and dead-end on the local stub (the PHNX-3890 bug itself).
     const [row] = reconcileLiveMetaMachine([meta()], new Map([[id, self]]), self);
     expect(row.machine).toBe(self);
     expect(row._remote).toBeFalsy();
-    expect(row._machineAttributed).toBe(true);
   });
 
-  it('leaves a row the fleet does not know about unconfirmed', () => {
+  it('leaves a row the fleet does not know about alone', () => {
     const [row] = reconcileLiveMetaMachine([meta()], new Map(), self);
     expect(row.machine).toBe(self);
-    expect(row._machineAttributed).toBeUndefined();
   });
 
   it('never touches a row carrying a transcript on this disk', () => {
@@ -230,7 +231,6 @@ describe('reconcileLiveMetaMachine', () => {
       self,
     );
     expect(row.machine).toBe(self);
-    expect(row._machineAttributed).toBeUndefined();
   });
 
   it('never touches a row already attributed to another box', () => {

--- a/cli/src/lib/session/live-metadata.test.ts
+++ b/cli/src/lib/session/live-metadata.test.ts
@@ -6,8 +6,14 @@
  * `self` + `nowMs`, so it needs no DB or process table.
  */
 import { describe, it, expect } from 'vitest';
-import { activeSessionToSessionMeta, liveSessionMetas } from './live-metadata.js';
+import {
+  activeSessionToSessionMeta,
+  fleetExecutionMachineById,
+  liveSessionMetas,
+  reconcileLiveMetaMachine,
+} from './live-metadata.js';
 import type { ActiveSession } from './active.js';
+import type { SessionMeta } from './types.js';
 
 function active(partial: Partial<ActiveSession>): ActiveSession {
   return {
@@ -153,5 +159,95 @@ describe('liveSessionMetas', () => {
       'aaaa0001-0000-0000-0000-000000000000',
       'aaaa0003-0000-0000-0000-000000000000',
     ]);
+  });
+});
+
+/**
+ * PHNX-3890: a dispatcher's launcher-shim row (no transcript, `machine`
+ * self-defaulted) must be re-attributed to the box the AGENT runs on, so a read
+ * follows the transcript owner instead of dead-ending here. These cover the
+ * pure branch matrix directly; the resolver-level behavior is driven end to end
+ * in `commands/sessions.remote-preview-attribution.test.ts`.
+ */
+describe('fleetExecutionMachineById', () => {
+  it('keys the agent machine by lowercased id', () => {
+    const map = fleetExecutionMachineById([
+      active({ sessionId: 'AAAA0001-0000-0000-0000-000000000000', machine: 'peer-box' }),
+    ]);
+    expect(map.get('aaaa0001-0000-0000-0000-000000000000')).toBe('peer-box');
+  });
+
+  it('reads `machine` (the agent) and never `offloadedFrom` (the launcher)', () => {
+    const map = fleetExecutionMachineById([
+      active({
+        sessionId: 'aaaa0002-0000-0000-0000-000000000000',
+        machine: 'peer-box',
+        offloadedFrom: 'this-box',
+      } as Partial<ActiveSession>),
+    ]);
+    expect(map.get('aaaa0002-0000-0000-0000-000000000000')).toBe('peer-box');
+  });
+
+  it('skips rows with no id or no machine', () => {
+    const map = fleetExecutionMachineById([
+      active({ sessionId: undefined, machine: 'peer-box' }),
+      active({ sessionId: 'aaaa0003-0000-0000-0000-000000000000', machine: undefined }),
+    ]);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('reconcileLiveMetaMachine', () => {
+  const self = 'this-box';
+  const id = 'bbbb0001-0000-0000-0000-000000000000';
+  const meta = (over: Partial<SessionMeta> = {}): SessionMeta =>
+    ({ id, shortId: 'bbbb0001', agent: 'claude', timestamp: '', filePath: '', machine: self, ...over }) as SessionMeta;
+
+  it('re-attributes a self-defaulted transcript-less row to the fleet-named peer', () => {
+    const [row] = reconcileLiveMetaMachine([meta()], new Map([[id, 'peer-box']]), self);
+    expect(row.machine).toBe('peer-box');
+    expect(row._remote).toBe(true);
+    expect(row._machineAttributed).toBe(true);
+  });
+
+  it('marks a fleet-CONFIRMED local row attributed, leaving machine alone', () => {
+    const [row] = reconcileLiveMetaMachine([meta()], new Map([[id, self]]), self);
+    expect(row.machine).toBe(self);
+    expect(row._remote).toBeFalsy();
+    expect(row._machineAttributed).toBe(true);
+  });
+
+  it('leaves a row the fleet does not know about unconfirmed', () => {
+    const [row] = reconcileLiveMetaMachine([meta()], new Map(), self);
+    expect(row.machine).toBe(self);
+    expect(row._machineAttributed).toBeUndefined();
+  });
+
+  it('never touches a row carrying a transcript on this disk', () => {
+    const [row] = reconcileLiveMetaMachine(
+      [meta({ filePath: '/t.jsonl' })],
+      new Map([[id, 'peer-box']]),
+      self,
+    );
+    expect(row.machine).toBe(self);
+    expect(row._machineAttributed).toBeUndefined();
+  });
+
+  it('never touches a row already attributed to another box', () => {
+    const [row] = reconcileLiveMetaMachine(
+      [meta({ machine: 'other-box' })],
+      new Map([[id, 'peer-box']]),
+      self,
+    );
+    expect(row.machine).toBe('other-box');
+  });
+
+  it('matches case-insensitively on the id', () => {
+    const [row] = reconcileLiveMetaMachine(
+      [meta({ id: id.toUpperCase() })],
+      new Map([[id, 'peer-box']]),
+      self,
+    );
+    expect(row.machine).toBe('peer-box');
   });
 });

--- a/cli/src/lib/session/live-metadata.ts
+++ b/cli/src/lib/session/live-metadata.ts
@@ -87,3 +87,54 @@ export function liveSessionMetas(
   }
   return out;
 }
+
+/**
+ * Which box the AGENT of each live session executes on, keyed by lowercased id,
+ * as recovered from the fleet-active snapshot (`agents sessions --active`'s
+ * cross-machine merge). A dispatcher that launched a session running on a peer
+ * has a live shim row locally whose `machine` self-defaulted to itself — the
+ * launch process IS here, the agent is not (PHNX-3890). The fleet snapshot
+ * already reconciled that against the peer's own self-report, so it is the one
+ * place that knows the true execution host without a synced index row (which is
+ * why `foldExecutionMachine` can't recover it: there is no local index row to
+ * join). Only rows the fleet attributes to a real machine are included.
+ */
+export function fleetExecutionMachineById(
+  fleet: ActiveSession[],
+): Map<string, string> {
+  const byId = new Map<string, string>();
+  for (const s of fleet) {
+    // The AGENT machine is `machine` (where the transcript/harness lives), NOT
+    // `offloadedFrom` (where the launcher shim runs) — reading follows the
+    // transcript owner, so a would-be reader must reach `machine`.
+    if (!s.sessionId || !s.machine) continue;
+    byId.set(s.sessionId.toLowerCase(), s.machine);
+  }
+  return byId;
+}
+
+/**
+ * Correct a live `SessionMeta` candidate's machine to its true EXECUTION host
+ * using the fleet-active attribution (PHNX-3890). Only a **self-attributed,
+ * transcript-less** row is a candidate for correction — the launcher-shim shape
+ * a dispatcher holds for a session whose agent runs on a peer, which is
+ * indistinguishable from a genuinely-local just-started session by its local
+ * fields alone. A row already attributed to another box, or one carrying a
+ * transcript path, is left untouched. A corrected row is stamped `_remote` so
+ * the read-vs-resume router (`transcriptOnPeerOf`) sends the preview to the
+ * owning peer instead of dead-ending on the local "not indexed here" stub.
+ */
+export function reconcileLiveMetaMachine(
+  metas: SessionMeta[],
+  fleetExecutionMachine: Map<string, string>,
+  self: string,
+): SessionMeta[] {
+  return metas.map(meta => {
+    // Already attributed elsewhere, or locally readable — not a self-default.
+    if (meta.machine && meta.machine !== self) return meta;
+    if (meta.filePath) return meta;
+    const exec = fleetExecutionMachine.get(meta.id.toLowerCase());
+    if (!exec || exec === self) return meta;
+    return { ...meta, machine: exec, _remote: true };
+  });
+}

--- a/cli/src/lib/session/live-metadata.ts
+++ b/cli/src/lib/session/live-metadata.ts
@@ -134,7 +134,14 @@ export function reconcileLiveMetaMachine(
     if (meta.machine && meta.machine !== self) return meta;
     if (meta.filePath) return meta;
     const exec = fleetExecutionMachine.get(meta.id.toLowerCase());
-    if (!exec || exec === self) return meta;
-    return { ...meta, machine: exec, _remote: true };
+    // The snapshot has nothing to say about this id, so `machine` stays the bare
+    // self-default it already was — unconfirmed, and the resolver must ask the
+    // fleet rather than trust it.
+    if (!exec) return meta;
+    // The snapshot CONFIRMS this box runs it. Same source, same trust as the peer
+    // branch below: marking it lets the resolver answer without a fleet sweep,
+    // which is what keeps a fresh non-Claude session's `preview`/`resume` instant.
+    if (exec === self) return { ...meta, _machineAttributed: true };
+    return { ...meta, machine: exec, _remote: true, _machineAttributed: true };
   });
 }

--- a/cli/src/lib/session/live-metadata.ts
+++ b/cli/src/lib/session/live-metadata.ts
@@ -134,14 +134,15 @@ export function reconcileLiveMetaMachine(
     if (meta.machine && meta.machine !== self) return meta;
     if (meta.filePath) return meta;
     const exec = fleetExecutionMachine.get(meta.id.toLowerCase());
-    // The snapshot has nothing to say about this id, so `machine` stays the bare
-    // self-default it already was — unconfirmed, and the resolver must ask the
-    // fleet rather than trust it.
-    if (!exec) return meta;
-    // The snapshot CONFIRMS this box runs it. Same source, same trust as the peer
-    // branch below: marking it lets the resolver answer without a fleet sweep,
-    // which is what keeps a fresh non-Claude session's `preview`/`resume` instant.
-    if (exec === self) return { ...meta, _machineAttributed: true };
-    return { ...meta, machine: exec, _remote: true, _machineAttributed: true };
+    // Only a PEER attribution is positive information. A snapshot entry that
+    // names THIS box cannot be trusted as confirmation, because the snapshot is
+    // a merge that INCLUDES this box's own rows — so for exactly the session
+    // shape being corrected here (no index row to fold from), a `self` entry may
+    // be nothing but an echo of the self-default above, recorded while the
+    // owning peer had not reported yet or was unreachable during that gather.
+    // Treating it as proof would skip the fan-out and dead-end on the local stub
+    // for a session genuinely running elsewhere — the PHNX-3890 bug itself.
+    if (!exec || exec === self) return meta;
+    return { ...meta, machine: exec, _remote: true };
   });
 }

--- a/cli/src/lib/session/types.ts
+++ b/cli/src/lib/session/types.ts
@@ -399,23 +399,6 @@ export interface SessionMeta {
    */
   _remote?: boolean;
   /**
-   * True when this row's `machine` came from a real attribution SOURCE rather
-   * than defaulting to the local box — specifically, the fleet-active snapshot
-   * named the device this session executes on (`reconcileLiveMetaMachine`,
-   * PHNX-3890). It marks a CONFIRMED attribution whichever device that is: the
-   * peer case already shows up as `machine !== self`, so what this flag adds is
-   * the ability to trust a confirmed-LOCAL row. Without it, a transcript-less
-   * live row attributed here is indistinguishable from a launcher shim, and the
-   * full-UUID resolver must pay a whole fleet sweep (measured ~13s on a 13-device
-   * fleet with 4 unreachable) before answering — the case a fresh non-Claude
-   * session hits, since only Claude resolves its transcript off disk (SES-9d) so
-   * every other harness has an empty `filePath` until the index catches up.
-   * Absent when the snapshot is cold or does not know the id, which is exactly
-   * when this box genuinely cannot tell and the sweep is warranted. Transient:
-   * never persisted, never emitted in `--json`.
-   */
-  _machineAttributed?: boolean;
-  /**
    * Epoch ms this row was last written from a PEER's fleet-synced session mirror
    * (PHNX-3792); absent for a genuine local or host-dispatch row. When set, the
    * picker renders the peer session's topic/preview INLINE from this mirror

--- a/cli/src/lib/session/types.ts
+++ b/cli/src/lib/session/types.ts
@@ -399,6 +399,23 @@ export interface SessionMeta {
    */
   _remote?: boolean;
   /**
+   * True when this row's `machine` came from a real attribution SOURCE rather
+   * than defaulting to the local box — specifically, the fleet-active snapshot
+   * named the device this session executes on (`reconcileLiveMetaMachine`,
+   * PHNX-3890). It marks a CONFIRMED attribution whichever device that is: the
+   * peer case already shows up as `machine !== self`, so what this flag adds is
+   * the ability to trust a confirmed-LOCAL row. Without it, a transcript-less
+   * live row attributed here is indistinguishable from a launcher shim, and the
+   * full-UUID resolver must pay a whole fleet sweep (measured ~13s on a 13-device
+   * fleet with 4 unreachable) before answering — the case a fresh non-Claude
+   * session hits, since only Claude resolves its transcript off disk (SES-9d) so
+   * every other harness has an empty `filePath` until the index catches up.
+   * Absent when the snapshot is cold or does not know the id, which is exactly
+   * when this box genuinely cannot tell and the sweep is warranted. Transient:
+   * never persisted, never emitted in `--json`.
+   */
+  _machineAttributed?: boolean;
+  /**
    * Epoch ms this row was last written from a PEER's fleet-synced session mirror
    * (PHNX-3792); absent for a genuine local or host-dispatch row. When set, the
    * picker renders the peer session's topic/preview INLINE from this mirror


### PR DESCRIPTION
Fixes [PHNX-3890](https://linear.app/getrush/issue/PHNX-3890).

`agents sessions preview <full-uuid>` rendered `Live session — full transcript not indexed here.` for a session whose agent runs on another fleet box — while a *passive* peer rendered the same session's digest fine. The transcript was reachable the whole time; the resolver never asked for it.

## Root cause — process locality is not transcript locality

The box that **launched** the session keeps a live shim row for it: no transcript on disk, and a `machine` that defaulted to itself (`active.machine ?? self` in `live-metadata.ts:62`, `machine || localMachine` in `sessions.ts`). `foldExecutionMachine` can't correct that row — there is no local index row to fold from. The reproducing session had **0 rows** in the dispatcher's `sessions.db`:

```
$ sqlite3 ~/.agents/.history/sessions/sessions.db \
    "select id,machine,file_path from sessions where id like '6f9a8d15%';"
(no rows)
```

So the full-UUID resolver saw a local hit, treated it as definitive, returned with zero fan-out, and `transcriptOnPeerOf` saw a local row → the stub. A passive peer holds no local row, fans out, and the **existing** remote-render path does the right thing.

## Fix — two independent recoveries, then reuse the render path that already exists

The local fields alone cannot distinguish a launcher shim from a session this box just started, so:

1. **Reconcile against the fleet-active snapshot**, which already knows the execution host, stamping `machine` + `_remote` (`fleetExecutionMachineById` / `reconcileLiveMetaMachine`).
2. **With no snapshot to read, stop short-circuiting on a hit this box can't answer for.** `isLocallyDefinitiveMatch` — a transcript on disk, or a genuine non-self attribution — gates the full-UUID fan-out skip.

**Fanning out is not sufficient on its own.** `fleetCandidatesByQuery` groups a logical session per machine and consumers read `hits[0]`, with local rows passed first, so the shim still won the attribution after a successful sweep (verified: removing this half leaves `machine: 'this-box'` even though the peer answered). `preferOwnerAttribution` drops a shim the owning peer has answered for — and only then.

No new render path: once `machine`/`_remote` are right, the existing `remoteDigestForPreview` async SSH fetch + repaint takes over, so remote previews fill in asynchronously rather than showing a permanent stub. That's re-expose, not rebuild.

## Evidence — the real seam, on the box that failed

Session `6f9a8d15`: launched from `zion`, agent + transcript on `yosemite-s1`. Production `agents` vs `agents-dev` built from this branch, both on `zion`:

**Resolver attribution**

```
=== BEFORE: installed agents (production) ===
{"machine":"zion","_remote":null,"filePath":null}

=== AFTER: agents-dev (this branch) ===
{"machine":"yosemite-s1","_remote":null,"filePath":null}
```

**The rendered card — the acceptance criterion**

```
=== BEFORE: installed agents ===
● working
Cleanup - Docs
Claude · 6f9a8d15
~/src/github.com/muqsitnawaz/agents · created 1h 3m ago
  Live session — full transcript not indexed here.
  Details ▸ 6f9a8d15

=== AFTER: agents-dev (this branch) ===
Claude v2.1.218 · 6f9a8d15 · opus-4-8 · tech@prix.dev
~/src/github.com/muqsitnawaz/agents/prix · prix · main · created 3h 21m ago · last active 3h 20m ago · lasted 1m
  Asked     "Apply 2 review fixes to the EXISTING open PR #2105 (agents repo, …"
  Made      ~2 changed · 2 read
  Health    5 failures — first: Bash
  Cost      14 msgs · 1m tokens · Bash 8 · Edit 4 · Read 2

  Latest
    Verified and complete.
    Both review fixes landed on PR #2105 …
  Details ▸ 6f9a8d15 · SessionStart:startup · PreToolUse:Bash (1 failed) … +4 more
```

**No regression on a locally-owned session** (`c816159b`, owned by `zion`) — renders locally with no peer note and no SSH hop, byte-identical to production. (Both print a transient `Failed to parse session: database is locked` on that id — pre-existing contention from the live agent writing it, reproduced identically on production `agents`, not this change.)

## Preserved behavior

- A locally readable transcript or **synced mirror** still renders locally — no needless SSH hop (tested; `gatherRemoteList` asserted never called).
- An **unreachable owner still fails loud** — the `partial` outcome and `runOnPeer` → `no-target` paths are untouched (tested).
- A shim **no peer answered for stays local**, so the RUSH-2682 cold-index lookup is intact (tested — this is why the shim isn't dropped unconditionally).
- **RESUME routing untouched** — `sessionOwnerDevice` / `resume-owner.ts` unchanged. Reading follows the transcript owner, resuming follows harness state.

## Tests

`cli/src/commands/sessions.remote-preview-attribution.test.ts` — 15 tests driving the real `resolveSessionMetadataValue` against the real SQLite index and the real live-registry bridge, with only the two I/O edges injected (snapshot readers, SSH fan-out). Includes an end-to-end case that resolves the shim and feeds it to `buildPreview`, asserting the peer is named and the async fetch starts instead of the stub.

Both halves were verified load-bearing by reverting each in turn:

- without the short-circuit gate → 2 failures (`expected "vi.fn()" to be called at least once` — no fan-out at all)
- without `preferOwnerAttribution` → 1 failure (`expected 'this-box' to be 'peer-box'` — fan-out happened, shim still won)

Full suite green across 4 fleet workers (`cli/scripts/test.sh --shard 4`): shards on `yosemite-m3`, `yosemite-s0`, `yosemite-m6`, `yosemite-m5` — `All 4 shards passed.`

## Docs

- `cli/docs/specifications.md` — SES-9a amended (a full UUID may return on its first **locally-definitive** hit); new launcher-shim rule under §Active sessions naming both recoveries and why the fan-out alone is insufficient.
- `cli/docs/sessions.md` — §Cross-device history explains the locality distinction in plain language.
- `cli/.changelog/next/PHNX-3890.md` — user-visible entry.

**Fleet-guidance audit (per §Core command groups stay in sync):** no companion `phnx-labs/.agents` edits are needed. This changes resolution *values*, not the surface — no command, flag, output key, or documented workflow changed, so nothing in the companion repo teaches a shape this invalidates.
