### PR TITLE
fix(secrets): sync serve fd 3 must be a socketpair, not a FIFO (net.Socket never EOFs a FIFO on macOS)

### DIFF
--- a/cli/.changelog/next/secrets-sync-fd-eof.md
+++ b/cli/.changelog/next/secrets-sync-fd-eof.md
@@ -1,0 +1,11 @@
+- **`agents run` no longer fails with `secrets request failed: spawnSync sh
+  ETIMEDOUT` when resolving an account credential.** The synchronous secrets path
+  (`agents view`, the account catalog, and account resolution on the `agents run`
+  hot path) fed the standalone `secrets __serve` its request over a named FIFO on
+  fd 3. The standalone wraps fd 3 in a `net.Socket`, and a Socket over a named FIFO
+  reads the request but never fires EOF on macOS — so its read loop blocked until
+  the 3s sync bound fired and every credential lookup timed out. The request now
+  rides `spawnSync`'s stdin (a real pipe/socketpair — the same fd type the async
+  path already hands the standalone) dup'd onto fd 3, so it EOFs and a real
+  handshake/lookup completes in tens of ms. Source: `cli/src/lib/secrets-client.ts`
+  (`serveOnceSync`).

--- a/cli/docs/secrets-client.md
+++ b/cli/docs/secrets-client.md
@@ -51,12 +51,14 @@ Both primitives spawn one `secrets __serve` per call:
 | Primitive | Transport |
 |---|---|
 | `secretsRequest(op, args?, context?)` | `spawn`; write+end `child.stdio[3]`, read `child.stdio[4]` to EOF. |
-| `secretsRequestSync(op, args?, context?)` | `spawnSync` under a POSIX **shell**, so only stdio 0-2 cross the `spawnSync` boundary (numbered fds 3+ are **dropped by the Bun runtime**, and this repo runs its whole CLI suite as `bun src/index.ts`). The shell does the fd wiring: the request rides a **named FIFO** fed by a backgrounded `cat` (fd 3), and fd 4 is redirected onto the child's stdout (`4>&1`), captured natively as `result.stdout` on every runtime. Both fds are FIFOs, which the standalone requires (it refuses a plain file or tty for either, so no secret is staged to disk). Bounded by `SYNC_SERVE_TIMEOUT_MS` (**3 s**), not the async path's 65 s. POSIX only — Windows has no `mkfifo` and fails loud, pointing at the async path. |
+| `secretsRequestSync(op, args?, context?)` | `spawnSync` under a POSIX **shell**, so only stdio 0-2 cross the `spawnSync` boundary (numbered fds 3+ are **dropped by the Bun runtime**, and this repo runs its whole CLI suite as `bun src/index.ts`). The shell does the fd wiring: the request rides `spawnSync`'s **stdin** (a real pipe/socketpair on every runtime), dup'd onto fd 3 (`3<&0`), and fd 4 is redirected onto the child's stdout (`4>&1`), captured natively as `result.stdout`. Both fds are then the **same anonymous pipe/socketpair the async path hands the standalone** — load-bearing, because the standalone wraps fd 3 in a `net.Socket` and a Socket over a **named FIFO** reads the request but never fires EOF on macOS, so the older FIFO wiring hung the read loop until the timeout. The standalone still requires a pipe or socket for both (it refuses a plain file or tty, so no secret is staged to disk). Bounded by `SYNC_SERVE_TIMEOUT_MS` (**3 s**), not the async path's 65 s. POSIX only — Windows fails loud, pointing at the async path. |
 
 `secretsRequestSync` exists for the read-only STATUS surfaces that resolve secrets
 on a synchronous path — `agents view`, the account-catalog rows, run-config and
 account-rotation resolution on the `agents run` hot path. There is no request-size
-bound (the request streams through the FIFO, not a fixed pipe buffer), and the 3 s
+bound (`spawnSync` services stdin and the fd-4 response concurrently, so a large
+request never deadlocks on a full pipe buffer — the standalone drains fd 3 to EOF
+while `spawnSync` is still writing it), and the 3 s
 timeout means a missing or unreachable standalone **fails fast**, never blocking
 the whole render/launch for the standalone's own 60 s deadline. Those callers
 catch the resulting `SecretsClientError` and surface one clear line while

--- a/cli/src/lib/secrets-client.test.ts
+++ b/cli/src/lib/secrets-client.test.ts
@@ -338,7 +338,20 @@ describe.skipIf(!REAL_BIN)('secrets protocol client against the real standalone'
 
   it('reports bundleExists=false on a fresh home', async () => {
     expect(await bundleExists('absent-bundle')).toBe(false);
-    expect(bundleExistsSync('absent-bundle')).toBe(false); // sync FIFO transport
+    expect(bundleExistsSync('absent-bundle')).toBe(false); // sync fd-3-over-stdin transport
+  });
+
+  it('the synchronous handshake round-trips well under the ~3s bound (no fd-3 EOF hang)', () => {
+    // Regression for the macOS sync-path hang: the standalone wraps fd 3 in a
+    // `net.Socket`, and a Socket over a NAMED FIFO reads the request but never
+    // fires EOF on macOS — so the old FIFO wiring left `for await (chunk of
+    // input)` blocked until the 3s SYNC_SERVE_TIMEOUT_MS fired (`ETIMEDOUT`).
+    // Feeding fd 3 the stdin pipe/socketpair (the async path's fd type) EOFs, so a
+    // real handshake now completes in tens of ms against the real standalone.
+    const t0 = Date.now();
+    const result = secretsRequestSync<{ protocol: number }>('handshake', []);
+    expect(result.protocol).toBe(PROTOCOL_VERSION);
+    expect(Date.now() - t0).toBeLessThan(2_000); // real op is tens of ms; never the 3s timeout
   });
 
   it('round-trips writeBundleWithItems -> readAndResolveBundleEnv on a file bundle', async () => {
@@ -351,15 +364,15 @@ describe.skipIf(!REAL_BIN)('secrets protocol client against the real standalone'
     expect(resolved.bundle.backend).toBe('file');
     expect(resolved.env).toEqual({ MY_KEY: value });
 
-    // The same read on the synchronous FIFO path returns the same env.
+    // The same read on the synchronous path returns the same env.
     const sync = readAndResolveBundleEnvSync('round-trip');
     expect(sync.env).toEqual({ MY_KEY: value });
   });
 
-  it('an arbitrarily large synchronous request completes — the request rides a FIFO, not a bounded pipe write', () => {
-    // The request now streams through a FIFO fed by a backgrounded `cat` rather
-    // than being pre-filled into a pipe buffer, so there is no size at which the
-    // sync path must be refused or deadlocks. A name well past any former
+  it('an arbitrarily large synchronous request completes — spawnSync services stdin and fd 4 concurrently, no deadlock', () => {
+    // The request rides spawnSync's stdin (dup'd onto fd 3), and the standalone
+    // drains fd 3 to EOF while spawnSync is still writing it, so there is no size
+    // at which the sync path deadlocks on a full pipe buffer. A name well past any
     // pipe-buffer bound (~64 KiB on Linux) still round-trips: the server answers
     // even when it rejects the oversized name, and nothing hangs.
     const bigName = 'x'.repeat(200_000);

--- a/cli/src/lib/secrets-client.ts
+++ b/cli/src/lib/secrets-client.ts
@@ -17,12 +17,17 @@
  *   - async: `spawn` with stdio ['ignore','ignore','inherit','pipe','pipe'];
  *     write+end child.stdio[3], read child.stdio[4] to EOF.
  *   - sync: `spawnSync` only wires stdio 0-2 portably (Bun drops numbered fds
- *     3+), so the fd 3/4 wiring is done in a POSIX shell: the request rides a
- *     named FIFO fed by a backgrounded `cat` (fd 3), and fd 4 is redirected onto
- *     the child's stdout (`4>&1`), which `spawnSync` captures natively on every
- *     runtime. Bounded to `SYNC_SERVE_TIMEOUT_MS` so a broken standalone fails
- *     fast, never for the server's 60s deadline. POSIX only; Windows has no
- *     `mkfifo` and fails loud pointing at the async path.
+ *     3+), so the fd 3/4 wiring is done in a POSIX shell: the request rides
+ *     `spawnSync`'s STDIN — a real pipe/socketpair on every runtime — which the
+ *     shell dups onto fd 3 (`3<&0`), and fd 4 is redirected onto the child's
+ *     stdout (`4>&1`), which `spawnSync` captures natively. Both fds are then the
+ *     SAME anonymous pipe/socketpair the async path hands the standalone, which
+ *     is load-bearing: the standalone wraps fd 3 in a `net.Socket`, and a Socket
+ *     over a NAMED FIFO reads the request but never fires EOF on macOS, so the
+ *     older FIFO wiring hung the read loop for the full timeout. Bounded to
+ *     `SYNC_SERVE_TIMEOUT_MS` so a broken standalone fails fast, never for the
+ *     server's 60s deadline. POSIX only; Windows fails loud pointing at the
+ *     async path.
  *
  * State root (MIG-1): the standalone selects its state root from `SECRETS_HOME`.
  * agents-cli points it at the user agents dir (`~/.agents`) by default so the
@@ -42,9 +47,6 @@
  * `@phnx-labs/secrets-cli` package is the only implementation.
  */
 import { spawn, spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import type { Readable, Writable } from 'node:stream';
 import { findInPath } from './agent-spec/agents.js';
 import { getUserAgentsDir } from './state.js';
@@ -435,69 +437,60 @@ function serveOnceSync(op: string, args: unknown[], context?: SecretsContext): u
   if (process.platform === 'win32') {
     throw new SecretsClientError(
       'SYNC_UNSUPPORTED',
-      'The synchronous secrets path needs a POSIX shell and FIFO; use secretsRequest (async) on Windows.',
+      'The synchronous secrets path needs a POSIX shell; use secretsRequest (async) on Windows.',
     );
   }
   const { command, prefix } = invocation(resolveSecretsBin());
   const request = Buffer.from(JSON.stringify(buildRequest(op, args, context)));
   // The standalone's private protocol reads the request from fd 3 and writes the
-  // response to fd 4, and it REFUSES a plain file or tty for either (it fails with
-  // `PRIVATE_PIPE_REQUIRED` so no secret is ever staged to disk). But `spawnSync`
-  // only wires stdio 0-2 portably — the Bun runtime (this repo runs its whole CLI
-  // suite as `bun src/index.ts`, so the 71 CLI-integration tests spawn agents-cli
-  // under Bun) silently DROPS numbered fds 3+, so the old direct-fd wiring left the
-  // child blocked on an empty fd 3 for the full timeout. Do the numbered-fd wiring
-  // in a POSIX shell against PIPES instead: the request rides a FIFO fed by a
-  // backgrounded `cat` (fd 3), and fd 4 is dup'd from the captured stdout pipe
-  // (`4>&1`), which `spawnSync` captures natively as an anonymous pipe on every
-  // runtime. The child's own fd 1 is then redirected to /dev/null (`1>/dev/null`,
-  // applied AFTER `4>&1` so fd 4 keeps the pipe): the response channel (fd 4) is
-  // structurally the ONLY writer to the captured stream, so even a stray write to
-  // the standalone's own stdout can never corrupt the fd-4 bytes. Both fd 3/4 are
-  // S_ISFIFO, satisfying the standalone; the response never touches disk.
-  // Identical on Node and Bun.
-  const dir = mkdtempSync(join(tmpdir(), 'agents-secrets-'));
-  const reqFile = join(dir, 'req');
-  const reqFifo = join(dir, 'reqfifo');
-  try {
-    writeFileSync(reqFile, request);
-    const mk = spawnSync('mkfifo', [reqFifo]);
-    if (mk.status !== 0) {
-      throw new SecretsClientError('SYNC_UNSUPPORTED', 'mkfifo is unavailable for the synchronous secrets path');
-    }
-    const serve = [command, ...prefix, '__serve'].map(shQuote).join(' ');
-    // `exec` so the wrapper `sh` BECOMES the standalone (same PID). Two things ride
-    // on that: `spawnSync` waits on the real process, so on return the store is
-    // fully flushed and its proper-lockfile lock dir released (the sync path never
-    // had the async path's resolve-before-exit race — spawnSync is a hard barrier);
-    // and `spawnSync`'s timeout SIGTERM lands on the standalone itself rather than
-    // orphaning a wedged child behind a dead wrapper. The backgrounded `cat` only
-    // feeds the tiny request into the FIFO and exits the instant the reader (fd 3)
-    // opens — long before the standalone finishes — so it is reaped by its own exit
-    // and never outlives the call. fd wiring is order-sensitive: `4>&1` dups the
-    // response channel from the captured stdout pipe, THEN `1>/dev/null` sends the
-    // child's own stdout to the bit bucket, so fd 4 stays the sole writer to the
-    // captured stream.
-    const script = `cat ${shQuote(reqFile)} > ${shQuote(reqFifo)} & exec ${serve} 3<${shQuote(reqFifo)} 4>&1 1>/dev/null`;
-    const result = spawnSync('sh', ['-c', script], {
-      stdio: ['ignore', 'pipe', 'inherit'],
-      env: buildServeEnv(),
-      timeout: SYNC_SERVE_TIMEOUT_MS,
-      maxBuffer: MAX_PROTOCOL_BYTES + 4096,
-    });
-    if (result.error) {
-      const err = result.error as NodeJS.ErrnoException;
-      const code = err.code === 'ETIMEDOUT' ? 'TIMEOUT' : 'SPAWN_FAILED';
-      throw new SecretsClientError(code, `secrets request failed: ${err.message}`);
-    }
-    const raw = (result.stdout as Buffer | undefined) ?? Buffer.alloc(0);
-    if (raw.length > MAX_PROTOCOL_BYTES) {
-      throw new SecretsClientError('RESPONSE_TOO_LARGE', 'secrets response exceeds the protocol limit');
-    }
-    return parseResponse(raw);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
+  // response to fd 4, wrapping BOTH in a `net.Socket` (secrets-cli
+  // `runProtocolServer`). It also REFUSES a plain file or tty for either — fd 3/4
+  // MUST be a pipe or socket (`PRIVATE_PIPE_REQUIRED`) — so no secret is ever
+  // staged to disk. But `spawnSync` only wires stdio 0-2 portably — the Bun
+  // runtime (this repo runs its whole CLI suite as `bun src/index.ts`, so the CLI-
+  // integration tests spawn agents-cli under Bun) silently DROPS numbered fds 3+,
+  // so the numbered-fd wiring is done in a POSIX shell.
+  //
+  // The request rides `spawnSync`'s STDIN, which every runtime backs with a real
+  // pipe/socketpair, and the shell dups it onto fd 3 (`3<&0`); fd 4 is dup'd from
+  // the captured stdout pipe (`4>&1`), then the child's own fd 1 is sent to
+  // /dev/null (`1>/dev/null`, AFTER `4>&1` so fd 4 keeps the pipe) — so the
+  // response channel (fd 4) is structurally the ONLY writer to the captured
+  // stream and a stray write to the standalone's own stdout can never corrupt the
+  // fd-4 bytes. Crucially, fd 3 and fd 4 are now the SAME anonymous
+  // pipe/socketpair the async path hands the standalone via `spawn` numbered
+  // stdio, rather than a named FIFO: a `net.Socket` wrapped around a named FIFO
+  // reads the request but never fires EOF on macOS, so the standalone's
+  // `for await (const chunk of input)` on fd 3 would hang for the full timeout
+  // (the bug the old FIFO wiring hit — spawnSync's stdout IS a socketpair, so fd 4
+  // was fine, but the FIFO on fd 3 never EOF'd). `exec` so the wrapper `sh`
+  // BECOMES the standalone (same PID): `spawnSync` waits on the real process, so
+  // on return the store is fully flushed and its lock dir released, and a timeout
+  // SIGTERM lands on the standalone itself rather than orphaning a wedged child.
+  // The response never touches disk. The shell wiring is parent-runtime-agnostic
+  // — `spawnSync`'s stdio is a socketpair under both Node and Bun — so fd 3 EOFs
+  // whenever the standalone itself runs under Node. (A standalone that `invocation`
+  // launches under BUN still hits its own PHNX-3989 EOF hang regardless of the
+  // wiring; that stays bounded by SYNC_SERVE_TIMEOUT_MS below, as before.)
+  const serve = [command, ...prefix, '__serve'].map(shQuote).join(' ');
+  const script = `exec ${serve} 3<&0 4>&1 1>/dev/null`;
+  const result = spawnSync('sh', ['-c', script], {
+    input: request,
+    stdio: ['pipe', 'pipe', 'inherit'],
+    env: buildServeEnv(),
+    timeout: SYNC_SERVE_TIMEOUT_MS,
+    maxBuffer: MAX_PROTOCOL_BYTES + 4096,
+  });
+  if (result.error) {
+    const err = result.error as NodeJS.ErrnoException;
+    const code = err.code === 'ETIMEDOUT' ? 'TIMEOUT' : 'SPAWN_FAILED';
+    throw new SecretsClientError(code, `secrets request failed: ${err.message}`);
   }
+  const raw = (result.stdout as Buffer | undefined) ?? Buffer.alloc(0);
+  if (raw.length > MAX_PROTOCOL_BYTES) {
+    throw new SecretsClientError('RESPONSE_TOO_LARGE', 'secrets response exceeds the protocol limit');
+  }
+  return parseResponse(raw);
 }
 
 // --- handshake (once per process) ------------------------------------------


### PR DESCRIPTION
## Problem

On a box where `secrets` resolves to the standalone `@phnx-labs/secrets-cli`,
`agents run` failed while resolving an account credential:

```
secrets request failed: spawnSync sh ETIMEDOUT
```

`agents run` resolves the account credential **synchronously** via
`getKeychainTokenSync` → `secretsRequestSync` → `ensureHandshakeSync` →
`serveOnceSync`, which is bounded by a hard 3s `SYNC_SERVE_TIMEOUT_MS`. Every such
lookup timed out. The async path (`agents secrets list`) was unaffected.

## Root cause

`serveOnceSync` fed the standalone `secrets __serve` its request over a **named
FIFO** on fd 3 (a backgrounded `cat` wrote the request into the FIFO). The
standalone wraps fd 3 in a `net.Socket` (`protocol-server.ts`
`runProtocolServer`), and **on macOS a `net.Socket` over a named FIFO reads the
request bytes but never fires `end`/EOF** — so the standalone's
`for await (const chunk of input)` on fd 3 blocked until the 3s bound fired.

The async path never hit this because `spawn` gives the standalone **socketpair**
stdio (numbered pipes), not a FIFO — and a `net.Socket` over a socketpair EOFs
correctly.

Proven in isolation on this machine (same shell wiring the client builds):

| fd 3 reader | result |
|---|---|
| `net.Socket({fd:3})` on a **FIFO** | reads 45 bytes, **NO EOF** → 1.5s timeout |
| `fs.createReadStream(null,{fd:3})` on the same FIFO | EOF in **57ms** |
| `net.Socket({fd:3})` on a **socketpair** (the fix) | EOF + responded in **57ms** |

## Fix (fd wiring only)

Drop the FIFO + `mkfifo` + backgrounded `cat` and ride the request on
`spawnSync`'s **stdin** (a real pipe/socketpair on every runtime), dup'd onto
fd 3 (`3<&0`); fd 4 stays `4>&1`. Both fds are now the **same anonymous
pipe/socketpair the async path hands the standalone**, so fd 3 EOFs and a real
handshake/lookup completes in tens of ms. `spawnSync` services stdin and the
fd‑4 response concurrently, so a large request still can't deadlock.

No timeout bump. No embedded-engine fallback (DIST-1 holds).

## Verification (real standalone `@phnx-labs/secrets-cli` 0.1.0)

- Direct against the real `secrets __serve`: handshake **102ms**; a **200KB**
  request completes in **130ms** (no deadlock).
- Installed dev build's compiled `serveOnceSync`: handshake **151ms**,
  `bundleExistsSync` **148ms**, **no ETIMEDOUT**, peak `secrets __serve` procs = 1
  (no fork bomb).
- `agents-dev run claude … --strategy pinned` gets **past** secrets resolution
  with no secrets error (fails only on an unrelated account-name lookup on this
  box, which never reaches the keychain call).
- Real-standalone integration tests (`AGENTS_TEST_SECRETS_BIN`): pristine
  `origin/main` had **3 `spawnSync sh ETIMEDOUT`** sync failures on macOS; with the
  fix those are **gone**. Added a regression test pinning a sub-timeout sync
  handshake. (The 3 remaining `NOT_FOUND` failures are a pre-existing keychain /
  standalone-version environment issue — they fail identically on `origin/main`,
  including the **async** `bundleExists` case this change never touches.)

## Out of scope (noted, not changed)

A standalone that `invocation()` launches **under Bun** — parent runtime = bun,
because the npm `secrets` bin symlinks straight to `index.js`, so `invocation`
runs it as `bun index.js __serve` — still hits its **own** PHNX-3989 EOF hang
regardless of the fd wiring (confirmed: old and new wiring both 3s-timeout under a
Bun standalone). That is the documented reason `SYNC_SERVE_TIMEOUT_MS` exists and
is unchanged here. The real `agents`/`agents-dev` binary runs under Node, where
this fix resolves the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdTx7YhBqhzWNYr43pefyZ
