### PR TITLE
fix(fleet-sync): clear untracked collisions before rebasing so devices stop drifting (PHNX-3923)

### DIFF
--- a/cli/src/lib/daemon/auth-sync-service.ts
+++ b/cli/src/lib/daemon/auth-sync-service.ts
@@ -35,6 +35,9 @@ export class AuthSyncService extends BasePeriodicService {
     const transport = await syncFleetSharedStateRepo();
     if (transport.skipped) ctx.log('WARN', `auth-sync: ${transport.skipped}`);
     if (transport.error) ctx.log('WARN', `auth-sync: shared-store transport: ${transport.error}`);
+    if (transport.untrackedBackedUp?.length) {
+      ctx.log('WARN', `auth-sync: backed up ${transport.untrackedBackedUp.length} untracked shared-store collision(s) to ${transport.untrackedBackupDir}: ${transport.untrackedBackedUp.join(', ')}`);
+    }
     if (!transport.success) return;
     const result = await syncReservedAuthBundle();
     if (result.pushed.length > 0) {

--- a/cli/src/lib/daemon/usage-sync-service.ts
+++ b/cli/src/lib/daemon/usage-sync-service.ts
@@ -48,6 +48,9 @@ export class UsageSyncService extends BasePeriodicService {
     const transport = await syncFleetSharedStateRepo();
     if (transport.skipped) ctx.log('WARN', `usage-sync: ${transport.skipped}`);
     if (transport.error) ctx.log('WARN', `usage-sync: shared-store transport: ${transport.error}`);
+    if (transport.untrackedBackedUp?.length) {
+      ctx.log('WARN', `usage-sync: backed up ${transport.untrackedBackedUp.length} untracked shared-store collision(s) to ${transport.untrackedBackupDir}: ${transport.untrackedBackedUp.join(', ')}`);
+    }
     if (!transport.success) return;
     const consumed = consumeUsageSnapshotsFromSharedStore();
     if (consumed.merged > 0) {

--- a/cli/src/lib/fleet-shared-repo-sync.test.ts
+++ b/cli/src/lib/fleet-shared-repo-sync.test.ts
@@ -316,4 +316,52 @@ describe('syncFleetSharedStateRepo (real git)', () => {
     // Origin's version is what ends up checked out.
     expect(fs.readFileSync(path.join(worker, rel))).toEqual(originBytes);
   });
+
+  it('hashes raw bytes (--no-filters) so a CRLF/LF filter near-match is backed up, not deleted (PHNX-3923 review)', async () => {
+    const root = tempDir();
+    const remote = path.join(root, 'remote.git');
+    const publisher = path.join(root, 'publisher');
+    const worker = path.join(root, 'worker');
+    git(root, ['init', '--bare', '--initial-branch=main', remote]);
+    git(root, ['clone', remote, publisher]);
+    configureIdentity(publisher);
+    fs.writeFileSync(path.join(publisher, 'README.md'), 'fleet store\n', 'utf-8');
+    git(publisher, ['add', 'README.md']);
+    git(publisher, ['commit', '-m', 'seed user store']);
+    git(publisher, ['push', 'origin', 'main']);
+    git(root, ['clone', remote, worker]);
+    configureIdentity(worker);
+    // A machine whose clean filter would normalize line endings. Without
+    // --no-filters, hash-object would fold the CRLF file to the LF blob and
+    // delete it as "identical"; --no-filters compares raw bytes instead.
+    git(worker, ['config', 'core.autocrlf', 'true']);
+
+    const rel = 'devices/peer/notes.txt';
+    const originBytes = Buffer.from('a\nb\n', 'utf-8'); // LF (stored on origin)
+    const localBytes = Buffer.from('a\r\nb\r\n', 'utf-8'); // CRLF (differs in raw bytes)
+    fs.mkdirSync(path.dirname(path.join(publisher, rel)), { recursive: true });
+    fs.writeFileSync(path.join(publisher, rel), originBytes);
+    git(publisher, ['add', rel]);
+    git(publisher, ['commit', '-m', 'peer publishes LF file']);
+    git(publisher, ['push', 'origin', 'main']);
+
+    fs.mkdirSync(path.dirname(path.join(worker, rel)), { recursive: true });
+    fs.writeFileSync(path.join(worker, rel), localBytes);
+
+    updateFleetSharedDeviceState('worker-a', { auth: { status: 'missing' } }, worker);
+    const result = await syncFleetSharedStateRepo({
+      userAgentsDir: worker,
+      device: 'worker-a',
+      timeoutMs: 10_000,
+      lockPath: path.join(root, 'worker.lock-target'),
+    });
+
+    expect(result).toMatchObject({ success: true, error: null });
+    // Raw CRLF bytes differ from the LF blob → preserved in backup, not deleted.
+    expect(result.untrackedBackedUp).toContain(rel);
+    expect(result.untrackedCleared).toBe(0);
+    const backupRoot = `${worker}-fleet-sync-backups`;
+    const stamps = fs.readdirSync(backupRoot);
+    expect(fs.readFileSync(path.join(backupRoot, stamps[0], rel))).toEqual(localBytes);
+  });
 });

--- a/cli/src/lib/fleet-shared-repo-sync.test.ts
+++ b/cli/src/lib/fleet-shared-repo-sync.test.ts
@@ -265,4 +265,55 @@ describe('syncFleetSharedStateRepo (real git)', () => {
       'chore(devices): publish worker-a daemon state',
     );
   });
+
+  it('uses byte identity, not UTF-8 string equality, so distinct invalid bytes are backed up not deleted (PHNX-3923 review)', async () => {
+    const root = tempDir();
+    const remote = path.join(root, 'remote.git');
+    const publisher = path.join(root, 'publisher');
+    const worker = path.join(root, 'worker');
+    git(root, ['init', '--bare', '--initial-branch=main', remote]);
+    git(root, ['clone', remote, publisher]);
+    configureIdentity(publisher);
+    fs.writeFileSync(path.join(publisher, 'README.md'), 'fleet store\n', 'utf-8');
+    git(publisher, ['add', 'README.md']);
+    git(publisher, ['commit', '-m', 'seed user store']);
+    git(publisher, ['push', 'origin', 'main']);
+    git(root, ['clone', remote, worker]);
+    configureIdentity(worker);
+
+    // Two byte strings that both decode to the same UTF-8 string (each trailing
+    // byte is an invalid lead byte → U+FFFD) but are NOT byte-identical. A
+    // string comparison would call these equal and delete the local copy.
+    const rel = 'devices/peer/state.bin';
+    const originBytes = Buffer.from([0x7b, 0x7d, 0xff]); // "{}" + 0xFF
+    const localBytes = Buffer.from([0x7b, 0x7d, 0xfe]); // "{}" + 0xFE (differs)
+    expect(originBytes.toString('utf8')).toBe(localBytes.toString('utf8')); // decode-collision
+
+    fs.mkdirSync(path.dirname(path.join(publisher, rel)), { recursive: true });
+    fs.writeFileSync(path.join(publisher, rel), originBytes);
+    git(publisher, ['add', rel]);
+    git(publisher, ['commit', '-m', 'peer publishes binary state']);
+    git(publisher, ['push', 'origin', 'main']);
+
+    fs.mkdirSync(path.dirname(path.join(worker, rel)), { recursive: true });
+    fs.writeFileSync(path.join(worker, rel), localBytes);
+
+    updateFleetSharedDeviceState('worker-a', { auth: { status: 'missing' } }, worker);
+    const result = await syncFleetSharedStateRepo({
+      userAgentsDir: worker,
+      device: 'worker-a',
+      timeoutMs: 10_000,
+      lockPath: path.join(root, 'worker.lock-target'),
+    });
+
+    expect(result).toMatchObject({ success: true, error: null });
+    // The differing bytes must be PRESERVED (backed up), never deleted as "identical".
+    expect(result.untrackedBackedUp).toContain(rel);
+    expect(result.untrackedCleared).toBe(0);
+    const backupRoot = `${worker}-fleet-sync-backups`;
+    const stamps = fs.readdirSync(backupRoot);
+    expect(fs.readFileSync(path.join(backupRoot, stamps[0], rel))).toEqual(localBytes);
+    // Origin's version is what ends up checked out.
+    expect(fs.readFileSync(path.join(worker, rel))).toEqual(originBytes);
+  });
 });

--- a/cli/src/lib/fleet-shared-repo-sync.test.ts
+++ b/cli/src/lib/fleet-shared-repo-sync.test.ts
@@ -199,4 +199,70 @@ describe('syncFleetSharedStateRepo (real git)', () => {
       clearInterval(heartbeat);
     }
   });
+
+  it('clears untracked files that collide with incoming tracked files so the rebase is not wedged (PHNX-3923)', async () => {
+    const root = tempDir();
+    const remote = path.join(root, 'remote.git');
+    const publisher = path.join(root, 'publisher');
+    const worker = path.join(root, 'worker');
+    git(root, ['init', '--bare', '--initial-branch=main', remote]);
+    git(root, ['clone', remote, publisher]);
+    configureIdentity(publisher);
+    fs.writeFileSync(path.join(publisher, 'README.md'), 'fleet store\n', 'utf-8');
+    git(publisher, ['add', 'README.md']);
+    git(publisher, ['commit', '-m', 'seed user store']);
+    git(publisher, ['push', 'origin', 'main']);
+
+    // Worker clones before the peer/project files exist on origin.
+    git(root, ['clone', remote, worker]);
+    configureIdentity(worker);
+
+    // A peer publishes files that origin now TRACKS at these paths.
+    const identicalRel = 'devices/peer/daemon-state.json';
+    const differsRel = 'projects/rush.yaml';
+    fs.mkdirSync(path.dirname(path.join(publisher, identicalRel)), { recursive: true });
+    fs.writeFileSync(path.join(publisher, identicalRel), '{"auth":"ok"}\n', 'utf-8');
+    fs.mkdirSync(path.dirname(path.join(publisher, differsRel)), { recursive: true });
+    fs.writeFileSync(path.join(publisher, differsRel), 'canonical: true\n', 'utf-8');
+    git(publisher, ['add', identicalRel, differsRel]);
+    git(publisher, ['commit', '-m', 'peer publishes shared files']);
+    git(publisher, ['push', 'origin', 'main']);
+
+    // The worker holds the SAME paths as UNTRACKED stale local snapshots: one
+    // byte-identical to origin, one that differs. Before PHNX-3923 the rebase
+    // aborted here ("untracked working tree files would be overwritten").
+    fs.mkdirSync(path.dirname(path.join(worker, identicalRel)), { recursive: true });
+    fs.writeFileSync(path.join(worker, identicalRel), '{"auth":"ok"}\n', 'utf-8');
+    fs.mkdirSync(path.dirname(path.join(worker, differsRel)), { recursive: true });
+    fs.writeFileSync(path.join(worker, differsRel), 'stale: local\n', 'utf-8');
+
+    updateFleetSharedDeviceState('worker-a', { auth: { status: 'missing' } }, worker);
+    const result = await syncFleetSharedStateRepo({
+      userAgentsDir: worker,
+      device: 'worker-a',
+      timeoutMs: 10_000,
+      lockPath: path.join(root, 'worker.lock-target'),
+    });
+
+    expect(result).toMatchObject({ success: true, timedOut: false, error: null });
+    // The byte-identical collision was dropped losslessly; the differing one
+    // was preserved in a backup, not destroyed.
+    expect(result.untrackedCleared).toBeGreaterThanOrEqual(1);
+    expect(result.untrackedBackedUp).toContain(differsRel);
+
+    // Origin's versions were checked out cleanly in the worker.
+    expect(fs.readFileSync(path.join(worker, identicalRel), 'utf-8')).toBe('{"auth":"ok"}\n');
+    expect(fs.readFileSync(path.join(worker, differsRel), 'utf-8')).toBe('canonical: true\n');
+
+    // The differing file's original content survives in the sibling backup dir.
+    const backupRoot = `${worker}-fleet-sync-backups`;
+    const stamps = fs.readdirSync(backupRoot);
+    expect(stamps.length).toBe(1);
+    expect(fs.readFileSync(path.join(backupRoot, stamps[0], differsRel), 'utf-8')).toBe('stale: local\n');
+
+    // The worker's own state commit still reached origin.
+    expect(git(root, ['--git-dir', remote, 'log', '--format=%s', 'main'])).toContain(
+      'chore(devices): publish worker-a daemon state',
+    );
+  });
 });

--- a/cli/src/lib/fleet-shared-repo-sync.ts
+++ b/cli/src/lib/fleet-shared-repo-sync.ts
@@ -55,9 +55,11 @@ export interface FleetSharedRepoSyncResult {
   untrackedCleared?: number;
   /**
    * Untracked working-tree files that collided with origin, differed from it,
-   * and were moved to a backup dir under the daemon dir before rebasing.
+   * and were moved to untrackedBackupDir before rebasing.
    */
   untrackedBackedUp?: string[];
+  /** Directory the differing untracked collisions were moved to, if any. */
+  untrackedBackupDir?: string;
 }
 
 function signalProcessTree(child: ChildProcess, signal: 'SIGTERM' | 'SIGKILL'): void {
@@ -220,7 +222,7 @@ async function clearCollidingUntracked(
   git: (args: string[], reserveMs?: number) => Promise<BoundedProcessResult>,
   root: string,
   branch: string,
-): Promise<{ cleared: number; backedUp: string[] } | { error: BoundedProcessResult }> {
+): Promise<{ cleared: number; backedUp: string[]; backupDir: string | null } | { error: BoundedProcessResult }> {
   const others = await git(['ls-files', '--others', '--exclude-standard', '-z']);
   if (others.code !== 0) return { error: others };
   const relPaths = others.stdout.split('\0').filter(Boolean);
@@ -232,14 +234,18 @@ async function clearCollidingUntracked(
     const onOrigin = await git(['cat-file', '-e', `origin/${branch}:${rel}`]);
     if (onOrigin.code !== 0) continue;
     const abs = path.join(root, rel);
-    let local: string;
-    try {
-      local = fs.readFileSync(abs, 'utf8');
-    } catch {
-      continue; // vanished under us (a concurrent writer) — nothing to clear
-    }
-    const originBlob = await git(['show', `origin/${branch}:${rel}`]);
-    const identical = originBlob.code === 0 && originBlob.stdout === local;
+    // Byte-accurate identity via git blob SHAs. Comparing UTF-8-decoded strings
+    // would collapse distinct invalid bytes to U+FFFD and could delete
+    // non-identical content; the blob SHA is over the exact bytes. A hash-object
+    // failure (file unreadable or vanished under a concurrent writer) means
+    // "leave it in place". Under a checkout filter the raw hash can differ from
+    // the stored blob even when checkout would match — that errs to backup, not
+    // delete, so it never loses data.
+    const localHash = await git(['hash-object', '--', abs]);
+    if (localHash.code !== 0 || !localHash.stdout.trim()) continue;
+    const originHash = await git(['rev-parse', `origin/${branch}:${rel}`]);
+    const identical = originHash.code === 0
+      && originHash.stdout.trim() === localHash.stdout.trim();
     try {
       if (identical) {
         fs.rmSync(abs, { force: true });
@@ -259,7 +265,7 @@ async function clearCollidingUntracked(
       // Could not clear this collision; leave it in place.
     }
   }
-  return { cleared, backedUp };
+  return { cleared, backedUp, backupDir };
 }
 
 async function performFleetSharedRepoSync(
@@ -325,6 +331,7 @@ async function performFleetSharedRepoSync(
 
   let untrackedCleared = 0;
   const untrackedBackedUp: string[] = [];
+  let untrackedBackupDir: string | undefined;
   for (let attempt = 1; attempt <= FLEET_SHARED_REPO_PUSH_ATTEMPTS; attempt++) {
     const fetch = await git(['fetch', 'origin']);
     if (fetch.code !== 0) return { ...failure('git fetch', fetch), committed };
@@ -338,6 +345,7 @@ async function performFleetSharedRepoSync(
     }
     untrackedCleared += reconcile.cleared;
     untrackedBackedUp.push(...reconcile.backedUp);
+    if (reconcile.backupDir) untrackedBackupDir = reconcile.backupDir;
 
     // Keep enough of the same wall-clock bound available to remove a botched
     // autostash pop from the operator's live checkout before returning.
@@ -404,6 +412,7 @@ async function performFleetSharedRepoSync(
         error: null,
         untrackedCleared,
         untrackedBackedUp,
+        untrackedBackupDir,
       };
     }
     if (attempt === FLEET_SHARED_REPO_PUSH_ATTEMPTS || !isPushRace(push)) {

--- a/cli/src/lib/fleet-shared-repo-sync.ts
+++ b/cli/src/lib/fleet-shared-repo-sync.ts
@@ -230,22 +230,21 @@ async function clearCollidingUntracked(
   const backedUp: string[] = [];
   let backupDir: string | null = null;
   for (const rel of relPaths) {
-    // Only paths that origin tracks are overwritten by the rebase's checkout.
-    const onOrigin = await git(['cat-file', '-e', `origin/${branch}:${rel}`]);
-    if (onOrigin.code !== 0) continue;
-    const abs = path.join(root, rel);
-    // Byte-accurate identity via git blob SHAs. Comparing UTF-8-decoded strings
-    // would collapse distinct invalid bytes to U+FFFD and could delete
-    // non-identical content; the blob SHA is over the exact bytes. A hash-object
-    // failure (file unreadable or vanished under a concurrent writer) means
-    // "leave it in place". Under a checkout filter the raw hash can differ from
-    // the stored blob even when checkout would match — that errs to backup, not
-    // delete, so it never loses data.
-    const localHash = await git(['hash-object', '--', abs]);
-    if (localHash.code !== 0 || !localHash.stdout.trim()) continue;
+    // rev-parse doubles as the "does origin track this path" test (non-zero =
+    // absent) — only paths origin tracks are overwritten by the rebase checkout.
     const originHash = await git(['rev-parse', `origin/${branch}:${rel}`]);
-    const identical = originHash.code === 0
-      && originHash.stdout.trim() === localHash.stdout.trim();
+    if (originHash.code !== 0 || !originHash.stdout.trim()) continue;
+    const abs = path.join(root, rel);
+    // Byte-exact identity via git blob SHAs. Comparing UTF-8-decoded strings
+    // would collapse distinct invalid bytes to U+FFFD and could delete
+    // non-identical content. `--no-filters` hashes the raw on-disk bytes (no
+    // clean/autocrlf normalization), so `identical` is true only when the local
+    // bytes exactly equal origin's stored blob — never a filter-normalized
+    // near-match. A hash-object failure (unreadable / vanished under a
+    // concurrent writer) means "leave it in place".
+    const localHash = await git(['hash-object', '--no-filters', '--', abs]);
+    if (localHash.code !== 0 || !localHash.stdout.trim()) continue;
+    const identical = originHash.stdout.trim() === localHash.stdout.trim();
     try {
       if (identical) {
         fs.rmSync(abs, { force: true });

--- a/cli/src/lib/fleet-shared-repo-sync.ts
+++ b/cli/src/lib/fleet-shared-repo-sync.ts
@@ -48,6 +48,16 @@ export interface FleetSharedRepoSyncResult {
   timedOut: boolean;
   skipped: string | null;
   error: string | null;
+  /**
+   * Untracked working-tree files that collided with origin and were dropped
+   * (byte-identical to origin) before rebasing. See clearCollidingUntracked.
+   */
+  untrackedCleared?: number;
+  /**
+   * Untracked working-tree files that collided with origin, differed from it,
+   * and were moved to a backup dir under the daemon dir before rebasing.
+   */
+  untrackedBackedUp?: string[];
 }
 
 function signalProcessTree(child: ChildProcess, signal: 'SIGTERM' | 'SIGKILL'): void {
@@ -189,6 +199,69 @@ function retainedAutostash(
   };
 }
 
+/**
+ * `git rebase` checks out its base (origin/<branch>) and aborts when an
+ * untracked working-tree file would be overwritten by a file that origin
+ * tracks. `--autostash` only sets aside *tracked* changes, so these untracked
+ * collisions wedge the rebase on every sync and the device silently falls
+ * hundreds of commits behind — the fleet-wide drift root cause (PHNX-3923).
+ *
+ * In this shared-state repo an untracked file that also exists on origin is a
+ * stale local snapshot: the canonical copy is on origin and every device
+ * republishes its own state (this device's own owned file is already committed
+ * before we get here, so it is tracked and never appears below). Drop the ones
+ * byte-identical to origin (lossless) and move any that differ into a backup
+ * dir beside the repo root — outside the repo's tracked tree, so the move
+ * cannot create a fresh collision — so nothing is silently destroyed. Then let
+ * the rebase check out origin's version. A file we cannot clear is left in
+ * place; the rebase may still abort, no worse than today and never losing data.
+ */
+async function clearCollidingUntracked(
+  git: (args: string[], reserveMs?: number) => Promise<BoundedProcessResult>,
+  root: string,
+  branch: string,
+): Promise<{ cleared: number; backedUp: string[] } | { error: BoundedProcessResult }> {
+  const others = await git(['ls-files', '--others', '--exclude-standard', '-z']);
+  if (others.code !== 0) return { error: others };
+  const relPaths = others.stdout.split('\0').filter(Boolean);
+  let cleared = 0;
+  const backedUp: string[] = [];
+  let backupDir: string | null = null;
+  for (const rel of relPaths) {
+    // Only paths that origin tracks are overwritten by the rebase's checkout.
+    const onOrigin = await git(['cat-file', '-e', `origin/${branch}:${rel}`]);
+    if (onOrigin.code !== 0) continue;
+    const abs = path.join(root, rel);
+    let local: string;
+    try {
+      local = fs.readFileSync(abs, 'utf8');
+    } catch {
+      continue; // vanished under us (a concurrent writer) — nothing to clear
+    }
+    const originBlob = await git(['show', `origin/${branch}:${rel}`]);
+    const identical = originBlob.code === 0 && originBlob.stdout === local;
+    try {
+      if (identical) {
+        fs.rmSync(abs, { force: true });
+        cleared++;
+      } else {
+        if (!backupDir) {
+          // A sibling of the repo root: outside the tracked tree (so the move
+          // cannot create a fresh collision) yet colocated for easy recovery.
+          backupDir = path.join(`${root}-fleet-sync-backups`, String(Date.now()));
+        }
+        const dest = path.join(backupDir, rel);
+        fs.mkdirSync(path.dirname(dest), { recursive: true });
+        fs.renameSync(abs, dest);
+        backedUp.push(rel);
+      }
+    } catch {
+      // Could not clear this collision; leave it in place.
+    }
+  }
+  return { cleared, backedUp };
+}
+
 async function performFleetSharedRepoSync(
   root: string,
   device: string,
@@ -250,9 +323,21 @@ async function performFleetSharedRepoSync(
     }
   }
 
+  let untrackedCleared = 0;
+  const untrackedBackedUp: string[] = [];
   for (let attempt = 1; attempt <= FLEET_SHARED_REPO_PUSH_ATTEMPTS; attempt++) {
     const fetch = await git(['fetch', 'origin']);
     if (fetch.code !== 0) return { ...failure('git fetch', fetch), committed };
+
+    // Untracked files that origin tracks would abort the rebase's checkout
+    // (autostash only covers tracked changes). Clear them first — this is the
+    // fleet-drift root cause (PHNX-3923).
+    const reconcile = await clearCollidingUntracked(git, root, branch);
+    if ('error' in reconcile) {
+      return { ...failure('git ls-files --others', reconcile.error), committed };
+    }
+    untrackedCleared += reconcile.cleared;
+    untrackedBackedUp.push(...reconcile.backedUp);
 
     // Keep enough of the same wall-clock bound available to remove a botched
     // autostash pop from the operator's live checkout before returning.
@@ -317,6 +402,8 @@ async function performFleetSharedRepoSync(
         timedOut: false,
         skipped: null,
         error: null,
+        untrackedCleared,
+        untrackedBackedUp,
       };
     }
     if (attempt === FLEET_SHARED_REPO_PUSH_ATTEMPTS || !isPushRace(push)) {


### PR DESCRIPTION
## Problem (PHNX-3923)

Every device's `~/.agents` user repo silently drifts hundreds of commits behind `origin/main` and never self-heals. Observed 2026-09-03: `agents repos status --devices-all` showed most boxes ↓25–30 behind on real content; raw git showed e.g. yosemite-m3 `[ahead 35, behind 384]`. A workflow fix merged to origin never reached the boxes' working trees even though their daemons were running.

**Root cause:** `performFleetSharedRepoSync` fetches then replays local commits with `rebase --autostash`. Autostash sets aside only *tracked* changes, so an **untracked** working-tree file at a path that origin **tracks** aborts the rebase's checkout:

```
error: The following untracked working tree files would be overwritten by checkout:
    devices/peer/daemon-state.json
    projects/rush.yaml
Aborting
```

Other subsystems leave exactly such untracked files (peer `daemon-state.json`, `projects/*.yaml`, peer device configs), so the rebase aborted on **every** sync → unbounded drift.

## Fix

Add `clearCollidingUntracked()` between fetch and rebase. For each untracked file that origin also tracks:
- **byte-identical to origin** → drop it (lossless; origin is canonical in this shared-state repo and each device republishes its own state)
- **differs** → move it to a `<root>-fleet-sync-backups/<ts>/` dir **beside** the repo root (outside the tracked tree, so the move can't create a fresh collision), so nothing is silently destroyed

New optional result fields `untrackedCleared` / `untrackedBackedUp` surface what happened. The device's own owned file is committed before this runs (tracked, never touched here). A file that can't be cleared is left in place — the rebase may still abort, no worse than before, never losing data.

## Verification

```
$ TZ=UTC vitest run src/lib/fleet-shared-repo-sync.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
$ tsc --noEmit    # clean, 0 errors
```

New test reproduces the collision (one identical + one differing untracked file that both land on origin) and asserts: sync now succeeds, the identical one is dropped (`untrackedCleared ≥ 1`), the differing one is preserved in the backup (`untrackedBackedUp` contains it), origin's versions are checked out, and the device's own state commit still reaches origin.

**Field-verified precursor:** the same reconcile logic, applied by hand across the live fleet 2026-09-03, brought 11/13 reachable boxes from ↓380+ back to in-sync. This PR moves that logic into the daemon so it self-heals.

## Note on rollout

Fix ships in the daemon; the fleet picks it up as devices update to a release carrying it. Until then, drift re-accumulates (that's why this is filed High).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxiY3k8dURikxBAz8KLp2s
