### PR TITLE
refactor(workflows): WORKFLOW_TARGETS registry behind sync, list, remove, drift, and the detector (PHNX-3993)

### DIFF
--- a/cli/.changelog/next/PHNX-3993-workflow-targets-registry.md
+++ b/cli/.changelog/next/PHNX-3993-workflow-targets-registry.md
@@ -1,0 +1,11 @@
+- **Workflows sync through one per-harness registry (PHNX-3993).** How each
+  workflows-capable harness stores a synced workflow (Claude bundle dir, Kimi flow
+  skill, Antigravity global_workflows file, Goose recipe, OpenClaw Lobster, Grok
+  Rhai) is declared once in `WORKFLOW_TARGETS`; sync, list, remove, the `agents
+  doctor` drift check, and the staleness detector are generic over it, where they
+  previously each branched on the harness id and the detector kept its own copy of
+  the ownership-marker parsers. Paths, markers, and error text are unchanged; a
+  foreign Kimi `<name>/` skill dir now blocks a sync the same way a foreign file
+  blocks the other harnesses instead of being written into. A completeness test
+  pins the table to `capableAgents('workflows')`. Source:
+  `cli/src/lib/workflows-registry.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1287,6 +1287,7 @@ src/
     agents.ts          # re-exports agent-spec/agents.ts (per-agent capability table)
     agent-spec/        # version-resolution engine + AGENTS table
     subagents-registry.ts  # SUBAGENT_TARGETS — declarative per-agent subagent shape (dir/layout/transform); generic install/list/remove engine
+    workflows-registry.ts  # WORKFLOW_TARGETS — declarative per-agent workflow shape (dir/layout/transform/marker); generic sync/list/remove/drift engine the staleness detector also reads
     installations/     # versions.ts (install, remove, syncResourcesToVersion), migrate.ts (one-shot idempotent migrations), store/resolve/strategies, shims.ts (shim generation, config symlink switching)
     hooks/             # hooks.yaml parser + per-agent registrar (install.ts), `matches:` evaluator (match.ts), cache/profile adapters
     browser/           # browser IPC service hosted by the shared daemon + existing CDP connection pool; browser clients may enable/disable this service but never stop/restart the shared daemon; registry.ts is the leaf (who declared what — never whether this machine should); resolve-target.ts is three outcomes (local / tunnel / loud undeclared); task-index.ts binds --device at start so later verbs resolve the task; ipc.ts owns one-shot and persistent socket clients, stream.ts owns the NDJSON action loop; hygiene.ts is the abandoned-task reaper (session-dead + idle, RUSH-2622) the daemon's 5-min tick and `agents browser prune` (alias `gc`) both call

--- a/cli/docs/resource-sync.md
+++ b/cli/docs/resource-sync.md
@@ -550,5 +550,6 @@ Behavior rules, per `src/lib/plugins.ts:379` and `src/lib/plugin-marketplace.ts`
 | `syncResourcesToVersion()` | versions.ts | Create symlinks in version home |
 | `pruneRemovedResources()` | staleness/prune.ts | Remove version-home resources deleted from source (manifest-bounded) |
 | `markdownToToml()` | convert.ts | Legacy command TOML conversion helper |
-| `syncWorkflowToGooseRecipe()` | workflows.ts | Convert workflows into Goose recipes and subrecipes |
+| `WORKFLOW_TARGETS` | workflows-registry.ts | Per-harness workflow shape (dir, layout, transform, ownership marker); `syncWorkflowToVersion` / `listWorkflowsForAgent` / `removeWorkflowFromVersion` / `workflowContentMatches` and the staleness detector are generic over it |
+| `renderGooseRecipeYaml()` | workflows.ts | Render the Goose recipe YAML the `goose` target writes and the drift check compares |
 | `transformWorkflowForOpenClaw()` | workflows.ts | Convert workflows into Lobster `.lobster` files |

--- a/cli/src/commands/workflows.ts
+++ b/cli/src/commands/workflows.ts
@@ -23,12 +23,11 @@ import {
   installWorkflowCentrally,
   removeWorkflow,
   listInstalledWorkflows,
-  listWorkflowsForAgent,
-  removeWorkflowFromVersion,
   iterWorkflowsCapableVersions,
   type WorkflowFrontmatter,
   type InstalledWorkflow,
 } from '../lib/workflows.js';
+import { listWorkflowsForAgent, removeWorkflowFromVersion } from '../lib/workflows-registry.js';
 import {
   getVersionHomePath,
   getGlobalDefault,

--- a/cli/src/lib/doctor-diff.ts
+++ b/cli/src/lib/doctor-diff.ts
@@ -55,7 +55,8 @@ import { dirsContentMatch, filesContentMatch } from './resource-content-diff.js'
 import { subagentContentMatches } from './subagents-registry.js';
 import { getMcpServersByName, mcpServerMatches } from './mcp.js';
 import { permissionsGroupMatches, PERMISSIONS_REPRESENTABLE } from './permissions.js';
-import { workflowContentMatches, resolveWorkflowRef } from './workflows.js';
+import { resolveWorkflowRef } from './workflows.js';
+import { workflowContentMatches } from './workflows-registry.js';
 import { listMemoryFacts, memoryTargetDir } from './memory.js';
 import {
   getAvailableResources,

--- a/cli/src/lib/installations/versions.ts
+++ b/cli/src/lib/installations/versions.ts
@@ -58,7 +58,7 @@ export * from './store.js';
 import { INSTALLATION_RECORD_FILE } from './types.js';
 import { composeWin32CommandLine } from '../platform/index.js';
 import { listInstalledSubagents, transformSubagentForClaude, syncSubagentToOpenclaw } from '../subagents.js';
-import { listInstalledWorkflows, syncWorkflowToVersion } from '../workflows.js';
+import { listInstalledWorkflows } from '../workflows.js';
 import { parseHookManifest, registerHooksToSettings, selectHookManifest, pruneVersionHomeHookEntriesFromSettings, installSessionTrackerHookSync, installSessionTrackerHook } from '../hooks/install.js';
 import { supports, explainSkip, capableAgents } from '../capabilities.js';
 import { discoverPlugins, syncPluginToVersion, isPluginSynced, pluginSupportsAgent, cleanOrphanedPluginSkills, marketplaceSpecForName } from '../plugins/plugins.js';

--- a/cli/src/lib/project-resources.ts
+++ b/cli/src/lib/project-resources.ts
@@ -10,7 +10,7 @@ import { safeJoin } from './paths.js';
 import { subagentTarget } from './subagents-registry.js';
 import { parseSubagentFrontmatter } from './subagents.js';
 import type { AgentId, InstalledSubagent } from './types.js';
-import { syncWorkflowToVersion } from './workflows.js';
+import { syncWorkflowToVersion } from './workflows-registry.js';
 
 const MANIFEST_FILE = '.agents-managed.json';
 const MANIFEST_VERSION = 1;

--- a/cli/src/lib/staleness/detectors/workflows.ts
+++ b/cli/src/lib/staleness/detectors/workflows.ts
@@ -1,15 +1,14 @@
 /**
- * Workflows detector — scans the agent-specific on-disk layout for synced
- * workflow names (Claude WORKFLOW.md trees, Kimi flow skills, Antigravity
- * global_workflows, Goose recipes, OpenClaw Lobster, Grok Rhai).
+ * Workflows detector — lists the workflows agents-cli has synced into a
+ * version home, in that harness's native layout (Claude WORKFLOW.md trees,
+ * Kimi flow skills, Antigravity global_workflows, Goose recipes, OpenClaw
+ * Lobster, Grok Rhai). The layout is not repeated here: the detector reads the
+ * same `WORKFLOW_TARGETS` entry the writer materializes through, so the two
+ * can never disagree about what counts as synced.
  */
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import * as yaml from 'yaml';
 import type { AgentId } from '../../types.js';
 import { capableAgents } from '../../capabilities.js';
-import { grokWorkflowMarker } from '../../workflows.js';
+import { workflowTarget } from '../../workflows-registry.js';
 import type { ResourceDetector, DetectArgs } from './types.js';
 import { lazyAgentMap } from '../writers/lazy-map.js';
 
@@ -18,87 +17,8 @@ function buildWorkflowsDetector(agent: AgentId): ResourceDetector {
     kind: 'workflows',
     agent,
     list({ versionHome }: DetectArgs): string[] {
-      if (agent === 'kimi') {
-        const skillsDir = path.join(versionHome, '.kimi-code', 'skills');
-        if (!fs.existsSync(skillsDir)) return [];
-        return fs.readdirSync(skillsDir, { withFileTypes: true })
-          .filter(d => d.isDirectory() && fs.existsSync(path.join(skillsDir, d.name, 'SKILL.md')))
-          .filter(d => {
-            try {
-              const skill = fs.readFileSync(path.join(skillsDir, d.name, 'SKILL.md'), 'utf-8');
-              const lines = skill.split('\n');
-              if (lines[0] !== '---') return false;
-              const endIndex = lines.slice(1).findIndex(l => l === '---');
-              if (endIndex < 0) return false;
-              const parsed = yaml.parse(lines.slice(1, endIndex + 1).join('\n')) as { type?: unknown; agents_workflow?: unknown } | null;
-              return parsed?.type === 'flow' && parsed.agents_workflow === d.name;
-            } catch { return false; }
-          })
-          .map(d => d.name);
-      }
-
-      if (agent === 'antigravity') {
-        // Antigravity user workflows are HOME-global and shared across versions,
-        // not version-isolated — see workflows.ts:antigravityWorkflowsDir(). agy
-        // scans the real ~/.gemini/config/global_workflows/, so the detector reads
-        // the same shared dir the writer targets (versionHome is intentionally unused).
-        const dir = path.join(process.env.HOME ?? os.homedir(), '.gemini', 'config', 'global_workflows');
-        if (!fs.existsSync(dir)) return [];
-        return fs.readdirSync(dir, { withFileTypes: true })
-          .filter(d => d.isFile() && d.name.endsWith('.md') && !d.name.startsWith('.'))
-          .filter(d => {
-            try {
-              const content = fs.readFileSync(path.join(dir, d.name), 'utf-8');
-              const lines = content.split('\n');
-              if (lines[0] !== '---') return false;
-              const endIndex = lines.slice(1).findIndex(l => l === '---');
-              if (endIndex < 0) return false;
-              const parsed = yaml.parse(lines.slice(1, endIndex + 1).join('\n')) as { agents_workflow?: unknown } | null;
-              return parsed?.agents_workflow === d.name.slice(0, -'.md'.length);
-            } catch { return false; }
-          })
-          .map(d => d.name.slice(0, -'.md'.length));
-      }
-
-      if (agent === 'goose') {
-        const recipesDir = path.join(versionHome, '.config', 'goose', 'recipes');
-        if (!fs.existsSync(recipesDir)) return [];
-        return fs.readdirSync(recipesDir, { withFileTypes: true })
-          .filter(d => d.isFile() && d.name.endsWith('.yaml') && !d.name.startsWith('.'))
-          .map(d => d.name.slice(0, -'.yaml'.length));
-      }
-
-      if (agent === 'openclaw') {
-        const dir = path.join(versionHome, '.openclaw', 'workflows');
-        if (!fs.existsSync(dir)) return [];
-        return fs.readdirSync(dir, { withFileTypes: true })
-          .filter(d => d.isFile() && d.name.endsWith('.lobster') && !d.name.startsWith('.'))
-          .filter(d => {
-            try {
-              const parsed = yaml.parse(fs.readFileSync(path.join(dir, d.name), 'utf-8')) as { env?: unknown } | null;
-              const env = parsed && typeof parsed === 'object' && parsed.env && typeof parsed.env === 'object' && !Array.isArray(parsed.env)
-                ? parsed.env as Record<string, unknown>
-                : {};
-              return env.AGENTS_CLI_WORKFLOW === d.name.slice(0, -'.lobster'.length);
-            } catch { return false; }
-          })
-          .map(d => d.name.slice(0, -'.lobster'.length));
-      }
-
-      if (agent === 'grok') {
-        const workflowsDir = path.join(versionHome, '.grok', 'workflows');
-        if (!fs.existsSync(workflowsDir)) return [];
-        return fs.readdirSync(workflowsDir, { withFileTypes: true })
-          .filter(d => d.isFile() && d.name.endsWith('.rhai') && !d.name.startsWith('.'))
-          .filter(d => grokWorkflowMarker(path.join(workflowsDir, d.name)) === d.name.slice(0, -'.rhai'.length))
-          .map(d => d.name.slice(0, -'.rhai'.length));
-      }
-
-      const workflowsDir = path.join(versionHome, 'workflows');
-      if (!fs.existsSync(workflowsDir)) return [];
-      return fs.readdirSync(workflowsDir, { withFileTypes: true })
-        .filter(d => d.isDirectory() && fs.existsSync(path.join(workflowsDir, d.name, 'WORKFLOW.md')))
-        .map(d => d.name);
+      const target = workflowTarget(agent);
+      return target.names(target.dir(versionHome));
     },
   };
 }

--- a/cli/src/lib/staleness/writers/workflows.ts
+++ b/cli/src/lib/staleness/writers/workflows.ts
@@ -1,12 +1,12 @@
 /**
- * Workflows writer — copies each selected workflow into the agent-specific
- * on-disk layout via `syncWorkflowToVersion` (Claude: WORKFLOW.md tree under
- * `{versionHome}/workflows/`; Grok: native `.rhai` under
- * `{versionHome}/.grok/workflows/`).
+ * Workflows writer — materializes each selected workflow into the harness's
+ * native layout via `syncWorkflowToVersion`, which is generic over
+ * `WORKFLOW_TARGETS` (workflows-registry.ts).
  */
 import type { AgentId } from '../../types.js';
 import { capableAgents } from '../../capabilities.js';
-import { listInstalledWorkflows, syncWorkflowToVersion } from '../../workflows.js';
+import { listInstalledWorkflows } from '../../workflows.js';
+import { syncWorkflowToVersion } from '../../workflows-registry.js';
 import type { ResourceWriter, WriteArgs, WriteResult } from './types.js';
 import { lazyAgentMap } from './lazy-map.js';
 

--- a/cli/src/lib/workflows-registry.test.ts
+++ b/cli/src/lib/workflows-registry.test.ts
@@ -117,6 +117,24 @@ describe('ownership markers refuse to clobber user-authored files', () => {
     expect(listWorkflowsForAgent('kimi', home)).toEqual([]);
   });
 
+  it('kimi: a foreign <name>/ dir with no SKILL.md is refused too, never written into', () => {
+    // The one deliberate tightening over the old arms: presence of the dir is
+    // the collision, the marker decides ownership. Old code only looked at the
+    // file and would have dropped SKILL.md into a user's directory.
+    const home = tmp('agents-wf-registry-kimi-bare-dir-');
+    const workflowDir = writeWorkflow('---\nname: F\ndescription: d\n---\n\nbody\n');
+    const foreign = path.join(home, '.kimi-code', 'skills', 'flow');
+    fs.mkdirSync(foreign, { recursive: true });
+    fs.writeFileSync(path.join(foreign, 'notes.txt'), 'user files live here', 'utf-8');
+
+    expect(syncWorkflowToVersion(workflowDir, 'flow', 'kimi', home)).toEqual({
+      success: false,
+      error: "Kimi skill 'flow' already exists and is not managed by agents-cli",
+    });
+    expect(fs.existsSync(path.join(foreign, 'SKILL.md'))).toBe(false);
+    expect(fs.readdirSync(foreign)).toEqual(['notes.txt']);
+  });
+
   it('grok: the rendered file carries the marker the lister and detector key on', () => {
     const home = tmp('agents-wf-registry-grok-');
     const workflowDir = writeWorkflow('---\nname: G\ndescription: d\n---\n\nbody\n');

--- a/cli/src/lib/workflows-registry.test.ts
+++ b/cli/src/lib/workflows-registry.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { capableAgents } from './capabilities.js';
+import { workflowsDetectors } from './staleness/detectors/workflows.js';
+import {
+  WORKFLOW_TARGETS,
+  listWorkflowsForAgent,
+  syncWorkflowToVersion,
+  workflowContentMatches,
+  workflowTarget,
+} from './workflows-registry.js';
+import type { AgentId } from './types.js';
+
+const tmpDirs: string[] = [];
+function tmp(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function writeWorkflow(body: string): string {
+  const dir = tmp('agents-wf-registry-src-');
+  fs.writeFileSync(path.join(dir, 'WORKFLOW.md'), body, 'utf-8');
+  return dir;
+}
+
+/** Antigravity's store is HOME-global, so point HOME at the fake home for the test. */
+function withHome<T>(home: string, fn: () => T): T {
+  const real = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    return fn();
+  } finally {
+    if (real === undefined) delete process.env.HOME; else process.env.HOME = real;
+  }
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('workflow registry completeness', () => {
+  it('has a shape for exactly every workflows-capable agent', () => {
+    // The `workflows` capability flag is the version gate; this table is the
+    // shape. A harness with one and not the other is a lying capability table.
+    const capable = capableAgents('workflows').sort();
+    const shaped = Object.keys(WORKFLOW_TARGETS).sort();
+    expect(shaped).toEqual(capable);
+  });
+
+  it('fails loud for a harness with no workflow shape', () => {
+    const uncapable = (['codex', 'cursor', 'gemini'] as AgentId[]).find((a) => !(a in WORKFLOW_TARGETS));
+    expect(uncapable).toBeDefined();
+    expect(() => workflowTarget(uncapable!)).toThrow(/no workflow target/);
+  });
+});
+
+describe('writer, lister, detector, and doctor drift agree per harness', () => {
+  const source = '---\nname: Registry Flow\ndescription: Round-trip through the registry\n---\n\nDo the work.\n';
+
+  for (const agent of capableAgents('workflows')) {
+    it(`${agent}: sync → list → detect → drift → remove round-trips through one table`, () => {
+      const home = tmp(`agents-wf-registry-${agent}-home-`);
+      withHome(home, () => {
+        const workflowDir = writeWorkflow(source);
+        const detector = workflowsDetectors[agent]!;
+        const detect = () => detector.list({ version: '0.0.0', versionHome: home, cwd: home });
+
+        expect(listWorkflowsForAgent(agent, home)).toEqual([]);
+        expect(detect()).toEqual([]);
+
+        const synced = syncWorkflowToVersion(workflowDir, 'registry-flow', agent, home);
+        expect(synced).toEqual({ success: true });
+
+        // The detector (what `agents doctor` believes is installed) and the
+        // lister (what `agents workflows` shows) read the same registry entry.
+        expect(listWorkflowsForAgent(agent, home)).toEqual(['registry-flow']);
+        expect(detect()).toEqual(['registry-flow']);
+        expect(workflowContentMatches(agent, home, 'registry-flow', workflowDir)).toBe(true);
+
+        // A body edit to the source under an unchanged name is drift, not `ok`.
+        fs.writeFileSync(path.join(workflowDir, 'WORKFLOW.md'), source.replace('Do the work.', 'Do different work.'), 'utf-8');
+        expect(workflowContentMatches(agent, home, 'registry-flow', workflowDir)).toBe(false);
+
+        // Re-sync is idempotent over an agents-cli-managed copy and clears the drift.
+        expect(syncWorkflowToVersion(workflowDir, 'registry-flow', agent, home)).toEqual({ success: true });
+        expect(workflowContentMatches(agent, home, 'registry-flow', workflowDir)).toBe(true);
+
+        // Removal goes through the same occupied() the writer populated.
+        const target = workflowTarget(agent);
+        const dir = target.dir(home);
+        for (const entry of target.occupied(dir, 'registry-flow')) fs.rmSync(entry, { recursive: true, force: true });
+        expect(target.occupied(dir, 'registry-flow')).toEqual([]);
+        expect(listWorkflowsForAgent(agent, home)).toEqual([]);
+        expect(detect()).toEqual([]);
+        expect(workflowContentMatches(agent, home, 'registry-flow', workflowDir)).toBe(false);
+      });
+    });
+  }
+});
+
+describe('ownership markers refuse to clobber user-authored files', () => {
+  it('kimi: a foreign <name>/ skill dir blocks sync with the harness label in the error', () => {
+    const home = tmp('agents-wf-registry-kimi-foreign-');
+    const workflowDir = writeWorkflow('---\nname: F\ndescription: d\n---\n\nbody\n');
+    const foreign = path.join(home, '.kimi-code', 'skills', 'flow');
+    fs.mkdirSync(foreign, { recursive: true });
+    fs.writeFileSync(path.join(foreign, 'SKILL.md'), '---\nname: flow\ndescription: mine\n---\n\nhand-written\n', 'utf-8');
+
+    expect(syncWorkflowToVersion(workflowDir, 'flow', 'kimi', home)).toEqual({
+      success: false,
+      error: "Kimi skill 'flow' already exists and is not managed by agents-cli",
+    });
+    expect(fs.readFileSync(path.join(foreign, 'SKILL.md'), 'utf-8')).toContain('hand-written');
+    expect(listWorkflowsForAgent('kimi', home)).toEqual([]);
+  });
+
+  it('grok: the rendered file carries the marker the lister and detector key on', () => {
+    const home = tmp('agents-wf-registry-grok-');
+    const workflowDir = writeWorkflow('---\nname: G\ndescription: d\n---\n\nbody\n');
+    expect(syncWorkflowToVersion(workflowDir, 'g-flow', 'grok', home).success).toBe(true);
+    const rendered = fs.readFileSync(path.join(home, '.grok', 'workflows', 'g-flow.rhai'), 'utf-8');
+    expect(rendered.split('\n')[0]).toBe('// agents_workflow: g-flow');
+    // Strip the marker: the file is now user-owned and disappears from both views.
+    fs.writeFileSync(path.join(home, '.grok', 'workflows', 'g-flow.rhai'), rendered.split('\n').slice(1).join('\n'), 'utf-8');
+    expect(listWorkflowsForAgent('grok', home)).toEqual([]);
+    expect(workflowsDetectors.grok!.list({ version: '0.0.0', versionHome: home, cwd: home })).toEqual([]);
+    expect(syncWorkflowToVersion(workflowDir, 'g-flow', 'grok', home)).toEqual({
+      success: false,
+      error: "Grok workflow 'g-flow' already exists and is not managed by agents-cli",
+    });
+  });
+});

--- a/cli/src/lib/workflows-registry.ts
+++ b/cli/src/lib/workflows-registry.ts
@@ -1,0 +1,368 @@
+/**
+ * Workflow target registry — the ONE place that says how each
+ * workflows-capable harness stores a synced workflow on disk.
+ *
+ * `WORKFLOW_TARGETS` is the declarative shape (container dir, file layout,
+ * transform, ownership marker); the engine below (`listWorkflowsForAgent`,
+ * `syncWorkflowToVersion`, `removeWorkflowFromVersion`,
+ * `workflowContentMatches`) and the staleness detector are generic over it, so
+ * adding a harness is one entry here plus its `workflows` capability flag in
+ * `agent-spec/agents.ts` — never another `if (agent === '...')` arm in the
+ * writer, the lister, the remover, the doctor drift check, and the detector.
+ * A completeness test pins `Object.keys(WORKFLOW_TARGETS)` to
+ * `capableAgents('workflows')` so the flag and the shape cannot drift.
+ *
+ * Same pattern as `SUBAGENT_TARGETS` in `subagents-registry.ts`.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AgentId } from './types.js';
+import { capableAgents } from './capabilities.js';
+import { getVersionHomePath } from './installations/versions.js';
+import { dirsContentMatch, normalizeResourceContent } from './resource-content-diff.js';
+import {
+  antigravityWorkflowMarker,
+  antigravityWorkflowsDir,
+  grokWorkflowMarker,
+  kimiWorkflowMarker,
+  openclawWorkflowMarker,
+  parseWorkflowFrontmatter,
+  renderGooseRecipeYaml,
+  selectedWorkflowSubagents,
+  transformWorkflowForAntigravity,
+  transformWorkflowForGrok,
+  transformWorkflowForKimi,
+  transformWorkflowForOpenClaw,
+  writeGooseSubrecipe,
+} from './workflows.js';
+
+/** A central workflow bundle: its synced name and the source dir holding WORKFLOW.md. */
+export interface WorkflowSource {
+  name: string;
+  path: string;
+}
+
+/**
+ * The complete on-disk contract for one harness's workflows. Every operation
+ * is expressed here so the engine below never branches on the agent id.
+ */
+export interface WorkflowTarget {
+  /** Noun used in ownership errors, e.g. "Kimi skill", "Grok workflow". */
+  readonly label: string;
+  /**
+   * Absolute container dir for `versionHome`. A harness whose native store is
+   * HOME-global (antigravity) ignores `versionHome` and resolves from `$HOME`.
+   */
+  dir(versionHome: string): string;
+  /** Names of the workflows in `dir` that agents-cli manages (lister + detector). */
+  names(dir: string): string[];
+  /** Materialize `wf` into `dir`. Throws on an invalid source or fs error. */
+  write(dir: string, wf: WorkflowSource): void;
+  /** Paths workflow `name` occupies in `dir`; empty when it is not installed. */
+  occupied(dir: string, name: string): string[];
+  /**
+   * Ownership of what sits at `name` in `dir`: `null` when nothing is there,
+   * `true` when agents-cli wrote it (or the format has no ownership marker),
+   * `false` when a user-authored file of the same name is in the way.
+   */
+  managed(dir: string, name: string): boolean | null;
+  /**
+   * True when the installed copy byte-matches what `write` would render from
+   * `wf.path` NOW — the drift predicate `agents doctor` uses. Re-renders the
+   * current source through the same transform the writer uses (never a stored
+   * hash), so a body edit to the source surfaces as drift under an unchanged name.
+   */
+  matches(dir: string, wf: WorkflowSource): boolean;
+}
+
+function readdirSafe(dir: string): fs.Dirent[] {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function renderedMatches(homePath: string, expected: string): boolean {
+  let actual: string;
+  try {
+    actual = fs.readFileSync(homePath, 'utf-8');
+  } catch {
+    return false;
+  }
+  return normalizeResourceContent(actual) === normalizeResourceContent(expected);
+}
+
+// ── layouts ──────────────────────────────────────────────────────────────────
+
+/**
+ * One rendered `<name><ext>` file per workflow, owned via a marker the
+ * transform embeds (antigravity, openclaw, grok).
+ */
+function renderedFile(opts: {
+  label: string;
+  dir: (versionHome: string) => string;
+  ext: string;
+  transform: (workflowPath: string, name: string) => string;
+  marker: (filePath: string) => string | null;
+}): WorkflowTarget {
+  const file = (dir: string, name: string): string => path.join(dir, `${name}${opts.ext}`);
+  return {
+    label: opts.label,
+    dir: opts.dir,
+    names(dir) {
+      return readdirSafe(dir)
+        .filter((d) => d.isFile() && d.name.endsWith(opts.ext) && !d.name.startsWith('.'))
+        .map((d) => d.name.slice(0, -opts.ext.length))
+        .filter((base) => opts.marker(file(dir, base)) === base);
+    },
+    write(dir, wf) {
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(file(dir, wf.name), opts.transform(wf.path, wf.name), 'utf-8');
+    },
+    occupied(dir, name) {
+      const target = file(dir, name);
+      return fs.existsSync(target) ? [target] : [];
+    },
+    managed(dir, name) {
+      const target = file(dir, name);
+      if (!fs.existsSync(target)) return null;
+      return opts.marker(target) === name;
+    },
+    matches(dir, wf) {
+      return renderedMatches(file(dir, wf.name), opts.transform(wf.path, wf.name));
+    },
+  };
+}
+
+/**
+ * Kimi flow skill: a `<name>/SKILL.md` directory whose frontmatter carries
+ * `type: flow` and the `agents_workflow` marker.
+ */
+const kimiFlowSkill: WorkflowTarget = {
+  label: 'Kimi skill',
+  dir: (versionHome) => path.join(versionHome, '.kimi-code', 'skills'),
+  names(dir) {
+    return readdirSafe(dir)
+      .filter((d) => d.isDirectory() && fs.existsSync(path.join(dir, d.name, 'SKILL.md')))
+      .filter((d) => kimiWorkflowMarker(path.join(dir, d.name, 'SKILL.md')) === d.name)
+      .map((d) => d.name);
+  },
+  write(dir, wf) {
+    const skillDir = path.join(dir, wf.name);
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), transformWorkflowForKimi(wf.path, wf.name), 'utf-8');
+  },
+  occupied(dir, name) {
+    const skillDir = path.join(dir, name);
+    return fs.existsSync(skillDir) ? [skillDir] : [];
+  },
+  managed(dir, name) {
+    const skillDir = path.join(dir, name);
+    if (!fs.existsSync(skillDir)) return null;
+    return kimiWorkflowMarker(path.join(skillDir, 'SKILL.md')) === name;
+  },
+  matches(dir, wf) {
+    return renderedMatches(path.join(dir, wf.name, 'SKILL.md'), transformWorkflowForKimi(wf.path, wf.name));
+  },
+};
+
+/**
+ * Goose recipe: `<name>.yaml` plus a `<name>.subrecipes/` dir holding one YAML
+ * per selected workflow subagent. Goose has no ownership marker, so presence
+ * is ownership.
+ */
+const gooseRecipe: WorkflowTarget = {
+  label: 'Goose recipe',
+  dir: (versionHome) => path.join(versionHome, '.config', 'goose', 'recipes'),
+  names(dir) {
+    return readdirSafe(dir)
+      .filter((d) => d.isFile() && d.name.endsWith('.yaml') && !d.name.startsWith('.'))
+      .map((d) => d.name.slice(0, -'.yaml'.length));
+  },
+  write(dir, wf) {
+    const frontmatter = parseWorkflowFrontmatter(wf.path);
+    const recipeYaml = frontmatter ? renderGooseRecipeYaml(wf.path, wf.name) : null;
+    if (!frontmatter || recipeYaml == null) {
+      throw new Error(`Workflow '${wf.name}' has invalid WORKFLOW.md frontmatter`);
+    }
+    const subrecipesDir = path.join(dir, `${wf.name}.subrecipes`);
+    fs.mkdirSync(dir, { recursive: true });
+    if (fs.existsSync(subrecipesDir)) {
+      fs.rmSync(subrecipesDir, { recursive: true, force: true });
+    }
+    for (const subagentName of selectedWorkflowSubagents(wf.path, frontmatter.allowedAgents)) {
+      writeGooseSubrecipe(wf.path, subagentName, subrecipesDir);
+    }
+    fs.writeFileSync(path.join(dir, `${wf.name}.yaml`), recipeYaml, 'utf-8');
+  },
+  occupied(dir, name) {
+    return [path.join(dir, `${name}.yaml`), path.join(dir, `${name}.subrecipes`)].filter((p) => fs.existsSync(p));
+  },
+  managed(dir, name) {
+    return gooseRecipe.occupied(dir, name).length > 0 ? true : null;
+  },
+  matches(dir, wf) {
+    const expected = renderGooseRecipeYaml(wf.path, wf.name);
+    if (expected == null) return false;
+    return renderedMatches(path.join(dir, `${wf.name}.yaml`), expected);
+  },
+};
+
+/**
+ * The canonical bundle copied verbatim: `<name>/WORKFLOW.md` (plus its
+ * subagents/ tree) under `{versionHome}/workflows/`. No marker — the dir is
+ * agents-cli's by construction.
+ */
+const workflowBundle: WorkflowTarget = {
+  label: 'Workflow',
+  dir: (versionHome) => path.join(versionHome, 'workflows'),
+  names(dir) {
+    return readdirSafe(dir)
+      .filter((d) => d.isDirectory() && fs.existsSync(path.join(dir, d.name, 'WORKFLOW.md')))
+      .map((d) => d.name);
+  },
+  write(dir, wf) {
+    const target = path.join(dir, wf.name);
+    fs.mkdirSync(dir, { recursive: true });
+    if (fs.existsSync(target)) {
+      fs.rmSync(target, { recursive: true, force: true });
+    }
+    fs.cpSync(wf.path, target, { recursive: true });
+  },
+  occupied(dir, name) {
+    const target = path.join(dir, name);
+    return fs.existsSync(target) ? [target] : [];
+  },
+  managed(dir, name) {
+    return fs.existsSync(path.join(dir, name)) ? true : null;
+  },
+  matches(dir, wf) {
+    return dirsContentMatch(wf.path, path.join(dir, wf.name));
+  },
+};
+
+// ── the registry ─────────────────────────────────────────────────────────────
+
+/**
+ * Single source of truth for how each workflows-capable harness stores
+ * workflows. The keys MUST match `capableAgents('workflows')` (the `workflows`
+ * flag in `agent-spec/agents.ts`): the capability flag is the version gate,
+ * this table is the shape.
+ */
+export const WORKFLOW_TARGETS: Partial<Record<AgentId, WorkflowTarget>> = {
+  claude: workflowBundle,
+  kimi: kimiFlowSkill,
+  goose: gooseRecipe,
+  // Antigravity discovers workflows in the shared HOME-global dir `agy` scans
+  // at startup, never in a version home — see `antigravityWorkflowsDir`.
+  antigravity: renderedFile({
+    label: 'Antigravity workflow',
+    dir: () => antigravityWorkflowsDir(),
+    ext: '.md',
+    transform: transformWorkflowForAntigravity,
+    marker: antigravityWorkflowMarker,
+  }),
+  openclaw: renderedFile({
+    label: 'OpenClaw workflow',
+    dir: (versionHome) => path.join(versionHome, '.openclaw', 'workflows'),
+    ext: '.lobster',
+    transform: transformWorkflowForOpenClaw,
+    marker: openclawWorkflowMarker,
+  }),
+  grok: renderedFile({
+    label: 'Grok workflow',
+    dir: (versionHome) => path.join(versionHome, '.grok', 'workflows'),
+    ext: '.rhai',
+    transform: transformWorkflowForGrok,
+    marker: grokWorkflowMarker,
+  }),
+};
+
+/** The registered target for `agent`; throws for a harness that has none. */
+export function workflowTarget(agent: AgentId): WorkflowTarget {
+  const target = WORKFLOW_TARGETS[agent];
+  if (!target) {
+    throw new Error(`${agent} has no workflow target (not in capableAgents('workflows'))`);
+  }
+  return target;
+}
+
+// ── the generic engine ───────────────────────────────────────────────────────
+
+/** Workflow names agents-cli has synced into `versionHome` for `agent`. */
+export function listWorkflowsForAgent(agent: AgentId, versionHome: string): string[] {
+  const target = workflowTarget(agent);
+  return target.names(target.dir(versionHome));
+}
+
+/**
+ * Materialize the central bundle at `workflowPath` as `name` in `agent`'s
+ * `versionHome`, in that harness's native layout. Refuses to clobber a
+ * user-authored file of the same name (the ownership marker is the tell) and
+ * is idempotent over an agents-cli-managed one.
+ */
+export function syncWorkflowToVersion(
+  workflowPath: string,
+  name: string,
+  agent: AgentId,
+  versionHome: string,
+): { success: boolean; error?: string } {
+  const target = workflowTarget(agent);
+  const dir = target.dir(versionHome);
+  try {
+    if (target.managed(dir, name) === false) {
+      return { success: false, error: `${target.label} '${name}' already exists and is not managed by agents-cli` };
+    }
+    target.write(dir, { name, path: workflowPath });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/** Remove workflow `name` from `agent@version`; refuses a user-authored file. */
+export function removeWorkflowFromVersion(
+  agent: AgentId,
+  version: string,
+  name: string,
+): { success: boolean; error?: string } {
+  const target = workflowTarget(agent);
+  const dir = target.dir(getVersionHomePath(agent, version));
+  const occupied = target.occupied(dir, name);
+  if (occupied.length === 0) {
+    return { success: false, error: `Workflow '${name}' not synced to ${agent}@${version}` };
+  }
+  if (target.managed(dir, name) === false) {
+    return { success: false, error: `${target.label} '${name}' is not managed by agents-cli` };
+  }
+  try {
+    for (const entry of occupied) {
+      fs.rmSync(entry, { recursive: true, force: true });
+    }
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/**
+ * True when workflow `name` materialized in `agent`'s `versionHome` byte-matches
+ * what the writer would produce NOW from `sourcePath` — the content-drift
+ * predicate `agents doctor` uses. Returns false when the home copy is absent
+ * (surfaced as `missing` at the name level, not here).
+ */
+export function workflowContentMatches(
+  agent: AgentId,
+  versionHome: string,
+  name: string,
+  sourcePath: string,
+): boolean {
+  const target = workflowTarget(agent);
+  return target.matches(target.dir(versionHome), { name, path: sourcePath });
+}
+
+/** Every harness that has a registered workflow shape. */
+export function workflowTargetAgents(): AgentId[] {
+  return capableAgents('workflows').filter((agent) => agent in WORKFLOW_TARGETS);
+}

--- a/cli/src/lib/workflows-registry.ts
+++ b/cli/src/lib/workflows-registry.ts
@@ -17,7 +17,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentId } from './types.js';
-import { capableAgents } from './capabilities.js';
 import { getVersionHomePath } from './installations/versions.js';
 import { dirsContentMatch, normalizeResourceContent } from './resource-content-diff.js';
 import {
@@ -360,9 +359,4 @@ export function workflowContentMatches(
 ): boolean {
   const target = workflowTarget(agent);
   return target.matches(target.dir(versionHome), { name, path: sourcePath });
-}
-
-/** Every harness that has a registered workflow shape. */
-export function workflowTargetAgents(): AgentId[] {
-  return capableAgents('workflows').filter((agent) => agent in WORKFLOW_TARGETS);
 }

--- a/cli/src/lib/workflows.test.ts
+++ b/cli/src/lib/workflows.test.ts
@@ -6,11 +6,9 @@ import * as yaml from 'yaml';
 import {
   parseLoopBlock,
   parseWorkflowFrontmatter,
-  listWorkflowsForAgent,
   resolveAllowedSubagents,
   pruneStaleWorkflowSubagents,
   ensureSubagentDispatchTool,
-  syncWorkflowToVersion,
   transformWorkflowForKimi,
   transformWorkflowForAntigravity,
   transformWorkflowForOpenClaw,
@@ -22,6 +20,7 @@ import {
   isBareWorkflowName,
   parseWorkflowRef,
 } from './workflows.js';
+import { listWorkflowsForAgent, syncWorkflowToVersion } from './workflows-registry.js';
 import * as state from './state.js';
 
 describe('parseLoopBlock — defensive coercion (issue #332)', () => {

--- a/cli/src/lib/workflows.ts
+++ b/cli/src/lib/workflows.ts
@@ -22,8 +22,7 @@ import {
   getSystemPluginsDir,
   getProjectPluginsDir,
 } from './state.js';
-import { listInstalledVersions, getVersionHomePath } from './installations/versions.js';
-import { dirsContentMatch, normalizeResourceContent } from './resource-content-diff.js';
+import { listInstalledVersions } from './installations/versions.js';
 
 // WORKFLOW_CAPABLE_AGENTS removed — use `capableAgents('workflows')` from
 // lib/capabilities.ts. The capability matrix on AgentConfig is the single
@@ -1010,89 +1009,8 @@ export function removeWorkflow(name: string): { success: boolean; error?: string
  * intentionally ignored. (Verified via strace of `agy`: it opens
  * `$HOME/.gemini/config/global_workflows/<name>.md` and never the version home.)
  */
-function antigravityWorkflowsDir(): string {
+export function antigravityWorkflowsDir(): string {
   return path.join(process.env.HOME ?? os.homedir(), '.gemini', 'config', 'global_workflows');
-}
-
-function workflowTargetRoot(agent: AgentId, versionHome: string): string {
-  if (agent === 'kimi') return path.join(versionHome, '.kimi-code', 'skills');
-  if (agent === 'antigravity') return antigravityWorkflowsDir();
-  if (agent === 'openclaw') return path.join(versionHome, '.openclaw', 'workflows');
-  if (agent === 'grok') return path.join(versionHome, '.grok', 'workflows');
-  return path.join(versionHome, 'workflows');
-}
-
-/** List workflow names synced into a specific agent version home. */
-export function listWorkflowsForAgent(agent: AgentId, versionHome: string): string[] {
-  if (agent === 'kimi') {
-    const skillsDir = workflowTargetRoot(agent, versionHome);
-    if (!fs.existsSync(skillsDir)) return [];
-    return fs.readdirSync(skillsDir, { withFileTypes: true })
-      .filter(d => d.isDirectory() && fs.existsSync(path.join(skillsDir, d.name, 'SKILL.md')))
-      .filter(d => kimiWorkflowMarker(path.join(skillsDir, d.name, 'SKILL.md')) === d.name)
-      .map(d => d.name);
-  }
-
-  if (agent === 'antigravity') {
-    const dir = workflowTargetRoot(agent, versionHome);
-    if (!fs.existsSync(dir)) return [];
-    try {
-      return fs.readdirSync(dir, { withFileTypes: true })
-        .filter(d => d.isFile() && d.name.endsWith('.md') && !d.name.startsWith('.'))
-        .map(d => d.name.slice(0, -'.md'.length))
-        .filter(base => antigravityWorkflowMarker(path.join(dir, `${base}.md`)) === base);
-    } catch {
-      return [];
-    }
-  }
-
-  if (agent === 'goose') {
-    const recipesDir = path.join(versionHome, '.config', 'goose', 'recipes');
-    if (!fs.existsSync(recipesDir)) return [];
-    try {
-      return fs.readdirSync(recipesDir, { withFileTypes: true })
-        .filter(d => d.isFile() && d.name.endsWith('.yaml') && !d.name.startsWith('.'))
-        .map(d => d.name.slice(0, -'.yaml'.length));
-    } catch {
-      return [];
-    }
-  }
-
-  if (agent === 'openclaw') {
-    const dir = workflowTargetRoot(agent, versionHome);
-    if (!fs.existsSync(dir)) return [];
-    try {
-      return fs.readdirSync(dir, { withFileTypes: true })
-        .filter(d => d.isFile() && d.name.endsWith('.lobster') && !d.name.startsWith('.'))
-        .map(d => d.name.slice(0, -'.lobster'.length))
-        .filter(base => openclawWorkflowMarker(path.join(dir, `${base}.lobster`)) === base);
-    } catch {
-      return [];
-    }
-  }
-
-  if (agent === 'grok') {
-    const dir = workflowTargetRoot(agent, versionHome);
-    if (!fs.existsSync(dir)) return [];
-    try {
-      return fs.readdirSync(dir, { withFileTypes: true })
-        .filter(d => d.isFile() && d.name.endsWith('.rhai') && !d.name.startsWith('.'))
-        .map(d => d.name.slice(0, -'.rhai'.length))
-        .filter(base => grokWorkflowMarker(path.join(dir, `${base}.rhai`)) === base);
-    } catch {
-      return [];
-    }
-  }
-
-  const workflowsDir = workflowTargetRoot(agent, versionHome);
-  if (!fs.existsSync(workflowsDir)) return [];
-  try {
-    return fs.readdirSync(workflowsDir, { withFileTypes: true })
-      .filter(d => d.isDirectory() && fs.existsSync(path.join(workflowsDir, d.name, 'WORKFLOW.md')))
-      .map(d => d.name);
-  } catch {
-    return [];
-  }
 }
 
 function parseSubrecipeFrontmatter(filePath: string): { name?: string; description?: string; body: string } {
@@ -1116,7 +1034,7 @@ function parseSubrecipeFrontmatter(filePath: string): { name?: string; descripti
   };
 }
 
-function selectedWorkflowSubagents(workflowPath: string, allowedAgents?: string[]): string[] {
+export function selectedWorkflowSubagents(workflowPath: string, allowedAgents?: string[]): string[] {
   const subagentsDir = path.join(workflowPath, 'subagents');
   if (!fs.existsSync(subagentsDir)) return [];
   const allowed = allowedAgents ? new Set(allowedAgents) : null;
@@ -1127,7 +1045,7 @@ function selectedWorkflowSubagents(workflowPath: string, allowedAgents?: string[
     .sort();
 }
 
-function writeGooseSubrecipe(workflowPath: string, subrecipeName: string, destDir: string): void {
+export function writeGooseSubrecipe(workflowPath: string, subrecipeName: string, destDir: string): void {
   const sourcePath = path.join(workflowPath, 'subagents', `${subrecipeName}.md`);
   const parsed = parseSubrecipeFrontmatter(sourcePath);
   const body = parsed.body || parsed.description || subrecipeName;
@@ -1143,12 +1061,12 @@ function writeGooseSubrecipe(workflowPath: string, subrecipeName: string, destDi
 }
 
 /**
- * Render the main Goose recipe YAML for a workflow — the exact bytes
- * `syncWorkflowToGooseRecipe` writes to `<name>.yaml`. Extracted so the sync
- * writer and the doctor content-drift check (`workflowContentMatches`) render
- * from ONE source and can never disagree. Returns null on invalid frontmatter.
+ * Render the main Goose recipe YAML for a workflow — the exact bytes the Goose
+ * `WORKFLOW_TARGETS` entry writes to `<name>.yaml`. Extracted so the writer and
+ * the doctor content-drift check (`matches`) render from ONE source and can
+ * never disagree. Returns null on invalid frontmatter.
  */
-function renderGooseRecipeYaml(workflowPath: string, name: string): string | null {
+export function renderGooseRecipeYaml(workflowPath: string, name: string): string | null {
   const frontmatter = parseWorkflowFrontmatter(workflowPath);
   if (!frontmatter) return null;
   const body = readWorkflowBody(workflowPath) || frontmatter.description || name;
@@ -1173,245 +1091,6 @@ function renderGooseRecipeYaml(workflowPath: string, name: string): string | nul
   return yaml.stringify(recipe);
 }
 
-function syncWorkflowToGooseRecipe(workflowPath: string, name: string, versionHome: string): { success: boolean; error?: string } {
-  const frontmatter = parseWorkflowFrontmatter(workflowPath);
-  if (!frontmatter) {
-    return { success: false, error: `Workflow '${name}' has invalid WORKFLOW.md frontmatter` };
-  }
-
-  const recipesDir = path.join(versionHome, '.config', 'goose', 'recipes');
-  const recipePath = path.join(recipesDir, `${name}.yaml`);
-  const subrecipesDir = path.join(recipesDir, `${name}.subrecipes`);
-  const subagents = selectedWorkflowSubagents(workflowPath, frontmatter.allowedAgents);
-  const recipeYaml = renderGooseRecipeYaml(workflowPath, name);
-  if (recipeYaml == null) {
-    return { success: false, error: `Workflow '${name}' has invalid WORKFLOW.md frontmatter` };
-  }
-
-  try {
-    fs.mkdirSync(recipesDir, { recursive: true });
-    if (fs.existsSync(subrecipesDir)) {
-      fs.rmSync(subrecipesDir, { recursive: true, force: true });
-    }
-    for (const subagentName of subagents) {
-      writeGooseSubrecipe(workflowPath, subagentName, subrecipesDir);
-    }
-    fs.writeFileSync(recipePath, recipeYaml, 'utf-8');
-    return { success: true };
-  } catch (err) {
-    return { success: false, error: (err as Error).message };
-  }
-}
-
-/**
- * True when workflow `name` materialized in `agent`'s version home byte-matches
- * what the writer would produce NOW from `sourcePath` — the content-drift
- * predicate `agents doctor` uses. Layout-aware per the same per-harness map the
- * writer (`syncWorkflowToVersion`) and detector use: Claude/default copy the
- * whole WORKFLOW.md tree (recursive dir compare); Kimi/Antigravity/OpenClaw/Grok
- * render one transformed file; Goose renders a recipe YAML. Antigravity's target
- * is the shared HOME-global dir, not a per-version path. Returns false when the
- * home copy is absent (surfaced as `missing` at the name level, not here).
- */
-export function workflowContentMatches(
-  agent: AgentId,
-  versionHome: string,
-  name: string,
-  sourcePath: string,
-): boolean {
-  const root = workflowTargetRoot(agent, versionHome);
-  const renderedMatches = (homePath: string, expected: string): boolean => {
-    let actual: string;
-    try { actual = fs.readFileSync(homePath, 'utf-8'); } catch { return false; }
-    return normalizeResourceContent(actual) === normalizeResourceContent(expected);
-  };
-  switch (agent) {
-    case 'kimi':
-      return renderedMatches(path.join(root, name, 'SKILL.md'), transformWorkflowForKimi(sourcePath, name));
-    case 'antigravity':
-      return renderedMatches(path.join(root, `${name}.md`), transformWorkflowForAntigravity(sourcePath, name));
-    case 'openclaw':
-      return renderedMatches(path.join(root, `${name}.lobster`), transformWorkflowForOpenClaw(sourcePath, name));
-    case 'grok':
-      return renderedMatches(path.join(root, `${name}.rhai`), transformWorkflowForGrok(sourcePath, name));
-    case 'goose': {
-      const expected = renderGooseRecipeYaml(sourcePath, name);
-      if (expected == null) return false;
-      return renderedMatches(path.join(versionHome, '.config', 'goose', 'recipes', `${name}.yaml`), expected);
-    }
-    default:
-      return dirsContentMatch(sourcePath, path.join(root, name));
-  }
-}
-
-/** Copy a workflow directory into a version home at {versionHome}/workflows/<name>/. */
-export function syncWorkflowToVersion(
-  workflowPath: string,
-  name: string,
-  agent: AgentId,
-  versionHome: string,
-): { success: boolean; error?: string } {
-  if (agent === 'goose') {
-    return syncWorkflowToGooseRecipe(workflowPath, name, versionHome);
-  }
-
-  try {
-    if (agent === 'kimi') {
-      const targetDir = path.join(workflowTargetRoot(agent, versionHome), name);
-      const targetFile = path.join(targetDir, 'SKILL.md');
-      if (fs.existsSync(targetFile)) {
-        const marker = kimiWorkflowMarker(targetFile);
-        if (marker !== name) {
-          return { success: false, error: `Kimi skill '${name}' already exists and is not managed by agents-cli` };
-        }
-      }
-      fs.mkdirSync(targetDir, { recursive: true });
-      fs.writeFileSync(targetFile, transformWorkflowForKimi(workflowPath, name), 'utf-8');
-      return { success: true };
-    }
-
-    if (agent === 'antigravity') {
-      const targetDir = workflowTargetRoot(agent, versionHome);
-      const targetFile = path.join(targetDir, `${name}.md`);
-      if (fs.existsSync(targetFile)) {
-        const marker = antigravityWorkflowMarker(targetFile);
-        if (marker !== name) {
-          return { success: false, error: `Antigravity workflow '${name}' already exists and is not managed by agents-cli` };
-        }
-      }
-      fs.mkdirSync(targetDir, { recursive: true });
-      fs.writeFileSync(targetFile, transformWorkflowForAntigravity(workflowPath, name), 'utf-8');
-      return { success: true };
-    }
-
-    if (agent === 'openclaw') {
-      const targetDir = workflowTargetRoot(agent, versionHome);
-      const targetFile = path.join(targetDir, `${name}.lobster`);
-      if (fs.existsSync(targetFile)) {
-        const marker = openclawWorkflowMarker(targetFile);
-        if (marker !== name) {
-          return { success: false, error: `OpenClaw workflow '${name}' already exists and is not managed by agents-cli` };
-        }
-      }
-      fs.mkdirSync(targetDir, { recursive: true });
-      fs.writeFileSync(targetFile, transformWorkflowForOpenClaw(workflowPath, name), 'utf-8');
-      return { success: true };
-    }
-
-    if (agent === 'grok') {
-      const targetDir = workflowTargetRoot(agent, versionHome);
-      const targetFile = path.join(targetDir, `${name}.rhai`);
-      if (fs.existsSync(targetFile)) {
-        const marker = grokWorkflowMarker(targetFile);
-        if (marker !== name) {
-          return { success: false, error: `Grok workflow '${name}' already exists and is not managed by agents-cli` };
-        }
-      }
-      fs.mkdirSync(targetDir, { recursive: true });
-      fs.writeFileSync(targetFile, transformWorkflowForGrok(workflowPath, name), 'utf-8');
-      return { success: true };
-    }
-
-    const targetDir = path.join(workflowTargetRoot(agent, versionHome), name);
-    fs.mkdirSync(workflowTargetRoot(agent, versionHome), { recursive: true });
-    if (fs.existsSync(targetDir)) {
-      fs.rmSync(targetDir, { recursive: true, force: true });
-    }
-    fs.cpSync(workflowPath, targetDir, { recursive: true });
-    return { success: true };
-  } catch (err) {
-    return { success: false, error: (err as Error).message };
-  }
-}
-
-/** Remove a workflow from a specific agent version home. */
-export function removeWorkflowFromVersion(
-  agent: AgentId,
-  version: string,
-  name: string,
-): { success: boolean; error?: string } {
-  const versionHome = getVersionHomePath(agent, version);
-  if (agent === 'antigravity') {
-    const targetFile = path.join(workflowTargetRoot(agent, versionHome), `${name}.md`);
-    if (!fs.existsSync(targetFile)) {
-      return { success: false, error: `Workflow '${name}' not synced to ${agent}@${version}` };
-    }
-    if (antigravityWorkflowMarker(targetFile) !== name) {
-      return { success: false, error: `Antigravity workflow '${name}' is not managed by agents-cli` };
-    }
-    try {
-      fs.rmSync(targetFile, { force: true });
-      return { success: true };
-    } catch (err) {
-      return { success: false, error: (err as Error).message };
-    }
-  }
-
-  if (agent === 'goose') {
-    const recipePath = path.join(versionHome, '.config', 'goose', 'recipes', `${name}.yaml`);
-    const subrecipesDir = path.join(versionHome, '.config', 'goose', 'recipes', `${name}.subrecipes`);
-    if (!fs.existsSync(recipePath) && !fs.existsSync(subrecipesDir)) {
-      return { success: false, error: `Workflow '${name}' not synced to ${agent}@${version}` };
-    }
-    try {
-      if (fs.existsSync(recipePath)) fs.rmSync(recipePath, { force: true });
-      if (fs.existsSync(subrecipesDir)) fs.rmSync(subrecipesDir, { recursive: true, force: true });
-      return { success: true };
-    } catch (err) {
-      return { success: false, error: (err as Error).message };
-    }
-  }
-
-  if (agent === 'openclaw') {
-    const targetFile = path.join(workflowTargetRoot(agent, versionHome), `${name}.lobster`);
-    if (!fs.existsSync(targetFile)) {
-      return { success: false, error: `Workflow '${name}' not synced to ${agent}@${version}` };
-    }
-    if (openclawWorkflowMarker(targetFile) !== name) {
-      return { success: false, error: `OpenClaw workflow '${name}' is not managed by agents-cli` };
-    }
-    try {
-      fs.rmSync(targetFile, { force: true });
-      return { success: true };
-    } catch (err) {
-      return { success: false, error: (err as Error).message };
-    }
-  }
-
-  if (agent === 'grok') {
-    const targetFile = path.join(workflowTargetRoot(agent, versionHome), `${name}.rhai`);
-    if (!fs.existsSync(targetFile)) {
-      return { success: false, error: `Workflow '${name}' not synced to ${agent}@${version}` };
-    }
-    if (grokWorkflowMarker(targetFile) !== name) {
-      return { success: false, error: `Grok workflow '${name}' is not managed by agents-cli` };
-    }
-    try {
-      fs.rmSync(targetFile, { force: true });
-      return { success: true };
-    } catch (err) {
-      return { success: false, error: (err as Error).message };
-    }
-  }
-
-  const targetPath = path.join(workflowTargetRoot(agent, versionHome), name);
-  if (!fs.existsSync(targetPath)) {
-    return { success: false, error: `Workflow '${name}' not synced to ${agent}@${version}` };
-  }
-  try {
-    if (agent === 'kimi') {
-      const targetFile = path.join(targetPath, 'SKILL.md');
-      if (kimiWorkflowMarker(targetFile) !== name) {
-        return { success: false, error: `Kimi skill '${name}' is not managed by agents-cli` };
-      }
-    }
-    fs.rmSync(targetPath, { recursive: true, force: true });
-    return { success: true };
-  } catch (err) {
-    return { success: false, error: (err as Error).message };
-  }
-}
-
 function parseSkillFrontmatter(filePath: string): Record<string, unknown> | null {
   const content = fs.readFileSync(filePath, 'utf-8');
   const lines = content.split('\n');
@@ -1423,7 +1102,7 @@ function parseSkillFrontmatter(filePath: string): Record<string, unknown> | null
   return parsed && typeof parsed === 'object' ? parsed : null;
 }
 
-function kimiWorkflowMarker(filePath: string): string | null {
+export function kimiWorkflowMarker(filePath: string): string | null {
   try {
     const fm = parseSkillFrontmatter(filePath) as { type?: unknown; agents_workflow?: unknown } | null;
     return fm?.type === 'flow' && typeof fm.agents_workflow === 'string' ? fm.agents_workflow : null;
@@ -1432,7 +1111,7 @@ function kimiWorkflowMarker(filePath: string): string | null {
   }
 }
 
-function antigravityWorkflowMarker(filePath: string): string | null {
+export function antigravityWorkflowMarker(filePath: string): string | null {
   try {
     const fm = parseSkillFrontmatter(filePath) as { agents_workflow?: unknown } | null;
     return typeof fm?.agents_workflow === 'string' ? fm.agents_workflow : null;
@@ -1441,7 +1120,7 @@ function antigravityWorkflowMarker(filePath: string): string | null {
   }
 }
 
-function openclawWorkflowMarker(filePath: string): string | null {
+export function openclawWorkflowMarker(filePath: string): string | null {
   try {
     const parsed = yaml.parse(fs.readFileSync(filePath, 'utf-8')) as { env?: unknown } | null;
     if (!parsed || typeof parsed !== 'object' || !parsed.env || typeof parsed.env !== 'object' || Array.isArray(parsed.env)) {


### PR DESCRIPTION
## Why

The 2026-08-20 `code:refactor` scan of the CLI (`.agents/artifacts/2026-08-20/refactor-161514`, ranked move 3: route agent-family arms through the table that exists) still leaves 207 harness-id arms in `src/lib` on today's main. `lib/workflows.ts` carried 19 of them and `staleness/detectors/workflows.ts` another 5, plus a second copy of the Kimi/Antigravity/OpenClaw ownership-marker parsers. Six places decided how a synced workflow looks on disk, and each could silently disagree with the others.

Ticket: PHNX-3993.

## What

One `WORKFLOW_TARGETS` entry per workflows-capable harness (`src/lib/workflows-registry.ts`), same pattern as `SUBAGENT_TARGETS`: `dir`, `names`, `write`, `occupied`, `managed`, `matches`. The engine (`listWorkflowsForAgent`, `syncWorkflowToVersion`, `removeWorkflowFromVersion`, `workflowContentMatches`) is generic over it, and the staleness detector lists through the same entry instead of re-implementing the layout.

| | before (origin/main) | after |
|---|---:|---:|
| `agent === '…'` arms in `lib/workflows.ts` | 19 | 0 |
| `agent === '…'` arms in `staleness/detectors/workflows.ts` | 5 | 0 |
| copies of the Kimi/Antigravity/OpenClaw marker parsers | 2 | 1 |

**Harness parity:** every harness in `capableAgents('workflows')` (claude, openclaw, goose, antigravity, grok, kimi) has an entry; the completeness test fails if the flag and the table drift.

**Behavior:** paths, markers, and error strings are unchanged. One deliberate tightening, called out here per the behavior-preserving rule: a foreign Kimi `<name>/` skill dir (present, no agents-cli marker) now blocks a sync with `Kimi skill '<name>' already exists and is not managed by agents-cli`, matching what the other marker-bearing harnesses already did for a foreign file, instead of having `SKILL.md` written into it. Removal of such a dir was already refused on main.

**Fail loud:** `workflowTarget()` throws for a harness with no entry; the old default branch silently copied into `{home}/workflows/` for any agent id.

**Docs:** `cli/AGENTS.md` source tree, `cli/docs/resource-sync.md` function table, changelog fragment `.changelog/next/PHNX-3993-workflow-targets-registry.md`.

**Companion `.agents` audit:** no command, flag, or output changed, so no hook, skill, or rule in the companion repo is affected.

**Out of scope, noted for the record:** `lib/project-resources.ts:702` still hard-codes `kimi || goose || openclaw` for project-level workflow sync (grok and antigravity are missing there); that is project-root sync with a different target root and a separate change.

## Verification

```
$ ./node_modules/.bin/tsc --noEmit -p tsconfig.json ; echo exit $?
exit 0
$ TZ=UTC node ./node_modules/vitest/vitest.mjs run src/lib/workflows-registry.test.ts src/lib/workflows.test.ts src/lib/doctor-diff.test.ts src/lib/staleness src/commands/workflows
 Test Files  21 passed (21)
      Tests  195 passed (195)
```

New tests in `src/lib/workflows-registry.test.ts`: registry keys equal `capableAgents('workflows')`; for each of the six harnesses, sync → list → detector → doctor drift (true, then false after a source body edit, then true after re-sync) → remove round-trips through the one table; a foreign Kimi skill dir and a de-markered Grok file are refused with the harness label in the error.