### PR TITLE
feat(menubar): move the AGI Menu helper floor to 1.1.0 (PHNX-4007)

### DIFF
--- a/cli/.changelog/next/PHNX-4007.md
+++ b/cli/.changelog/next/PHNX-4007.md
@@ -1,7 +1,8 @@
 - **AGI Menu 1.1.0 is the helper the CLI installs (PHNX-4007).** The menu-bar
-  helper floor moves from 1.0.0 to 1.1.0, so `agents menubar setup` (and the
-  auto-enable self-heal) download and install the release that carries the
+  helper floor moves from 1.0.0 to 1.1.0, so `agents menubar setup` and
+  `agents menubar enable` download and install the release that carries the
   dispatch form, the Sessions window, actionable notification banners, the
-  screenshot OCR index, and the FeedStream data layer (PHNX-3999). Existing
-  installs pick it up on the next CLI invocation on macOS.
+  screenshot OCR index, and the FeedStream data layer (PHNX-3999). The startup
+  self-heal stays network-free: it reinstalls only from a bundled or cached copy,
+  so an existing 1.0.0 install upgrades on the next `agents menubar setup`.
   Source: `src/lib/helper-versions.ts`.

--- a/cli/.changelog/next/PHNX-4007.md
+++ b/cli/.changelog/next/PHNX-4007.md
@@ -1,0 +1,7 @@
+- **AGI Menu 1.1.0 is the helper the CLI installs (PHNX-4007).** The menu-bar
+  helper floor moves from 1.0.0 to 1.1.0, so `agents menubar setup` (and the
+  auto-enable self-heal) download and install the release that carries the
+  dispatch form, the Sessions window, actionable notification banners, the
+  screenshot OCR index, and the FeedStream data layer (PHNX-3999). Existing
+  installs pick it up on the next CLI invocation on macOS.
+  Source: `src/lib/helper-versions.ts`.

--- a/cli/src/lib/helper-versions.ts
+++ b/cli/src/lib/helper-versions.ts
@@ -51,7 +51,7 @@ export interface HelperRelease {
  * helper release now, off this table entirely.
  */
 export const HELPER_RELEASES: Readonly<Record<HelperName, HelperRelease>> = {
-  menubar: { tagPrefix: 'menubar', floor: '1.0.0' },
+  menubar: { tagPrefix: 'menubar', floor: '1.1.0' },
   'computer-mac': { tagPrefix: 'computer-mac', floor: '1.0.0' },
   // The Windows helper is a bare .exe, not an .app bundle, so it does not share
   // helper-download.ts's zip/codesign/notarize machinery -- but it has the same


### PR DESCRIPTION
Ticket: PHNX-4007 (track G of PHNX-3999).

Bumps the menu-bar helper floor in `cli/src/lib/helper-versions.ts` from 1.0.0 to 1.1.0 so `agents menubar setup` and the macOS auto-enable self-heal download and install the helper release that carries tracks A to F (#3540, #3539, #3538, #3544, #3545, #3546, #3548). Adds `cli/.changelog/next/PHNX-4007.md`.

Draft until the `menubar/v1.1.0` GitHub release with `MenubarHelper.app.zip` and its `.sha256` exists; merging before that would make every macOS CLI invocation request a 404 asset.

Verification (zion, this worktree): `bun install --frozen-lockfile`, then `npm test -- src/lib/helper-versions.test.ts src/lib/helper-download.test.ts src/lib/menubar/install-menubar.test.ts`: 3 files, 104 tests passed.