### PR TITLE
test(release-lease): share a current timestamp, not a past literal, for the byte-identical claims

### DIFF
--- a/cli/scripts/release-lease.test.ts
+++ b/cli/scripts/release-lease.test.ts
@@ -187,7 +187,15 @@ describeWin('release-lease: mutual exclusion across machines', () => {
     git(boxA, 'config', 'user.name', 'shared');
     git(boxB, 'config', 'user.email', 'shared@test.local');
     git(boxB, 'config', 'user.name', 'shared');
-    const fixed = '2026-09-04T12:00:00Z';
+    // The shared timestamp must be NOW, not a literal: the script measures lease
+    // age from the committer timestamp (`lease_age_min` → `git log --format=%ct`),
+    // so a fixed past date makes the loser see a "stale" lease older than the
+    // TTL and reclaim it — two winners, and the test fails from the moment the
+    // literal is more than TTL minutes in the past (it did: merged 2026-09-04
+    // 03:00Z with '2026-09-04T12:00:00Z', red from 12:30Z on, and the failing
+    // attestation wedged every release since). One value computed once keeps
+    // both commits byte-identical except for claim-id, which is the point.
+    const fixed = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
     const env = { GIT_AUTHOR_DATE: fixed, GIT_COMMITTER_DATE: fixed };
     const [a, b] = await Promise.all([
       leaseAsync(boxA, ['claim', '1.20.82'], env),


### PR DESCRIPTION
## Problem

`cli/scripts/release-lease.test.ts` › "guards absent-ref creation and reclaims stale leases with one CAS push" has failed deterministically since 2026-09-04 12:30Z, locally and in the `Attest main` lane. Because the attestation producer refuses a red tree, **no commit on main has been attested since**, and every release (including 1.22.75 today) was cut from the last attested commit `a3087bab0`, now 31 commits behind.

Cause: the test pins both claimants to a literal `GIT_COMMITTER_DATE = '2026-09-04T12:00:00Z'` so the two lease commits are byte-identical except for `claim-id`. `release-lease.sh` measures lease age from the committer timestamp (`lease_age_min` → `git log -1 --format=%ct`). Once the literal was more than the 30-minute TTL in the past, the losing claimant saw a "stale" lease and reclaimed it, so both claims exit 0:

```
a rc=0  release lease acquired for 1.20.82
b rc=0  reclaiming a stale release lease (1412min old, TTL 30min)
        release lease reclaimed for 1.20.82
AssertionError: expected [...] to have a length of 1 but got 2   (release-lease.test.ts:196)
```

The mutex itself is fine: b's expected-absent push was rejected; the reclaim path fired only because the test-supplied timestamp aged past the TTL. Production never sets these env vars.

## Fix

Compute the shared timestamp once at test time (`new Date().toISOString()` to the second). Both commits remain byte-identical apart from `claim-id`, which is the property under test.

```
bun run vitest run scripts/release-lease.test.ts   ×3
      Tests  30 passed (30)
```

Test-only change. Once merged, the `Attest main` lane should go green again and releases resume from the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrawhbEgkZyL2knyfi6epU
