### PR TITLE
fix(accounts): non-interactive picker fallback recommends accounts default (PHNX-3940)

### DIFF
--- a/cli/src/commands/accounts.ts
+++ b/cli/src/commands/accounts.ts
@@ -453,7 +453,7 @@ export async function runAccountsSwitch(
   }
   if (!isInteractiveTerminal()) {
     throw new Error(
-      `Selecting a ${agent} account requires an interactive terminal.\nUse: agents accounts switch ${agent} <account>\nOr:  agents accounts set-default ${agent} <account>`,
+      `Selecting a ${agent} account requires an interactive terminal.\nUse: agents accounts default ${agent} <account>`,
     );
   }
   const selected = await pickSwitchAccount(agent, rows);


### PR DESCRIPTION
Follow-up from the T8 re-review of #3522: the non-interactive fallback in accounts.ts still told users to run the hidden switch / set-default verbs. It now names agents accounts default <harness> <account>, the one taught write path. One-line change; tsc clean; accounts.test.ts green.

Refs PHNX-3940