### PR TITLE
fix(accounts): provision worker slots for pre-T1 claude rows; headed device publishes; reconcile first (PHNX-3940)

### DIFF
--- a/cli/.changelog/next/PHNX-3940-legacy-worker-slots.md
+++ b/cli/.changelog/next/PHNX-3940-legacy-worker-slots.md
@@ -1,0 +1,19 @@
+- **Workers now materialize a slot for every registered Claude account, not only
+  the ones added through the v2 `accounts add` flow (PHNX-3940).** The daemon's
+  slot reconciliation skipped any account row without a `workerCredential` field —
+  every account registered before the v2 model — on the assumption that a legacy
+  row "resolves its token at spawn". That holds for `agents run claude#<name>` but
+  not for the interactive picker, so on a worker whose `auth` bundle already held
+  all eight setup-tokens `agents run claude --interactive --device auto` listed the
+  installed version labels, showed most of them `logged out`, and launching one put
+  a Claude login screen on a headless box. `reconcileLocalWorkerSlots` now resolves
+  each row through the same `reservedSyncTargets` the push plan uses (a v2 row's
+  reserved `__claude__` key, a legacy row's email-keyed `auth` token), so every
+  account whose token is on the box gets a `durable` slot with a 0600
+  `.oauth_token` and the seeded identity the adapter injects from. Two related
+  fixes ride along: the credential publisher is now a ready **headed** device
+  (`electPublisher`, headed-first then by name) instead of the alphabetically first
+  ready box, which had made a worker the fleet's source of truth; and slot
+  reconciliation runs first in the `auth-sync` tick, so a failed shared-state git
+  exchange no longer postpones local provisioning. Source:
+  `cli/src/lib/secrets/reserved-sync.ts`, `cli/src/lib/daemon/auth-sync-service.ts`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1007,10 +1007,17 @@ legacy `auth` alias keyed by email); the elected single publisher (`syncReserved
 [`secrets-policy.ts`](src/lib/secrets-policy.ts)) pushes a reserved store to a
 peer whenever that peer is missing **any** of its keys — so a newly-added account
 propagates within one tick instead of hiding behind a coarse "already has the bundle"
-verdict. Pushes target `role=worker` peers only: a headed (`personal`/`desktop`) peer
+verdict. **The publisher is a ready HEADED device** (`electPublisher`: `personal`/
+`desktop` first — where tokens are minted — then by name to break ties); a worker is
+elected only when no headed box is ready. Pushes target `role=worker` peers only: a
+headed (`personal`/`desktop`) peer
 receives the account **row** through the normal repo sync but **never a durable key**
-(`isHeadedDeviceRole`, invariant 7). After a key lands on a worker,
-`reconcileLocalWorkerSlots` → `provisionWorkerSlot` materializes that account's slot;
+(`isHeadedDeviceRole`, invariant 7). On a worker, `reconcileLocalWorkerSlots` →
+`provisionWorkerSlot` materializes a slot for **every** registered account whose key
+is on the box — a v2 row through its reserved key, a pre-v2 claude row through the
+email-keyed `auth` token (both via `reservedSyncTargets`, so the push plan and the
+materialization can never disagree) — and it runs **first** in the tick so a failed
+shared-state git exchange cannot postpone it;
 a native OAuth/session file is never transported (`fleet/auth-sync.ts`
 `isCredentialSafeToPropagate` stays `false`). Each exceptional push is async with a
 hard deadline that kills the direct SSH client and remote connection. The store path

--- a/cli/docs/credential-management.md
+++ b/cli/docs/credential-management.md
@@ -217,19 +217,37 @@ from the single legacy `auth` bundle to every portable account:
   of its keys — so a newly-added account propagates within one tick, instead of
   being hidden behind a bundle-coarse "already has the bundle" verdict.
   (`planReservedStoreSync` / `reservedSyncTargets`, `lib/secrets-policy.ts`.)
+- **The publisher is a ready HEADED device.** `electPublisher` ranks every device
+  reporting `auth: ready` headed-first (`personal`/`desktop`, where tokens are
+  minted and the copy of record lives), then by name to break ties, so every box
+  elects the same one. A worker is elected only when no headed device is ready.
+  Sorting by name alone (the pre-fix rule) elected `mac-mini` — a worker holding a
+  six-day-old copy of `auth` — over `zion`, and zion then skipped every peer as
+  "another ready device is the elected publisher".
 - **Pushes target `role=worker` devices only.** A headed (`personal`/`desktop`)
   peer receives the account **row** through the normal repo sync, but **never a
   durable key** — it authenticates from its own native login (invariant 7). The
   filter is `isHeadedDeviceRole` on the peer's synced role.
-- **After a key lands on a worker, the daemon materializes a slot for it.**
-  `reconcileLocalWorkerSlots` → `provisionWorkerSlot` runs `ensureSlot` (T1) and
-  writes the credential the way the pre-slot Claude worker home was provisioned —
-  for `claude`, the setup-token → `.oauth_token` (0600) plus the seeded identity
-  email (the read-side join then completes the account/org uuids from the registry
-  row); an API-key harness gets a `durable` slot with **no** file (the key is
-  injected at spawn); a token-less harness (`kimi`, `antigravity`) gets a
-  `per-device` slot and no push. Slot reconciliation runs only on a non-headed
-  device.
+- **After a key lands on a worker, the daemon materializes a slot for it — for
+  every registered account, T1 or legacy.** `reconcileLocalWorkerSlots` walks
+  `reservedSyncTargets` (the same resolver the push plan uses), so a T1 row keys
+  its reserved `__<harness>__` store and a claude row predating T1 keys the legacy
+  `auth` bundle by email; whichever key is on the box, `provisionWorkerSlot` runs
+  `ensureSlot` (T1) and writes the credential the way the pre-slot Claude worker
+  home was provisioned — for `claude`, the setup-token → `.oauth_token` (0600) plus
+  the seeded identity email (the read-side join then completes the account/org
+  uuids from the registry row); an API-key harness gets a `durable` slot with
+  **no** file (the key is injected at spawn); a token-less harness (`kimi`,
+  `antigravity`) gets a `per-device` slot and no push. A row whose key has not
+  reached the box is reported `durable key not synced yet` and retried next tick.
+  Slot reconciliation runs only on a non-headed device, and it runs **first** in
+  the tick, before the shared-state git exchange: it reads only local state, so a
+  `git rebase timed out` on that tick never postpones it. (Before this, legacy
+  rows were skipped on the assumption that "a legacy worker resolves its token at
+  spawn" — true only for `agents run claude#<name>`, never for the interactive
+  picker, which enumerates slots and version homes and therefore showed the 8
+  registered accounts as logged out on a worker whose `auth` bundle held all 8
+  tokens.)
 - **Invariant 1 (transport, retain nothing).** The daemon moves a durable key over
   the existing encrypted SSH bundle push (the process client's
   `pushBundleToHostAsync`, `lib/secrets-client.ts`) and retains

--- a/cli/src/lib/daemon/auth-sync-service.ts
+++ b/cli/src/lib/daemon/auth-sync-service.ts
@@ -28,7 +28,28 @@ export class AuthSyncService extends BasePeriodicService {
   }
 
   protected async onTick(ctx: DaemonContext): Promise<void> {
-    const { publishReservedAuthVerdict, syncReservedAuthBundle } = await import('../secrets-policy.js');
+    const {
+      publishReservedAuthVerdict,
+      reconcileLocalWorkerSlots,
+      syncReservedAuthBundle,
+      syncReservedStores,
+    } = await import('../secrets-policy.js');
+
+    // Worker-side slot materialization FIRST (PHNX-3940 T6): for each registered
+    // account whose durable key is already on this box, create the HOME-shaped
+    // slot the picker and spawn read. It touches only local state — the registry
+    // copy and the file-backed store — so it never waits on the git exchange
+    // below. It used to sit after `if (!transport.success) return`, so a single
+    // `git rebase timed out` postponed every slot on the box by another tick.
+    // Self-gated on device role: a headed box returns immediately.
+    try {
+      const slots = reconcileLocalWorkerSlots();
+      if (slots.provisioned.length > 0) ctx.log('INFO', `auth-sync: provisioned worker slot(s) for ${slots.provisioned.join(', ')}`);
+      for (const err of slots.errors) ctx.log('WARN', `auth-sync: worker slot ${err.accountId}: ${err.message}`);
+    } catch (err) {
+      ctx.log('WARN', `auth-sync: worker slot reconcile: ${(err as Error).message}`);
+    }
+
     const published = await publishReservedAuthVerdict();
     if (published.error) ctx.log('WARN', `auth-sync: verdict: ${published.error}`);
     const { syncFleetSharedStateRepo } = await import('../fleet-shared-repo-sync.js');
@@ -47,26 +68,16 @@ export class AuthSyncService extends BasePeriodicService {
       ctx.log('WARN', `auth-sync: ${err.device}: ${err.message}`);
     }
 
-    // Generalized per-account, per-key, per-role reserved-store sync (PHNX-3940
+    // Generalized per-account, per-key, per-role reserved-store push (PHNX-3940
     // T6). On the elected headed publisher this pushes every portable account's
-    // reserved `__<harness>__` store to the worker peers missing it; on a worker
-    // it materializes a slot for each account whose durable key has landed. Each
-    // self-gates on device role, so exactly one arm acts per box. The push is the
-    // only transport — provisioning writes only locally (invariant 1).
-    const { syncReservedStores, reconcileLocalWorkerSlots } = await import('../secrets-policy.js');
+    // reserved `__<harness>__` store to the worker peers missing it. The push is
+    // the only transport — provisioning (above) writes only locally (invariant 1).
     try {
       const stores = await syncReservedStores();
       for (const p of stores.pushed) ctx.log('INFO', `auth-sync: pushed ${p.bundle} (${p.keys.length} key(s)) to ${p.device}`);
       for (const err of stores.errors) ctx.log('WARN', `auth-sync: reserved-store ${err.device}: ${err.message}`);
     } catch (err) {
       ctx.log('WARN', `auth-sync: reserved-store sync: ${(err as Error).message}`);
-    }
-    try {
-      const slots = reconcileLocalWorkerSlots();
-      if (slots.provisioned.length > 0) ctx.log('INFO', `auth-sync: provisioned worker slot(s) for ${slots.provisioned.join(', ')}`);
-      for (const err of slots.errors) ctx.log('WARN', `auth-sync: worker slot ${err.accountId}: ${err.message}`);
-    } catch (err) {
-      ctx.log('WARN', `auth-sync: worker slot reconcile: ${(err as Error).message}`);
     }
   }
 }

--- a/cli/src/lib/secrets-policy.test.ts
+++ b/cli/src/lib/secrets-policy.test.ts
@@ -5,17 +5,26 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { updateFleetSharedDeviceState } from './fleet-shared-state.js';
 import type { DeviceProfile } from './devices/registry.js';
+import type { ConfiguredDeviceRole } from './device-config.js';
 import {
+  electPublisher,
   peerPresentKeys,
   planAuthBundlePush,
   planReservedStoreSync,
   reconcileLocalWorkerSlots,
   reservedSyncTargets,
   syncReservedAuthBundle,
+  syncReservedStores,
   type AuthSyncDevice,
   type ReservedSyncAccount,
   type ReservedSyncPeer,
 } from './secrets-policy.js';
+import { claudeAccountTokenKey, readClaudeAccountEmail } from './claude-account-token.js';
+import { readSlots, slotDir } from './accounts/slots.js';
+import { keychainRef, secretsKeychainItem, writeBundleWithItemsSync } from './secrets-client.js';
+import type { SecretsBundle } from './secrets-types.js';
+import { readMeta } from './state.js';
+import { useFreshSecretsHome } from '../../tests/secrets-standalone.js';
 import type { Meta, NativeAccountRecord } from './types.js';
 
 const dirs: string[] = [];
@@ -272,5 +281,150 @@ describe('reconcileLocalWorkerSlots', () => {
     const res = reconcileLocalWorkerSlots({ selfRole: 'worker', readMetaFn: withSlot, hasLocalKey: () => true, provision: () => { throw new Error('should not re-provision'); } });
     expect(res.provisioned).toEqual([]);
     expect(res.skipped[0]).toMatchObject({ accountId: 'a1', reason: expect.stringContaining('already provisioned') });
+  });
+
+  // The mac-mini 2026-09-06 gap: every registered claude row predated T1 (no
+  // `workerCredential`), so the loop skipped all 8 while their tokens sat in the
+  // legacy `auth` bundle on the box. A legacy row resolves to (auth, email key)
+  // exactly as the push plan does, and gets a slot from the same key.
+  it('provisions a legacy claude row (no workerCredential) from its email-keyed auth token', () => {
+    const legacy: NativeAccountRecord = { id: 'l1', name: 'dev', agent: 'claude', identityKey: 'claude:account=b:org=o', scope: 'version', identityLabel: 'dev@getrush.ai' };
+    const kimi: NativeAccountRecord = { id: 'k1', name: 'kimi', agent: 'kimi', identityKey: 'kimi:user=k', scope: 'version', identityLabel: 'k@x.io' };
+    const meta = () => ({ accounts: { native: { l1: legacy, k1: kimi } }, deviceAccounts: {} }) as Pick<Meta, 'accounts' | 'deviceAccounts'>;
+    const asked: Array<[string, string]> = [];
+    const provisioned: string[] = [];
+    const res = reconcileLocalWorkerSlots({
+      selfRole: 'worker',
+      readMetaFn: meta,
+      hasLocalKey: (bundle, key) => { asked.push([bundle, key]); return true; },
+      provision: (a) => provisioned.push(a.id),
+    });
+    expect(asked).toEqual([['auth', claudeAccountTokenKey('dev@getrush.ai')]]);
+    expect(provisioned).toEqual(['l1']);
+    // A per-device harness row has no derivable durable credential: neither
+    // provisioned nor reported as "not synced" — there is nothing to sync.
+    expect(res.skipped).toEqual([]);
+  });
+
+  it('reports a legacy row whose auth key is not on this box as not synced yet', () => {
+    const legacy: NativeAccountRecord = { id: 'l1', name: 'dev', agent: 'claude', identityKey: 'claude:account=b:org=o', scope: 'version', identityLabel: 'dev@getrush.ai' };
+    const meta = () => ({ accounts: { native: { l1: legacy } }, deviceAccounts: {} }) as Pick<Meta, 'accounts' | 'deviceAccounts'>;
+    const res = reconcileLocalWorkerSlots({ selfRole: 'worker', readMetaFn: meta, hasLocalKey: () => false, provision: () => { throw new Error('should not provision'); } });
+    expect(res.skipped).toEqual([{ accountId: 'l1', reason: 'durable key not synced yet' }]);
+  });
+});
+
+// End to end through the real standalone secrets store and the real slot
+// writer: a legacy row + its token in a file-backed `auth` bundle ⇒ a durable
+// slot with a 0600 `.oauth_token` and the seeded email the claude adapter keys
+// the token on at spawn. No mocks; HOME is the vitest sandbox (tests/setup.ts).
+describe('reconcileLocalWorkerSlots through the real auth bundle', () => {
+  useFreshSecretsHome();
+  const created: string[] = [];
+  afterEach(() => {
+    for (const dir of created.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeAuthBundle(values: Record<string, string>): void {
+    const bundle: SecretsBundle = { name: 'auth', backend: 'file', policy: 'never', vars: {}, meta: {} };
+    const items = new Map<string, string>();
+    for (const [key, value] of Object.entries(values)) {
+      bundle.vars[key] = keychainRef(key);
+      bundle.meta![key] = { type: 'token' };
+      items.set(secretsKeychainItem('auth', key), value);
+    }
+    writeBundleWithItemsSync(bundle, items);
+  }
+
+  it('materializes a slot for a pre-T1 claude row from the synced auth token, and only once', () => {
+    writeAuthBundle({
+      [claudeAccountTokenKey('prix@example.com')]: 'sk-ant-oat01-prix',
+      [claudeAccountTokenKey('trp@example.com')]: 'sk-ant-oat01-trp',
+    });
+    const rows: NativeAccountRecord[] = [
+      { id: 'lp', name: 'prix', agent: 'claude', identityKey: 'claude:account=p:org=o', scope: 'version', identityLabel: 'prix@example.com' },
+      { id: 'lt', name: 'trp', agent: 'claude', identityKey: 'claude:account=t:org=o', scope: 'version', identityLabel: 'trp@example.com' },
+      // Registered, but its token never reached this box.
+      { id: 'lm', name: 'smores', agent: 'claude', identityKey: 'claude:account=m:org=o', scope: 'version', identityLabel: 'smores@example.com' },
+    ];
+    const readMetaFn = () => ({ ...readMeta(), accounts: { native: Object.fromEntries(rows.map((r) => [r.id, r])) } });
+    for (const id of ['lp', 'lt', 'lm']) created.push(slotDir('claude', id));
+
+    const first = reconcileLocalWorkerSlots({ selfRole: 'worker', readMetaFn });
+    expect(first.errors).toEqual([]);
+    expect(first.provisioned.sort()).toEqual(['lp', 'lt']);
+    expect(first.skipped).toEqual([{ accountId: 'lm', reason: 'durable key not synced yet' }]);
+
+    for (const [id, token, email] of [['lp', 'sk-ant-oat01-prix', 'prix@example.com'], ['lt', 'sk-ant-oat01-trp', 'trp@example.com']] as const) {
+      const dir = slotDir('claude', id);
+      const tokenPath = path.join(dir, '.claude', '.oauth_token');
+      expect(fs.readFileSync(tokenPath, 'utf-8')).toBe(token);
+      expect(fs.statSync(tokenPath).mode & 0o777).toBe(0o600);
+      expect(readClaudeAccountEmail(dir)).toBe(email);
+      expect(readSlots(readMeta())[id]).toMatchObject({ slotDir: dir, authMode: 'durable' });
+    }
+
+    const second = reconcileLocalWorkerSlots({ selfRole: 'worker', readMetaFn });
+    expect(second.provisioned).toEqual([]);
+    expect(second.skipped.map((s) => s.accountId).sort()).toEqual(['lm', 'lp', 'lt']);
+  });
+});
+
+describe('electPublisher', () => {
+  const roles: Record<string, ConfiguredDeviceRole | undefined> = {
+    zion: 'personal',
+    'mac-studio': 'desktop',
+    'mac-mini': 'worker',
+    'yosemite-s1': 'worker',
+    unmarked: undefined,
+  };
+  const roleOf = (name: string) => roles[name];
+
+  it('prefers a ready headed device over a ready worker whatever the name order', () => {
+    // The live 2026-09-06 shape: every device ready, name order alone elected mac-mini.
+    expect(electPublisher(['mac-mini', 'yosemite-s1', 'zion'], roleOf)).toBe('zion');
+    expect(electPublisher(['mac-mini', 'unmarked', 'mac-studio'], roleOf)).toBe('mac-studio');
+  });
+
+  it('breaks ties by name within a tier, and returns null with nobody ready', () => {
+    expect(electPublisher(['zion', 'mac-studio'], roleOf)).toBe('mac-studio');
+    expect(electPublisher(['yosemite-s1', 'mac-mini'], roleOf)).toBe('mac-mini');
+    expect(electPublisher([], roleOf)).toBeNull();
+  });
+
+  it('is what both sync arms elect with, through real shared-state files', async () => {
+    const root = tempStore();
+    updateFleetSharedDeviceState('mac-mini', { auth: { status: 'ready' } }, root);
+    const devices = [profile('mac-mini')];
+    const peerRole = (name: string) => roles[name];
+    const legacy = await syncReservedAuthBundle({
+      userAgentsDir: root,
+      localName: 'zion',
+      inspectLocal: () => ({ exists: true, ok: true }),
+      listDevices: () => devices,
+      isPinned: () => true,
+      peerRole,
+      selfRole: () => 'personal',
+      push: async () => ({ ok: true, message: 'pushed' }),
+    });
+    expect(legacy.publisher).toBe('zion');
+    // mac-mini reports `ready`, so the legacy plan (bundle-coarse) skips it as present.
+    expect(legacy.skipped).toEqual([{ device: 'mac-mini', reason: 'already present' }]);
+
+    const reserved = await syncReservedStores({
+      userAgentsDir: root,
+      cacheDir: tempStore(),
+      localName: 'zion',
+      localReady: true,
+      listDevices: () => devices,
+      isPinned: () => true,
+      peerRole,
+      selfRole: () => 'personal',
+      readMetaFn: () => ({ accounts: { native: { a1: { id: 'a1', name: 'work', agent: 'claude', identityKey: 'claude:account=a:org=o', scope: 'version', identityLabel: 'w@x.io', workerCredential: { bundle: '__claude__', key: 'K1', kind: 'setup-token', mintedAt: 'm1' } } } } }),
+      hasLocalKey: () => true,
+      push: async () => ({ ok: true, message: 'pushed' }),
+    });
+    expect(reserved.publisher).toBe('zion');
+    expect(reserved.pushed).toEqual([{ device: 'mac-mini', bundle: '__claude__', keys: ['K1'] }]);
   });
 });

--- a/cli/src/lib/secrets-policy.ts
+++ b/cli/src/lib/secrets-policy.ts
@@ -205,8 +205,27 @@ export interface AuthSyncDeps {
   localName?: string;
   userAgentsDir?: string;
   isPinned?: (name: string) => boolean;
+  peerRole?: (name: string) => ReturnType<typeof selfConfiguredDeviceRole>;
+  selfRole?: () => ReturnType<typeof selfConfiguredDeviceRole>;
   push?: (bundle: string, host: string) => Promise<PushBundleResult>;
   sshTarget?: (device: DeviceProfile) => string;
+}
+
+/**
+ * The one device that pushes credentials this tick. A ready HEADED device
+ * (`personal`/`desktop`) wins over any ready worker: the headed box is where
+ * tokens are minted (invariant 7), so it is the copy of record; a worker holds
+ * only what was once pushed to it. Name order breaks ties so every box elects
+ * the same publisher from the same shared verdicts. Before this rule the sort
+ * was by name alone, which elected `mac-mini` (a worker with a 6-day-old copy)
+ * over `zion`, and zion then skipped every peer as a non-publisher.
+ */
+export function electPublisher(
+  ready: readonly string[],
+  roleOf: (name: string) => ReturnType<typeof selfConfiguredDeviceRole>,
+): string | null {
+  const rank = (name: string): number => (isHeadedDeviceRole(roleOf(name)) ? 0 : 1);
+  return [...ready].sort((a, b) => rank(a) - rank(b) || normalizeHost(a).localeCompare(normalizeHost(b)))[0] ?? null;
 }
 
 export interface PublishAuthVerdictOptions {
@@ -280,8 +299,9 @@ export async function syncReservedAuthBundle(deps: AuthSyncDeps = {}): Promise<A
   if (localStatus === 'ready' && !readyPublishers.some((name) => normalizeHost(name) === localNorm)) {
     readyPublishers.push(localName);
   }
-  readyPublishers.sort((a, b) => normalizeHost(a).localeCompare(normalizeHost(b)));
-  result.publisher = readyPublishers[0] ?? null;
+  const peerRole = deps.peerRole ?? configuredDeviceRole;
+  const selfRole = deps.selfRole ?? selfConfiguredDeviceRole;
+  result.publisher = electPublisher(readyPublishers, (name) => (normalizeHost(name) === localNorm ? selfRole() : peerRole(name)));
   const localIsPublisher = result.publisher !== null && normalizeHost(result.publisher) === localNorm;
 
   const pinned = deps.isPinned ?? ((name: string) => isHostPinned(name, managedKnownHostsPath()));
@@ -509,6 +529,7 @@ export interface ReservedStoreSyncDeps {
   readMetaFn?: () => Pick<Meta, 'accounts' | 'deviceAccounts'>;
   isPinned?: (name: string) => boolean;
   peerRole?: (name: string) => ReturnType<typeof selfConfiguredDeviceRole>;
+  selfRole?: () => ReturnType<typeof selfConfiguredDeviceRole>;
   localReady?: boolean;
   /** Does THIS publisher hold (bundle, key) to push? Defaults to a local bundle read. */
   hasLocalKey?: (bundle: string, key: string) => boolean;
@@ -554,8 +575,9 @@ export async function syncReservedStores(deps: ReservedStoreSyncDeps = {}): Prom
     })
     .map((s) => s.device);
   if (localReady && !readyPublishers.some((n) => normalizeHost(n) === localNorm)) readyPublishers.push(localName);
-  readyPublishers.sort((a, b) => normalizeHost(a).localeCompare(normalizeHost(b)));
-  result.publisher = readyPublishers[0] ?? null;
+  const peerRole = deps.peerRole ?? configuredDeviceRole;
+  const selfRole = deps.selfRole ?? selfConfiguredDeviceRole;
+  result.publisher = electPublisher(readyPublishers, (name) => (normalizeHost(name) === localNorm ? selfRole() : peerRole(name)));
   const localIsPublisher = result.publisher !== null && normalizeHost(result.publisher) === localNorm;
   if (targets.length === 0 || !localIsPublisher) {
     for (const d of devices) {
@@ -566,7 +588,6 @@ export async function syncReservedStores(deps: ReservedStoreSyncDeps = {}): Prom
 
   const memo = readDeliveryMemo(deps.cacheDir);
   const pinned = deps.isPinned ?? ((name: string) => isHostPinned(name, managedKnownHostsPath()));
-  const peerRole = deps.peerRole ?? configuredDeviceRole;
   const peers: ReservedSyncPeer[] = devices.map((d) => ({
     name: d.name,
     headed: isHeadedDeviceRole(peerRole(d.name)),
@@ -634,10 +655,18 @@ export function reconcileLocalWorkerSlots(deps: ReconcileWorkerSlotsDeps = {}): 
   const slots = readSlots(meta as Pick<Meta, 'deviceAccounts'>);
   const hasLocalKey = deps.hasLocalKey ?? defaultHasLocalKey;
   const provision = deps.provision ?? provisionWorkerSlot;
-  for (const account of listNativeAccounts(meta)) {
-    const cred = account.workerCredential;
-    if (!cred) continue; // legacy claude worker resolves its token at spawn
-    if (!hasLocalKey(cred.bundle, cred.key)) { result.skipped.push({ accountId: account.id, reason: 'durable key not synced yet' }); continue; }
+  const byId = new Map(listNativeAccounts(meta).map((account) => [account.id, account]));
+  // Resolve each account to the one (bundle, key) the push plan uses: a T1 row's
+  // reserved `__<harness>__` key, or the legacy `auth` key by email for a claude
+  // row predating T1. Both are worker credentials this box may already hold, so
+  // both get a slot. Skipping the legacy rows here is what left every registered
+  // pre-T1 account without a slot on every worker while its token sat in `auth`:
+  // the picker then fell back to identity-less version homes and Claude showed a
+  // login screen on a headless box (the mac-mini 2026-09-06 incident).
+  for (const target of reservedSyncTargets(meta)) {
+    const account = byId.get(target.accountId);
+    if (!account) continue;
+    if (!hasLocalKey(target.bundle, target.key)) { result.skipped.push({ accountId: account.id, reason: 'durable key not synced yet' }); continue; }
     if (slots[account.id]?.authMode === 'durable') { result.skipped.push({ accountId: account.id, reason: 'slot already provisioned' }); continue; }
     try { provision(account); result.provisioned.push(account.id); }
     catch (err) { result.errors.push({ accountId: account.id, message: (err as Error).message }); }


### PR DESCRIPTION
## Why

Owner-reported (2026-09-06): `agents run claude --interactive --device auto` landed on mac-mini (role `worker`, macOS) and the picker listed 7 version labels with only 2 logged in, while `agents secrets view auth` on that box already held all 8 registered accounts' setup-tokens. No worker had a slot dir. Root cause and secondary defects: `~/.agents/artifacts/2026-09-06/worker-claude-accounts-gap/report.md` (diagnosis) and `plan.md` (this change). Umbrella ticket PHNX-3940; no sub-ticket per owner request.

Every registered Claude row predates T1 (`grep -c workerCredential ~/.agents/agents.yaml` = 0), and `reconcileLocalWorkerSlots` skipped any row without `workerCredential` ("legacy claude worker resolves its token at spawn") — true for `agents run claude#<name>`, false for the picker path, which reads slots + version homes and then strips `CLAUDE_CODE_OAUTH_TOKEN` when the home has no identity (`harness/adapters/claude.ts:87-91`).

## What changed

- **`reconcileLocalWorkerSlots`** (`cli/src/lib/secrets-policy.ts`) iterates `reservedSyncTargets(meta)` — the resolver the push plan already uses — so a T1 row keys its reserved `__<harness>__` store and a legacy claude row keys the email-keyed `auth` token. Both get a `durable` slot through the existing `provisionWorkerSlot` legacy branch (`claude-account-token.ts:365-373`). A row whose key is absent is `skipped: durable key not synced yet` and retried; a per-device harness row is neither provisioned nor reported.
- **`electPublisher`** (new, exported): a ready **headed** (`personal`/`desktop`) device wins over a ready worker; name order breaks ties. Both `syncReservedAuthBundle` and `syncReservedStores` use it (`peerRole`/`selfRole` deps added). Before: sort by name → `mac-mini` (a worker, 6-day-old `auth` copy) was the fleet's publisher and zion skipped every peer.
- **`AuthSyncService.onTick`** (`cli/src/lib/daemon/auth-sync-service.ts`): slot reconciliation runs first — it reads only local state — so `if (!transport.success) return` (git rebase timeout / lock held, seen all day in zion's daemon log) no longer postpones provisioning.
- Docs: `cli/docs/credential-management.md` §How the daemon reconciles it, `cli/AGENTS.md`; changelog fragment `cli/.changelog/next/PHNX-3940-legacy-worker-slots.md`.

**Out of scope, stated:** per-key inventory in the shared verdict (`peerPresentKeys` still treats `auth: ready` as "holds every legacy key", `secrets-policy.ts` — matters only after a re-mint; every worker holds all 8 keys today); `workerCredential` backfill for the 8 rows (with this change the legacy path is first-class, so it is cleanup); PR #3512's picker redesign (display; this PR makes its input exist on a worker).

## Evidence

Changed test files on a fleet worker (`scripts/test.sh --device yosemite-s1 -- src/lib/secrets-policy.test.ts src/lib/claude-account-token.test.ts src/lib/daemon/guard-no-sync-io.test.ts`):

```
 Test Files  3 passed (3)
      Tests  73 passed (73)
```

New coverage, no mocks:
- `reconcileLocalWorkerSlots through the real auth bundle › materializes a slot for a pre-T1 claude row from the synced auth token, and only once` — real standalone `secrets` file store (`useFreshSecretsHome`), sandboxed HOME: two legacy rows with tokens → two `durable` slots, `.oauth_token` mode `0600`, `readClaudeAccountEmail(slot)` returns the seeded email, `readSlots(readMeta())` records them; a third registered row with no token on the box → `durable key not synced yet`; second pass provisions nothing.
- `reconcileLocalWorkerSlots › provisions a legacy claude row (no workerCredential) from its email-keyed auth token` — asserts the exact `(auth, CLAUDE_CODE_OAUTH_TOKEN_DEV_AT_GETRUSH_DOT_AI)` lookup; a kimi row is neither provisioned nor reported.
- `electPublisher` — the live 2026-09-06 shape (`mac-mini`, `yosemite-s1`, `zion` all ready) elects `zion`; ties by name within a tier; both sync arms through real fleet-shared state files elect `zion` and the reserved arm pushes `__claude__` to the worker.
- `guard-no-sync-io.test.ts` stays green after the tick reorder (no new sync IO; `provisionWorkerSlot` already ran on the tick).

Full suite: `scripts/test.sh --shard 3` result posted below when it settles.

## After merge

Fleet runs `1.22.84` (tagged 2 s before T6 merged; 61 commits behind `main`), so this reaches a worker only after a release. Then, per worker, within one `auth-sync` tick (15 min; 60 s after a daemon restart): `ls ~/.agents/.history/accounts/claude` = 8 dirs, and the owner's original command lists 8 named launchable accounts.

> Rebased onto `main` after PHNX-3989 landed: `reserved-sync.ts` was folded into `secrets-policy.ts` there, so the same three hunks now live in `cli/src/lib/secrets-policy.ts` and the tests in `cli/src/lib/secrets-policy.test.ts`. Head: 2ad6f9a8f.