### PR TITLE
perf(feed): make `agents feed watch` cheap enough to leave running (PHNX-3939)

### DIFF
--- a/cli/.changelog/next/PHNX-3939-feed-watch-cost.md
+++ b/cli/.changelog/next/PHNX-3939-feed-watch-cost.md
@@ -1,13 +1,15 @@
 - **`agents feed watch` is cheap enough to leave running (PHNX-3939).** The watcher
-  cost ~44% of a core steadily on a box with 1,431 activity logs / 64 MB, because
+  cost ~42% of a core steadily on a box with 1,437 activity logs / 64 MB, because
   every 500 ms tick re-read and re-parsed the whole activity corpus and re-read
   every row's block, resolution, and PR status. It now keeps a per-file cursor and
   reads only the bytes appended since the last tick (`ActivityStream`), and
   reconciles attention only when something announced a change — a block or
   resolution written under the feed dir, watched directly — or when the 45 s
-  PR-status TTL has expired. Measured on the same box: **44.7% → 1.5% CPU**
-  (5-minute steady state), RSS 391 MB → 76 MB, with an identical envelope stream.
-  Source: `cli/src/lib/feed/activity-stream.ts`, `cli/src/lib/feed/watch.ts`.
+  PR-status TTL has expired. Measured on the same box over 5 minutes, steady
+  state: `--local` **41.9% → 0.31% CPU** (RSS 313 MB → 140 MB) and the full
+  13-peer fleet fan-out **50.0% → 0.37% CPU** (RSS 606 MB → 143 MB), with an
+  identical envelope stream. Source: `cli/src/lib/feed/activity-stream.ts`,
+  `cli/src/lib/feed/watch.ts`.
 
 - **A fleet peer that cannot be reached no longer gets a fresh `ssh` every few
   seconds (PHNX-3939).** `agents feed watch` and `agents sessions watch` respawned

--- a/cli/.changelog/next/PHNX-3939-feed-watch-cost.md
+++ b/cli/.changelog/next/PHNX-3939-feed-watch-cost.md
@@ -1,0 +1,21 @@
+- **`agents feed watch` is cheap enough to leave running (PHNX-3939).** The watcher
+  cost ~44% of a core steadily on a box with 1,431 activity logs / 64 MB, because
+  every 500 ms tick re-read and re-parsed the whole activity corpus and re-read
+  every row's block, resolution, and PR status. It now keeps a per-file cursor and
+  reads only the bytes appended since the last tick (`ActivityStream`), and
+  reconciles attention only when something announced a change — a block or
+  resolution written under the feed dir, watched directly — or when the 45 s
+  PR-status TTL has expired. Measured on the same box: **44.7% → 1.5% CPU**
+  (5-minute steady state), RSS 391 MB → 76 MB, with an identical envelope stream.
+  Source: `cli/src/lib/feed/activity-stream.ts`, `cli/src/lib/feed/watch.ts`.
+
+- **A fleet peer that cannot be reached no longer gets a fresh `ssh` every few
+  seconds (PHNX-3939).** `agents feed watch` and `agents sessions watch` respawned
+  each peer's `--local` subscription on a bare 2 s timer with the child's stderr
+  discarded, so an offline box burned a ConnectTimeout-plus-2s cycle for the whole
+  life of the watcher and reported only `ssh exited 255`. Both fan-outs now share
+  one implementation with per-peer exponential backoff (2 s doubling to a 60 s
+  cap, reset on a healthy protocol event), the peer's own stderr surfaced as the
+  `unavailable` reason, and a peer parked after three consecutive failed spawns
+  until the device registry changes or the capped delay elapses. Source:
+  `cli/src/lib/session/remote/peer-stream.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -118,8 +118,8 @@ breaks either is a regression, not a detail:
   no files at all — every log is registered past its own bytes, so history is
   never replayed. Do **not** put `readRecentActivity` back on the tick: it tails
   and parses every session log in the directory, which on a real operator box is
-  1,431 files / 64 MB every 500 ms (measured 44% of a core; the cursor reader is
-  1.5%). `readRecentActivity` remains right for a one-shot `agents feed` render.
+  1,437 files / 64 MB every 500 ms (measured 41.9% of a core over a 5-minute
+  steady state; the cursor reader is 0.31%). `readRecentActivity` remains right for a one-shot `agents feed` render.
 - **Attention is reconciled on change, not on the tick.** A reconcile pass reads
   each row's block and resolution and its PR status, so running it twice a second
   was two file reads per row per tick for a value that almost never moved. It runs

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -104,6 +104,41 @@ composes the existing session watcher with feed attention and activity, while
 Answers go through `agents feed answer <attention-key>` so the CLI atomically
 claims the first reply and routes it over the recorded session reply rail.
 
+**It is designed to run for as long as a VS Code window is open, so every tick is
+budgeted (PHNX-3939).** AGI EXT's elected leader spawns exactly ONE `feed watch
+--json` child and fans it out to every window, so a per-tick cost here is paid for
+the whole session, not per render. Two rules keep it flat, and a change that
+breaks either is a regression, not a detail:
+
+- **Activity is read incrementally, never re-scanned.**
+  [`ActivityStream`](src/lib/feed/activity-stream.ts) holds a per-file cursor
+  (inode, offset, mtime, a trailing partial line, and the bytes behind the cursor)
+  and reads only what was appended since the last tick, driven by an `fs.watch` on
+  the activity dir with a 5 s stat sweep as the fallback. The opening scan opens
+  no files at all — every log is registered past its own bytes, so history is
+  never replayed. Do **not** put `readRecentActivity` back on the tick: it tails
+  and parses every session log in the directory, which on a real operator box is
+  1,431 files / 64 MB every 500 ms (measured 44% of a core; the cursor reader is
+  1.5%). `readRecentActivity` remains right for a one-shot `agents feed` render.
+- **Attention is reconciled on change, not on the tick.** A reconcile pass reads
+  each row's block and resolution and its PR status, so running it twice a second
+  was two file reads per row per tick for a value that almost never moved. It runs
+  when something announced a change — the feed dir and `feed/resolutions` are
+  watched directly, which is how an external `agents feed post --blocked` still
+  raises promptly — or when `PR_STATUS_TTL_MS` (45 s) has expired and the cached
+  PR verdicts are stale. Nothing else in `reconcileAttention` is time-dependent.
+
+The fleet fan-out has its own budget: both `watchFleetFeed` and
+`watchFleetSessions` subscribe to peers through
+[`streamFromPeer`](src/lib/session/remote/peer-stream.ts), which backs off per peer
+(2 s doubling to a 60 s cap, reset on a healthy protocol event), captures the
+child's stderr into the `unavailable` reason instead of discarding it, and parks a
+peer after three consecutive failed spawns until the device registry changes.
+`isDialableDevice` deliberately never excludes an unreachable box
+([`devices/registry.ts`](src/lib/devices/registry.ts)), so backoff — not the
+dialable set — is what keeps an offline peer from minting an ssh child every few
+seconds. Add a third fan-out and it uses this helper; do not re-roll the loop.
+
 ### Per-session summarizer (PHNX-3939)
 
 Each session can carry a daemon-computed **`goal`** (1–2 lines), progress

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -112,7 +112,9 @@ breaks either is a regression, not a detail:
 
 - **Activity is read incrementally, never re-scanned.**
   [`ActivityStream`](src/lib/feed/activity-stream.ts) holds a per-file cursor
-  (inode, offset, mtime, a trailing partial line, and the bytes behind the cursor)
+  (inode, offset, mtime, ctime, a trailing partial line, and the bytes behind the
+  cursor — ctime is what catches a same-length in-place rewrite, exactly as
+  `activityStamp` keys the one-shot reader's cache)
   and reads only what was appended since the last tick, driven by an `fs.watch` on
   the activity dir with a 5 s stat sweep as the fallback. The opening scan opens
   no files at all — every log is registered past its own bytes, so history is

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -808,7 +808,11 @@ SSH access (§7); rendering sessions that no harness produced.
   or with the number of rows on the stream. Activity MUST be read from a
   per-file cursor that reads only appended bytes, with a directory watcher and
   a bounded fallback sweep; the opening scan MUST NOT replay history onto the
-  stream. Attention MUST be reconciled on an announced change (a block or
+  stream. A log that was replaced, truncated, or rewritten in place — including
+  a rewrite that lands on its previous byte length — MUST be detected and
+  re-read rather than retired at a cursor past unread content, and a log the
+  stream is already tracking MUST NOT be re-registered as new work while it
+  still exists (that would replay its tail as duplicate events). Attention MUST be reconciled on an announced change (a block or
   resolution write under the feed dir) or on the PR-status TTL, NOT on the
   activity tick. Emitted `activity.append` events MUST match what
   `readRecentActivity` would emit for the same appended lines, in the same

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -815,9 +815,9 @@ SSH access (§7); rendering sessions that no harness produced.
   order (`lib/feed/activity-stream.ts`, `lib/feed/watch.ts`;
   `lib/feed/activity-stream.test.ts`, `lib/feed/watch.reconcile.test.ts`).
 
-  *Given* an activity dir of 1,431 logs / 64 MB and an idle fleet, *when*
+  *Given* an activity dir of 1,437 logs / 64 MB and an idle fleet, *when*
   `agents feed watch --json --local` runs for five minutes, *then* it reads only
-  the bytes appended in that window and holds under 2% of one core.
+  the bytes appended in that window and holds under 1% of one core.
 - **SES-40e (MUST).** A fleet fan-out (`watchFleetFeed`, `watchFleetSessions`)
   MUST NOT respawn a peer's subscription on a fixed short timer. Each peer MUST
   back off exponentially from 2 s to a 60 s cap, reset on a healthy protocol

--- a/cli/docs/specifications.md
+++ b/cli/docs/specifications.md
@@ -803,6 +803,29 @@ SSH access (§7); rendering sessions that no harness produced.
   projections MUST be sourced by the CLI on a bounded TTL and include
   `number,title,state,isDraft,reviewDecision,mergeable,statusCheckRollup`
   (`lib/feed/pr-status.ts`).
+- **SES-40d (MUST).** The stream is long-lived — one child per VS Code leader —
+  so its steady-state cost MUST NOT scale with the size of the activity corpus
+  or with the number of rows on the stream. Activity MUST be read from a
+  per-file cursor that reads only appended bytes, with a directory watcher and
+  a bounded fallback sweep; the opening scan MUST NOT replay history onto the
+  stream. Attention MUST be reconciled on an announced change (a block or
+  resolution write under the feed dir) or on the PR-status TTL, NOT on the
+  activity tick. Emitted `activity.append` events MUST match what
+  `readRecentActivity` would emit for the same appended lines, in the same
+  order (`lib/feed/activity-stream.ts`, `lib/feed/watch.ts`;
+  `lib/feed/activity-stream.test.ts`, `lib/feed/watch.reconcile.test.ts`).
+
+  *Given* an activity dir of 1,431 logs / 64 MB and an idle fleet, *when*
+  `agents feed watch --json --local` runs for five minutes, *then* it reads only
+  the bytes appended in that window and holds under 2% of one core.
+- **SES-40e (MUST).** A fleet fan-out (`watchFleetFeed`, `watchFleetSessions`)
+  MUST NOT respawn a peer's subscription on a fixed short timer. Each peer MUST
+  back off exponentially from 2 s to a 60 s cap, reset on a healthy protocol
+  event; the child's stderr MUST be captured (bounded) and surfaced as the
+  `scope: unavailable` reason; a peer failing three consecutive spawns MUST be
+  parked until the device registry changes or the capped delay elapses. Abort
+  listeners MUST NOT accumulate across reconnects
+  (`lib/session/remote/peer-stream.ts`; `lib/session/remote/peer-stream.test.ts`).
 
 - **SES-41 (MUST).** `agents sessions watch --json` MUST emit newline-delimited,
   versioned envelopes carrying `streamId`, a strictly increasing `sequence`, and

--- a/cli/src/lib/feed/activity-stream.test.ts
+++ b/cli/src/lib/feed/activity-stream.test.ts
@@ -118,6 +118,56 @@ describe('incremental activity stream over real files', () => {
     stream.close();
   });
 
+  it('reads a same-length in-place rewrite that leaves size and mtime untouched', () => {
+    const dir = root();
+    const file = path.join(dir, 's.jsonl');
+    // Two records of identical byte length, so the rewrite moves neither the
+    // size nor the 64-byte anchor behind the cursor, and both states are pinned
+    // to the SAME mtime. ctime is then the only remaining signal; without it
+    // this reader retires the file for good and never emits the rewrite.
+    const before = line('s', 'aaaaaaaa', '2026-09-06T00:00:01.000Z');
+    const after = line('s', 'bbbbbbbb', '2026-09-06T00:00:02.000Z');
+    expect(Buffer.byteLength(after)).toBe(Buffer.byteLength(before));
+    const pinned = new Date('2026-09-06T12:00:00.000Z');
+
+    fs.writeFileSync(file, '');
+    const stream = new ActivityStream({ root: dir, watch: false });
+    const sinceMs = Date.parse('2026-09-06T00:00:00.000Z');
+    fs.appendFileSync(file, before);
+    fs.utimesSync(file, pinned, pinned);
+    expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['aaaaaaaa']);
+    const was = fs.statSync(file, { bigint: true });
+
+    fs.writeFileSync(file, after);
+    fs.utimesSync(file, pinned, pinned);
+    const now = fs.statSync(file, { bigint: true });
+    expect(now.size).toBe(was.size);
+    expect(now.mtimeNs).toBe(was.mtimeNs);
+    expect(now.ctimeNs).not.toBe(was.ctimeNs);
+
+    expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['bbbbbbbb']);
+    stream.close();
+  });
+
+  it('never replays a log it is already tracking, however many logs there are', () => {
+    const dir = root();
+    const sinceMs = Date.parse('2026-09-06T00:00:00.000Z');
+    const files = Array.from({ length: 40 }, (_, i) => path.join(dir, `s${i}.jsonl`));
+    for (const [i, file] of files.entries()) fs.writeFileSync(file, line(`s${i}`, `seed-${i}`, '2026-09-05T00:00:00.000Z'));
+    const stream = new ActivityStream({ root: dir, watch: false });
+
+    // One log is written to, the rest stay put. Cursors are kept for every log
+    // in the directory — no size cap — so a quiet log is never re-registered as
+    // new work and never replays its tail as a duplicate.
+    fs.appendFileSync(files[0], line('s0', 'appended', '2026-09-06T00:00:00.000Z'));
+    expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['appended']);
+    for (let tick = 1; tick <= 5; tick += 1) {
+      expect(stream.read(sinceMs, Date.now() + tick * 10_000)).toEqual([]);
+    }
+    expect(stream.bytesRead).toBe(Buffer.byteLength(line('s0', 'appended', '2026-09-06T00:00:00.000Z')));
+    stream.close();
+  });
+
   it('keeps only the newest bytes when one tick appends more than the read budget', () => {
     const dir = root();
     const file = path.join(dir, 's.jsonl');

--- a/cli/src/lib/feed/activity-stream.test.ts
+++ b/cli/src/lib/feed/activity-stream.test.ts
@@ -17,6 +17,28 @@ function line(sessionId: string, detail: string, ts: string, event = 'status.pos
   return `${JSON.stringify({ v: 1, sessionId, event, ts, detail, host: 'box', runtime: 'headless' })}\n`;
 }
 
+/**
+ * Wait until the filesystem's timestamp clock has advanced.
+ *
+ * Linux stamps ctime from a coarse clock, so two writes inside the same tick
+ * share a ctime and the same-length-rewrite guard has nothing to see. That is a
+ * property of the filesystem, not of the reader, so the test waits it out
+ * instead of asserting through it.
+ */
+async function tickFsClock(dir: string): Promise<void> {
+  const probe = path.join(dir, '.tick'); // not *.jsonl, so the stream ignores it
+  fs.writeFileSync(probe, 'a');
+  const start = fs.statSync(probe, { bigint: true }).ctimeNs;
+  const deadline = Date.now() + 5_000;
+  for (let i = 0; ; i += 1) {
+    fs.writeFileSync(probe, `b${i}`);
+    if (fs.statSync(probe, { bigint: true }).ctimeNs !== start) break;
+    if (Date.now() > deadline) throw new Error('filesystem ctime never advanced');
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+  fs.unlinkSync(probe);
+}
+
 /** Wait for a real fs.watch notification to land, bounded so a miss fails loud. */
 async function settle(ms = 120): Promise<void> { await new Promise((resolve) => setTimeout(resolve, ms)); }
 
@@ -118,7 +140,7 @@ describe('incremental activity stream over real files', () => {
     stream.close();
   });
 
-  it('reads a same-length in-place rewrite that leaves size and mtime untouched', () => {
+  it('reads a same-length in-place rewrite that leaves size and mtime untouched', async () => {
     const dir = root();
     const file = path.join(dir, 's.jsonl');
     // Two records of identical byte length, so the rewrite moves neither the
@@ -138,6 +160,7 @@ describe('incremental activity stream over real files', () => {
     expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['aaaaaaaa']);
     const was = fs.statSync(file, { bigint: true });
 
+    await tickFsClock(dir);
     fs.writeFileSync(file, after);
     fs.utimesSync(file, pinned, pinned);
     const now = fs.statSync(file, { bigint: true });

--- a/cli/src/lib/feed/activity-stream.test.ts
+++ b/cli/src/lib/feed/activity-stream.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { readRecentActivity } from './activity.js';
+import { ActivityStream } from './activity-stream.js';
+
+const roots: string[] = [];
+function root() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'activity-stream-'));
+  roots.push(dir);
+  return dir;
+}
+afterEach(() => { for (const dir of roots.splice(0)) fs.rmSync(dir, { recursive: true, force: true }); });
+
+function line(sessionId: string, detail: string, ts: string, event = 'status.posted'): string {
+  return `${JSON.stringify({ v: 1, sessionId, event, ts, detail, host: 'box', runtime: 'headless' })}\n`;
+}
+
+/** Wait for a real fs.watch notification to land, bounded so a miss fails loud. */
+async function settle(ms = 120): Promise<void> { await new Promise((resolve) => setTimeout(resolve, ms)); }
+
+describe('incremental activity stream over real files', () => {
+  it('emits exactly what readRecentActivity emits for the same appended lines', () => {
+    const dir = root();
+    // History the stream must never replay: it predates the cursor.
+    fs.writeFileSync(path.join(dir, 'a.jsonl'), line('a', 'old-a', '2026-09-05T00:00:00.000Z'));
+    fs.writeFileSync(path.join(dir, 'b.jsonl'), line('b', 'old-b', '2026-09-05T00:00:01.000Z'));
+    const sinceMs = Date.parse('2026-09-06T00:00:00.000Z');
+    const stream = new ActivityStream({ root: dir, watch: false });
+
+    // Appended out of timestamp order and across files, so ordering is a real assertion.
+    fs.appendFileSync(path.join(dir, 'a.jsonl'), line('a', 'a-2', '2026-09-06T00:00:02.000Z'));
+    fs.appendFileSync(path.join(dir, 'b.jsonl'), line('b', 'b-1', '2026-09-06T00:00:01.000Z'));
+    fs.appendFileSync(path.join(dir, 'a.jsonl'), line('a', 'a-3', '2026-09-06T00:00:03.000Z'));
+    fs.writeFileSync(path.join(dir, 'c.jsonl'), line('c', 'c-1', '2026-09-06T00:00:00.000Z'));
+
+    const streamed = stream.read(sinceMs);
+    const oneShot = readRecentActivity({ root: dir, sinceMs });
+    expect(streamed).toEqual(oneShot);
+    expect(streamed.map((event) => event.detail)).toEqual(['a-3', 'a-2', 'b-1', 'c-1']);
+    stream.close();
+  });
+
+  it('reads only the appended bytes, not the corpus, across a thousand session logs', () => {
+    const dir = root();
+    for (let i = 0; i < 1_000; i++) {
+      fs.writeFileSync(path.join(dir, `s${i}.jsonl`), line(`s${i}`, `seed-${i}`, '2026-09-05T00:00:00.000Z'));
+    }
+    const corpusBytes = fs.readdirSync(dir).reduce((sum, name) => sum + fs.statSync(path.join(dir, name)).size, 0);
+    expect(corpusBytes).toBeGreaterThan(100_000);
+
+    const stream = new ActivityStream({ root: dir, watch: false });
+    // The opening scan stats every log and opens none of them.
+    expect(stream.bytesRead).toBe(0);
+
+    const appended = line('s7', 'live', '2026-09-06T00:00:00.000Z');
+    fs.appendFileSync(path.join(dir, 's7.jsonl'), appended);
+    const events = stream.read(Date.parse('2026-09-06T00:00:00.000Z'));
+    expect(events.map((event) => event.detail)).toEqual(['live']);
+    expect(stream.bytesRead).toBe(Buffer.byteLength(appended));
+
+    // An idle tick over the same thousand logs reads nothing at all.
+    const before = stream.bytesRead;
+    expect(stream.read(Date.parse('2026-09-06T00:00:00.000Z'))).toEqual([]);
+    expect(stream.bytesRead).toBe(before);
+    stream.close();
+  });
+
+  it('holds a half-written line until its newline arrives, and emits it exactly once', () => {
+    const dir = root();
+    const file = path.join(dir, 's.jsonl');
+    fs.writeFileSync(file, '');
+    const stream = new ActivityStream({ root: dir, watch: false });
+    const sinceMs = Date.parse('2026-09-06T00:00:00.000Z');
+    const record = line('s', 'torn', '2026-09-06T00:00:00.000Z');
+
+    fs.appendFileSync(file, record.slice(0, 20));
+    expect(stream.read(sinceMs)).toEqual([]);
+    fs.appendFileSync(file, record.slice(20));
+    expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['torn']);
+    // No duplicate on the next tick.
+    expect(stream.read(sinceMs)).toEqual([]);
+    stream.close();
+  });
+
+  it('recovers from an in-place rewrite, truncation, atomic replacement, deletion, and a log created later', () => {
+    const dir = root();
+    const file = path.join(dir, 's.jsonl');
+    fs.writeFileSync(file, line('s', 'seed', '2026-09-05T00:00:00.000Z'));
+    const stream = new ActivityStream({ root: dir, watch: false });
+    const sinceMs = Date.parse('2026-09-06T00:00:00.000Z');
+    fs.appendFileSync(file, line('s', 'appended', '2026-09-06T00:00:00.000Z'));
+    expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['appended']);
+
+    // Rewritten in place to a LONGER file: growth alone would read the tail as
+    // an append and parse the middle of a record. The bytes behind the cursor
+    // no longer match, so the file restarts instead.
+    fs.writeFileSync(file, line('s', 'rewritten-in-place-and-longer', '2026-09-06T00:00:01.000Z'));
+    expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['rewritten-in-place-and-longer']);
+
+    // Truncated below the cursor: the shorter file is re-read from its start.
+    fs.writeFileSync(file, line('s', 'short', '2026-09-06T00:00:02.000Z'));
+    expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['short']);
+
+    // Atomic replacement (new inode, same path).
+    const staged = path.join(dir, 'staged');
+    fs.writeFileSync(staged, line('s', 'replaced', '2026-09-06T00:00:03.000Z'));
+    fs.renameSync(staged, file);
+    expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['replaced']);
+
+    // A log created after the opening scan is new work, so it IS read.
+    fs.writeFileSync(path.join(dir, 'new.jsonl'), line('new', 'fresh', '2026-09-06T00:00:04.000Z'));
+    expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['fresh']);
+
+    fs.unlinkSync(file);
+    expect(stream.read(sinceMs)).toEqual([]);
+    stream.close();
+  });
+
+  it('keeps only the newest bytes when one tick appends more than the read budget', () => {
+    const dir = root();
+    const file = path.join(dir, 's.jsonl');
+    fs.writeFileSync(file, '');
+    const stream = new ActivityStream({ root: dir, watch: false, maxBytesPerRead: 400 });
+    const sinceMs = Date.parse('2026-09-06T00:00:00.000Z');
+    const burst = Array.from({ length: 20 }, (_, i) => line('s', `burst-${i}`, `2026-09-06T00:00:${String(i).padStart(2, '0')}.000Z`)).join('');
+    expect(Buffer.byteLength(burst)).toBeGreaterThan(400);
+    fs.appendFileSync(file, burst);
+    const details = stream.read(sinceMs).map((event) => event.detail);
+    // Bounded like readRecentActivity's tail: the newest records survive, the
+    // partial leading record is dropped rather than parsed as garbage.
+    expect(details.length).toBeGreaterThan(0);
+    expect(details[0]).toBe('burst-19');
+    expect(stream.bytesRead).toBeLessThanOrEqual(400);
+    stream.close();
+  });
+
+  it('picks up an appended log through the directory watcher without sweeping every tick', async () => {
+    const dir = root();
+    fs.writeFileSync(path.join(dir, 's.jsonl'), line('s', 'seed', '2026-09-05T00:00:00.000Z'));
+    // A sweep cadence far beyond the test window, so a hit here proves the
+    // watcher — not the fallback poll — delivered the change.
+    const stream = new ActivityStream({ root: dir, sweepMs: 3_600_000 });
+    const sinceMs = Date.parse('2026-09-06T00:00:00.000Z');
+    fs.appendFileSync(path.join(dir, 's.jsonl'), line('s', 'watched', '2026-09-06T00:00:00.000Z'));
+    await settle();
+    expect(stream.read(sinceMs).map((event) => event.detail)).toEqual(['watched']);
+    stream.close();
+  });
+});

--- a/cli/src/lib/feed/activity-stream.ts
+++ b/cli/src/lib/feed/activity-stream.ts
@@ -5,7 +5,7 @@
  * every session log in the directory. That is the right shape for a one-shot
  * `agents feed` render and the wrong shape for `agents feed watch`, which asks
  * the same question twice a second for as long as a VS Code window is open: on
- * a real operator box the directory holds 1,431 logs / 64 MB, so every tick
+ * a real operator box the directory holds 1,437 logs / 64 MB, so every tick
  * re-read and re-parsed the whole corpus to emit, almost always, nothing.
  *
  * This reader keeps a per-file cursor instead. The opening scan opens no files

--- a/cli/src/lib/feed/activity-stream.ts
+++ b/cli/src/lib/feed/activity-stream.ts
@@ -1,0 +1,283 @@
+/**
+ * Incremental reader for the activity log directory.
+ *
+ * `readRecentActivity` answers "what happened since T?" by tailing and parsing
+ * every session log in the directory. That is the right shape for a one-shot
+ * `agents feed` render and the wrong shape for `agents feed watch`, which asks
+ * the same question twice a second for as long as a VS Code window is open: on
+ * a real operator box the directory holds 1,431 logs / 64 MB, so every tick
+ * re-read and re-parsed the whole corpus to emit, almost always, nothing.
+ *
+ * This reader keeps a per-file cursor instead. The opening scan opens no files
+ * at all — it records each log's size, inode, and mtime — so only bytes appended
+ * *after* the stream started are ever read. Steady-state cost is one `stat` per
+ * changed file plus a parse of exactly the appended bytes.
+ *
+ * The emitted events, their order, and the `sinceMs` filter match
+ * `readRecentActivity` for everything appended while the stream is open; the
+ * equivalence is pinned by `activity-stream.test.ts`.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getActivityDir } from '../state.js';
+import { ACTIVITY_TAIL_BYTES, parseActivityLine, type ActivityEvent } from './activity.js';
+
+/** How often the stream falls back to a full directory stat sweep. */
+export const ACTIVITY_SWEEP_MS = 5_000;
+/** Upper bound on the per-file cursors held in memory. */
+export const ACTIVITY_MAX_TRACKED_FILES = 8_192;
+/** Bytes behind the cursor re-verified before appended bytes are trusted. */
+export const ACTIVITY_ANCHOR_BYTES = 64;
+
+const NEWLINE = 0x0a;
+const EMPTY = Buffer.alloc(0);
+
+interface FileCursor {
+  /** `dev:ino` of the tracked inode; a change means the path was replaced. */
+  identity: string;
+  /** Bytes of this inode already consumed. */
+  offset: number;
+  /** Trailing bytes after the last newline, waiting for the line to finish. */
+  partial: Buffer;
+  /** True when `partial` starts mid-record and must not be parsed. */
+  partialIsFragment: boolean;
+  /**
+   * The last {@link ACTIVITY_ANCHOR_BYTES} bytes already consumed, once this
+   * reader has actually read from the file. Growth alone cannot tell an append
+   * from an in-place rewrite that happens to be longer, so those bytes are
+   * re-verified — they ride the same read, at no extra syscall — and a mismatch
+   * restarts the file rather than parsing the middle of a record.
+   */
+  anchor: Buffer;
+  /** Last observed size and mtime, so an untouched file is never opened. */
+  size: number;
+  mtimeMs: number;
+}
+
+export interface ActivityStreamOptions {
+  /** Override the activity dir (tests). */
+  root?: string;
+  /**
+   * Newest bytes read from one file in one tick. A burst larger than this keeps
+   * only the tail, exactly as `readRecentActivity`'s bounded tail does.
+   */
+  maxBytesPerRead?: number;
+  /** Full stat sweep cadence, covering anything the directory watcher misses. */
+  sweepMs?: number;
+  /** Cursor budget; the least recently modified logs are dropped past it. */
+  maxTrackedFiles?: number;
+  /** Subscribe to directory change notifications (default true). */
+  watch?: boolean;
+}
+
+/**
+ * A cursor over the activity directory. Construct it at the moment the caller's
+ * activity cursor starts, then call {@link read} once per tick.
+ */
+export class ActivityStream {
+  private readonly dir: string;
+  private readonly maxBytesPerRead: number;
+  private readonly sweepMs: number;
+  private readonly maxTrackedFiles: number;
+  private readonly cursors = new Map<string, FileCursor>();
+  private readonly dirty = new Set<string>();
+  private watcher?: fs.FSWatcher;
+  private watchRequested: boolean;
+  private lastSweepMs = 0;
+  /** False during the opening scan, so it registers history without reading it. */
+  private started = false;
+  /** Bytes read from activity logs since construction. Observability + tests. */
+  bytesRead = 0;
+
+  constructor(options: ActivityStreamOptions = {}) {
+    this.dir = options.root ?? getActivityDir();
+    this.maxBytesPerRead = options.maxBytesPerRead ?? ACTIVITY_TAIL_BYTES;
+    this.sweepMs = options.sweepMs ?? ACTIVITY_SWEEP_MS;
+    this.maxTrackedFiles = options.maxTrackedFiles ?? ACTIVITY_MAX_TRACKED_FILES;
+    this.watchRequested = options.watch ?? true;
+    this.sweep(Date.now());
+    this.armWatcher();
+  }
+
+  /**
+   * Events appended since the last call, newest first, filtered to `sinceMs`
+   * inclusive — the same shape and order `readRecentActivity({ sinceMs })`
+   * returns for those events.
+   */
+  read(sinceMs: number, nowMs = Date.now()): ActivityEvent[] {
+    const out: ActivityEvent[] = [];
+    for (const name of this.candidates(nowMs)) {
+      for (const event of this.readFile(name)) {
+        const at = Date.parse(event.ts);
+        if (Number.isFinite(at) && at >= sinceMs) out.push(event);
+      }
+    }
+    out.sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts));
+    return out;
+  }
+
+  /** Release the directory watcher. Safe to call more than once. */
+  close(): void {
+    this.watchRequested = false;
+    this.watcher?.close();
+    this.watcher = undefined;
+  }
+
+  /** Which log names could have changed since the previous tick. */
+  private candidates(nowMs: number): string[] {
+    // A watcher that never armed (unsupported filesystem, or a directory that
+    // did not exist at construction) means every tick sweeps. That is the
+    // fallback: never a silent no-op that would drop events.
+    if (!this.watcher) this.armWatcher();
+    if (!this.watcher || nowMs - this.lastSweepMs >= this.sweepMs) this.sweep(nowMs);
+    const names = [...this.dirty];
+    this.dirty.clear();
+    return names;
+  }
+
+  /**
+   * Stat every log, marking the ones that could have changed. Opens nothing: a
+   * log the opening scan sees is registered past its own bytes, so history is
+   * never replayed onto the stream.
+   */
+  private sweep(nowMs: number): void {
+    this.lastSweepMs = nowMs;
+    let names: string[];
+    try {
+      names = fs.readdirSync(this.dir).filter((name) => name.endsWith('.jsonl'));
+    } catch {
+      return; // The directory appears with the first logged event.
+    }
+    const seen = new Set<string>();
+    for (const name of names) {
+      seen.add(name);
+      const stat = this.statOf(name);
+      if (!stat) continue;
+      const cursor = this.cursors.get(name);
+      if (!cursor) {
+        // A log first seen after the opening scan is new work: left
+        // unregistered so `readFile` opens it from a bounded tail.
+        if (this.started) this.dirty.add(name);
+        else this.cursors.set(name, {
+          identity: stat.identity, offset: stat.size, partial: EMPTY, partialIsFragment: false,
+          anchor: EMPTY, size: stat.size, mtimeMs: stat.mtimeMs,
+        });
+        continue;
+      }
+      if (stat.identity !== cursor.identity || stat.size !== cursor.size || stat.mtimeMs !== cursor.mtimeMs) this.dirty.add(name);
+    }
+    for (const name of [...this.cursors.keys()]) if (!seen.has(name)) this.cursors.delete(name);
+    this.evict();
+    this.started = true;
+  }
+
+  private statOf(name: string): { identity: string; size: number; mtimeMs: number } | undefined {
+    try {
+      const st = fs.statSync(path.join(this.dir, name), { bigint: true });
+      return { identity: `${st.dev}:${st.ino}`, size: Number(st.size), mtimeMs: Number(st.mtimeNs) };
+    } catch {
+      return undefined; // Deleted between readdir and stat.
+    }
+  }
+
+  /** A cursor starting at a bounded tail of the file as it stands right now. */
+  private freshCursor(stat: { identity: string; size: number; mtimeMs: number }): FileCursor {
+    const offset = Math.max(0, stat.size - this.maxBytesPerRead);
+    return {
+      identity: stat.identity, offset, partial: EMPTY, partialIsFragment: offset > 0,
+      anchor: EMPTY, size: stat.size, mtimeMs: stat.mtimeMs,
+    };
+  }
+
+  /** Read and parse only the bytes appended to one log since its cursor. */
+  private readFile(name: string, restarted = false): ActivityEvent[] {
+    const stat = this.statOf(name);
+    if (!stat) { this.cursors.delete(name); return []; }
+    let cursor = this.cursors.get(name);
+    // Unseen, replaced, or truncated: restart from a bounded tail of the file as
+    // it now stands. The caller's `sinceMs` drops whatever predates the stream.
+    if (!cursor || cursor.identity !== stat.identity || stat.size < cursor.offset) {
+      cursor = this.freshCursor(stat);
+      this.cursors.set(name, cursor);
+    }
+    cursor.size = stat.size;
+    cursor.mtimeMs = stat.mtimeMs;
+    if (stat.size <= cursor.offset) return [];
+    // A burst larger than the budget keeps the newest bytes; the skipped span is
+    // exactly what the bounded-tail reader would have dropped as well.
+    const start = Math.max(cursor.offset, stat.size - this.maxBytesPerRead);
+    if (start > cursor.offset) {
+      cursor.partial = EMPTY;
+      cursor.partialIsFragment = true;
+      cursor.anchor = EMPTY;
+    }
+    const verify = Math.min(cursor.anchor.length, start);
+    const buf = this.readRange(name, start - verify, stat.size - start + verify);
+    if (buf === undefined) return []; // Transient I/O error: retry next tick.
+    if (verify > 0 && !buf.subarray(0, verify).equals(cursor.anchor.subarray(cursor.anchor.length - verify))) {
+      // The bytes behind the cursor changed, so this file was rewritten rather
+      // than appended to. Restart it once from a bounded tail.
+      if (restarted) return [];
+      this.cursors.delete(name);
+      return this.readFile(name, true);
+    }
+    const fresh = buf.subarray(verify);
+    cursor.offset = stat.size;
+    cursor.anchor = Buffer.concat([cursor.anchor, fresh]).subarray(-ACTIVITY_ANCHOR_BYTES);
+    const chunk = Buffer.concat([cursor.partial, fresh]);
+    const fragment = cursor.partialIsFragment;
+    const end = chunk.lastIndexOf(NEWLINE);
+    // Hold an unterminated trailing line: the writer appends whole
+    // newline-terminated records (`appendActivityEvent`), so a tail without a
+    // newline is a write in progress and completes on a later tick.
+    cursor.partial = end < 0 ? chunk : chunk.subarray(end + 1);
+    cursor.partialIsFragment = end < 0 ? fragment : false;
+    if (end < 0) return [];
+    const lines = chunk.subarray(0, end).toString('utf-8').split('\n');
+    // A range that began mid-file starts inside a record; that leading fragment
+    // is not one, exactly as the bounded-tail reader drops it.
+    if (fragment) lines.shift();
+    const events: ActivityEvent[] = [];
+    for (const line of lines) {
+      const event = parseActivityLine(line);
+      if (event) events.push(event);
+    }
+    return events;
+  }
+
+  private readRange(name: string, start: number, length: number): Buffer | undefined {
+    let fd: number | undefined;
+    try {
+      fd = fs.openSync(path.join(this.dir, name), 'r');
+      const buf = Buffer.allocUnsafe(length);
+      const read = fs.readSync(fd, buf, 0, length, start);
+      this.bytesRead += read;
+      return buf.subarray(0, read);
+    } catch {
+      return undefined;
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
+    }
+  }
+
+  private armWatcher(): void {
+    if (!this.watchRequested || this.watcher) return;
+    try {
+      this.watcher = fs.watch(this.dir, (_event, name) => {
+        if (typeof name === 'string' && name.endsWith('.jsonl')) this.dirty.add(name);
+      });
+      // A watch error (the directory is removed) degrades to sweeping rather
+      // than taking down the watcher process.
+      this.watcher.on('error', () => { this.watcher?.close(); this.watcher = undefined; });
+    } catch {
+      this.watcher = undefined;
+    }
+  }
+
+  /** Keep the cursor map bounded; the least recently modified logs go first. */
+  private evict(): void {
+    if (this.cursors.size <= this.maxTrackedFiles) return;
+    const byAge = [...this.cursors.entries()].sort((a, b) => a[1].mtimeMs - b[1].mtimeMs);
+    for (const [name] of byAge.slice(0, this.cursors.size - this.maxTrackedFiles)) this.cursors.delete(name);
+  }
+}

--- a/cli/src/lib/feed/activity-stream.ts
+++ b/cli/src/lib/feed/activity-stream.ts
@@ -24,13 +24,27 @@ import { ACTIVITY_TAIL_BYTES, parseActivityLine, type ActivityEvent } from './ac
 
 /** How often the stream falls back to a full directory stat sweep. */
 export const ACTIVITY_SWEEP_MS = 5_000;
-/** Upper bound on the per-file cursors held in memory. */
-export const ACTIVITY_MAX_TRACKED_FILES = 8_192;
 /** Bytes behind the cursor re-verified before appended bytes are trusted. */
 export const ACTIVITY_ANCHOR_BYTES = 64;
 
 const NEWLINE = 0x0a;
 const EMPTY = Buffer.alloc(0);
+
+/** What one `stat` tells this reader about a log. */
+interface FileStat {
+  identity: string;
+  size: number;
+  mtimeNs: number;
+  ctimeNs: number;
+}
+
+/** Could this file have changed since its cursor last looked? */
+function changed(cursor: FileCursor, stat: FileStat): boolean {
+  return stat.identity !== cursor.identity
+    || stat.size !== cursor.size
+    || stat.mtimeNs !== cursor.mtimeNs
+    || stat.ctimeNs !== cursor.ctimeNs;
+}
 
 interface FileCursor {
   /** `dev:ino` of the tracked inode; a change means the path was replaced. */
@@ -49,9 +63,16 @@ interface FileCursor {
    * restarts the file rather than parsing the middle of a record.
    */
   anchor: Buffer;
-  /** Last observed size and mtime, so an untouched file is never opened. */
+  /**
+   * Last observed size, mtime, and ctime, so an untouched file is never opened.
+   * ctime is load-bearing, not belt-and-braces: a same-size in-place rewrite
+   * that restores mtime is invisible to the other three, and the byte cursor
+   * would then sit past content it never read. The sibling tail reader keys its
+   * cache the same way for the same reason (`activity.ts` `activityStamp`).
+   */
   size: number;
-  mtimeMs: number;
+  mtimeNs: number;
+  ctimeNs: number;
 }
 
 export interface ActivityStreamOptions {
@@ -64,8 +85,6 @@ export interface ActivityStreamOptions {
   maxBytesPerRead?: number;
   /** Full stat sweep cadence, covering anything the directory watcher misses. */
   sweepMs?: number;
-  /** Cursor budget; the least recently modified logs are dropped past it. */
-  maxTrackedFiles?: number;
   /** Subscribe to directory change notifications (default true). */
   watch?: boolean;
 }
@@ -78,7 +97,6 @@ export class ActivityStream {
   private readonly dir: string;
   private readonly maxBytesPerRead: number;
   private readonly sweepMs: number;
-  private readonly maxTrackedFiles: number;
   private readonly cursors = new Map<string, FileCursor>();
   private readonly dirty = new Set<string>();
   private watcher?: fs.FSWatcher;
@@ -93,7 +111,6 @@ export class ActivityStream {
     this.dir = options.root ?? getActivityDir();
     this.maxBytesPerRead = options.maxBytesPerRead ?? ACTIVITY_TAIL_BYTES;
     this.sweepMs = options.sweepMs ?? ACTIVITY_SWEEP_MS;
-    this.maxTrackedFiles = options.maxTrackedFiles ?? ACTIVITY_MAX_TRACKED_FILES;
     this.watchRequested = options.watch ?? true;
     this.sweep(Date.now());
     this.armWatcher();
@@ -160,32 +177,41 @@ export class ActivityStream {
         if (this.started) this.dirty.add(name);
         else this.cursors.set(name, {
           identity: stat.identity, offset: stat.size, partial: EMPTY, partialIsFragment: false,
-          anchor: EMPTY, size: stat.size, mtimeMs: stat.mtimeMs,
+          anchor: EMPTY, size: stat.size, mtimeNs: stat.mtimeNs, ctimeNs: stat.ctimeNs,
         });
         continue;
       }
-      if (stat.identity !== cursor.identity || stat.size !== cursor.size || stat.mtimeMs !== cursor.mtimeMs) this.dirty.add(name);
+      if (changed(cursor, stat)) this.dirty.add(name);
     }
+    // A cursor is dropped only when its log is gone. There is deliberately no
+    // size cap: the map cannot outgrow the directory this sweep already had to
+    // enumerate, so a cap bounds nothing the readdir does not — while dropping
+    // a live log's cursor would re-register it as new work on the next sweep
+    // and replay a bounded tail of it onto the stream as duplicates.
     for (const name of [...this.cursors.keys()]) if (!seen.has(name)) this.cursors.delete(name);
-    this.evict();
     this.started = true;
   }
 
-  private statOf(name: string): { identity: string; size: number; mtimeMs: number } | undefined {
+  private statOf(name: string): FileStat | undefined {
     try {
       const st = fs.statSync(path.join(this.dir, name), { bigint: true });
-      return { identity: `${st.dev}:${st.ino}`, size: Number(st.size), mtimeMs: Number(st.mtimeNs) };
+      return {
+        identity: `${st.dev}:${st.ino}`,
+        size: Number(st.size),
+        mtimeNs: Number(st.mtimeNs),
+        ctimeNs: Number(st.ctimeNs),
+      };
     } catch {
       return undefined; // Deleted between readdir and stat.
     }
   }
 
   /** A cursor starting at a bounded tail of the file as it stands right now. */
-  private freshCursor(stat: { identity: string; size: number; mtimeMs: number }): FileCursor {
+  private freshCursor(stat: FileStat): FileCursor {
     const offset = Math.max(0, stat.size - this.maxBytesPerRead);
     return {
       identity: stat.identity, offset, partial: EMPTY, partialIsFragment: offset > 0,
-      anchor: EMPTY, size: stat.size, mtimeMs: stat.mtimeMs,
+      anchor: EMPTY, size: stat.size, mtimeNs: stat.mtimeNs, ctimeNs: stat.ctimeNs,
     };
   }
 
@@ -194,14 +220,22 @@ export class ActivityStream {
     const stat = this.statOf(name);
     if (!stat) { this.cursors.delete(name); return []; }
     let cursor = this.cursors.get(name);
-    // Unseen, replaced, or truncated: restart from a bounded tail of the file as
-    // it now stands. The caller's `sinceMs` drops whatever predates the stream.
-    if (!cursor || cursor.identity !== stat.identity || stat.size < cursor.offset) {
+    // Unseen, replaced, truncated, or rewritten in place at the same length:
+    // restart from a bounded tail of the file as it now stands. The caller's
+    // `sinceMs` drops whatever predates the stream.
+    //
+    // The same-length case is why ctime is tracked. Growth is caught by the
+    // 64-byte anchor and a shrink by the offset compare, but a rewrite that
+    // lands on exactly the previous size moves neither, and the early return
+    // below would otherwise retire the file for good with content unread.
+    if (!cursor || cursor.identity !== stat.identity || stat.size < cursor.offset
+      || (stat.size === cursor.size && stat.ctimeNs !== cursor.ctimeNs)) {
       cursor = this.freshCursor(stat);
       this.cursors.set(name, cursor);
     }
     cursor.size = stat.size;
-    cursor.mtimeMs = stat.mtimeMs;
+    cursor.mtimeNs = stat.mtimeNs;
+    cursor.ctimeNs = stat.ctimeNs;
     if (stat.size <= cursor.offset) return [];
     // A burst larger than the budget keeps the newest bytes; the skipped span is
     // exactly what the bounded-tail reader would have dropped as well.
@@ -272,12 +306,5 @@ export class ActivityStream {
     } catch {
       this.watcher = undefined;
     }
-  }
-
-  /** Keep the cursor map bounded; the least recently modified logs go first. */
-  private evict(): void {
-    if (this.cursors.size <= this.maxTrackedFiles) return;
-    const byAge = [...this.cursors.entries()].sort((a, b) => a[1].mtimeMs - b[1].mtimeMs);
-    for (const [name] of byAge.slice(0, this.cursors.size - this.maxTrackedFiles)) this.cursors.delete(name);
   }
 }

--- a/cli/src/lib/feed/activity.ts
+++ b/cli/src/lib/feed/activity.ts
@@ -259,7 +259,11 @@ export function appendActivityEvent(
   fs.appendFileSync(activityPath(dir, event.sessionId), `${JSON.stringify(record)}\n`, { mode: 0o644 });
 }
 
-function parseLine(line: string): ActivityEvent | undefined {
+/**
+ * Parse one activity log line. Tolerant by design: a blank, corrupt, or
+ * half-written line is skipped rather than failing the whole read.
+ */
+export function parseActivityLine(line: string): ActivityEvent | undefined {
   const trimmed = line.trim();
   if (!trimmed) return undefined;
   try {
@@ -297,6 +301,9 @@ function parseLine(line: string): ActivityEvent | undefined {
     return undefined; // skip corrupt / partial lines (fail-open reader)
   }
 }
+
+/** Per-session byte budget for a bounded tail read of an activity log. */
+export const ACTIVITY_TAIL_BYTES = 256 * 1024;
 
 /** Read the tail of a file as UTF-8, bounded to the last `maxBytes`. */
 function readTail(file: string, maxBytes: number): string | undefined {
@@ -371,7 +378,7 @@ function readActivityTail(file: string, maxBytes: number, sinceMs = -Infinity): 
   const events: ActivityEvent[] = [];
   let newestMs = -Infinity;
   for (const line of text.split('\n')) {
-    const event = parseLine(line);
+    const event = parseActivityLine(line);
     if (!event) continue;
     events.push(event);
     try {
@@ -411,7 +418,7 @@ function readActivityTail(file: string, maxBytes: number, sinceMs = -Infinity): 
 }
 
 /** Read all events for one session (bounded tail). */
-export function readSessionActivity(sessionId: string, root?: string, maxBytes = 256 * 1024): ActivityEvent[] {
+export function readSessionActivity(sessionId: string, root?: string, maxBytes = ACTIVITY_TAIL_BYTES): ActivityEvent[] {
   const dir = root ?? getActivityDir();
   return structuredClone(readActivityTail(activityPath(dir, sessionId), maxBytes).events ?? []);
 }
@@ -455,7 +462,7 @@ export function readRecentActivity(opts: RecentActivityOptions = {}): ActivityEv
   const wanted = opts.events && opts.events.length > 0 ? new Set(opts.events) : null;
   const all: ActivityEvent[] = [];
   for (const sessionId of listActivitySessions(dir)) {
-    const tail = readActivityTail(activityPath(dir, sessionId), opts.maxBytesPerSession ?? 256 * 1024, sinceMs);
+    const tail = readActivityTail(activityPath(dir, sessionId), opts.maxBytesPerSession ?? ACTIVITY_TAIL_BYTES, sinceMs);
     if (tail.newestMs < sinceMs) continue;
     for (const ev of tail.events ?? []) {
       if (wanted && !wanted.has(ev.event)) continue;

--- a/cli/src/lib/feed/watch.reconcile.test.ts
+++ b/cli/src/lib/feed/watch.reconcile.test.ts
@@ -1,0 +1,115 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// The feed and activity dirs derive from HOME at module load, so this has to be
+// set before the modules under test are imported.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'feed-watch-reconcile-'));
+process.env.HOME = TEST_HOME;
+
+import { afterAll, describe, expect, it } from 'vitest';
+import type { ActiveSession } from '../session/active.js';
+import { getActivityDir, getFeedDir } from '../state.js';
+import { appendActivityEvent } from './activity.js';
+import { watchLocalFeed, type FeedWatchEnvelope } from './watch.js';
+
+afterAll(() => { fs.rmSync(TEST_HOME, { recursive: true, force: true }); });
+
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const liveSession = (sessionId: string): ActiveSession => ({
+  context: 'terminal', kind: 'claude', sessionId, status: 'running', cwd: TEST_HOME, lastActivityMs: 10,
+});
+
+interface Harness {
+  events: FeedWatchEnvelope[];
+  stop: () => Promise<void>;
+}
+
+/** Start the real local feed watcher over the temp HOME with one live row. */
+function start(options: { reconcileMs: number; sessionId?: string; withFeedDir?: boolean }): Harness {
+  fs.mkdirSync(getActivityDir(), { recursive: true });
+  if (options.withFeedDir !== false) fs.mkdirSync(getFeedDir(), { recursive: true });
+  const events: FeedWatchEnvelope[] = [];
+  const controller = new AbortController();
+  const journalPath = path.join(TEST_HOME, `journal-${Math.random().toString(36).slice(2)}.jsonl`);
+  const sessions = options.sessionId ? [liveSession(options.sessionId)] : [];
+  const watching = watchLocalFeed({
+    scope: 'test-box',
+    signal: controller.signal,
+    emit: (event) => events.push(event),
+    activityPollMs: 25,
+    reconcileMs: options.reconcileMs,
+    sessions: {
+      journalPath,
+      journalPollMs: 10,
+      heartbeatMs: 60_000,
+      readCache: () => ({ version: 1, scope: 'test-box', capturedAt: 1, sessions }),
+      readPrevious: () => [],
+    },
+  });
+  return { events, stop: async () => { controller.abort(); await watching; } };
+}
+
+/** The one open block an `agents feed post --blocked` would have written. */
+function writeBlock(sessionId: string): void {
+  fs.writeFileSync(path.join(getFeedDir(), `block-${sessionId}.json`), JSON.stringify({
+    blockId: `block-${sessionId}`,
+    sessionId,
+    generation: 1,
+    createdAt: new Date().toISOString(),
+    questions: [{ text: 'Approve the plan?', reason: 'plan_review' }],
+  }));
+}
+
+describe('feed watch reconcile cadence', () => {
+  it('drains appended activity every tick without reconciling attention on any of them', async () => {
+    // A reconcile window far beyond the test run: attention traffic here could
+    // only come from a per-tick pass, which is the regression being pinned.
+    const harness = start({ reconcileMs: 3_600_000, sessionId: 'live-quiet' });
+    await settle(80);
+    appendActivityEvent({ sessionId: 'live-quiet', event: 'status.posted', ts: new Date().toISOString(), detail: 'first' });
+    await settle(120);
+    appendActivityEvent({ sessionId: 'live-quiet', event: 'status.posted', ts: new Date().toISOString(), detail: 'second' });
+    await settle(200);
+    await harness.stop();
+
+    const appended = harness.events.filter((event) => event.type === 'activity.append');
+    expect(appended.map((event) => (event as Extract<FeedWatchEnvelope, { type: 'activity.append' }>).event.detail))
+      .toEqual(['first', 'second']);
+    // ~16 ticks ran in that window. The startup reset carries attention; no tick
+    // after it re-read the attention stores for an unchanged row.
+    expect(harness.events.filter((event) => event.type === 'attention.upsert' || event.type === 'attention.remove')).toEqual([]);
+  });
+
+  it('reconciles a row as soon as a block is written, without waiting for the PR-status cadence', async () => {
+    const harness = start({ reconcileMs: 3_600_000, sessionId: 'live-blocked' });
+    await settle(120); // Let the startup reset land and the dir watcher arm.
+    const beforeBlock = harness.events.length;
+    writeBlock('live-blocked');
+    await settle(300);
+    await harness.stop();
+
+    const raised = harness.events.slice(beforeBlock).filter((event) => event.type === 'attention.upsert');
+    expect(raised).toHaveLength(1);
+    expect(raised[0]).toMatchObject({ type: 'attention.upsert', attention: { kind: 'question', sessionId: 'live-blocked' } });
+  });
+
+  it('reconciles on the timed cadence when no directory watcher could arm', async () => {
+    // Start with no feed dir at all, the state of a box that has never posted:
+    // `watchAttentionStores` has nothing to subscribe to, so the timed pass is
+    // the ONLY path left. It has to exist — a PR verdict also changes with no
+    // local file write, and that is what the cadence is sized for.
+    fs.rmSync(getFeedDir(), { recursive: true, force: true });
+    const harness = start({ reconcileMs: 50, sessionId: 'live-timed', withFeedDir: false });
+    await settle(80);
+    fs.mkdirSync(getFeedDir(), { recursive: true });
+    writeBlock('live-timed');
+    await settle(300);
+    await harness.stop();
+
+    const raised = harness.events.filter((event) => event.type === 'attention.upsert');
+    expect(raised).toHaveLength(1);
+    expect(raised[0]).toMatchObject({ attention: { kind: 'question', sessionId: 'live-timed' } });
+  });
+});

--- a/cli/src/lib/feed/watch.ts
+++ b/cli/src/lib/feed/watch.ts
@@ -117,8 +117,13 @@ export interface WatchLocalFeedOptions {
 
 export async function watchLocalFeed(options: WatchLocalFeedOptions): Promise<void> {
   const state = new FeedWatchState();
-  let activityCursor = Date.now();
+  // The stream's opening scan registers every log past its own bytes, so the
+  // cursor has to be taken *after* it: a record appended while the scan was
+  // walking the directory is unreadable from the byte cursor, and only a
+  // timestamp taken after the scan classifies it as history rather than
+  // dropping it from a window the caller believes was covered.
   const activity = new ActivityStream();
+  let activityCursor = Date.now();
   const agents = new Map<string, SessionWatchRow>();
   const attention = new Map<string, string>();
   let pending = Promise.resolve();

--- a/cli/src/lib/feed/watch.ts
+++ b/cli/src/lib/feed/watch.ts
@@ -1,16 +1,18 @@
 import { randomUUID } from 'node:crypto';
-import { spawn } from 'node:child_process';
-import { createInterface } from 'node:readline';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { loadDevices, isDialableDevice } from '../devices/registry.js';
-import { deviceIdentityArgs, sshTargetFor } from '../devices/connect.js';
 import { machineId, normalizeHost } from '../machine-id.js';
-import { SSH_OPTS, controlOpts, shellQuote } from '../ssh-exec.js';
+import { shellQuote } from '../ssh-exec.js';
 import { buildWindowsAgentsCommand, remoteShellFor } from '../hosts/remote-cmd.js';
-import { watchLocalSessions, type SessionWatchEnvelope, type SessionWatchRow, type SessionWatchScopeStatus } from '../session/watch.js';
+import { getFeedDir } from '../state.js';
+import { streamFromPeer } from '../session/remote/peer-stream.js';
+import { watchLocalSessions, type SessionWatchEnvelope, type SessionWatchRow, type SessionWatchScopeStatus, type WatchLocalOptions } from '../session/watch.js';
 import { readBlock, readResolution, blockIdForSession } from './feed.js';
 import { reconcileAttention, type AttentionItem } from './attention.js';
-import { readRecentActivity, type ActivityEvent } from './activity.js';
-import { readPullRequestStatus } from './pr-status.js';
+import { type ActivityEvent } from './activity.js';
+import { ActivityStream } from './activity-stream.js';
+import { PR_STATUS_TTL_MS, readPullRequestStatus } from './pr-status.js';
 
 export const FEED_WATCH_VERSION = 1 as const;
 type Base = { v: 1; type: string; streamId: string; sequence: number; scope: string };
@@ -79,9 +81,44 @@ export async function projectSessionEnvelope(event: SessionWatchEnvelope, state:
   return [state.emit({ type: 'heartbeat', capturedAt: event.capturedAt, scope: event.scope })];
 }
 
-export async function watchLocalFeed(options: { scope: string; signal: AbortSignal; emit: (event: FeedWatchEnvelope) => void; activityPollMs?: number }): Promise<void> {
+/**
+ * Watch the feed dirs that can change attention without a session event: an
+ * `agents feed post --blocked` writes a block, `feed answer` writes a
+ * resolution. Both are external processes, so nothing on the session stream
+ * announces them — this is what lets the reconcile pass be event-driven instead
+ * of a poll over every row twice a second.
+ */
+function watchAttentionStores(onChange: () => void): () => void {
+  const feedDir = getFeedDir();
+  const watchers: fs.FSWatcher[] = [];
+  for (const dir of [feedDir, path.join(feedDir, 'resolutions')]) {
+    try {
+      const watcher = fs.watch(dir, () => onChange());
+      // A directory that disappears must not take the watcher process down; the
+      // PR-status cadence below still reconciles on its own timer.
+      watcher.on('error', () => watcher.close());
+      watchers.push(watcher);
+    } catch { /* the dir appears with the first block; the timed pass covers it */ }
+  }
+  return () => { for (const watcher of watchers) watcher.close(); };
+}
+
+export interface WatchLocalFeedOptions {
+  scope: string;
+  signal: AbortSignal;
+  emit: (event: FeedWatchEnvelope) => void;
+  /** Activity drain cadence. */
+  activityPollMs?: number;
+  /** Attention reconcile cadence when nothing has announced a change. */
+  reconcileMs?: number;
+  /** Session-watch inputs, forwarded verbatim to {@link watchLocalSessions}. */
+  sessions?: Pick<WatchLocalOptions, 'readCache' | 'readPrevious' | 'journalPath' | 'journalPollMs' | 'heartbeatMs'>;
+}
+
+export async function watchLocalFeed(options: WatchLocalFeedOptions): Promise<void> {
   const state = new FeedWatchState();
   let activityCursor = Date.now();
+  const activity = new ActivityStream();
   const agents = new Map<string, SessionWatchRow>();
   const attention = new Map<string, string>();
   let pending = Promise.resolve();
@@ -96,20 +133,33 @@ export async function watchLocalFeed(options: { scope: string; signal: AbortSign
         : state.emit({ type: 'attention.remove', scope: options.scope, rowKey }));
     }
   };
+  // Attention is reconciled when something can actually have changed it — a row
+  // moved, a block/resolution file was written — or when the PR-status TTL has
+  // expired and the cached verdicts are stale. Re-running it every 500 ms cost
+  // two file reads per row per tick and changed nothing.
+  const reconcileMs = options.reconcileMs ?? PR_STATUS_TTL_MS;
+  let attentionDirty = true;
+  let lastReconcileMs = 0;
+  const markAttentionDirty = () => { attentionDirty = true; };
+  const stopAttentionWatch = watchAttentionStores(markAttentionDirty);
   const activityTimer = setInterval(() => {
     pending = pending.then(async () => {
-    const events = readRecentActivity({ sinceMs: activityCursor + 1 }).reverse();
-    for (const event of events) {
-      activityCursor = Math.max(activityCursor, Date.parse(event.ts));
-      options.emit(state.emit({ type: 'activity.append', scope: options.scope, event }));
-    }
+      const nowMs = Date.now();
+      const events = activity.read(activityCursor + 1, nowMs).reverse();
+      for (const event of events) {
+        activityCursor = Math.max(activityCursor, Date.parse(event.ts));
+        options.emit(state.emit({ type: 'activity.append', scope: options.scope, event }));
+      }
+      if (!attentionDirty && nowMs - lastReconcileMs < reconcileMs) return;
+      attentionDirty = false;
+      lastReconcileMs = nowMs;
       await reconcileRows();
     });
   }, options.activityPollMs ?? 500);
-  const stopActivity = () => clearInterval(activityTimer);
+  const stopActivity = () => { clearInterval(activityTimer); stopAttentionWatch(); activity.close(); };
   options.signal.addEventListener('abort', stopActivity, { once: true });
   try {
-    await watchLocalSessions({ scope: options.scope, signal: options.signal, emit: (event) => {
+    await watchLocalSessions({ ...options.sessions, scope: options.scope, signal: options.signal, emit: (event) => {
       if (event.type === 'reset') {
         agents.clear();
         for (const row of event.rows) agents.set(row.rowKey, row);
@@ -152,24 +202,23 @@ export async function watchFleetFeed(options: { signal: AbortSignal; emit: (even
   try { devices = await loadDevices(); } catch { await local; return; }
   const self = machineId();
   const peers = Object.values(devices).filter((device) => isDialableDevice(device) && normalizeHost(device.name) !== self && ['windows', 'linux', 'macos'].includes(device.platform));
-  const tasks = peers.map(async (device) => {
+  const tasks = peers.map((device) => {
     const scope = normalizeHost(device.name);
-    while (!options.signal.aborted) {
-      let target: string;
-      try { target = sshTargetFor(device); } catch (error) {
-        options.emit(coordinator.emit({ type: 'scope', capturedAt: Date.now(), scope, status: 'unavailable', reason: String(error) })); break;
-      }
-      const child = spawn('ssh', [...SSH_OPTS, ...controlOpts(), ...deviceIdentityArgs(device), target, remoteFeedWatchCommand(device.platform)], { stdio: ['ignore', 'pipe', 'ignore'] });
-      const stop = () => child.kill('SIGTERM');
-      options.signal.addEventListener('abort', stop, { once: true });
-      const reader = createInterface({ input: child.stdout! });
-      reader.on('line', (line) => { try { const event = JSON.parse(line) as FeedWatchEnvelope; if (event.v === 1) forward(event); } catch { /* protocol only */ } });
-      const code = await new Promise<number | null>((resolve) => { child.once('error', () => resolve(null)); child.once('close', resolve); });
-      reader.close(); options.signal.removeEventListener('abort', stop);
-      if (options.signal.aborted) break;
-      options.emit(coordinator.emit({ type: 'scope', capturedAt: Date.now(), scope, status: 'unavailable', reason: code == null ? 'ssh failed' : `ssh exited ${code}` }));
-      await new Promise<void>((resolve) => { const timer = setTimeout(resolve, options.reconnectMs ?? 2_000); options.signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true }); });
-    }
+    return streamFromPeer({
+      device,
+      signal: options.signal,
+      command: remoteFeedWatchCommand(device.platform),
+      backoffBaseMs: options.reconnectMs,
+      onLine: (line) => {
+        try {
+          const event = JSON.parse(line) as FeedWatchEnvelope;
+          if (event.v !== 1) return false;
+          forward(event);
+          return true;
+        } catch { return false; /* protocol only */ }
+      },
+      onUnavailable: (reason) => options.emit(coordinator.emit({ type: 'scope', capturedAt: Date.now(), scope, status: 'unavailable', reason })),
+    });
   });
   await Promise.all([local, ...tasks]);
 }

--- a/cli/src/lib/session/remote/peer-stream.test.ts
+++ b/cli/src/lib/session/remote/peer-stream.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { DeviceProfile } from '../../devices/registry.js';
+import {
+  PEER_BACKOFF_BASE_MS,
+  PEER_BACKOFF_CAP_MS,
+  PEER_PARK_AFTER_FAILURES,
+  peerBackoffDelayMs,
+  streamFromPeer,
+} from './peer-stream.js';
+
+const roots: string[] = [];
+function root() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'peer-stream-'));
+  roots.push(dir);
+  return dir;
+}
+afterEach(() => { for (const dir of roots.splice(0)) fs.rmSync(dir, { recursive: true, force: true }); });
+
+function device(name = 'peer-a'): DeviceProfile {
+  return {
+    name,
+    platform: 'linux',
+    shell: 'posix',
+    user: 'agent',
+    auth: { method: 'key' },
+    address: { via: 'manual', dnsName: '127.0.0.1' },
+    createdAt: '2026-09-06T00:00:00.000Z',
+    updatedAt: '2026-09-06T00:00:00.000Z',
+  } as DeviceProfile;
+}
+
+/**
+ * A real executable standing in for ssh. It records each invocation, writes the
+ * given stderr, and exits with the given code — the shape of a peer that cannot
+ * be reached.
+ */
+function fakeSsh(dir: string, body: string): string {
+  const bin = path.join(dir, 'fake-ssh');
+  fs.writeFileSync(bin, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  return bin;
+}
+
+describe('peer subscription backoff', () => {
+  it('doubles from the base delay and saturates at the cap', () => {
+    expect(peerBackoffDelayMs(0)).toBe(0);
+    expect([1, 2, 3, 4, 5, 6, 7].map((n) => peerBackoffDelayMs(n)))
+      .toEqual([2_000, 4_000, 8_000, 16_000, 32_000, 60_000, 60_000]);
+    expect(peerBackoffDelayMs(1)).toBe(PEER_BACKOFF_BASE_MS);
+    expect(peerBackoffDelayMs(99)).toBe(PEER_BACKOFF_CAP_MS);
+  });
+
+  it('backs off a failing peer, surfaces its stderr, and parks it after three spawns', async () => {
+    const dir = root();
+    const log = path.join(dir, 'invocations');
+    const ssh = fakeSsh(dir, `echo "$#" >> ${JSON.stringify(log)}\necho "ssh: connect to host peer-a port 22: No route to host" >&2\nexit 255`);
+    const controller = new AbortController();
+    const reasons: string[] = [];
+    const started = Date.now();
+
+    await streamFromPeer({
+      device: device(),
+      signal: controller.signal,
+      command: 'agents sessions watch --json --local',
+      sshBin: ssh,
+      // Scaled down so the schedule is observable in a test, with the same
+      // doubling and park behaviour the shipped defaults have.
+      backoffBaseMs: 20,
+      backoffCapMs: 80,
+      registryPollMs: 10,
+      registryPath: path.join(dir, 'registry.json'),
+      onLine: () => false,
+      onUnavailable: (reason) => {
+        reasons.push(reason);
+        // Three failed spawns is the park threshold; stop the loop there so the
+        // assertion is about the schedule, not the test's patience.
+        if (reasons.length >= PEER_PARK_AFTER_FAILURES) controller.abort();
+      },
+    });
+
+    const invocations = fs.readFileSync(log, 'utf-8').trim().split('\n');
+    expect(invocations).toHaveLength(3);
+    // The reason carries the peer's own stderr instead of discarding it.
+    expect(reasons[0]).toBe('ssh exited 255: ssh: connect to host peer-a port 22: No route to host');
+    expect(reasons[1]).toBe(reasons[0]);
+    expect(reasons[2]).toContain('parked after 3 failed connections');
+    // 20ms + 40ms of backoff separates the three spawns.
+    expect(Date.now() - started).toBeGreaterThanOrEqual(50);
+  });
+
+  it('resets the backoff when a peer delivers a healthy protocol line', async () => {
+    const dir = root();
+    const attempts = path.join(dir, 'attempts');
+    // Fails twice, then serves one protocol line and exits; the healthy line
+    // must clear the failure streak so the peer is not parked on the next exit.
+    const ssh = fakeSsh(dir, [
+      `n=$(cat ${JSON.stringify(attempts)} 2>/dev/null || echo 0)`,
+      `echo $((n + 1)) > ${JSON.stringify(attempts)}`,
+      'if [ "$n" -ge 2 ]; then echo \'{"ok":true}\'; fi',
+      'exit 1',
+    ].join('\n'));
+    const controller = new AbortController();
+    const reasons: string[] = [];
+    let lines = 0;
+
+    await streamFromPeer({
+      device: device(),
+      signal: controller.signal,
+      command: 'agents sessions watch --json --local',
+      sshBin: ssh,
+      backoffBaseMs: 10,
+      backoffCapMs: 40,
+      registryPollMs: 10,
+      registryPath: path.join(dir, 'registry.json'),
+      onLine: () => { lines += 1; return true; },
+      onUnavailable: (reason) => {
+        reasons.push(reason);
+        if (reasons.length >= 4) controller.abort();
+      },
+    });
+
+    expect(lines).toBeGreaterThanOrEqual(1);
+    // Two failures, then a healthy connection resets the streak — so the fourth
+    // exit is failure #1 again and reports no park.
+    expect(reasons.slice(0, 2).every((reason) => !reason.includes('parked'))).toBe(true);
+    expect(reasons[3]).not.toContain('parked');
+  });
+
+  it('gives up without retrying when the device has no address at all', async () => {
+    const dir = root();
+    const ssh = fakeSsh(dir, 'exit 0');
+    const reasons: string[] = [];
+    await streamFromPeer({
+      device: { ...device(), address: { via: 'manual' } } as DeviceProfile,
+      signal: new AbortController().signal,
+      command: 'agents sessions watch --json --local',
+      sshBin: ssh,
+      registryPath: path.join(dir, 'registry.json'),
+      onLine: () => false,
+      onUnavailable: (reason) => reasons.push(reason),
+    });
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain('has no address');
+  });
+});

--- a/cli/src/lib/session/remote/peer-stream.ts
+++ b/cli/src/lib/session/remote/peer-stream.ts
@@ -1,0 +1,166 @@
+/**
+ * One peer's `--local` watch subscription, with connection hygiene.
+ *
+ * Both fleet fan-outs (`watchFleetSessions`, `watchFleetFeed`) subscribe to
+ * every dialable device with a long-lived `ssh <peer> agents … watch --json
+ * --local`. Both used to respawn that child on a bare 2 s timer with the
+ * child's stderr set to `'ignore'`, so an offline peer — and `isDialableDevice`
+ * deliberately never excludes one — got a fresh ssh every ConnectTimeout + 2 s
+ * for the whole life of the watcher, with the reason discarded. That is the
+ * ssh-child churn the 2026-09-03 incident reported.
+ *
+ * This module is the single implementation both fan-outs call:
+ *
+ * - exponential backoff per peer, {@link PEER_BACKOFF_BASE_MS} doubling to
+ *   {@link PEER_BACKOFF_CAP_MS}, reset the moment the peer delivers a healthy
+ *   protocol event;
+ * - the child's stderr captured (bounded to {@link PEER_STDERR_BYTES}) and
+ *   surfaced as the `unavailable` reason instead of being thrown away;
+ * - a peer that fails {@link PEER_PARK_AFTER_FAILURES} spawns in a row parked —
+ *   it stops the reconnect cycle and re-dials only when the device registry
+ *   changes or the capped backoff elapses;
+ * - abort listeners removed per iteration, so a watcher open for hours does not
+ *   accumulate one per reconnect on the caller's AbortSignal.
+ */
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import { createInterface } from 'node:readline';
+import { deviceIdentityArgs, sshTargetFor } from '../../devices/connect.js';
+import type { DeviceProfile } from '../../devices/registry.js';
+import { SSH_OPTS, controlOpts } from '../../ssh-exec.js';
+import { getDevicesRegistryPath } from '../../state.js';
+
+/** First reconnect delay after a failed subscription. */
+export const PEER_BACKOFF_BASE_MS = 2_000;
+/** Ceiling the doubling delay saturates at. */
+export const PEER_BACKOFF_CAP_MS = 60_000;
+/** Consecutive failed spawns before the peer is parked. */
+export const PEER_PARK_AFTER_FAILURES = 3;
+/** Bytes of a peer's stderr retained for the `unavailable` reason. */
+export const PEER_STDERR_BYTES = 2_048;
+/** How often a parked peer re-checks the device registry for a refresh. */
+export const PEER_REGISTRY_POLL_MS = 5_000;
+
+/**
+ * Reconnect delay for `failures` consecutive failed spawns: 0 for a healthy
+ * peer, then {@link PEER_BACKOFF_BASE_MS} doubling to {@link PEER_BACKOFF_CAP_MS}.
+ */
+export function peerBackoffDelayMs(
+  failures: number,
+  base = PEER_BACKOFF_BASE_MS,
+  cap = PEER_BACKOFF_CAP_MS,
+): number {
+  if (failures <= 0) return 0;
+  return Math.min(cap, base * 2 ** (failures - 1));
+}
+
+export interface PeerStreamOptions {
+  /** The device to subscribe to. */
+  device: DeviceProfile;
+  /** Remote command to run over ssh, already shell-quoted for the peer's OS. */
+  command: string;
+  signal: AbortSignal;
+  /**
+   * One line of the peer's stdout. Return `true` when the line was a valid
+   * protocol event — that is the health signal that resets the backoff.
+   */
+  onLine: (line: string) => boolean;
+  /** Report the peer as unavailable, with the captured reason. */
+  onUnavailable: (reason: string) => void;
+  /** Override the first backoff delay (tests). */
+  backoffBaseMs?: number;
+  /** Override the backoff ceiling (tests). */
+  backoffCapMs?: number;
+  /** Override the park threshold (tests). */
+  parkAfterFailures?: number;
+  /** Override the ssh binary (tests). */
+  sshBin?: string;
+  /** Override the parked peer's registry re-check cadence (tests). */
+  registryPollMs?: number;
+  /** Override the registry file a parked peer waits on (tests). */
+  registryPath?: string;
+}
+
+/** Bounded tail of a child's stderr, kept for the unavailable reason. */
+function stderrTail(chunks: string, next: string, limit: number): string {
+  const joined = chunks + next;
+  return joined.length > limit ? joined.slice(joined.length - limit) : joined;
+}
+
+/** Collapse captured stderr to one quotable line. */
+function reasonFor(exit: string, stderr: string): string {
+  const detail = stderr.split('\n').map((line) => line.trim()).filter(Boolean).pop();
+  return detail ? `${exit}: ${detail}` : exit;
+}
+
+/** Await a delay, a device-registry change, or abort — whichever comes first. */
+async function parkedWait(options: PeerStreamOptions, delayMs: number): Promise<void> {
+  const registry = options.registryPath ?? getDevicesRegistryPath();
+  const pollMs = options.registryPollMs ?? PEER_REGISTRY_POLL_MS;
+  const stampOf = () => {
+    try { const st = fs.statSync(registry); return `${st.size}:${st.mtimeMs}`; } catch { return ''; }
+  };
+  const before = stampOf();
+  await new Promise<void>((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      clearTimeout(deadline);
+      clearInterval(poll);
+      options.signal.removeEventListener('abort', finish);
+      resolve();
+    };
+    const deadline = setTimeout(finish, delayMs);
+    const poll = setInterval(() => { if (stampOf() !== before) finish(); }, Math.min(pollMs, Math.max(delayMs, 1)));
+    options.signal.addEventListener('abort', finish, { once: true });
+  });
+}
+
+/**
+ * Hold one peer subscription open for the life of the signal, reconnecting with
+ * backoff. Resolves when the signal aborts or the peer cannot be addressed.
+ */
+export async function streamFromPeer(options: PeerStreamOptions): Promise<void> {
+  const parkAfter = options.parkAfterFailures ?? PEER_PARK_AFTER_FAILURES;
+  let failures = 0;
+  while (!options.signal.aborted) {
+    let target: string;
+    try { target = sshTargetFor(options.device); } catch (error) {
+      // No address at all is not a transient failure: retrying cannot fix it.
+      options.onUnavailable(error instanceof Error ? error.message : String(error));
+      return;
+    }
+    const child = spawn(options.sshBin ?? 'ssh', [
+      ...SSH_OPTS, ...controlOpts(), ...deviceIdentityArgs(options.device), target, options.command,
+    ], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const stop = () => child.kill('SIGTERM');
+    options.signal.addEventListener('abort', stop, { once: true });
+    let stderr = '';
+    child.stderr?.setEncoding('utf-8');
+    child.stderr?.on('data', (chunk: string) => { stderr = stderrTail(stderr, chunk, PEER_STDERR_BYTES); });
+    const reader = createInterface({ input: child.stdout! });
+    reader.on('line', (line) => {
+      // A peer that is delivering protocol is healthy, so the next disconnect
+      // starts the backoff over rather than inheriting an old failure streak.
+      if (options.onLine(line)) failures = 0;
+    });
+    const code = await new Promise<number | null>((resolve) => {
+      child.once('error', () => resolve(null));
+      child.once('close', resolve);
+    });
+    reader.close();
+    // Removed per iteration: a watcher open for hours would otherwise leak one
+    // listener per reconnect onto the caller's signal.
+    options.signal.removeEventListener('abort', stop);
+    if (options.signal.aborted) return;
+    failures += 1;
+    const exit = code == null ? 'ssh failed' : `ssh exited ${code}`;
+    const parked = failures >= parkAfter;
+    const delay = peerBackoffDelayMs(failures, options.backoffBaseMs, options.backoffCapMs);
+    options.onUnavailable(parked
+      ? `${reasonFor(exit, stderr)} — parked after ${failures} failed connections, retrying in ${Math.round(delay / 1000)}s or on a device refresh`
+      : reasonFor(exit, stderr));
+    await parkedWait(options, delay);
+  }
+}

--- a/cli/src/lib/session/remote/watch.ts
+++ b/cli/src/lib/session/remote/watch.ts
@@ -1,12 +1,10 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { spawn } from 'node:child_process';
-import { createInterface } from 'node:readline';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { loadDevices, isDialableDevice } from '../../devices/registry.js';
-import { deviceIdentityArgs, sshTargetFor } from '../../devices/connect.js';
 import { machineId, normalizeHost } from '../../machine-id.js';
-import { SSH_OPTS, controlOpts, shellQuote } from '../../ssh-exec.js';
+import { shellQuote } from '../../ssh-exec.js';
+import { streamFromPeer } from './peer-stream.js';
 import { buildWindowsAgentsCommand, remoteShellFor } from '../../hosts/remote-cmd.js';
 import { isReapableOrphan, type ActiveSession } from '../active.js';
 import { querySessions, readSessionSummaryAny } from '../db.js';
@@ -448,42 +446,24 @@ export async function watchFleetSessions(options: WatchFleetOptions): Promise<vo
     && normalizeHost(device.name) !== self
     && ['windows', 'linux', 'macos'].includes(device.platform),
   );
-  const reconnectMs = options.reconnectMs ?? 2_000;
   const peerTasks = peers.map(async (device) => {
     const scope = normalizeHost(device.name);
     const state = new SessionWatchState();
-    while (!options.signal.aborted) {
-      let target: string;
-      try { target = sshTargetFor(device); }
-      catch (error) {
-        options.emit(state.scope(scope, 'unavailable', error instanceof Error ? error.message : String(error)));
-        break;
-      }
-      const child = spawn('ssh', [
-        ...SSH_OPTS, ...controlOpts(), ...deviceIdentityArgs(device), target, remoteWatchCommand(device.platform),
-      ], { stdio: ['ignore', 'pipe', 'ignore'] });
-      const stop = () => child.kill('SIGTERM');
-      options.signal.addEventListener('abort', stop, { once: true });
-      const reader = createInterface({ input: child.stdout! });
-      reader.on('line', (line) => {
+    await streamFromPeer({
+      device,
+      signal: options.signal,
+      command: remoteWatchCommand(device.platform),
+      backoffBaseMs: options.reconnectMs,
+      onLine: (line) => {
         try {
           const event = JSON.parse(line) as SessionWatchEnvelope;
-          if (event.version === SESSION_WATCH_VERSION && typeof event.sequence === 'number') options.emit(event);
-        } catch { /* incomplete/non-protocol peer output is not state */ }
-      });
-      const code = await new Promise<number | null>((resolve) => {
-        child.once('error', () => resolve(null));
-        child.once('close', resolve);
-      });
-      reader.close();
-      options.signal.removeEventListener('abort', stop);
-      if (options.signal.aborted) break;
-      options.emit(state.scope(scope, 'unavailable', code === null ? 'ssh failed' : `ssh exited ${code}`));
-      await new Promise<void>((resolve) => {
-        const timer = setTimeout(resolve, reconnectMs);
-        options.signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
-      });
-    }
+          if (event.version !== SESSION_WATCH_VERSION || typeof event.sequence !== 'number') return false;
+          options.emit(event);
+          return true;
+        } catch { return false; /* incomplete/non-protocol peer output is not state */ }
+      },
+      onUnavailable: (reason) => options.emit(state.scope(scope, 'unavailable', reason)),
+    });
   });
   await Promise.all([local, ...peerTasks]);
 }


### PR DESCRIPTION
`agents feed watch --json` is the stream AGI EXT's elected leader keeps open for the
whole life of a VS Code window — one child, fanned out to every window — so its
per-tick cost is paid continuously. On an operator box with 1,437 activity logs /
64 MB it burned **~44% of a core, steadily, forever**, and minted a fresh `ssh`
child every few seconds for every peer that could not be reached. This fixes both
at the source. The envelope shape is untouched: `reset` / `agent.upsert` /
`agent.remove` / `attention.upsert` / `attention.remove` / `activity.append` /
`scope` / `heartbeat`, same fields, same ordering.

## What was costing what

- `cli/src/lib/feed/watch.ts:99-108` — a 500 ms `setInterval` called
  `readRecentActivity({ sinceMs })` with no limit and no file filter.
- `cli/src/lib/feed/activity.ts:339-346` — `listActivitySessions()` `readdirSync`s
  every session ever recorded; `:327-336` tails 256 KiB **per file**; `:371-386`
  parses every line of every file and only then applies `sinceMs`. The tail cache
  landed in `734035bc6` bounds itself to 1,024 files / 32 MB, so a 1,437-file
  corpus is a cyclic scan larger than the cache — pessimal for LRU, every entry
  missing on every tick. Twice a second.
- `reconcileRows` (`watch.ts:88-98`) ran on the same tick over every row:
  `readBlock` + `readResolution` (two `readFileSync` + `JSON.parse` each) plus
  `readPullRequestStatus`, whose TTL is 45 s — so 89 of every 90 calls returned a
  cached value that could not have changed.
- `watch.ts:155-172` and `session/remote/watch.ts:440-479` respawned each peer's
  `ssh … --local` subscription on a bare 2 s timer with `stdio` stderr `'ignore'`.
  `isDialableDevice` deliberately never excludes an unreachable peer
  (`devices/registry.ts:120-128`, and that is the right call — a probe false
  negative must not hide a healthy box's sessions), so an offline box got a fresh
  ssh every ConnectTimeout + 2 s for the life of the watcher, with the reason
  thrown away. Each iteration also added an `abort` listener it never removed.

## The change

**1. `ActivityStream` — an incremental cursor over the activity dir**
(`cli/src/lib/feed/activity-stream.ts`, new). Per file: inode, byte offset,
mtime, the trailing partial line, and the last 64 bytes behind the cursor. Ticks
read only appended bytes. Candidates come from an `fs.watch` on the dir, with a
5 s stat sweep as the fallback (and every tick sweeps if the watcher could not
arm — the degradation is more work, never a dropped event). **The opening scan
opens no files at all** — every log is registered past its own bytes, so history
is never replayed; that is stricter than the "bounded window" the brief suggested
and costs strictly less. Truncation, atomic replacement, an in-place rewrite that
happens to be longer (caught by the 64-byte anchor), a burst larger than the
budget, deletion, and a log created mid-stream are all handled and tested.

**2. Attention reconciles on change, not on the tick** (`watch.ts`). The feed dir
and `feed/resolutions` are watched directly, so an external
`agents feed post --blocked` still raises promptly; otherwise the pass runs when
`PR_STATUS_TTL_MS` (45 s) has expired. Nothing else in `reconcileAttention` is
time-dependent, so that TTL is the whole reason a timed pass exists at all.

**3. One peer-subscription implementation for both fan-outs**
(`cli/src/lib/session/remote/peer-stream.ts`, new; `watchFleetFeed` and
`watchFleetSessions` both call it). Per-peer exponential backoff (2 s doubling to
a 60 s cap, reset the moment the peer delivers a healthy protocol event); the
child's stderr captured (bounded to 2 KiB) and surfaced as the `scope:
unavailable` reason instead of discarded; a peer parked after three consecutive
failed spawns until the device registry changes or the capped delay elapses; and
the abort listener removed per iteration. `isDialableDevice` is untouched.

## Measured

Same box, same 1,437-log / 64 MB activity dir, 5 minutes each, CPU% computed from
`/proc/<pid>/stat` utime+stime deltas over each 60 s interval.

| minute | `--local` CPU | `--local` RSS | fleet CPU | fleet RSS |
|---|---|---|---|---|
| 1 | 45.80% | 313 MB | 52.90% | 559 MB |
| 2 | 41.90% | 310 MB | 49.73% | 560 MB |
| 3 | 42.57% | 309 MB | 50.42% | 651 MB |
| 4 | 41.28% | 314 MB | 49.47% | 653 MB |
| 5 | 42.03% | 317 MB | 50.57% | 654 MB |

Steady state (minutes 2-5): **41.9%** of a core local, **50.0%** fleet.

| minute | `--local` CPU | `--local` RSS | fleet CPU | fleet RSS |
|---|---|---|---|---|
| 1 | 5.75% | 205 MB | 6.32% | 231 MB |
| 2 | 0.37% | 137 MB | 0.45% | 141 MB |
| 3 | 0.28% | 141 MB | 0.35% | 143 MB |
| 4 | 0.33% | 139 MB | 0.36% | 143 MB |
| 5 | 0.27% | 142 MB | 0.32% | 144 MB |

Steady state (minutes 2-5): **0.31%** local, **0.37%** fleet — 135x lower in
both shapes. Minute 1 is the opening scan (one `stat` per log, no reads)
plus the session watcher's own cold start; it settles within the first minute and
does not recur. RSS: 313 MB -> 140 MB local, 606 MB -> 143 MB fleet.

Raw logs: `.agents/scratch/final-v2.log` (not committed).

## ssh churn on an unreachable peer

Two of this fleet's devices are offline (`yosemite-m4`, `winbox`), and
`isDialableDevice` correctly still lists them. Counting **distinct ssh child
pids** spawned for those two peers, sampled at 1 Hz over a 150 s window of
`agents feed watch --json`:

| | distinct ssh children for the 2 offline peers | all ssh children |
|---|---|---|
| before | **13** | 25 |
| after | **6** | 18 |

Before, each offline peer re-dialed on a flat ConnectTimeout + 2 s cycle for as
long as the watcher lived — the rate never drops. After, the delay doubles
(2 s -> 60 s cap), so the gap keeps widening past this window; the exact schedule
is pinned by `peerBackoffDelayMs` in `peer-stream.test.ts` rather than inferred
from the sample. The reason text also changed from a bare `ssh exited 255` to the
peer's own stderr.

## Tests

- `cli/src/lib/feed/activity-stream.test.ts` — real temp dirs, real files. Feeds
  the same appended lines through `ActivityStream` and `readRecentActivity` and
  asserts the results are **deeply equal** (`toEqual`, whole events, not just
  details) including newest-first ordering across files; 1,000 session logs with
  `bytesRead` asserted equal to exactly the appended bytes and `0` for the opening
  scan and for an idle tick; the half-written-line hold-and-emit-once path;
  rewrite / truncate / replace / delete / created-later; the over-budget burst;
  and one test driven by a real `fs.watch` notification with the sweep cadence set
  to an hour, so a hit proves the watcher and not the fallback.
- `cli/src/lib/session/remote/peer-stream.test.ts` — the backoff schedule, and a
  real fake-`ssh` executable that exits 255 with real stderr: asserts exactly
  three spawns before the park, the peer's own stderr in the reason, the elapsed
  backoff, that a healthy protocol line resets the streak, and that an
  address-less device gives up without retrying.
- `cli/src/lib/feed/watch.reconcile.test.ts` — the real `watchLocalFeed` over a
  temp `HOME`: activity drains every tick with zero attention traffic across ~16
  ticks; an externally written block raises `attention.upsert` promptly through
  the directory watcher; and, starting with no feed dir so no watcher can arm, the
  timed cadence still reconciles.

Full suite, sharded across three fleet workers from this tree
(`cli/scripts/test.sh --shard 3`):

```
Sharding the suite across 3 workers
  shard 1/3 -> yosemite-m1
  shard 2/3 -> yosemite-m0
  shard 3/3 -> yosemite-m3
  shard 1/3 passed on yosemite-m1
  shard 2/3 passed on yosemite-m0
  shard 3/3 passed on yosemite-m3
All 3 shards passed.
```

## Docs

`cli/AGENTS.md` (feed section — the two per-tick rules and the fan-out budget, so
the next change does not put `readRecentActivity` back on the tick),
`cli/docs/specifications.md` (SES-40d, SES-40e), and a CHANGELOG fragment.

Ticket: PHNX-3939.


## One follow-up fix in this branch

`e31ff4afc` takes the activity timestamp cursor **after** the stream's opening
scan rather than before it. The scan registers every log past its own bytes, so a
record appended while it walked the directory is unreadable from the byte cursor;
taking the timestamp first left such a record inside the window the caller
believes is covered, and it would be dropped. Taken after the scan it is
classified as history, which is what it is. No test: the window is sub-scan and
any test for it would be a race, so the guarantee is stated at the call site.
