### PR TITLE
test(sessions): cover remote previews and snippets (PHNX-3944)

### DIFF
--- a/cli/src/lib/picker.test.ts
+++ b/cli/src/lib/picker.test.ts
@@ -161,6 +161,47 @@ describe('itemPicker preview at default height (RUSH-2198 regression)', () => {
     expect(clean).toContain('session row s0');
     expect(clean).toContain('─');
   });
+
+  it('repaints the preview when registerPreviewRepaint fires without a keypress', async () => {
+    const pickerUrl = pathToFileURL(path.resolve('src/lib/picker.ts')).href;
+    const program = `
+      import { itemPicker } from ${JSON.stringify(pickerUrl)};
+      let ready = false;
+      await itemPicker({
+        message: 'Search sessions:',
+        items: [{ id: 'remote-1' }],
+        filter: () => [{ id: 'remote-1' }],
+        labelFor: () => 'remote session',
+        buildPreview: () => ready ? 'ASYNC_PREVIEW_READY' : 'fetching remote preview',
+        registerPreviewRepaint: (repaint) => setTimeout(() => { ready = true; repaint(); }, 50),
+      });
+    `;
+    const child = spawn(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', program], {
+      cols: 120,
+      rows: 24,
+      cwd: process.cwd(),
+      env: { ...process.env, TERM: 'xterm-256color' },
+    });
+
+    const output = await new Promise<string>((resolve, reject) => {
+      let captured = '';
+      const timeout = setTimeout(() => {
+        child.kill();
+        reject(new Error(`picker did not repaint:\n${stripVTControlCharacters(captured)}`));
+      }, 10_000);
+      child.onData((data) => {
+        captured += data;
+        if (!captured.includes('ASYNC_PREVIEW_READY')) return;
+        clearTimeout(timeout);
+        child.kill();
+        resolve(captured);
+      });
+    });
+
+    const clean = stripVTControlCharacters(output);
+    expect(clean).toContain('fetching remote preview');
+    expect(clean).toContain('ASYNC_PREVIEW_READY');
+  });
 });
 
 describe('itemPicker numbered rows', () => {

--- a/cli/src/lib/session/db.query-hotpath.test.ts
+++ b/cli/src/lib/session/db.query-hotpath.test.ts
@@ -227,3 +227,20 @@ describe('ftsSearch label tier routes through the FTS5 index, not a leading-wild
     expect(() => ftsSearch('...')).not.toThrow();
   });
 });
+
+describe('ftsSearch snippets', () => {
+  it('returns a bounded excerpt from the matching assistant answer', () => {
+    upsertSession(
+      meta('assistant-snippet'),
+      'the user prompt contains no diagnostic terms',
+      undefined,
+      'Root cause: the grombulator flux capacitor overheated during the canary rollout.',
+    );
+
+    const hit = ftsSearch('grombulator overheated').find((row) => row.sessionId === 'assistant-snippet');
+    expect(hit).toBeDefined();
+    expect(hit!.snippet).toContain('**grombulator**');
+    expect(hit!.snippet).toContain('**overheated**');
+    expect(hit!.snippet!.length).toBeLessThan(200);
+  });
+});

--- a/cli/src/lib/session/remote/remote-list.test.ts
+++ b/cli/src/lib/session/remote/remote-list.test.ts
@@ -19,6 +19,7 @@ import {
   consumeRemoteToolByteBudget,
   parseRemoteList,
   parseRemoteListPayload,
+  parsePeerPreviewDigest,
   parseRemoteToolSearch,
   parseRemoteToolProgramCount,
   RemoteUtf8Accumulator,
@@ -441,6 +442,25 @@ describe('remoteListCommand', () => {
     expect(cmd).toContain('deploy');
     expect(cmd).toContain('--since');
     expect(cmd).toContain('--json');
+  });
+});
+
+describe('parsePeerPreviewDigest', () => {
+  it('returns the preview object from the peer JSON envelope verbatim', () => {
+    const preview = { summary: 'remote result', files: ['src/a.ts'], nested: { ok: true } };
+    expect(parsePeerPreviewDigest({ preview, ignored: 'peer metadata' })).toBe(preview);
+  });
+
+  it.each([
+    { payload: null },
+    { payload: [] },
+    { payload: 'not an envelope' },
+    { payload: {} },
+    { payload: { preview: null } },
+    { payload: { preview: 'not an object' } },
+    { payload: { preview: [] } },
+  ])('rejects a missing or malformed preview envelope: $payload', ({ payload }) => {
+    expect(parsePeerPreviewDigest(payload)).toBeUndefined();
   });
 });
 

--- a/cli/src/lib/session/remote/remote-list.ts
+++ b/cli/src/lib/session/remote/remote-list.ts
@@ -651,6 +651,11 @@ export async function fetchPeerPreviewDigest(
   } catch {
     return undefined;
   }
+  return parsePeerPreviewDigest(parsed);
+}
+
+/** Parse the JSON envelope returned by `sessions preview --json`. */
+export function parsePeerPreviewDigest(parsed: unknown): unknown | undefined {
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
   const preview = (parsed as { preview?: unknown }).preview;
   if (!preview || typeof preview !== 'object' || Array.isArray(preview)) return undefined;


### PR DESCRIPTION
## Summary
- extract and cover peer preview JSON-envelope validation
- exercise picker preview repaint through the existing PTY harness
- cover bounded BM25 snippets sourced from assistant-answer text

## Evidence
- bun run build: passed
- bun test src/lib/session/remote/remote-list.test.ts: 39 passed
- bun test src/lib/session/db.query-hotpath.test.ts: 12 passed
- direct PTY run: WAIT repainted to READY without keyboard input
- raw bun test attempted; blocked by pre-existing runner/setup failures (HOME/opener sandbox absent, vi.mock importOriginal unavailable, and all existing picker PTY children time out under Bun process.execPath)

## Scope intentionally not duplicated
- import /tmp isolation is already present on main
- supervisor wiring already has dedicated real-service tests and overlaps open PR #3447
- per-harness assistant extraction and doctor comparator consolidation remain on PHNX-3944 because completing them cleanly exceeds this no-production-behavior test-only slice

Linear: PHNX-3944