### PR TITLE
fix(postinstall): stop writing the secrets alias shim; remove the retired one on install (PHNX-3989)

### DIFF
--- a/cli/.changelog/next/PHNX-3989-legacy-secrets-shim.md
+++ b/cli/.changelog/next/PHNX-3989-legacy-secrets-shim.md
@@ -8,6 +8,9 @@
   shim without bound. The resolver now skips agents-cli's own shims dir when looking
   for the standalone (`SECRETS_BIN` still wins; a miss still fails loud with the
   install command), and the self-heal shim pass removes that legacy `secrets` shim
-  even though its target install is alive, since it can only recurse. Install the
-  standalone with `npm i -g @phnx-labs/secrets-cli` if `agents secrets` reports it
-  missing.
+  even though its target install is alive, since it can only recurse. The package's
+  postinstall — which used to write that very shim on every install, so an upgrade
+  kept bringing it back — no longer writes a `secrets` alias at all and removes one
+  a previous install left behind; the bare-command aliases are now `sessions`,
+  `browser`, `pty`, and `teams`. Install the standalone with
+  `npm i -g @phnx-labs/secrets-cli` if `agents secrets` reports it missing.

--- a/cli/scripts/postinstall.js
+++ b/cli/scripts/postinstall.js
@@ -50,9 +50,37 @@ function shellQuote(value) {
 }
 
 // Shorthands that delegate to the installed agents-cli entrypoint.
-const ALIASES = ['sessions', 'secrets', 'browser', 'pty', 'teams'];
+const ALIASES = ['sessions', 'browser', 'pty', 'teams'];
+
+// Aliases this script USED to write and must now remove on every install.
+// `secrets`: the name belongs to the standalone `@phnx-labs/secrets-cli` binary
+// (PHNX-3989); `agents secrets` is a passthrough to it, so an alias shim that
+// `exec`s `agents secrets` can only re-enter the passthrough, and it shadows the
+// real `secrets` bin because the shims dir sits first on PATH. The self-heal
+// shim pass prunes it too, but that only runs from a daemon or a TTY session —
+// postinstall is what every upgrade path actually executes, so it cleans up here.
+const RETIRED_ALIASES = ['secrets'];
+
+function removeRetiredAliasShims() {
+  for (const name of RETIRED_ALIASES) {
+    for (const file of [path.join(SHIMS_DIR, name), path.join(SHIMS_DIR, name + '.cmd')]) {
+      let content;
+      try {
+        content = fs.readFileSync(file, 'utf8');
+      } catch {
+        continue;
+      }
+      // Only ever remove OUR alias — the POSIX shim ends in `<name> "$@"`, the
+      // Windows companion in `<name> %*` — never an unrelated file someone placed
+      // under that name.
+      if (!content.includes(`${name} "$@"`) && !content.includes(`${name} %*`)) continue;
+      fs.rmSync(file, { force: true });
+    }
+  }
+}
 
 function writeAliasShims() {
+  removeRetiredAliasShims();
   const written = [];
   for (const name of ALIASES) {
     const target = path.join(SHIMS_DIR, name);

--- a/cli/scripts/postinstall.js
+++ b/cli/scripts/postinstall.js
@@ -72,7 +72,9 @@ function removeRetiredAliasShims() {
       }
       // Only ever remove OUR alias — the POSIX shim ends in `<name> "$@"`, the
       // Windows companion in `<name> %*` — never an unrelated file someone placed
-      // under that name.
+      // under that name, and never a user's own `agents setup alias` shim, which
+      // is marked `# Alias shim:` (the same guard pruneOrphanedCommandShim keeps).
+      if (content.includes('# Alias shim:')) continue;
       if (!content.includes(`${name} "$@"`) && !content.includes(`${name} %*`)) continue;
       fs.rmSync(file, { force: true });
     }

--- a/cli/scripts/postinstall.test.ts
+++ b/cli/scripts/postinstall.test.ts
@@ -111,11 +111,40 @@ describe('postinstall alias shims', () => {
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toBe('');
 
-    for (const name of ['sessions', 'secrets', 'browser', 'pty', 'teams']) {
+    for (const name of ['sessions', 'browser', 'pty', 'teams']) {
       const script = readShim(home, name);
       expect(script).toContain(`exec "$AGENTS_BIN" ${name} "$@"`);
       expect(script).toContain(path.join(root, 'dist', 'index.js'));
     }
+    // `secrets` is the standalone binary's name (PHNX-3989): never written here.
+    expect(fs.existsSync(path.join(home, '.agents', '.cache', 'shims', 'secrets'))).toBe(false);
+  });
+
+  it('removes the retired `secrets` alias a previous install wrote, and only that (PHNX-3989)', () => {
+    // An in-place upgrade from a pre-standalone release leaves the old alias
+    // behind; every install path runs this script, so this is where it goes.
+    const home = makeTempHome();
+    const root = stagePackageTree();
+    const shims = path.join(home, '.agents', '.cache', 'shims');
+    fs.mkdirSync(shims, { recursive: true });
+    const legacy = `#!/bin/sh\nAGENTS_BIN='/old/install/dist/index.js'\nexec "$AGENTS_BIN" secrets "$@"\n`;
+    fs.writeFileSync(path.join(shims, 'secrets'), legacy, { mode: 0o755 });
+    fs.writeFileSync(path.join(shims, 'secrets.cmd'), `@echo off\r\nnode "/old/install/dist/index.js" secrets %*\r\n`);
+    // An unrelated file under a retired name is not ours and must survive.
+    const foreign = path.join(shims, 'secrets-foreign');
+    fs.writeFileSync(foreign, '#!/bin/sh\necho unrelated\n', { mode: 0o755 });
+
+    const result = runPostinstall(root, home, {
+      npm_config_global: undefined,
+      AGENTS_INIT_SHELL: undefined,
+      AGENTS_POSTINSTALL_SHIMS_ONLY: '1',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fs.existsSync(path.join(shims, 'secrets'))).toBe(false);
+    expect(fs.existsSync(path.join(shims, 'secrets.cmd'))).toBe(false);
+    expect(fs.existsSync(foreign)).toBe(true);
+    expect(readShim(home, 'sessions')).toContain('exec "$AGENTS_BIN" sessions "$@"');
   });
 });
 

--- a/cli/scripts/postinstall.test.ts
+++ b/cli/scripts/postinstall.test.ts
@@ -146,6 +146,26 @@ describe('postinstall alias shims', () => {
     expect(fs.existsSync(foreign)).toBe(true);
     expect(readShim(home, 'sessions')).toContain('exec "$AGENTS_BIN" sessions "$@"');
   });
+
+  it("leaves a user's own `# Alias shim:` under a retired name alone", () => {
+    // `agents setup alias` shims carry the marker and end in the same
+    // `<name> "$@"` tail; a pre-existing user alias is the user's, not ours.
+    const home = makeTempHome();
+    const root = stagePackageTree();
+    const shims = path.join(home, '.agents', '.cache', 'shims');
+    fs.mkdirSync(shims, { recursive: true });
+    const userAlias = path.join(shims, 'secrets');
+    fs.writeFileSync(userAlias, `#!/bin/sh\n# Alias shim: secrets -> agents secrets\nexec agents secrets "$@"\n`, { mode: 0o755 });
+
+    const result = runPostinstall(root, home, {
+      npm_config_global: undefined,
+      AGENTS_INIT_SHELL: undefined,
+      AGENTS_POSTINSTALL_SHIMS_ONLY: '1',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fs.readFileSync(userAlias, 'utf-8')).toContain('# Alias shim: secrets');
+  });
 });
 
 describe('postinstall signed-binary resolution (#315)', () => {

--- a/cli/src/commands/alias.test.ts
+++ b/cli/src/commands/alias.test.ts
@@ -125,6 +125,14 @@ describe('the nested `agents setup alias` surface', () => {
     expect(r.status).not.toBe(0);
     expect(r.stderr).toMatch(/reserved/);
   });
+
+  it('refuses `secrets`, the standalone CLI name the shims dir would shadow (PHNX-3989)', () => {
+    const home = guardedHome();
+    const r = run(['setup', 'alias', 'add', 'secrets'], home);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/reserved/);
+    expect(fs.existsSync(path.join(home, '.agents', '.cache', 'shims', 'secrets'))).toBe(false);
+  });
 });
 
 describe('the retired top-level `agents alias`', () => {

--- a/cli/src/commands/alias.ts
+++ b/cli/src/commands/alias.ts
@@ -25,9 +25,13 @@ function aliasesFile(): string {
   return path.join(getUserAgentsDir(), 'aliases.json');
 }
 
-/** Names that would clobber an agent CLI shim or the `agents` binary itself. */
+/**
+ * Names that would clobber an agent CLI shim, the `agents` binary itself, or the
+ * standalone `secrets` CLI (PHNX-3989): the shims dir sits first on PATH, so an
+ * alias named `secrets` would shadow `@phnx-labs/secrets-cli` for every caller.
+ */
 function reservedNames(): Set<string> {
-  const reserved = new Set<string>(['agents']);
+  const reserved = new Set<string>(['agents', 'secrets']);
   for (const id of ALL_AGENT_IDS) reserved.add(AGENTS[id].cliCommand);
   return reserved;
 }
@@ -107,7 +111,7 @@ export function registerAliasCommand(setupCmd: Command): void {
         process.exit(1);
       }
       if (reservedNames().has(name)) {
-        console.error(chalk.red(`"${name}" is reserved (collides with an agent CLI or the agents binary).`));
+        console.error(chalk.red(`"${name}" is reserved (collides with an agent CLI, the agents binary, or the standalone secrets CLI).`));
         process.exit(1);
       }
 

--- a/cli/src/lib/installations/shims.ts
+++ b/cli/src/lib/installations/shims.ts
@@ -2259,11 +2259,12 @@ const LEGACY_SHIMS_ALWAYS_PRUNED: ReadonlySet<string> = new Set(['secrets']);
 /**
  * Prune a stale, orphaned shim: one that is NOT a managed agent shim and NOT a user
  * alias, whose baked `AGENTS_BIN` points at an install that no longer exists. These
- * are legacy `exec "$AGENTS_BIN" <cmd>` command shims (browser/secrets/sessions/…)
- * left behind by a removed install — the current source never generates them, and
- * they either die with `exit 127` or shadow the real package bin on PATH. Only
- * removed when the baked target is gone, so a working shim is never touched —
- * except the `LEGACY_SHIMS_ALWAYS_PRUNED` set, which cannot work at all.
+ * are `exec "$AGENTS_BIN" <cmd>` command shims (browser/sessions/pty/teams) that
+ * `scripts/postinstall.js` writes for the LIVE install; one baked at a removed
+ * install either dies with `exit 127` or shadows the real package bin on PATH.
+ * Only removed when the baked target is gone, so a working shim is never touched —
+ * except the `LEGACY_SHIMS_ALWAYS_PRUNED` set, which cannot work at all (and which
+ * postinstall no longer writes).
  * Returns true if removed.
  */
 export function pruneOrphanedCommandShim(fileName: string): boolean {


### PR DESCRIPTION
## Why

Follow-up to #3530. While verifying the installed pair on this box I found `~/.agents/.cache/shims/secrets` re-created at the exact minute the box auto-updated to 1.22.85: `scripts/postinstall.js` writes a `secrets` alias shim on **every** install, including the self-updater's `AGENTS_POSTINSTALL_SHIMS_ONLY=1` re-run. So the self-heal prune #3530 added is undone by the next upgrade, and on a headless worker with no daemon tick or TTY heal (the reviewer's finding 2 on #3530) the shim just persists. The resolver fix in #3530 already prevents the recursion regardless; this closes the source so the shim stops shadowing the real `@phnx-labs/secrets-cli` bin for bare `secrets` calls.

## Change

- `ALIASES` drops `secrets`; the bare-command aliases are now `sessions`, `browser`, `pty`, `teams`.
- `RETIRED_ALIASES = ['secrets']`: `writeAliasShims` first removes a leftover POSIX shim and its `.cmd` companion. Ownership is matched on the alias tail (`secrets "$@"` / `secrets %*`) so an unrelated file under that name is never touched. Runs on every install path.
- `postinstall.test.ts`: the shims-only run writes no `secrets`; a planted legacy shim + `.cmd` is removed while a foreign `secrets-foreign` file survives (real process, temp HOME, no mocks).
- `shims.ts` prune docblock corrected: postinstall does regenerate the live alias set, so "the current source never generates them" was false.
- Changelog fragment amended (same PHNX-3989 entry).

## Verification

- `tsc --noEmit` clean; `scripts/postinstall.test.ts` 9/9 (+3 platform skips); `shims.drift.test.ts` and `secrets-client.test.ts` green.
- Fleet: the stale shim was removed by hand on the 9 reachable 1.22.85 workers as an interim mitigation; this PR makes 1.22.86's install do that itself.

Fleet guidance (phnx-labs/.agents): no consumer references the shim; #446 documents the standalone install.