### PR TITLE
chore: gitignore eve's local .eve/ cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ scripts/scrub-history.sh
 **/.droid
 **/.goose
 **/.openclaw
+**/.eve
 **/.tmp
 **/.tmp-bun
 


### PR DESCRIPTION
## What

Add `**/.eve` to `.gitignore`.

## Why

Running the `eve` CLI inside this repo creates a `.eve/` dir (cache, dev-hosts) at the root, which shows up as an untracked entry in `git status`. It belongs with the other agent-tool local dirs already ignored in that block (`.claude`, `.codex`, `.droid`, `.goose`, `.openclaw`, …) so it never dirties the tree or blocks a release build.

## Verification

```
$ git check-ignore -v .eve
.gitignore:93:**/.eve	.eve
```

One-line, docs-exempt (internal ignore rule; no flag/command/behavior change).