### PR TITLE
fix(accounts): scope label uniqueness per harness and persist labels across daemon publish

### DIFF
--- a/cli/.changelog/next/PHNX-3887.md
+++ b/cli/.changelog/next/PHNX-3887.md
@@ -1,0 +1,14 @@
+- **Account labels are per-harness, and survive a daemon publish (PHNX-3887).** One
+  identity signed into several harnesses can now carry the SAME label on each —
+  `claude#icloud`, `codex#icloud`, and `grok#icloud` all resolve to that harness's own
+  login, instead of the first-labelled harness squatting the name and forcing prefixes
+  (`cxicloud`, `gkicloud`) on the rest. Uniqueness is scoped to `(agent, label)`;
+  provider accounts, selected by bare name via `--account`, stay globally unique, and a
+  duplicate label within one harness is still refused. Separately, `agents accounts
+  label` wrote version-scoped rows into the central `agents.yaml` as a plain file write
+  with no commit, so the daemon's `publish <device> daemon state` tick — which committed
+  only the per-device doc and then rebased `--autostash` over the dirty central file —
+  silently destroyed them: every box lost its account labels on its next publish. The
+  publish now commits `agents.yaml` alongside the device doc, so labels persist and
+  actually sync fleet-wide as `accounts label --help` already promised. Source:
+  `cli/src/lib/account-registry.ts`, `cli/src/lib/fleet-shared-repo-sync.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1075,6 +1075,28 @@ box. A git merge of two independently labeled boxes can union two UUID rows for
 one identity; `accounts remove` / `rename` / `label` operate on every matching
 row so a sibling cannot silently survive.
 
+**A label name is unique per HARNESS, not globally (PHNX-3887).** One human
+identity is routinely signed into several harnesses — the same email is a claude
+login AND a codex login AND a grok login — so a global namespace let whichever
+harness was labelled first squat the good name and forced prefixed junk
+(`cxicloud`, `gkicloud`) on the rest. `assertUniqueUnifiedName`
+([`src/lib/account-registry.ts`](src/lib/account-registry.ts)) scopes the check by
+`agent`, so `claude#icloud` / `codex#icloud` / `grok#icloud` each resolve to that
+harness's own row. Nothing is ambiguous at the point of use: the selector already
+names the harness, and `findUnifiedAccount`'s `preferAgent` already disambiguated
+on the read side. A duplicate label WITHIN one harness is still refused, and
+**provider** (non-native) accounts stay globally unique — they are selected by bare
+name via `--account`, with no harness to scope them by. Management lookups with no
+harness in hand (`rename` / `remove`) keep the fleet-wide check.
+
+**Writing a label commits `agents.yaml`.** Version-scoped rows land in the central
+`agents.yaml` via a plain file write, while the daemon's shared-state tick committed
+only `devices/<device>/daemon-state.json` and then rebased `--autostash` over the
+dirty central file — so every box silently lost its account labels on its next
+publish. The publish stages `agents.yaml` alongside the device doc
+([`src/lib/fleet-shared-repo-sync.ts`](src/lib/fleet-shared-repo-sync.ts)) so the
+rebase carries the rows instead of stashing them.
+
 `interactive.host` is a **user-level** preference: it lives in central
 `~/.agents/agents.yaml` under `config.interactiveHost`, syncs fleet-wide via
 `agents repo push/pull`, and answers "which device shows me artifacts?" It is

--- a/cli/src/lib/account-registry.test.ts
+++ b/cli/src/lib/account-registry.test.ts
@@ -44,6 +44,27 @@ describe('native account labels', () => {
     expect(() => labelNativeAccount('kimi', 'kimi:opaque=1', undefined, undefined, 'version')).toThrow('pass a manual label');
   });
 
+  // PHNX-3887: one human identity signed into several harnesses must be able to
+  // carry the SAME label on each. A global namespace let the first harness
+  // labelled squat the good name and forced prefixes (cxicloud, gkicloud).
+  it('lets separate harnesses share one label name', () => {
+    const claude = labelNativeAccount('claude', 'claude:user=1', 'me@example.com', 'icloud', 'version');
+    const codex = labelNativeAccount('codex', 'codex:user=1', 'me@example.com', 'icloud', 'version');
+    const grok = labelNativeAccount('grok', 'grok:user=1', 'me@example.com', 'icloud', 'version');
+    expect(new Set([claude.id, codex.id, grok.id]).size).toBe(3);
+    // `<harness>#<label>` resolves to that harness's own row, not whichever
+    // happened to be written first.
+    expect(findUnifiedAccount('icloud', readMeta(), undefined, 'claude')).toMatchObject({ id: claude.id, agent: 'claude' });
+    expect(findUnifiedAccount('icloud', readMeta(), undefined, 'codex')).toMatchObject({ id: codex.id, agent: 'codex' });
+    expect(findUnifiedAccount('icloud', readMeta(), undefined, 'grok')).toMatchObject({ id: grok.id, agent: 'grok' });
+  });
+
+  it('still rejects a duplicate label within the same harness', () => {
+    labelNativeAccount('codex', 'codex:user=1', 'first@example.com', 'work', 'version');
+    expect(() => labelNativeAccount('codex', 'codex:user=2', 'second@example.com', 'work', 'version'))
+      .toThrow("Account 'work' already exists for the codex harness.");
+  });
+
   it('removeAccount deletes every central row for the resolved (agent, identityKey)', () => {
     // Two independently labeled boxes merge via git into two UUID rows for one identity.
     const identityKey = 'codex:account=dup:user=x:org=y';

--- a/cli/src/lib/account-registry.ts
+++ b/cli/src/lib/account-registry.ts
@@ -223,17 +223,42 @@ function nativeRowsForNameOrId(meta: Pick<Meta, 'accounts' | 'deviceAccounts'>, 
   return nativeIdentityRows(meta, found.agent, found.identityKey);
 }
 
+/**
+ * Native label names are unique per HARNESS, not globally (PHNX-3887).
+ *
+ * One human identity is commonly signed into several harnesses —
+ * `muqsitnawaz@icloud.com` is a claude login AND a codex login AND a grok login.
+ * A global namespace let whichever harness was labelled first squat the good
+ * name, forcing prefixed junk (`cxicloud`, `gkicloud`) on the rest. Nothing is
+ * actually ambiguous at the point of use: the selector is `<harness>#<label>`,
+ * and `findUnifiedAccount` already disambiguates via `preferAgent`.
+ *
+ * Pass `agent` to scope the check to that harness. Omit it for management
+ * lookups with no harness in hand (rename/remove), which keep the old
+ * fleet-wide check so a rename cannot collide with an unrelated harness's row.
+ *
+ * Provider (non-native) accounts stay globally unique — they are selected by
+ * bare name via `--account`, with no harness to scope them by.
+ */
 function assertUniqueUnifiedName(
   name: string,
   meta: Pick<Meta, 'accounts' | 'deviceAccounts'>,
   doc?: AccountRegistryDocument,
   exceptIds?: ReadonlySet<string>,
+  agent?: AgentId,
 ): void {
   const needle = name.toLowerCase();
   const nativeHits = listNativeAccounts(meta).filter(account =>
-    account.id === name || account.name.toLowerCase() === needle || account.identityLabel?.toLowerCase() === needle,
+    (agent === undefined || account.agent === agent)
+    && (account.id === name || account.name.toLowerCase() === needle || account.identityLabel?.toLowerCase() === needle),
   );
-  if (nativeHits.some(account => !exceptIds?.has(account.id))) throw new Error(`Account '${name}' already exists.`);
+  if (nativeHits.some(account => !exceptIds?.has(account.id))) {
+    throw new Error(
+      agent === undefined
+        ? `Account '${name}' already exists.`
+        : `Account '${name}' already exists for the ${agent} harness.`,
+    );
+  }
   // Same laziness as findUnifiedAccount: a native row that already owns this
   // name (even one we are mutating) means we never open the provider store.
   if (nativeHits.length > 0) return;
@@ -250,7 +275,7 @@ export function addNativeAccount(
 ): NativeAccount {
   assertNativeLabel(name);
   const meta = readMeta();
-  assertUniqueUnifiedName(name, meta);
+  assertUniqueUnifiedName(name, meta, undefined, undefined, agent);
   const duplicate = listNativeAccounts(meta).find(account => account.agent === agent && account.identityKey === identityKey);
   if (duplicate) throw new Error(`This ${agent} login is already named '${duplicate.name}'.`);
   const account: NativeAccount = { id: crypto.randomUUID(), name, kind: 'native', agent, identityKey, identityLabel, scope };
@@ -291,7 +316,7 @@ export function labelNativeAccount(
   assertNativeLabel(resolvedLabel);
   const meta = readMeta();
   const matches = nativeIdentityRows(meta, agent, identityKey);
-  assertUniqueUnifiedName(resolvedLabel, meta, undefined, new Set(matches.map(account => account.id)));
+  assertUniqueUnifiedName(resolvedLabel, meta, undefined, new Set(matches.map(account => account.id)), agent);
   if (matches.length === 0) return addNativeAccount(resolvedLabel, agent, identityKey, identityLabel, scope);
   // Sweep every row for this identity (PHNX-3206), routing the whole sweep to the
   // store that owns them: all rows for one identityKey share a scope (same agent),

--- a/cli/src/lib/fleet-shared-repo-sync.test.ts
+++ b/cli/src/lib/fleet-shared-repo-sync.test.ts
@@ -124,6 +124,44 @@ describe('syncFleetSharedStateRepo (real git)', () => {
     expect(remoteLog).toContain('chore(devices): publish worker-a daemon state');
   });
 
+  // PHNX-3887: `agents accounts label` writes version-scoped account rows into the
+  // central agents.yaml as a plain file write. Publishing only the per-device doc and
+  // then rebasing --autostash over the dirty central file destroyed those labels, so
+  // every box silently lost its account labels on its next daemon publish.
+  it('publishes central agents.yaml so account labels survive the rebase', async () => {
+    const root = tempDir();
+    const remote = path.join(root, 'remote.git');
+    const publisher = path.join(root, 'publisher');
+    git(root, ['init', '--bare', '--initial-branch=main', remote]);
+    git(root, ['clone', remote, publisher]);
+    configureIdentity(publisher);
+    fs.writeFileSync(path.join(publisher, 'agents.yaml'), 'accounts: {}\n', 'utf-8');
+    git(publisher, ['add', 'agents.yaml']);
+    git(publisher, ['commit', '-m', 'seed user store']);
+    git(publisher, ['push', 'origin', 'main']);
+
+    // A label write: central agents.yaml modified, left uncommitted.
+    fs.writeFileSync(
+      path.join(publisher, 'agents.yaml'),
+      'accounts:\n  native:\n    abc:\n      name: icloud\n      agent: claude\n',
+      'utf-8',
+    );
+    updateFleetSharedDeviceState('zion', { auth: { status: 'ok' } }, publisher);
+
+    const published = await syncFleetSharedStateRepo({
+      userAgentsDir: publisher,
+      device: 'zion',
+      timeoutMs: 10_000,
+      lockPath: path.join(root, 'publisher.lock-target'),
+    });
+    expect(published).toMatchObject({ success: true, committed: true, error: null });
+
+    // The label must survive on disk AND have reached the remote.
+    expect(fs.readFileSync(path.join(publisher, 'agents.yaml'), 'utf-8')).toContain('name: icloud');
+    const remoteYaml = git(root, ['--git-dir', remote, 'show', 'main:agents.yaml']);
+    expect(remoteYaml).toContain('name: icloud');
+  });
+
   it('refuses to push and removes conflict markers when an autostash pop conflicts', async () => {
     const root = tempDir();
     const remote = path.join(root, 'remote.git');

--- a/cli/src/lib/fleet-shared-repo-sync.ts
+++ b/cli/src/lib/fleet-shared-repo-sync.ts
@@ -233,17 +233,30 @@ async function performFleetSharedRepoSync(
 
   const ownedFile = fleetSharedStatePath(device, root);
   const relativeOwnedFile = path.relative(root, ownedFile).split(path.sep).join('/');
+  // The central `agents.yaml` is fleet-shared state too — `agents accounts label`
+  // writes version-scoped native account rows there (lib/state.ts writeMetaUnlocked),
+  // as a plain file write with no commit. Publishing only the per-device file and
+  // then `rebase --autostash`-ing over a dirty central file silently destroyed
+  // those labels: every box lost its account labels on its next daemon publish
+  // (PHNX-3887). Commit it alongside the device doc so the rebase carries the
+  // rows instead of stashing them, which is also what `accounts label --help`
+  // already promises ("labels live on the central account rows in agents.yaml,
+  // which repo push/pull already syncs fleet-wide").
+  const centralFile = path.join(root, 'agents.yaml');
+  const publishPaths = [relativeOwnedFile];
+  if (fs.existsSync(centralFile)) publishPaths.push('agents.yaml');
+  const existingPaths = publishPaths.filter(rel => fs.existsSync(path.join(root, rel)));
   let committed = false;
-  if (fs.existsSync(ownedFile)) {
-    const status = await git(['status', '--porcelain=v1', '--', relativeOwnedFile]);
+  if (existingPaths.length > 0) {
+    const status = await git(['status', '--porcelain=v1', '--', ...existingPaths]);
     if (status.code !== 0) return failure('git status', status);
     if (status.stdout.trim()) {
-      const add = await git(['add', '--', relativeOwnedFile]);
+      const add = await git(['add', '--', ...existingPaths]);
       if (add.code !== 0) return failure('git add', add);
       const commit = await git([
         '-c', 'commit.gpgsign=false',
         'commit', '--no-verify', '-m', `chore(devices): publish ${device} daemon state`,
-        '--', relativeOwnedFile,
+        '--', ...existingPaths,
       ]);
       if (commit.code !== 0) return failure('git commit', commit);
       committed = true;


### PR DESCRIPTION
Closes PHNX-3887.

## Why

Two defects, both surfaced while applying a canonical account-naming scheme across a 12-box fleet.

**1. A label name was globally unique, but each row is bound to one harness.** One human identity is routinely signed into several harnesses — the same email is a claude login AND a codex login AND a grok login. So whichever harness was labelled first squatted the good name, and the rest were forced onto prefixes:

```
$ agents accounts label claude icloud --account muqsitnawaz@icloud.com
Labeled claude account muqsitnawaz@icloud.com as 'icloud'.

$ agents accounts label grok icloud --account muqsitnawaz@icloud.com
Account 'icloud' already exists.
```

`attach` — the obvious escape hatch — is harness-scoped and refuses:

```
$ agents accounts attach personal claude@2.1.186
Account 'personal' is a codex login; 'claude@2.1.186' runs claude.
```

The only workaround was renaming the losing harness off-scheme (`cxicloud`, `gkicloud`), which defeats the point of having a canonical scheme at all.

**2. Labels did not survive.** `agents accounts label` writes version-scoped rows into the central `agents.yaml` as a plain file write with **no commit** (`writeIfChanged(META_FILE, …)`, `state.ts`). The daemon's shared-state tick committed only `devices/<device>/daemon-state.json` and then `rebase --autostash`'d over the dirty central file — destroying them. Measured across a 9-box fleet after a successful rollout, **5 boxes had already silently reverted**:

```
yosemite-s1  8/8 labeled     yosemite-m2  0/5    ← reverted
yosemite-m1  8/8 labeled     yosemite-m3  0/5    ← reverted
yosemite-m5  5/5 labeled     yosemite-m6  0/5    ← reverted
yosemite-m0  5/5 labeled     yosemite-s0  0/1    ← reverted
                             mac-mini     0/2    ← reverted
```

The split is exactly "has the daemon published since?" — reflog on a reverted box:

```
rebase (finish): returning to refs/heads/main
rebase (pick): chore(devices): publish yosemite-m2 daemon state
rebase (start): checkout origin/main
```

Boxes that kept their labels show ` M agents.yaml` (dirty, uncommitted); reverted boxes show a clean tree with the rows gone. The command reported success every time.

## What changed

**`cli/src/lib/account-registry.ts`** — `assertUniqueUnifiedName` takes an optional `agent` and scopes the native-row check to it. `labelNativeAccount` and `addNativeAccount` pass theirs.

Nothing is ambiguous at the point of use: the selector is already `<harness>#<label>`, and `findUnifiedAccount`'s `preferAgent` already disambiguated on the read side — this makes the write side agree with a design the read side had. Deliberately unchanged:

- a duplicate label **within** one harness is still refused (now with a clearer message naming the harness)
- **provider** (non-native) accounts stay globally unique — they are selected by bare name via `--account`, with no harness to scope them by
- management lookups with no harness in hand (`rename`, `remove`) keep the fleet-wide check, so a rename cannot collide with an unrelated harness's row

**`cli/src/lib/fleet-shared-repo-sync.ts`** — the publish stages `agents.yaml` alongside the device doc, so the rebase carries the rows instead of stashing them. This is also what `accounts label --help` already promised ("labels live on the central account rows in agents.yaml, which repo push/pull already syncs fleet-wide") — the code just never did it.

I chose the publish seam rather than committing inside the label write: the publish already commits fleet-shared state and then rebases over it, so the bug is that it committed *part* of what it was about to rebase over. Committing on every `updateMeta` would also add commit churn the surrounding code explicitly avoids for pins.

## Tests

`cli/src/lib/account-registry.test.ts`
- separate harnesses share one label name, and each `#label` resolves to its own harness's row
- a duplicate label within the same harness is still refused

`cli/src/lib/fleet-shared-repo-sync.test.ts`
- a dirty central `agents.yaml` survives a publish and reaches the remote — real git, real bare remote, no mocking

**Both were verified to fail without the fix.** Disabling only the `publishPaths` line:

```
× publishes central agents.yaml so account labels survive the rebase
AssertionError: expected 'accounts: {}' to contain 'name: icloud'
```

`44 passed (44)` across both files with the fix in place.

## Docs

`cli/AGENTS.md` — the native-account-labels section documented the old global-uniqueness model and the (false) claim that labels sync fleet-wide; both paragraphs updated. Changelog fragment added at `cli/.changelog/next/PHNX-3887.md`.

## Risk

Existing labels are untouched — this only widens what is *accepted*, so nothing that resolved before stops resolving. The publish change adds one path to an existing `git add`/`git commit`, guarded by `fs.existsSync`, so a repo with no central `agents.yaml` behaves exactly as before.
