### PR TITLE
fix(cli): harden routines, spawn, sessions, and webhooks (PHNX-3943)

### DIFF
--- a/cli/src/commands/exec.test.ts
+++ b/cli/src/commands/exec.test.ts
@@ -19,9 +19,23 @@ import {
   runAccountPickerConflicts,
   runAutoDefaultsToAffinity,
   hostInteractiveNeedsCorrelationId,
+  parseExplicitSessionId,
   RUN_AUTO_KEYWORD,
 } from './exec.js';
 import { ALL_AGENT_IDS } from '../lib/agents.js';
+
+describe('--session-id CLI boundary (PHNX-3943)', () => {
+  it('accepts UUIDs and conservative ASCII handles', () => {
+    expect(parseExplicitSessionId('01a0555d-0675-78c1-9758-8214d1afdca2')).toBe('01a0555d-0675-78c1-9758-8214d1afdca2');
+    expect(parseExplicitSessionId('session.name_1')).toBe('session.name_1');
+  });
+
+  it.each(['emoji-🚀', '会话', 'space id', 'slash/id', '#{session_name}', ''])('rejects %j', (value) => {
+    expect(() => parseExplicitSessionId(value)).toThrow(
+      'must contain only ASCII letters, digits, dots, underscores, or hyphens',
+    );
+  });
+});
 
 describe('degraded run governance mode', () => {
   it('records the resolved writable mode in the audit chain', () => {

--- a/cli/src/commands/exec.ts
+++ b/cli/src/commands/exec.ts
@@ -6,7 +6,7 @@
  * injection, and multi-agent fallback chains for rate-limit resilience.
  */
 
-import { Option, type Command } from 'commander';
+import { InvalidArgumentError, Option, type Command } from 'commander';
 import chalk from 'chalk';
 import type { ExecOptions, ExecMode, ExecEffort, FallbackEntry } from '../lib/exec.js';
 import { isTierToken } from '../lib/model-tiers.js';
@@ -130,6 +130,16 @@ interface ExecCommandActionOptions {
   results?: string | true;
   /** --concurrency <n>: broadcast cell parallelism. */
   concurrency?: string;
+}
+
+/** Validate a caller-supplied session id before it reaches tmux, paths, indexes, or remote dispatch. */
+export function parseExplicitSessionId(value: string): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(value)) {
+    throw new InvalidArgumentError(
+      'must contain only ASCII letters, digits, dots, underscores, or hyphens',
+    );
+  }
+  return value;
 }
 
 export interface RunAccountPickerRequest {
@@ -718,7 +728,7 @@ export function registerRunCommand(program: Command): void {
     .option('--results [run-id]', 'With --broadcast: show one saved matrix run, or list saved runs newest first')
     .option('--concurrency <n>', 'With --broadcast: maximum cells running at once', '3')
     .option('--resume [id]', 'Recover a previous conversation on its origin device. The exact healthy origin uses native resume; otherwise a healthy version of the same harness replays via /continue. Pair with a prompt to continue headlessly.')
-    .option('--session-id <id>', 'Force a NEW conversation to use this exact session UUID (Claude only). This CREATES a session — to resume an existing one, use --resume.')
+    .option('--session-id <id>', 'Force a NEW conversation to use this exact session UUID (Claude only). This CREATES a session — to resume an existing one, use --resume.', parseExplicitSessionId)
     .option('--name <slug>', 'Name the run — seeds the session label so it shows up as `<name>` in `agents sessions` and resolves by it (and `agents hosts logs <name>` for --device runs) instead of an opaque id. An agent-generated title later refines the label; your name shows until then. Optional.')
     .option('--notify', 'Post a desktop notification when a headless run finishes. Fired by this process on exit, so it survives whatever launched the run (the menu bar dispatching it, a terminal you closed).')
     .option('--no-trace-sync', 'Skip the run-exit trace auto-sync for this run. Auto-sync fires by default only for local runs and only once you have run `agents traces sync` at least once (also silenced by AGENTS_NO_TRACE_SYNC=1).')

--- a/cli/src/commands/webhook.test.ts
+++ b/cli/src/commands/webhook.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { closeWebhookServer } from './webhook.js';
+
+describe('closeWebhookServer (PHNX-3943)', () => {
+  it('closes promptly and destroys a real HTTP keep-alive socket', async () => {
+    const sockets = new Set<import('node:net').Socket>();
+    const server = http.createServer((_request, response) => {
+      response.end('ok');
+    });
+    server.on('connection', (socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    const agent = new http.Agent({ keepAlive: true });
+    let clientSocket: import('node:net').Socket | undefined;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const request = http.get({ host: '127.0.0.1', port, agent }, (response) => {
+          response.resume();
+          response.once('end', resolve);
+        });
+        request.once('socket', (socket) => { clientSocket = socket; });
+        request.once('error', reject);
+      });
+      expect(clientSocket?.destroyed).toBe(false);
+
+      const socket = clientSocket!;
+      const clientClosed = new Promise<void>((resolve) => socket.once('close', resolve));
+      await Promise.race([
+        Promise.all([closeWebhookServer(server, sockets), clientClosed]),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('shutdown exceeded 500ms')), 500)),
+      ]);
+
+      expect(socket.destroyed).toBe(true);
+    } finally {
+      agent.destroy();
+      await closeWebhookServer(server, sockets);
+    }
+  });
+});

--- a/cli/src/commands/webhook.ts
+++ b/cli/src/commands/webhook.ts
@@ -7,9 +7,11 @@
  */
 import type { Command } from 'commander';
 import type { Server } from 'http';
+import type { Socket } from 'net';
 import * as path from 'path';
 import chalk from 'chalk';
 import { readAndResolveBundleEnv } from '../lib/secrets/bundles.js';
+import { closeServerBounded } from '../lib/secrets/agent.js';
 import { createFileDeliveryStore, startWebhookServer, waitForListening, type WebhookSecrets } from '../lib/triggers/webhook.js';
 import { getRuntimeStateDir } from '../lib/state.js';
 
@@ -42,6 +44,13 @@ function readWebhookSecrets(bundleName: string): WebhookSecrets {
     );
   }
   return secrets;
+}
+
+/** Stop accepting requests and destroy persistent connections so shutdown is bounded. */
+export async function closeWebhookServer(server: Server, sockets: Set<Socket>): Promise<void> {
+  const closing = closeServerBounded(server);
+  for (const socket of sockets) socket.destroy();
+  await closing;
 }
 
 export function registerWebhooksCommand(program: Command): void {
@@ -99,6 +108,11 @@ export function registerWebhooksCommand(program: Command): void {
             ));
           },
         });
+        const sockets = new Set<Socket>();
+        server.on('connection', (socket: Socket) => {
+          sockets.add(socket);
+          socket.once('close', () => sockets.delete(socket));
+        });
         await waitForListening(server);
         const address = server.address();
         const bound = typeof address === 'object' && address ? address.port : port;
@@ -106,11 +120,15 @@ export function registerWebhooksCommand(program: Command): void {
         console.log(chalk.dim('signed · localhost by default · endpoints: /hooks/github, /hooks/linear, /hooks/slack · acks 202 then dispatches · Ctrl-C to stop'));
         console.log(chalk.dim('for a supervised receiver that survives reboot: agents daemon webhooks add --secrets-bundle <name>'));
 
-        const shutdown = () => {
-          server.close(() => process.exit(0));
+        let shuttingDown = false;
+        const shutdown = async () => {
+          if (shuttingDown) return;
+          shuttingDown = true;
+          await closeWebhookServer(server, sockets);
+          process.exit(0);
         };
-        process.on('SIGINT', shutdown);
-        process.on('SIGTERM', shutdown);
+        process.on('SIGINT', () => { void shutdown(); });
+        process.on('SIGTERM', () => { void shutdown(); });
       } catch (err) {
         console.error(chalk.red(`Could not start webhook receiver: ${(err as Error).message}`));
         process.exit(1);

--- a/cli/src/lib/exec.test.ts
+++ b/cli/src/lib/exec.test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, stampedAgentName, customHarnessName, resolveTmuxWrap, buildTmuxAgentCommand, writeTmuxEnvFile, formatPaneTail, detectRateLimit, detectOutOfCredits, classifyClaudeRunRefusal, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, resolveLaunchId, shouldRecapDeadPane, isPaneKnownAliveFromQueryResult, tmuxRunExitCode, UNKNOWN_OUTCOME_EXIT_CODE, type TmuxWrapContext } from './exec.js';
+import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, ensureVendorHomeDir, stampedAgentName, customHarnessName, resolveTmuxWrap, buildTmuxAgentCommand, writeTmuxEnvFile, formatPaneTail, detectRateLimit, detectOutOfCredits, classifyClaudeRunRefusal, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, resolveLaunchId, shouldRecapDeadPane, isPaneKnownAliveFromQueryResult, tmuxRunExitCode, UNKNOWN_OUTCOME_EXIT_CODE, type TmuxWrapContext } from './exec.js';
 import type { ExecOptions } from './exec.js';
 import { isTmuxInstalled } from './tmux/binary.js';
 import { mailboxDir } from './mailbox.js';
@@ -330,6 +330,33 @@ describe('buildExecEnv — Grok labeled-account overlay', () => {
     const env = buildExecEnv(execOpts({ agent: 'grok', version: '0.3.0', configVersion: '0.2.9' }));
     expect(env.GROK_HOME).toBe(path.join(getVersionHomePath('grok', '0.2.9'), '.grok'));
     expect(env.GROK_HOME).not.toContain(path.join('grok', '0.3.0'));
+  });
+});
+
+describe('ensureVendorHomeDir — fresh local spawn roots (PHNX-3943)', () => {
+  it.each([
+    ['cursor', '.cursor'],
+    ['grok', '.grok'],
+    ['copilot', '.copilot'],
+  ] as const)('creates %s vendor home recursively', (agent, configDir) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `agents-${agent}-home-`));
+    const versionHome = path.join(root, 'missing', 'home');
+    try {
+      expect(ensureVendorHomeDir(agent, versionHome)).toBe(path.join(versionHome, configDir));
+      expect(fs.statSync(path.join(versionHome, configDir)).isDirectory()).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not create a vendor directory for unrelated harnesses', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-claude-home-'));
+    try {
+      expect(ensureVendorHomeDir('claude', path.join(root, 'home'))).toBeNull();
+      expect(fs.existsSync(path.join(root, 'home'))).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentId, Mode, RunStrategy } from './types.js';
 import { ALL_MODES, REMOTE_INTERACTIVE_ENV } from './types.js';
-import { AGENTS, findInPath } from './agents.js';
+import { AGENTS, agentConfigDirName, findInPath } from './agents.js';
 import { parseTimeout } from './scheduling/routines.js';
 import { compareVersions, getBinaryPath, getVersionHomePath, isVersionInstalled, listInstalledVersions, resolveVersion } from './installations/versions.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
@@ -631,6 +631,23 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
     ...result,
     ...options.env,
   };
+}
+
+/** Materialize config roots for vendor CLIs that do not create parents recursively. */
+export function ensureVendorHomeDir(agent: AgentId, versionHome: string): string | null {
+  if (agent !== 'cursor' && agent !== 'grok' && agent !== 'copilot') return null;
+  const vendorHome = path.join(versionHome, agentConfigDirName(agent));
+  fs.mkdirSync(vendorHome, { recursive: true });
+  return vendorHome;
+}
+
+function ensureVendorHomeForSpawn(options: ExecOptions): void {
+  const { versionHome } = resolveConfigVersion(
+    options.agent,
+    options.cwd || process.cwd(),
+    options.configVersion ?? options.version,
+  );
+  if (versionHome) ensureVendorHomeDir(options.agent, versionHome);
 }
 
 
@@ -1366,6 +1383,7 @@ export async function execShimPassthrough(
   // practice (POSIX uses the bash shim, which execs the binary and never reaches
   // buildExecEnv — `installations/shims.ts` generateShimScript).
   const env = buildExecEnv({ agent, version, cwd, mode: defaultModeFor(agent), effort: 'auto', env: { AGENT_LAUNCH_ID: launchId } });
+  ensureVendorHomeDir(agent, getVersionHomePath(agent, version));
   const { command, args, shell } = resolveShimSpawn(process.platform, binary, [...launchArgs, ...rawArgs]);
 
   // Pre-launch marker for the SECOND live launch path: the Windows generated
@@ -2084,6 +2102,7 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
   if (options.agent === 'claude' && !options.resume && !options.sessionId) {
     options = { ...options, sessionId: randomUUID() };
   }
+  ensureVendorHomeForSpawn(options);
   // Record the run's --name against its session id (when both are known at
   // launch) so `agents sessions <name>` resolves it. Best-effort; unnamed runs
   // and agents whose id isn't known up front simply skip this.

--- a/cli/src/lib/hosts/reconnect.test.ts
+++ b/cli/src/lib/hosts/reconnect.test.ts
@@ -432,6 +432,8 @@ describe('notices — human readable', () => {
     // so the notice counts the window down and advertises the safe way out.
     expect(s).toContain('14m51s left');
     expect(s).toContain('Ctrl-C to stop');
+    expect(s).toContain('reconnecting to 94c75686');
+    expect(s).not.toContain('still running there');
   });
 
   test('exhausted notice hands back the manual reconnect command', () => {
@@ -613,7 +615,8 @@ describe('reconnectInteractiveSession — the loop over the real state machine',
     expect(calls).toBe(0); // interrupted during the FIRST wait — never reattached
     const notice = writes.join('');
     expect(notice).toContain('Stopped reconnecting');
-    expect(notice).toContain('still running on zion');
+    expect(notice).toContain('on zion. Recover it when the link is stable');
+    expect(notice).not.toContain('still running');
     expect(notice).toContain(`agents sessions resume ${SID}`);
     // It must not read as a failure: nothing was lost.
     expect(notice).not.toContain("Couldn't reconnect");

--- a/cli/src/lib/hosts/reconnect.ts
+++ b/cli/src/lib/hosts/reconnect.ts
@@ -110,7 +110,9 @@ export function formatDuration(ms: number): string {
 export function reconnectNotice(target: ReconnectTarget, host: string, attempt: number, waitMs: number, remainingMs: number): string {
   const secs = Math.round(waitMs / 1000);
   const when = secs <= 1 ? 'now' : `in ${secs}s`;
-  return `\nConnection to ${host} dropped — ${targetLabel(target)} is still running there.`
+  // A tmux-wrapped run is still live; a bare run was SIGHUPed and focus will
+  // resume it from disk. This wording is truthful for either peer configuration.
+  return `\nConnection to ${host} dropped — reconnecting to ${targetLabel(target)}.`
     + `\n  Reconnecting ${when} · ${formatDuration(remainingMs)} left · attempt ${attempt} · Ctrl-C to stop\n`;
 }
 
@@ -132,7 +134,7 @@ export function remoteExitNotice(target: ReconnectTarget, host: string): string 
 
 /** Notice shown when the user stops the wait with Ctrl-C. */
 export function interruptedNotice(target: ReconnectTarget, host: string): string {
-  return `\nStopped reconnecting. ${targetLabel(target)} is still running on ${host}:\n${recoveryHint(target, host)}`;
+  return `\nStopped reconnecting to ${targetLabel(target)} on ${host}. Recover it when the link is stable:\n${recoveryHint(target, host)}`;
 }
 
 /**

--- a/cli/src/lib/scheduling/routines.test.ts
+++ b/cli/src/lib/scheduling/routines.test.ts
@@ -77,6 +77,23 @@ describe('validateJob — schedule OR trigger', () => {
   });
 });
 
+describe('validateJob — YAML null path diagnostics (PHNX-3943)', () => {
+  it('explains that a bare cwd: ~ parses as YAML null and gives the quoted form', () => {
+    const parsed = yaml.parse('cwd: ~\n') as { cwd: null };
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', cwd: parsed.cwd as unknown as string }));
+
+    expect(errors).toContain('cwd is null — a bare ~ is YAML null; quote it as "~" for the home directory');
+    expect(errors).not.toContain('cwd (the portable execution directory) must be a non-empty path string');
+  });
+
+  it('names a null project separately from an empty project name', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', project: null as unknown as string }));
+
+    expect(errors).toContain('project is null — quote YAML values that look like null literals');
+    expect(errors).not.toContain('project (the singular execution anchor) must be a non-empty project name');
+  });
+});
+
 describe('validateJob — resume', () => {
   it('accepts resume with a native-resume agent', () => {
     expect(validateJob(baseJob({ schedule: '0 3 * * *', agent: 'claude', resume: 'sess-1' }))).toEqual([]);

--- a/cli/src/lib/scheduling/routines.ts
+++ b/cli/src/lib/scheduling/routines.ts
@@ -1506,10 +1506,14 @@ export function validateJob(config: Partial<JobConfig>): string[] {
   if (config.remoteCwd !== undefined && strategy !== 'host' && strategy !== 'fleet') {
     errors.push('remoteCwd only applies to host/fleet-placed routines — set hostStrategy: host|fleet, or drop it');
   }
-  if (config.project !== undefined && (typeof config.project !== 'string' || config.project.trim() === '')) {
+  if (config.project === null) {
+    errors.push('project is null — quote YAML values that look like null literals');
+  } else if (config.project !== undefined && (typeof config.project !== 'string' || config.project.trim() === '')) {
     errors.push('project (the singular execution anchor) must be a non-empty project name');
   }
-  if (config.cwd !== undefined && (typeof config.cwd !== 'string' || config.cwd.trim() === '')) {
+  if (config.cwd === null) {
+    errors.push('cwd is null — a bare ~ is YAML null; quote it as "~" for the home directory');
+  } else if (config.cwd !== undefined && (typeof config.cwd !== 'string' || config.cwd.trim() === '')) {
     errors.push('cwd (the portable execution directory) must be a non-empty path string');
   }
   // `remoteCwd` is the legacy host-placement path; `cwd` is its canonical


### PR DESCRIPTION
Summary:
- diagnose YAML-null routine paths, including cwd: ~ quoting guidance
- validate explicit session IDs at the Commander boundary and create Cursor/Grok/Copilot vendor homes before local spawn
- make remote reconnect wording truthful for bare and tmux-wrapped runs
- bound agents webhooks serve shutdown and destroy tracked keep-alive sockets

Plugin sync was already fixed on main by 26791d7b1, so it is not duplicated here.

Verification:
- focused Vitest: 5 files, 353 tests passed
- bun run build: passed
- built CLI rejects emoji session IDs at option parsing
- full suite: 15,041 passed; 85 unrelated sandbox/concurrency failures; all changed suites passed

Not included: PHNX-3404, PHNX-3612, PHNX-3683 require product/operational work outside the owned code surfaces.

Linear: PHNX-3943