### PR TITLE
fix(run): mark an exhausted codex account so rotation stops re-picking it (PHNX-3859)

### DIFF
--- a/cli/.changelog/next/PHNX-3859-codex-account-refusal.md
+++ b/cli/.changelog/next/PHNX-3859-codex-account-refusal.md
@@ -1,0 +1,13 @@
+- **`agents run codex` marks an exhausted account so rotation stops re-picking it
+  (PHNX-3859).** When a headless codex run ended with `You've hit your usage limit
+  … try again at <date>` (or an out-of-credits refusal), that account's throttle
+  was never recorded, so the balanced picker kept selecting it from a stale usage
+  snapshot and every subsequent run died the same way instead of rotating to a
+  healthy sibling. Codex now persists a per-account refusal marker the same way
+  Claude already did — the usage cache is identity-keyed and shared across
+  harnesses — so `collectRunCandidates` excludes the dead account and picks a
+  healthy one. A usage limit is noted with its reset clock (it auto-clears when the
+  window resets), a genuine credit/quota exhaustion is noted clock-less (cleared by
+  a later successful run), and a limit with no parseable reset is left untouched
+  rather than persisted as an unexpirable marker. Source: `cli/src/lib/exec.ts`
+  (`classifyCodexRunRefusal`, `parseCodexUsageLimitReset`).

--- a/cli/src/lib/exec.test.ts
+++ b/cli/src/lib/exec.test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, ensureVendorHomeDir, stampedAgentName, customHarnessName, resolveTmuxWrap, buildTmuxAgentCommand, writeTmuxEnvFile, formatPaneTail, detectRateLimit, detectOutOfCredits, classifyClaudeRunRefusal, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, resolveLaunchId, shouldRecapDeadPane, isPaneKnownAliveFromQueryResult, tmuxRunExitCode, UNKNOWN_OUTCOME_EXIT_CODE, type TmuxWrapContext } from './exec.js';
+import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, ensureVendorHomeDir, stampedAgentName, customHarnessName, resolveTmuxWrap, buildTmuxAgentCommand, writeTmuxEnvFile, formatPaneTail, detectRateLimit, detectOutOfCredits, classifyClaudeRunRefusal, classifyCodexRunRefusal, parseCodexUsageLimitReset, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, resolveLaunchId, shouldRecapDeadPane, isPaneKnownAliveFromQueryResult, tmuxRunExitCode, UNKNOWN_OUTCOME_EXIT_CODE, type TmuxWrapContext } from './exec.js';
 import type { ExecOptions } from './exec.js';
 import { isTmuxInstalled } from './tmux/binary.js';
 import { mailboxDir } from './mailbox.js';
@@ -1292,5 +1292,62 @@ describe('classifyClaudeRunRefusal (RUSH-3018 — persist/clear decision on the 
 
   it('a non-zero exit with no recognized refusal leaves the marker untouched', () => {
     expect(classifyClaudeRunRefusal('some unrelated error', 1)).toEqual({ action: 'none' });
+  });
+});
+
+describe('classifyCodexRunRefusal (PHNX-3859 — codex account marked so rotation stops re-picking it)', () => {
+  // The exact string a headless `agents run codex` prints when its account is
+  // over its weekly limit — reproduced 2026-09-06 on yosemite-s1.
+  const REAL =
+    "ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage " +
+    'to purchase more credits or try again at Sep 12th, 2026 8:32 AM.';
+
+  it("codex's usage-limit reset parses to a future Date (ordinal suffix stripped)", () => {
+    const now = Date.parse('2026-09-06T00:00:00Z');
+    const reset = parseCodexUsageLimitReset(REAL, now);
+    expect(reset).toBeInstanceOf(Date);
+    // Sep 12 2026, well after the Sep 6 "now".
+    expect(reset!.getTime()).toBeGreaterThan(now);
+    expect(reset!.getTime()).toBe(Date.parse('Sep 12, 2026 8:32 AM'));
+  });
+
+  it('a time-only reset resolves against today/tomorrow', () => {
+    const now = Date.parse('2026-09-06T08:00:00Z');
+    const reset = parseCodexUsageLimitReset(
+      "You've hit your usage limit. try again at 8:32 AM.",
+      now,
+    );
+    expect(reset).toBeInstanceOf(Date);
+    expect(reset!.getTime()).toBeGreaterThan(now);
+  });
+
+  it('the real usage-limit run is note_session with its reset clock — NOT sticky out_of_credits', () => {
+    const now = Date.parse('2026-09-06T00:00:00Z');
+    const r = classifyCodexRunRefusal(REAL, 1, now);
+    expect(r.action).toBe('note_session');
+    if (r.action === 'note_session') expect(r.resetsAt.getTime()).toBeGreaterThan(now);
+  });
+
+  it('a clock-less credit/quota exhaustion is note_out_of_credits', () => {
+    expect(classifyCodexRunRefusal("You're out of usage credits", 1)).toEqual({
+      action: 'note_out_of_credits',
+    });
+  });
+
+  it('a clean run (exit 0) clears any stale marker', () => {
+    expect(classifyCodexRunRefusal('done: `main`', 0)).toEqual({ action: 'clear' });
+  });
+
+  it('a usage limit with no parseable reset is left untouched, never persisted as unexpirable', () => {
+    // Without a "try again at <when>", persisting a clock-less marker would
+    // deadlock the account (excluded, so it can never get the successful run that
+    // clears it). Leave it to the cascade (detectRateLimit) instead.
+    expect(classifyCodexRunRefusal("You've hit your usage limit.", 1)).toEqual({ action: 'none' });
+    expect(parseCodexUsageLimitReset("You've hit your usage limit.")).toBeNull();
+  });
+
+  it('an unrelated non-zero exit leaves the marker untouched', () => {
+    expect(classifyCodexRunRefusal('some unrelated error', 1)).toEqual({ action: 'none' });
+    expect(parseCodexUsageLimitReset('some unrelated error')).toBeNull();
   });
 });

--- a/cli/src/lib/exec.test.ts
+++ b/cli/src/lib/exec.test.ts
@@ -1338,6 +1338,23 @@ describe('classifyCodexRunRefusal (PHNX-3859 — codex account marked so rotatio
     expect(classifyCodexRunRefusal('done: `main`', 0)).toEqual({ action: 'clear' });
   });
 
+  it('does NOT fire on transcript content that merely mentions "usage limit" (false-positive guard)', () => {
+    // captureStdoutTail feeds a 16KB tail of the codex transcript, which streams
+    // the whole session — a run that discusses billing/quota code prints "usage
+    // limit" without being the CLI's own refusal. Only "hit your usage limit"
+    // triggers, so a healthy account is never wrongly excluded.
+    const transcript =
+      'Looking at the usage limit handling in billing.ts — the docs say try again at Sep 12th, 2026 8:32 AM if exceeded.';
+    expect(parseCodexUsageLimitReset(transcript)).toBeNull();
+    expect(classifyCodexRunRefusal(transcript, 1)).toEqual({ action: 'none' });
+  });
+
+  it('a reset already in the past is not noted (window recovered), never rolled to a clock', () => {
+    const now = Date.parse('2026-09-20T00:00:00Z'); // after REAL's Sep 12 reset
+    expect(parseCodexUsageLimitReset(REAL, now)).toBeNull();
+    expect(classifyCodexRunRefusal(REAL, 1, now)).toEqual({ action: 'none' });
+  });
+
   it('a usage limit with no parseable reset is left untouched, never persisted as unexpirable', () => {
     // Without a "try again at <when>", persisting a clock-less marker would
     // deadlock the account (excluded, so it can never get the successful run that

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -2571,6 +2571,58 @@ export function classifyClaudeRunRefusal(output: string, exitCode: number): Clau
 }
 
 /**
+ * Parse Codex's usage-limit refusal reset. Codex prints
+ * `ERROR: You've hit your usage limit. … try again at Sep 12th, 2026 8:32 AM.`
+ * (or `…try again at 8:32 AM.` for the 5-hour window). The reset is what makes
+ * this a session-style limit that auto-clears on its clock rather than a
+ * clock-less billing exhaustion. Ordinal suffixes (`12th`) are stripped so
+ * `Date.parse` accepts the date; a time-only reset resolves against today/tomorrow.
+ * Returns null when there is no future reset to parse (caller then leaves the
+ * marker untouched rather than persisting a sticky one it cannot expire).
+ */
+export function parseCodexUsageLimitReset(text: string, nowMs = Date.now()): Date | null {
+  if (!/usage limit/i.test(text)) return null;
+  const match = /try again (?:at|on)\s+([^.\n]+)/i.exec(text);
+  if (!match) return null;
+  const segment = match[1].trim().replace(/(\d{1,2})(st|nd|rd|th)\b/gi, '$1');
+  const absolute = Date.parse(segment);
+  if (!Number.isNaN(absolute) && absolute > nowMs) return new Date(absolute);
+  const clock = /(\d{1,2})(?::(\d{2}))?\s*(am|pm)/i.exec(segment);
+  if (!clock) return null;
+  let hour = Number(clock[1]) % 12;
+  if (clock[3].toLowerCase() === 'pm') hour += 12;
+  const minute = clock[2] ? Number(clock[2]) : 0;
+  const result = new Date(nowMs);
+  result.setHours(hour, minute, 0, 0);
+  if (result.getTime() <= nowMs) result.setDate(result.getDate() + 1);
+  return result;
+}
+
+/**
+ * Classify what a Codex run's output + exit code means for the account's
+ * persisted refusal marker — the Codex sibling of {@link classifyClaudeRunRefusal}
+ * (the `ClaudeRefusalAction` shape is harness-generic; the usage cache it drives
+ * is identity-keyed and shared across harnesses). Codex's usage limit is
+ * time-windowed and carries a reset ("try again at <date>"), so it is noted as a
+ * clock-bearing session limit that auto-clears — NOT a clock-less out_of_credits,
+ * which would stay sticky until a successful run the excluded account can never
+ * get. A genuine credit/quota exhaustion IS clock-less. A clean run clears any
+ * stale marker; a limit with no parseable reset is left untouched (the run still
+ * cascades via detectRateLimit) rather than persisting an unexpirable marker.
+ */
+export function classifyCodexRunRefusal(
+  output: string,
+  exitCode: number,
+  nowMs = Date.now(),
+): ClaudeRefusalAction {
+  const reset = parseCodexUsageLimitReset(output, nowMs);
+  if (reset) return { action: 'note_session', resetsAt: reset };
+  if (detectOutOfCredits(output)) return { action: 'note_out_of_credits' };
+  if (exitCode === 0) return { action: 'clear' };
+  return { action: 'none' };
+}
+
+/**
  * Patterns that indicate an authentication failure — the agent is logged out,
  * its token was revoked, or the session expired. These are the user-visible
  * strings a logged-out agent surfaces (observed across the routine-run corpus).
@@ -2845,22 +2897,27 @@ export async function runWithFallback(options: FallbackOptions): Promise<number>
 
     const output = `${result.stderr}\n${result.stdout}`;
     // Persist a per-account refusal marker so rotation stops re-picking a
-    // known-dead account: a session-limit recovers on its clock, a billing
+    // known-dead account: a session/usage limit recovers on its clock, a billing
     // exhaustion (tokens/credits) recovers only on a later successful run, and a
-    // clean run clears any stale marker. Decision extracted + unit-tested in
-    // classifyClaudeRunRefusal.
+    // clean run clears any stale marker. Claude and Codex both surface these as
+    // run-ending text, and the usage cache is identity-keyed (shared across
+    // harnesses), so one path notes either. Decisions extracted + unit-tested in
+    // classify{Claude,Codex}RunRefusal.
+    const refusal =
+      agent === 'claude'
+        ? classifyClaudeRunRefusal(output, result.exitCode ?? 1)
+        : agent === 'codex'
+          ? classifyCodexRunRefusal(output, result.exitCode ?? 1)
+          : null;
     const sessionLimitReset =
-      agent === 'claude' ? parseClaudeSessionLimitReset(output) : null;
-    if (agent === 'claude' && version) {
-      const refusal = classifyClaudeRunRefusal(output, result.exitCode ?? 1);
-      if (refusal.action !== 'none') {
-        const account = await getAccountInfo(agent, getVersionHomePath(agent, version));
-        const usageKey = getUsageLookupKey(account);
-        if (usageKey) {
-          if (refusal.action === 'note_session') noteClaudeSessionLimit(usageKey, refusal.resetsAt);
-          else if (refusal.action === 'note_out_of_credits') noteClaudeOutOfCredits(usageKey);
-          else if (refusal.action === 'clear') clearClaudeAccountRefusal(usageKey);
-        }
+      refusal?.action === 'note_session' ? refusal.resetsAt : null;
+    if (refusal && version && refusal.action !== 'none') {
+      const account = await getAccountInfo(agent, getVersionHomePath(agent, version));
+      const usageKey = getUsageLookupKey(account);
+      if (usageKey) {
+        if (refusal.action === 'note_session') noteClaudeSessionLimit(usageKey, refusal.resetsAt);
+        else if (refusal.action === 'note_out_of_credits') noteClaudeOutOfCredits(usageKey);
+        else if (refusal.action === 'clear') clearClaudeAccountRefusal(usageKey);
       }
     }
 

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -2581,12 +2581,25 @@ export function classifyClaudeRunRefusal(output: string, exitCode: number): Clau
  * marker untouched rather than persisting a sticky one it cannot expire).
  */
 export function parseCodexUsageLimitReset(text: string, nowMs = Date.now()): Date | null {
-  if (!/usage limit/i.test(text)) return null;
+  // Gate on the CLI's own refusal phrasing, NOT a bare "usage limit" substring:
+  // this runs against a 16KB stdout tail of `codex exec`, which streams the whole
+  // agent transcript, so a session that merely *discusses* usage-limit code would
+  // otherwise false-positive and wrongly mark a HEALTHY account excluded. Mirrors
+  // the narrow Claude convention (`hit your session limit`).
+  if (!/hit your usage limit/i.test(text)) return null;
   const match = /try again (?:at|on)\s+([^.\n]+)/i.exec(text);
   if (!match) return null;
   const segment = match[1].trim().replace(/(\d{1,2})(st|nd|rd|th)\b/gi, '$1');
   const absolute = Date.parse(segment);
-  if (!Number.isNaN(absolute) && absolute > nowMs) return new Date(absolute);
+  if (!Number.isNaN(absolute)) {
+    // A full date parsed — honor it only while still in the future; a past reset
+    // means the window already recovered, so there is nothing to note. Do NOT
+    // fall through to the clock path, which would understate the real date as
+    // today/tomorrow.
+    return absolute > nowMs ? new Date(absolute) : null;
+  }
+  // No date parsed — the 5-hour "try again at 8:32 AM" (time-only) form. Resolve
+  // it against today, rolling to tomorrow when the clock has already passed.
   const clock = /(\d{1,2})(?::(\d{2}))?\s*(am|pm)/i.exec(segment);
   if (!clock) return null;
   let hour = Number(clock[1]) % 12;


### PR DESCRIPTION
## What

When a headless `agents run codex` ends with `You've hit your usage limit … try again at <date>` (or an out-of-credits refusal), the account's throttle was **never recorded**. The per-account refusal-noting in `exec.ts` was gated `agent === 'claude'`, so the balanced picker kept selecting the exhausted codex account from a stale usage snapshot and every subsequent run died the same way instead of rotating to a healthy sibling.

This is the `Ask 4` reliability gap surfaced by PHNX-3899 (codex undispatchable fleet-wide) and the exact class PHNX-3859 names.

## Root cause (evidence)

Reproduced 2026-09-06 on `yosemite-s1` — the picker chose `gmail` (shown at `W: 59%` by `agents view`, but actually over its weekly limit) and the run died without rotating to healthy `icloud`/`smores`:

```
$ agents run codex "print the current git branch" --mode auto
[agents] account 'gmail' · codex
...
ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage
to purchase more credits or try again at Sep 12th, 2026 8:32 AM.
# exit 1 — gmail never marked, next run re-picks it
```

Pinning a healthy account proves the run path itself is fine:
```
$ agents run codex "print the current git branch" --mode auto --account icloud
exec /usr/bin/zsh -lc 'git branch --show-current'  succeeded in 0ms: main
codex: `main`   # exit 0
```

The usage cache (`claude-usage.json`) is **already identity-keyed and shared across harnesses** (`usage.ts`: "keyed by usageKey, namespaced per agent … one cache file holds every account"), and `deriveUsageStatusFromSnapshot` already honors an `unavailable` marker to exclude a candidate. The only missing piece was the writer wiring for codex.

## Change

- `classifyCodexRunRefusal` + `parseCodexUsageLimitReset` in `exec.ts` — the codex sibling of `classifyClaudeRunRefusal`. Codex's limit is time-windowed and carries a reset, so it is noted as a **clock-bearing session limit** that auto-clears — **not** a clock-less `out_of_credits` (which would deadlock the account: excluded, so it can never get the successful run that clears it). A genuine credit/quota exhaustion is clock-less; a limit with **no** parseable reset is left untouched (the run still cascades via `detectRateLimit`) rather than persisting an unexpirable marker.
- The run-exit block now notes claude **and** codex through the shared, identity-keyed cache functions. Behavior for claude is unchanged (the derived `sessionLimitReset` is equivalent).

Effect: `collectRunCandidates` excludes the dead codex account on the next pick, `agents view` shows it throttled, and the balanced picker rotates to a healthy sibling.

## Tests

`cli/src/lib/exec.test.ts` — new `classifyCodexRunRefusal` block (7 cases) exercising the **real** reproduced error string: reset parses to a future `Date` (ordinal stripped), note_session vs clock-less out_of_credits, clean-run clear, and the no-parseable-reset → `none` guard against a deadlocking sticky marker.

```
exec.test.ts       148 passed
rotate + usage     220 passed
tsc --noEmit       clean
```

## Scope

Codex-specific by design — codex is the harness whose runtime usage-limit was unrecorded (the reproduced failure). Claude already had this; the other token harnesses surface limits differently and are out of scope for this fix. Relates PHNX-3899, closes the account-selection half of PHNX-3859.
