### PR TITLE
fix(daemon): serialize stop/start and cover supervisor wiring

### DIFF
--- a/cli/.changelog/next/PHNX-3941.md
+++ b/cli/.changelog/next/PHNX-3941.md
@@ -1,0 +1,1 @@
+- **Keep one daemon alive across concurrent stop/start (PHNX-3941).** Prevent a replacement daemon from exiting while stop holds the lifecycle lock, so concurrent stop/start cannot leave zero instances, and extend real-boot supervisor-wiring coverage to all 20 services. Source: `cli/src/lib/daemon/daemon.ts`.

--- a/cli/src/lib/daemon/daemon.lifecycle.test.ts
+++ b/cli/src/lib/daemon/daemon.lifecycle.test.ts
@@ -18,7 +18,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as net from 'net';
 import * as path from 'path';
-import { execFileSync } from 'child_process';
+import { pathToFileURL } from 'url';
+import { execFileSync, spawn } from 'child_process';
 import { startDetached, startDaemon, assertTestDaemonHome } from './daemon.js';
 import { ipcEndpoint } from '../platform/index.js';
 import { DIST_ENTRY, REPO_ROOT, installKeychainHermeticity } from './daemon.test-fixture.js';
@@ -245,6 +246,57 @@ describe('startDaemon (RUSH-2417: the start lock is released before the child-pi
 //    daemon's pid file (else two schedulers double-fire every routine).
 //  - A start that produced no OS pid must fail loudly, never surface null.
 describe('daemon single-instance (#414)', () => {
+  it.skipIf(process.platform === 'win32')(
+    'a replacement waits for an in-progress stop lifecycle lock, then claims the singleton',
+    async () => {
+      if (!fs.existsSync(DIST_ENTRY)) {
+        execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
+      }
+
+      const tmpHome = fs.mkdtempSync(path.join('/tmp', 'agd-stop-start-'));
+      const daemonDir = path.join(tmpHome, 'daemon');
+      const lockPath = path.join(daemonDir, 'daemon.lock');
+      const pidPath = path.join(daemonDir, 'daemon.pid');
+      fs.mkdirSync(daemonDir, { recursive: true });
+      // This process stands in for stopDaemon() while it owns the lifecycle
+      // lock through teardown. The child drives the real claim implementation.
+      fs.writeFileSync(lockPath, String(process.pid), 'utf-8');
+
+      const builtDaemonUrl = new URL('lib/daemon/daemon.js', pathToFileURL(DIST_ENTRY)).href;
+      const script = [
+        `import { claimDaemonInstance } from ${JSON.stringify(builtDaemonUrl)};`,
+        `process.stdout.write(JSON.stringify({ claimed: claimDaemonInstance(), pid: process.pid }));`,
+      ].join('\n');
+      const child = spawn(process.execPath, ['--input-type=module', '-e', script], {
+        env: { ...process.env, HOME: tmpHome, AGENTS_DAEMON_DIR: daemonDir },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+      child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+
+      try {
+        // Pre-fix claimDaemonInstance returned false and this child exited while
+        // stop still held the lock, guaranteeing no replacement after teardown.
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        expect(child.exitCode).toBeNull();
+
+        fs.unlinkSync(lockPath);
+        const exitCode = await new Promise<number | null>((resolve) => child.once('close', resolve));
+        expect(exitCode, stderr).toBe(0);
+        const result = JSON.parse(stdout);
+        expect(result.claimed).toBe(true);
+        expect(fs.readFileSync(pidPath, 'utf-8').trim()).toBe(String(result.pid));
+        expect(fs.existsSync(lockPath)).toBe(false);
+      } finally {
+        try { child.kill('SIGKILL'); } catch { /* already gone */ }
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    },
+    20_000,
+  );
+
   it('startDetached fails loudly instead of returning a null PID when the binary is unspawnable', () => {
     // A non-JS entry is spawned directly (getDaemonLaunch), so a missing binary
     // makes spawn() yield an undefined pid — the exact `child.pid || null`

--- a/cli/src/lib/daemon/daemon.supervisor-wiring.test.ts
+++ b/cli/src/lib/daemon/daemon.supervisor-wiring.test.ts
@@ -130,6 +130,51 @@ describe('runDaemon() supervisor wiring (integration: real daemon subprocess)', 
     'catchup',
   ] as const;
 
+  // PHNX-3373 / PHNX-3941: registration is a separate invariant from a clean
+  // first tick. Socket/lifecycle services can legitimately report a failure in
+  // a bare HOME (for example auth-sync with no configured account), but every
+  // enabled service must still publish a supervisor-owned health record on a
+  // real daemon boot.
+  const ALL_SUPERVISED_SERVICE_IDS = [
+    'session-state', 'secrets-broker', 'monitors', 'account-state',
+    'account-auth', 'catchup', 'browser-ipc', 'session-index', 'watchdog',
+    'device-probe', 'self-heal', 'self-update', 'keychain-reap', 'auth-sync',
+    'usage-sync', 'webhook-receiver', 'daemon-heartbeat', 'tmux-reap',
+    'browser-task-reap', 'state-dir-check',
+  ] as const;
+
+  it('registers every supervised service during a real daemon boot', async () => {
+    if (!fs.existsSync(DIST_ENTRY)) execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
+
+    const tmpHome = freshHome();
+    const logPath = path.join(tmpHome, 'daemon-stdio.log');
+    const healthPath = path.join(tmpHome, '.agents', '.cache', 'helpers', 'daemon', 'health.json');
+    const childEnv = { ...process.env, HOME: tmpHome };
+    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
+
+    const { pid } = startDetached({ agentsBin: DIST_ENTRY, logPath, env: childEnv });
+    expect(pid).toBeTruthy();
+
+    try {
+      const readHealth = (): Record<string, unknown> => {
+        try { return JSON.parse(fs.readFileSync(healthPath, 'utf-8')); } catch { return {}; }
+      };
+
+      let all: Record<string, unknown> = {};
+      for (let i = 0; i < 200 && ALL_SUPERVISED_SERVICE_IDS.some((id) => !all[id]); i++) {
+        all = readHealth();
+        if (ALL_SUPERVISED_SERVICE_IDS.some((id) => !all[id])) await new Promise((r) => setTimeout(r, 100));
+      }
+
+      for (const id of ALL_SUPERVISED_SERVICE_IDS) {
+        expect(all[id], `expected a supervisor health record for '${id}'`).toBeDefined();
+      }
+    } finally {
+      if (pid) await killAndWait(pid);
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   it('registers every periodic maintenance service on the supervisor and each reports healthy shortly after boot', async () => {
     if (!fs.existsSync(DIST_ENTRY)) execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
 

--- a/cli/src/lib/daemon/daemon.ts
+++ b/cli/src/lib/daemon/daemon.ts
@@ -297,7 +297,7 @@ function acquireStartLock(): (() => void) | null {
 const STOP_LOCK_WAIT_MS = 10_000;
 const STOP_LOCK_POLL_MS = 50;
 
-function acquireStopLock(): (() => void) | null {
+function acquireLifecycleLock(): (() => void) | null {
   const deadline = Date.now() + STOP_LOCK_WAIT_MS;
   for (;;) {
     const release = acquireStartLock();
@@ -504,14 +504,13 @@ export function isDaemonRunning(): boolean {
  * liveness check and the write.
  */
 export function claimDaemonInstance(): boolean {
-  const release = acquireStartLock();
-  // acquireStartLock() returns null only when another __daemon-run currently
-  // holds the O_EXCL lock — a dead holder's lock is reclaimed and retried inside
-  // acquireStartLock, so null means a *live* claimer is mid-claim. Bail rather
-  // than run the read-evict-write unlocked: otherwise two first-start processes
-  // could each see no pid file (before either writes one) and both claim,
-  // running the concurrent JobScheduler this guard exists to prevent. The live
-  // claimer we bailed for becomes the singleton, so last-wins still holds.
+  // A stop owns this same lock through teardown. Waiting here is load-bearing:
+  // returning false while stopDaemon() holds it lets this replacement exit 0,
+  // then the stop completes with no singleton left alive. The bounded lifecycle
+  // acquisition also preserves concurrent-start serialization: after the first
+  // claimer publishes its pid, the waiter takes the lock and performs the normal
+  // last-wins takeover rather than ever running the read-evict-write unlocked.
+  const release = acquireLifecycleLock();
   if (!release) return false;
   try {
     // Do not overwrite a live-but-uninspectable owner. This is the non-
@@ -2274,7 +2273,7 @@ export function findSurvivingStateDirDaemons(exclude: Set<number>): number[] {
  * never reports success on an unverified stop.
  */
 export function stopDaemon(): DaemonStopResult {
-  const releaseLock = acquireStopLock();
+  const releaseLock = acquireLifecycleLock();
   if (!releaseLock) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary
- serialize `claimDaemonInstance()` through the bounded lifecycle lock so a replacement waits for an in-progress stop instead of exiting and leaving no daemon
- extend the real-daemon boot test to require health records for all 20 supervised services

## Verification
- `scripts/build.sh --skip-tests` — passed (1728 files, 15394 KB)
- `bun test src/lib/daemon/daemon.lifecycle.test.ts -t "replacement waits"` — 1 passed, 0 failed
- `bun test src/lib/daemon/daemon.supervisor-wiring.test.ts` — 5 passed, 0 failed
- requested raw `bun test` was run; it fails outside this subsystem because raw Bun bypasses the repository Vitest hermetic profile (examples: `tests/teams-events.test.ts` timeout, `vi.mock importOriginal is not a function`, HOME sandbox assertions). The run also deleted fixture-managed tracked files; they were restored exactly from HEAD before the daemon patch was reapplied and reverified.

## Remaining folded PHNX-3941 items
- already-running pre-self-update daemon bootstrap requires a foreground bootstrap/startup integration outside `cli/src/lib/daemon/**`; not half-implemented in this daemon-only PR
- `session-encryption-salt-v1` storage is not implemented anywhere under `cli/src/lib/daemon/**` (repository search finds only keychain probe controls outside the subsystem); file fallback belongs to the session encryption/keychain owner
- `self-update.test.ts` foreign-path repair flake is outside the owned daemon subsystem

Refs PHNX-3941.