### PR TITLE
fix(sync): managed ignores go to .git/info/exclude, stop dirtying tracked .gitignore (PHNX-3718)

### DIFF
--- a/cli/.changelog/next/PHNX-3718.md
+++ b/cli/.changelog/next/PHNX-3718.md
@@ -1,0 +1,15 @@
+- **Launching an agent no longer dirties your tracked `.gitignore` (PHNX-3718).**
+  The per-harness resource sync self-manages ignore rules for the generated
+  `.claude/`, `.cursor/`, `.codex/`, … dirs it writes on every launch. Those
+  rules used to be written into the tracked `<project>/.gitignore`, but they are
+  never committed upstream — so every launch left the repo with a permanent
+  `M .gitignore` (one managed block per harness that had run there) that in turn
+  blocked `git pull` with *"local changes to .gitignore would be overwritten by
+  merge"*. The managed block now lives in `.git/info/exclude` (git's per-clone,
+  uncommitted ignore file, resolved via `git rev-parse --git-path info/exclude`
+  so it works from a subdir, linked worktree, or submodule), keeping the
+  generated dirs hidden while leaving the working tree clean. On the next launch,
+  a repo already dirtied by the old behavior self-heals: the leftover managed
+  block is stripped from the tracked `.gitignore` (hand-written rules untouched;
+  an untracked file that held only our block is removed). Source:
+  `cli/src/lib/project-resources.ts`.

--- a/cli/docs/resource-sync.md
+++ b/cli/docs/resource-sync.md
@@ -100,10 +100,19 @@ project resources. If a destination exists after manifest-owned paths are
 removed, it is yours: agents-cli leaves it exactly as it is and reports it once
 per sync as a single grouped line (`Kept 6 of your own files in
 .claude/commands: debug.md, doc-gaps.md, image-nbp.md, +3 more`) rather than one
-warning per file. The
-generated `.<agent>/` directory is intentionally not auto-added to `.gitignore`;
-projects that do not want to commit generated agent resources should ignore it
-themselves.
+warning per file.
+
+The generated `.<agent>/` directory is a regenerable copy, so agents-cli keeps it
+out of `git status` for you — but never by touching a tracked file. It maintains a
+per-agent, marker-fenced block listing exactly the paths it manages in
+**`.git/info/exclude`** (git's per-clone, uncommitted ignore file), resolved with
+`git rev-parse --git-path info/exclude` so it lands correctly from a subdirectory,
+a linked worktree, or a submodule. It is deliberately **not** written to the
+tracked `.gitignore`: those entries are never committed upstream, so a
+`.gitignore` block left every launch with a permanent `M .gitignore` that blocked
+`git pull` (PHNX-3718). A repo dirtied by that earlier behavior self-heals on the
+next launch — the leftover block is stripped from `.gitignore` and moved to
+`info/exclude`. Outside a git repo the whole step is a no-op.
 
 ## Sync Targets: Version Selectors, Repo Scoping, and Kind Filtering
 

--- a/cli/src/lib/project-resources.test.ts
+++ b/cli/src/lib/project-resources.test.ts
@@ -236,35 +236,62 @@ describe('formatKeptProjectResources', () => {
   });
 });
 
-describe('syncProjectResourcesToAgent — self-managed .gitignore', () => {
-  // Build a project that is a git repo (has .git) with one project command.
-  function makeRepoWithCommand(): { project: string; projectAgentsDir: string; gitignore: string } {
+describe('syncProjectResourcesToAgent — self-managed ignores in .git/info/exclude', () => {
+  const CURSOR_BEGIN = '# >>> agents-cli project resources: cursor (generated on launch — do not edit) >>>';
+  const CURSOR_END = '# <<< agents-cli project resources: cursor <<<';
+
+  function initRepo(project: string): (...args: string[]) => string {
+    fs.mkdirSync(project, { recursive: true });
+    const git = (...args: string[]) => execFileSync('git', ['-C', project, ...args], { encoding: 'utf-8' });
+    git('init', '-q');
+    git('config', 'user.email', 'demo@x.co');
+    git('config', 'user.name', 'demo');
+    return git;
+  }
+
+  // Build a real git repo with one project command. Managed ignores now land in
+  // `.git/info/exclude`, so the helper hands back that path — and the .git dir
+  // must be a genuine repo (git rev-parse resolves the exclude path), not a
+  // faked empty `.git` directory.
+  function makeRepoWithCommand(): {
+    project: string;
+    projectAgentsDir: string;
+    excludePath: string;
+    gitignore: string;
+    git: (...args: string[]) => string;
+  } {
     const project = makeTempProject();
+    const git = initRepo(project);
     const projectAgentsDir = path.join(project, '.agents');
-    fs.mkdirSync(path.join(project, '.git'), { recursive: true });
     const command = path.join(projectAgentsDir, 'commands', 'ping.md');
     fs.mkdirSync(path.dirname(command), { recursive: true });
     fs.writeFileSync(command, 'Ping from the project.', 'utf-8');
-    return { project, projectAgentsDir, gitignore: path.join(project, '.gitignore') };
+    return {
+      project,
+      projectAgentsDir,
+      git,
+      excludePath: path.join(project, '.git', 'info', 'exclude'),
+      gitignore: path.join(project, '.gitignore'),
+    };
   }
 
-  it('ignores the generated per-harness dir, anchored and scoped to that dir', () => {
-    const { project, projectAgentsDir, gitignore } = makeRepoWithCommand();
+  it('ignores the generated per-harness dir in .git/info/exclude, never the tracked .gitignore', () => {
+    const { projectAgentsDir, excludePath, gitignore } = makeRepoWithCommand();
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
 
-    const gi = fs.readFileSync(gitignore, 'utf-8');
-    expect(gi).toContain('# >>> agents-cli project resources: cursor');
-    expect(gi).toContain('# <<< agents-cli project resources: cursor <<<');
-    // Every entry is anchored (/) and lives under the harness root — never
-    // outside it, and never a bare unanchored root that could match elsewhere.
-    const entries = gi.split('\n').filter((l) => l.startsWith('/'));
+    const excl = fs.readFileSync(excludePath, 'utf-8');
+    expect(excl).toContain(CURSOR_BEGIN);
+    expect(excl).toContain(CURSOR_END);
+    // Every managed entry is anchored (/) and lives under the harness root.
+    const entries = excl.split('\n').filter((l) => l.startsWith('/'));
     expect(entries.length).toBeGreaterThan(0);
     for (const e of entries) expect(e.startsWith('/.cursor/')).toBe(true);
-    // The generated file is actually covered by an entry.
-    expect(gi).toContain('/.cursor/commands/ping.md');
+    expect(excl).toContain('/.cursor/commands/ping.md');
+    // The tracked .gitignore is never touched — that was the whole bug (PHNX-3718).
+    expect(fs.existsSync(gitignore)).toBe(false);
   });
 
-  it('does NOT create a .gitignore in a non-git directory', () => {
+  it('does NOT write any ignore file outside a git repo', () => {
     const project = makeTempProject();
     const projectAgentsDir = path.join(project, '.agents');
     const command = path.join(projectAgentsDir, 'commands', 'ping.md');
@@ -273,63 +300,55 @@ describe('syncProjectResourcesToAgent — self-managed .gitignore', () => {
 
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
     expect(fs.existsSync(path.join(project, '.gitignore'))).toBe(false);
+    expect(fs.existsSync(path.join(project, '.git'))).toBe(false);
   });
 
-  it('amends an existing .gitignore, preserving hand-written rules', () => {
-    const { projectAgentsDir, gitignore } = makeRepoWithCommand();
-    fs.writeFileSync(gitignore, 'node_modules/\n.env\n', 'utf-8');
+  it('preserves git\'s default info/exclude content and any hand-written excludes', () => {
+    const { projectAgentsDir, excludePath } = makeRepoWithCommand();
+    // git init already wrote a default header into info/exclude; add a rule too.
+    fs.appendFileSync(excludePath, 'scratch/\n');
+    const before = fs.readFileSync(excludePath, 'utf-8');
 
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
-    const gi = fs.readFileSync(gitignore, 'utf-8');
-    expect(gi).toContain('node_modules/');
-    expect(gi).toContain('.env');
-    expect(gi).toContain('# >>> agents-cli project resources: cursor');
-    // Hand-written rules come first, the managed block is appended after them.
-    expect(gi.indexOf('node_modules/')).toBeLessThan(gi.indexOf('# >>> agents-cli'));
+    const excl = fs.readFileSync(excludePath, 'utf-8');
+    // Everything that was there survives, and the managed block is appended after it.
+    expect(excl.startsWith(before.replace(/\n+$/, ''))).toBe(true);
+    expect(excl).toContain('scratch/');
+    expect(excl).toContain(CURSOR_BEGIN);
+    expect(excl.indexOf('scratch/')).toBeLessThan(excl.indexOf(CURSOR_BEGIN));
   });
 
-  it('is idempotent — a second sync leaves .gitignore byte-for-byte identical', () => {
-    const { projectAgentsDir, gitignore } = makeRepoWithCommand();
+  it('is idempotent — a second sync leaves info/exclude byte-for-byte identical', () => {
+    const { projectAgentsDir, excludePath } = makeRepoWithCommand();
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
-    const first = fs.readFileSync(gitignore, 'utf-8');
+    const first = fs.readFileSync(excludePath, 'utf-8');
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
-    const second = fs.readFileSync(gitignore, 'utf-8');
+    const second = fs.readFileSync(excludePath, 'utf-8');
     expect(second).toBe(first);
   });
 
   it('drops resource entries but keeps the manifest ignored when the source resources are gone', () => {
-    const { projectAgentsDir, gitignore } = makeRepoWithCommand();
+    const { projectAgentsDir, excludePath } = makeRepoWithCommand();
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
-    expect(fs.readFileSync(gitignore, 'utf-8')).toContain('/.cursor/commands/ping.md');
+    expect(fs.readFileSync(excludePath, 'utf-8')).toContain('/.cursor/commands/ping.md');
 
     // Remove the project command, then re-sync. The sync still leaves an
     // (emptied) .agents-managed.json in the harness dir, so the block must NOT
     // vanish — it shrinks to just the manifest entry, keeping the dir clean.
     fs.rmSync(path.join(projectAgentsDir, 'commands', 'ping.md'));
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
-    const gi = fs.readFileSync(gitignore, 'utf-8');
-    expect(gi).not.toContain('/.cursor/commands/ping.md');
-    expect(gi).toContain('/.cursor/.agents-managed.json');
-  });
-
-  it('keeps a hand-written rule intact when resources are removed', () => {
-    const { projectAgentsDir, gitignore } = makeRepoWithCommand();
-    fs.writeFileSync(gitignore, 'dist/\n', 'utf-8');
-    syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
-    fs.rmSync(path.join(projectAgentsDir, 'commands', 'ping.md'));
-    syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
-    const gi = fs.readFileSync(gitignore, 'utf-8');
-    expect(gi).toContain('dist/');
-    expect(gi).not.toContain('/.cursor/commands/ping.md');
+    const excl = fs.readFileSync(excludePath, 'utf-8');
+    expect(excl).not.toContain('/.cursor/commands/ping.md');
+    expect(excl).toContain('/.cursor/.agents-managed.json');
   });
 
   it('managedGitignoreEntries drops any path that escapes the harness dir', () => {
     // grok writes commands back into the tracked .agents/ tree via a ../ subdir
     // (commandsSubdir = ../.agents/commands). Ignoring tracked source is exactly
     // the wrong move — the escape guard must drop those, keep in-root paths.
-    const projectRoot = path.join(os.tmpdir(), 'proj');
-    const agentRoot = path.join(projectRoot, '.grok');
-    const entries = managedGitignoreEntries(agentRoot, projectRoot, [
+    const referenceRoot = path.join(os.tmpdir(), 'proj');
+    const agentRoot = path.join(referenceRoot, '.grok');
+    const entries = managedGitignoreEntries(agentRoot, referenceRoot, [
       'commands/ok.md',
       path.join('..', '.agents', 'commands', 'leak.md'),
       path.join('..', '..', 'outside.md'),
@@ -340,72 +359,81 @@ describe('syncProjectResourcesToAgent — self-managed .gitignore', () => {
     expect(entries).toHaveLength(1);
   });
 
+  it('anchors entries at the WORKTREE root for a repo whose .agents lives in a subdir', () => {
+    // A monorepo subdir carries its own .agents/ while .git is a level up. An
+    // info/exclude pattern anchors at the worktree TOP, so the entry must be
+    // /sub/.cursor/…, not /.cursor/… (which would anchor at the wrong dir).
+    const repo = makeTempProject();
+    initRepo(repo);
+    const sub = path.join(repo, 'sub');
+    const projectAgentsDir = path.join(sub, '.agents');
+    const command = path.join(projectAgentsDir, 'commands', 'ping.md');
+    fs.mkdirSync(path.dirname(command), { recursive: true });
+    fs.writeFileSync(command, 'Ping.', 'utf-8');
+
+    syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
+    const excl = fs.readFileSync(path.join(repo, '.git', 'info', 'exclude'), 'utf-8');
+    expect(excl).toContain('/sub/.cursor/commands/ping.md');
+    expect(excl).toContain('/sub/.cursor/.agents-managed.json');
+  });
+
   it('re-syncing one harness does not reorder another harness block (no churn)', () => {
     // The blocker regression: strip-then-append moved the re-synced agent's
     // block to the end, bumping the other agent every launch. In-place
-    // replacement must leave a multi-harness .gitignore byte-stable.
+    // replacement must leave a multi-harness info/exclude byte-stable.
     const project = makeTempProject();
+    initRepo(project);
     const projectAgentsDir = path.join(project, '.agents');
-    fs.mkdirSync(path.join(project, '.git'), { recursive: true });
     const command = path.join(projectAgentsDir, 'commands', 'ping.md');
     fs.mkdirSync(path.dirname(command), { recursive: true });
     fs.writeFileSync(command, 'Ping.', 'utf-8');
     const skillDir = path.join(projectAgentsDir, 'skills', 'myskill');
     fs.mkdirSync(skillDir, { recursive: true });
     fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'Project skill.', 'utf-8');
-    const gitignore = path.join(project, '.gitignore');
+    const excludePath = path.join(project, '.git', 'info', 'exclude');
 
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
     syncProjectResourcesToAgent('opencode', '1.0.0', projectAgentsDir);
-    const afterBoth = fs.readFileSync(gitignore, 'utf-8');
-    // Both harness blocks are present.
+    const afterBoth = fs.readFileSync(excludePath, 'utf-8');
     expect(afterBoth).toContain('agents-cli project resources: cursor');
     expect(afterBoth).toContain('agents-cli project resources: opencode');
 
     // Re-sync the first harness: the file must not change at all.
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
-    expect(fs.readFileSync(gitignore, 'utf-8')).toBe(afterBoth);
+    expect(fs.readFileSync(excludePath, 'utf-8')).toBe(afterBoth);
     // And re-syncing the second is also a no-op.
     syncProjectResourcesToAgent('opencode', '1.0.0', projectAgentsDir);
-    expect(fs.readFileSync(gitignore, 'utf-8')).toBe(afterBoth);
+    expect(fs.readFileSync(excludePath, 'utf-8')).toBe(afterBoth);
   });
 
-  it('never truncates the file when the managed block has an orphaned begin marker', () => {
-    const { projectAgentsDir, gitignore } = makeRepoWithCommand();
+  it('never truncates info/exclude when the managed block has an orphaned begin marker', () => {
+    const { projectAgentsDir, excludePath } = makeRepoWithCommand();
     // A begin marker with NO matching end (hand-truncated / botched merge),
     // with a legitimate hand-written rule below it.
-    const orphaned =
-      'node_modules/\n' +
-      '# >>> agents-cli project resources: cursor (generated on launch — do not edit) >>>\n' +
-      '/.cursor/commands/ping.md\n' +
-      'dist/\n';
-    fs.writeFileSync(gitignore, orphaned, 'utf-8');
+    const orphaned = `node_modules/\n${CURSOR_BEGIN}\n/.cursor/commands/ping.md\ndist/\n`;
+    fs.writeFileSync(excludePath, orphaned, 'utf-8');
 
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
-    const gi = fs.readFileSync(gitignore, 'utf-8');
+    const excl = fs.readFileSync(excludePath, 'utf-8');
     // The hand-written rule below the orphaned marker must survive untouched.
-    expect(gi).toContain('dist/');
-    expect(gi).toContain('node_modules/');
+    expect(excl).toContain('dist/');
+    expect(excl).toContain('node_modules/');
   });
 
   it('ignores the .agents-managed.json manifest too, not just the synced resources', () => {
-    const { projectAgentsDir, gitignore } = makeRepoWithCommand();
+    const { projectAgentsDir, excludePath } = makeRepoWithCommand();
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
     // The manifest file the sync writes into the harness dir must be ignored —
     // otherwise the dir still shows as untracked on the strength of that one file.
-    expect(fs.readFileSync(gitignore, 'utf-8')).toContain('/.cursor/.agents-managed.json');
+    expect(fs.readFileSync(excludePath, 'utf-8')).toContain('/.cursor/.agents-managed.json');
   });
 
-  it('leaves the whole generated harness dir clean in a REAL git status (the actual goal)', () => {
-    // The assertion the earlier tests missed: not "a block exists" but "git no
-    // longer reports the harness dir". Uses a real git repo so gitignore is
-    // actually evaluated over every file the sync wrote, manifest included.
+  it('leaves the whole generated harness dir clean in a REAL git status, tree untouched', () => {
+    // The actual goal: git reports NOTHING new — not the .cursor/ dir, and not
+    // a .gitignore (the PHNX-3718 regression). info/exclude lives inside .git,
+    // so it never shows in status.
     const project = makeTempProject();
-    fs.mkdirSync(project, { recursive: true });
-    const git = (...args: string[]) => execFileSync('git', args, { cwd: project }).toString();
-    git('init', '-q');
-    git('config', 'user.email', 'demo@x.co');
-    git('config', 'user.name', 'demo');
+    const git = initRepo(project);
     const projectAgentsDir = path.join(project, '.agents');
     const command = path.join(projectAgentsDir, 'commands', 'ping.md');
     fs.mkdirSync(path.dirname(command), { recursive: true });
@@ -418,18 +446,61 @@ describe('syncProjectResourcesToAgent — self-managed .gitignore', () => {
 
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
 
-    const status = git('status', '--porcelain').split('\n').filter(Boolean);
-    // The generated .cursor/ dir (commands, skills, AND its manifest) is fully
-    // ignored — the only new untracked path is .gitignore itself.
-    expect(status.some((l) => l.includes('.cursor'))).toBe(false);
-    expect(status.every((l) => l.includes('.gitignore'))).toBe(true);
+    // A completely clean tree: no .cursor/, no .gitignore, nothing.
+    expect(git('status', '--porcelain').trim()).toBe('');
 
-    // Manifest-only state: remove every source resource and resync, so .cursor/
-    // holds just .agents-managed.json. It must STILL be clean in real git.
+    // Manifest-only state: remove every source resource and resync. Still clean.
     fs.rmSync(path.join(projectAgentsDir, 'commands', 'ping.md'));
     fs.rmSync(skillDir, { recursive: true });
     syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
+    // (The committed .agents lost two files, so status shows those deletions —
+    //  but nothing generated leaks in.)
     const after = git('status', '--porcelain').split('\n').filter(Boolean);
     expect(after.some((l) => l.includes('.cursor'))).toBe(false);
+    expect(after.some((l) => l.includes('.gitignore'))).toBe(false);
+  });
+
+  describe('migration off the legacy tracked-.gitignore location (PHNX-3718)', () => {
+    it('strips this agent\'s leftover block from a tracked .gitignore and moves it to info/exclude', () => {
+      const { project, projectAgentsDir, gitignore, excludePath, git } = makeRepoWithCommand();
+      // Commit real hand-written rules, then simulate the OLD behavior: append
+      // our managed block, dirtying the committed file (the bug that blocked git pull).
+      fs.writeFileSync(gitignore, 'node_modules/\n.env\n', 'utf-8');
+      git('add', '.gitignore');
+      git('commit', '-qm', 'gitignore');
+      fs.appendFileSync(
+        gitignore,
+        `\n${CURSOR_BEGIN}\n/.cursor/commands/ping.md\n/.cursor/.agents-managed.json\n${CURSOR_END}\n`,
+      );
+      expect(git('status', '--porcelain')).toContain('.gitignore');
+
+      syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
+
+      // The tracked file is back to exactly its committed content — clean tree.
+      expect(fs.readFileSync(gitignore, 'utf-8')).toBe('node_modules/\n.env\n');
+      expect(git('status', '--porcelain').split('\n').filter(Boolean).some((l) => l.includes('.gitignore'))).toBe(false);
+      // The block now lives in info/exclude instead.
+      expect(fs.readFileSync(excludePath, 'utf-8')).toContain('/.cursor/commands/ping.md');
+      // Unused variable guard.
+      expect(project).toBeTruthy();
+    });
+
+    it('removes an untracked .gitignore that held only the old managed block', () => {
+      const { projectAgentsDir, gitignore } = makeRepoWithCommand();
+      // The old code, in a repo with no prior .gitignore, wrote a file whose
+      // only content was our block. Migration must delete it, not leave an
+      // empty `?? .gitignore`.
+      fs.writeFileSync(gitignore, `${CURSOR_BEGIN}\n/.cursor/commands/ping.md\n${CURSOR_END}\n`, 'utf-8');
+      syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
+      expect(fs.existsSync(gitignore)).toBe(false);
+    });
+
+    it('leaves a foreign .gitignore untouched (only strips our own fenced block)', () => {
+      const { projectAgentsDir, gitignore } = makeRepoWithCommand();
+      fs.writeFileSync(gitignore, 'dist/\ncoverage/\n', 'utf-8');
+      syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
+      // No block of ours was there, so the file is left exactly as written.
+      expect(fs.readFileSync(gitignore, 'utf-8')).toBe('dist/\ncoverage/\n');
+    });
   });
 });

--- a/cli/src/lib/project-resources.ts
+++ b/cli/src/lib/project-resources.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { AGENTS, agentConfigDirName, isAgentHardDeprecated } from './agents.js';
@@ -62,10 +63,14 @@ export function syncProjectResourcesToAgent(
     // .agents/{commands,skills,…}, refreshed on every launch. Left untracked it
     // dirties `git status` and can block `git merge`/`checkout` when a stray
     // commit of the same path collides. So the generator owns its ignore rule:
-    // reconcile a per-agent marker block in <projectRoot>/.gitignore listing
-    // exactly the paths it manages. Passing the manifest set (empty when a sync
-    // clears a harness) also prunes the block. See PHNX-3717.
-    reconcileProjectGitignore(projectRoot, agent, agentRoot, Array.from(next).sort());
+    // reconcile a per-agent marker block listing exactly the paths it manages.
+    // That block lives in `.git/info/exclude` — git's per-clone, uncommitted
+    // ignore file — NOT the tracked `.gitignore`: these entries are never
+    // committed upstream, so writing them into `.gitignore` left every launch
+    // with a permanent `M .gitignore` that blocked `git pull` (PHNX-3718).
+    // Passing the manifest set (empty when a sync clears a harness) also prunes
+    // the block. See PHNX-3717 for the self-managed-ignore feature.
+    reconcileManagedIgnore(projectRoot, agent, agentRoot, Array.from(next).sort());
   }
 
   return result;
@@ -101,7 +106,11 @@ function gitignoreMarkers(agent: AgentId): { begin: string; end: string } {
 
 /**
  * Turn the manifest's managed paths (relative to agentRoot) into anchored,
- * POSIX, projectRoot-relative `.gitignore` entries. Two guards keep it honest:
+ * POSIX, `referenceRoot`-relative ignore entries. `referenceRoot` is the
+ * directory the anchored `/…` patterns resolve against — the git worktree root
+ * for a `.git/info/exclude` block, since git anchors info/exclude patterns at
+ * the top of the working tree (not at the harness dir). Two guards keep it
+ * honest:
  *   - drop any path that escapes the harness config dir (e.g. grok writes
  *     commands back into the tracked `.agents/` tree via a `../` subdir —
  *     ignoring that would hide tracked source; separate bug, PHNX-3718);
@@ -110,37 +119,71 @@ function gitignoreMarkers(agent: AgentId): { begin: string; end: string } {
  *     these never masks a hand-authored or committed file (e.g. a repo that
  *     commits its own `.claude/CLAUDE.md` keeps it — it is not in the manifest).
  */
-export function managedGitignoreEntries(agentRoot: string, projectRoot: string, managed: string[]): string[] {
+export function managedGitignoreEntries(agentRoot: string, referenceRoot: string, managed: string[]): string[] {
   const root = path.resolve(agentRoot);
   const entries = new Set<string>();
   for (const rel of managed) {
     if (path.isAbsolute(rel)) continue;
     const abs = path.resolve(agentRoot, rel);
     if (abs !== root && !abs.startsWith(root + path.sep)) continue;
-    const fromProject = toPosixRel(path.relative(projectRoot, abs));
-    if (!fromProject || fromProject === '..' || fromProject.startsWith('../')) continue;
-    entries.add('/' + fromProject);
+    const fromRoot = toPosixRel(path.relative(referenceRoot, abs));
+    if (!fromRoot || fromRoot === '..' || fromRoot.startsWith('../')) continue;
+    entries.add('/' + fromRoot);
   }
   return Array.from(entries).sort();
 }
 
-/** True when `dir` is inside a git working tree — walks up to the filesystem
- *  root looking for a `.git` entry. `projectRoot` (the parent of the resolved
- *  `.agents/` dir) is not guaranteed to be the git root: a monorepo subdir can
- *  carry its own `.agents/` while `.git` lives several levels up. A root-only
- *  check would silently no-op the whole feature there. */
-function isInsideGitRepo(dir: string): boolean {
-  let cur = path.resolve(dir);
-  for (;;) {
-    if (pathExists(path.join(cur, '.git'))) return true;
-    const parent = path.dirname(cur);
-    if (parent === cur) return false;
-    cur = parent;
+interface GitExcludeTarget {
+  /** Absolute path to the ignore file managed entries are written into —
+   *  `<git-common-dir>/info/exclude`. */
+  excludePath: string;
+  /** Absolute path to the top of the working tree; anchored `/…` entries
+   *  resolve against this, since git anchors info/exclude patterns there. */
+  worktreeRoot: string;
+}
+
+/**
+ * Ask git where the local, per-clone ignore file lives and where the worktree
+ * top is, resolved robustly for every layout by delegating to git itself:
+ *   - normal repo → `<root>/.git/info/exclude`;
+ *   - monorepo subdir → the same file even when `.git` is several levels up
+ *     (`projectRoot`, the parent of `.agents/`, is not the git root);
+ *   - linked worktree / submodule → `.git` is a FILE (`gitdir: …`), and
+ *     `--git-path info/exclude` resolves to the shared COMMON dir so the block
+ *     applies across every worktree.
+ * `--path-format=absolute` forces absolute paths regardless of the `-C` cwd.
+ * Returns null when `dir` is not inside a git repo (git exits non-zero), which
+ * fails the feature open (no-op) exactly like the old in-tree check did.
+ */
+function resolveGitExcludeTarget(dir: string): GitExcludeTarget | null {
+  try {
+    const run = (...args: string[]) =>
+      execFileSync('git', ['-C', dir, ...args], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    const excludePath = run('rev-parse', '--path-format=absolute', '--git-path', 'info/exclude');
+    const worktreeRoot = run('rev-parse', '--show-toplevel');
+    if (!excludePath || !worktreeRoot) return null;
+    return { excludePath, worktreeRoot };
+  } catch {
+    return null;
+  }
+}
+
+/** True when git tracks `absPath` in the repo `dir` sits in. */
+function isTrackedByGit(dir: string, absPath: string): boolean {
+  try {
+    execFileSync('git', ['-C', dir, 'ls-files', '--error-unmatch', '--', absPath], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
   }
 }
 
 /**
- * Apply this agent's managed block to `.gitignore` content, IN PLACE.
+ * Apply this agent's managed block to ignore-file content, IN PLACE — used both
+ * to write the block into `.git/info/exclude` and to strip a leftover block from
+ * a legacy tracked `.gitignore` (entries `[]` prunes).
  *
  * In-place replacement (not strip-then-append) is load-bearing: appending would
  * move this agent's block behind every other agent's block on each resync, so in
@@ -163,9 +206,11 @@ function applyManagedBlock(content: string, begin: string, end: string, entries:
     if (entries.length > 0) {
       return [...lines.slice(0, bi), begin, ...entries, end, ...lines.slice(ei + 1)].join('\n');
     }
-    // Prune the block, tidying the blank lines that hugged it. Vestigial on the
-    // reconcileProjectGitignore path (its entries always include the manifest,
-    // so entries.length is never 0 there) — kept for a direct caller/unit test.
+    // Prune the block, tidying the blank lines that hugged it. Unreached on the
+    // reconcileManagedIgnore write path (its entries always include the manifest,
+    // so entries.length is never 0 there), but the load-bearing case for
+    // stripLegacyManagedGitignoreBlock, which calls with entries=[] to migrate a
+    // leftover block out of the tracked .gitignore.
     const before = lines.slice(0, bi);
     const after = lines.slice(ei + 1);
     while (before.length && before[before.length - 1].trim() === '') before.pop();
@@ -180,44 +225,92 @@ function applyManagedBlock(content: string, begin: string, end: string, entries:
 }
 
 /**
- * Reconcile a per-agent managed block in `<projectRoot>/.gitignore` so the
- * generated per-harness resource dir never shows as untracked dirt. Idempotent
- * and convergent: replaces the block in place and writes only when the content
- * actually changes, so the launch hot path does not churn the file (or its
- * watchers) every run — even in a project synced by several harnesses. When a
- * sync clears a harness's resources the block does not vanish: it shrinks to the
- * lone `.agents-managed.json` entry (that file still sits in the harness dir and
- * must stay ignored), so the block is only ever fully pruned by hand, never via
- * this call path. Never creates a `.gitignore` outside a git working tree.
+ * Reconcile a per-agent managed block in `.git/info/exclude` so the generated
+ * per-harness resource dir never shows as untracked dirt — WITHOUT dirtying the
+ * tracked `.gitignore`. Idempotent and convergent: replaces the block in place
+ * and writes only when the content actually changes, so the launch hot path does
+ * not churn the file (or its watchers) every run — even in a project synced by
+ * several harnesses. When a sync clears a harness's resources the block does not
+ * vanish: it shrinks to the lone `.agents-managed.json` entry (that file still
+ * sits in the harness dir and must stay ignored), so the block is only ever
+ * fully pruned by hand, never via this call path. Fails open (no-op) outside a
+ * git working tree.
+ *
+ * Also self-heals repos dirtied by the previous behavior: PHNX-3717 wrote these
+ * blocks into `<projectRoot>/.gitignore`, which is never committed upstream, so
+ * every launch left a permanent `M .gitignore` that blocked `git pull`
+ * (PHNX-3718). `stripLegacyManagedGitignoreBlock` removes this agent's leftover
+ * block from that tracked file on the next launch, cleaning the diff instead of
+ * stranding it.
  */
-function reconcileProjectGitignore(
+function reconcileManagedIgnore(
   projectRoot: string,
   agent: AgentId,
   agentRoot: string,
   managed: string[],
 ): void {
-  const gitignorePath = path.join(projectRoot, '.gitignore');
-  if (!isInsideGitRepo(projectRoot) && !pathExists(gitignorePath)) return;
+  // Migrate away from the old tracked-.gitignore location first, so an already
+  // dirtied repo cleans itself even if git resolution below fails.
+  stripLegacyManagedGitignoreBlock(projectRoot, agent);
+
+  const target = resolveGitExcludeTarget(projectRoot);
+  if (!target) return; // not a git repo — fail open
 
   const { begin, end } = gitignoreMarkers(agent);
   // Ignore the manifest marker file too, not just the synced resources: the
   // sync always writes `<agentRoot>/.agents-managed.json`, so without this the
   // harness dir still shows as untracked in `git status` on the strength of that
   // one file (defeating the whole point). It lives at agentRoot, so it resolves
-  // through the same anchoring + escape guard as any managed path.
-  const entries = managedGitignoreEntries(agentRoot, projectRoot, [MANIFEST_FILE, ...managed]);
+  // through the same anchoring + escape guard as any managed path. Anchored to
+  // the worktree root, since info/exclude patterns resolve against the tree top.
+  const entries = managedGitignoreEntries(agentRoot, target.worktreeRoot, [MANIFEST_FILE, ...managed]);
 
   let original = '';
   try {
-    original = fs.readFileSync(gitignorePath, 'utf-8');
+    original = fs.readFileSync(target.excludePath, 'utf-8');
   } catch {
     original = '';
   }
 
   const next = applyManagedBlock(original, begin, end, entries);
   if (next === null || next === original) return;
-  const tmp = gitignorePath + '.tmp';
+  fs.mkdirSync(path.dirname(target.excludePath), { recursive: true }); // create info/ if missing
+  const tmp = target.excludePath + '.tmp';
   fs.writeFileSync(tmp, next);
+  fs.renameSync(tmp, target.excludePath);
+}
+
+/**
+ * Remove this agent's leftover managed block from a tracked `<projectRoot>/
+ * .gitignore` written by the pre-PHNX-3718 behavior. Strips ONLY the fenced
+ * block (leaving every hand-written rule untouched), never creates the file,
+ * and never touches a `.gitignore` that carries no block of ours. If stripping
+ * empties a file we created (its only content was our block), the empty file is
+ * removed when git does not track it — an empty untracked `.gitignore` would
+ * still read as `?? .gitignore` dirt, the very thing this migration clears.
+ */
+function stripLegacyManagedGitignoreBlock(projectRoot: string, agent: AgentId): void {
+  const gitignorePath = path.join(projectRoot, '.gitignore');
+  let original: string;
+  try {
+    original = fs.readFileSync(gitignorePath, 'utf-8');
+  } catch {
+    return; // no .gitignore — nothing to migrate
+  }
+
+  const { begin, end } = gitignoreMarkers(agent);
+  // Empty entries → applyManagedBlock prunes the block; returns `original`
+  // unchanged when there is no block, or null on an orphaned begin marker
+  // (which we refuse to touch rather than truncate the user's rules).
+  const stripped = applyManagedBlock(original, begin, end, []);
+  if (stripped === null || stripped === original) return;
+
+  if (stripped === '' && !isTrackedByGit(projectRoot, gitignorePath)) {
+    removePath(gitignorePath);
+    return;
+  }
+  const tmp = gitignorePath + '.tmp';
+  fs.writeFileSync(tmp, stripped);
   fs.renameSync(tmp, gitignorePath);
 }
 

--- a/cli/src/lib/project-resources.ts
+++ b/cli/src/lib/project-resources.ts
@@ -152,16 +152,26 @@ interface GitExcludeTarget {
  *     `--git-path info/exclude` resolves to the shared COMMON dir so the block
  *     applies across every worktree.
  * `--path-format=absolute` forces absolute paths regardless of the `-C` cwd.
+ * One `git rev-parse` yields both paths (exclude path first, worktree root
+ * second), so the launch path spawns git ONCE, not twice.
  * Returns null when `dir` is not inside a git repo (git exits non-zero), which
  * fails the feature open (no-op) exactly like the old in-tree check did.
  */
 function resolveGitExcludeTarget(dir: string): GitExcludeTarget | null {
   try {
-    const run = (...args: string[]) =>
-      execFileSync('git', ['-C', dir, ...args], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-    const excludePath = run('rev-parse', '--path-format=absolute', '--git-path', 'info/exclude');
-    const worktreeRoot = run('rev-parse', '--show-toplevel');
+    const out = execFileSync(
+      'git',
+      ['-C', dir, 'rev-parse', '--path-format=absolute', '--git-path', 'info/exclude', '--show-toplevel'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    const [excludePath, worktreeRoot] = out.split('\n').map((l) => l.trim());
     if (!excludePath || !worktreeRoot) return null;
+    // Fail open on anything that isn't a clean pair of ABSOLUTE paths. A git
+    // older than 2.31 (predates `--path-format`) echoes the unrecognized flag
+    // back on stdout instead of erroring, which would otherwise shift the parse
+    // and have mkdirSync create a stray `--path-format=absolute` dir. The
+    // absolute-path check turns that into a clean no-op.
+    if (!path.isAbsolute(excludePath) || !path.isAbsolute(worktreeRoot)) return null;
     return { excludePath, worktreeRoot };
   } catch {
     return null;


### PR DESCRIPTION
## The bug

PHNX-3717 taught the per-harness project resource sync to self-manage ignore rules
for the generated `.claude/`, `.cursor/`, `.codex/`, … dirs it rewrites on every
launch. But it wrote the managed block into the **tracked** `<project>/.gitignore`.
Those blocks are never committed upstream, so every launch left the repo with:

```
$ git status
	modified:   .gitignore        # one managed block per harness that ran here
```

It's idempotent, so it never grows — but it never clears, and it **blocks `git pull`**:

```
error: Your local changes to the following files would be overwritten by merge:
	.gitignore
```

This bit the owner directly. `origin/main:.gitignore` carries no such blocks, confirming they were only ever local dirt.

## The fix (fix-at-source, no band-aid)

Write the managed block to **`.git/info/exclude`** — git's standard per-clone,
uncommitted ignore file — instead of the tracked `.gitignore`. The generated dirs
stay hidden AND the working tree stays clean.

- **Robust gitdir resolution** via `git rev-parse --git-path info/exclude` +
  `--show-toplevel` (`--path-format=absolute`): handles a normal repo, a monorepo
  subdir whose `.agents/` sits below `.git`, and a **linked worktree / submodule**
  (`.git` is a file → git resolves the shared **common** dir, so the block applies
  across worktrees). Entries are anchored at the **worktree root**, since
  `info/exclude` patterns anchor at the tree top (not at the harness dir).
- **Fails open** (no-op) outside a git repo, matching the old guard. Creates
  `info/` if missing.
- Keeps the in-place, per-agent marker-block reconciliation (no append-forever churn).
- **Migration / self-heal:** on reconcile, strips this agent's leftover managed
  block from a tracked `.gitignore` written by the old behavior — hand-written
  rules untouched; an untracked file that held *only* our block is deleted (an
  empty `?? .gitignore` would still be dirt). So an already-dirtied repo cleans
  itself on the next launch instead of stranding the diff.

## Before / after

| | Before | After |
|---|---|---|
| Fresh launch in a repo | `M .gitignore` (permanent) | clean tree |
| `git pull` after launches | blocked | works |
| Repo already dirtied by old behavior | stays `M .gitignore` | self-heals to clean on next launch |

## Tests

`cli/src/lib/project-resources.test.ts` rewritten onto **real git repos** (the old
fixtures faked an empty `.git/` dir, which a real `git rev-parse` rejects), asserting:

- the managed block lands in `.git/info/exclude`, never the tracked `.gitignore`;
- git's default `info/exclude` content + hand-written excludes are preserved; idempotent; no cross-harness churn; orphaned-marker safety; manifest ignored;
- **worktree-root anchoring** for a repo whose `.agents/` lives in a subdir (`/sub/.cursor/…`);
- a **REAL `git status`** is fully clean after sync (no `.cursor/`, no `.gitignore`);
- migration: strips a leftover block from a tracked `.gitignore` (→ clean committed content), deletes an untracked block-only file, and leaves a foreign `.gitignore` untouched.

```
$ bun run test project-resources
 Test Files  2 passed (2)
      Tests  43 passed (43)
$ bunx tsc --noEmit    # clean
```

Docs (`cli/docs/resource-sync.md`) and CHANGELOG (`.changelog/next/PHNX-3718.md`) updated.

## Lineage

Fixes the tracked-`.gitignore` dirtiness introduced by **PHNX-3717** (self-managed project ignores); sibling **PHNX-3718**. Internal launch-path change — no user-facing command/flag surface, so no companion `phnx-labs/.agents` guidance to audit.

## Review note

`prix-cloud` is PAUSED (#1767); a `code-reviewer` subagent verdict is posted on this PR per the documented fallback.