### PR TITLE
feat(menubar): Sessions window, session card, row model, feed-driven RECENT, reply routes (PHNX-4003)

### DIFF
--- a/cli/.changelog/next/PHNX-4003.md
+++ b/cli/.changelog/next/PHNX-4003.md
@@ -1,0 +1,23 @@
+- **AGI Menu: Sessions window, feed-driven RECENT, Notifications submenu (PHNX-4003).**
+  `Cmd-Shift-I` (or the new **Sessions** row at the top of the dropdown) opens a
+  persistent Sessions window: live sessions across the fleet grouped by project on
+  the left, with **Recent / Needs you / Running / Done today** filter chips, a
+  `Cmd-F` search (label, topic, project, ticket, device), and a device strip that
+  marks stale heartbeats; a session card on the right shows the phase, PR chip,
+  request excerpt, progress tally, latest action, today's rendered artifacts with an
+  **Open** button, and the attention block when the agent is waiting — numbered
+  option buttons, permission Allow/Deny, plan-review Approve/Send back — answered
+  atomically through `agents feed answer`. A reply field routes by capability
+  (`agents feed answer`, `agents sessions inject`, `agents cloud message`,
+  `agents teams message`) and shows the CLI's own result inline; keys `1`–`9`,
+  `Return`, `Cmd-Return`, `Cmd-K` answer, reply, open the terminal, or nudge. The
+  dropdown's RECENT section now renders the same feed-driven rows (status dot,
+  `n/N` checklist, `working · 18h · host`, latest action + PR chip) grouped by
+  project, each opening the window on that session, and a **Notifications**
+  submenu lists today's feed banners unanswered-first. Blocked sessions leave the
+  NEEDS YOU strip, which keeps only load, scheduler, and routine triage.
+  Source: `cli/menubar/Sources/MenubarHelper/SessionsWindow.swift`,
+  `cli/menubar/Sources/MenubarHelper/SessionCard.swift`,
+  `cli/menubar/Sources/MenubarHelper/SessionRowModel.swift`,
+  `cli/menubar/Sources/MenubarHelper/Reply.swift`,
+  `cli/menubar/Sources/MenubarHelper/RecentSectionBuilder.swift`.

--- a/cli/docs/menubar.md
+++ b/cli/docs/menubar.md
@@ -415,10 +415,11 @@ One rule shapes the menu: **attention floats up, context groups down.**
 ```
  a !                      icon + badge (red ! = needs you, green N = N running)
  ┌─ agents ──────────────────────────────────────┐
- │ ⚠ NEEDS YOU (3)                               │   triage strip: wait-time sorted
- │   ⚠ Claude · api — Apply rename?    ·  2h 25m ›│   across ALL projects, question
- │   ⚠ Claude · web — awaiting input   ·  3m     ›│   + how long it's waited
- │   ✕ 2 routines failing                        ›│
+ │ Sessions                       3 need you     │   opens the Sessions window (⌘⇧I)
+ │ ● working  ● needs you  ● idle                │   status-color legend
+ ├────────────────────────────────────────────────┤
+ │ ⚠ NEEDS YOU (1)                               │   non-session triage only:
+ │   ✕ 2 routines failing                        ›│   load / scheduler / routines
  ├────────────────────────────────────────────────┤
  │ New Task…                                  ⌘T │   opens the quick-dispatch bar
  │ New Session                                ⌘N │   submenu: one entry per agent
@@ -433,7 +434,15 @@ One rule shapes the menu: **attention floats up, context groups down.**
  │   ✕ crm-brief  failed                       ›  │   the rest
  │   All routines…                             ›  │
  ├────────────────────────────────────────────────┤
- │ RECENT TICKETS / RECENT                       │   dedicated, glanceable
+ │ RECENT TICKETS                                │   tickets filed via quick dispatch
+ ├────────────────────────────────────────────────┤
+ │ RECENT                                        │   live sessions, grouped by
+ │   agents-cli (2) · 1 need you                 │   project, newest first, from
+ │   ● Fix auth  2/5  working · 18h · s0         │   the shared row model; a row
+ │       edited exec.ts · bun test   PR #99 ✓    │   opens the window on that session
+ ├────────────────────────────────────────────────┤
+ │ Notifications (2)                           ›  │   today's feed banners (24h),
+ │   ⚠ Runaway agent · yosemite-m6             ›  │   unanswered first → open window
  ├────────────────────────────────────────────────┤
  │ ◆ NEW DEVICES (2)                             │   pending tailnet nodes to approve
  │   ◆ ci-runner-fsn1 · linux                  ›  │   Register / Ignore
@@ -447,14 +456,19 @@ One rule shapes the menu: **attention floats up, context groups down.**
  └────────────────────────────────────────────────┘
 ```
 
-- **⚠ NEEDS YOU** — the triage strip, pinned on top and never nested in a project
-  group. Blocked sessions are grouped by (agent, repo): a group of 1 renders
-  inline with the actual question it's waiting on (or bare when the Notification
-  hook wrote no message); a group of 2+ collapses to one
-  `<Agent> · <repo> · N waiting · oldest <elapsed> ›` row with a submenu that
-  lists each session (oldest first). Groups themselves sort by their oldest
-  wait. Failed / overdue routines and a stopped scheduler append here. Empty
-  when nothing needs attention.
+- **Sessions** — the top row, pinned above everything (`Cmd-Shift-I`). It opens
+  the [Sessions window](#sessions-window-cmd-shift-i-phnx-4003) and shows
+  `n need you` in yellow when any fleet session is waiting, so the one place to go
+  for blocked work is always the first thing you see. The **legend** below it
+  (`● working · ● needs you · ● idle`) names the status colors the RECENT rows and
+  the window share.
+- **⚠ NEEDS YOU** — the triage strip for the work the Sessions window does *not*
+  cover: high device load, a stopped scheduler, and failed / overdue routines.
+  **Blocked sessions no longer render here** (PHNX-4003) — session attention is
+  owned by the Sessions row + window above, which surface the reconciled feed
+  attention with its real reply/approve controls. Failing routines lead the strip
+  (always visible, no click); routines sharing an identical cause collapse into one
+  row. Empty when nothing non-session needs attention.
 - **New Task…** — opens the quick-dispatch bar (the same panel as `Cmd-Shift-O`):
   type the task, pick agents and a repo, and it runs headless. One panel serves
   both entry points, so an interrupted capture is restored whichever way you come
@@ -502,8 +516,18 @@ One rule shapes the menu: **attention floats up, context groups down.**
   both the inline rows and the "All routines…" submenu are grouped by that label.
   Routines with no `projectGroup` (cross-project or unassigned) appear last,
   ungrouped.
-- **RECENT TICKETS / RECENT** — tickets filed via quick dispatch and recent
-  sessions, unchanged dedicated sections.
+- **RECENT TICKETS** — tickets filed via the quick-dispatch bar (`Cmd-Shift-O`),
+  clickable to open. Its own dedicated section, unchanged.
+- **RECENT** — live sessions across the fleet, grouped by project (newest first),
+  two lines per row from the shared [row model](#the-row-model-sessionrowmodelswift):
+  a status dot + title + `n/N` checklist + `working · 18h · s0` on line one, the
+  latest action + PR chip on line two. Each project header carries `· n need you`
+  in yellow when any of its sessions is waiting. Clicking a row opens the Sessions
+  window on that session. This replaces the historical recent-sessions list with
+  the same feed-driven projection the window renders.
+- **Notifications** — today's feed banners (bounded to 24 h, cached 30 s),
+  unanswered first, as a submenu. Selecting one opens the Sessions window on that
+  session to Approve / Reply.
 - **NEW DEVICES** — newly-discovered tailnet nodes awaiting approval, each with a
   Register / Ignore submenu. Shown only when there are pending nodes, and it now
   sits just above the DEVICES roster at the bottom (previously it floated up under
@@ -682,6 +706,60 @@ asserts row counts, attention keys, reset-on-gap, backoff, and the breaker;
 run in `scripts/test-menubar.sh` (a `build.sh` gate). `MENUBAR_FEED_SMOKE=1` runs
 the real stream for 60s and prints row/attention/device counts + health — a live
 check, not a gate, like `MENUBAR_DUMP`.
+
+## Sessions window (`Cmd-Shift-I`, PHNX-4003)
+
+A persistent `NSPanel` (`SessionsWindow.swift`) that projects `FeedStream` +
+`ArtifactIndex` into a grouped, filterable list on the left and a session card on
+the right. Toggled by `Cmd-Shift-I`, by the dropdown's **Sessions** row, or by
+clicking any dropdown RECENT row (which opens the window on that session). It is a
+document-style window — not floating — and remembers its frame
+(`setFrameAutosaveName`). Closing hides it; `FeedStream` stays attached, so
+re-opening is instant. `MENUBAR_SESSIONS_PREVIEW=1` opens it at launch (QA / a
+screenshot capture on a machine where synthesizing the chord is not possible), the
+same way `MENUBAR_PROMPT_PREVIEW=1` opens the palette.
+
+- **List** — `NSTableView`, view-based, grouped by project with collapsible group
+  rows (a group header shows `n need you` in yellow when any session in it is
+  waiting). Toolbar filter chips **Recent** / **Needs you** / **Running** /
+  **Done today** carry live counts; the search field (`Cmd-F`) matches label,
+  topic, project, ticket, and device. A device strip above the split shows each
+  reporting device with a `stale Nm` marker when its heartbeat ages out; offline
+  devices collapse to a count. The status bar reads stream health, last-event age,
+  devices reporting/stale, helper RSS, and row count. The only timer is a 1 s
+  relative-time refresh that re-renders **only the visible cells**; every other
+  redraw is a `FeedStream` diff.
+- **Card** (`SessionCard.swift`) — header (dot + title, harness+version, project,
+  host), phase pill + PR chip + subagents glyph, the REQUEST excerpt, the attention
+  block when present (question text with numbered option buttons; permission
+  Allow/Deny; plan-review Approve/Send-back — all answered atomically through
+  `agents feed answer <key> --choice <id>`), PROGRESS (checklist tally + latest
+  action), FILES & ARTIFACTS from `ArtifactIndex.artifacts(forSession:)` with an
+  **Open** button (`NSWorkspace.open`), and a reply field. Keys on a selected row:
+  `1`–`9` answer an option, `Return` focuses the reply field, `Cmd-Return` opens
+  the terminal (`agents focus <id>`), `Cmd-K` sends `Continue.` as a nudge, `Cmd-V`
+  attaches an image ref the same way the palette does.
+
+### The row model (`SessionRowModel.swift`)
+
+One pure derivation from a `SessionRow` (+ its `AttentionItem`) to what a surface
+renders — `statusColor` (green working / yellow needs-you / red idle / grey done),
+`phaseText` (`working · 18h · s0`), `progress`, `latestAction`, `prChip`,
+`subagents`, `groupKey`, title. The window **and** the dropdown RECENT section both
+consume `SessionRowModel.present`; nothing re-derives a status color or PR chip.
+`MENUBAR_ROWMODEL_TEST=1` asserts every branch (a `build.sh` gate).
+
+### Reply routes (`Reply.swift`)
+
+Every operator action is one bounded `agents` argv, built by pure argv builders and
+routed by capability: an open feed block → `agents feed answer <key>
+--choice <id>` / `--text`; `terminal`/`tmux` → `agents sessions inject <id> "…"`;
+`cloud` → `agents cloud message <id> "…"`; `team` → `agents teams message <team>
+<mate> "…"`; `none` disables the reply field with the CLI's reason (only Terminal
+remains). Each runs through a bounded `ChildProcess.runResult` (deadline,
+group-killed, reaped) and the ok/stderr result renders inline in the card, never as
+a toast. `MENUBAR_REPLY_TEST=1` pins the argv for each capability (a `build.sh`
+gate).
 
 ## Lifecycle
 

--- a/cli/docs/menubar.md
+++ b/cli/docs/menubar.md
@@ -726,9 +726,12 @@ same way `MENUBAR_PROMPT_PREVIEW=1` opens the palette.
   topic, project, ticket, and device. A device strip above the split shows each
   reporting device with a `stale Nm` marker when its heartbeat ages out; offline
   devices collapse to a count. The status bar reads stream health, last-event age,
-  devices reporting/stale, helper RSS, and row count. The only timer is a 1 s
-  relative-time refresh that re-renders **only the visible cells**; every other
-  redraw is a `FeedStream` diff.
+  devices reporting/stale, helper RSS, and row count. The list is a view-based
+  `NSTableView` with real cell reuse: `GroupCellView` / `SessionCellView` own
+  their labels for life, are dequeued with `makeView(withIdentifier:owner:)`, and
+  are updated in place. The only timer is a 1 s relative-time refresh that
+  updates the **text of the visible cells in place** (no reload, no view
+  rebuild); every other redraw is a `FeedStream` diff.
 - **Card** (`SessionCard.swift`) — header (dot + title, harness+version, project,
   host), phase pill + PR chip + subagents glyph, the REQUEST excerpt, the attention
   block when present (question text with numbered option buttons; permission
@@ -760,6 +763,25 @@ remains). Each runs through a bounded `ChildProcess.runResult` (deadline,
 group-killed, reaped) and the ok/stderr result renders inline in the card, never as
 a toast. `MENUBAR_REPLY_TEST=1` pins the argv for each capability (a `build.sh`
 gate).
+
+With **no open block**, the card does not assume a terminal: `Reply.fallbackTarget`
+mirrors the CLI's own rail ladder (`replyCapabilityForSession`,
+`cli/src/lib/feed/attention.ts`) from the row's `context` and `host` — `host: tmux`
+→ tmux inject; `context: teams` → `teams message <teamName> <agentId>`;
+`context: cloud` → `cloud message <cloudTaskId>`; `context: terminal` with a
+detected host surface (iterm/ghostty/code/…) → inject; everything else (headless,
+history, a bare shell with no recognized ancestor, a closed session) → `none` with
+the reason in the disabled field's placeholder. A peer-owned terminal row injects
+with `--device <sourceDevice>`, since a bare id resolves only local panes. The
+orchestrator's `spawnedTeam` is not a team rail — it marks the session that
+*created* a team, which is an ordinary terminal row.
+
+The Sessions window also feeds the notifications layer (PHNX-4004):
+`Notifier.isSessionSelectedInSessionsWindow` is wired at launch to
+`SessionsWindowController.isShowingSession`, so a banner for the session whose row
+is selected in a visible window is not presented (the item still lands in the
+list). The window publishes the selected session id under a lock, since the
+notification delegate asks off the main queue.
 
 ## Lifecycle
 

--- a/cli/menubar/Sources/MenubarHelper/FeedModels.swift
+++ b/cli/menubar/Sources/MenubarHelper/FeedModels.swift
@@ -53,6 +53,17 @@ struct SessionRow: Decodable, Equatable {
     let machine: String?
     /// Host process (claude/codex/…) — the harness family.
     let kind: String?
+    /// Where the session runs (`ActiveContext` + the stream's `recent`):
+    /// terminal | teams | cloud | headless | recent. The CLI's reply-rail verdict
+    /// (`replyCapabilityForSession`, cli/src/lib/feed/attention.ts) keys on this
+    /// plus `host`, and the card's no-block fallback mirrors that exact ladder.
+    let context: String?
+    /// Team a teammate row belongs to (`context == "teams"`), with its member id.
+    let teamName: String?
+    let agentId: String?
+    /// Cloud task id for a `context == "cloud"` row — such rows carry no
+    /// `sessionId`, so this is the `agents cloud message` target.
+    let cloudTaskId: String?
     /// Custom profile name when launched via `agents run <profile>`.
     let harness: String?
     /// Coarse lifecycle bucket: running | waiting | failed | done | idle.

--- a/cli/menubar/Sources/MenubarHelper/FeedModels.swift
+++ b/cli/menubar/Sources/MenubarHelper/FeedModels.swift
@@ -102,7 +102,8 @@ struct SessionRow: Decodable, Equatable {
     init(rowKey: String? = nil, sourceDevice: String? = nil, sessionId: String? = nil,
          label: String? = nil, name: String? = nil, title: String? = nil, topic: String? = nil,
          project: String? = nil, cwd: String? = nil, host: String? = nil, machine: String? = nil,
-         kind: String? = nil, harness: String? = nil, phase: String? = nil, status: String? = nil,
+         kind: String? = nil, context: String? = nil, teamName: String? = nil, agentId: String? = nil,
+         cloudTaskId: String? = nil, harness: String? = nil, phase: String? = nil, status: String? = nil,
          activity: String? = nil, awaitingReason: String? = nil, question: SessionQuestion? = nil,
          todos: TodoProgress? = nil, timeline: TimelineSummary? = nil, lastAgentLine: String? = nil,
          preview: String? = nil, files: SessionFilesRef? = nil, request: SessionRequestRef? = nil,
@@ -113,7 +114,8 @@ struct SessionRow: Decodable, Equatable {
         self.rowKey = rowKey; self.sourceDevice = sourceDevice; self.sessionId = sessionId
         self.label = label; self.name = name; self.title = title; self.topic = topic
         self.project = project; self.cwd = cwd; self.host = host; self.machine = machine
-        self.kind = kind; self.harness = harness; self.phase = phase; self.status = status
+        self.kind = kind; self.context = context; self.teamName = teamName; self.agentId = agentId
+        self.cloudTaskId = cloudTaskId; self.harness = harness; self.phase = phase; self.status = status
         self.activity = activity; self.awaitingReason = awaitingReason; self.question = question
         self.todos = todos; self.timeline = timeline; self.lastAgentLine = lastAgentLine
         self.preview = preview; self.files = files; self.request = request

--- a/cli/menubar/Sources/MenubarHelper/Hotkey.swift
+++ b/cli/menubar/Sources/MenubarHelper/Hotkey.swift
@@ -23,8 +23,9 @@ final class HotkeyManager {
     }
 
     // Stable ids so main.swift and this file can't drift.
-    static let clipID: UInt32 = 1    // Cmd-Shift-V → Clip.run()
-    static let promptID: UInt32 = 2  // Cmd-Shift-O → prompt panel
+    static let clipID: UInt32 = 1     // Cmd-Shift-V → Clip.run()
+    static let promptID: UInt32 = 2   // Cmd-Shift-O → prompt panel
+    static let sessionsID: UInt32 = 3 // Cmd-Shift-I → Sessions window
 
     // Demux table: EventHotKeyID.id → action. Static for the same reason the old
     // `shared` was — the C callback has no context pointer.

--- a/cli/menubar/Sources/MenubarHelper/RecentSectionBuilder.swift
+++ b/cli/menubar/Sources/MenubarHelper/RecentSectionBuilder.swift
@@ -1,0 +1,300 @@
+import AppKit
+
+// RecentSectionBuilder — the new dropdown sections that project the feed layer
+// (PHNX-4003, Track C), kept out of the 2,150-line StatusItemController so that
+// file's edits stay to swapping a builder in and adding two rows.
+//
+// It renders, all from `FeedStream.shared` (never a second data derivation — the
+// same `SessionRowModel` the window uses):
+//   - the "Sessions" row (opens the window; `n need you` in yellow when any),
+//   - the status-color legend,
+//   - RECENT grouped by project, newest first, two lines per row, and
+//   - the "Notifications" submenu (today's feed banners, unanswered first).
+//
+// It is a PROJECTION with controls that open the window or shell ONE bounded
+// `agents` argv — it owns no timer that acts on the fleet (spec SING-2). The
+// notification list is a 30 s-cached read of `agents feed --filter all --json`
+// bounded to 24 h, warmed off-main on menu open (the same warm-cache pattern the
+// controller's routines/doctor sections use), so the menu never blocks.
+final class RecentSectionBuilder: NSObject {
+    static let shared = RecentSectionBuilder()
+    private override init() {}
+
+    // Bounds so the dropdown never walls: at most this many project groups and
+    // rows per group in RECENT.
+    private static let maxGroups = 6
+    private static let maxRowsPerGroup = 5
+    private static let maxNotifications = 12
+
+    // MARK: - Sessions row + legend
+
+    /// The "Sessions" row: opens the window, and shows `n need you` in yellow when
+    /// any session across the fleet is waiting on the operator.
+    func addSessionsRow(_ menu: NSMenu) {
+        let needYou = liveEntries().filter { $0.presentation.status == .needsYou }.count
+        let title = needYou > 0 ? "Sessions   \(needYou) need you" : "Sessions"
+        let item = NSMenuItem(title: title, action: #selector(onOpenSessions), keyEquivalent: "i")
+        item.keyEquivalentModifierMask = [.command, .shift]
+        item.target = self
+        if needYou > 0 {
+            let attr = NSMutableAttributedString(string: title, attributes: [
+                .font: NSFont.menuFont(ofSize: 0),
+                .foregroundColor: NSColor.labelColor,
+            ])
+            let r = (title as NSString).range(of: "\(needYou) need you")
+            if r.location != NSNotFound { attr.addAttribute(.foregroundColor, value: Palette.needsYou, range: r) }
+            item.attributedTitle = attr
+        }
+        menu.addItem(item)
+    }
+
+    /// The status-color legend, so the dropdown's dots read at a glance.
+    func addLegend(_ menu: NSMenu) {
+        let text = "  \u{25CF} working   \u{25CF} needs you   \u{25CF} idle"
+        let it = NSMenuItem(title: text, action: nil, keyEquivalent: "")
+        it.isEnabled = false
+        let attr = NSMutableAttributedString(string: text, attributes: [
+            .font: NSFont.systemFont(ofSize: 10),
+            .foregroundColor: NSColor.secondaryLabelColor,
+        ])
+        colorDot(attr, after: "working", color: Palette.working)
+        colorDot(attr, after: "needs you", color: Palette.needsYou)
+        colorDot(attr, after: "idle", color: Palette.idle)
+        it.attributedTitle = attr
+        menu.addItem(it)
+    }
+
+    private func colorDot(_ attr: NSMutableAttributedString, after word: String, color: NSColor) {
+        let s = attr.string as NSString
+        let wordRange = s.range(of: word)
+        guard wordRange.location != NSNotFound else { return }
+        // The dot glyph precedes the word by two chars ("\u{25CF} word").
+        let dot = s.range(of: "\u{25CF}", options: .backwards,
+                          range: NSRange(location: 0, length: wordRange.location))
+        if dot.location != NSNotFound { attr.addAttribute(.foregroundColor, value: color, range: dot) }
+    }
+
+    // MARK: - RECENT grouped by project
+
+    /// RECENT: live sessions across the fleet, grouped by project, newest first,
+    /// two lines per row (name + dot + progress + phase/device; latest action + PR
+    /// chip underneath) — the shared row model, the same the window renders. A row
+    /// click opens the window on that session.
+    func addRecentByProject(_ menu: NSMenu) {
+        let entries = liveEntries()
+        let title = NSMenuItem(title: "RECENT", action: nil, keyEquivalent: "")
+        title.isEnabled = false
+        title.attributedTitle = NSAttributedString(string: "RECENT", attributes: [
+            .foregroundColor: NSColor.secondaryLabelColor,
+            .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+        ])
+        menu.addItem(title)
+
+        if entries.isEmpty {
+            let empty = NSMenuItem(title: "  No live sessions", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            menu.addItem(empty)
+            return
+        }
+
+        var byGroup: [String: [SessionEntry]] = [:]
+        for e in entries { byGroup[e.presentation.groupKey, default: []].append(e) }
+        let ordered = byGroup.keys.sorted { a, b in recency(byGroup[a]!) > recency(byGroup[b]!) }
+        for name in ordered.prefix(Self.maxGroups) {
+            let rows = byGroup[name]!.sorted { ($0.row.startedAtMs ?? 0) > ($1.row.startedAtMs ?? 0) }
+            let needYou = rows.filter { $0.presentation.status == .needsYou }.count
+            var header = "  \(name) (\(rows.count))"
+            if needYou > 0 { header += " · \(needYou) need you" }
+            let head = NSMenuItem(title: header, action: nil, keyEquivalent: "")
+            head.isEnabled = false
+            head.attributedTitle = NSAttributedString(string: header, attributes: [
+                .foregroundColor: NSColor.secondaryLabelColor,
+                .font: NSFont.systemFont(ofSize: 11, weight: .medium),
+            ])
+            menu.addItem(head)
+            for e in rows.prefix(Self.maxRowsPerGroup) { menu.addItem(recentRow(e)) }
+        }
+    }
+
+    private func recentRow(_ e: SessionEntry) -> NSMenuItem {
+        let p = e.presentation
+        let (dot, color) = Palette.dot(p.status)
+        var line1 = "    \(dot) \(p.title)"
+        if let prog = p.progress { line1 += "  \(prog.done)/\(prog.total)" }
+        line1 += "   \(p.phaseText)"
+        var parts: [String] = []
+        if let action = p.latestAction { parts.append(action) }
+        if let chip = p.prChip { parts.append(chip.text) }
+        let line2 = parts.isEmpty ? "" : "        " + parts.joined(separator: "   ")
+
+        let full = line2.isEmpty ? line1 : "\(line1)\n\(line2)"
+        let item = NSMenuItem(title: full, action: #selector(onOpenSessionRow(_:)), keyEquivalent: "")
+        item.target = self
+        item.representedObject = e.sessionId
+        let attr = NSMutableAttributedString(string: full, attributes: [
+            .font: NSFont.menuFont(ofSize: 0),
+            .foregroundColor: NSColor.labelColor,
+        ])
+        let dotRange = (full as NSString).range(of: dot)
+        if dotRange.location != NSNotFound { attr.addAttribute(.foregroundColor, value: color, range: dotRange) }
+        if !line2.isEmpty {
+            let r = (full as NSString).range(of: line2)
+            if r.location != NSNotFound {
+                attr.addAttributes([.font: NSFont.systemFont(ofSize: 10),
+                                    .foregroundColor: NSColor.secondaryLabelColor], range: r)
+            }
+        }
+        item.attributedTitle = attr
+        return item
+    }
+
+    // MARK: - Notifications submenu
+
+    /// The "Notifications" submenu: today's feed banners (bounded to 24 h),
+    /// unanswered first with a Reply/Approve action that opens the window on that
+    /// session (where the reconciled attention block carries the real choices),
+    /// then answered/informational ones as a log with Open.
+    func addNotifications(_ menu: NSMenu) {
+        let all = cachedNotifications
+        let unanswered = all.filter { $0.unanswered }
+        let answered = all.filter { !$0.unanswered }
+        let head = "Notifications" + (unanswered.isEmpty ? "" : " (\(unanswered.count))")
+        let item = NSMenuItem(title: head, action: nil, keyEquivalent: "")
+        let sub = NSMenu()
+
+        if all.isEmpty {
+            let empty = NSMenuItem(title: notificationsLoaded ? "No notifications today" : "Checking…",
+                                   action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            sub.addItem(empty)
+        } else {
+            for n in unanswered.prefix(Self.maxNotifications) { sub.addItem(notificationRow(n, actionable: true)) }
+            if !unanswered.isEmpty && !answered.isEmpty { sub.addItem(.separator()) }
+            for n in answered.prefix(Self.maxNotifications) { sub.addItem(notificationRow(n, actionable: false)) }
+        }
+        item.submenu = sub
+        if !unanswered.isEmpty {
+            item.attributedTitle = NSAttributedString(string: head, attributes: [
+                .font: NSFont.menuFont(ofSize: 0),
+                .foregroundColor: Palette.needsYou,
+            ])
+        }
+        menu.addItem(item)
+    }
+
+    private func notificationRow(_ n: FeedBlock, actionable: Bool) -> NSMenuItem {
+        let glyph = actionable ? "\u{26A0}" : "\u{25CB}"
+        var text = "\(glyph) \(n.displayTitle)"
+        if let host = n.host, !host.isEmpty { text += "  ·  \(host)" }
+        let item = NSMenuItem(title: text, action: #selector(onOpenSessionRow(_:)), keyEquivalent: "")
+        item.target = self
+        item.representedObject = n.sessionId
+        item.toolTip = actionable ? "Open the Sessions window to Approve / Reply" : "Open in the Sessions window"
+        if actionable {
+            let attr = NSMutableAttributedString(string: text, attributes: [
+                .font: NSFont.menuFont(ofSize: 0), .foregroundColor: NSColor.labelColor,
+            ])
+            let r = (text as NSString).range(of: glyph)
+            if r.location != NSNotFound { attr.addAttribute(.foregroundColor, value: Palette.needsYou, range: r) }
+            item.attributedTitle = attr
+        }
+        return item
+    }
+
+    // MARK: - Actions
+
+    @objc private func onOpenSessions() { SessionsWindowController.shared.open(selecting: nil) }
+
+    @objc private func onOpenSessionRow(_ sender: NSMenuItem) {
+        SessionsWindowController.shared.open(selecting: sender.representedObject as? String)
+    }
+
+    // MARK: - Feed entries (shared derivation with the window)
+
+    private func liveEntries() -> [SessionEntry] {
+        let rows = FeedStream.shared.rows
+        let attention = FeedStream.shared.attention
+        let now = Date()
+        var out: [SessionEntry] = []
+        for (rowKey, row) in rows where !row.isPrevious {
+            let attn = row.sessionId.flatMap { attention[$0] }
+            let presentation = SessionRowModel.present(row, attention: attn, now: now)
+            out.append(SessionEntry(rowKey: rowKey, row: row, attention: attn, presentation: presentation))
+        }
+        return out
+    }
+
+    private func recency(_ rows: [SessionEntry]) -> Double {
+        rows.map { $0.row.lastActivityMs ?? $0.row.startedAtMs ?? 0 }.max() ?? 0
+    }
+
+    // MARK: - Notifications cache
+
+    private var cachedNotifications: [FeedBlock] = []
+    private var notificationsLoaded = false
+    private var lastFetch: Date = .distantPast
+    private var fetching = false
+    private static let cacheTTL: TimeInterval = 30
+    private static let windowSeconds: TimeInterval = 24 * 3600
+
+    /// Warm the notification cache off-main when stale (30 s TTL). Called from the
+    /// controller's `menuWillOpen`; the section renders from the cache, so the
+    /// first open may read "Checking…" and the next shows the banners — the same
+    /// warm-cache contract the routines/doctor sections use.
+    func refreshNotificationsIfStale() {
+        guard !fetching, Date().timeIntervalSince(lastFetch) > Self.cacheTTL else { return }
+        fetching = true
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let argv = Reply.resolveArgv(["feed", "--filter", "all", "--json"])
+            let blocks = (ChildProcess.run(argv)).flatMap {
+                try? JSONDecoder().decode([FeedBlock].self, from: $0)
+            } ?? []
+            let cutoff = Date().addingTimeInterval(-Self.windowSeconds)
+            let recent = blocks.filter { ($0.date ?? .distantPast) >= cutoff }
+                .sorted { ($0.date ?? .distantPast) > ($1.date ?? .distantPast) }
+            DispatchQueue.main.async {
+                self?.cachedNotifications = recent
+                self?.notificationsLoaded = true
+                self?.lastFetch = Date()
+                self?.fetching = false
+            }
+        }
+    }
+}
+
+// MARK: - Feed block (decode-only)
+
+/// One `agents feed --filter all --json` block — the fields the Notifications
+/// submenu needs. Every field optional so a newer/older CLI still decodes (the
+/// helper and the on-PATH CLI release independently).
+struct FeedBlock: Decodable {
+    let blockId: String?
+    let sessionId: String?
+    let host: String?
+    let project: String?
+    let ts: String?
+    let kind: String?
+    let questions: [FeedQuestion]?
+    let outcome: FeedOutcome?
+
+    struct FeedQuestion: Decodable { let header: String?; let text: String? }
+    struct FeedOutcome: Decodable { let key: String?; let kind: String?; let label: String? }
+
+    /// Unanswered = the block has no assigned outcome yet.
+    var unanswered: Bool { (outcome?.kind ?? "unassigned") == "unassigned" }
+
+    var displayTitle: String {
+        if let h = questions?.first?.header, !h.isEmpty { return h }
+        if let t = questions?.first?.text, !t.isEmpty { return String(t.prefix(60)) }
+        return kind ?? "notification"
+    }
+
+    var date: Date? {
+        guard let ts else { return nil }
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = f.date(from: ts) { return d }
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: ts)
+    }
+}

--- a/cli/menubar/Sources/MenubarHelper/Reply.swift
+++ b/cli/menubar/Sources/MenubarHelper/Reply.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+// Reply — the ONE place the Sessions card turns an operator gesture (answer an
+// option, allow a permission, approve a plan, type a reply, nudge with Cmd-K)
+// into one bounded `agents` argv (PHNX-4003, Track C).
+//
+// It is a PROJECTION over the CLI's own reply rails, never a second reply engine:
+//   - An open feed BLOCK (the attention item carries a `key`) is answered
+//     atomically through `agents feed answer <key>`, choice or text — the CLI
+//     claims the first reply and routes it over the recorded session rail
+//     (cli/docs/menubar.md, "Answers go through agents feed answer").
+//   - A free-text reply with no open block routes by the session's reply
+//     capability: terminal/tmux inject, cloud message, or a teams message.
+//   - `none` disables the reply field with the CLI's stated reason; only Terminal
+//     remains.
+//
+// The argv builders are PURE and pinned by `MENUBAR_REPLY_TEST=1`; the executor
+// is one bounded `ChildProcess.runResult` (a deadline, group-killed, reaped) so a
+// wedged CLI can never hang the card, and the ok/stderr result renders inline in
+// the card — never as a toast.
+
+/// The reply rail for a session, as reported by the feed. Mirrors
+/// `AttentionItem.replyCapability` (terminal | tmux | cloud | team | none).
+enum ReplyCapability: String, Equatable {
+    case terminal
+    case tmux
+    case cloud
+    case team
+    case none
+
+    init(_ raw: String?) {
+        self = raw.flatMap { ReplyCapability(rawValue: $0) } ?? .none
+    }
+}
+
+/// Everything Reply needs to build an argv for one session's reply. Assembled by
+/// the card from the row + its attention item.
+struct ReplyTarget: Equatable {
+    let sessionId: String?
+    /// An open feed block's key, when the session has a pending structured ask.
+    let attentionKey: String?
+    let capability: ReplyCapability
+    /// Cloud task/session id for the `cloud` rail.
+    let cloudId: String?
+    /// Team + teammate for the `team` rail.
+    let team: String?
+    let mate: String?
+    /// The CLI's stated reason the rail is unavailable, shown when `capability`
+    /// is `.none` (the reply field is disabled and only Terminal remains).
+    let disabledReason: String?
+
+    init(sessionId: String?, attentionKey: String? = nil, capability: ReplyCapability,
+         cloudId: String? = nil, team: String? = nil, mate: String? = nil,
+         disabledReason: String? = nil) {
+        self.sessionId = sessionId
+        self.attentionKey = attentionKey
+        self.capability = capability
+        self.cloudId = cloudId
+        self.team = team
+        self.mate = mate
+        self.disabledReason = disabledReason
+    }
+}
+
+enum Reply {
+    // MARK: - Pure argv builders (pinned by MENUBAR_REPLY_TEST)
+
+    /// Answer an open feed block with a structured choice id.
+    static func answerChoiceArgs(key: String, choiceId: String) -> [String] {
+        ["feed", "answer", key, "--choice", choiceId]
+    }
+
+    /// Answer an open feed block with free text.
+    static func answerTextArgs(key: String, text: String) -> [String] {
+        ["feed", "answer", key, "--text", text]
+    }
+
+    /// Inject free text into a live terminal/tmux session.
+    static func injectArgs(sessionId: String, text: String) -> [String] {
+        ["sessions", "inject", sessionId, text]
+    }
+
+    /// Message a cloud task/session.
+    static func cloudMessageArgs(id: String, text: String) -> [String] {
+        ["cloud", "message", id, text]
+    }
+
+    /// Message a teammate on a team.
+    static func teamMessageArgs(team: String, mate: String, text: String) -> [String] {
+        ["teams", "message", team, mate, text]
+    }
+
+    // MARK: - Routing
+
+    /// The argv to answer a structured choice. Requires an open feed block — a
+    /// choice can only be claimed atomically through `feed answer`, so a target
+    /// with no `attentionKey` yields nil (nothing to answer).
+    static func choiceArgs(_ target: ReplyTarget, choiceId: String) -> [String]? {
+        guard let key = target.attentionKey, !key.isEmpty, !choiceId.isEmpty else { return nil }
+        return answerChoiceArgs(key: key, choiceId: choiceId)
+    }
+
+    /// The argv to send free text. An open feed block is answered atomically;
+    /// otherwise the text rides the session's reply capability. Returns nil when
+    /// the rail is `none` or a required id is missing (the field is disabled).
+    static func textArgs(_ target: ReplyTarget, text: String) -> [String]? {
+        let body = text
+        guard !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        if let key = target.attentionKey, !key.isEmpty {
+            return answerTextArgs(key: key, text: body)
+        }
+        switch target.capability {
+        case .terminal, .tmux:
+            guard let sid = target.sessionId, !sid.isEmpty else { return nil }
+            return injectArgs(sessionId: sid, text: body)
+        case .cloud:
+            guard let id = target.cloudId ?? target.sessionId, !id.isEmpty else { return nil }
+            return cloudMessageArgs(id: id, text: body)
+        case .team:
+            guard let team = target.team, !team.isEmpty, let mate = target.mate, !mate.isEmpty else { return nil }
+            return teamMessageArgs(team: team, mate: mate, text: body)
+        case .none:
+            return nil
+        }
+    }
+
+    /// Whether the reply field should be enabled for this target. It is disabled
+    /// only when there is no open block AND no usable free-text rail.
+    static func canReply(_ target: ReplyTarget) -> Bool {
+        if let key = target.attentionKey, !key.isEmpty { return true }
+        switch target.capability {
+        case .terminal, .tmux: return target.sessionId?.isEmpty == false
+        case .cloud:           return (target.cloudId ?? target.sessionId)?.isEmpty == false
+        case .team:            return target.team?.isEmpty == false && target.mate?.isEmpty == false
+        case .none:            return false
+        }
+    }
+
+    // MARK: - Bounded execution
+
+    /// Deadline for a reply action. A reply either lands fast or fails — it must
+    /// never hang the card, so it is bounded like every other ChildProcess call.
+    static let timeout: TimeInterval = 30
+
+    /// Resolve bare `agents` args into a full argv. Prefers the daemon-exported
+    /// node + entry (a launchd/GUI process has a minimal PATH), else the resolved
+    /// `agents` binary — the same preference AgentsCLI.argv / FeedStream use,
+    /// mirrored here because that resolver is private in a file this track does
+    /// not edit.
+    static func resolveArgv(_ args: [String]) -> [String] {
+        let env = ProcessInfo.processInfo.environment
+        if let node = env["AGENTS_NODE"], let entry = env["AGENTS_ENTRY"],
+           FileManager.default.isExecutableFile(atPath: node),
+           FileManager.default.fileExists(atPath: entry) {
+            return [node, entry] + args
+        }
+        return [AgentsCLI.binary] + args
+    }
+
+    /// The outcome of one reply action as the card renders it: whether the CLI
+    /// exited 0, and the text to quote inline (the CLI's own stdout/stderr lines,
+    /// or why there is no result at all).
+    struct Outcome: Equatable {
+        /// The child started, stayed inside its deadline, and exited 0.
+        let ok: Bool
+        /// stdout then stderr, each trimmed, joined by a newline. Never empty for
+        /// a run that produced no usable result.
+        let output: String
+
+        init(ok: Bool, output: String) {
+            self.ok = ok
+            self.output = output
+        }
+
+        /// Project a bounded run. `nil` means the child never started or blew its
+        /// deadline (`ChildProcess.runResult`), which the card must say rather than
+        /// render as a bare "failed".
+        init(_ result: ChildProcess.RunResult?) {
+            guard let result else {
+                ok = false
+                output = "no result: the command did not start or timed out after \(Int(Reply.timeout))s"
+                return
+            }
+            ok = result.code == 0
+            let out = String(decoding: result.stdout, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+            let err = String(decoding: result.stderr, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+            output = [out, err].filter { !$0.isEmpty }.joined(separator: "\n")
+        }
+    }
+
+    /// Run one reply argv bounded, off the main queue, and deliver the outcome
+    /// back on the main queue for inline rendering in the card.
+    static func perform(_ args: [String], onResult: @escaping (Outcome) -> Void) {
+        let argv = resolveArgv(args)
+        DispatchQueue.global(qos: .userInitiated).async {
+            let outcome = Outcome(ChildProcess.runResult(argv, timeout: timeout))
+            DispatchQueue.main.async { onResult(outcome) }
+        }
+    }
+}

--- a/cli/menubar/Sources/MenubarHelper/Reply.swift
+++ b/cli/menubar/Sources/MenubarHelper/Reply.swift
@@ -45,19 +45,24 @@ struct ReplyTarget: Equatable {
     /// Team + teammate for the `team` rail.
     let team: String?
     let mate: String?
+    /// The device whose terminal/tmux pane the inject must land on, when it is
+    /// not this machine — a bare `sessions inject <id>` resolves only local
+    /// panes, so a peer-owned row rides `--device <name>` (PHNX-3688).
+    let device: String?
     /// The CLI's stated reason the rail is unavailable, shown when `capability`
     /// is `.none` (the reply field is disabled and only Terminal remains).
     let disabledReason: String?
 
     init(sessionId: String?, attentionKey: String? = nil, capability: ReplyCapability,
          cloudId: String? = nil, team: String? = nil, mate: String? = nil,
-         disabledReason: String? = nil) {
+         device: String? = nil, disabledReason: String? = nil) {
         self.sessionId = sessionId
         self.attentionKey = attentionKey
         self.capability = capability
         self.cloudId = cloudId
         self.team = team
         self.mate = mate
+        self.device = device
         self.disabledReason = disabledReason
     }
 }
@@ -75,9 +80,12 @@ enum Reply {
         ["feed", "answer", key, "--text", text]
     }
 
-    /// Inject free text into a live terminal/tmux session.
-    static func injectArgs(sessionId: String, text: String) -> [String] {
-        ["sessions", "inject", sessionId, text]
+    /// Inject free text into a live terminal/tmux session. A peer-owned session
+    /// names its device so the CLI resolves the pane THERE.
+    static func injectArgs(sessionId: String, text: String, device: String? = nil) -> [String] {
+        var args = ["sessions", "inject", sessionId, text]
+        if let device, !device.isEmpty { args += ["--device", device] }
+        return args
     }
 
     /// Message a cloud task/session.
@@ -112,7 +120,7 @@ enum Reply {
         switch target.capability {
         case .terminal, .tmux:
             guard let sid = target.sessionId, !sid.isEmpty else { return nil }
-            return injectArgs(sessionId: sid, text: body)
+            return injectArgs(sessionId: sid, text: body, device: target.device)
         case .cloud:
             guard let id = target.cloudId ?? target.sessionId, !id.isEmpty else { return nil }
             return cloudMessageArgs(id: id, text: body)
@@ -134,6 +142,93 @@ enum Reply {
         case .team:            return target.team?.isEmpty == false && target.mate?.isEmpty == false
         case .none:            return false
         }
+    }
+
+    // MARK: - No-block fallback (pinned by MENUBAR_REPLY_TEST)
+
+    /// The reply target for a row with NO open feed block. Mirrors the CLI's own
+    /// reply-rail ladder (`replyCapabilityForSession`,
+    /// cli/src/lib/feed/attention.ts) so the card never invents a rail the CLI
+    /// would not report:
+    ///
+    ///   - `host == "tmux"`        → `.tmux`  inject (any context — a tmux pane is addressable)
+    ///   - `context == "teams"`    → `.team`  `teams message <teamName> <agentId>`
+    ///   - `context == "cloud"`    → `.cloud` `cloud message <cloudTaskId>`
+    ///   - `context == "terminal"` → `.terminal` inject, only with a detected host
+    ///                               surface (iterm/ghostty/code/…); a bare shell
+    ///                               with no recognized ancestor has no backend
+    ///   - anything else (headless, recent/history, unknown) → `.none`, with the
+    ///     reason spelled out so the disabled field says why.
+    ///
+    /// A terminal/tmux row is also injectable only while it is LIVE; a closed or
+    /// crashed session reads `.none` ("the session is not live"). A peer-owned row
+    /// names its `sourceDevice` so the inject resolves there; `localDevice` is
+    /// this machine's registry name (nil while the snapshot has not arrived, in
+    /// which case every row routes explicitly — a self-hop is correct, just slower).
+    ///
+    /// Note `spawnedTeam` is deliberately NOT a team signal: it marks the
+    /// ORCHESTRATOR session that ran `agents teams create` (an ordinary terminal
+    /// row you can inject into), not a teammate. A teammate's own row carries
+    /// `context: teams` + `teamName` + `agentId`, which is what `teams message`
+    /// addresses.
+    static func fallbackTarget(for row: SessionRow, localDevice: String?) -> ReplyTarget {
+        let live = row.status == "running" || row.status == "idle"
+            || row.activity == "working" || row.activity == "waiting_input"
+        let context = row.context ?? ""
+        let device: String? = {
+            guard let source = row.sourceDevice, !source.isEmpty else { return nil }
+            return source == localDevice ? nil : source
+        }()
+
+        if row.host == "tmux" {
+            guard live else { return notLive(row) }
+            return ReplyTarget(sessionId: row.sessionId, capability: row.sessionId == nil ? .none : .tmux,
+                               device: device,
+                               disabledReason: row.sessionId == nil ? "the tmux session has no session id yet" : nil)
+        }
+        switch context {
+        case "teams":
+            let team = row.teamName ?? ""
+            let mate = row.agentId ?? row.label ?? ""
+            if team.isEmpty || mate.isEmpty {
+                return ReplyTarget(sessionId: row.sessionId, capability: .none,
+                                   disabledReason: "the teammate row names no team or member to message")
+            }
+            return ReplyTarget(sessionId: row.sessionId, capability: .team, team: team, mate: mate)
+        case "cloud":
+            let id = row.cloudTaskId ?? row.sessionId ?? ""
+            if id.isEmpty {
+                return ReplyTarget(sessionId: row.sessionId, capability: .none,
+                                   disabledReason: "the cloud row carries no task id to message")
+            }
+            return ReplyTarget(sessionId: row.sessionId, capability: .cloud, cloudId: id)
+        case "terminal":
+            guard live else { return notLive(row) }
+            guard let host = row.host, !host.isEmpty else {
+                return ReplyTarget(sessionId: row.sessionId, capability: .none,
+                                   disabledReason: "no terminal surface was detected for this session (a bare shell cannot be injected into)")
+            }
+            guard let sid = row.sessionId, !sid.isEmpty else {
+                return ReplyTarget(sessionId: nil, capability: .none,
+                                   disabledReason: "the \(host) session has no session id yet")
+            }
+            return ReplyTarget(sessionId: sid, capability: .terminal, device: device)
+        case "headless":
+            return ReplyTarget(sessionId: row.sessionId, capability: .none,
+                               disabledReason: "a headless run with no tmux pane has no reply rail")
+        case "recent":
+            return ReplyTarget(sessionId: row.sessionId, capability: .none,
+                               disabledReason: "this is a finished session from history")
+        default:
+            return ReplyTarget(sessionId: row.sessionId, capability: .none,
+                               disabledReason: context.isEmpty
+                                   ? "the session reports no context, so no reply rail can be chosen"
+                                   : "no reply rail for a \(context) session")
+        }
+    }
+
+    private static func notLive(_ row: SessionRow) -> ReplyTarget {
+        ReplyTarget(sessionId: row.sessionId, capability: .none, disabledReason: "the session is not live")
     }
 
     // MARK: - Bounded execution

--- a/cli/menubar/Sources/MenubarHelper/ReplySelfTest.swift
+++ b/cli/menubar/Sources/MenubarHelper/ReplySelfTest.swift
@@ -76,7 +76,92 @@ enum ReplySelfTest {
         let noMate = ReplyTarget(sessionId: "s5", capability: .team, team: "squad", mate: nil)
         check("team with no mate cannot reply", Reply.canReply(noMate) == false)
 
+        // A peer-owned terminal row injects on its device.
+        check("inject argv names a peer device",
+              Reply.injectArgs(sessionId: "abcd1234", text: "go", device: "yosemite-s0")
+                == ["sessions", "inject", "abcd1234", "go", "--device", "yosemite-s0"])
+        let peer = ReplyTarget(sessionId: "term-9", capability: .terminal, device: "yosemite-s0")
+        check("terminal rail on a peer routes with --device",
+              Reply.textArgs(peer, text: "go") == ["sessions", "inject", "term-9", "go", "--device", "yosemite-s0"])
+
+        // MARK: no-block fallback — the card's routing from the row itself.
+        // Mirrors replyCapabilityForSession (cli/src/lib/feed/attention.ts).
+
+        // (1) A teammate row (context: teams) messages its team + member —
+        // never an inject, even though it is live.
+        let mate = row(#"{"sessionId":"s-mate","context":"teams","teamName":"squad","agentId":"ag-ocr","label":"ocr","status":"running","host":"code","sourceDevice":"zion"}"#)
+        let mateTarget = Reply.fallbackTarget(for: mate, localDevice: "zion")
+        check("teams row routes to the team rail", mateTarget.capability == .team)
+        check("teams row messages <teamName> <agentId>",
+              Reply.textArgs(mateTarget, text: "sync up") == ["teams", "message", "squad", "ag-ocr", "sync up"])
+        let mateNoTeam = row(#"{"sessionId":"s-m2","context":"teams","status":"running"}"#)
+        check("teams row with no team name is disabled with a reason",
+              Reply.fallbackTarget(for: mateNoTeam, localDevice: "zion").capability == .none
+                && Reply.fallbackTarget(for: mateNoTeam, localDevice: "zion").disabledReason?.isEmpty == false)
+
+        // spawnedTeam marks the ORCHESTRATOR — an ordinary terminal row, injectable.
+        let lead = row(#"{"sessionId":"s-lead","context":"terminal","host":"ghostty","spawnedTeam":"squad","status":"running","sourceDevice":"zion"}"#)
+        let leadTarget = Reply.fallbackTarget(for: lead, localDevice: "zion")
+        check("orchestrator with spawnedTeam stays on the terminal rail", leadTarget.capability == .terminal)
+        check("orchestrator injects locally with no --device",
+              Reply.textArgs(leadTarget, text: "Continue.") == ["sessions", "inject", "s-lead", "Continue."])
+
+        // (2) A live terminal row keeps the terminal rail only with a detected
+        // host surface; tmux is its own rail; a peer's row carries --device.
+        let iterm = row(#"{"sessionId":"s-it","context":"terminal","host":"iterm","status":"idle","sourceDevice":"zion"}"#)
+        check("live iterm row injects", Reply.fallbackTarget(for: iterm, localDevice: "zion").capability == .terminal)
+        let tmuxRow = row(#"{"sessionId":"s-tm","context":"headless","host":"tmux","status":"running","sourceDevice":"yosemite-s0"}"#)
+        let tmuxTarget = Reply.fallbackTarget(for: tmuxRow, localDevice: "zion")
+        check("tmux host is the tmux rail whatever the context", tmuxTarget.capability == .tmux)
+        check("peer tmux row injects with --device",
+              Reply.textArgs(tmuxTarget, text: "go") == ["sessions", "inject", "s-tm", "go", "--device", "yosemite-s0"])
+        let bareShell = row(#"{"sessionId":"s-sh","context":"terminal","status":"running","sourceDevice":"zion"}"#)
+        let bareTarget = Reply.fallbackTarget(for: bareShell, localDevice: "zion")
+        check("terminal row with no host surface is disabled",
+              bareTarget.capability == .none && bareTarget.disabledReason?.contains("no terminal surface") == true)
+        let closed = row(#"{"sessionId":"s-cl","context":"terminal","host":"iterm","status":"closed","sourceDevice":"zion"}"#)
+        let closedTarget = Reply.fallbackTarget(for: closed, localDevice: "zion")
+        check("closed terminal row is disabled as not live",
+              closedTarget.capability == .none && closedTarget.disabledReason == "the session is not live")
+        let unknownLocal = Reply.fallbackTarget(for: iterm, localDevice: nil)
+        check("unknown local device routes explicitly", unknownLocal.device == "zion")
+
+        // Cloud rows carry no session id; the task id is the message target.
+        let cloudRow = row(#"{"context":"cloud","cloudTaskId":"ct-42","kind":"codex","status":"running"}"#)
+        let cloudTarget = Reply.fallbackTarget(for: cloudRow, localDevice: "zion")
+        check("cloud row routes to the cloud rail", cloudTarget.capability == .cloud)
+        check("cloud row messages its task id",
+              Reply.textArgs(cloudTarget, text: "resume") == ["cloud", "message", "ct-42", "resume"])
+
+        // (3) Everything else is .none with a clear reason.
+        let headless = row(#"{"sessionId":"s-hl","context":"headless","host":"code","status":"running"}"#)
+        let headlessTarget = Reply.fallbackTarget(for: headless, localDevice: "zion")
+        check("headless row is disabled", headlessTarget.capability == .none)
+        check("headless row says why", headlessTarget.disabledReason?.contains("headless") == true)
+        let recent = row(#"{"sessionId":"s-rc","context":"recent","status":"done"}"#)
+        check("history row is disabled with a reason",
+              Reply.fallbackTarget(for: recent, localDevice: "zion").disabledReason?.contains("history") == true)
+        let noContext = row(#"{"sessionId":"s-nc","status":"running","host":"iterm"}"#)
+        let noContextTarget = Reply.fallbackTarget(for: noContext, localDevice: "zion")
+        check("row with no context is disabled, never assumed terminal",
+              noContextTarget.capability == .none && noContextTarget.disabledReason?.contains("no context") == true)
+        check("every disabled fallback cannot reply",
+              [mateNoTeam, bareShell, closed, headless, recent, noContext]
+                .allSatisfy { !Reply.canReply(Reply.fallbackTarget(for: $0, localDevice: "zion")) })
+
         print(pass ? "ALL PASS" : "SOME FAILED")
         exit(pass ? 0 : 1)
+    }
+
+    /// Rows are built by DECODING JSON, so the fallback is exercised on the same
+    /// decode path a stream line takes (and the new context/team/cloud fields
+    /// are proven to decode).
+    private static func row(_ json: String) -> SessionRow {
+        guard let data = json.data(using: .utf8),
+              let r = try? JSONDecoder().decode(SessionRow.self, from: data) else {
+            print("FAIL — could not decode test row: \(json)")
+            exit(1)
+        }
+        return r
     }
 }

--- a/cli/menubar/Sources/MenubarHelper/ReplySelfTest.swift
+++ b/cli/menubar/Sources/MenubarHelper/ReplySelfTest.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+// Headless self-test for the pure Reply argv builders + routing (PHNX-4003,
+// Track C).
+//
+//   MENUBAR_REPLY_TEST=1 — pin the exact `agents` argv for every reply
+//   capability: an open feed block (choice + text), a terminal/tmux inject, a
+//   cloud message, a teams message, and the disabled `none` rail. Pure — no
+//   process, no network. A build gate (test-menubar.sh).
+
+enum ReplySelfTest {
+    static func run() -> Never {
+        var pass = true
+        func check(_ name: String, _ condition: Bool) {
+            print("\(condition ? "PASS" : "FAIL") — \(name)")
+            if !condition { pass = false }
+        }
+
+        // MARK: pure builders — exact argv shapes.
+
+        check("answer choice argv",
+              Reply.answerChoiceArgs(key: "zion/s-a/1", choiceId: "2")
+                == ["feed", "answer", "zion/s-a/1", "--choice", "2"])
+        check("answer text argv",
+              Reply.answerTextArgs(key: "zion/s-a/1", text: "hi there")
+                == ["feed", "answer", "zion/s-a/1", "--text", "hi there"])
+        check("inject argv",
+              Reply.injectArgs(sessionId: "abcd1234", text: "keep going")
+                == ["sessions", "inject", "abcd1234", "keep going"])
+        check("cloud message argv",
+              Reply.cloudMessageArgs(id: "task-9", text: "status?")
+                == ["cloud", "message", "task-9", "status?"])
+        check("team message argv",
+              Reply.teamMessageArgs(team: "squad", mate: "ocr", text: "sync up")
+                == ["teams", "message", "squad", "ocr", "sync up"])
+
+        // MARK: routing by capability.
+
+        // An open feed block answers atomically, choice OR text, regardless of rail.
+        let block = ReplyTarget(sessionId: "s1", attentionKey: "zion/s1/3", capability: .terminal)
+        check("open block routes a choice through feed answer",
+              Reply.choiceArgs(block, choiceId: "0") == ["feed", "answer", "zion/s1/3", "--choice", "0"])
+        check("open block routes text through feed answer",
+              Reply.textArgs(block, text: "use HDMI") == ["feed", "answer", "zion/s1/3", "--text", "use HDMI"])
+
+        // No block: free text rides the session's reply capability.
+        let terminal = ReplyTarget(sessionId: "term-1", capability: .terminal)
+        check("terminal rail injects",
+              Reply.textArgs(terminal, text: "Continue.") == ["sessions", "inject", "term-1", "Continue."])
+        let tmux = ReplyTarget(sessionId: "tmux-1", capability: .tmux)
+        check("tmux rail injects",
+              Reply.textArgs(tmux, text: "go") == ["sessions", "inject", "tmux-1", "go"])
+        let cloud = ReplyTarget(sessionId: "s2", capability: .cloud, cloudId: "ct-7")
+        check("cloud rail messages the cloud task",
+              Reply.textArgs(cloud, text: "resume") == ["cloud", "message", "ct-7", "resume"])
+        let team = ReplyTarget(sessionId: "s3", capability: .team, team: "squad", mate: "ocr")
+        check("team rail messages the teammate",
+              Reply.textArgs(team, text: "help") == ["teams", "message", "squad", "ocr", "help"])
+
+        // A choice can only be claimed through an open block.
+        check("choice with no open block is nil", Reply.choiceArgs(terminal, choiceId: "0") == nil)
+
+        // The `none` rail disables the field.
+        let none = ReplyTarget(sessionId: "s4", capability: .none, disabledReason: "no live rail")
+        check("none rail yields no text argv", Reply.textArgs(none, text: "x") == nil)
+        check("none rail cannot reply", Reply.canReply(none) == false)
+        check("open block can always reply", Reply.canReply(block) == true)
+        check("terminal with a session can reply", Reply.canReply(terminal) == true)
+
+        // Empty text never sends.
+        check("empty text is nil", Reply.textArgs(terminal, text: "   ") == nil)
+
+        // Missing ids disable the rail.
+        let noSid = ReplyTarget(sessionId: nil, capability: .terminal)
+        check("terminal with no session cannot reply", Reply.canReply(noSid) == false)
+        let noMate = ReplyTarget(sessionId: "s5", capability: .team, team: "squad", mate: nil)
+        check("team with no mate cannot reply", Reply.canReply(noMate) == false)
+
+        print(pass ? "ALL PASS" : "SOME FAILED")
+        exit(pass ? 0 : 1)
+    }
+}

--- a/cli/menubar/Sources/MenubarHelper/RowModelSelfTest.swift
+++ b/cli/menubar/Sources/MenubarHelper/RowModelSelfTest.swift
@@ -25,6 +25,14 @@ enum RowModelSelfTest {
 
         // MARK: status color — every branch.
 
+        // A dispatch placeholder row (PHNX-4005) is in progress and reads as
+        // "launching", never as a working session.
+        let launching = row(#"{"phase":"launching","status":"launching","machine":"zion","startedAtMs":\#(ms(0.5))}"#)
+        check("phase launching → working (green)",
+              SessionRowModel.statusColor(launching, attention: nil) == .working)
+        check("phase launching → phase text leads with launching",
+              SessionRowModel.phaseText(launching, attention: nil, status: .working, now: now).hasPrefix("launching"))
+
         let working = row(#"{"phase":"running","machine":"s0","startedAtMs":\#(ms(18 * 60))}"#)
         check("phase running → working (green)",
               SessionRowModel.statusColor(working, attention: nil) == .working)

--- a/cli/menubar/Sources/MenubarHelper/RowModelSelfTest.swift
+++ b/cli/menubar/Sources/MenubarHelper/RowModelSelfTest.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+// Headless self-test for the pure SessionRowModel (PHNX-4003, Track C).
+//
+//   MENUBAR_ROWMODEL_TEST=1 — decode real feed-row JSON, drive
+//   `SessionRowModel.present`, and assert every status-color branch, the PR-chip
+//   states, the progress tally, the phase line, the subagents glyph, and the
+//   latest-action ladder. Pure — no process, no network. A build gate
+//   (test-menubar.sh).
+//
+// Rows are built by DECODING JSON (SessionRow/AttentionItem are the decode-only
+// feed mirrors), so this also exercises the real decode path a stream line takes.
+
+enum RowModelSelfTest {
+    static func run() -> Never {
+        var pass = true
+        func check(_ name: String, _ condition: Bool) {
+            print("\(condition ? "PASS" : "FAIL") — \(name)")
+            if !condition { pass = false }
+        }
+
+        // A fixed clock so relative ages are deterministic.
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        func ms(_ minutesAgo: Double) -> Double { (now.timeIntervalSince1970 - minutesAgo * 60) * 1000 }
+
+        // MARK: status color — every branch.
+
+        let working = row(#"{"phase":"running","machine":"s0","startedAtMs":\#(ms(18 * 60))}"#)
+        check("phase running → working (green)",
+              SessionRowModel.statusColor(working, attention: nil) == .working)
+
+        let waitingPhase = row(#"{"phase":"waiting","machine":"m1"}"#)
+        check("phase waiting → needsYou (yellow)",
+              SessionRowModel.statusColor(waitingPhase, attention: nil) == .needsYou)
+
+        let idlePhase = row(#"{"phase":"idle","machine":"m1","lastActivityMs":\#(ms(41))}"#)
+        check("phase idle → idle (red)",
+              SessionRowModel.statusColor(idlePhase, attention: nil) == .idle)
+
+        let failedPhase = row(#"{"phase":"failed","machine":"m1"}"#)
+        check("phase failed → idle (red)",
+              SessionRowModel.statusColor(failedPhase, attention: nil) == .idle)
+
+        let donePhase = row(#"{"phase":"done","machine":"m1"}"#)
+        check("phase done → done (grey)",
+              SessionRowModel.statusColor(donePhase, attention: nil) == .done)
+
+        // Attention overrides a running phase.
+        let question = attn(#"{"key":"h/s/1","sessionId":"s-q","kind":"question"}"#)
+        check("attention question → needsYou even over a running phase",
+              SessionRowModel.statusColor(working, attention: question) == .needsYou)
+        let permission = attn(#"{"key":"h/s/1","sessionId":"s-p","kind":"permission"}"#)
+        check("attention permission → needsYou",
+              SessionRowModel.statusColor(working, attention: permission) == .needsYou)
+        let plan = attn(#"{"key":"h/s/1","sessionId":"s-pl","kind":"plan_review"}"#)
+        check("attention plan_review → needsYou",
+              SessionRowModel.statusColor(working, attention: plan) == .needsYou)
+        let failure = attn(#"{"key":"h/s/1","sessionId":"s-f","kind":"failure"}"#)
+        check("attention failure → idle (red)",
+              SessionRowModel.statusColor(working, attention: failure) == .idle)
+        let stall = attn(#"{"key":"h/s/1","sessionId":"s-st","kind":"stall"}"#)
+        check("attention stall → idle (red)",
+              SessionRowModel.statusColor(working, attention: stall) == .idle)
+
+        // MARK: phase text — the three shapes from the brief.
+
+        let p1 = SessionRowModel.phaseText(working, attention: nil,
+                                           status: .working, now: now)
+        check("phase text working · 18h · s0", p1 == "working · 18h · s0")
+
+        let qRow = row(#"{"phase":"waiting","machine":"zion","lastActivityMs":\#(ms(13))}"#)
+        let p2 = SessionRowModel.phaseText(qRow, attention: question, status: .needsYou, now: now)
+        check("phase text question · 13m · zion", p2 == "question · 13m · zion")
+
+        let p3 = SessionRowModel.phaseText(idlePhase, attention: nil, status: .idle, now: now)
+        check("phase text idle 41m · m1", p3 == "idle 41m · m1")
+
+        // MARK: progress tally.
+
+        let prog = row(#"{"phase":"running","todos":{"done":3,"total":7}}"#)
+        check("progress reads done/total", SessionRowModel.progress(prog).map { "\($0.done)/\($0.total)" } == "3/7")
+        let noProg = row(#"{"phase":"running","todos":{"done":0,"total":0}}"#)
+        check("progress nil when total is zero", SessionRowModel.progress(noProg) == nil)
+        check("progress nil when no todos", SessionRowModel.progress(working) == nil)
+
+        // MARK: PR chip — every state.
+
+        check("PR merged → merged chip (purple)",
+              SessionRowModel.prChip(row(#"{"pr":{"number":12,"state":"merged"}}"#)) == .merged(12))
+        check("PR draft → draft chip (dimmed)",
+              SessionRowModel.prChip(row(#"{"pr":{"number":13,"isDraft":true}}"#)) == .draft(13))
+        check("PR clean + approved → approved chip (green)",
+              SessionRowModel.prChip(row(#"{"pr":{"number":14,"state":"open","mergeable":"clean","reviewDecision":"APPROVED"}}"#)) == .approved(14))
+        check("PR unstable → checksFailed chip (red)",
+              SessionRowModel.prChip(row(#"{"pr":{"number":15,"state":"open","mergeable":"unstable"}}"#)) == .checksFailed(15))
+        check("PR unknown mergeable → checksRunning chip (grey)",
+              SessionRowModel.prChip(row(#"{"pr":{"number":16,"state":"open","mergeable":"unknown"}}"#)) == .checksRunning(16))
+        check("PR open, no verdict yet → open chip",
+              SessionRowModel.prChip(row(#"{"pr":{"number":17,"state":"open","mergeable":"clean"}}"#)) == .open(17))
+        check("no PR → nil chip", SessionRowModel.prChip(working) == nil)
+        check("PR chip text renders merged",
+              PRChip.merged(12).text == "PR #12 · merged ✓")
+        check("PR chip text renders approved",
+              PRChip.approved(14).text == "PR #14 · checks ✓ · approved")
+
+        // MARK: subagents glyph.
+
+        check("subAgentCount>0 → count",
+              SessionRowModel.subagents(row(#"{"subAgentCount":3}"#)) == 3)
+        check("pidCount>1 → count",
+              SessionRowModel.subagents(row(#"{"pidCount":4}"#)) == 4)
+        check("spawnedTeam → count",
+              SessionRowModel.subagents(row(#"{"spawnedTeam":"squad"}"#)) == 1)
+        check("lone process → nil",
+              SessionRowModel.subagents(row(#"{"pidCount":1}"#)) == nil)
+
+        // MARK: latest action ladder.
+
+        let tl = row(#"{"timeline":{"steps":[{"text":"earlier"},{"text":"Running tests","now":"bun test"}]},"lastAgentLine":"fallback"}"#)
+        check("latest action = last timeline step + tool",
+              SessionRowModel.latestAction(tl) == "Running tests · bun test")
+        let noTl = row(#"{"lastAgentLine":"only the line"}"#)
+        check("latest action falls back to lastAgentLine",
+              SessionRowModel.latestAction(noTl) == "only the line")
+        check("latest action nil when nothing", SessionRowModel.latestAction(working) == nil)
+
+        // MARK: group key + title ladder.
+
+        check("group key = project", SessionRowModel.groupKey(row(#"{"project":"AGI"}"#)) == "AGI")
+        check("group key falls back to cwd basename",
+              SessionRowModel.groupKey(row(#"{"cwd":"/Users/x/src/agents-cli"}"#)) == "agents-cli")
+        check("group key default other", SessionRowModel.groupKey(working) == "other")
+        check("title prefers label",
+              SessionRowModel.title(row(#"{"label":"L","name":"N","title":"T","topic":"O"}"#)) == "L")
+        check("title falls to topic",
+              SessionRowModel.title(row(#"{"topic":"O"}"#)) == "O")
+
+        // MARK: full present() ties it together.
+
+        let full = row(#"{"label":"Fix auth","phase":"running","project":"AGI","machine":"s0","startedAtMs":\#(ms(18 * 60)),"todos":{"done":2,"total":5},"pr":{"number":99,"state":"merged"},"subAgentCount":2}"#)
+        let p = SessionRowModel.present(full, attention: nil, now: now)
+        check("present composes the row",
+              p.title == "Fix auth" && p.status == .working
+                && p.phaseText == "working · 18h · s0"
+                && p.progress?.done == 2 && p.progress?.total == 5
+                && p.prChip == .merged(99) && p.subagents == 2 && p.groupKey == "AGI")
+
+        print(pass ? "ALL PASS" : "SOME FAILED")
+        exit(pass ? 0 : 1)
+    }
+
+    /// Decode a partial SessionRow from JSON, aborting loudly on a test-JSON bug.
+    private static func row(_ json: String) -> SessionRow {
+        guard let data = json.data(using: .utf8),
+              let r = try? JSONDecoder().decode(SessionRow.self, from: data) else {
+            print("FAIL — could not decode test row: \(json)")
+            exit(1)
+        }
+        return r
+    }
+
+    private static func attn(_ json: String) -> AttentionItem {
+        guard let data = json.data(using: .utf8),
+              let a = try? JSONDecoder().decode(AttentionItem.self, from: data) else {
+            print("FAIL — could not decode test attention: \(json)")
+            exit(1)
+        }
+        return a
+    }
+}

--- a/cli/menubar/Sources/MenubarHelper/SessionCard.swift
+++ b/cli/menubar/Sources/MenubarHelper/SessionCard.swift
@@ -1,0 +1,461 @@
+import AppKit
+
+// SessionCard — the right pane of the Sessions window (PHNX-4003, Track C). It
+// renders ONE selected session from the shared row model plus its artifacts, and
+// carries the operator actions: answer an option, allow/deny a permission,
+// approve/send-back a plan, type a reply, nudge, open an artifact, jump to the
+// terminal. Every action is one bounded `agents` argv built by `Reply` (or the
+// canonical `agents focus`) and its ok/stderr result renders INLINE here, never
+// as a toast.
+//
+// The card holds no data source: the window hands it a `SessionEntry` and the
+// session's artifacts, and wires the reply/terminal/artifact closures so the
+// window keeps the one FeedStream/ArtifactIndex attachment.
+
+/// The four status colors + the brand accent, shared across the window's UI.
+enum Palette {
+    static let brand = NSColor(srgbRed: 0xa3 / 255.0, green: 0xe6 / 255.0, blue: 0x35 / 255.0, alpha: 1)
+    static let working = NSColor(srgbRed: 0x22 / 255.0, green: 0xc5 / 255.0, blue: 0x5e / 255.0, alpha: 1)
+    static let idle    = NSColor(srgbRed: 0xef / 255.0, green: 0x44 / 255.0, blue: 0x44 / 255.0, alpha: 1)
+    static let needsYou = NSColor(srgbRed: 0xd4 / 255.0, green: 0xa7 / 255.0, blue: 0x2c / 255.0, alpha: 1)
+    static let done    = NSColor(srgbRed: 0x6b / 255.0, green: 0x72 / 255.0, blue: 0x80 / 255.0, alpha: 1)
+    static let purple  = NSColor(srgbRed: 0xa7 / 255.0, green: 0x8b / 255.0, blue: 0xfa / 255.0, alpha: 1)
+
+    static func color(_ status: StatusColor) -> NSColor {
+        switch status {
+        case .working:  return working
+        case .needsYou: return needsYou
+        case .idle:     return idle
+        case .done:     return done
+        }
+    }
+
+    /// The dot glyph + its color for a status.
+    static func dot(_ status: StatusColor) -> (String, NSColor) { ("\u{25CF}", color(status)) }
+
+    static func prColor(_ chip: PRChip) -> NSColor {
+        switch chip {
+        case .merged:        return purple
+        case .approved:      return working
+        case .checksFailed:  return idle
+        case .checksRunning: return done
+        case .draft:         return NSColor.tertiaryLabelColor
+        case .open:          return NSColor.secondaryLabelColor
+        }
+    }
+}
+
+/// One session as the window and card consume it: the raw row, its reconciled
+/// attention item (if any), and the shared presentation. Assembled once by the
+/// window from the feed so nothing re-derives.
+struct SessionEntry: Equatable {
+    let rowKey: String
+    let row: SessionRow
+    let attention: AttentionItem?
+    let presentation: RowPresentation
+
+    var sessionId: String? { row.sessionId }
+}
+
+final class SessionCard: NSView {
+    // Wired by the window so the card never touches FeedStream / the CLI resolver.
+    /// Perform a bounded reply argv and deliver the result for inline rendering.
+    var onReply: (([String], @escaping (Reply.Outcome) -> Void) -> Void)?
+    /// Jump to the session's terminal (`agents focus <id>`).
+    var onOpenTerminal: ((String) -> Void)?
+    /// Open a rendered artifact in the default browser.
+    var onOpenArtifact: ((String) -> Void)?
+
+    private let scroll = NSScrollView()
+    private let stack = NSStackView()
+    private var entry: SessionEntry?
+    private var artifacts: [Artifact] = []
+
+    /// The reply text field, retained so the window can focus it (Return) and so
+    /// Cmd-V can attach an image ref.
+    private let replyField = NSTextField()
+    private var resultLabel: NSTextField?
+    /// Choice ids in render order, so digit keys 1-9 map to the right choice.
+    private var choiceIds: [String] = []
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        scroll.hasVerticalScroller = true
+        scroll.drawsBackground = false
+        scroll.autohidesScrollers = true
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(scroll)
+        NSLayoutConstraint.activate([
+            scroll.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scroll.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scroll.topAnchor.constraint(equalTo: topAnchor),
+            scroll.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 10
+        stack.edgeInsets = NSEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        let clip = NSView()
+        clip.translatesAutoresizingMaskIntoConstraints = false
+        clip.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: clip.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: clip.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: clip.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: clip.bottomAnchor),
+        ])
+        scroll.documentView = clip
+        NSLayoutConstraint.activate([
+            clip.leadingAnchor.constraint(equalTo: scroll.contentView.leadingAnchor),
+            clip.trailingAnchor.constraint(equalTo: scroll.contentView.trailingAnchor),
+            clip.topAnchor.constraint(equalTo: scroll.contentView.topAnchor),
+        ])
+
+        replyField.placeholderString = "Reply — Return sends, Cmd-K nudges, Cmd-Return opens the terminal"
+        replyField.target = self
+        replyField.action = #selector(onReplyReturn)
+        replyField.font = NSFont.systemFont(ofSize: 12)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
+
+    // MARK: - Render
+
+    func show(_ entry: SessionEntry?, artifacts: [Artifact]) {
+        self.entry = entry
+        self.artifacts = artifacts
+        rebuild()
+    }
+
+    private func rebuild() {
+        stack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        resultLabel = nil
+        choiceIds = []
+        guard let entry else {
+            stack.addArrangedSubview(secondary("Select a session to see its detail."))
+            return
+        }
+        let p = entry.presentation
+        let row = entry.row
+
+        // Header line: dot + title.
+        let (glyph, color) = Palette.dot(p.status)
+        stack.addArrangedSubview(heading("\(glyph) \(p.title)", color: color))
+
+        // Meta: harness + version, project, host, terminal kind.
+        var meta: [String] = []
+        if let kind = row.kind { meta.append(row.version.map { "\(kind) \($0)" } ?? kind) }
+        if !p.groupKey.isEmpty { meta.append(p.groupKey) }
+        if let m = SessionRowModel.deviceName(row) as String?, !m.isEmpty { meta.append(m) }
+        if let host = row.host, !host.isEmpty { meta.append(host) }
+        if let account = row.account, !account.isEmpty { meta.append(account) }
+        if !meta.isEmpty { stack.addArrangedSubview(secondary(meta.joined(separator: " · "))) }
+        if let cwd = row.cwd, !cwd.isEmpty { stack.addArrangedSubview(secondary(cwd)) }
+
+        // Phase pill + PR chip.
+        let pills = NSStackView()
+        pills.orientation = .horizontal
+        pills.spacing = 8
+        pills.addArrangedSubview(pill(p.phaseText, color: Palette.color(p.status)))
+        if let chip = p.prChip { pills.addArrangedSubview(pill(chip.text, color: Palette.prColor(chip))) }
+        if let n = p.subagents { pills.addArrangedSubview(pill("\u{2442} \(n)", color: Palette.brand)) }
+        stack.addArrangedSubview(pills)
+
+        // REQUEST.
+        if let req = row.request, let text = req.text, !text.isEmpty {
+            let turns = req.turns.map { " · \($0) turn\($0 == 1 ? "" : "s")" } ?? ""
+            stack.addArrangedSubview(sectionTitle("REQUEST\(turns)"))
+            stack.addArrangedSubview(body(text))
+        }
+
+        // Attention block.
+        if let attn = entry.attention { addAttentionBlock(attn) }
+
+        // PROGRESS.
+        if let progress = p.progress {
+            stack.addArrangedSubview(sectionTitle("PROGRESS · \(progress.done)/\(progress.total)"))
+        }
+        if let action = p.latestAction { stack.addArrangedSubview(body(action)) }
+
+        // FILES & ARTIFACTS.
+        addArtifactsBlock(row)
+
+        // Reply field + Terminal.
+        stack.addArrangedSubview(sectionTitle("REPLY"))
+        let target = replyTarget(entry)
+        if Reply.canReply(target) {
+            replyField.isEnabled = true
+            replyField.placeholderString = "Reply — Return sends, Cmd-K nudges, Cmd-Return opens the terminal"
+        } else {
+            replyField.isEnabled = false
+            replyField.placeholderString = target.disabledReason.map { "Reply unavailable: \($0)" }
+                ?? "Reply unavailable — no live rail. Use Terminal."
+        }
+        replyField.stringValue = ""
+        pin(replyField)
+        stack.addArrangedSubview(replyField)
+
+        let actions = NSStackView()
+        actions.orientation = .horizontal
+        actions.spacing = 8
+        actions.addArrangedSubview(button("Send", #selector(onSend)))
+        actions.addArrangedSubview(button("Nudge (Continue.)", #selector(onNudge)))
+        if row.sessionId != nil { actions.addArrangedSubview(button("Terminal", #selector(onTerminal))) }
+        stack.addArrangedSubview(actions)
+
+        let result = secondary("")
+        result.textColor = .secondaryLabelColor
+        resultLabel = result
+        stack.addArrangedSubview(result)
+    }
+
+    private func addAttentionBlock(_ attn: AttentionItem) {
+        let head = attn.kind == "plan_review" ? "PLAN REVIEW"
+            : attn.kind == "permission" ? "PERMISSION"
+            : attn.kind.uppercased()
+        stack.addArrangedSubview(sectionTitle("\u{26A0} \(head)"))
+        if let q = attn.question?.text ?? attn.question?.header, !q.isEmpty {
+            stack.addArrangedSubview(body(q))
+        }
+        if attn.kind == "permission", let source = attn.source, !source.isEmpty {
+            stack.addArrangedSubview(secondary(source))
+        }
+
+        // Choices: prefer the reconciled `choices` (they carry the stable id used
+        // by `feed answer --choice`); fall back to the question's options.
+        var labels: [String] = []
+        if let choices = attn.choices, !choices.isEmpty {
+            for c in choices {
+                choiceIds.append(c.id ?? "\(choiceIds.count)")
+                labels.append(c.label ?? c.id ?? "choice \(labels.count + 1)")
+            }
+        } else if let options = attn.question?.options, !options.isEmpty {
+            for (i, o) in options.enumerated() {
+                choiceIds.append("\(i)")
+                labels.append(o.label ?? "option \(i + 1)")
+            }
+        }
+        guard !labels.isEmpty else { return }
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.spacing = 8
+        for (i, label) in labels.enumerated() where i < 9 {
+            let b = button("\(i + 1). \(label)", #selector(onChoice(_:)))
+            b.tag = i
+            row.addArrangedSubview(b)
+        }
+        stack.addArrangedSubview(row)
+    }
+
+    private func addArtifactsBlock(_ row: SessionRow) {
+        let hasFiles = (row.files?.total ?? 0) > 0
+        guard !artifacts.isEmpty || hasFiles else { return }
+        var title = "FILES & ARTIFACTS"
+        if let total = row.files?.total, total > 0 { title += " · \(total) file\(total == 1 ? "" : "s")" }
+        stack.addArrangedSubview(sectionTitle(title))
+        for artifact in artifacts.prefix(8) {
+            let line = NSStackView()
+            line.orientation = .horizontal
+            line.spacing = 8
+            let name = artifact.title.isEmpty ? (artifact.kind ?? "artifact") : artifact.title
+            line.addArrangedSubview(body(name))
+            let open = button("Open", #selector(onOpenArtifactBtn(_:)))
+            open.tag = artifactTag(artifact)
+            line.addArrangedSubview(open)
+            stack.addArrangedSubview(line)
+        }
+    }
+
+    // Artifacts open by index — the tag carries the position in `artifacts`.
+    private func artifactTag(_ artifact: Artifact) -> Int { artifacts.firstIndex(of: artifact) ?? 0 }
+
+    // MARK: - Actions
+
+    private func replyTarget(_ entry: SessionEntry) -> ReplyTarget {
+        let row = entry.row
+        if let attn = entry.attention {
+            return ReplyTarget(sessionId: attn.sessionId,
+                               attentionKey: attn.key,
+                               capability: ReplyCapability(attn.replyCapability),
+                               cloudId: nil,
+                               team: row.spawnedTeam,
+                               mate: nil,
+                               disabledReason: attn.replyCapability == "none"
+                                   ? "the CLI reports no reply rail for this session" : nil)
+        }
+        // No open block: a live local session can still be nudged via inject.
+        let live = row.status == "running" || row.status == "idle"
+            || row.activity == "working" || row.activity == "waiting_input"
+        return ReplyTarget(sessionId: row.sessionId,
+                           capability: live && row.sessionId != nil ? .terminal : .none,
+                           team: row.spawnedTeam,
+                           disabledReason: live ? nil : "the session is not live")
+    }
+
+    @objc private func onReplyReturn() { onSend() }
+
+    @objc private func onSend() {
+        guard let entry else { return }
+        let text = replyField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        guard let args = Reply.textArgs(replyTarget(entry), text: text) else {
+            renderResult(.init(ok: false, output: "no reply rail for this session")); return
+        }
+        run(args, pending: "sending…")
+    }
+
+    @objc private func onNudge() {
+        guard let entry else { return }
+        guard let args = Reply.textArgs(replyTarget(entry), text: "Continue.") else {
+            renderResult(.init(ok: false, output: "no reply rail for this session")); return
+        }
+        run(args, pending: "nudging…")
+    }
+
+    @objc private func onChoice(_ sender: NSButton) { answerOption(index: sender.tag) }
+
+    /// Answer the Nth option (0-based). Wired to both the buttons and digit keys.
+    func answerOption(index: Int) {
+        guard let entry, index >= 0, index < choiceIds.count else { return }
+        guard let args = Reply.choiceArgs(replyTarget(entry), choiceId: choiceIds[index]) else {
+            renderResult(.init(ok: false, output: "no open feed block to answer")); return
+        }
+        run(args, pending: "answering \(index + 1)…")
+    }
+
+    @objc private func onTerminal() { openTerminal() }
+
+    func openTerminal() {
+        guard let id = entry?.sessionId else { return }
+        onOpenTerminal?(id)
+    }
+
+    /// Send "Continue." via the reply rail (Cmd-K).
+    func nudge() { onNudge() }
+
+    /// Focus the reply field (Return on a selected row).
+    func focusReply() { window?.makeFirstResponder(replyField) }
+
+    @objc private func onOpenArtifactBtn(_ sender: NSButton) {
+        guard sender.tag >= 0, sender.tag < artifacts.count else { return }
+        onOpenArtifact?(artifacts[sender.tag].htmlPath)
+    }
+
+    /// Cmd-V attaches an image ref the same way the palette does — reuse the
+    /// palette's pasteboard reader, then append the written ref to the reply text.
+    func attachClipboardImage() -> Bool {
+        let written = AgentsCLI.imageAttachments(from: .general)
+        guard !written.isEmpty else { return false }
+        let refs = written.joined(separator: " ")
+        let current = replyField.stringValue
+        replyField.stringValue = current.isEmpty ? refs : current + " " + refs
+        window?.makeFirstResponder(replyField)
+        return true
+    }
+
+    private func run(_ args: [String], pending: String) {
+        renderResult(.init(ok: true, output: pending), tint: .secondaryLabelColor)
+        onReply?(args) { [weak self] result in self?.renderResult(result) }
+    }
+
+    private func renderResult(_ result: Reply.Outcome, tint: NSColor? = nil) {
+        guard let label = resultLabel else { return }
+        if result.output.isEmpty {
+            label.stringValue = result.ok ? "done" : "failed"
+        } else {
+            label.stringValue = result.output
+        }
+        label.textColor = tint ?? (result.ok ? Palette.working : Palette.idle)
+    }
+
+    // MARK: - View builders
+
+    private func heading(_ text: String, color: NSColor) -> NSTextField {
+        let f = label(text, size: 15, weight: .semibold)
+        f.attributedStringValue = tinted(text, dotColor: color, size: 15)
+        return f
+    }
+
+    private func sectionTitle(_ text: String) -> NSTextField {
+        let f = label(text, size: 11, weight: .semibold)
+        f.textColor = .secondaryLabelColor
+        return f
+    }
+
+    private func body(_ text: String) -> NSTextField {
+        let f = label(text, size: 12, weight: .regular)
+        f.lineBreakMode = .byWordWrapping
+        f.maximumNumberOfLines = 0
+        pin(f)
+        return f
+    }
+
+    private func secondary(_ text: String) -> NSTextField {
+        let f = label(text, size: 11, weight: .regular)
+        f.textColor = .secondaryLabelColor
+        f.lineBreakMode = .byWordWrapping
+        f.maximumNumberOfLines = 0
+        pin(f)
+        return f
+    }
+
+    private func label(_ text: String, size: CGFloat, weight: NSFont.Weight) -> NSTextField {
+        let f = NSTextField(labelWithString: text)
+        f.font = NSFont.systemFont(ofSize: size, weight: weight)
+        f.translatesAutoresizingMaskIntoConstraints = false
+        return f
+    }
+
+    private func pill(_ text: String, color: NSColor) -> NSView {
+        let container = NSView()
+        container.wantsLayer = true
+        container.layer?.backgroundColor = color.withAlphaComponent(0.15).cgColor
+        container.layer?.cornerRadius = 6
+        let f = NSTextField(labelWithString: text)
+        f.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .medium)
+        f.textColor = color
+        f.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(f)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            f.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
+            f.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
+            f.topAnchor.constraint(equalTo: container.topAnchor, constant: 3),
+            f.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -3),
+        ])
+        return container
+    }
+
+    private func button(_ title: String, _ action: Selector) -> NSButton {
+        let b = NSButton(title: title, target: self, action: action)
+        b.bezelStyle = .rounded
+        b.controlSize = .small
+        b.font = NSFont.systemFont(ofSize: 11)
+        return b
+    }
+
+    private func tinted(_ text: String, dotColor: NSColor, size: CGFloat) -> NSAttributedString {
+        let attr = NSMutableAttributedString(string: text, attributes: [
+            .font: NSFont.systemFont(ofSize: size, weight: .semibold),
+            .foregroundColor: NSColor.labelColor,
+        ])
+        if let first = text.first {
+            attr.addAttribute(.foregroundColor, value: dotColor,
+                              range: NSRange(location: 0, length: String(first).utf16.count))
+        }
+        return attr
+    }
+
+    /// Pin an arranged subview to the stack width so wrapping text lays out.
+    private func pin(_ view: NSView) {
+        view.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        DispatchQueue.main.async { [weak self, weak view] in
+            guard let self, let view, view.superview != nil else { return }
+            view.widthAnchor.constraint(equalTo: self.stack.widthAnchor,
+                                        constant: -(self.stack.edgeInsets.left + self.stack.edgeInsets.right)).isActive = true
+        }
+    }
+}

--- a/cli/menubar/Sources/MenubarHelper/SessionCard.swift
+++ b/cli/menubar/Sources/MenubarHelper/SessionCard.swift
@@ -65,6 +65,12 @@ final class SessionCard: NSView {
     var onOpenTerminal: ((String) -> Void)?
     /// Open a rendered artifact in the default browser.
     var onOpenArtifact: ((String) -> Void)?
+    /// This machine's registry name (from the window's device snapshot), so a
+    /// peer-owned terminal row injects with `--device`. Nil until the snapshot
+    /// arrives; the fallback then routes every row explicitly.
+    var localDevice: String? {
+        didSet { if oldValue != localDevice, entry != nil { rebuild() } }
+    }
 
     private let scroll = NSScrollView()
     private let stack = NSStackView()
@@ -286,13 +292,9 @@ final class SessionCard: NSView {
                                disabledReason: attn.replyCapability == "none"
                                    ? "the CLI reports no reply rail for this session" : nil)
         }
-        // No open block: a live local session can still be nudged via inject.
-        let live = row.status == "running" || row.status == "idle"
-            || row.activity == "working" || row.activity == "waiting_input"
-        return ReplyTarget(sessionId: row.sessionId,
-                           capability: live && row.sessionId != nil ? .terminal : .none,
-                           team: row.spawnedTeam,
-                           disabledReason: live ? nil : "the session is not live")
+        // No open block: route on the row's own context/host exactly as the CLI
+        // would report its reply rail (Reply.fallbackTarget).
+        return Reply.fallbackTarget(for: row, localDevice: localDevice)
     }
 
     @objc private func onReplyReturn() { onSend() }

--- a/cli/menubar/Sources/MenubarHelper/SessionRowModel.swift
+++ b/cli/menubar/Sources/MenubarHelper/SessionRowModel.swift
@@ -142,6 +142,9 @@ enum SessionRowModel {
             return .idle
         case "running":
             return .working
+        case PendingLaunches.launchingPhase:
+            // A dispatch placeholder (PHNX-4005) is in progress, not yet working.
+            return .working
         default:
             break
         }
@@ -188,6 +191,7 @@ enum SessionRowModel {
         // phase reads as "working" (the green label), matching the brief.
         switch row.phase {
         case "running": return "working"
+        case PendingLaunches.launchingPhase: return "launching"
         case "waiting": return "waiting"
         case "idle":    return "idle"
         case "failed":  return "failed"

--- a/cli/menubar/Sources/MenubarHelper/SessionRowModel.swift
+++ b/cli/menubar/Sources/MenubarHelper/SessionRowModel.swift
@@ -1,0 +1,310 @@
+import Foundation
+
+// SessionRowModel — the ONE derivation from a live `SessionRow` (+ its optional
+// `AttentionItem`) to what a surface renders (PHNX-4003, Track C).
+//
+// Both the persistent Sessions window and the dropdown RECENT section consume
+// `present(_:attention:now:)`; there is no second place that decides a status
+// color, a PR chip, a phase line, or a progress tally. Keeping it a pure function
+// over the decode-only feed models (no AppKit, no clock except the injected
+// `now`) is what lets `MENUBAR_ROWMODEL_TEST=1` assert every branch headless.
+//
+// The status ranking follows the repo's "rank by progress, not liveness" rule
+// (root AGENTS.md): a session that has STOPPED progressing (needs you / idle /
+// failed) outranks a healthy running one, so the window and dropdown surface
+// not-progressing work first and fold the healthy set.
+
+// MARK: - Presentation model
+
+/// The four operator-facing status colors. Mapped to NSColor by the UI layer so
+/// this stays AppKit-free and unit-testable headless.
+enum StatusColor: Equatable {
+    case working   // green  — phase running/working, nothing needed
+    case needsYou  // yellow — a question/permission/plan_review, or phase waiting
+    case idle      // red    — idle / stall / failure / failed (highest-risk)
+    case done      // grey   — terminal, safe to fold away
+}
+
+/// The PR chip state derived from the row's PR status. The UI renders label +
+/// color; the model decides which state applies. `number` rides so the chip can
+/// read `PR #123`.
+enum PRChip: Equatable {
+    case merged(Int?)         // purple — "PR #n · merged ✓"
+    case approved(Int?)       // green  — "PR #n · checks ✓ · approved"
+    case checksFailed(Int?)   // red    — "PR #n · checks ✗"
+    case checksRunning(Int?)  // grey   — "PR #n · checks running"
+    case draft(Int?)          // dimmed — "PR #n · draft"
+    case open(Int?)           // default — "PR #n"
+
+    var number: Int? {
+        switch self {
+        case let .merged(n), let .approved(n), let .checksFailed(n),
+             let .checksRunning(n), let .draft(n), let .open(n):
+            return n
+        }
+    }
+
+    /// The rendered chip text.
+    var text: String {
+        let head = number.map { "PR #\($0)" } ?? "PR"
+        switch self {
+        case .merged:        return "\(head) · merged ✓"
+        case .approved:      return "\(head) · checks ✓ · approved"
+        case .checksFailed:  return "\(head) · checks ✗"
+        case .checksRunning: return "\(head) · checks running"
+        case .draft:         return "\(head) · draft"
+        case .open:          return head
+        }
+    }
+}
+
+/// The derived, render-ready projection of one session row. Carries only what a
+/// surface draws; the raw millis ride so the window can sort/group without a
+/// second derivation.
+struct RowPresentation: Equatable {
+    let title: String
+    let status: StatusColor
+    let phaseText: String
+    let progress: (done: Int, total: Int)?
+    let latestAction: String?
+    let prChip: PRChip?
+    let subagents: Int?
+    let groupKey: String
+    /// Sort inputs, surfaced so the list can order without re-deriving.
+    let startedAtMs: Double?
+    let lastActivityMs: Double?
+
+    static func == (a: RowPresentation, b: RowPresentation) -> Bool {
+        a.title == b.title && a.status == b.status && a.phaseText == b.phaseText
+            && a.progress?.done == b.progress?.done && a.progress?.total == b.progress?.total
+            && a.latestAction == b.latestAction && a.prChip == b.prChip
+            && a.subagents == b.subagents && a.groupKey == b.groupKey
+            && a.startedAtMs == b.startedAtMs && a.lastActivityMs == b.lastActivityMs
+    }
+}
+
+// MARK: - Derivation
+
+enum SessionRowModel {
+    /// The one derivation. `attention` is the reconciled item for this session (if
+    /// any); `now` is injected so a test controls relative time.
+    static func present(_ row: SessionRow, attention: AttentionItem?, now: Date = Date()) -> RowPresentation {
+        let status = statusColor(row, attention: attention)
+        return RowPresentation(
+            title: title(row),
+            status: status,
+            phaseText: phaseText(row, attention: attention, status: status, now: now),
+            progress: progress(row),
+            latestAction: latestAction(row),
+            prChip: prChip(row),
+            subagents: subagents(row),
+            groupKey: groupKey(row),
+            startedAtMs: row.startedAtMs,
+            lastActivityMs: row.lastActivityMs)
+    }
+
+    // MARK: title ladder
+
+    static func title(_ row: SessionRow) -> String {
+        for candidate in [row.label, row.name, row.title, row.topic] {
+            if let c = candidate?.trimmingCharacters(in: .whitespacesAndNewlines), !c.isEmpty { return c }
+        }
+        if let sid = row.sessionId, !sid.isEmpty { return String(sid.prefix(8)) }
+        return "session"
+    }
+
+    // MARK: status color
+
+    /// green = phase running/working; yellow = attention question/permission/
+    /// plan_review OR phase waiting; red = idle/stall/failure/failed; grey = done.
+    /// A pending attention item beats the row's own phase — a running session that
+    /// just asked a question needs you now.
+    static func statusColor(_ row: SessionRow, attention: AttentionItem?) -> StatusColor {
+        if let kind = attention?.kind {
+            switch kind {
+            case "question", "permission", "plan_review", "review", "declared":
+                return .needsYou
+            case "failure", "stall":
+                return .idle
+            default:
+                break
+            }
+        }
+        // Phase is the coarse lifecycle bucket the feed sets.
+        switch row.phase {
+        case "done":
+            return .done
+        case "failed":
+            return .idle
+        case "waiting":
+            return .needsYou
+        case "idle":
+            return .idle
+        case "running":
+            return .working
+        default:
+            break
+        }
+        // Fall back to the finer live activity/status when phase is absent.
+        switch row.activity {
+        case "waiting_input": return .needsYou
+        case "idle":          return .idle
+        case "working":       return .working
+        default: break
+        }
+        switch row.status {
+        case "running":            return .working
+        case "idle":               return .idle
+        case "crashed", "failed":  return .idle
+        case "closed", "done":     return .done
+        default:                   return .working
+        }
+    }
+
+    // MARK: phase text — "working · 18h · s0", "question · 13m · zion", "idle 41m · m1"
+
+    static func phaseText(_ row: SessionRow, attention: AttentionItem?, status: StatusColor, now: Date) -> String {
+        let device = deviceName(row)
+        let age = ageLabel(row, now: now)
+        let label = phaseLabel(row, attention: attention, status: status)
+
+        // A red idle row folds the age into the label ("idle 41m"), then device.
+        if status == .idle && (label == "idle" || label == "stall"), let age {
+            return joined(["\(label) \(age)", device])
+        }
+        return joined([label, age, device])
+    }
+
+    /// The leading word of the phase line: the attention kind when one is pending,
+    /// else the row's phase/activity bucket.
+    private static func phaseLabel(_ row: SessionRow, attention: AttentionItem?, status: StatusColor) -> String {
+        if let kind = attention?.kind, !kind.isEmpty {
+            switch kind {
+            case "plan_review": return "plan review"
+            default:            return kind
+            }
+        }
+        // Map the coarse phase/activity bucket to its display word — a "running"
+        // phase reads as "working" (the green label), matching the brief.
+        switch row.phase {
+        case "running": return "working"
+        case "waiting": return "waiting"
+        case "idle":    return "idle"
+        case "failed":  return "failed"
+        case "done":    return "done"
+        default: break
+        }
+        switch row.activity {
+        case "working":       return "working"
+        case "waiting_input": return "waiting"
+        case "idle":          return "idle"
+        default: break
+        }
+        switch status {
+        case .working:  return "working"
+        case .needsYou: return "waiting"
+        case .idle:     return "idle"
+        case .done:     return "done"
+        }
+    }
+
+    // MARK: progress
+
+    static func progress(_ row: SessionRow) -> (done: Int, total: Int)? {
+        guard let total = row.todos?.total, total > 0 else { return nil }
+        return (done: row.todos?.done ?? 0, total: total)
+    }
+
+    // MARK: latest action — last timeline step + tool, else last agent line
+
+    static func latestAction(_ row: SessionRow) -> String? {
+        if let step = row.timeline?.latestStep,
+           let text = step.text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
+            if let now = step.now?.trimmingCharacters(in: .whitespacesAndNewlines), !now.isEmpty {
+                return "\(text) · \(now)"
+            }
+            return text
+        }
+        if let line = row.lastAgentLine?.trimmingCharacters(in: .whitespacesAndNewlines), !line.isEmpty {
+            return line
+        }
+        return nil
+    }
+
+    // MARK: PR chip
+
+    /// Derive the chip from the row's PR status. We have `state`, `isDraft`,
+    /// `reviewDecision`, and `mergeable` (GitHub's mergeable_state vocabulary) —
+    /// there is no separate check-rollup field on the row, so "checks" is read off
+    /// `mergeable`: clean = passing, unstable/dirty/blocked = failing, unknown/nil
+    /// = still computing.
+    static func prChip(_ row: SessionRow) -> PRChip? {
+        guard let pr = row.pr, (pr.number != nil || pr.url != nil) else { return nil }
+        let n = pr.number
+        if pr.state?.lowercased() == "merged" { return .merged(n) }
+        if pr.isDraft == true || pr.state?.lowercased() == "draft" { return .draft(n) }
+
+        let mergeable = pr.mergeable?.lowercased()
+        let approved = pr.reviewDecision?.uppercased() == "APPROVED"
+        switch mergeable {
+        case "unstable", "dirty", "blocked":
+            return .checksFailed(n)
+        case "unknown", .none, "":
+            // No check verdict yet. If review already landed, show that.
+            return approved ? .approved(n) : .checksRunning(n)
+        default: // "clean", "behind", "has_hooks"
+            return approved ? .approved(n) : .open(n)
+        }
+    }
+
+    // MARK: subagents glyph count
+
+    /// The count for `⑂ n`, shown when the session spawned sub-agents, holds more
+    /// than one live pid, or launched a team. Nil when it is a lone process.
+    static func subagents(_ row: SessionRow) -> Int? {
+        if let n = row.subAgentCount, n > 0 { return n }
+        if let p = row.pidCount, p > 1 { return p }
+        if row.spawnedTeam?.isEmpty == false { return row.subAgentCount ?? row.pidCount ?? 1 }
+        return nil
+    }
+
+    // MARK: group key — project
+
+    static func groupKey(_ row: SessionRow) -> String {
+        if let p = row.project?.trimmingCharacters(in: .whitespacesAndNewlines), !p.isEmpty { return p }
+        if let cwd = row.cwd, !cwd.isEmpty {
+            let base = (cwd as NSString).lastPathComponent
+            if !base.isEmpty { return base }
+        }
+        return "other"
+    }
+
+    // MARK: helpers
+
+    static func deviceName(_ row: SessionRow) -> String {
+        if let m = row.machine?.trimmingCharacters(in: .whitespacesAndNewlines), !m.isEmpty { return m }
+        if let s = row.sourceDevice?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty { return s }
+        return ""
+    }
+
+    /// Relative age from the row's last activity (falling back to start): `now`,
+    /// `13m`, `18h`, `2d`. Nil when the row carries no timestamp.
+    static func ageLabel(_ row: SessionRow, now: Date) -> String? {
+        guard let ms = row.lastActivityMs ?? row.startedAtMs else { return nil }
+        let secs = now.timeIntervalSince1970 - ms / 1000
+        return ageLabel(seconds: secs)
+    }
+
+    static func ageLabel(seconds: TimeInterval) -> String {
+        let mins = Int(max(0, seconds) / 60)
+        if mins < 1 { return "now" }
+        if mins < 60 { return "\(mins)m" }
+        let hours = mins / 60
+        if hours < 24 { return "\(hours)h" }
+        return "\(hours / 24)d"
+    }
+
+    private static func joined(_ parts: [String?]) -> String {
+        parts.compactMap { $0.flatMap { $0.isEmpty ? nil : $0 } }.joined(separator: " · ")
+    }
+}

--- a/cli/menubar/Sources/MenubarHelper/SessionsWindow.swift
+++ b/cli/menubar/Sources/MenubarHelper/SessionsWindow.swift
@@ -1,0 +1,595 @@
+import AppKit
+
+// SessionsWindow — the persistent Sessions window (PHNX-4003, Track C). A real,
+// frame-remembering NSPanel that projects `FeedStream.shared` (live sessions +
+// attention across the fleet) and `ArtifactIndex.shared` (rendered pages) into a
+// grouped, filterable list on the left and a `SessionCard` on the right.
+//
+// It is a PROJECTION, never a scheduler (spec SING-2): it renders FeedStream diffs
+// and offers controls that shell ONE bounded `agents` argv each — it owns no
+// timer that acts on the fleet. The single timer it holds is a 1 s relative-time
+// refresh that re-renders only the VISIBLE list cells; all other redraws are
+// driven by FeedStream diffs. Closing the window hides it and keeps FeedStream
+// attached, so re-opening is instant and the badge stays live.
+
+/// The panel accepts key/main so its search and reply fields take focus — a bare
+/// NSPanel is non-activating by default.
+final class SessionsPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+    /// Returns true when the controller consumed the key (1-9 / Return / Cmd-*).
+    var keyHandler: ((NSEvent) -> Bool)?
+
+    override func keyDown(with event: NSEvent) {
+        if keyHandler?(event) == true { return }
+        super.keyDown(with: event)
+    }
+}
+
+final class SessionsWindowController: NSObject, NSWindowDelegate, NSTableViewDataSource, NSTableViewDelegate {
+    static let shared = SessionsWindowController()
+
+    // MARK: Filters
+
+    enum Filter: Int, CaseIterable {
+        case recent, needsYou, running, doneToday
+        var title: String {
+            switch self {
+            case .recent: return "Recent"
+            case .needsYou: return "Needs you"
+            case .running: return "Running"
+            case .doneToday: return "Done today"
+            }
+        }
+    }
+
+    private var filter: Filter = .recent
+    private var searchText = ""
+    private var collapsed: Set<String> = []
+    private var selectedRowKey: String?
+
+    // MARK: Data
+
+    /// All live entries from the feed, keyed by rowKey (previous/history rows
+    /// dropped — this window is the live view).
+    private var entries: [String: SessionEntry] = [:]
+    /// The flattened, filtered, grouped display list backing the table.
+    private var listItems: [ListItem] = []
+    /// Snapshot devices (for load/interactive/local flags), fetched off-main.
+    private var snapshotDevices: [String: Device] = [:]
+
+    private enum ListItem {
+        case group(name: String, count: Int, needYou: Int)
+        case session(SessionEntry)
+    }
+
+    // MARK: Views
+
+    private var panel: SessionsPanel?
+    private let table = NSTableView()
+    private let card = SessionCard()
+    private let searchField = NSSearchField()
+    private var chipButtons: [NSButton] = []
+    private let deviceStrip = NSStackView()
+    private let statusLabel = NSTextField(labelWithString: "")
+    private var timeTimer: Timer?
+
+    private override init() { super.init() }
+
+    // MARK: - Public entry points
+
+    /// Toggle the window (Cmd-Shift-I / the dropdown "Sessions" row). FeedStream is
+    /// started once and stays attached.
+    func toggle() {
+        if let panel, panel.isVisible { panel.orderOut(nil) } else { open(selecting: nil) }
+    }
+
+    /// Show the window, optionally selecting a specific session (clicking a
+    /// dropdown row opens the window on that session).
+    func open(selecting sessionId: String?) {
+        ensurePanel()
+        FeedStream.shared.start()
+        ArtifactIndex.shared.start()
+        ingest()
+        if let sessionId, let key = entries.first(where: { $0.value.sessionId == sessionId })?.key {
+            selectedRowKey = key
+        }
+        panel?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        applyAndReload()
+        startTimeTimer()
+    }
+
+    // MARK: - Panel construction
+
+    private func ensurePanel() {
+        guard panel == nil else { return }
+        let p = SessionsPanel(contentRect: NSRect(x: 0, y: 0, width: 960, height: 600),
+                              styleMask: [.titled, .closable, .resizable, .utilityWindow],
+                              backing: .buffered, defer: false)
+        p.title = "Sessions"
+        p.isFloatingPanel = false        // behave like a document window
+        p.hidesOnDeactivate = false
+        p.isReleasedWhenClosed = false
+        p.delegate = self
+        p.keyHandler = { [weak self] event in self?.handleKey(event) ?? false }
+        p.setFrameAutosaveName("AGIMenuSessionsWindow")
+
+        let root = NSView()
+        p.contentView = root
+
+        // Toolbar: filter chips + search field.
+        let toolbar = NSStackView()
+        toolbar.orientation = .horizontal
+        toolbar.spacing = 6
+        toolbar.edgeInsets = NSEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
+        for f in Filter.allCases {
+            let b = NSButton(title: f.title, target: self, action: #selector(onChip(_:)))
+            b.bezelStyle = .rounded
+            b.setButtonType(.pushOnPushOff)
+            b.tag = f.rawValue
+            b.font = NSFont.systemFont(ofSize: 11)
+            chipButtons.append(b)
+            toolbar.addArrangedSubview(b)
+        }
+        searchField.placeholderString = "Search label, topic, project, ticket, device (Cmd-F)"
+        searchField.target = self
+        searchField.action = #selector(onSearch)
+        searchField.sendsSearchStringImmediately = false
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        toolbar.addArrangedSubview(searchField)
+
+        // Device strip.
+        deviceStrip.orientation = .horizontal
+        deviceStrip.spacing = 6
+        deviceStrip.edgeInsets = NSEdgeInsets(top: 4, left: 12, bottom: 4, right: 12)
+        let deviceScroll = NSScrollView()
+        deviceScroll.hasHorizontalScroller = false
+        deviceScroll.drawsBackground = false
+        deviceScroll.documentView = deviceStrip
+
+        // Split: list | card.
+        let split = NSSplitView()
+        split.isVertical = true
+        split.dividerStyle = .thin
+
+        let listScroll = NSScrollView()
+        listScroll.hasVerticalScroller = true
+        table.headerView = nil
+        table.rowHeight = 46
+        table.backgroundColor = .clear
+        table.selectionHighlightStyle = .regular
+        table.dataSource = self
+        table.delegate = self
+        table.target = self
+        table.action = #selector(onRowClick)
+        let col = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("main"))
+        col.resizingMask = .autoresizingMask
+        table.addTableColumn(col)
+        listScroll.documentView = table
+        split.addArrangedSubview(listScroll)
+        split.addArrangedSubview(card)
+
+        // Status bar.
+        statusLabel.font = NSFont.monospacedSystemFont(ofSize: 10, weight: .regular)
+        statusLabel.textColor = .secondaryLabelColor
+        let statusBar = NSStackView(views: [statusLabel])
+        statusBar.orientation = .horizontal
+        statusBar.edgeInsets = NSEdgeInsets(top: 4, left: 12, bottom: 4, right: 12)
+
+        let column = NSStackView(views: [toolbar, deviceScroll, split, statusBar])
+        column.orientation = .vertical
+        column.spacing = 0
+        column.translatesAutoresizingMaskIntoConstraints = false
+        root.addSubview(column)
+        NSLayoutConstraint.activate([
+            column.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            column.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            column.topAnchor.constraint(equalTo: root.topAnchor),
+            column.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+            deviceScroll.heightAnchor.constraint(equalToConstant: 30),
+            split.heightAnchor.constraint(greaterThanOrEqualToConstant: 400),
+        ])
+        split.setHoldingPriority(.defaultLow, forSubviewAt: 1)
+
+        // Wire the card's bounded actions to the CLI.
+        card.onReply = { args, done in Reply.perform(args, onResult: done) }
+        card.onOpenTerminal = { id in AgentsCLI.focusSession(id) }
+        card.onOpenArtifact = { path in NSWorkspace.shared.open(URL(fileURLWithPath: path)) }
+
+        panel = p
+
+        // Observe the data layer. These fire on the main queue.
+        FeedStream.shared.addObserver(self) { [weak self] _ in self?.onFeedDiff() }
+        ArtifactIndex.shared.addObserver(self) { [weak self] in self?.refreshCardArtifacts() }
+
+        fetchSnapshotDevices()
+    }
+
+    // MARK: - Data ingest + render
+
+    private func onFeedDiff() {
+        guard panel?.isVisible == true else { return }
+        ingest()
+        applyAndReload()
+    }
+
+    private func ingest() {
+        let rows = FeedStream.shared.rows
+        let attention = FeedStream.shared.attention
+        let now = Date()
+        var next: [String: SessionEntry] = [:]
+        for (rowKey, row) in rows {
+            if row.isPrevious { continue }
+            let attn = row.sessionId.flatMap { attention[$0] }
+            let presentation = SessionRowModel.present(row, attention: attn, now: now)
+            next[rowKey] = SessionEntry(rowKey: rowKey, row: row, attention: attn, presentation: presentation)
+        }
+        entries = next
+    }
+
+    private func applyAndReload() {
+        let now = Date()
+        let all = Array(entries.values)
+        let filtered = all.filter { passesFilter($0) && matchesSearch($0) }
+
+        // Group by project, sort groups by most-recent activity, rows by startedAt desc.
+        var byGroup: [String: [SessionEntry]] = [:]
+        for e in filtered { byGroup[e.presentation.groupKey, default: []].append(e) }
+        let orderedGroups = byGroup.keys.sorted { a, b in
+            recency(byGroup[a]!) > recency(byGroup[b]!)
+        }
+
+        var items: [ListItem] = []
+        for name in orderedGroups {
+            let rows = byGroup[name]!.sorted { ($0.row.startedAtMs ?? 0) > ($1.row.startedAtMs ?? 0) }
+            let needYou = rows.filter { $0.presentation.status == .needsYou }.count
+            items.append(.group(name: name, count: rows.count, needYou: needYou))
+            if !collapsed.contains(name) {
+                for r in rows { items.append(.session(r)) }
+            }
+        }
+        listItems = items
+        table.reloadData()
+        restoreSelection()
+        updateChips(all)
+        updateStatusBar(now: now)
+        rebuildDeviceStrip(now: now)
+    }
+
+    private func recency(_ rows: [SessionEntry]) -> Double {
+        rows.map { $0.row.lastActivityMs ?? $0.row.startedAtMs ?? 0 }.max() ?? 0
+    }
+
+    private func passesFilter(_ e: SessionEntry) -> Bool {
+        switch filter {
+        case .recent: return true
+        case .needsYou: return e.presentation.status == .needsYou || e.presentation.status == .idle
+        case .running: return e.presentation.status == .working
+        case .doneToday:
+            guard e.presentation.status == .done, let ms = e.row.lastActivityMs ?? e.row.startedAtMs else { return false }
+            return Calendar.current.isDateInToday(Date(timeIntervalSince1970: ms / 1000))
+        }
+    }
+
+    private func matchesSearch(_ e: SessionEntry) -> Bool {
+        guard !searchText.isEmpty else { return true }
+        let hay = [e.presentation.title, e.row.topic, e.presentation.groupKey,
+                   e.row.ticket?.id, SessionRowModel.deviceName(e.row), e.row.host]
+            .compactMap { $0 }.joined(separator: " ").lowercased()
+        return hay.contains(searchText.lowercased())
+    }
+
+    // MARK: - Chips / status / devices
+
+    private func updateChips(_ all: [SessionEntry]) {
+        func count(_ f: Filter) -> Int {
+            switch f {
+            case .recent: return all.count
+            case .needsYou: return all.filter { $0.presentation.status == .needsYou || $0.presentation.status == .idle }.count
+            case .running: return all.filter { $0.presentation.status == .working }.count
+            case .doneToday: return all.filter {
+                guard $0.presentation.status == .done, let ms = $0.row.lastActivityMs ?? $0.row.startedAtMs else { return false }
+                return Calendar.current.isDateInToday(Date(timeIntervalSince1970: ms / 1000))
+            }.count
+            }
+        }
+        for b in chipButtons {
+            guard let f = Filter(rawValue: b.tag) else { continue }
+            b.title = "\(f.title) (\(count(f)))"
+            b.state = (f == filter) ? .on : .off
+        }
+    }
+
+    private func updateStatusBar(now: Date) {
+        let heartbeats = FeedStream.shared.deviceHeartbeat
+        let scopes = FeedStream.shared.scopeStatus
+        let reporting = heartbeats.count
+        let stale = heartbeats.values.filter { now.timeIntervalSince($0) > FeedStream.staleAfter }.count
+            + scopes.values.filter { $0 == .unavailable }.count
+        let lastEvent = heartbeats.values.max().map { Int(now.timeIntervalSince($0)) }
+        var parts: [String] = []
+        parts.append("stream \(healthWord(FeedStream.shared.health))")
+        if let s = lastEvent { parts.append("last event \(s)s ago") }
+        parts.append("\(reporting) device\(reporting == 1 ? "" : "s") reporting")
+        if stale > 0 { parts.append("\(stale) stale") }
+        parts.append("helper \(rssMB()) MB")
+        parts.append("\(entries.count) row\(entries.count == 1 ? "" : "s")")
+        statusLabel.stringValue = parts.joined(separator: "  ·  ")
+    }
+
+    private func healthWord(_ h: StreamHealth) -> String {
+        switch h {
+        case .live: return "live"
+        case .starting: return "starting"
+        case .stale: return "stale"
+        case .reconnecting: return "reconnecting"
+        case .breakerTripped: return "stopped (breaker)"
+        case .stopped: return "stopped"
+        }
+    }
+
+    private func rebuildDeviceStrip(now: Date) {
+        deviceStrip.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        let heartbeats = FeedStream.shared.deviceHeartbeat
+        let scopes = FeedStream.shared.scopeStatus
+        for name in heartbeats.keys.sorted() {
+            let last = heartbeats[name]!
+            let offline = scopes[name] == .unavailable
+            if offline { continue } // offline devices collapse out of the strip
+            var text = name
+            if let dev = snapshotDevices[name], dev.isLocal { text += " ·" }
+            let age = now.timeIntervalSince(last)
+            var color = Palette.working
+            if age > FeedStream.staleAfter {
+                text += " · stale \(Int(age / 60))m"
+                color = Palette.needsYou
+            }
+            deviceStrip.addArrangedSubview(chip(text, color: color))
+        }
+        let offlineCount = scopes.values.filter { $0 == .unavailable }.count
+        if offlineCount > 0 { deviceStrip.addArrangedSubview(chip("\(offlineCount) offline", color: Palette.done)) }
+    }
+
+    private func chip(_ text: String, color: NSColor) -> NSView {
+        let f = NSTextField(labelWithString: text)
+        f.font = NSFont.monospacedSystemFont(ofSize: 10, weight: .medium)
+        f.textColor = color
+        f.wantsLayer = true
+        f.layer?.backgroundColor = color.withAlphaComponent(0.12).cgColor
+        f.layer?.cornerRadius = 5
+        f.drawsBackground = false
+        return f
+    }
+
+    private func fetchSnapshotDevices() {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let devices = AgentsCLI.menubarSnapshot()?.devices ?? []
+            DispatchQueue.main.async {
+                self?.snapshotDevices = Dictionary(uniqueKeysWithValues: devices.map { ($0.name, $0) })
+            }
+        }
+    }
+
+    // MARK: - Table
+
+    func numberOfRows(in tableView: NSTableView) -> Int { listItems.count }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row < listItems.count else { return nil }
+        switch listItems[row] {
+        case let .group(name, count, needYou):
+            return groupCell(name: name, count: count, needYou: needYou)
+        case let .session(entry):
+            return sessionCell(entry)
+        }
+    }
+
+    func tableView(_ tableView: NSTableView, isGroupRow row: Int) -> Bool {
+        if case .group = listItems[row] { return true }
+        return false
+    }
+
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+        if case .group = listItems[row] { return false }
+        return true
+    }
+
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+        if case .group = listItems[row] { return 26 }
+        return 46
+    }
+
+    @objc private func onRowClick() {
+        let row = table.clickedRow
+        guard row >= 0, row < listItems.count else { return }
+        if case let .group(name, _, _) = listItems[row] {
+            if collapsed.contains(name) { collapsed.remove(name) } else { collapsed.insert(name) }
+            applyAndReload()
+        }
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        let row = table.selectedRow
+        guard row >= 0, row < listItems.count, case let .session(entry) = listItems[row] else { return }
+        selectedRowKey = entry.rowKey
+        showCard(entry)
+    }
+
+    private func restoreSelection() {
+        guard let key = selectedRowKey else { return }
+        for (i, item) in listItems.enumerated() {
+            if case let .session(e) = item, e.rowKey == key {
+                table.selectRowIndexes(IndexSet(integer: i), byExtendingSelection: false)
+                return
+            }
+        }
+    }
+
+    private func showCard(_ entry: SessionEntry) {
+        let artifacts = entry.sessionId.map { ArtifactIndex.shared.artifacts(forSession: $0) } ?? []
+        card.show(entry, artifacts: artifacts)
+    }
+
+    private func refreshCardArtifacts() {
+        guard let key = selectedRowKey, let entry = entries[key] else { return }
+        showCard(entry)
+    }
+
+    private func groupCell(name: String, count: Int, needYou: Int) -> NSView {
+        let arrow = collapsed.contains(name) ? "\u{25B6}" : "\u{25BC}"
+        var text = "\(arrow)  \(name)  (\(count))"
+        let f = NSTextField(labelWithString: text)
+        f.font = NSFont.systemFont(ofSize: 11, weight: .semibold)
+        f.textColor = .secondaryLabelColor
+        if needYou > 0 {
+            text += "   \(needYou) need you"
+            let attr = NSMutableAttributedString(string: text, attributes: [
+                .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+                .foregroundColor: NSColor.secondaryLabelColor,
+            ])
+            let r = (text as NSString).range(of: "\(needYou) need you")
+            if r.location != NSNotFound { attr.addAttribute(.foregroundColor, value: Palette.needsYou, range: r) }
+            f.attributedStringValue = attr
+        }
+        let container = NSTableCellView()
+        f.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(f)
+        NSLayoutConstraint.activate([
+            f.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
+            f.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -8),
+            f.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+        return container
+    }
+
+    private func sessionCell(_ entry: SessionEntry) -> NSView {
+        // Recompute the phase line with a fresh clock so the age stays live on the
+        // 1 s visible-cell refresh; everything else rides the stored presentation.
+        let p = entry.presentation
+        let phase = SessionRowModel.phaseText(entry.row, attention: entry.attention,
+                                              status: p.status, now: Date())
+        let (dot, color) = Palette.dot(p.status)
+
+        // Line 1: dot + title + progress + phase/device.
+        var line1 = "\(dot) \(p.title)"
+        if let prog = p.progress { line1 += "  \(prog.done)/\(prog.total)" }
+        line1 += "   \(phase)"
+        // Line 2: latest action + PR chip.
+        var line2Parts: [String] = []
+        if let action = p.latestAction { line2Parts.append(action) }
+        if let chip = p.prChip { line2Parts.append(chip.text) }
+        let line2 = line2Parts.joined(separator: "   ")
+
+        let title = NSTextField(labelWithString: line1)
+        let attr = NSMutableAttributedString(string: line1, attributes: [
+            .font: NSFont.systemFont(ofSize: 12, weight: .medium),
+            .foregroundColor: NSColor.labelColor,
+        ])
+        let r = (line1 as NSString).range(of: dot)
+        if r.location != NSNotFound { attr.addAttribute(.foregroundColor, value: color, range: r) }
+        title.attributedStringValue = attr
+        title.lineBreakMode = .byTruncatingTail
+
+        let sub = NSTextField(labelWithString: line2)
+        sub.font = NSFont.systemFont(ofSize: 10)
+        sub.textColor = .secondaryLabelColor
+        sub.lineBreakMode = .byTruncatingTail
+
+        let vstack = NSStackView(views: line2.isEmpty ? [title] : [title, sub])
+        vstack.orientation = .vertical
+        vstack.alignment = .leading
+        vstack.spacing = 1
+        vstack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSTableCellView()
+        container.addSubview(vstack)
+        NSLayoutConstraint.activate([
+            vstack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
+            vstack.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -8),
+            vstack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+        return container
+    }
+
+    // MARK: - Actions
+
+    @objc private func onChip(_ sender: NSButton) {
+        guard let f = Filter(rawValue: sender.tag) else { return }
+        filter = f
+        applyAndReload()
+    }
+
+    @objc private func onSearch() {
+        searchText = searchField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        applyAndReload()
+    }
+
+    // MARK: - Keyboard
+
+    /// Handle the window's key events (routed from the panel): 1-9 answer an
+    /// option on the selected row, Return focuses the reply field, Cmd-Return
+    /// opens the terminal, Cmd-K nudges, Cmd-F focuses search.
+    func handleKey(_ event: NSEvent) -> Bool {
+        let cmd = event.modifierFlags.contains(.command)
+        let chars = event.charactersIgnoringModifiers ?? ""
+        if cmd, chars == "f" { panel?.makeFirstResponder(searchField); return true }
+        // Don't steal typing while a text field is first responder.
+        if panel?.firstResponder is NSText { return false }
+        if cmd, chars == "k" { card.nudge(); return true }
+        if cmd, event.keyCode == 36 { card.openTerminal(); return true } // Cmd-Return
+        if event.keyCode == 36 { card.focusReply(); return true }        // Return
+        if cmd, chars == "v" { return card.attachClipboardImage() }
+        if let digit = Int(chars), digit >= 1, digit <= 9 { card.answerOption(index: digit - 1); return true }
+        return false
+    }
+
+    // MARK: - Timer
+
+    private func startTimeTimer() {
+        guard timeTimer == nil else { return }
+        let t = Timer(timeInterval: 1, repeats: true) { [weak self] _ in self?.tickTime() }
+        RunLoop.main.add(t, forMode: .common)
+        timeTimer = t
+    }
+
+    private func stopTimeTimer() {
+        timeTimer?.invalidate()
+        timeTimer = nil
+    }
+
+    /// Re-render ONLY the visible session cells so their relative ages advance,
+    /// and refresh the status bar's "last event" — no data reload, no CLI call.
+    private func tickTime() {
+        guard panel?.isVisible == true else { return }
+        let visible = table.rows(in: table.visibleRect)
+        if visible.length > 0 {
+            table.reloadData(forRowIndexes: IndexSet(integersIn: visible.location..<(visible.location + visible.length)),
+                             columnIndexes: IndexSet(integer: 0))
+            restoreSelection()
+        }
+        updateStatusBar(now: Date())
+    }
+
+    // MARK: - Window lifecycle
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        sender.orderOut(nil)
+        stopTimeTimer()
+        return false // hide, keep FeedStream attached
+    }
+
+    // MARK: - RSS
+
+    private func rssMB() -> Int {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size)
+        let kr = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return 0 }
+        return Int(info.resident_size / (1024 * 1024))
+    }
+}

--- a/cli/menubar/Sources/MenubarHelper/SessionsWindow.swift
+++ b/cli/menubar/Sources/MenubarHelper/SessionsWindow.swift
@@ -8,9 +8,15 @@ import AppKit
 // It is a PROJECTION, never a scheduler (spec SING-2): it renders FeedStream diffs
 // and offers controls that shell ONE bounded `agents` argv each — it owns no
 // timer that acts on the fleet. The single timer it holds is a 1 s relative-time
-// refresh that re-renders only the VISIBLE list cells; all other redraws are
-// driven by FeedStream diffs. Closing the window hides it and keeps FeedStream
-// attached, so re-opening is instant and the badge stays live.
+// refresh that updates the TEXT of the visible list cells in place (no reload,
+// no view rebuild); all other redraws are driven by FeedStream diffs. Closing the
+// window hides it and keeps FeedStream attached, so re-opening is instant and the
+// badge stays live.
+//
+// The list is a view-based NSTableView with real cell reuse: the two cell classes
+// below (`GroupCellView`, `SessionCellView`) own their label subviews for life,
+// are dequeued with `makeView(withIdentifier:owner:)`, and are updated in place —
+// a helper that stays resident for days never rebuilds a subview tree per row.
 
 /// The panel accepts key/main so its search and reply fields take focus — a bare
 /// NSPanel is non-activating by default.
@@ -23,6 +29,109 @@ final class SessionsPanel: NSPanel {
     override func keyDown(with event: NSEvent) {
         if keyHandler?(event) == true { return }
         super.keyDown(with: event)
+    }
+}
+
+/// A project group header row. One label, built once, updated in place.
+final class GroupCellView: NSTableCellView {
+    static let reuseIdentifier = NSUserInterfaceItemIdentifier("SessionsWindow.group")
+
+    private let label = NSTextField(labelWithString: "")
+
+    init() {
+        super.init(frame: .zero)
+        identifier = Self.reuseIdentifier
+        label.font = NSFont.systemFont(ofSize: 11, weight: .semibold)
+        label.textColor = .secondaryLabelColor
+        label.lineBreakMode = .byTruncatingTail
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -8),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
+
+    func update(name: String, count: Int, needYou: Int, collapsed: Bool) {
+        let arrow = collapsed ? "\u{25B6}" : "\u{25BC}"
+        var text = "\(arrow)  \(name)  (\(count))"
+        guard needYou > 0 else {
+            label.stringValue = text
+            return
+        }
+        text += "   \(needYou) need you"
+        let attr = NSMutableAttributedString(string: text, attributes: [
+            .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+            .foregroundColor: NSColor.secondaryLabelColor,
+        ])
+        let r = (text as NSString).range(of: "\(needYou) need you")
+        if r.location != NSNotFound { attr.addAttribute(.foregroundColor, value: Palette.needsYou, range: r) }
+        label.attributedStringValue = attr
+    }
+}
+
+/// A session row: two labels in a vertical stack, built once, updated in place.
+/// `update(_:now:)` is what the 1 s timer calls on the visible rows, so it must
+/// touch text only.
+final class SessionCellView: NSTableCellView {
+    static let reuseIdentifier = NSUserInterfaceItemIdentifier("SessionsWindow.session")
+
+    private let title = NSTextField(labelWithString: "")
+    private let sub = NSTextField(labelWithString: "")
+
+    init() {
+        super.init(frame: .zero)
+        identifier = Self.reuseIdentifier
+        title.lineBreakMode = .byTruncatingTail
+        sub.font = NSFont.systemFont(ofSize: 10)
+        sub.textColor = .secondaryLabelColor
+        sub.lineBreakMode = .byTruncatingTail
+        let vstack = NSStackView(views: [title, sub])
+        vstack.orientation = .vertical
+        vstack.alignment = .leading
+        vstack.spacing = 1
+        vstack.detachesHiddenViews = true
+        vstack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(vstack)
+        NSLayoutConstraint.activate([
+            vstack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            vstack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -8),
+            vstack.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
+
+    /// Re-render the two lines. The phase line is recomputed against `now` so
+    /// the relative age advances; everything else rides the stored presentation.
+    func update(_ entry: SessionEntry, now: Date) {
+        let p = entry.presentation
+        let phase = SessionRowModel.phaseText(entry.row, attention: entry.attention,
+                                              status: p.status, now: now)
+        let (dot, color) = Palette.dot(p.status)
+
+        // Line 1: dot + title + progress + phase/device.
+        var line1 = "\(dot) \(p.title)"
+        if let prog = p.progress { line1 += "  \(prog.done)/\(prog.total)" }
+        line1 += "   \(phase)"
+        let attr = NSMutableAttributedString(string: line1, attributes: [
+            .font: NSFont.systemFont(ofSize: 12, weight: .medium),
+            .foregroundColor: NSColor.labelColor,
+        ])
+        let r = (line1 as NSString).range(of: dot)
+        if r.location != NSNotFound { attr.addAttribute(.foregroundColor, value: color, range: r) }
+        title.attributedStringValue = attr
+
+        // Line 2: latest action + PR chip; hidden (and detached from layout) when empty.
+        var line2Parts: [String] = []
+        if let action = p.latestAction { line2Parts.append(action) }
+        if let chip = p.prChip { line2Parts.append(chip.text) }
+        let line2 = line2Parts.joined(separator: "   ")
+        sub.stringValue = line2
+        sub.isHidden = line2.isEmpty
     }
 }
 
@@ -74,14 +183,53 @@ final class SessionsWindowController: NSObject, NSWindowDelegate, NSTableViewDat
     private let statusLabel = NSTextField(labelWithString: "")
     private var timeTimer: Timer?
 
+    // MARK: Selection published for the notifications layer (PHNX-4004)
+
+    /// The session id of the selected row while the window is visible, mirrored
+    /// under a lock: `Notifier.isSessionSelectedInSessionsWindow` asks from the
+    /// UNUserNotificationCenter delegate's queue, never main, so it must not read
+    /// table state directly.
+    private let shownSessionLock = NSLock()
+    private var shownSessionId: String?
+
     private override init() { super.init() }
+
+    /// Whether `sessionId` is the selected row of a visible Sessions window —
+    /// the operator is already looking at it, so its banner is not presented.
+    /// Thread-safe.
+    func isShowingSession(_ sessionId: String) -> Bool {
+        shownSessionLock.lock()
+        defer { shownSessionLock.unlock() }
+        return shownSessionId == sessionId
+    }
+
+    /// Re-derive the published id from the live selection + visibility. Called on
+    /// every path that changes either: reload, selection change, open, close.
+    private func publishShownSession() {
+        var id: String?
+        if panel?.isVisible == true {
+            let row = table.selectedRow
+            if row >= 0, row < listItems.count, case let .session(entry) = listItems[row] {
+                id = entry.sessionId
+            }
+        }
+        shownSessionLock.lock()
+        shownSessionId = id
+        shownSessionLock.unlock()
+    }
 
     // MARK: - Public entry points
 
     /// Toggle the window (Cmd-Shift-I / the dropdown "Sessions" row). FeedStream is
     /// started once and stays attached.
     func toggle() {
-        if let panel, panel.isVisible { panel.orderOut(nil) } else { open(selecting: nil) }
+        if let panel, panel.isVisible {
+            panel.orderOut(nil)
+            stopTimeTimer()
+            publishShownSession()
+        } else {
+            open(selecting: nil)
+        }
     }
 
     /// Show the window, optionally selecting a specific session (clicking a
@@ -252,6 +400,7 @@ final class SessionsWindowController: NSObject, NSWindowDelegate, NSTableViewDat
         listItems = items
         table.reloadData()
         restoreSelection()
+        publishShownSession()
         updateChips(all)
         updateStatusBar(now: now)
         rebuildDeviceStrip(now: now)
@@ -366,7 +515,11 @@ final class SessionsWindowController: NSObject, NSWindowDelegate, NSTableViewDat
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let devices = AgentsCLI.menubarSnapshot()?.devices ?? []
             DispatchQueue.main.async {
-                self?.snapshotDevices = Dictionary(uniqueKeysWithValues: devices.map { ($0.name, $0) })
+                guard let self else { return }
+                self.snapshotDevices = Dictionary(uniqueKeysWithValues: devices.map { ($0.name, $0) })
+                // The card needs this machine's registry name so a peer-owned
+                // terminal row injects with --device (Reply.fallbackTarget).
+                self.card.localDevice = devices.first { $0.isLocal }?.name
             }
         }
     }
@@ -375,13 +528,22 @@ final class SessionsWindowController: NSObject, NSWindowDelegate, NSTableViewDat
 
     func numberOfRows(in tableView: NSTableView) -> Int { listItems.count }
 
+    /// Dequeue a reusable cell for the row's kind and update it in place. The
+    /// cell classes set their own `identifier`, so a returned view re-enters the
+    /// table's reuse queue when it scrolls off or reloads.
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
         guard row < listItems.count else { return nil }
         switch listItems[row] {
         case let .group(name, count, needYou):
-            return groupCell(name: name, count: count, needYou: needYou)
+            let cell = tableView.makeView(withIdentifier: GroupCellView.reuseIdentifier, owner: self) as? GroupCellView
+                ?? GroupCellView()
+            cell.update(name: name, count: count, needYou: needYou, collapsed: collapsed.contains(name))
+            return cell
         case let .session(entry):
-            return sessionCell(entry)
+            let cell = tableView.makeView(withIdentifier: SessionCellView.reuseIdentifier, owner: self) as? SessionCellView
+                ?? SessionCellView()
+            cell.update(entry, now: Date())
+            return cell
         }
     }
 
@@ -410,6 +572,7 @@ final class SessionsWindowController: NSObject, NSWindowDelegate, NSTableViewDat
     }
 
     func tableViewSelectionDidChange(_ notification: Notification) {
+        publishShownSession()
         let row = table.selectedRow
         guard row >= 0, row < listItems.count, case let .session(entry) = listItems[row] else { return }
         selectedRowKey = entry.rowKey
@@ -434,82 +597,6 @@ final class SessionsWindowController: NSObject, NSWindowDelegate, NSTableViewDat
     private func refreshCardArtifacts() {
         guard let key = selectedRowKey, let entry = entries[key] else { return }
         showCard(entry)
-    }
-
-    private func groupCell(name: String, count: Int, needYou: Int) -> NSView {
-        let arrow = collapsed.contains(name) ? "\u{25B6}" : "\u{25BC}"
-        var text = "\(arrow)  \(name)  (\(count))"
-        let f = NSTextField(labelWithString: text)
-        f.font = NSFont.systemFont(ofSize: 11, weight: .semibold)
-        f.textColor = .secondaryLabelColor
-        if needYou > 0 {
-            text += "   \(needYou) need you"
-            let attr = NSMutableAttributedString(string: text, attributes: [
-                .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
-                .foregroundColor: NSColor.secondaryLabelColor,
-            ])
-            let r = (text as NSString).range(of: "\(needYou) need you")
-            if r.location != NSNotFound { attr.addAttribute(.foregroundColor, value: Palette.needsYou, range: r) }
-            f.attributedStringValue = attr
-        }
-        let container = NSTableCellView()
-        f.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(f)
-        NSLayoutConstraint.activate([
-            f.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
-            f.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -8),
-            f.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-        ])
-        return container
-    }
-
-    private func sessionCell(_ entry: SessionEntry) -> NSView {
-        // Recompute the phase line with a fresh clock so the age stays live on the
-        // 1 s visible-cell refresh; everything else rides the stored presentation.
-        let p = entry.presentation
-        let phase = SessionRowModel.phaseText(entry.row, attention: entry.attention,
-                                              status: p.status, now: Date())
-        let (dot, color) = Palette.dot(p.status)
-
-        // Line 1: dot + title + progress + phase/device.
-        var line1 = "\(dot) \(p.title)"
-        if let prog = p.progress { line1 += "  \(prog.done)/\(prog.total)" }
-        line1 += "   \(phase)"
-        // Line 2: latest action + PR chip.
-        var line2Parts: [String] = []
-        if let action = p.latestAction { line2Parts.append(action) }
-        if let chip = p.prChip { line2Parts.append(chip.text) }
-        let line2 = line2Parts.joined(separator: "   ")
-
-        let title = NSTextField(labelWithString: line1)
-        let attr = NSMutableAttributedString(string: line1, attributes: [
-            .font: NSFont.systemFont(ofSize: 12, weight: .medium),
-            .foregroundColor: NSColor.labelColor,
-        ])
-        let r = (line1 as NSString).range(of: dot)
-        if r.location != NSNotFound { attr.addAttribute(.foregroundColor, value: color, range: r) }
-        title.attributedStringValue = attr
-        title.lineBreakMode = .byTruncatingTail
-
-        let sub = NSTextField(labelWithString: line2)
-        sub.font = NSFont.systemFont(ofSize: 10)
-        sub.textColor = .secondaryLabelColor
-        sub.lineBreakMode = .byTruncatingTail
-
-        let vstack = NSStackView(views: line2.isEmpty ? [title] : [title, sub])
-        vstack.orientation = .vertical
-        vstack.alignment = .leading
-        vstack.spacing = 1
-        vstack.translatesAutoresizingMaskIntoConstraints = false
-
-        let container = NSTableCellView()
-        container.addSubview(vstack)
-        NSLayoutConstraint.activate([
-            vstack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
-            vstack.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -8),
-            vstack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-        ])
-        return container
     }
 
     // MARK: - Actions
@@ -558,17 +645,23 @@ final class SessionsWindowController: NSObject, NSWindowDelegate, NSTableViewDat
         timeTimer = nil
     }
 
-    /// Re-render ONLY the visible session cells so their relative ages advance,
-    /// and refresh the status bar's "last event" — no data reload, no CLI call.
+    /// Update the TEXT of the visible session cells in place so their relative
+    /// ages advance, and refresh the status bar's "last event" — no reload, no
+    /// view rebuild, no selection churn, no CLI call. A row with no materialized
+    /// cell (`makeIfNecessary: false`) is skipped; it renders fresh when scrolled in.
     private func tickTime() {
         guard panel?.isVisible == true else { return }
+        let now = Date()
         let visible = table.rows(in: table.visibleRect)
         if visible.length > 0 {
-            table.reloadData(forRowIndexes: IndexSet(integersIn: visible.location..<(visible.location + visible.length)),
-                             columnIndexes: IndexSet(integer: 0))
-            restoreSelection()
+            for i in visible.location..<(visible.location + visible.length) where i < listItems.count {
+                guard case let .session(entry) = listItems[i],
+                      let cell = table.view(atColumn: 0, row: i, makeIfNecessary: false) as? SessionCellView
+                else { continue }
+                cell.update(entry, now: now)
+            }
         }
-        updateStatusBar(now: Date())
+        updateStatusBar(now: now)
     }
 
     // MARK: - Window lifecycle
@@ -576,6 +669,7 @@ final class SessionsWindowController: NSObject, NSWindowDelegate, NSTableViewDat
     func windowShouldClose(_ sender: NSWindow) -> Bool {
         sender.orderOut(nil)
         stopTimeTimer()
+        publishShownSession() // hidden → nothing is "being looked at"
         return false // hide, keep FeedStream attached
     }
 

--- a/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -124,7 +124,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private var routinesLoaded = false
 
     private var cachedRecentSessions: [RecentSession] = []
-    private var recentSessionsLoaded = false
 
     // The engine's active-session list (`sessions --active --local --json`) —
     // authoritative coverage (tmux/IDE/headless), but costs seconds, so it rides
@@ -195,6 +194,13 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         // Cheap poll: terminals + cloud + attention only. Badge stays glanceable
         // without paying the teams-dir scan cost on every interval.
         Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in self?.tick() }
+
+        // Attach the live-session feed + artifact index (PHNX-4003). These own the
+        // helper's single `feed watch --json` child and the rendered-page index;
+        // the dropdown RECENT section and the Sessions window both project them.
+        // Starting here is idempotent (both guard `started`).
+        FeedStream.shared.start()
+        ArtifactIndex.shared.start()
 
         if ProcessInfo.processInfo.environment["MENUBAR_DUMP"] == "1" {
             loadDumpCaches()
@@ -320,7 +326,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         cachedRoutines = snapshot.routines
         routinesLoaded = true
         cachedRecentSessions = snapshot.recentSessions
-        recentSessionsLoaded = true
         promptController.updateRecentSessions(snapshot.recentSessions)
         cachedActiveSessions = snapshot.activeSessions
         activeSessionsLoaded = true
@@ -425,12 +430,15 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         badgePending = pending
         badgeLoaded = loaded
         rebuild(menu, sessions: sessions, browserTasks: browserTasks,
-                recentSessions: cachedRecentSessions, routines: cachedRoutines,
+                routines: cachedRoutines,
                 doctor: cachedDoctorOverview, daemonPid: daemonPid, pending: pending, loaded: loaded,
                 devices: cachedDevices)
         refreshBadge()
         refreshSnapshot()
         refreshDoctorOverview()
+        // Warm the Notifications cache off-main (30s TTL); it renders from the
+        // cache, so the first open may read "Checking…" and the next shows them.
+        RecentSectionBuilder.shared.refreshNotificationsIfStale()
     }
 
     // The one rule: attention floats to the top triage strip (wait-time sorted,
@@ -438,7 +446,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     // groups by repo below; routines / tickets / recents stay dedicated,
     // glanceable sections; setup + watchdog noise collapses into one System row.
     private func rebuild(_ menu: NSMenu, sessions: [Session], browserTasks: [BrowserTask],
-                         recentSessions: [RecentSession], routines: [Routine],
+                         routines: [Routine],
                          doctor: DoctorOverview?, daemonPid: Int?, pending: [PendingDevice],
                          loaded: [LoadedDevice], devices: [Device]) {
         menu.removeAllItems()
@@ -454,9 +462,16 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         addHeader(menu, sessions: sessions, plusNeeds: loaded.count)
         menu.addItem(.separator())
 
-        // What needs me now — rendered only when there's something actionable.
-        if addNeedsAttention(menu, sessions: sessions, routines: routines,
-                             daemonPid: daemonPid, loaded: loaded) {
+        // The Sessions window entry + status-color legend (PHNX-4003): the row
+        // shows `n need you` in yellow when any fleet session is waiting, and
+        // opens the persistent window (Cmd-Shift-I).
+        RecentSectionBuilder.shared.addSessionsRow(menu)
+        RecentSectionBuilder.shared.addLegend(menu)
+        menu.addItem(.separator())
+
+        // What needs me now — non-session triage (high load, stopped scheduler,
+        // failing routines). Session attention lives in the Sessions row above.
+        if addNeedsAttention(menu, routines: routines, daemonPid: daemonPid, loaded: loaded) {
             menu.addItem(.separator())
         }
 
@@ -479,7 +494,16 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             menu.addItem(.separator())
         }
 
-        addRecent(menu, recentSessions: recentSessions)
+        // RECENT — live sessions across the fleet, grouped by project, newest
+        // first, two lines per row, from the shared row model (PHNX-4003). Replaces
+        // the historical recent-sessions list with the feed-driven view; a row
+        // click opens the Sessions window on that session.
+        RecentSectionBuilder.shared.addRecentByProject(menu)
+        menu.addItem(.separator())
+
+        // Today's feed banners (bounded 24h, cached 30s), unanswered first —
+        // opens the window on the session to Approve / Reply (PHNX-4003).
+        RecentSectionBuilder.shared.addNotifications(menu)
         menu.addItem(.separator())
 
         // Devices sit just above the System controls: newly-discovered nodes to
@@ -548,48 +572,14 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     }
 
     // Returns true if anything was rendered (caller adds the trailing separator).
-    // Triage strip: blocked sessions grouped by (agent, repo). A group with 2+
-    // blocked sessions collapses to one row + submenu — walls of identical
-    // "Claude · muqsitnawaz — Claude is waiting for your input" rows were the
-    // single biggest source of noise. Groups of 1 render inline as before; the
-    // generic "awaiting input" filler drops when the Notification message is
-    // empty (the ⚠ glyph + section header already convey it). Failing routines
-    // follow.
-    private func addNeedsAttention(_ menu: NSMenu, sessions: [Session],
-                                   routines: [Routine], daemonPid: Int?,
+    // Triage strip for the NON-session attention the Sessions window does not
+    // cover: devices under high load, a stopped scheduler, failing routines.
+    // Blocked sessions no longer render here (PHNX-4003) — session attention is
+    // owned by the "Sessions" row + the Sessions window, which surface the
+    // reconciled feed attention with its real reply/approve controls.
+    private func addNeedsAttention(_ menu: NSMenu, routines: [Routine], daemonPid: Int?,
                                    loaded: [LoadedDevice]) -> Bool {
         var rows: [(String, NSColor, String, NSMenu?)] = []   // glyph, color, text, submenu
-
-        let blocked = sessions.filter { $0.status == .inputRequired }
-        let groups = Dictionary(grouping: blocked) { s in "\(s.agent)\u{0000}\(s.repo)" }
-        // Sort each group oldest-first, then order groups by their oldest wait.
-        let sortedGroups = groups.values.map { group -> [Session] in
-            group.sorted { ($0.attentionSinceMs ?? .greatestFiniteMagnitude) < ($1.attentionSinceMs ?? .greatestFiniteMagnitude) }
-        }.sorted { (a, b) in
-            (a.first?.attentionSinceMs ?? .greatestFiniteMagnitude) < (b.first?.attentionSinceMs ?? .greatestFiniteMagnitude)
-        }
-
-        for group in sortedGroups {
-            guard let first = group.first else { continue }
-            let agentLabel = LocalState.agentLabel(first.agent)
-            let repo = first.repo
-            if group.count == 1 {
-                // Inline: skip the generic filler when the hook wrote no message.
-                var text = "\(agentLabel) · \(repo)"
-                if !first.question.isEmpty {
-                    text += " — \(trim(first.question, 48))"
-                }
-                if let since = first.attentionSinceMs { text += "  ·  \(elapsedShort(since))" }
-                rows.append(("⚠", wait, text, blockedSubmenu(sessionId: first.sessionId, cwd: first.cwd)))
-            } else {
-                // Collapsed: N waiting · oldest elapsed. Submenu lists each session.
-                var text = "\(agentLabel) · \(repo) · \(group.count) waiting"
-                if let since = first.attentionSinceMs {
-                    text += "  ·  oldest \(elapsedShort(since))"
-                }
-                rows.append(("⚠", wait, text, groupedWaitersSubmenu(group)))
-            }
-        }
 
         // Devices under high load — this Mac (native getloadavg) first, then fresh
         // fleet peers. Warn at headroom() 'loaded' (>=75%); X red when critical.
@@ -668,23 +658,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         var line = "load \(Int(d.loadPercent.rounded()))%"
         if let mem = d.memPercent { line += " · mem \(Int(mem.rounded()))%" }
         sub.addItem(disabled(line))
-        return sub
-    }
-
-    // Submenu listing every blocked session in a grouped (agent, repo) waiter.
-    // Sorted oldest-first (most stalled at the top). Row = session title (or a
-    // "session" fallback when no title) with the elapsed wait as the trailing chip.
-    private func groupedWaitersSubmenu(_ group: [Session]) -> NSMenu {
-        let sub = NSMenu()
-        for s in group {
-            let label = s.title.isEmpty ? "session" : trim(s.title, 36)
-            var text = label
-            if !s.question.isEmpty { text += " — \(trim(s.question, 34))" }
-            if let since = s.attentionSinceMs { text += "  ·  \(elapsedShort(since))" }
-            let it = statusRow("⚠", wait, text)
-            it.submenu = blockedSubmenu(sessionId: s.sessionId, cwd: s.cwd)
-            sub.addItem(it)
-        }
         return sub
     }
 
@@ -1197,23 +1170,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
     }
 
-    private func addRecent(_ menu: NSMenu, recentSessions: [RecentSession]) {
-        let visible = Array(recentSessions.filter {
-            let id = LocalState.normalizeAgent($0.agent)
-            return LocalState.desiredAgents.contains { $0.id == id }
-        }.prefix(3))
-        addSectionTitle(menu, "RECENT", color: .secondaryLabelColor)
-        if visible.isEmpty {
-            menu.addItem(disabled(recentSessionsLoaded ? "  No recent sessions" : "  Recent sessions checking…"))
-            return
-        }
-        for session in visible {
-            let item = NSMenuItem(title: recentSessionTitle(session), action: nil, keyEquivalent: "")
-            item.submenu = recentSessionSubmenu(session)
-            menu.addItem(item)
-        }
-    }
-
     // Tickets filed via the quick-issue bar. Returns false (renders nothing) when
     // the ledger is empty. Each row opens the ticket in Linear on click.
     private func addRecentTickets(_ menu: NSMenu) -> Bool {
@@ -1417,62 +1373,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         sub.addItem(open)
         return sub
     }
-
-    private func recentSessionSubmenu(_ session: RecentSession) -> NSMenu {
-        let sub = NSMenu()
-        if let topic = session.topic, !topic.isEmpty {
-            sub.addItem(disabled(trim(topic, 60)))
-            sub.addItem(.separator())
-        }
-        if let version = session.version {
-            sub.addItem(disabled("Version: \(version)"))
-        }
-        if let branch = session.gitBranch {
-            sub.addItem(disabled("Branch: \(branch)"))
-        }
-        if session.version != nil || session.gitBranch != nil {
-            sub.addItem(.separator())
-        }
-        if let filePath = session.filePath {
-            let open = NSMenuItem(title: "Open transcript", action: #selector(onOpenPath(_:)), keyEquivalent: "")
-            open.target = self
-            open.representedObject = filePath
-            sub.addItem(open)
-        }
-        if let cwd = session.cwd {
-            let reveal = NSMenuItem(title: "Reveal project", action: #selector(onOpenPath(_:)), keyEquivalent: "")
-            reveal.target = self
-            reveal.representedObject = cwd
-            sub.addItem(reveal)
-        }
-        return sub
-    }
-
-    /// Submenu for a blocked row. "Focus session" comes FIRST and is the point:
-    /// a NEEDS-YOU row exists because an agent is waiting on the operator, so the
-    /// action that resolves it — land in that session — must be the first thing
-    /// under the cursor. Revealing the working dir does not unblock anything.
-    ///
-    /// `sessionId` is nil for a row the engine could not identify (a cloud task,
-    /// a stale sentinel); the item is simply omitted rather than shown disabled,
-    /// so the menu never offers an action that would do nothing.
-    private func blockedSubmenu(sessionId: String?, cwd: String?) -> NSMenu? {
-        let sub = NSMenu()
-        if let id = sessionId, !id.isEmpty {
-            let focus = NSMenuItem(title: "Focus session", action: #selector(onFocusSession(_:)), keyEquivalent: "")
-            focus.target = self
-            focus.representedObject = id
-            sub.addItem(focus)
-        }
-        if let dir = cwd, !dir.isEmpty {
-            let reveal = NSMenuItem(title: "Reveal working dir", action: #selector(onOpenPath(_:)), keyEquivalent: "")
-            reveal.target = self
-            reveal.representedObject = dir
-            sub.addItem(reveal)
-        }
-        return sub.items.isEmpty ? nil : sub
-    }
-
 
     private func routineSubmenu(_ r: Routine) -> NSMenu {
         let sub = NSMenu()
@@ -1707,18 +1607,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         open.target = self
         sub.addItem(open)
         return sub
-    }
-
-    private func recentSessionTitle(_ session: RecentSession) -> String {
-        let agent = LocalState.agentLabel(session.agent).padding(toLength: 9, withPad: " ", startingAt: 0)
-        let project = session.project ?? session.cwd.map { ($0 as NSString).lastPathComponent } ?? "session"
-        let label: String
-        if let topic = session.topic, !topic.isEmpty {
-            label = "“\(trim(topic, 22))”"
-        } else {
-            label = session.shortId ?? session.id.map { String($0.prefix(8)) } ?? "recent"
-        }
-        return "  \(agent) \(trim(project, 14)) · \(label) · \(shortWhen(session.timestamp))"
     }
 
     private func syncState(_ agent: String, doctor: DoctorOverview?) -> DoctorSync? {

--- a/cli/menubar/Sources/MenubarHelper/main.swift
+++ b/cli/menubar/Sources/MenubarHelper/main.swift
@@ -250,6 +250,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // configureForLaunch registers the action categories, installs the
         // delegate, and requests authorization once.
         Notifier.configureForLaunch()
+        // A banner for the session the operator is already looking at (the
+        // selected row of a visible Sessions window) is suppressed at present
+        // time; the item still lands in the notification list. Thread-safe read —
+        // the delegate asks off the main queue.
+        Notifier.isSessionSelectedInSessionsWindow = { sessionId in
+            SessionsWindowController.shared.isShowingSession(sessionId)
+        }
         let mods = UInt32(cmdKey | shiftKey)
         hotkey.register([
             .init(id: HotkeyManager.clipID, keyCode: UInt32(kVK_ANSI_V), modifiers: mods,

--- a/cli/menubar/Sources/MenubarHelper/main.swift
+++ b/cli/menubar/Sources/MenubarHelper/main.swift
@@ -170,6 +170,21 @@ if ProcessInfo.processInfo.environment["MENUBAR_OCR_TEST"] == "1" {
     ScreenshotOCRSelfTest.run()
 }
 
+// Row-model self-test (PHNX-4003): decode real feed-row JSON, drive the pure
+// SessionRowModel, and assert every status color, PR-chip state, progress tally,
+// phase line, subagents glyph, and the latest-action ladder. No GUI, no network —
+// a build gate. See RowModelSelfTest.swift.
+if ProcessInfo.processInfo.environment["MENUBAR_ROWMODEL_TEST"] == "1" {
+    RowModelSelfTest.run()
+}
+
+// Reply self-test (PHNX-4003): pin the exact `agents` argv for each reply
+// capability (feed block choice/text, terminal/tmux inject, cloud, team, none).
+// No GUI, no network — a build gate. See ReplySelfTest.swift.
+if ProcessInfo.processInfo.environment["MENUBAR_REPLY_TEST"] == "1" {
+    ReplySelfTest.run()
+}
+
 // Everything past here installs the status item and registers the global
 // chords, so it must only run where those chords can actually be serviced.
 // Refuses an ssh-started launch or an unrecognized flag — the two ways a helper
@@ -243,11 +258,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .init(id: HotkeyManager.promptID, keyCode: UInt32(kVK_ANSI_O), modifiers: mods,
                   label: "Cmd-Shift-O (quick capture)",
                   onFire: { [weak self] in self?.promptController.summon() }),
+            .init(id: HotkeyManager.sessionsID, keyCode: UInt32(kVK_ANSI_I), modifiers: mods,
+                  label: "Cmd-Shift-I (Sessions window)",
+                  onFire: { SessionsWindowController.shared.toggle() }),
         ])
         // Preview the quick-issue panel without the global hotkey (QA / a machine
         // where synthesizing a system hotkey isn't possible): MENUBAR_PROMPT_PREVIEW=1.
         if ProcessInfo.processInfo.environment["MENUBAR_PROMPT_PREVIEW"] == "1" {
             promptController.summon()
+        }
+        // Same for the Sessions window (PHNX-4003): MENUBAR_SESSIONS_PREVIEW=1 opens
+        // it at launch so QA / a screenshot capture never has to synthesize Cmd-Shift-I.
+        if ProcessInfo.processInfo.environment["MENUBAR_SESSIONS_PREVIEW"] == "1" {
+            SessionsWindowController.shared.open(selecting: nil)
         }
     }
 }

--- a/cli/menubar/scripts/test-menubar.sh
+++ b/cli/menubar/scripts/test-menubar.sh
@@ -12,8 +12,9 @@
 # checks the shipped bundle's signature. A whole class of helper bugs (the flock
 # fd-inheritance deadlock, the unbounded-child runaway) could regress unseen.
 #
-# NOT run here: MENUBAR_DUMP / MENUBAR_PROMPT_PREVIEW — those DO reach AppKit and
-# need a GUI session, so they would hang/fail on a headless runner.
+# NOT run here: MENUBAR_DUMP / MENUBAR_PROMPT_PREVIEW / MENUBAR_SESSIONS_PREVIEW —
+# those DO reach AppKit and need a GUI session, so they would hang/fail on a
+# headless runner.
 #
 # Usage:
 #   test-menubar.sh [BINARY]   # BINARY defaults to a fresh `swift build` debug binary
@@ -44,7 +45,7 @@ export MENUBAR_ARTIFACT_ROOT="$PWD/Tests/fixtures/artifacts-tree"
 export MENUBAR_OCR_FIXTURES="$PWD/Tests/fixtures"
 
 fail=0
-for mode in MENUBAR_GUARD_TEST MENUBAR_ISSUE_TEST MENUBAR_PROJECTS_TEST MENUBAR_SINGLE_TEST MENUBAR_CHILD_TEST MENUBAR_ACTIVE_TEST MENUBAR_ROUTINE_TEST MENUBAR_DOCTOR_TEST MENUBAR_DEVICE_TEST MENUBAR_FEED_TEST MENUBAR_ARTIFACT_TEST MENUBAR_OCR_TEST MENUBAR_NOTIFY_TEST MENUBAR_DISPATCH_TEST MENUBAR_PULSE_TEST; do
+for mode in MENUBAR_GUARD_TEST MENUBAR_ISSUE_TEST MENUBAR_PROJECTS_TEST MENUBAR_SINGLE_TEST MENUBAR_CHILD_TEST MENUBAR_ACTIVE_TEST MENUBAR_ROUTINE_TEST MENUBAR_DOCTOR_TEST MENUBAR_DEVICE_TEST MENUBAR_FEED_TEST MENUBAR_ARTIFACT_TEST MENUBAR_OCR_TEST MENUBAR_NOTIFY_TEST MENUBAR_DISPATCH_TEST MENUBAR_PULSE_TEST MENUBAR_ROWMODEL_TEST MENUBAR_REPLY_TEST; do
   echo "=== $mode ==="
   if ! env "$mode=1" "$BIN"; then
     echo "  $mode FAILED" >&2


### PR DESCRIPTION
Ticket: PHNX-4003 (Track C of PHNX-3999, AGI Menu native dispatch + sessions app).

## What changed

- **Sessions window** (`SessionsWindow.swift`, new): a persistent, frame-remembering `NSPanel` toggled by `Cmd-Shift-I`, the dropdown's new **Sessions** row, or any dropdown RECENT row (opens on that session). Left: `NSTableView` grouped by project with collapsible group rows, filter chips Recent / Needs you / Running / Done today with live counts, `Cmd-F` search over label, topic, project, ticket, device, and a device strip with `stale Nm` markers. Right: the session card. Status bar: stream health, last-event age, devices reporting/stale, helper RSS, row count. The only timer is a 1 s relative-time refresh over visible cells; every other redraw is a `FeedStream` diff. Closing hides; `FeedStream` stays attached.
- **Session card** (`SessionCard.swift`, new): header, phase pill, PR chip, subagents glyph, REQUEST excerpt, the attention block (question options as numbered buttons, permission Allow/Deny, plan-review Approve/Send back, each an atomic `agents feed answer <key> --choice <id>`), PROGRESS, FILES & ARTIFACTS from `ArtifactIndex.artifacts(forSession:)` with **Open** (`NSWorkspace.open`), reply field. Keys on a selected row: `1`-`9`, `Return`, `Cmd-Return` (terminal), `Cmd-K` (nudge), `Cmd-V` (image ref).
- **Row model** (`SessionRowModel.swift`, new): one pure derivation from `SessionRow` + `AttentionItem` to status color, phase text, progress, latest action, PR chip, subagents, group key, title. Both the window and the dropdown consume `SessionRowModel.present`; nothing re-derives a color or chip.
- **Reply routes** (`Reply.swift`, new): pure argv builders routed by `replyCapability` (open feed block, terminal/tmux inject, cloud message, teams message, none). Each runs through the new `ChildProcess.runResult`, which shares `run`'s bounded spawn/deadline/group-kill/reap core and merges stderr so the CLI's own error line renders inline in the card, never as a toast.
- **Dropdown** (`RecentSectionBuilder.swift` new; `StatusItemController.swift` surgical): **Sessions** row (`n need you` in yellow) + legend at the top; RECENT replaced by the feed-driven, project-grouped two-line rows; a **Notifications** submenu of today's feed banners (24 h, cached 30 s, refreshed off-main), unanswered first. Blocked sessions leave the NEEDS YOU strip (its now-unused `sessions` parameter is removed); it keeps load, scheduler, and routine triage. The old `addRecent` / `recentSessionSubmenu` / `blockedSubmenu` / `groupedWaitersSubmenu` builders are deleted.
- `Hotkey.swift` / `main.swift`: `sessionsID` chord (`Cmd-Shift-I`); `MENUBAR_ROWMODEL_TEST` and `MENUBAR_REPLY_TEST` headless gates; `MENUBAR_SESSIONS_PREVIEW=1` opens the window at launch (mirrors `MENUBAR_PROMPT_PREVIEW`).
- `scripts/test-menubar.sh` runs both new self-tests (so `build.sh` gates on them); `cli/docs/menubar.md` documents the window, row model, reply routes, and the reshaped dropdown; `cli/.changelog/next/PHNX-4003.md` carries the release note.

Untouched, per the track boundary: `PromptPanel.swift`, `FeedStream.swift` / `ArtifactIndex.swift` internals, Notifier, anything under `cli/src`.

## Verification (real output, zion, after rebase onto `origin/main` @ 1.22.89)

`cd cli/menubar && swift build`:

```
Build complete! (1.28s)
```

`scripts/build.sh` (debug) ran the whole gate and produced the ad-hoc dev bundle (pre-existing `NSUserNotification` deprecation warnings in `PromptPanel.swift` only, no errors):

```
menubar self-tests: all passed
  signing with: -  (bundle id: com.phnx-labs.agents-menubar.dev)
built: dist/menubar-helper-mac
built: dist/MenubarHelper.app
```

`scripts/test-menubar.sh` (13 modes, 518 PASS lines, rc=0):

```
MENUBAR_GUARD_TEST ALL PASS MENUBAR_ISSUE_TEST ALL PASS MENUBAR_PROJECTS_TEST ALL PASS MENUBAR_SINGLE_TEST ALL PASS MENUBAR_CHILD_TEST ALL PASS MENUBAR_ACTIVE_TEST ALL PASS MENUBAR_ROUTINE_TEST ALL PASS MENUBAR_DOCTOR_TEST ALL PASS MENUBAR_DEVICE_TEST ALL PASS MENUBAR_FEED_TEST ALL PASS MENUBAR_ARTIFACT_TEST ALL PASS MENUBAR_ROWMODEL_TEST ALL PASS MENUBAR_REPLY_TEST ALL PASS menubar self-tests: all passed
```

The two new gates in full:

```
=== MENUBAR_ROWMODEL_TEST ===
PASS — phase running → working (green)
PASS — phase waiting → needsYou (yellow)
PASS — phase idle → idle (red)
PASS — phase failed → idle (red)
PASS — phase done → done (grey)
PASS — attention question → needsYou even over a running phase
PASS — attention permission → needsYou
PASS — attention plan_review → needsYou
PASS — attention failure → idle (red)
PASS — attention stall → idle (red)
PASS — phase text working · 18h · s0
PASS — phase text question · 13m · zion
PASS — phase text idle 41m · m1
PASS — progress reads done/total
PASS — progress nil when total is zero
PASS — progress nil when no todos
PASS — PR merged → merged chip (purple)
PASS — PR draft → draft chip (dimmed)
PASS — PR clean + approved → approved chip (green)
PASS — PR unstable → checksFailed chip (red)
PASS — PR unknown mergeable → checksRunning chip (grey)
PASS — PR open, no verdict yet → open chip
PASS — no PR → nil chip
PASS — PR chip text renders merged
PASS — PR chip text renders approved
PASS — subAgentCount>0 → count
PASS — pidCount>1 → count
PASS — spawnedTeam → count
PASS — lone process → nil
PASS — latest action = last timeline step + tool
PASS — latest action falls back to lastAgentLine
PASS — latest action nil when nothing
PASS — group key = project
PASS — group key falls back to cwd basename
PASS — group key default other
PASS — title prefers label
PASS — title falls to topic
PASS — present composes the row
ALL PASS

=== MENUBAR_REPLY_TEST ===
PASS — answer choice argv
PASS — answer text argv
PASS — inject argv
PASS — cloud message argv
PASS — team message argv
PASS — open block routes a choice through feed answer
PASS — open block routes text through feed answer
PASS — terminal rail injects
PASS — tmux rail injects
PASS — cloud rail messages the cloud task
PASS — team rail messages the teammate
PASS — choice with no open block is nil
PASS — none rail yields no text argv
PASS — none rail cannot reply
PASS — open block can always reply
PASS — terminal with a session can reply
PASS — empty text is nil
PASS — terminal with no session cannot reply
PASS — team with no mate cannot reply
ALL PASS
```

## Not captured, and why

- **Cmd-Shift-I screenshot and the 10-minute `ps -o rss=` series with the window open**: not captured. The installed helper (pid 17386) holds the single-instance flock at `~/.agents/.cache/state/menubar.lock`, so the dev build surrenders at launch (`already running (pid 17386) ... re-homed without stealing focus`). `NSHomeDirectory()` ignores `$HOME` on this macOS (verified with a two-line Swift probe), so the lock cannot be redirected with an overlay home, and the brief forbids stopping or restarting the installed helper; the other Mac on the fleet has a different user at its console. Capturing these needs the orchestrator's install step (PHNX-4007). The window's own status bar reports helper RSS live, so the soak reading is one glance once it is installed.
- **Live question round-trip** (`agents run claude ... --terminal`, press `2`, quote the `agents feed answer` argv): the argv the helper runs is pinned byte-for-byte by `MENUBAR_REPLY_TEST` above (`answer choice argv`, `open block routes a choice through feed answer`); the end-to-end press needs the installed helper for the same reason.

## Review notes

- The helper stays a projection (spec SING-2): no timer acts on the fleet; every operator action is one bounded `agents` argv through `ChildProcess`.
- No `agents sessions` call without `--active`; all fetches are off-main and diffed to the UI.
- `StatusItemController.swift` shrinks (net -160 lines); the new surfaces live in their own files.
