### PR TITLE
fix(webhooks): bound hosted receiver shutdown

### DIFF
--- a/cli/src/lib/daemon-webhooks.test.ts
+++ b/cli/src/lib/daemon-webhooks.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as http from 'http';
 import * as os from 'os';
@@ -173,6 +174,68 @@ describe('startHostedWebhookReceivers', () => {
       if (previousStateDir === undefined) delete process.env.AGENTS_STATE_DIR;
       else process.env.AGENTS_STATE_DIR = previousStateDir;
       fs.rmSync(bundleDir, { recursive: true, force: true });
+    }
+  });
+
+  it('closes promptly and destroys HTTP keep-alive sockets', async () => {
+    const previousStateDir = process.env.AGENTS_STATE_DIR;
+    process.env.AGENTS_STATE_DIR = configDir;
+    const portProbe = http.createServer();
+    await new Promise<void>((resolve) => portProbe.listen(0, '127.0.0.1', resolve));
+    const port = (portProbe.address() as AddressInfo).port;
+    await new Promise<void>((resolve) => portProbe.close(() => resolve()));
+
+    writeDaemonWebhooksConfig({ receivers: [{ bundle: 'keep-alive', port }] });
+    const hosted = await startHostedWebhookReceivers({
+      log: () => {},
+      resolveSecrets: () => ({ linear: 'test-secret' }),
+    });
+    const agent = new http.Agent({ keepAlive: true });
+    let clientSocket: import('net').Socket | undefined;
+
+    try {
+      const body = JSON.stringify({ type: 'Issue', webhookTimestamp: Date.now() });
+      const signature = crypto.createHmac('sha256', 'test-secret').update(body).digest('hex');
+      await new Promise<void>((resolve, reject) => {
+        const request = http.request({
+          host: '127.0.0.1',
+          port,
+          path: '/hooks/linear',
+          method: 'POST',
+          agent,
+          headers: {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(body),
+            'linear-signature': signature,
+          },
+        }, (response) => {
+          expect(response.statusCode).toBe(202);
+          response.resume();
+          response.once('end', resolve);
+        });
+        request.once('socket', (socket) => { clientSocket = socket; });
+        request.once('error', reject);
+        request.end(body);
+      });
+      expect(clientSocket).toBeDefined();
+      const socket = clientSocket!;
+      expect(socket.destroyed).toBe(false);
+
+      const clientClosed = new Promise<void>((resolve) => socket.once('close', () => resolve()));
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('hosted webhook close exceeded 500ms')), 500);
+        Promise.all([hosted.close(), clientClosed]).then(
+          () => { clearTimeout(timer); resolve(); },
+          (error) => { clearTimeout(timer); reject(error); },
+        );
+      });
+
+      expect(socket.destroyed).toBe(true);
+    } finally {
+      agent.destroy();
+      await hosted.close();
+      if (previousStateDir === undefined) delete process.env.AGENTS_STATE_DIR;
+      else process.env.AGENTS_STATE_DIR = previousStateDir;
     }
   });
 

--- a/cli/src/lib/daemon-webhooks.ts
+++ b/cli/src/lib/daemon-webhooks.ts
@@ -18,8 +18,10 @@ import * as path from 'path';
 import * as yaml from 'yaml';
 import { exec } from 'child_process';
 import type { Server } from 'http';
+import type { Socket } from 'net';
 import { getDaemonConfigDir, getRuntimeStateDir } from './state.js';
 import { atomicWriteFileSync } from './fs-atomic.js';
+import { closeServerBounded } from './secrets/agent.js';
 import { readAndResolveBundleEnv } from './secrets/bundles.js';
 import { startWebhookServer, createFileDeliveryStore, waitForListening, type WebhookSecrets } from './triggers/webhook.js';
 import { buildFunnelUpCommand, FUNNEL_PORTS, type FunnelPort } from './funnel.js';
@@ -203,7 +205,7 @@ export async function startHostedWebhookReceivers(opts: {
   const { log } = opts;
   const resolveSecrets = opts.resolveSecrets ?? resolveReceiverSecrets;
   const { receivers } = readDaemonWebhooksConfig();
-  const servers: Server[] = [];
+  const servers: Array<{ server: Server; sockets: Set<Socket> }> = [];
 
   for (const receiver of receivers) {
     const port = receiver.port ?? DEFAULT_WEBHOOK_PORT;
@@ -241,8 +243,13 @@ export async function startHostedWebhookReceivers(opts: {
           log('WARN', `webhook ${webhook.source}:${webhook.event} dispatch failed after ack: ${err.message}`);
         },
       });
+      const sockets = new Set<Socket>();
+      server.on('connection', (socket: Socket) => {
+        sockets.add(socket);
+        socket.once('close', () => sockets.delete(socket));
+      });
       await waitForListening(server);
-      servers.push(server);
+      servers.push({ server, sockets });
       log('INFO', `webhook receiver bound on 127.0.0.1:${port} (bundle ${receiver.bundle})`);
       if (receiver.funnel) reconcileFunnel(receiver.funnel.publicPort, port, log);
     } catch (err) {
@@ -257,9 +264,13 @@ export async function startHostedWebhookReceivers(opts: {
     count: servers.length,
     close: () =>
       Promise.all(
-        servers.map(
-          (s) => new Promise<void>((resolve) => s.close(() => resolve())),
-        ),
+        servers.map(async ({ server, sockets }) => {
+          // Stop accepting first, then force every persistent HTTP connection
+          // closed so keep-alive cannot hold daemon shutdown open indefinitely.
+          const closing = closeServerBounded(server);
+          for (const socket of sockets) socket.destroy();
+          await closing;
+        }),
       ).then(() => undefined),
   };
 }


### PR DESCRIPTION
## Summary
- reuse closeServerBounded for daemon-hosted webhook receivers
- track and destroy open HTTP sockets so keep-alive connections cannot stall SIGTERM
- cover a signed Linear webhook 202 response over a real keep-alive connection

## Verification
- bun run test -- src/lib/daemon-webhooks.test.ts — 13 passed
- bun test src/lib/daemon-webhooks.test.ts --test-name-pattern "closes promptly" — 1 passed
- bun run build — passed
- bun test — attempted; unrelated baseline/runtime failures include it.runIf unavailable in Bun test, scripts/test.sh message mismatch, and release dry-run timeout

Ticket: https://linear.app/getrush/issue/PHNX-2704/webhook-receiver-close-has-no-timeout-sigterm-can-hang-on-keep-alive