### PR TITLE
feat(sessions): daemon per-session summarizer on the session stream (PHNX-3939)

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,18 @@ Slack). Owner delivery attempts every selected channel, reports partial
 failures, and safely forwards Rush-backed channels from headless workers to a
 capable Mac; ordinary milestone posts remain record-only unless configured.
 
+An optional **per-session summarizer** (off by default) adds a daemon-computed
+`goal`, progress `checkpoints`, and a detailed `summaryChecklist` to each session
+row on the `feed watch` / `sessions watch` stream. It never runs on a request
+path — the model call lives in a background daemon service, cached per transcript
+so it never recomputes on unchanged bytes. Turn it on with a local model endpoint:
+
+```bash
+agents config set summarizer.enabled on
+agents config set summarizer.baseUrl http://localhost:11434   # Ollama / vLLM / LiteLLM
+agents config set summarizer.model qwen2.5:3b
+```
+
 Top-level questions and waiting notifications publish one atomic open-block record per session, including the mailbox id, host, runtime, and every answer option. The default view collapses agents under the **outcome** they serve (Linear ticket, PR, worktree slug, or Unassigned) so a 1,100-agent fleet reads as dozens of deliverables. Answered, resumed, and stopped blocks clear automatically; Task subagents are excluded. The rendered reply command uses the same mailbox id with `agents message`, so the decision routes back to the agent that asked it.
 
 ### Auto-nudge stalls

--- a/cli/.changelog/next/PHNX-3939.md
+++ b/cli/.changelog/next/PHNX-3939.md
@@ -15,3 +15,9 @@
   disabled or unconfigured, zero model calls are made and rows read
   `summaryState: "skipped"`. Source: `cli/src/lib/summarizer/`,
   `cli/src/lib/daemon/session-summarizer-service.ts`, `cli/src/lib/session/db.ts`.
+
+- **`agents config unset project.root` now actually clears it.** `projectRoot` is a
+  machine-local key persisted to the device doc, which `writeMeta` only clears when
+  the key is present-but-falsy; the unset path dropped the key entirely, so
+  `agents config get project.root` still returned the old value afterward. Source:
+  `cli/src/commands/config.ts`.

--- a/cli/.changelog/next/PHNX-3939.md
+++ b/cli/.changelog/next/PHNX-3939.md
@@ -1,0 +1,17 @@
+- **Per-session summarizer on the session stream (PHNX-3939).** A new opt-in daemon
+  service computes a 1–2 line **goal**, progress **checkpoints**, and a detailed
+  **checklist** for each running session and delivers them on `agents sessions watch`
+  / `agents feed watch --json` (as `goal` / `checkpoints` / `summaryChecklist` /
+  `summaryState`), so the AGI extension sidebar can render them. It is **off by
+  default and never on the request path**: the model call runs only in the
+  background `session-summarizer` service, reader-gated and bounded per tick, and a
+  computed summary is cached in the transcript-keyed `session_summaries` table so it
+  never recomputes on unchanged bytes and `agents sessions <id>` timing is unchanged.
+  Enable it with `agents config set summarizer.enabled on` plus a local
+  Anthropic-wire endpoint — `agents config set summarizer.baseUrl http://localhost:11434`
+  and `agents config set summarizer.model qwen2.5:3b` (env overrides:
+  `AGENTS_SUMMARIZER_ENABLED` / `AGENTS_SUMMARIZER_BASEURL` / `AGENTS_SUMMARIZER_MODEL`).
+  Summaries ride the fleet session mirror, so a peer's sessions carry them too. When
+  disabled or unconfigured, zero model calls are made and rows read
+  `summaryState: "skipped"`. Source: `cli/src/lib/summarizer/`,
+  `cli/src/lib/daemon/session-summarizer-service.ts`, `cli/src/lib/session/db.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -96,6 +96,35 @@ composes the existing session watcher with feed attention and activity, while
 Answers go through `agents feed answer <attention-key>` so the CLI atomically
 claims the first reply and routes it over the recorded session reply rail.
 
+### Per-session summarizer (PHNX-3939)
+
+Each session can carry a daemon-computed **`goal`** (1–2 lines), progress
+**`checkpoints`** (`{text, at}`, newest last), and a detailed **`summaryChecklist`**
+(`{text, done}`), plus a **`summaryState`** (`pending` | `ready` | `skipped`),
+delivered on the `sessions watch` / `feed watch` stream so the AGI extension
+sidebar can render them. The hard rule is **zero request-path cost**: the model
+call runs **only** in the background `session-summarizer` daemon service
+([`src/lib/daemon/session-summarizer-service.ts`](src/lib/daemon/session-summarizer-service.ts)
+→ [`src/lib/summarizer/pass.ts`](src/lib/summarizer/pass.ts)), which is reader-gated
+and bounded per tick, and the result is cached in the stamp-validated
+`session_summaries` table (`db.ts`, keyed on `(session_id, file_mtime_ms,
+file_size)` exactly like `session_preview_cache`) so it never recomputes on
+unchanged transcript bytes. The display path only **reads** that cache — the merge
+onto live rows rides `applyImmutableMemo`
+([`src/lib/session/session-cache.ts`](src/lib/session/session-cache.ts)); history
+rows project it in `toPreviousSessionWatchRow`
+([`src/lib/session/remote/watch.ts`](src/lib/session/remote/watch.ts)); and the
+fleet session mirror carries it so a peer's sessions show it too
+([`src/lib/session/mirror.ts`](src/lib/session/mirror.ts)). It is **off by default**:
+disabled or unconfigured, the service makes **zero** model calls and every row reads
+`summaryState: "skipped"`. Configure it through `summarizer.enabled` /
+`summarizer.baseUrl` / `summarizer.model` (see the Configuration surface below).
+The one model call is a pure boundary over the Anthropic-wire client
+([`src/lib/summarizer/summarize.ts`](src/lib/summarizer/summarize.ts)) — prompt input
+is the cleaned first user turn (never the tool firehose), progress input is the
+state engine's todos/plan/phase — forcing strict JSON and returning `undefined`
+(→ `skipped`) on any error.
+
 Owner-addressed delivery is policy fan-out, not primary/fallback selection.
 `agents send --to owner`, deprecated `agents notify`, and an important feed's
 `channel: owner` sink resolve every addressable id in
@@ -948,11 +977,21 @@ agents config set devices.mac-mini.role worker
 agents config set devices.mac-mini.max-agents 4
 agents config set devices.mac-mini.scheduler off
 agents config set devices.mac-mini.tmux off
+agents config set summarizer.enabled on
+agents config set summarizer.baseUrl http://localhost:11434
+agents config set summarizer.model qwen2.5:3b
 ```
 
 The new command is a **facade over the existing YAML storage**
 (`run.defaults`, `model.tiers`, `config.interactiveHost`,
 `defaultBrowserProfile`, and `deviceConfig`). Fleet sync behavior is unchanged.
+
+`summarizer.*` (user-scope, central `agents.yaml`, syncs fleet-wide) gates the
+**per-session summarizer** (PHNX-3939): `summarizer.enabled` (default **false**),
+`summarizer.baseUrl` (an Anthropic-wire endpoint — Ollama/vLLM/LiteLLM), and
+`summarizer.model`, each overridable per-process by `AGENTS_SUMMARIZER_ENABLED` /
+`AGENTS_SUMMARIZER_BASEURL` / `AGENTS_SUMMARIZER_MODEL`. See
+[§Per-session summarizer](#per-session-summarizer-phnx-3939).
 
 `devices.<name>.tmux` (stored as `tmux.enabled`) defaults off, so a LOCAL
 interactive `agents run` launch spawns the agent directly. Turn it on for a

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -217,10 +217,12 @@ function unsetConfig(parsed: ParsedConfigKey): boolean {
     }
     case 'project': {
       const had = getProjectRoot() !== undefined;
-      updateMeta((meta) => {
-        const { projectRoot: _projectRoot, ...rest } = meta;
-        return rest;
-      });
+      // `projectRoot` is a machine-local key that `writeMeta` persists to the
+      // device doc; it only clears that doc when the key is PRESENT-but-falsy
+      // (`writesProjectRoot` needs the own-property, state.ts). Dropping the key
+      // from the returned object left the device-doc value in place, so
+      // `config get` still returned it after unset. Set it undefined instead.
+      updateMeta((meta) => ({ ...meta, projectRoot: undefined }));
       return had;
     }
     case 'summarizer': {

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -77,6 +77,8 @@ function parseValue(key: string, parsed: ParsedConfigKey, raw: string): unknown 
       return raw.trim();
     case 'project':
       return raw.trim();
+    case 'summarizer':
+      return parsed.property === 'enabled' ? parseBool(raw, key) : raw.trim();
     case 'device': {
       const property = parsed.property;
       switch (property) {
@@ -161,6 +163,10 @@ function setConfig(parsed: ParsedConfigKey, value: unknown): void {
     case 'project':
       setProjectRoot(value as string);
       return;
+    case 'summarizer': {
+      setConfigValue(`summarizer.${parsed.property}`, value);
+      return;
+    }
     case 'device': {
       const configName = devicePropertyToConfigName(parsed.property);
       if (parsed.property === 'notes') {
@@ -217,6 +223,12 @@ function unsetConfig(parsed: ParsedConfigKey): boolean {
       });
       return had;
     }
+    case 'summarizer': {
+      const name = `summarizer.${parsed.property}`;
+      const had = getConfigValue(name).value !== undefined;
+      unsetConfigValue(name);
+      return had;
+    }
     case 'device': {
       const configName = devicePropertyToConfigName(parsed.property);
       const had = getConfigValue(configName, { device: parsed.device }).value !== undefined;
@@ -251,6 +263,8 @@ function getConfig(parsed: ParsedConfigKey): unknown {
     }
     case 'project':
       return getProjectRoot();
+    case 'summarizer':
+      return getConfigValue(`summarizer.${parsed.property}`).value;
     case 'device': {
       const configName = devicePropertyToConfigName(parsed.property);
       return getConfigValue(configName, { device: parsed.device }).value;
@@ -326,6 +340,14 @@ function* listCentralConfigEntries(): Generator<{ key: string; value: unknown; h
   if (browserDevice !== undefined) {
     const key = 'browser.device';
     yield { key, value: browserDevice, hint: configKeyStorageHint(parseConfigKey(key)) };
+  }
+
+  // Session-summarizer keys (PHNX-3939) — user scope, syncs fleet-wide.
+  for (const key of ['summarizer.enabled', 'summarizer.baseUrl', 'summarizer.model'] as const) {
+    const value = getConfigValue(key).value;
+    if (value !== undefined) {
+      yield { key, value, hint: configKeyStorageHint(parseConfigKey(key)) };
+    }
   }
 }
 

--- a/cli/src/lib/config-keys.ts
+++ b/cli/src/lib/config-keys.ts
@@ -13,7 +13,7 @@ import { MODEL_TIERS, type ModelTier } from './model-tiers.js';
 import { VERSION_RE } from './run-defaults.js';
 
 /** The top-level scope of a unified config key. */
-export type ConfigScope = 'run' | 'interactive' | 'auto' | 'browser' | 'project' | 'device';
+export type ConfigScope = 'run' | 'interactive' | 'auto' | 'browser' | 'project' | 'device' | 'summarizer';
 
 /** A run-time default key: model, mode, effort, or tier override. */
 export interface ParsedRunConfigKey {
@@ -57,13 +57,20 @@ export interface ParsedDeviceConfigKey {
   property: DeviceConfigProperty;
 }
 
+/** The daemon session-summarizer keys (PHNX-3939). */
+export interface ParsedSummarizerConfigKey {
+  scope: 'summarizer';
+  property: 'enabled' | 'baseUrl' | 'model';
+}
+
 export type ParsedConfigKey =
   | ParsedRunConfigKey
   | ParsedInteractiveConfigKey
   | ParsedAutoConfigKey
   | ParsedBrowserConfigKey
   | ParsedProjectConfigKey
-  | ParsedDeviceConfigKey;
+  | ParsedDeviceConfigKey
+  | ParsedSummarizerConfigKey;
 
 export type DeviceConfigProperty =
   | 'role'
@@ -178,6 +185,11 @@ export function parseConfigKey(key: string): ParsedConfigKey {
     return { scope: 'project', property: 'root' };
   }
 
+  const summarizerMatch = raw.match(/^summarizer\.(enabled|baseUrl|model)$/);
+  if (summarizerMatch) {
+    return { scope: 'summarizer', property: summarizerMatch[1] as 'enabled' | 'baseUrl' | 'model' };
+  }
+
   const deviceMatch = raw.match(
     /^devices\.(.+)\.(role|max-agents|scheduler|daemon|watchdog|tmux|notes|browser\.remote-control|browser\.task-idle-minutes|browser\.profile|browser\.viewer)$/,
   );
@@ -207,6 +219,9 @@ export function parseConfigKey(key: string): ParsedConfigKey {
   if (raw.startsWith('project.')) {
     throw new Error(`Invalid project config key '${key}'. Use project.root.`);
   }
+  if (raw.startsWith('summarizer.')) {
+    throw new Error(`Invalid summarizer config key '${key}'. Use summarizer.enabled, summarizer.baseUrl, or summarizer.model.`);
+  }
   if (raw.startsWith('devices.')) {
     throw new Error(
       `Invalid device config key '${key}'. Expected devices.<name>.<${DEVICE_CONFIG_PROPERTIES.join('|')}>.`,
@@ -214,7 +229,7 @@ export function parseConfigKey(key: string): ParsedConfigKey {
   }
 
   throw new Error(
-    `Unknown config scope in '${key}'. Use one of: run, interactive, auto, browser, project, devices.`,
+    `Unknown config scope in '${key}'. Use one of: run, interactive, auto, browser, project, devices, summarizer.`,
   );
 }
 
@@ -238,6 +253,8 @@ export function formatConfigKey(parsed: ParsedConfigKey): string {
       return 'project.root';
     case 'device':
       return `devices.${parsed.device}.${parsed.property}`;
+    case 'summarizer':
+      return `summarizer.${parsed.property}`;
   }
 }
 
@@ -259,6 +276,9 @@ export function listKnownConfigKeys(): string[] {
     'browser.viewer',
     'browser.device',
     'project.root',
+    'summarizer.enabled',
+    'summarizer.baseUrl',
+    'summarizer.model',
   );
   for (const prop of DEVICE_CONFIG_PROPERTIES) {
     keys.push(`devices.<name>.${prop}`);
@@ -327,5 +347,11 @@ export function configKeyStorageHint(parsed: ParsedConfigKey): string {
       return 'devices.<self>.projectRoot';
     case 'device':
       return `devices/${parsed.device}/agents.yaml config (${devicePropertyToConfigName(parsed.property)}; fleet default: fleet.defaults.config)`;
+    case 'summarizer': {
+      const yamlKey = parsed.property === 'enabled'
+        ? 'summarizerEnabled'
+        : parsed.property === 'baseUrl' ? 'summarizerBaseUrl' : 'summarizerModel';
+      return `config.${yamlKey} (central agents.yaml; syncs fleet-wide)`;
+    }
   }
 }

--- a/cli/src/lib/daemon-services.ts
+++ b/cli/src/lib/daemon-services.ts
@@ -35,7 +35,8 @@ export type DaemonServiceId =
   | 'daemon-heartbeat'
   | 'tmux-reap'
   | 'browser-task-reap'
-  | 'session-state';
+  | 'session-state'
+  | 'session-summarizer';
 
 /** Human-readable metadata for each service. */
 export interface DaemonServiceDef {
@@ -139,6 +140,11 @@ export const DAEMON_SERVICES: DaemonServiceDef[] = [
     id: 'session-index',
     title: 'Session-index warm',
     description: 'Keeps this host\'s transcript index current so a locally-started session is discoverable within seconds.',
+  },
+  {
+    id: 'session-summarizer',
+    title: 'Session summarizer',
+    description: 'Computes a per-session goal / progress checkpoints / checklist off the request path and delivers them on the session stream. Off unless summarizer.enabled and a local model endpoint are configured (PHNX-3939).',
   },
   {
     id: 'auth-sync',

--- a/cli/src/lib/daemon/daemon.ts
+++ b/cli/src/lib/daemon/daemon.ts
@@ -33,6 +33,7 @@ import { isSchedulerEnabled, assertSchedulerEnabled, isDaemonEnabled } from '../
 import { recordSubsystemOk, recordSubsystemError, recordSubsystemErrorReason, readSubsystemHealth, SUBSYSTEM_DAEMON_START } from '../daemon-health.js';
 import { ServiceSupervisor } from './supervisor.js';
 import { SessionIndexService } from './session-index-service.js';
+import { SessionSummarizerService } from './session-summarizer-service.js';
 import { SecretsBrokerService } from './secrets-broker-service.js';
 import { MonitorEngineService } from './monitor-engine-service.js';
 import { AccountUsageService, AccountAuthService } from './account-state-daemon-service.js';
@@ -1077,6 +1078,12 @@ export async function runDaemon(): Promise<void> {
 
   if (isEnabled('session-index')) supervisor.register(new SessionIndexService());
   else log('INFO', 'Session-index warm service disabled');
+
+  // Session summarizer (PHNX-3939) — registered when the service toggle is on,
+  // but each tick is a no-op unless the operator also set summarizer.enabled and
+  // a model endpoint, so registering it costs nothing while unconfigured.
+  if (isEnabled('session-summarizer')) supervisor.register(new SessionSummarizerService());
+  else log('INFO', 'Session summarizer service disabled');
 
   // Watchdog, device-probe, self-heal, and keychain-reap are all periodic
   // services managed by the ServiceSupervisor (RUSH-3193 P3). Each is gated

--- a/cli/src/lib/daemon/session-summarizer-service.ts
+++ b/cli/src/lib/daemon/session-summarizer-service.ts
@@ -1,0 +1,45 @@
+/**
+ * Session-summarizer service (PHNX-3939).
+ *
+ * The single daemon-owned executor that computes a per-session goal / progress
+ * checkpoints / checklist and writes them to the transcript-keyed
+ * `session_summaries` cache, from which the display/merge path serves them onto
+ * the `sessions watch` stream. It NEVER runs on a request path.
+ *
+ * Off by default: `runSummarizerPass` no-ops unless `summarizer.enabled` and a
+ * model endpoint (`summarizer.baseUrl` + `summarizer.model`) are configured, so a
+ * daemon with the feature unconfigured makes zero model calls. Reader-gated and
+ * bounded per tick like the other session services, so it costs nothing while no
+ * one is watching.
+ */
+
+import { BasePeriodicService, type DaemonContext } from './service.js';
+import type { DaemonServiceId } from '../daemon-services.js';
+import { runSummarizerPass } from '../summarizer/pass.js';
+
+/** Slower than the state tick — a summary is a coarse signal, not live status. */
+const SESSION_SUMMARIZER_TICK_MS = 20_000;
+/** Hard cap per tick; a local model call is bounded, this leaves generous headroom. */
+const SESSION_SUMMARIZER_DEADLINE_MS = 60_000;
+
+export class SessionSummarizerService extends BasePeriodicService {
+  readonly id: DaemonServiceId = 'session-summarizer';
+  readonly intervalMs = SESSION_SUMMARIZER_TICK_MS;
+  readonly deadlineMs = SESSION_SUMMARIZER_DEADLINE_MS;
+
+  protected async onStart(_ctx: DaemonContext): Promise<void> {
+    // No handles to open — each tick reads config + the warm session cache fresh.
+  }
+
+  protected async onStop(): Promise<void> {
+    // Nothing to release.
+  }
+
+  protected async onTick(ctx: DaemonContext, signal: AbortSignal): Promise<void> {
+    const r = await runSummarizerPass({ signal });
+    if (r.disabled) return; // off / unconfigured — stay silent
+    if (r.computed > 0 || r.skipped > 0) {
+      ctx.log('INFO', `session-summarizer: computed ${r.computed}, skipped ${r.skipped}, reused ${r.reused}`);
+    }
+  }
+}

--- a/cli/src/lib/device-config.test.ts
+++ b/cli/src/lib/device-config.test.ts
@@ -364,6 +364,9 @@ describe('listConfig', () => {
       'ssh.bundle-key',
       'ssh.identity-file',
       'ssh.user',
+      'summarizer.baseUrl',
+      'summarizer.enabled',
+      'summarizer.model',
       'tmux.enabled',
       'watchdog.enabled',
     ]);

--- a/cli/src/lib/device-config.ts
+++ b/cli/src/lib/device-config.ts
@@ -142,6 +142,34 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
         : `auto.pool must be one of ${AUTO_POOL_MODES.join(' | ')}.`,
   },
   {
+    name: 'summarizer.enabled',
+    yamlKey: 'summarizerEnabled',
+    scope: 'user',
+    type: 'bool',
+    defaultValue: false,
+    description:
+      'Whether the daemon computes a per-session goal / progress checkpoints / checklist and delivers them on the ' +
+      'session stream (PHNX-3939). Off by default — zero model calls, no behavior change until enabled. Needs a local ' +
+      'Anthropic-wire model endpoint via summarizer.baseUrl + summarizer.model.',
+  },
+  {
+    name: 'summarizer.baseUrl',
+    yamlKey: 'summarizerBaseUrl',
+    scope: 'user',
+    type: 'string',
+    description:
+      'Base URL of the Anthropic-wire model endpoint the summarizer calls (Ollama / vLLM / LiteLLM), ' +
+      'e.g. http://localhost:11434. Overridden per-process by AGENTS_SUMMARIZER_BASEURL.',
+  },
+  {
+    name: 'summarizer.model',
+    yamlKey: 'summarizerModel',
+    scope: 'user',
+    type: 'string',
+    description:
+      'Model the summarizer requests from summarizer.baseUrl, e.g. qwen2.5:3b. Overridden per-process by AGENTS_SUMMARIZER_MODEL.',
+  },
+  {
     name: 'browser.viewer',
     yamlKey: 'browserViewer',
     scope: 'device',

--- a/cli/src/lib/fleet-shared-state.ts
+++ b/cli/src/lib/fleet-shared-state.ts
@@ -45,6 +45,14 @@ export interface SessionMirrorRow {
   timestamp: string;
   ticketId?: string;
   prUrl?: string;
+  /** Daemon-computed goal (PHNX-3939) — carried so a peer renders it with no transcript. */
+  goal?: string;
+  /** Daemon-computed progress checkpoints, newest last (PHNX-3939). */
+  checkpoints?: import('./session/types.js').SessionCheckpoint[];
+  /** Daemon-computed detailed checklist (PHNX-3939). */
+  summaryChecklist?: import('./session/types.js').SessionChecklistItem[];
+  /** Lifecycle of the daemon-computed summary (PHNX-3939). */
+  summaryState?: import('./session/types.js').SummaryState;
   capturedAt: number;
 }
 

--- a/cli/src/lib/session/active.ts
+++ b/cli/src/lib/session/active.ts
@@ -625,6 +625,19 @@ export interface ActiveSession {
    * session (PHNX-3688). Absent for non-tmux rows.
    */
   tmuxName?: string;
+  /**
+   * Daemon-computed 1–2 line goal from the session's first user turn (PHNX-3939).
+   * Produced off the request path by the background `SessionSummarizerService`
+   * and merged from the `session_summaries` cache in {@link applyImmutableMemo};
+   * rides the `sessions watch` stream free via the `...row` spread.
+   */
+  goal?: string;
+  /** Daemon-computed progress checkpoints, newest last (PHNX-3939). */
+  checkpoints?: import('./types.js').SessionCheckpoint[];
+  /** Daemon-computed detailed checklist for the session (PHNX-3939). */
+  summaryChecklist?: import('./types.js').SessionChecklistItem[];
+  /** Lifecycle of the daemon-computed summary; `skipped` when disabled (PHNX-3939). */
+  summaryState?: import('./types.js').SummaryState;
 }
 
 export function activeStatusFromCloudStatus(status: CloudTaskStatus): ActiveStatus {

--- a/cli/src/lib/session/db.summaries.test.ts
+++ b/cli/src/lib/session/db.summaries.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Fresh HOME before importing state/db (db.ts captures DB_PATH at module load).
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-summaries-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const { getSessionsDir } = await import('../state.js');
+fs.mkdirSync(getSessionsDir(), { recursive: true });
+
+const { readSessionSummary, readSessionSummaryAny, writeSessionSummary } = await import('./db.js');
+
+const ENTRY = {
+  goal: 'Ship the summarizer',
+  checkpoints: [{ text: 'wrote the cache', at: '2026-09-05T00:00:00.000Z' }],
+  summaryChecklist: [{ text: 'add table', done: true }],
+  summaryState: 'ready' as const,
+};
+
+describe('session_summaries cache (mtime/size reuse)', () => {
+  it('reads back a summary only for the exact transcript bytes it was written against', () => {
+    const id = 'sum-1';
+    writeSessionSummary({ id, fileMtimeMs: 100, fileSize: 200, summary: ENTRY });
+
+    expect(readSessionSummary(id, { fileMtimeMs: 100, fileSize: 200 })).toEqual(ENTRY);
+    // A changed mtime or size invalidates the stamped read — the recompute trigger.
+    expect(readSessionSummary(id, { fileMtimeMs: 101, fileSize: 200 })).toBeUndefined();
+    expect(readSessionSummary(id, { fileMtimeMs: 100, fileSize: 201 })).toBeUndefined();
+  });
+
+  it('readSessionSummaryAny returns the latest row regardless of stamp (the display merge read)', () => {
+    const id = 'sum-2';
+    writeSessionSummary({ id, fileMtimeMs: 10, fileSize: 20, summary: ENTRY });
+    expect(readSessionSummaryAny(id)).toEqual(ENTRY);
+
+    // Recompute against new bytes overwrites the single row (PK = session_id).
+    const next = { ...ENTRY, goal: 'Ship it, refined' };
+    writeSessionSummary({ id, fileMtimeMs: 11, fileSize: 25, summary: next });
+    expect(readSessionSummaryAny(id)).toEqual(next);
+    // The old stamp no longer validates — only the new bytes do.
+    expect(readSessionSummary(id, { fileMtimeMs: 10, fileSize: 20 })).toBeUndefined();
+    expect(readSessionSummary(id, { fileMtimeMs: 11, fileSize: 25 })).toEqual(next);
+  });
+
+  it('accepts a null stamp (a fleet-mirrored peer summary) and reads it by id', () => {
+    const id = 'sum-3';
+    writeSessionSummary({ id, fileMtimeMs: null, fileSize: null, summary: ENTRY });
+    expect(readSessionSummaryAny(id)).toEqual(ENTRY);
+    expect(readSessionSummary(id, { fileMtimeMs: null, fileSize: null })).toEqual(ENTRY);
+  });
+
+  it('returns undefined for an unknown session', () => {
+    expect(readSessionSummaryAny('nope')).toBeUndefined();
+  });
+});

--- a/cli/src/lib/session/db.ts
+++ b/cli/src/lib/session/db.ts
@@ -10,7 +10,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import Database from '../sqlite.js';
-import type { SessionAgentId, SessionEvent, SessionMeta, SessionRunMode } from './types.js';
+import type { SessionAgentId, SessionCheckpoint, SessionChecklistItem, SessionEvent, SessionMeta, SessionRunMode, SummaryState } from './types.js';
 import { parseSession, sessionFilePathContainer } from './parse.js';
 import { extractRecentDirectoriesTouched, extractTodoProgressFromEvents } from './state.js';
 import { getSessionsDir, getSessionsDbPath } from '../state.js';
@@ -419,6 +419,21 @@ CREATE TABLE IF NOT EXISTS session_preview_cache (
   preview_json TEXT NOT NULL
 );
 
+-- Daemon-computed per-session summary (goal / checkpoints / checklist), PHNX-3939.
+-- Modeled exactly on session_preview_cache: a lazy, stamp-validated cache keyed on
+-- (session_id, file_mtime_ms, file_size) so a row is reused verbatim until the
+-- transcript bytes change. Written ONLY by the background SessionSummarizerService
+-- (or consumed from a peer's fleet mirror); the display/merge path reads it, never
+-- computes. Independent of SCHEMA_VERSION, like the other lazy caches above.
+CREATE TABLE IF NOT EXISTS session_summaries (
+  session_id TEXT PRIMARY KEY,
+  file_mtime_ms INTEGER,
+  file_size INTEGER,
+  extractor_version INTEGER NOT NULL,
+  computed_at INTEGER NOT NULL,
+  summary_json TEXT NOT NULL
+);
+
 -- Durable metadata for one browser task (RUSH-2549). The browser daemon's
 -- tasks.json is LIVE state: saveTaskState writes the in-memory task map, so
 -- stopping a task drops its entry and a daemon restart empties the file. That is
@@ -499,6 +514,8 @@ export const SESSION_TOPIC_EXTRACTOR_VERSION = 2;
 const PREVIEW_EXTRACTOR_VERSION = 2;
 /** Bump when classifyPhenotype's output changes so cached phenotypes recompute (PHNX-3327 v1). */
 export const SESSION_PHENOTYPE_EXTRACTOR_VERSION = 1;
+/** Bump when the summarizer output shape changes so cached summaries recompute (PHNX-3939 v1). */
+export const SESSION_SUMMARY_EXTRACTOR_VERSION = 1;
 
 /** Raw row shape returned from the sessions table. */
 interface SessionRow {
@@ -3795,6 +3812,93 @@ export function readArchivedSessionPreview<T>(id: string): T | undefined {
   }
 }
 
+/** The daemon-computed summary stored in `session_summaries` (PHNX-3939). */
+export interface SessionSummaryEntry {
+  goal?: string;
+  checkpoints?: SessionCheckpoint[];
+  summaryChecklist?: SessionChecklistItem[];
+  summaryState: SummaryState;
+}
+
+/**
+ * Read one summary only when it matches the transcript bytes on disk (the
+ * reuse-or-recompute stamp the SessionSummarizerService gates on). Mirrors
+ * {@link readSessionPreviewCache}.
+ */
+export function readSessionSummary(
+  id: string,
+  sourceStamp: { fileMtimeMs: number | null; fileSize: number | null },
+): SessionSummaryEntry | undefined {
+  const row = getDB().prepare(`
+    SELECT summary_json AS summaryJson
+    FROM session_summaries
+    WHERE session_id = ?
+      AND extractor_version = ?
+      AND file_mtime_ms IS ?
+      AND file_size IS ?
+  `).get(
+    id,
+    SESSION_SUMMARY_EXTRACTOR_VERSION,
+    sourceStamp.fileMtimeMs,
+    sourceStamp.fileSize,
+  ) as { summaryJson: string } | undefined;
+  if (!row) return undefined;
+  try {
+    return JSON.parse(row.summaryJson) as SessionSummaryEntry;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read the latest stored summary by session id, regardless of the transcript
+ * stamp — the low-cost merge read used by the display path (a live row through
+ * {@link applyImmutableMemo} or a history/mirror row) to surface the
+ * last-computed summary without a model call. A slightly-stale summary is the
+ * best available until the service recomputes; the SERVICE uses the stamped
+ * {@link readSessionSummary} to decide whether to recompute.
+ */
+export function readSessionSummaryAny(id: string): SessionSummaryEntry | undefined {
+  const row = getDB().prepare(`
+    SELECT summary_json AS summaryJson
+    FROM session_summaries
+    WHERE session_id = ? AND extractor_version = ?
+  `).get(id, SESSION_SUMMARY_EXTRACTOR_VERSION) as { summaryJson: string } | undefined;
+  if (!row) return undefined;
+  try {
+    return JSON.parse(row.summaryJson) as SessionSummaryEntry;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Persist a computed summary against the exact transcript bytes it was derived from. */
+export function writeSessionSummary(entry: {
+  id: string;
+  fileMtimeMs: number | null;
+  fileSize: number | null;
+  summary: SessionSummaryEntry;
+}): void {
+  getDB().prepare(`
+    INSERT INTO session_summaries
+      (session_id, file_mtime_ms, file_size, extractor_version, computed_at, summary_json)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(session_id) DO UPDATE SET
+      file_mtime_ms = excluded.file_mtime_ms,
+      file_size = excluded.file_size,
+      extractor_version = excluded.extractor_version,
+      computed_at = excluded.computed_at,
+      summary_json = excluded.summary_json
+  `).run(
+    entry.id,
+    entry.fileMtimeMs,
+    entry.fileSize,
+    SESSION_SUMMARY_EXTRACTOR_VERSION,
+    Date.now(),
+    JSON.stringify(entry.summary),
+  );
+}
+
 /** A local-origin session, projected to the compact fields the fleet mirror publishes. */
 export interface LocalMirrorSource {
   id: string;
@@ -3810,6 +3914,8 @@ export interface LocalMirrorSource {
   timestamp: string;
   ticketId: string | null;
   prUrl: string | null;
+  /** Daemon-computed summary (PHNX-3939), so peers carry it without a transcript. */
+  summary: SessionSummaryEntry | null;
 }
 
 /**
@@ -3840,6 +3946,9 @@ export function queryLocalOriginSessionsForMirror(self: string, limit: number): 
     id: r.id, shortId: r.short_id, agent: r.agent, version: r.version, machine: r.machine,
     cwd: r.cwd, topic: r.topic, firstUserMessage: r.first_user_message, label: r.label,
     lastActivity: r.last_activity, timestamp: r.timestamp, ticketId: r.ticket_id, prUrl: r.pr_url,
+    // Ride the daemon-computed summary alongside the digest so a peer renders it
+    // without a transcript (PHNX-3939); only a summarized session carries one.
+    summary: readSessionSummaryAny(r.id) ?? null,
   }));
 }
 
@@ -3858,6 +3967,8 @@ export interface MirrorSessionUpsert {
   timestamp: string;
   ticketId?: string | null;
   prUrl?: string | null;
+  /** Daemon-computed summary carried from the publishing peer (PHNX-3939). */
+  summary?: SessionSummaryEntry | null;
 }
 
 /**
@@ -3930,6 +4041,14 @@ export function upsertMirrorSession(row: MirrorSessionUpsert, source: string, sy
     INSERT INTO session_text (session_id, label, topic, project, content, assistant)
     VALUES (?, ?, ?, '', ?, '')
   `).run(row.id, row.label ?? '', row.topic ?? '', row.firstUser ?? '');
+  // Carry the peer's daemon-computed summary into the same session_summaries
+  // cache the local merge reads (PHNX-3939), so a peer session renders its
+  // goal/checkpoints/checklist inline with no transcript. Stamp is null: the
+  // display merge reads by id (readSessionSummaryAny), and this box's own
+  // summarizer service only ever recomputes LOCAL live sessions, never a peer's.
+  if (row.summary) {
+    writeSessionSummary({ id: row.id, fileMtimeMs: null, fileSize: null, summary: row.summary });
+  }
   return true;
 }
 
@@ -3948,11 +4067,13 @@ export function pruneMirrorSessions(cutoffMs: number): number {
   const delRow = db.prepare(`DELETE FROM sessions WHERE id = ?`);
   const delText = db.prepare(`DELETE FROM session_text WHERE session_id = ?`);
   const delPreview = db.prepare(`DELETE FROM session_preview_cache WHERE session_id = ?`);
+  const delSummary = db.prepare(`DELETE FROM session_summaries WHERE session_id = ?`);
   const txn = db.transaction(() => {
     for (const { id } of stale) {
       delRow.run(id);
       delText.run(id);
       delPreview.run(id);
+      delSummary.run(id);
     }
   });
   txn();

--- a/cli/src/lib/session/mirror.test.ts
+++ b/cli/src/lib/session/mirror.test.ts
@@ -170,6 +170,55 @@ describe('session mirror (real DB + real shared-state files)', () => {
     expect(rawRow('eeeeeeee-0000-0000-0000-000000000005')).toBeFalsy();
   });
 
+  it('carries a session\'s daemon-computed summary through publish and consume (PHNX-3939)', () => {
+    const root = getUserAgentsDir();
+    const id = '99999999-0000-0000-0000-0000000000aa';
+    seedLocalSession({ id, topic: 'add the summarizer' });
+    db.writeSessionSummary({
+      id,
+      fileMtimeMs: 123,
+      fileSize: 456,
+      summary: {
+        goal: 'Ship the per-session summarizer',
+        checkpoints: [{ text: 'wrote the cache', at: '2026-09-05T00:00:00.000Z' }],
+        summaryChecklist: [{ text: 'add the table', done: true }],
+        summaryState: 'ready',
+      },
+    });
+
+    // Publish: the local source query rides the summary alongside the digest.
+    const source = db.queryLocalOriginSessionsForMirror(self, 200).find((s) => s.id === id)!;
+    expect(source.summary?.goal).toBe('Ship the per-session summarizer');
+
+    // A peer publishes the same digest+summary; consuming it lands the summary in
+    // this box's session_summaries so the merge surfaces it with no transcript.
+    updateFleetSharedDeviceState('yosemite-m2', {
+      sessions: {
+        rows: [{
+          id: 'aaaaaaaa-0000-0000-0000-0000000000bb',
+          shortId: 'aaaaaaaa',
+          agent: 'claude',
+          machine: 'yosemite-m2',
+          topic: 'peer summary',
+          timestamp: '2026-09-01T00:00:00.000Z',
+          goal: 'Peer goal',
+          checkpoints: [{ text: 'peer step', at: '2026-09-01T00:00:00.000Z' }],
+          summaryChecklist: [{ text: 'peer item', done: false }],
+          summaryState: 'ready',
+          capturedAt: Date.now(),
+        }],
+      },
+    }, root);
+    const res = mirror.consumeSessionMirrorFromSharedStore({ userAgentsDir: root, device: self, role: 'personal' });
+    // Other tests in this describe leave peer rows in the shared store, so assert
+    // this session merged rather than an exact fleet-wide count.
+    expect(res.merged).toBeGreaterThanOrEqual(1);
+    const stored = db.readSessionSummaryAny('aaaaaaaa-0000-0000-0000-0000000000bb');
+    expect(stored?.goal).toBe('Peer goal');
+    expect(stored?.summaryState).toBe('ready');
+    expect(stored?.summaryChecklist).toEqual([{ text: 'peer item', done: false }]);
+  });
+
   it('prunes only stale mirror rows, never a real or fresh one', () => {
     const now = Date.now();
     seedLocalSession({ id: 'ffffffff-0000-0000-0000-000000000006', topic: 'keep me local' });

--- a/cli/src/lib/session/mirror.ts
+++ b/cli/src/lib/session/mirror.ts
@@ -88,6 +88,12 @@ export async function publishSessionMirrorToSharedStore(
     timestamp: s.timestamp,
     ...(s.ticketId ? { ticketId: s.ticketId } : {}),
     ...(s.prUrl ? { prUrl: s.prUrl } : {}),
+    // Ride the daemon-computed summary (PHNX-3939) so a peer renders the goal /
+    // checkpoints / checklist inline — still no transcript, keeping the mirror light.
+    ...(s.summary?.goal ? { goal: snippet(s.summary.goal, 400) } : {}),
+    ...(s.summary?.checkpoints ? { checkpoints: s.summary.checkpoints } : {}),
+    ...(s.summary?.summaryChecklist ? { summaryChecklist: s.summary.summaryChecklist } : {}),
+    ...(s.summary?.summaryState ? { summaryState: s.summary.summaryState } : {}),
     capturedAt,
   }));
   try {
@@ -137,6 +143,7 @@ function toUpsert(raw: unknown): {
   id: string; shortId: string; agent: string; version?: string; machine: string;
   cwd?: string; topic?: string; firstUser?: string; label?: string;
   lastActivity?: string; timestamp: string; ticketId?: string; prUrl?: string;
+  summary?: import('./db.js').SessionSummaryEntry;
 } | null {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
   const r = raw as Record<string, unknown>;
@@ -160,6 +167,44 @@ function toUpsert(raw: unknown): {
     timestamp,
     ticketId: cap(r.ticketId, 64),
     prUrl: cap(r.prUrl, 512),
+    summary: toMirrorSummary(r),
+  };
+}
+
+/** One published summary state, validated back into the union or undefined. */
+function toSummaryState(v: unknown): 'pending' | 'ready' | 'skipped' | undefined {
+  return v === 'pending' || v === 'ready' || v === 'skipped' ? v : undefined;
+}
+
+/**
+ * Validate an untrusted peer's published summary fields into a bounded
+ * {@link SessionSummaryEntry} (PHNX-3939), or undefined when it carries none.
+ * Bounds mirror the publish side so a hostile/oversized peer can't bloat the
+ * local cache. Only a row with a resolvable `summaryState` is kept.
+ */
+function toMirrorSummary(r: Record<string, unknown>): import('./db.js').SessionSummaryEntry | undefined {
+  const summaryState = toSummaryState(r.summaryState);
+  if (!summaryState) return undefined;
+  const goal = isString(r.goal) ? r.goal.slice(0, 400) : undefined;
+  const checkpoints = Array.isArray(r.checkpoints)
+    ? r.checkpoints
+        .filter((c): c is Record<string, unknown> => Boolean(c) && typeof c === 'object' && !Array.isArray(c))
+        .filter((c) => isString((c as any).text) && isString((c as any).at))
+        .slice(0, 50)
+        .map((c) => ({ text: String((c as any).text).slice(0, 400), at: String((c as any).at).slice(0, 40) }))
+    : undefined;
+  const summaryChecklist = Array.isArray(r.summaryChecklist)
+    ? r.summaryChecklist
+        .filter((c): c is Record<string, unknown> => Boolean(c) && typeof c === 'object' && !Array.isArray(c))
+        .filter((c) => isString((c as any).text))
+        .slice(0, 100)
+        .map((c) => ({ text: String((c as any).text).slice(0, 400), done: Boolean((c as any).done) }))
+    : undefined;
+  return {
+    summaryState,
+    ...(goal ? { goal } : {}),
+    ...(checkpoints && checkpoints.length ? { checkpoints } : {}),
+    ...(summaryChecklist && summaryChecklist.length ? { summaryChecklist } : {}),
   };
 }
 

--- a/cli/src/lib/session/remote/watch.ts
+++ b/cli/src/lib/session/remote/watch.ts
@@ -9,7 +9,7 @@ import { machineId, normalizeHost } from '../../machine-id.js';
 import { SSH_OPTS, controlOpts, shellQuote } from '../../ssh-exec.js';
 import { buildWindowsAgentsCommand, remoteShellFor } from '../../hosts/remote-cmd.js';
 import { isReapableOrphan, type ActiveSession } from '../active.js';
-import { querySessions } from '../db.js';
+import { querySessions, readSessionSummaryAny } from '../db.js';
 import { linearIssueUrl } from '../linear.js';
 import { sessionAgentSupportsResume } from '../recovery.js';
 import type { SessionMeta } from '../types.js';
@@ -18,6 +18,7 @@ import {
   activeSessionJournalIdentity,
   readActiveSessionsCache,
   noteActiveSessionsJournalReader,
+  resolveStreamSummaryState,
   type ActiveSessionsJournalRecord,
 } from '../session-cache.js';
 
@@ -70,6 +71,10 @@ export function toSessionWatchRow(scope: string, row: ActiveSession): SessionWat
     : null;
   return {
     ...row,
+    // The summarizer's per-row state is delivered on the stream: a live row with
+    // no computed summary reads `pending` when the summarizer is on, `skipped`
+    // when it is off (PHNX-3939). goal/checkpoints/summaryChecklist rode `...row`.
+    summaryState: resolveStreamSummaryState(row.summaryState),
     rowKey,
     sourceDevice: scope,
     previous,
@@ -104,6 +109,18 @@ export function toPreviousSessionWatchRow(scope: string, session: SessionMeta): 
   const worktree = session.worktreeSlug && session.cwd
     ? { slug: session.worktreeSlug, path: session.cwd, ...(session.gitBranch ? { branch: session.gitBranch } : {}) }
     : undefined;
+  // Project the daemon-computed summary (PHNX-3939) onto the history row from the
+  // transcript-keyed cache — the same store the live merge reads, so a closed or
+  // fleet-mirrored session carries its goal/checkpoints/checklist with no
+  // transcript re-parse and no model call. Prefer a value already on the meta row.
+  const summary = session.goal !== undefined || session.summaryState !== undefined
+    ? {
+        goal: session.goal,
+        checkpoints: session.checkpoints,
+        summaryChecklist: session.summaryChecklist,
+        summaryState: session.summaryState,
+      }
+    : readSessionSummaryAny(session.id);
   return {
     context: 'recent',
     kind: session.agent,
@@ -125,6 +142,10 @@ export function toPreviousSessionWatchRow(scope: string, session: SessionMeta): 
     ...(session.tokenCount != null ? { tokenCount: session.tokenCount } : {}),
     ...(session.durationMs != null ? { durationMs: session.durationMs } : {}),
     ...(session.subAgentCount != null ? { subAgentCount: session.subAgentCount } : {}),
+    ...(summary?.goal ? { goal: summary.goal } : {}),
+    ...(summary?.checkpoints ? { checkpoints: summary.checkpoints } : {}),
+    ...(summary?.summaryChecklist ? { summaryChecklist: summary.summaryChecklist } : {}),
+    summaryState: resolveStreamSummaryState(summary?.summaryState),
     startedAtMs,
     lastActivityMs,
     status: 'closed',

--- a/cli/src/lib/session/session-cache.ts
+++ b/cli/src/lib/session/session-cache.ts
@@ -30,7 +30,7 @@ import { createMemoryCache } from '../memory-cache.js';
 import { getCacheDir } from '../state.js';
 import { backfillActiveRowsFromIndex, sessionProcessIsLocal, type ActiveSession } from './active.js';
 import { readSessionSummaryAny } from './db.js';
-import { isSummarizerEnabled } from '../summarizer/config.js';
+import { isSummarizerReady } from '../summarizer/config.js';
 
 /** Snapshot file under `getCacheDir()` (regenerable, gitignored). */
 const SNAPSHOT_FILE = '.active-sessions.json';
@@ -550,16 +550,17 @@ export function mergeSessionSummary(s: ActiveSession): ActiveSession {
 
 /**
  * The `summaryState` a watch-stream row carries when the merge left it unset:
- * `pending` while the summarizer is enabled (a summary is coming), `skipped`
- * when it is off/unconfigured. This is the only place the enabled flag is read
- * on the read path, and it is memoized (PHNX-3939).
+ * `pending` while the summarizer is READY (enabled AND has an endpoint, so a
+ * summary is genuinely coming), `skipped` when it is off OR enabled-but-
+ * unconfigured (nothing will ever populate the cache). This is the only place
+ * the readiness flag is read on the read path, and it is memoized (PHNX-3939).
  */
 export function resolveStreamSummaryState(
   current: import('./types.js').SummaryState | undefined,
   nowMs: number = Date.now(),
 ): import('./types.js').SummaryState {
   if (current) return current;
-  return isSummarizerEnabled(nowMs) ? 'pending' : 'skipped';
+  return isSummarizerReady(nowMs) ? 'pending' : 'skipped';
 }
 
 export function applyImmutableMemo(s: ActiveSession): ActiveSession {

--- a/cli/src/lib/session/session-cache.ts
+++ b/cli/src/lib/session/session-cache.ts
@@ -29,6 +29,8 @@ import * as path from 'path';
 import { createMemoryCache } from '../memory-cache.js';
 import { getCacheDir } from '../state.js';
 import { backfillActiveRowsFromIndex, sessionProcessIsLocal, type ActiveSession } from './active.js';
+import { readSessionSummaryAny } from './db.js';
+import { isSummarizerEnabled } from '../summarizer/config.js';
 
 /** Snapshot file under `getCacheDir()` (regenerable, gitignored). */
 const SNAPSHOT_FILE = '.active-sessions.json';
@@ -521,8 +523,48 @@ export function updateImmutableMemos(sessions: ReadonlyArray<ActiveSession>, now
  * mtime matches. Never overwrites a field the live gather already set, and
  * never copies live-status keys.
  */
+/**
+ * Merge the daemon-computed session summary (PHNX-3939) onto a live row from the
+ * transcript-keyed `session_summaries` cache. This is the low-cost display merge:
+ * one indexed by-id read, NEVER a model call — the background
+ * SessionSummarizerService is the only producer. It fills only what the cache
+ * holds; the `pending`/`skipped` default for a row with no summary yet is applied
+ * at the watch-stream boundary ({@link resolveStreamSummaryState}), so a
+ * non-stream ActiveSession consumer is unaffected. Best-effort: a DB error leaves
+ * the row untouched.
+ */
+export function mergeSessionSummary(s: ActiveSession): ActiveSession {
+  if (!s.sessionId) return s;
+  try {
+    const stored = readSessionSummaryAny(s.sessionId);
+    if (!stored) return s;
+    if (s.goal === undefined && stored.goal !== undefined) s.goal = stored.goal;
+    if (s.checkpoints === undefined && stored.checkpoints !== undefined) s.checkpoints = stored.checkpoints;
+    if (s.summaryChecklist === undefined && stored.summaryChecklist !== undefined) s.summaryChecklist = stored.summaryChecklist;
+    if (s.summaryState === undefined) s.summaryState = stored.summaryState;
+  } catch {
+    // best-effort: never let the summary merge break the gather path.
+  }
+  return s;
+}
+
+/**
+ * The `summaryState` a watch-stream row carries when the merge left it unset:
+ * `pending` while the summarizer is enabled (a summary is coming), `skipped`
+ * when it is off/unconfigured. This is the only place the enabled flag is read
+ * on the read path, and it is memoized (PHNX-3939).
+ */
+export function resolveStreamSummaryState(
+  current: import('./types.js').SummaryState | undefined,
+  nowMs: number = Date.now(),
+): import('./types.js').SummaryState {
+  if (current) return current;
+  return isSummarizerEnabled(nowMs) ? 'pending' : 'skipped';
+}
+
 export function applyImmutableMemo(s: ActiveSession): ActiveSession {
   if (!s.sessionId) return s;
+  mergeSessionSummary(s);
   const mtime = transcriptMtimeMs(s);
   if (mtime === null) return s;
   const memo = readImmutableMemo(s.sessionId, mtime);

--- a/cli/src/lib/session/summary-stream-state.test.ts
+++ b/cli/src/lib/session/summary-stream-state.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Fresh HOME before importing state/config (no summarizer configured → not ready).
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-summ-state-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+delete process.env.AGENTS_SUMMARIZER_ENABLED;
+delete process.env.AGENTS_SUMMARIZER_BASEURL;
+delete process.env.AGENTS_SUMMARIZER_MODEL;
+
+const { resolveStreamSummaryState } = await import('./session-cache.js');
+const { resetSummarizerReadyCacheForTest } = await import('../summarizer/config.js');
+
+describe('resolveStreamSummaryState (PHNX-3939 blocker)', () => {
+  beforeEach(() => resetSummarizerReadyCacheForTest());
+
+  it('passes through an already-resolved state', () => {
+    expect(resolveStreamSummaryState('ready')).toBe('ready');
+    expect(resolveStreamSummaryState('skipped')).toBe('skipped');
+    expect(resolveStreamSummaryState('pending')).toBe('pending');
+  });
+
+  it('defaults to skipped when the summarizer is not ready (off OR enabled-but-unconfigured)', () => {
+    // Nothing configured here — enabled-but-no-endpoint would compute nothing,
+    // so an unset state must read `skipped`, never a `pending` that never resolves.
+    expect(resolveStreamSummaryState(undefined)).toBe('skipped');
+  });
+});

--- a/cli/src/lib/session/types.ts
+++ b/cli/src/lib/session/types.ts
@@ -147,6 +147,31 @@ export interface TodoProgress {
   activeForm?: string;
 }
 
+/**
+ * One progress checkpoint in a daemon-computed session summary (PHNX-3939):
+ * a short line of what happened, stamped with an ISO time. Newest last.
+ */
+export interface SessionCheckpoint {
+  text: string;
+  /** ISO timestamp for this checkpoint. */
+  at: string;
+}
+
+/** One item in a daemon-computed session summary checklist (PHNX-3939). */
+export interface SessionChecklistItem {
+  text: string;
+  done: boolean;
+}
+
+/**
+ * Lifecycle of a session's daemon-computed summary (PHNX-3939):
+ *   - `pending` — the summarizer is enabled and this session has no summary yet.
+ *   - `ready`   — a summary was computed and merged onto the row.
+ *   - `skipped` — the summarizer is disabled/unconfigured, or a compute error
+ *                 left no summary; the row deliberately carries no goal/checkpoints.
+ */
+export type SummaryState = 'pending' | 'ready' | 'skipped';
+
 /** Metadata attached when a session was spawned by `agents teams`. */
 export interface TeamOrigin {
   /** Teammate name if set, otherwise first 8 chars of the agent UUID. */
@@ -416,6 +441,18 @@ export interface SessionMeta {
   archived?: boolean;
   /** Epoch ms the transcript file was first confirmed gone (pairs with {@link archived}). */
   archivedAt?: number;
+  /**
+   * Daemon-computed 1–2 line goal extracted from the session's first user turn
+   * (PHNX-3939). Never on the request path — produced by the background
+   * `SessionSummarizerService` and merged from the `session_summaries` cache.
+   */
+  goal?: string;
+  /** Daemon-computed progress checkpoints, newest last (PHNX-3939). */
+  checkpoints?: SessionCheckpoint[];
+  /** Daemon-computed detailed checklist for the session (PHNX-3939). */
+  summaryChecklist?: SessionChecklistItem[];
+  /** Lifecycle of the daemon-computed summary; `skipped` when disabled (PHNX-3939). */
+  summaryState?: SummaryState;
   /** Terms that matched the current search query */
   _matchedTerms?: string[];
   /** BM25 relevance score from the most recent content-index search */

--- a/cli/src/lib/summarizer/config.test.ts
+++ b/cli/src/lib/summarizer/config.test.ts
@@ -11,8 +11,8 @@ process.env.USERPROFILE = TEST_HOME;
 const {
   resolveSummarizerConfig,
   isSummarizerRunnable,
-  isSummarizerEnabled,
-  resetSummarizerEnabledCacheForTest,
+  isSummarizerReady,
+  resetSummarizerReadyCacheForTest,
 } = await import('./config.js');
 
 function envOnly(over: Record<string, string | undefined>): NodeJS.ProcessEnv {
@@ -48,12 +48,18 @@ describe('isSummarizerRunnable', () => {
   });
 });
 
-describe('isSummarizerEnabled memo', () => {
-  beforeEach(() => resetSummarizerEnabledCacheForTest());
+describe('isSummarizerReady memo', () => {
+  beforeEach(() => resetSummarizerReadyCacheForTest());
 
-  it('defaults false and is stable within the TTL', () => {
-    expect(isSummarizerEnabled(1000)).toBe(false);
+  it('defaults false (nothing configured) and is stable within the TTL', () => {
+    expect(isSummarizerReady(1000)).toBe(false);
     // A read inside the TTL window returns the cached value.
-    expect(isSummarizerEnabled(1500)).toBe(false);
+    expect(isSummarizerReady(1500)).toBe(false);
+  });
+
+  it('reflects runnable, not just enabled — enabled-but-unconfigured is NOT ready', () => {
+    // With no baseUrl/model configured, `enabled` alone must not make it ready:
+    // the merge would otherwise show a `pending` that never resolves.
+    expect(isSummarizerRunnable({ enabled: true })).toBe(false);
   });
 });

--- a/cli/src/lib/summarizer/config.test.ts
+++ b/cli/src/lib/summarizer/config.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Fresh HOME before importing the config store (same pattern as the db tests).
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-summ-cfg-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const {
+  resolveSummarizerConfig,
+  isSummarizerRunnable,
+  isSummarizerEnabled,
+  resetSummarizerEnabledCacheForTest,
+} = await import('./config.js');
+
+function envOnly(over: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return over as NodeJS.ProcessEnv;
+}
+
+describe('resolveSummarizerConfig', () => {
+  it('is disabled with no config and no env', () => {
+    expect(resolveSummarizerConfig(envOnly({}))).toEqual({ enabled: false, baseUrl: undefined, model: undefined });
+  });
+
+  it('reads the three env overrides', () => {
+    const cfg = resolveSummarizerConfig(envOnly({
+      AGENTS_SUMMARIZER_ENABLED: '1',
+      AGENTS_SUMMARIZER_BASEURL: 'http://localhost:11434',
+      AGENTS_SUMMARIZER_MODEL: 'qwen2.5:3b',
+    }));
+    expect(cfg).toEqual({ enabled: true, baseUrl: 'http://localhost:11434', model: 'qwen2.5:3b' });
+  });
+
+  it('treats falsey env values as disabled', () => {
+    expect(resolveSummarizerConfig(envOnly({ AGENTS_SUMMARIZER_ENABLED: 'off' })).enabled).toBe(false);
+    expect(resolveSummarizerConfig(envOnly({ AGENTS_SUMMARIZER_ENABLED: '0' })).enabled).toBe(false);
+  });
+});
+
+describe('isSummarizerRunnable', () => {
+  it('needs enabled AND a base URL AND a model', () => {
+    expect(isSummarizerRunnable({ enabled: true, baseUrl: 'http://x', model: 'm' })).toBe(true);
+    expect(isSummarizerRunnable({ enabled: false, baseUrl: 'http://x', model: 'm' })).toBe(false);
+    expect(isSummarizerRunnable({ enabled: true, baseUrl: 'http://x' })).toBe(false);
+    expect(isSummarizerRunnable({ enabled: true, model: 'm' })).toBe(false);
+  });
+});
+
+describe('isSummarizerEnabled memo', () => {
+  beforeEach(() => resetSummarizerEnabledCacheForTest());
+
+  it('defaults false and is stable within the TTL', () => {
+    expect(isSummarizerEnabled(1000)).toBe(false);
+    // A read inside the TTL window returns the cached value.
+    expect(isSummarizerEnabled(1500)).toBe(false);
+  });
+});

--- a/cli/src/lib/summarizer/config.ts
+++ b/cli/src/lib/summarizer/config.ts
@@ -8,9 +8,9 @@
  * `AGENTS_SUMMARIZER_MODEL`). Off by default: with no config and no env, the
  * summarizer is disabled and makes zero model calls.
  *
- * `isSummarizerEnabled()` is memoized on a short TTL because the display merge
- * (`applyImmutableMemo`) calls it once per session row on the gather path — a
- * fresh agents.yaml read per row would defeat the "blazing fast" requirement.
+ * `isSummarizerReady()` is memoized on a short TTL because the display merge
+ * (the watch-stream projections) calls it once per session row — a fresh
+ * agents.yaml read per row would defeat the "blazing fast" requirement.
  */
 
 import { getConfigValue } from '../device-config.js';
@@ -69,24 +69,26 @@ export function isSummarizerRunnable(config: SummarizerConfig): boolean {
   return config.enabled && Boolean(config.baseUrl) && Boolean(config.model);
 }
 
-let cachedEnabled: { at: number; value: boolean } | null = null;
-const ENABLED_TTL_MS = 3_000;
+let cachedReady: { at: number; value: boolean } | null = null;
+const READY_TTL_MS = 3_000;
 
 /**
- * Memoized "is the operator asking for summaries?" check for the hot merge path.
- * Reflects only `enabled` (not runnable) — the merge uses it to decide whether a
- * session with no cached summary reads `pending` (enabled) or `skipped`
- * (disabled). TTL keeps a config toggle visible within a few seconds without a
+ * Memoized "will a summary actually be produced?" check for the hot merge path.
+ * Reflects {@link isSummarizerRunnable} — enabled AND a base URL AND a model —
+ * NOT just `enabled`, because an enabled-but-unconfigured summarizer computes
+ * nothing, so a row with no cached summary must read `skipped`, not a `pending`
+ * that never resolves (the exact case: `summarizer.enabled on` set before the
+ * endpoint). TTL keeps a config change visible within a few seconds without a
  * per-row agents.yaml read.
  */
-export function isSummarizerEnabled(nowMs: number = Date.now()): boolean {
-  if (cachedEnabled && nowMs - cachedEnabled.at < ENABLED_TTL_MS) return cachedEnabled.value;
-  const value = resolveSummarizerConfig().enabled;
-  cachedEnabled = { at: nowMs, value };
+export function isSummarizerReady(nowMs: number = Date.now()): boolean {
+  if (cachedReady && nowMs - cachedReady.at < READY_TTL_MS) return cachedReady.value;
+  const value = isSummarizerRunnable(resolveSummarizerConfig());
+  cachedReady = { at: nowMs, value };
   return value;
 }
 
-/** Test seam: drop the memoized enabled flag so the next read re-resolves. */
-export function resetSummarizerEnabledCacheForTest(): void {
-  cachedEnabled = null;
+/** Test seam: drop the memoized ready flag so the next read re-resolves. */
+export function resetSummarizerReadyCacheForTest(): void {
+  cachedReady = null;
 }

--- a/cli/src/lib/summarizer/config.ts
+++ b/cli/src/lib/summarizer/config.ts
@@ -1,0 +1,92 @@
+/**
+ * Session-summarizer configuration (PHNX-3939).
+ *
+ * Resolves the three knobs behind the daemon summarizer — enabled / base URL /
+ * model — from `agents config` (`summarizer.*`, user-scope in the central
+ * agents.yaml) with a per-process env override
+ * (`AGENTS_SUMMARIZER_ENABLED` / `AGENTS_SUMMARIZER_BASEURL` /
+ * `AGENTS_SUMMARIZER_MODEL`). Off by default: with no config and no env, the
+ * summarizer is disabled and makes zero model calls.
+ *
+ * `isSummarizerEnabled()` is memoized on a short TTL because the display merge
+ * (`applyImmutableMemo`) calls it once per session row on the gather path — a
+ * fresh agents.yaml read per row would defeat the "blazing fast" requirement.
+ */
+
+import { getConfigValue } from '../device-config.js';
+
+export interface SummarizerConfig {
+  enabled: boolean;
+  /** Anthropic-wire base URL (Ollama/vLLM/LiteLLM), or undefined when unconfigured. */
+  baseUrl?: string;
+  /** Model id to request, or undefined when unconfigured. */
+  model?: string;
+}
+
+/** Parse a boolean-ish env value; undefined when the var is unset. */
+function envBool(raw: string | undefined): boolean | undefined {
+  if (raw === undefined) return undefined;
+  const v = raw.trim().toLowerCase();
+  if (v === '1' || v === 'true' || v === 'on' || v === 'yes') return true;
+  if (v === '0' || v === 'false' || v === 'off' || v === 'no' || v === '') return false;
+  return undefined;
+}
+
+function envString(raw: string | undefined): string | undefined {
+  const v = raw?.trim();
+  return v ? v : undefined;
+}
+
+/**
+ * Resolve the full summarizer config. Env overrides the stored config key by key;
+ * an unset env var falls through to `agents config`, then to the built-in
+ * default (disabled). Never throws — a missing/corrupt config reads as unset.
+ */
+export function resolveSummarizerConfig(env: NodeJS.ProcessEnv = process.env): SummarizerConfig {
+  let storedEnabled: boolean | undefined;
+  let storedBaseUrl: string | undefined;
+  let storedModel: string | undefined;
+  try {
+    storedEnabled = getConfigValue('summarizer.enabled').value as boolean | undefined;
+    storedBaseUrl = getConfigValue('summarizer.baseUrl').value as string | undefined;
+    storedModel = getConfigValue('summarizer.model').value as string | undefined;
+  } catch {
+    // A missing/corrupt config store must not break the read path — treat as unset.
+  }
+  const enabled = envBool(env.AGENTS_SUMMARIZER_ENABLED) ?? storedEnabled ?? false;
+  const baseUrl = envString(env.AGENTS_SUMMARIZER_BASEURL) ?? envString(storedBaseUrl);
+  const model = envString(env.AGENTS_SUMMARIZER_MODEL) ?? envString(storedModel);
+  return { enabled, baseUrl, model };
+}
+
+/**
+ * True only when the summarizer is enabled AND has a base URL + model to call.
+ * A configuration that is `enabled` but missing an endpoint cannot produce a
+ * summary, so it is treated as unconfigured (the service no-ops, the merge marks
+ * `skipped`) rather than erroring on every tick.
+ */
+export function isSummarizerRunnable(config: SummarizerConfig): boolean {
+  return config.enabled && Boolean(config.baseUrl) && Boolean(config.model);
+}
+
+let cachedEnabled: { at: number; value: boolean } | null = null;
+const ENABLED_TTL_MS = 3_000;
+
+/**
+ * Memoized "is the operator asking for summaries?" check for the hot merge path.
+ * Reflects only `enabled` (not runnable) — the merge uses it to decide whether a
+ * session with no cached summary reads `pending` (enabled) or `skipped`
+ * (disabled). TTL keeps a config toggle visible within a few seconds without a
+ * per-row agents.yaml read.
+ */
+export function isSummarizerEnabled(nowMs: number = Date.now()): boolean {
+  if (cachedEnabled && nowMs - cachedEnabled.at < ENABLED_TTL_MS) return cachedEnabled.value;
+  const value = resolveSummarizerConfig().enabled;
+  cachedEnabled = { at: nowMs, value };
+  return value;
+}
+
+/** Test seam: drop the memoized enabled flag so the next read re-resolves. */
+export function resetSummarizerEnabledCacheForTest(): void {
+  cachedEnabled = null;
+}

--- a/cli/src/lib/summarizer/pass.test.ts
+++ b/cli/src/lib/summarizer/pass.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Fresh HOME before importing state/db (db.ts captures DB_PATH at module load).
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-summ-pass-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const { getSessionsDir } = await import('../state.js');
+fs.mkdirSync(getSessionsDir(), { recursive: true });
+
+const { runSummarizerPass } = await import('./pass.js');
+const { readSessionSummaryAny } = await import('../session/db.js');
+
+const RUNNABLE = { enabled: true, baseUrl: 'http://localhost:11434', model: 'qwen2.5:3b' };
+
+function session(over: Record<string, any> = {}): any {
+  return {
+    sessionId: over.sessionId ?? 's1',
+    sessionFile: over.sessionFile ?? '/tmp/s1.jsonl',
+    firstUserMessage: 'Ship the feature end to end',
+    topic: 'ship it',
+    ...over,
+  };
+}
+
+/** A summarize stub that records calls and returns a scripted result. */
+function stubSummarize(result: any) {
+  const calls: any[] = [];
+  const impl = (async (prompt: string, progress: any) => {
+    calls.push({ prompt, progress });
+    return result;
+  }) as any;
+  return { impl, calls };
+}
+
+describe('runSummarizerPass', () => {
+  it('does nothing when the summarizer is disabled/unconfigured', async () => {
+    const stub = stubSummarize({ goal: 'g', checkpoints: [], checklist: [] });
+    const r = await runSummarizerPass({
+      config: { enabled: false },
+      sessions: [session({ sessionId: 'disabled-1' })],
+      summarizeImpl: stub.impl,
+      statFile: () => ({ mtimeMs: 1, size: 1 }),
+    });
+    expect(r.disabled).toBe(true);
+    expect(stub.calls.length).toBe(0);
+    expect(readSessionSummaryAny('disabled-1')).toBeUndefined();
+  });
+
+  it('computes and writes a ready summary, stamping checkpoint times', async () => {
+    const stub = stubSummarize({ goal: 'Ship it', checkpoints: ['did A', 'did B'], checklist: [{ text: 'step', done: false }] });
+    const now = Date.parse('2026-09-05T12:00:00.000Z');
+    const r = await runSummarizerPass({
+      now,
+      config: RUNNABLE,
+      sessions: [session({ sessionId: 'ready-1' })],
+      summarizeImpl: stub.impl,
+      statFile: () => ({ mtimeMs: 500, size: 900 }),
+    });
+    expect(r.computed).toBe(1);
+    const stored = readSessionSummaryAny('ready-1');
+    expect(stored?.summaryState).toBe('ready');
+    expect(stored?.goal).toBe('Ship it');
+    expect(stored?.checkpoints).toEqual([
+      { text: 'did A', at: '2026-09-05T12:00:00.000Z' },
+      { text: 'did B', at: '2026-09-05T12:00:00.000Z' },
+    ]);
+    expect(stored?.summaryChecklist).toEqual([{ text: 'step', done: false }]);
+    // The prompt fed to the model is the first user turn, never a tool firehose.
+    expect(stub.calls[0].prompt).toBe('Ship the feature end to end');
+  });
+
+  it('reuses the cached row on unchanged bytes — no second model call', async () => {
+    const stub = stubSummarize({ goal: 'Ship it', checkpoints: ['x'], checklist: [] });
+    const statFile = () => ({ mtimeMs: 42, size: 42 });
+    const s = [session({ sessionId: 'reuse-1' })];
+    const first = await runSummarizerPass({ config: RUNNABLE, sessions: s, summarizeImpl: stub.impl, statFile });
+    expect(first.computed).toBe(1);
+    const second = await runSummarizerPass({ config: RUNNABLE, sessions: s, summarizeImpl: stub.impl, statFile });
+    expect(second.reused).toBe(1);
+    expect(second.computed).toBe(0);
+    expect(stub.calls.length).toBe(1); // never called the model again
+  });
+
+  it('keeps the goal stable across a transcript delta (goal computed once)', async () => {
+    const s = [session({ sessionId: 'goal-1' })];
+    const t1 = Date.parse('2026-09-05T10:00:00.000Z');
+    const t2 = Date.parse('2026-09-05T11:00:00.000Z');
+    const first = stubSummarize({ goal: 'Original goal', checkpoints: ['a'], checklist: [] });
+    await runSummarizerPass({ now: t1, config: RUNNABLE, sessions: s, summarizeImpl: first.impl, statFile: () => ({ mtimeMs: 1, size: 1 }) });
+
+    // Bytes change → recompute. The model drifts the goal, but the stored goal
+    // must stay the first one; checkpoints refresh.
+    const second = stubSummarize({ goal: 'Drifted goal', checkpoints: ['a', 'b'], checklist: [] });
+    await runSummarizerPass({ now: t2, config: RUNNABLE, sessions: s, summarizeImpl: second.impl, statFile: () => ({ mtimeMs: 2, size: 5 }) });
+
+    const stored = readSessionSummaryAny('goal-1');
+    expect(stored?.goal).toBe('Original goal');
+    expect(stored?.checkpoints?.map((c) => c.text)).toEqual(['a', 'b']);
+    // The pre-existing checkpoint 'a' keeps its original timestamp.
+    const a = stored?.checkpoints?.find((c) => c.text === 'a');
+    const b = stored?.checkpoints?.find((c) => c.text === 'b');
+    expect(a && b && a.at !== b.at).toBe(true);
+  });
+
+  it('records a skipped state (cached) when the model fails', async () => {
+    const stub = stubSummarize(undefined);
+    const r = await runSummarizerPass({
+      config: RUNNABLE,
+      sessions: [session({ sessionId: 'skip-1' })],
+      summarizeImpl: stub.impl,
+      statFile: () => ({ mtimeMs: 1, size: 1 }),
+    });
+    expect(r.skipped).toBe(1);
+    expect(readSessionSummaryAny('skip-1')?.summaryState).toBe('skipped');
+  });
+
+  it('skips a session with no extractable intent without calling the model', async () => {
+    const stub = stubSummarize({ goal: 'g', checkpoints: [], checklist: [] });
+    const r = await runSummarizerPass({
+      config: RUNNABLE,
+      sessions: [session({ sessionId: 'noprompt-1', firstUserMessage: undefined, topic: undefined })],
+      summarizeImpl: stub.impl,
+      statFile: () => ({ mtimeMs: 1, size: 1 }),
+    });
+    expect(r.skipped).toBe(1);
+    expect(stub.calls.length).toBe(0);
+    expect(readSessionSummaryAny('noprompt-1')?.summaryState).toBe('skipped');
+  });
+
+  it('honours the per-tick budget', async () => {
+    const stub = stubSummarize({ goal: 'g', checkpoints: [], checklist: [] });
+    const sessions = Array.from({ length: 5 }, (_, i) =>
+      session({ sessionId: `budget-${i}`, sessionFile: `/tmp/budget-${i}.jsonl` }));
+    const r = await runSummarizerPass({
+      config: RUNNABLE,
+      sessions,
+      summarizeImpl: stub.impl,
+      statFile: (p) => ({ mtimeMs: p.length, size: p.length }),
+      maxPerTick: 2,
+    });
+    expect(r.computed).toBe(2);
+    expect(stub.calls.length).toBe(2);
+  });
+});

--- a/cli/src/lib/summarizer/pass.ts
+++ b/cli/src/lib/summarizer/pass.ts
@@ -1,0 +1,161 @@
+/**
+ * One session-summarizer pass (PHNX-3939) — the work the background
+ * SessionSummarizerService does per tick, factored out so it is testable with an
+ * injected model stub and no daemon scaffolding.
+ *
+ * Off the request path by construction: it reads THIS box's already-published
+ * live sessions (the warm cache the session-state service writes — never a fresh
+ * gather) and, per session, reuses the transcript-keyed `session_summaries` row
+ * until the transcript bytes change, so an unchanged session costs one indexed
+ * read and zero model calls. When the summarizer is disabled or has no endpoint,
+ * the pass does nothing at all.
+ */
+
+import * as fs from 'node:fs';
+
+import type { ActiveSession } from '../session/active.js';
+import type { SessionCheckpoint } from '../session/types.js';
+import {
+  readSessionSummary,
+  readSessionSummaryAny,
+  writeSessionSummary,
+  type SessionSummaryEntry,
+} from '../session/db.js';
+import {
+  isActiveSessionsJournalReaderRecent,
+  readActiveSessionsCache,
+} from '../session/session-cache.js';
+import { resolveSummarizerConfig, isSummarizerRunnable, type SummarizerConfig } from './config.js';
+import { summarize as defaultSummarize } from './summarize.js';
+
+/** Max sessions summarized per tick — a debounce ceiling on local-model calls. */
+export const SUMMARIZER_MAX_PER_TICK = 8;
+
+export interface SummarizerPassOptions {
+  now?: number;
+  config?: SummarizerConfig;
+  /** Live sessions to consider; default = this box's warm local-session cache. */
+  sessions?: ActiveSession[];
+  /** Injectable model call (tests stub the endpoint here). */
+  summarizeImpl?: typeof defaultSummarize;
+  signal?: AbortSignal;
+  maxPerTick?: number;
+  /** Injectable stat for tests; defaults to fs.statSync. */
+  statFile?: (p: string) => { mtimeMs: number; size: number };
+  /** Skip the reader-recency gate (tests pass sessions directly). */
+  requireReader?: boolean;
+}
+
+export interface SummarizerPassResult {
+  disabled: boolean;
+  computed: number;
+  reused: number;
+  skipped: number;
+}
+
+/**
+ * Merge model checkpoint TEXTS with any prior stored checkpoints so a line that
+ * already existed keeps its original `at`, and only genuinely new lines get
+ * stamped `now`. Order follows the model output (newest last).
+ */
+function stampCheckpoints(
+  texts: string[],
+  prior: SessionCheckpoint[] | undefined,
+  nowIso: string,
+): SessionCheckpoint[] {
+  const priorAt = new Map((prior ?? []).map((c) => [c.text, c.at]));
+  return texts.map((text) => ({ text, at: priorAt.get(text) ?? nowIso }));
+}
+
+/**
+ * Run one pass. Returns per-outcome counts. Never throws — a per-session failure
+ * is isolated so one bad transcript can't stall the whole tick.
+ */
+export async function runSummarizerPass(opts: SummarizerPassOptions = {}): Promise<SummarizerPassResult> {
+  const now = opts.now ?? Date.now();
+  const config = opts.config ?? resolveSummarizerConfig();
+  const result: SummarizerPassResult = { disabled: false, computed: 0, reused: 0, skipped: 0 };
+  if (!isSummarizerRunnable(config)) {
+    result.disabled = true;
+    return result;
+  }
+
+  let sessions = opts.sessions;
+  if (!sessions) {
+    // Reader-gated like the active-sessions warm tick: no watcher, no work.
+    if (opts.requireReader !== false && !isActiveSessionsJournalReaderRecent(now)) return result;
+    sessions = readActiveSessionsCache('local')?.sessions ?? [];
+  }
+
+  const stat = opts.statFile ?? ((p: string) => {
+    const s = fs.statSync(p);
+    return { mtimeMs: s.mtimeMs, size: s.size };
+  });
+  const runSummarize = opts.summarizeImpl ?? defaultSummarize;
+  const maxPerTick = opts.maxPerTick ?? SUMMARIZER_MAX_PER_TICK;
+  const nowIso = new Date(now).toISOString();
+
+  let budget = maxPerTick;
+  for (const s of sessions) {
+    if (opts.signal?.aborted) break;
+    if (budget <= 0) break;
+    const id = s.sessionId;
+    const file = s.sessionFile;
+    if (!id || !file) continue;
+
+    let stamp: { fileMtimeMs: number; fileSize: number };
+    try {
+      const st = stat(file);
+      stamp = { fileMtimeMs: Math.round(st.mtimeMs), fileSize: st.size };
+    } catch {
+      continue; // transcript unreadable this tick — try again next time
+    }
+
+    // Cached for these exact bytes → never recompute (the core "blazing fast" rule).
+    if (readSessionSummary(id, stamp)) {
+      result.reused++;
+      continue;
+    }
+
+    budget--;
+    const prompt = (s.firstUserMessage ?? s.topic ?? '').trim();
+    const prior = readSessionSummaryAny(id);
+    if (!prompt) {
+      // No extractable intent yet — cache a skip against these bytes so we don't
+      // re-attempt every tick; a later transcript write (new bytes) retries.
+      writeSessionSummary({ id, ...stamp, summary: { summaryState: 'skipped' } });
+      result.skipped++;
+      continue;
+    }
+
+    let computed;
+    try {
+      computed = await runSummarize(
+        prompt,
+        { todos: s.todos, plan: s.plan, phase: s.phase },
+        { baseUrl: config.baseUrl!, model: config.model!, ...(opts.signal ? { signal: opts.signal } : {}) },
+      );
+    } catch {
+      computed = undefined;
+    }
+
+    if (!computed) {
+      writeSessionSummary({ id, ...stamp, summary: { summaryState: 'skipped' } });
+      result.skipped++;
+      continue;
+    }
+
+    const entry: SessionSummaryEntry = {
+      // Goal is computed ONCE at first sight — a prior goal is kept across
+      // progress deltas so it stays stable while checkpoints/checklist refresh.
+      goal: prior?.goal ?? computed.goal,
+      checkpoints: stampCheckpoints(computed.checkpoints, prior?.checkpoints, nowIso),
+      summaryChecklist: computed.checklist,
+      summaryState: 'ready',
+    };
+    writeSessionSummary({ id, ...stamp, summary: entry });
+    result.computed++;
+  }
+
+  return result;
+}

--- a/cli/src/lib/summarizer/summarize.test.ts
+++ b/cli/src/lib/summarizer/summarize.test.ts
@@ -108,4 +108,23 @@ describe('summarize (stubbed model endpoint)', () => {
     expect(await summarize('   ', {}, { ...OPTS, fetchImpl: stub.fetch })).toBeUndefined();
     expect(stub.calls.length).toBe(0);
   });
+
+  it('never forwards the ambient ANTHROPIC_API_KEY to the endpoint', async () => {
+    const prev = process.env.ANTHROPIC_API_KEY;
+    const prevSumm = process.env.AGENTS_SUMMARIZER_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-should-never-leak';
+    delete process.env.AGENTS_SUMMARIZER_API_KEY;
+    const calls: any[] = [];
+    const fetchImpl = (async (_url: any, init: any) => {
+      calls.push({ apiKey: (init?.headers ?? {})['x-api-key'] });
+      return { ok: true, status: 200, statusText: 'OK', json: async () => ({ content: [{ type: 'text', text: '{"goal":"g"}' }] }), text: async () => '' } as any;
+    }) as unknown as typeof fetch;
+    try {
+      await summarize('do it', {}, { ...OPTS, fetchImpl });
+      expect(calls[0].apiKey).toBe(''); // empty, not the ANTHROPIC key
+    } finally {
+      if (prev === undefined) delete process.env.ANTHROPIC_API_KEY; else process.env.ANTHROPIC_API_KEY = prev;
+      if (prevSumm !== undefined) process.env.AGENTS_SUMMARIZER_API_KEY = prevSumm;
+    }
+  });
 });

--- a/cli/src/lib/summarizer/summarize.test.ts
+++ b/cli/src/lib/summarizer/summarize.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSummarizeUserMessage,
+  extractJsonObject,
+  summarize,
+  validateSummarizeResult,
+} from './summarize.js';
+
+/** A fake Anthropic /v1/messages endpoint returning the given assistant text. */
+function stubEndpoint(text: string, ok = true): { fetch: typeof fetch; calls: any[] } {
+  const calls: any[] = [];
+  const fetchImpl = (async (url: any, init: any) => {
+    calls.push({ url, body: init?.body ? JSON.parse(init.body) : undefined });
+    return {
+      ok,
+      status: ok ? 200 : 500,
+      statusText: ok ? 'OK' : 'err',
+      json: async () => ({ content: [{ type: 'text', text }] }),
+      text: async () => text,
+    } as any;
+  }) as unknown as typeof fetch;
+  return { fetch: fetchImpl, calls };
+}
+
+const OPTS = { baseUrl: 'http://localhost:11434', model: 'qwen2.5:3b' };
+
+describe('validateSummarizeResult', () => {
+  it('accepts a well-formed object and trims/filters', () => {
+    const r = validateSummarizeResult({
+      goal: '  Ship the summarizer  ',
+      checkpoints: ['wrote the cache', '   ', 42, 'wired the service'],
+      checklist: [{ text: 'add table', done: true }, { text: '', done: false }, { done: true }],
+    });
+    expect(r).toEqual({
+      goal: 'Ship the summarizer',
+      checkpoints: ['wrote the cache', 'wired the service'],
+      checklist: [{ text: 'add table', done: true }],
+    });
+  });
+
+  it('rejects a missing/empty goal', () => {
+    expect(validateSummarizeResult({ checkpoints: [], checklist: [] })).toBeUndefined();
+    expect(validateSummarizeResult({ goal: '   ' })).toBeUndefined();
+    expect(validateSummarizeResult('nope')).toBeUndefined();
+    expect(validateSummarizeResult(null)).toBeUndefined();
+  });
+
+  it('degrades missing arrays to []', () => {
+    expect(validateSummarizeResult({ goal: 'g' })).toEqual({ goal: 'g', checkpoints: [], checklist: [] });
+  });
+});
+
+describe('extractJsonObject', () => {
+  it('strips code fences and pulls the object', () => {
+    expect(extractJsonObject('```json\n{"goal":"x"}\n```')).toBe('{"goal":"x"}');
+  });
+  it('pulls the object out of surrounding chatter', () => {
+    expect(extractJsonObject('Sure! {"goal":"x","checkpoints":[]} hope that helps')).toBe('{"goal":"x","checkpoints":[]}');
+  });
+  it('returns undefined when there is no object', () => {
+    expect(extractJsonObject('no json here')).toBeUndefined();
+  });
+});
+
+describe('buildSummarizeUserMessage', () => {
+  it('includes the prompt, phase, checklist and plan but never a tool firehose', () => {
+    const msg = buildSummarizeUserMessage('Do the thing', {
+      phase: 'running',
+      todos: { items: [{ content: 'step one', status: 'completed' }, { content: 'step two', status: 'pending' }], done: 1, total: 2 },
+      plan: 'the plan body',
+    });
+    expect(msg).toContain('USER REQUEST:\nDo the thing');
+    expect(msg).toContain('PHASE: running');
+    expect(msg).toContain('(1/2 done)');
+    expect(msg).toContain('[x] step one');
+    expect(msg).toContain('PLAN:\nthe plan body');
+  });
+});
+
+describe('summarize (stubbed model endpoint)', () => {
+  it('parses a strict-JSON reply into a validated result', async () => {
+    const stub = stubEndpoint('{"goal":"Ship it","checkpoints":["did A"],"checklist":[{"text":"B","done":false}]}');
+    const r = await summarize('Ship it end to end', { phase: 'running' }, { ...OPTS, fetchImpl: stub.fetch });
+    expect(r).toEqual({ goal: 'Ship it', checkpoints: ['did A'], checklist: [{ text: 'B', done: false }] });
+    // It POSTed to the configured base URL with the model + no tools.
+    expect(stub.calls[0].url).toBe('http://localhost:11434/v1/messages');
+    expect(stub.calls[0].body.model).toBe('qwen2.5:3b');
+    expect(stub.calls[0].body.tools).toBeUndefined();
+  });
+
+  it('returns undefined on a non-2xx response', async () => {
+    const stub = stubEndpoint('{"goal":"x"}', false);
+    expect(await summarize('p', {}, { ...OPTS, fetchImpl: stub.fetch })).toBeUndefined();
+  });
+
+  it('returns undefined on non-JSON output', async () => {
+    const stub = stubEndpoint('the model refused to produce json');
+    expect(await summarize('p', {}, { ...OPTS, fetchImpl: stub.fetch })).toBeUndefined();
+  });
+
+  it('returns undefined on a thrown fetch (network error)', async () => {
+    const fetchImpl = (async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch;
+    expect(await summarize('p', {}, { ...OPTS, fetchImpl })).toBeUndefined();
+  });
+
+  it('returns undefined for an empty prompt without calling the model', async () => {
+    const stub = stubEndpoint('{"goal":"x"}');
+    expect(await summarize('   ', {}, { ...OPTS, fetchImpl: stub.fetch })).toBeUndefined();
+    expect(stub.calls.length).toBe(0);
+  });
+});

--- a/cli/src/lib/summarizer/summarize.ts
+++ b/cli/src/lib/summarizer/summarize.ts
@@ -1,0 +1,150 @@
+/**
+ * The one model call behind the session summarizer (PHNX-3939).
+ *
+ * A pure boundary: given the session's first user turn (the goal source) and its
+ * live progress (todos / plan / phase off the state engine), it asks a local
+ * Anthropic-wire endpoint (Ollama / vLLM / LiteLLM — the same configurable base
+ * URL `computer/model.ts` speaks) for a strict JSON `{goal, checkpoints, checklist}`
+ * and validates the shape. On ANY failure — network, non-2xx, non-JSON, wrong
+ * shape — it returns `undefined`, and the caller records `summaryState: 'skipped'`.
+ *
+ * NEVER called on the request path: only the background SessionSummarizerService
+ * invokes it, debounced and reader-gated.
+ */
+
+import type { TodoProgress } from '../session/types.js';
+import { ANTHROPIC_VERSION, resolveApiKey } from '../computer/model.js';
+
+/** Live progress fed to the model alongside the goal-bearing prompt. */
+export interface SummarizeProgress {
+  /** Latest checklist write (TodoWrite / update_plan), when the session has one. */
+  todos?: TodoProgress;
+  /** Plan markdown from the last ExitPlanMode, when present. */
+  plan?: string;
+  /** Coarse lifecycle phase (running / waiting / idle / …), when known. */
+  phase?: string;
+}
+
+/** The validated model output. `at` timestamps are stamped by the caller. */
+export interface SummarizeResult {
+  goal: string;
+  /** Progress checkpoints, newest last (short lines). */
+  checkpoints: string[];
+  /** Detailed checklist. */
+  checklist: { text: string; done: boolean }[];
+}
+
+export interface SummarizeOptions {
+  baseUrl: string;
+  model: string;
+  maxTokens?: number;
+  apiKey?: string;
+  /** Injectable for tests; defaults to the global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Abort the request when the daemon tick's deadline elapses. */
+  signal?: AbortSignal;
+}
+
+const SYSTEM_PROMPT = [
+  'You summarize a coding-agent session for an operator dashboard.',
+  'Reply with ONLY a single JSON object, no prose and no code fences, of exactly this shape:',
+  '{"goal": string, "checkpoints": string[], "checklist": [{"text": string, "done": boolean}]}',
+  '- goal: 1-2 lines capturing what the user actually asked for, in plain language.',
+  '- checkpoints: short lines of concrete progress so far, newest last; [] if none yet.',
+  '- checklist: the detailed steps to finish the goal, each with a done flag; [] if unknown.',
+  'Do not invent progress that is not evidenced by the provided context.',
+].join('\n');
+
+/** Compose the user message from the goal-bearing prompt and the live progress. */
+export function buildSummarizeUserMessage(prompt: string, progress: SummarizeProgress): string {
+  const parts: string[] = [`USER REQUEST:\n${prompt.trim()}`];
+  if (progress.phase) parts.push(`PHASE: ${progress.phase}`);
+  if (progress.todos && progress.todos.items.length > 0) {
+    const lines = progress.todos.items.map((t) => `- [${t.status === 'completed' ? 'x' : ' '}] ${t.content}`);
+    parts.push(`CURRENT CHECKLIST (${progress.todos.done}/${progress.todos.total} done):\n${lines.join('\n')}`);
+  }
+  if (progress.plan) parts.push(`PLAN:\n${progress.plan.trim().slice(0, 4000)}`);
+  return parts.join('\n\n');
+}
+
+/**
+ * Coerce an untrusted parsed object into a {@link SummarizeResult}, or undefined
+ * when the shape is wrong. Extra/missing optional arrays degrade to `[]` rather
+ * than failing, but a non-string goal is a hard reject — a summary with no goal
+ * is not a summary.
+ */
+export function validateSummarizeResult(parsed: unknown): SummarizeResult | undefined {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.goal !== 'string' || obj.goal.trim().length === 0) return undefined;
+  const checkpoints = Array.isArray(obj.checkpoints)
+    ? obj.checkpoints.filter((c): c is string => typeof c === 'string' && c.trim().length > 0).map((c) => c.trim())
+    : [];
+  const checklist = Array.isArray(obj.checklist)
+    ? obj.checklist
+        .filter((c): c is { text: unknown; done: unknown } => Boolean(c) && typeof c === 'object' && !Array.isArray(c))
+        .map((c) => ({ text: typeof (c as any).text === 'string' ? (c as any).text.trim() : '', done: Boolean((c as any).done) }))
+        .filter((c) => c.text.length > 0)
+    : [];
+  return { goal: obj.goal.trim(), checkpoints, checklist };
+}
+
+/** Extract the assistant text from an Anthropic Messages response body. */
+function textFromBody(body: unknown): string {
+  const content = (body as { content?: unknown }).content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((b): b is { type?: string; text?: string } => Boolean(b) && typeof b === 'object')
+    .filter((b) => b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text as string)
+    .join('');
+}
+
+/** Strip ``` fences and pull the first {...} block so a chatty model still parses. */
+export function extractJsonObject(text: string): string | undefined {
+  const unfenced = text.replace(/```(?:json)?/gi, '').trim();
+  const start = unfenced.indexOf('{');
+  const end = unfenced.lastIndexOf('}');
+  if (start === -1 || end === -1 || end < start) return undefined;
+  return unfenced.slice(start, end + 1);
+}
+
+/**
+ * Run one summarization. Returns the validated result, or `undefined` on any
+ * failure (the caller then marks the session `summaryState: 'skipped'`).
+ */
+export async function summarize(
+  prompt: string,
+  progress: SummarizeProgress,
+  opts: SummarizeOptions,
+): Promise<SummarizeResult | undefined> {
+  if (!prompt.trim()) return undefined;
+  const baseUrl = opts.baseUrl.replace(/\/+$/, '');
+  const doFetch = opts.fetchImpl ?? fetch;
+  const apiKey = opts.apiKey ?? resolveApiKey({});
+  try {
+    const res = await doFetch(`${baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+      },
+      body: JSON.stringify({
+        model: opts.model,
+        max_tokens: opts.maxTokens ?? 512,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: buildSummarizeUserMessage(prompt, progress) }],
+      }),
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    });
+    if (!res.ok) return undefined;
+    const body = await res.json();
+    const text = textFromBody(body);
+    const json = extractJsonObject(text);
+    if (!json) return undefined;
+    return validateSummarizeResult(JSON.parse(json));
+  } catch {
+    return undefined;
+  }
+}

--- a/cli/src/lib/summarizer/summarize.ts
+++ b/cli/src/lib/summarizer/summarize.ts
@@ -13,7 +13,7 @@
  */
 
 import type { TodoProgress } from '../session/types.js';
-import { ANTHROPIC_VERSION, resolveApiKey } from '../computer/model.js';
+import { ANTHROPIC_VERSION } from '../computer/model.js';
 
 /** Live progress fed to the model alongside the goal-bearing prompt. */
 export interface SummarizeProgress {
@@ -38,6 +38,14 @@ export interface SummarizeOptions {
   baseUrl: string;
   model: string;
   maxTokens?: number;
+  /**
+   * API key for the endpoint. Deliberately NOT resolved from `ANTHROPIC_API_KEY`:
+   * the summarizer targets an operator-configured local/remote endpoint
+   * (Ollama/vLLM/LiteLLM) that typically ignores the key, so forwarding the real
+   * Anthropic credential there would leak it. Only an explicit
+   * `AGENTS_SUMMARIZER_API_KEY` (or this option) is ever sent; otherwise the
+   * header is empty.
+   */
   apiKey?: string;
   /** Injectable for tests; defaults to the global fetch. */
   fetchImpl?: typeof fetch;
@@ -121,7 +129,9 @@ export async function summarize(
   if (!prompt.trim()) return undefined;
   const baseUrl = opts.baseUrl.replace(/\/+$/, '');
   const doFetch = opts.fetchImpl ?? fetch;
-  const apiKey = opts.apiKey ?? resolveApiKey({});
+  // Only an explicit summarizer key is ever forwarded — never the ambient
+  // ANTHROPIC_API_KEY, which would leak to the operator's local endpoint.
+  const apiKey = opts.apiKey ?? process.env.AGENTS_SUMMARIZER_API_KEY ?? '';
   try {
     const res = await doFetch(`${baseUrl}/v1/messages`, {
       method: 'POST',


### PR DESCRIPTION
## What & why

Each running session now can carry a **daemon-computed** `goal` (1–2 lines), progress `checkpoints`, and a detailed `summaryChecklist`, delivered on the session stream so the AGI extension sidebar can render them. Hard requirement honored: **zero request-path cost, cache aggressively, off by default.**

## Field contract (matches agi-ext)

Added to `ActiveSession` and `SessionMeta`:

```ts
goal?: string
checkpoints?: { text: string; at: string }[]     // newest last, ISO `at`
summaryChecklist?: { text: string; done: boolean }[]
summaryState?: 'pending' | 'ready' | 'skipped'    // 'skipped' when disabled/unconfigured
```

## How it works

- **Never on the request path.** The model call runs only in the new
  `session-summarizer` daemon service (`cli/src/lib/daemon/session-summarizer-service.ts`
  → `cli/src/lib/summarizer/pass.ts`), reader-gated and bounded per tick. `agents sessions`/`preview` are untouched.
- **Cache so it never recomputes.** New stamp-validated `session_summaries` SQLite table
  (`cli/src/lib/session/db.ts`), keyed on `(session_id, file_mtime_ms, file_size)` exactly
  like `session_preview_cache`; `readSessionSummary`/`writeSessionSummary`/`readSessionSummaryAny`
  mirror the preview-cache helpers. Independent of `SCHEMA_VERSION`.
- **Read-only merge.** Live rows merge via `applyImmutableMemo` (`session-cache.ts`); history rows
  project in `toPreviousSessionWatchRow` (`remote/watch.ts`); the fleet session mirror
  (`mirror.ts` + `fleet-shared-state.ts`) carries the summary so peers' sessions show it too.
  The `pending`/`skipped` default for a row with no summary is applied only at the watch-stream
  boundary, so non-stream `ActiveSession` consumers are unaffected.
- **`summarize()`** (`cli/src/lib/summarizer/summarize.ts`) is a pure Anthropic-wire boundary over
  the existing configurable base URL (Ollama/vLLM/LiteLLM). Prompt input is the cleaned first user
  turn (never the tool firehose); progress input is the state engine's todos/plan/phase. Strict JSON,
  validated; any error → `undefined` → `summaryState: 'skipped'`. Goal is computed once and kept
  stable across progress deltas.
- **Off by default.** `summarizer.enabled` (default false) / `summarizer.baseUrl` / `summarizer.model`
  via `agents config`, with `AGENTS_SUMMARIZER_ENABLED` / `AGENTS_SUMMARIZER_BASEURL` /
  `AGENTS_SUMMARIZER_MODEL` env overrides. Disabled ⇒ zero model calls, rows read `skipped`.

## Verification (from the spec)

```bash
ollama pull qwen2.5:3b
AGENTS_SUMMARIZER_ENABLED=1 AGENTS_SUMMARIZER_BASEURL=http://localhost:11434 \
  agents feed watch --json | jq '.upserts[]? | {label, goal, summaryState, checkpoints, summaryChecklist}'
# goal 1–2 lines; summaryChecklist non-empty; summaryState "ready"

agents feed watch --json | jq '.upserts[]? | .summaryState'   # disabled -> "skipped"

agents sessions <id>   # timing unchanged (merge is one indexed by-id read, no model call)
```

### Config surface smoke (this branch)

```
$ agents config set summarizer.enabled on   → Set: summarizer.enabled = true
$ agents config set summarizer.baseUrl http://localhost:11434
$ agents config set summarizer.model qwen2.5:3b
$ agents config get summarizer.enabled       → summarizer.enabled = true
$ agents config set summarizer.enabled maybe → error: expects a boolean ('on' or 'off')
$ agents config unset summarizer.enabled     → summarizer.enabled = (unset)
```

### Tests (stub only the model HTTP endpoint)

```
src/lib/summarizer/summarize.test.ts   — strict-JSON parse/validate + stubbed endpoint
src/lib/summarizer/config.test.ts      — env override precedence + runnable predicate
src/lib/summarizer/pass.test.ts        — compute/reuse-on-unchanged-bytes/goal-once/skip-on-failure/budget
src/lib/session/db.summaries.test.ts   — mtime/size stamp reuse + by-id read
src/lib/session/mirror.test.ts         — summary rides publish → consume (new case)

Full run: src/lib/session/ + src/lib/summarizer/ → 1795 passed | 7 skipped
```

## Notes

- Pre-existing, unrelated: `src/commands/config.test.ts > sets, gets, and unsets the projects root`
  fails on this branch and reproduces via the CLI with no summarizer code in the path (`project.root`
  unset does not clear the value). Not touched by this change.