### PR TITLE
fix(test): pack the tarball from an isolated build, not the live dist (PHNX-3989)

### DIFF
--- a/cli/scripts/packed-tarball.test.ts
+++ b/cli/scripts/packed-tarball.test.ts
@@ -1,6 +1,6 @@
 /**
  * Proves the packed `@phnx-labs/agents-cli` tarball ships no trace of the
- * in-repo secrets engine (PHNX-3989 DIST-1) — real `bun run build` + real
+ * in-repo secrets engine (PHNX-3989 DIST-1) — a real `tsc` build + real
  * `npm pack` + a real `tar tzf` of the produced .tgz, not a grep of the
  * `files` allowlist in package.json. The engine (`cli/src/lib/secrets/**`,
  * the keychain-helper Swift source, the two build/verify scripts) is gone
@@ -16,28 +16,55 @@ import * as path from 'node:path';
 const CLI_ROOT = path.resolve(__dirname, '..');
 
 function packedEntries(): string[] {
-  // Always rebuild — never trust a pre-existing dist/. `dist/` is gitignored, so on a
-  // shared/reused worktree (a fleet test-runner's cached tree, in particular) a stale
-  // build from a prior commit can still be sitting there; skipping the rebuild let this
-  // test pass against yesterday's artifact instead of proving anything about the tree
-  // it just checked out.
-  execFileSync('bun', ['run', 'build'], { cwd: CLI_ROOT, stdio: 'inherit' });
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-pack-'));
+  // Build into a throwaway package dir and pack THAT — never the live `dist/`.
+  //
+  // `dist/` is gitignored and `tsc` never deletes an output whose source is gone,
+  // so on a reused worktree (a fleet test-runner's cached tree, in particular) a
+  // rebuild in place still leaves yesterday's `dist/lib/secrets/*.js` sitting
+  // beside today's output, and `npm pack` ships them: this test then fails on a
+  // tree that is actually clean (the 1.22.85 attestation run on a shard box).
+  // Wiping `dist/` first is not an option either — other tests in the same run
+  // exec `dist/index.js`. So the build goes to a fresh dir, mirroring what
+  // `release-attestation-produce.sh` does (`rm -rf dist` before its build):
+  // the listing proves the checked-out tree, not whatever the box had lying around.
+  const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-pack-'));
   try {
-    const pack = spawnSync('npm', ['pack', '--silent', '--pack-destination', tmp], {
-      cwd: CLI_ROOT,
+    execFileSync(
+      path.join(CLI_ROOT, 'node_modules', '.bin', 'tsc'),
+      ['-p', CLI_ROOT, '--outDir', path.join(stage, 'dist')],
+      { cwd: CLI_ROOT, stdio: 'inherit' },
+    );
+    // Everything else the `files` allowlist admits, copied from the tree so the
+    // pack sees the same allowlist against the same non-dist inputs a release does.
+    // `prepack` (`cp ../README.md README.md`) is what puts README.md in place; the
+    // pack below runs with --ignore-scripts, so do that copy here.
+    const pkg = JSON.parse(fs.readFileSync(path.join(CLI_ROOT, 'package.json'), 'utf-8')) as {
+      files: string[];
+    };
+    for (const entry of pkg.files) {
+      if (entry.startsWith('dist/')) continue;
+      const src = path.join(CLI_ROOT, entry);
+      if (!fs.existsSync(src)) continue;
+      fs.mkdirSync(path.dirname(path.join(stage, entry)), { recursive: true });
+      fs.cpSync(src, path.join(stage, entry), { recursive: true });
+    }
+    fs.copyFileSync(path.join(CLI_ROOT, 'package.json'), path.join(stage, 'package.json'));
+    fs.copyFileSync(path.join(CLI_ROOT, '..', 'README.md'), path.join(stage, 'README.md'));
+
+    const pack = spawnSync('npm', ['pack', '--silent', '--ignore-scripts', '--pack-destination', stage], {
+      cwd: stage,
       encoding: 'utf-8',
     });
     if (pack.status !== 0) {
       throw new Error(`npm pack failed (status ${pack.status}): ${pack.stdout}${pack.stderr}`);
     }
     const tgzName = pack.stdout.trim().split('\n').pop()!;
-    const tgzPath = path.join(tmp, tgzName);
-    expect(fs.existsSync(tgzPath), `npm pack did not produce ${tgzName} in ${tmp}`).toBe(true);
+    const tgzPath = path.join(stage, tgzName);
+    expect(fs.existsSync(tgzPath), `npm pack did not produce ${tgzName} in ${stage}`).toBe(true);
     const listing = execFileSync('tar', ['tzf', tgzPath], { encoding: 'utf-8' });
     return listing.trim().split('\n');
   } finally {
-    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(stage, { recursive: true, force: true });
   }
 }
 

--- a/cli/scripts/packed-tarball.test.ts
+++ b/cli/scripts/packed-tarball.test.ts
@@ -36,10 +36,16 @@ function packedEntries(): string[] {
     );
     // Everything else the `files` allowlist admits, copied from the tree so the
     // pack sees the same allowlist against the same non-dist inputs a release does.
-    // `prepack` (`cp ../README.md README.md`) is what puts README.md in place; the
-    // pack below runs with --ignore-scripts, so do that copy here.
+    // `prepack` (`cp ../README.md README.md`) is what puts README.md in place, so
+    // do that copy here. The staged package.json carries NO `scripts` block: the
+    // allowlist alone decides tarball content, and `npm pack --ignore-scripts` is
+    // not honored for `prepare` on every npm (the GitHub runner's ran
+    // `prepare` -> `npm run build` -> a global tsc against a dir with no
+    // tsconfig and failed the pack) — the flag is a courtesy, the absent block is
+    // the guarantee.
     const pkg = JSON.parse(fs.readFileSync(path.join(CLI_ROOT, 'package.json'), 'utf-8')) as {
       files: string[];
+      scripts?: Record<string, string>;
     };
     for (const entry of pkg.files) {
       if (entry.startsWith('dist/')) continue;
@@ -48,7 +54,8 @@ function packedEntries(): string[] {
       fs.mkdirSync(path.dirname(path.join(stage, entry)), { recursive: true });
       fs.cpSync(src, path.join(stage, entry), { recursive: true });
     }
-    fs.copyFileSync(path.join(CLI_ROOT, 'package.json'), path.join(stage, 'package.json'));
+    const { scripts: _scripts, ...packable } = pkg;
+    fs.writeFileSync(path.join(stage, 'package.json'), JSON.stringify(packable, null, 2));
     fs.copyFileSync(path.join(CLI_ROOT, '..', 'README.md'), path.join(stage, 'README.md'));
 
     const pack = spawnSync('npm', ['pack', '--silent', '--ignore-scripts', '--pack-destination', stage], {


### PR DESCRIPTION
## Why

The 1.22.85 release attestation (`release-attestation-produce.sh origin/main --test-shard 3` on `44ec9b6`) went red on shard 1 (yosemite-m5): `scripts/packed-tarball.test.ts` reported 68 `package/dist/lib/secrets/*` entries in the packed tarball on a tree where that directory no longer exists.

Cause: the test rebuilt with `bun run build` (plain `tsc`) and then packed `cli/dist`. tsc never deletes an output whose source is gone, so on a reused fleet worktree the pre-Track-D engine outputs survived the rebuild and `npm pack` shipped them. The test's own comment claimed "always rebuild, never trust a pre-existing dist/" while doing exactly that.

The shipped artifact was never at risk: `release-attestation-produce.sh:348` does `rm -rf dist` before its build. Only the test was wrong.

## Change

`packedEntries()` now builds into a fresh temp package dir (`tsc -p cli --outDir <tmp>/dist`), copies the non-`dist` entries of the `files` allowlist plus the README that `prepack` would place, and packs that dir with `--ignore-scripts`. The live `dist/` is never wiped or written (other tests in the same run exec `dist/index.js`), and the listing proves the checked-out tree the way the release path does.

Test-only change: no CHANGELOG/docs.

## Verification

- With a stale `dist/lib/secrets/agent.js` planted in the worktree's live `dist/`, the rewritten test passes 5/5 (`TZ=UTC node ./node_modules/vitest/vitest.mjs run scripts/packed-tarball.test.ts`).
- The shard-1 log (`/tmp/agents-shard-1.xkmYcl` on this box) shows the previous version failing on exactly that state.

Unblocks the 1.22.85 release (PHNX-3989 delivery).