### PR TITLE
browser: Firefox backend over WebDriver BiDi with native profile discovery (PHNX-4043)

### DIFF
--- a/cli/.changelog/next/firefox-bidi.md
+++ b/cli/.changelog/next/firefox-bidi.md
@@ -1,0 +1,11 @@
+- **Firefox automation over WebDriver BiDi (PHNX-4043).** `agents browser` now drives
+  Firefox, which dropped the Chrome DevTools Protocol in 129. Every Firefox profile in
+  `profiles.ini` is discovered read-only as a `firefox-<name>` browser profile
+  (`firefox-default`, `firefox-default-release`, …) pinned to that profile directory;
+  agents launch it headless with a debug port (or attach to a running one, failing loud
+  when a portless Firefox already holds the profile). Supported verbs: start, navigate,
+  tab add, tabs, evaluate, refs, click, fill/type, scroll, screenshot, done — with the
+  same same-task reopen semantics as the rest of the service. A trusted pointer click
+  goes through `input.performActions`. Network capture, upload, and PDF fail loud with a
+  structured error naming a Chromium-family profile. Source: `apps/cli/src/lib/browser/drivers/firefox.ts`,
+  `apps/cli/src/lib/browser/firefox-discovery.ts`, `apps/cli/src/lib/browser/service.ts`.

--- a/cli/docs/browser.md
+++ b/cli/docs/browser.md
@@ -167,8 +167,9 @@ each machine keeps its own choice — the profile it points at may hold
 machine-local logins. It is machine-local: only this box can set it. Set it
 once per machine.
 
-Safari and Firefox are not supported. They do not implement the Chrome
-DevTools Protocol.
+Safari is not supported — it implements neither the Chrome DevTools Protocol
+nor WebDriver BiDi. **Firefox is supported over WebDriver BiDi** (Firefox 129+
+dropped CDP); see [Firefox automation](#firefox-automation-webdriver-bidi).
 
 ### Attach-only profiles — one canonical browser (PHNX-3967)
 
@@ -494,6 +495,80 @@ sockets or SSH tunnels. The existing remote-control consent gate still applies.
 
 This is why Arc is never used as the [viewer](#which-browser-shows-you-a-page-browserviewer)
 (showing a human a page needs its own fresh tab).
+
+### Firefox automation (WebDriver BiDi)
+
+Firefox 129 removed the Chrome DevTools Protocol, so `agents browser` drives it
+over **WebDriver BiDi** — a JSON-RPC protocol on a WebSocket at
+`ws://127.0.0.1:<port>/session`. Every **Firefox profile in `profiles.ini` is
+listed as a browser profile** — `firefox-default`, `firefox-default-release`,
+`firefox-<name>` — discovered read-only from Firefox's own metadata. A profile
+already carries its cookies and logins, so it IS the profile agents pick with
+`--profile`; there is nothing to create.
+
+Unlike Arc, agents **launch** Firefox for you: a bare
+`agents browser start --profile firefox-<name>` starts a headless Firefox bound
+to that profile directory with a debug port, or attaches to one already serving
+the port. If a Firefox is already open on that profile without a debug port,
+agents fail loud with the exact relaunch rather than starting a rival (Firefox
+is single-instance per profile directory).
+
+```bash
+agents browser profiles list                     # one row per profiles.ini entry
+agents browser profiles show firefox-default
+agents browser use firefox-default               # agents default to this profile
+
+agents browser start --profile firefox-default --url https://example.com
+agents browser refs                              # the accessibility listing
+agents browser type 1 --text "hello"             # DOM value + input/change events
+agents browser click 2                           # trusted pointer via input.performActions
+agents browser screenshot -o /tmp/shot.png
+agents browser done                              # closes the task's tabs; Firefox stays up
+```
+
+Firefox profiles use a `firefox-bidi:` endpoint protocol and support this set of
+operations:
+
+| Capability | Status |
+|---|---|
+| Profile discovery from `profiles.ini`, one profile per entry | Supported |
+| Launch headless (or attach to a running debug port) | Supported |
+| Start, navigate, tab add, tabs, tab focus, done | Supported |
+| Same-task reopen (navigate to an owned URL refreshes it, no duplicate) | Supported |
+| Evaluate JavaScript (async/promise capable) | Supported (`script.evaluate`) |
+| `refs` accessibility listing, `click`, `fill`/`type`, `scroll` | Supported |
+| Trusted pointer click | Supported (`input.performActions`) |
+| Screenshot | Supported (`browsingContext.captureScreenshot`) |
+| Network capture, upload, PDF, trusted key input, recording, viewport emulation | Unsupported |
+
+Unsupported capabilities throw a structured `FirefoxCapabilityError` naming a
+Chromium-family profile (chrome/comet/chromium/brave/edge). They never return
+fabricated success or silently switch to another browser.
+
+**Discovery.** `firefox-discovery.ts` reads `profiles.ini` under
+`~/.mozilla/firefox` and the snap location `~/snap/firefox/common/.mozilla/firefox`
+(macOS: `~/Library/Application Support/Firefox`; Windows: `%APPDATA%\Mozilla\Firefox`)
+as read-only metadata; `AGENTS_FIREFOX_DIRS` (a path-separator list) points at
+another root. Each entry's directory is authoritative; the profile name is
+display + slug source, and each profile is pinned to a stable port in the 9600–9699
+range (derived from its directory) so the relaunch hint and a post-restart
+reattach address the same Firefox. A torn or malformed `profiles.ini` read is
+reported where a `firefox-` profile is asked for by name and never breaks listing
+the other browsers.
+
+**Transport.** `drivers/firefox.ts` launches
+`firefox --remote-debugging-port <port> --profile <dir> --no-remote [--headless]`,
+connects the BiDi WebSocket, and runs `session.new`. Page work uses
+`browsingContext.create/navigate/reload/close/getTree/captureScreenshot`,
+`script.evaluate`, and `input.performActions`; `script.evaluate` results are
+deserialized from BiDi's structured `RemoteValue` back into plain JS values.
+
+**Remote dispatch.** A worker dispatches the whole command to the device that
+declares the Firefox profile (the BiDi socket is local to that box). The
+task-to-device index records that owner, so later task verbs follow it. Firefox
+endpoints are never exposed as fake local CDP sockets or SSH tunnels, and the
+remote-control consent gate still applies. A headless-automation Firefox is never
+used as the [viewer](#which-browser-shows-you-a-page-browserviewer).
 
 ### Cleaning up dead profiles (`prune`)
 

--- a/cli/src/commands/browser.ts
+++ b/cli/src/commands/browser.ts
@@ -617,7 +617,7 @@ function registerProfilesCommands(browser: Command): void {
           allProfiles.map((profile) => ({
             ...profile,
             devices: profile.devices,
-            kind: profile.arc ? 'identity' : profileKind(profile.name),
+            kind: profile.arc || profile.firefox ? 'identity' : profileKind(profile.name),
             isConfiguredDefault: profile.name === configuredDefault,
           })),
           null,
@@ -1106,6 +1106,10 @@ function registerProfilesCommands(browser: Command): void {
         console.log(`Arc Space: ${profile.arc.spaceTitle} (${profile.arc.spaceId})`);
         console.log(`Arc profile: ${profile.arc.profileName} (${profile.arc.profileId})`);
       }
+      if (profile.firefox) {
+        console.log(`Firefox profile: ${profile.firefox.profileName}${profile.firefox.isDefault ? ' (default)' : ''}`);
+        if (profile.userDataDir) console.log(`Profile directory: ${profile.userDataDir}`);
+      }
       const presets = getEndpointPresets(profile);
       const defaultName = profile.defaultEndpoint && presets[profile.defaultEndpoint]
         ? profile.defaultEndpoint
@@ -1128,7 +1132,7 @@ function registerProfilesCommands(browser: Command): void {
 
       // Login state per known service: live session + account identity + whether
       // login creds are declared in the profile's secrets bundle.
-      if (profile.arc) return;
+      if (profile.arc || profile.firefox) return;
       const active = await loginsForProfile(profile.name);
       const accounts = await accountsForProfile(profile.name);
       const lines: string[] = [];
@@ -1310,7 +1314,7 @@ function registerProfilesCommands(browser: Command): void {
         process.exit(1);
       }
 
-      if (profile.arc && !isFleetRemoteInvocation()) {
+      if ((profile.arc || profile.firefox) && !isFleetRemoteInvocation()) {
         const routed = resolveBrowserTarget(profile.name);
         if (!routed.local && routed.commandDispatch) {
           const result = await dispatchBrowserToDevice(

--- a/cli/src/lib/browser/chrome.ts
+++ b/cli/src/lib/browser/chrome.ts
@@ -30,6 +30,10 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
     brave: ['/Applications/Brave Browser.app/Contents/MacOS/Brave Browser'],
     edge: ['/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'],
     arc: ['/Applications/Arc.app/Contents/MacOS/Arc'],
+    firefox: [
+      '/Applications/Firefox.app/Contents/MacOS/firefox',
+      '/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox',
+    ],
     custom: [],
   },
   linux: {
@@ -40,6 +44,10 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
     edge: ['/usr/bin/microsoft-edge'],
     // Arc has no Linux build (macOS + Windows only).
     arc: [],
+    // `/usr/bin/firefox` on Ubuntu is the snap wrapper script: it execs the snap
+    // in place, so the pid survives and `--remote-debugging-port` works through
+    // it. The driver reads the real pid from the BiDi handshake anyway.
+    firefox: ['/usr/bin/firefox', '/snap/bin/firefox', '/usr/lib/firefox/firefox', '/opt/firefox/firefox'],
     custom: [],
   },
   win32: {
@@ -69,6 +77,11 @@ const BROWSER_PATHS: Record<string, Record<BrowserType, string[]>> = {
     // Arc ships a Windows build, but its install path is not yet verified here;
     // leave unlisted (undetected) rather than guess a path that false-positives.
     arc: [],
+    firefox: [
+      `${WIN_PROGRAMFILES}\\Mozilla Firefox\\firefox.exe`,
+      `${WIN_PROGRAMFILES_X86}\\Mozilla Firefox\\firefox.exe`,
+      `${WIN_LOCALAPPDATA}\\Mozilla Firefox\\firefox.exe`,
+    ],
     custom: [],
   },
 };

--- a/cli/src/lib/browser/drivers/firefox.test.ts
+++ b/cli/src/lib/browser/drivers/firefox.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  deserializeBidi,
+  FirefoxCapabilityError,
+  firefoxAttachRequiredError,
+  connectFirefox,
+  bidiCreateTab,
+  bidiNavigate,
+  bidiEvaluate,
+  bidiScreenshot,
+  bidiTopLevelContexts,
+  bidiCloseTab,
+  bidiClickAt,
+  type FirefoxConnection,
+} from './firefox.js';
+import type { BrowserProfile, ConnectionKey } from '../types.js';
+
+describe('deserializeBidi', () => {
+  it('unwraps primitives, arrays, and plain objects into a JS value', () => {
+    expect(deserializeBidi({ type: 'string', value: 'hi' })).toBe('hi');
+    expect(deserializeBidi({ type: 'number', value: 42 })).toBe(42);
+    expect(deserializeBidi({ type: 'boolean', value: true })).toBe(true);
+    expect(deserializeBidi({ type: 'null' })).toBeNull();
+    expect(deserializeBidi({ type: 'undefined' })).toBeUndefined();
+    expect(
+      deserializeBidi({ type: 'array', value: [{ type: 'number', value: 1 }, { type: 'string', value: 'x' }, { type: 'null' }] }),
+    ).toEqual([1, 'x', null]);
+    expect(
+      deserializeBidi({
+        type: 'object',
+        value: [
+          ['t', { type: 'string', value: 'Title' }],
+          ['n', { type: 'number', value: 2 }],
+          ['nested', { type: 'object', value: [['a', { type: 'boolean', value: true }]] }],
+        ],
+      }),
+    ).toEqual({ t: 'Title', n: 2, nested: { a: true } });
+  });
+
+  it('maps the string-encoded specials number BiDi uses', () => {
+    expect(deserializeBidi({ type: 'number', value: 'Infinity' })).toBe(Infinity);
+    expect(deserializeBidi({ type: 'number', value: '-Infinity' })).toBe(-Infinity);
+    expect(Number.isNaN(deserializeBidi({ type: 'number', value: 'NaN' }) as number)).toBe(true);
+  });
+
+  it('yields undefined for a node/window RemoteValue that has no JS value', () => {
+    expect(deserializeBidi({ type: 'node' })).toBeUndefined();
+    expect(deserializeBidi({ type: 'window' })).toBeUndefined();
+  });
+});
+
+describe('FirefoxCapabilityError', () => {
+  it('names the missing capability and steers to a Chromium-family profile', () => {
+    const err = new FirefoxCapabilityError('pdf');
+    expect(err.capability).toBe('pdf');
+    expect(err.message).toContain('pdf');
+    expect(err.message.toLowerCase()).toContain('chromium');
+  });
+});
+
+describe('firefoxAttachRequiredError', () => {
+  it('names the exact relaunch command with port and profile directory', () => {
+    const err = firefoxAttachRequiredError(
+      { name: 'firefox-default', firefox: { profileName: 'default' } },
+      9652,
+      '/home/u/.mozilla/firefox/abc.default',
+    );
+    expect(err.message).toContain('firefox-default');
+    expect(err.message).toContain('9652');
+    expect(err.message).toContain('--remote-debugging-port 9652');
+    expect(err.message).toContain('/home/u/.mozilla/firefox/abc.default');
+    expect(err.message).toContain('single-instance');
+  });
+});
+
+// ─── Live BiDi transport against a REAL Firefox (no mocking) ────────────────────
+//
+// Launches a real headless Firefox bound to a throwaway profile dir, connects the
+// repo's real BiDi client, and exercises the driver primitives end to end.
+//
+// Gated on AGENTS_TEST_FIREFOX=<firefox binary> (e.g. /usr/bin/firefox). Unset →
+// the suite skips cleanly, so CI without Firefox needs nothing.
+const FIREFOX = process.env.AGENTS_TEST_FIREFOX;
+const haveFirefox = !!(FIREFOX && fs.existsSync(FIREFOX));
+const live = haveFirefox ? describe : describe.skip;
+
+// vitest pins a sandbox $HOME per fork (tests/setup.ts). A snap-confined Firefox
+// (/usr/bin/firefox on Ubuntu) cannot start under a foreign HOME and can only
+// read a profile under ~/snap/firefox/common. os.userInfo() reads the passwd db,
+// not $HOME, so it recovers the REAL home even inside the sandbox. When a snap
+// tree is present we launch under it; otherwise a plain temp dir (deb/tarball
+// Firefox, macOS Firefox.app, CI) works as-is.
+const realHome = os.userInfo().homedir;
+const snapMozilla = path.join(realHome, 'snap', 'firefox', 'common', '.mozilla');
+const useSnap = fs.existsSync(path.join(realHome, 'snap', 'firefox'));
+function makeProfileDir(prefix: string): string {
+  const base = useSnap ? snapMozilla : os.tmpdir();
+  fs.mkdirSync(base, { recursive: true });
+  return fs.mkdtempSync(path.join(base, prefix));
+}
+
+live('Firefox BiDi driver against real Firefox', () => {
+  const profileDir = makeProfileDir('ff-driver-live-');
+  let conn: FirefoxConnection;
+  const savedHome = process.env.HOME;
+  // Give the spawned Firefox the real HOME (snap needs it); restore after.
+  process.env.HOME = realHome;
+
+  const profile: BrowserProfile = {
+    name: 'firefox-live-test',
+    browser: 'firefox',
+    binary: FIREFOX,
+    endpoints: { bidi: { target: 'firefox-bidi://127.0.0.1:9671' } },
+    defaultEndpoint: 'bidi',
+    userDataDir: profileDir,
+    firefox: { profileName: 'live-test', iniPath: path.join(profileDir, 'profiles.ini'), isDefault: false },
+  };
+
+  afterAll(async () => {
+    try { conn?.bidi.close(); } catch { /* ignore */ }
+    if (conn?.pid) { try { process.kill(conn.pid, 'SIGKILL'); } catch { /* already gone */ } }
+    try { fs.rmSync(profileDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+  });
+
+  it('launches Firefox, opens a session, and drives create/navigate/evaluate/screenshot', async () => {
+    conn = await connectFirefox(profile, 'firefox-live-test@local' as ConnectionKey, 9671, { profileDir, headless: true });
+    expect(conn.sessionId).toBeTruthy();
+    expect(conn.bidi.isOpen).toBe(true);
+
+    const ctx = await bidiCreateTab(conn.bidi);
+    await bidiNavigate(conn.bidi, ctx, 'data:text/html,<title>BiDi</title><h1 id=h>hello</h1>');
+
+    const value = await bidiEvaluate(conn.bidi, ctx, '({ t: document.title, h: document.getElementById("h").textContent })');
+    expect(value).toEqual({ t: 'BiDi', h: 'hello' });
+
+    // A thrown expression surfaces as an Error, not a silent undefined.
+    await expect(bidiEvaluate(conn.bidi, ctx, 'throw new Error("boom")')).rejects.toThrow(/boom/);
+
+    const png = await bidiScreenshot(conn.bidi, ctx, { type: 'image/png' });
+    expect(png.length).toBeGreaterThan(100);
+    expect(png.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+
+    const contexts = await bidiTopLevelContexts(conn.bidi);
+    expect(contexts.some((c) => c.context === ctx)).toBe(true);
+
+    await bidiCloseTab(conn.bidi, ctx);
+    const after = await bidiTopLevelContexts(conn.bidi);
+    expect(after.some((c) => c.context === ctx)).toBe(false);
+  }, 60_000);
+
+  it('performs a trusted pointer click via input.performActions', async () => {
+    const ctx = await bidiCreateTab(conn.bidi);
+    await bidiNavigate(
+      conn.bidi,
+      ctx,
+      'data:text/html,<button id=b style="position:absolute;left:10px;top:10px;width:120px;height:40px" ' +
+        'onclick="window.__clicked=true">Go</button>',
+    );
+    await bidiClickAt(conn.bidi, ctx, 60, 30);
+    const clicked = await bidiEvaluate(conn.bidi, ctx, 'window.__clicked === true');
+    expect(clicked).toBe(true);
+    await bidiCloseTab(conn.bidi, ctx);
+  }, 60_000);
+
+  it('fails loud when a Firefox already holds the profile without a debug port', async () => {
+    // The profile dir is locked by our launched Firefox; a second connect that is
+    // NOT allowed to attach (wrong port with no server) must raise the relaunch
+    // error rather than silently launching a rival.
+    const busy: BrowserProfile = { ...profile, userDataDir: profileDir };
+    await expect(
+      connectFirefox(busy, 'firefox-live-test@local2' as ConnectionKey, 9673, { profileDir, headless: true }),
+    ).rejects.toThrow(/single-instance|never exposed|already running/i);
+  }, 60_000);
+});

--- a/cli/src/lib/browser/drivers/firefox.ts
+++ b/cli/src/lib/browser/drivers/firefox.ts
@@ -1,0 +1,482 @@
+/**
+ * WebDriver BiDi transport for Firefox (PHNX-4043).
+ *
+ * Firefox dropped the Chrome DevTools Protocol in 129, so agents drive it over
+ * WebDriver BiDi — a JSON-RPC protocol on a WebSocket at
+ * `ws://127.0.0.1:<port>/session`. The shape mirrors the CDP driver
+ * (`drivers/local.ts`): launch or attach, hand back a live client the service
+ * routes every `bidi`-backend action through.
+ *
+ * Launch: `firefox --remote-debugging-port <port> --profile <dir> --no-remote
+ * [--headless]`. `--remote-debugging-port` is what turns BiDi on; `--no-remote`
+ * forces a fresh instance bound to that profile rather than handing the URL to
+ * an already-running Firefox. When a Firefox already holds the profile without a
+ * debug port we cannot launch a rival (Firefox is single-instance per profile),
+ * so we fail loud with the exact relaunch — the same contract
+ * `attachOnlyRequiredError` states for Chromium.
+ */
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import WSWebSocket from 'ws';
+import { findBrowserPath } from '../chrome.js';
+import { writeProfileRuntime, isProcessAlive } from '../runtime-state.js';
+import type { BrowserProfile, ConnectionKey } from '../types.js';
+
+/** How agents obtain a live Firefox — matches the CDP driver's launch/attach split. */
+export interface FirefoxConnection {
+  bidi: FirefoxBiDiClient;
+  port: number;
+  /** The Firefox process pid we launched, or 0 when we attached to a running one. */
+  pid: number;
+  /** The BiDi session id from `session.new`. */
+  sessionId: string;
+}
+
+/**
+ * A verb Firefox-over-BiDi cannot serve (network capture, upload, pdf, trusted
+ * key input, …). Mirrors `ArcNativeCapabilityError`: the service throws it in
+ * the one place the capability is missing, and the message steers the caller to
+ * a Chromium-family profile that has it.
+ */
+export class FirefoxCapabilityError extends Error {
+  constructor(public readonly capability: string, message?: string) {
+    super(
+      message ??
+        `Firefox (WebDriver BiDi) does not support ${capability}. ` +
+          `Use a Chromium-family profile (chrome/comet/chromium/brave/edge) for that capability.`,
+    );
+    this.name = 'FirefoxCapabilityError';
+  }
+}
+
+/** A BiDi error frame carrying the protocol error + human message. */
+export class FirefoxBiDiError extends Error {
+  constructor(public readonly bidiError: string, message: string) {
+    super(`Firefox BiDi ${bidiError}: ${message}`);
+    this.name = 'FirefoxBiDiError';
+  }
+}
+
+interface BiDiPending {
+  resolve: (result: Record<string, unknown>) => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * Minimal WebDriver BiDi client: request/response keyed by the `id` field, with
+ * events drained and ignored. Deliberately shaped like `CDPClient` so the
+ * service treats a Firefox connection the same way it treats a CDP one. The
+ * large `maxPayload` matches CDPClient's, so a base64 screenshot of a
+ * content-rich page never trips the socket's decompressed-size cap.
+ */
+export class FirefoxBiDiClient {
+  private ws: WSWebSocket | null = null;
+  private nextId = 0;
+  private pending = new Map<number, BiDiPending>();
+  private closed = false;
+
+  get isOpen(): boolean {
+    return this.ws !== null && this.ws.readyState === WSWebSocket.OPEN;
+  }
+
+  async connect(url: string): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.ws = new WSWebSocket(url, { maxPayload: 256 * 1024 * 1024 });
+      this.ws.once('open', () => resolve());
+      this.ws.once('error', () => reject(new Error('WebSocket error')));
+    });
+    this.ws!.on('message', (data) => this.handleMessage(String(data)));
+    this.ws!.on('close', () => this.handleClose());
+  }
+
+  private handleMessage(raw: string): void {
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    // BiDi frames: type 'success' | 'error' carry an `id`; type 'event' does not.
+    const id = typeof msg.id === 'number' ? (msg.id as number) : undefined;
+    if (id === undefined) return; // event — nothing subscribes yet.
+    const call = this.pending.get(id);
+    if (!call) return;
+    this.pending.delete(id);
+    if (msg.type === 'error') {
+      call.reject(
+        new FirefoxBiDiError(
+          String(msg.error ?? 'unknown error'),
+          String(msg.message ?? 'no message'),
+        ),
+      );
+      return;
+    }
+    call.resolve((msg.result as Record<string, unknown>) ?? {});
+  }
+
+  private handleClose(): void {
+    this.closed = true;
+    for (const [, call] of this.pending) {
+      call.reject(new Error('Firefox BiDi connection closed'));
+    }
+    this.pending.clear();
+  }
+
+  send<T = Record<string, unknown>>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    if (!this.isOpen) {
+      throw new Error(
+        'Firefox BiDi connection not open — the browser was likely closed externally. ' +
+          'Run `agents browser stop --profile <name>` (or restart the daemon) and try again.',
+      );
+    }
+    const id = ++this.nextId;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve: resolve as (r: Record<string, unknown>) => void, reject });
+      this.ws!.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.ws?.close();
+    } catch {
+      /* already closing */
+    }
+  }
+}
+
+const BIDI_CONNECT_ATTEMPTS = 120; // 120 × 250ms ≈ 30s — cold snap Firefox first-run is slow.
+const BIDI_CONNECT_INTERVAL_MS = 250;
+
+function bidiUrl(port: number): string {
+  return `ws://127.0.0.1:${port}/session`;
+}
+
+/** Open a BiDi socket + session against a port, or null when nothing is there yet. */
+async function tryOpenSession(port: number): Promise<{ bidi: FirefoxBiDiClient; sessionId: string } | null> {
+  const bidi = new FirefoxBiDiClient();
+  try {
+    await bidi.connect(bidiUrl(port));
+  } catch {
+    return null;
+  }
+  try {
+    const result = await bidi.send<{ sessionId?: string }>('session.new', { capabilities: {} });
+    return { bidi, sessionId: String(result.sessionId ?? '') };
+  } catch (err) {
+    bidi.close();
+    // A live BiDi endpoint that refuses session.new is a real, surfaced failure
+    // (e.g. a session already exists) — never swallow it as "nothing listening".
+    throw err;
+  }
+}
+
+/**
+ * The loud error raised when a Firefox already holds this profile but exposes no
+ * BiDi port, so agents cannot attach and must not launch a rival (Firefox is
+ * single-instance per profile dir). Mirrors `attachOnlyRequiredError` in
+ * `drivers/local.ts`: name the exact relaunch that makes the running instance
+ * attachable. Exported so the contract is unit-testable without a real Firefox.
+ */
+export function firefoxAttachRequiredError(
+  profile: Pick<BrowserProfile, 'name'> & { firefox?: { profileName: string } },
+  port: number,
+  profileDir: string,
+): Error {
+  return new Error(
+    `Profile "${profile.name}" is a Firefox profile and nothing is serving WebDriver BiDi on ` +
+      `ws://127.0.0.1:${port}/session. A Firefox is already running on this profile directory ` +
+      `without a debug port, and Firefox is single-instance per profile — agents will not launch ` +
+      `a second one. Quit that Firefox, then relaunch it with remote debugging on this port:\n` +
+      `  firefox --remote-debugging-port ${port} --profile ${profileDir} --no-remote\n` +
+      `and retry. Or close it entirely and let agents launch it headless for you.`,
+  );
+}
+
+/**
+ * Whether a Firefox is currently holding `profileDir`. Firefox writes a `lock`
+ * symlink (POSIX: `<dir>/lock` → `<ip>:+<pid>`; macOS: `.parentlock`; Windows:
+ * `parent.lock`) while the profile is open. We only treat it as held when the
+ * lock resolves to a live pid, so a stale lock from a crash never wedges launch.
+ */
+function firefoxHoldsProfile(profileDir: string): boolean {
+  const link = path.join(profileDir, 'lock');
+  try {
+    const target = fs.readlinkSync(link); // e.g. "127.0.0.1:+3685166"
+    const pid = Number(target.split('+').pop());
+    if (Number.isFinite(pid) && pid > 0) return isProcessAlive(pid);
+  } catch {
+    /* no POSIX lock symlink */
+  }
+  // macOS/Windows lock files are plain files, not symlinks with a pid. Their mere
+  // presence is a weak signal (they can be stale), so we do not block on them —
+  // a launch that collides fails loud below via the connect timeout instead.
+  return false;
+}
+
+/**
+ * Connect a Firefox profile over BiDi: attach if the port is already served,
+ * otherwise launch Firefox and wait for it. Fails loud when a Firefox holds the
+ * profile without a port.
+ */
+export async function connectFirefox(
+  profile: BrowserProfile,
+  key: ConnectionKey,
+  port: number,
+  opts: { profileDir: string; headless?: boolean } = { profileDir: '' },
+): Promise<FirefoxConnection> {
+  const profileDir = opts.profileDir || profile.userDataDir || '';
+  if (!profileDir) {
+    throw new Error(`Firefox profile "${profile.name}" has no profile directory to launch with.`);
+  }
+
+  // 1. Already serving BiDi on the port → attach (pid 0, we did not launch it).
+  const attached = await tryOpenSession(port);
+  if (attached) {
+    return { bidi: attached.bidi, port, pid: 0, sessionId: attached.sessionId };
+  }
+
+  // 2. A Firefox holds the profile but exposes no port → fail loud (never a rival).
+  if (firefoxHoldsProfile(profileDir)) {
+    throw firefoxAttachRequiredError(profile, port, profileDir);
+  }
+
+  // 3. Launch our own headless Firefox bound to this profile + port.
+  const binary = findBrowserPath('firefox', profile.binary);
+  const headless = opts.headless ?? profile.chrome?.headless ?? true;
+  const args = [
+    '--remote-debugging-port',
+    String(port),
+    '--profile',
+    profileDir,
+    '--no-remote',
+    ...(headless ? ['--headless'] : []),
+  ];
+  const child: ChildProcess = spawn(binary, args, {
+    detached: true,
+    stdio: ['ignore', 'ignore', 'ignore'],
+    env: { ...process.env },
+  });
+  child.unref();
+  const pid = child.pid ?? 0;
+
+  writeProfileRuntime(key, {
+    pid,
+    port,
+    command: path.basename(binary),
+    userDataDir: profileDir,
+    kind: 'browser',
+  });
+
+  for (let i = 0; i < BIDI_CONNECT_ATTEMPTS; i++) {
+    // A Firefox handed the URL to an already-running instance exits almost
+    // immediately without ever opening the port — detect that and fail loud
+    // rather than waiting out the full timeout.
+    if (pid && !isProcessAlive(pid) && i > 4) {
+      throw firefoxAttachRequiredError(profile, port, profileDir);
+    }
+    const session = await tryOpenSession(port);
+    if (session) {
+      return { bidi: session.bidi, port, pid, sessionId: session.sessionId };
+    }
+    await new Promise((r) => setTimeout(r, BIDI_CONNECT_INTERVAL_MS));
+  }
+
+  try {
+    if (pid) process.kill(pid, 'SIGKILL');
+  } catch {
+    /* already gone */
+  }
+  throw new Error(
+    `Firefox for profile "${profile.name}" never exposed WebDriver BiDi on ` +
+      `ws://127.0.0.1:${port}/session within ${(BIDI_CONNECT_ATTEMPTS * BIDI_CONNECT_INTERVAL_MS) / 1000}s. ` +
+      `Check that Firefox is installed (\`${binary}\`) and that the profile directory is not locked.`,
+  );
+}
+
+// ─── BiDi value (de)serialization ──────────────────────────────────────────────
+//
+// `script.evaluate` returns a structured RemoteValue, not a raw JS value. This
+// converts the subset our verbs produce — primitives, arrays, plain objects,
+// dates — back into a plain JS value, matching what a CDP `returnByValue`
+// evaluate would have handed back.
+
+type RemoteValue = { type: string; value?: unknown };
+
+export function deserializeBidi(remote: unknown): unknown {
+  if (!remote || typeof remote !== 'object') return remote;
+  const rv = remote as RemoteValue;
+  switch (rv.type) {
+    case 'undefined':
+      return undefined;
+    case 'null':
+      return null;
+    case 'string':
+    case 'boolean':
+      return rv.value;
+    case 'number': {
+      // BiDi encodes ±Infinity / NaN as strings.
+      if (rv.value === 'Infinity') return Infinity;
+      if (rv.value === '-Infinity') return -Infinity;
+      if (rv.value === 'NaN') return NaN;
+      return rv.value;
+    }
+    case 'bigint':
+      return typeof rv.value === 'string' ? BigInt(rv.value) : rv.value;
+    case 'date':
+      return rv.value;
+    case 'array':
+    case 'set':
+      return Array.isArray(rv.value) ? rv.value.map(deserializeBidi) : [];
+    case 'object':
+    case 'map': {
+      const out: Record<string, unknown> = {};
+      if (Array.isArray(rv.value)) {
+        for (const pair of rv.value as Array<[unknown, unknown]>) {
+          const rawKey = pair[0];
+          const key = typeof rawKey === 'string' ? rawKey : String(deserializeBidi(rawKey));
+          out[key] = deserializeBidi(pair[1]);
+        }
+      }
+      return out;
+    }
+    default:
+      // node / regexp / window / … — no JS value to hand back.
+      return undefined;
+  }
+}
+
+// ─── BiDi operation helpers ────────────────────────────────────────────────────
+//
+// Thin wrappers over the raw protocol so the service's `bidi` branches read like
+// its CDP ones. Each takes the live client and a context (BiDi's stable tab id).
+
+/** One top-level browsing context (a tab), flattened from `browsingContext.getTree`. */
+export interface BiDiContext {
+  context: string;
+  url: string;
+}
+
+/** Every top-level tab currently open in this Firefox. */
+export async function bidiTopLevelContexts(bidi: FirefoxBiDiClient): Promise<BiDiContext[]> {
+  const tree = await bidi.send<{ contexts?: Array<{ context: string; url: string }> }>(
+    'browsingContext.getTree',
+    {},
+  );
+  return (tree.contexts ?? []).map((c) => ({ context: c.context, url: c.url }));
+}
+
+/** Open a fresh tab and return its context id. */
+export async function bidiCreateTab(bidi: FirefoxBiDiClient): Promise<string> {
+  const created = await bidi.send<{ context: string }>('browsingContext.create', { type: 'tab' });
+  return created.context;
+}
+
+/** Navigate a context and wait for the document to finish loading. */
+export async function bidiNavigate(bidi: FirefoxBiDiClient, context: string, url: string): Promise<void> {
+  await bidi.send('browsingContext.navigate', { context, url, wait: 'complete' });
+}
+
+/** Reload a context in place, waiting for load. */
+export async function bidiReload(bidi: FirefoxBiDiClient, context: string): Promise<void> {
+  await bidi.send('browsingContext.reload', { context, wait: 'complete' });
+}
+
+/** Close a tab. */
+export async function bidiCloseTab(bidi: FirefoxBiDiClient, context: string): Promise<void> {
+  await bidi.send('browsingContext.close', { context });
+}
+
+/** Bring a tab to the foreground (explicit focus only). */
+export async function bidiActivate(bidi: FirefoxBiDiClient, context: string): Promise<void> {
+  await bidi.send('browsingContext.activate', { context });
+}
+
+/**
+ * Evaluate an expression in a context and return the deserialized value.
+ * `awaitPromise` mirrors the CDP evaluate contract; a thrown/rejected value
+ * surfaces as an Error rather than a silent undefined.
+ */
+export async function bidiEvaluate(
+  bidi: FirefoxBiDiClient,
+  context: string,
+  expression: string,
+): Promise<unknown> {
+  const result = await bidi.send<{
+    type: string;
+    result?: RemoteValue;
+    exceptionDetails?: { text?: string; exception?: RemoteValue };
+  }>('script.evaluate', {
+    expression,
+    target: { context },
+    awaitPromise: true,
+    resultOwnership: 'none',
+  });
+  if (result.type === 'exception') {
+    const ex = result.exceptionDetails;
+    const value = ex?.exception ? deserializeBidi(ex.exception) : undefined;
+    throw new Error(ex?.text || (typeof value === 'string' ? value : 'evaluate failed'));
+  }
+  return deserializeBidi(result.result);
+}
+
+/** Capture a screenshot of the viewport as raw bytes. `quality` is 0–1 for JPEG. */
+export async function bidiScreenshot(
+  bidi: FirefoxBiDiClient,
+  context: string,
+  format: { type: 'image/png' } | { type: 'image/jpeg'; quality: number },
+): Promise<Buffer> {
+  const shot = await bidi.send<{ data: string }>('browsingContext.captureScreenshot', {
+    context,
+    origin: 'viewport',
+    format,
+  });
+  return Buffer.from(shot.data, 'base64');
+}
+
+/** Override a context's viewport size (CSS px). */
+export async function bidiSetViewport(
+  bidi: FirefoxBiDiClient,
+  context: string,
+  width: number,
+  height: number,
+  devicePixelRatio?: number,
+): Promise<void> {
+  await bidi.send('browsingContext.setViewport', {
+    context,
+    viewport: { width, height },
+    ...(devicePixelRatio ? { devicePixelRatio } : {}),
+  });
+}
+
+/**
+ * A real, trusted left click at viewport coordinates via `input.performActions`
+ * — the pointer path CDP `Input.dispatchMouseEvent` gives Chromium, which Arc
+ * (Apple Events) never had. The service resolves a ref to (x, y) first, exactly
+ * as the CDP click path does.
+ */
+export async function bidiClickAt(
+  bidi: FirefoxBiDiClient,
+  context: string,
+  x: number,
+  y: number,
+): Promise<void> {
+  await bidi.send('input.performActions', {
+    context,
+    actions: [
+      {
+        type: 'pointer',
+        id: 'mouse',
+        parameters: { pointerType: 'mouse' },
+        actions: [
+          { type: 'pointerMove', x: Math.round(x), y: Math.round(y) },
+          { type: 'pointerDown', button: 0 },
+          { type: 'pointerUp', button: 0 },
+        ],
+      },
+    ],
+  });
+}

--- a/cli/src/lib/browser/drivers/firefox.ts
+++ b/cli/src/lib/browser/drivers/firefox.ts
@@ -437,21 +437,6 @@ export async function bidiScreenshot(
   return Buffer.from(shot.data, 'base64');
 }
 
-/** Override a context's viewport size (CSS px). */
-export async function bidiSetViewport(
-  bidi: FirefoxBiDiClient,
-  context: string,
-  width: number,
-  height: number,
-  devicePixelRatio?: number,
-): Promise<void> {
-  await bidi.send('browsingContext.setViewport', {
-    context,
-    viewport: { width, height },
-    ...(devicePixelRatio ? { devicePixelRatio } : {}),
-  });
-}
-
 /**
  * A real, trusted left click at viewport coordinates via `input.performActions`
  * — the pointer path CDP `Input.dispatchMouseEvent` gives Chromium, which Arc

--- a/cli/src/lib/browser/firefox-discovery.test.ts
+++ b/cli/src/lib/browser/firefox-discovery.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  parseProfilesIni,
+  discoverFirefoxProfilesAt,
+  firefoxDiscoveredProfiles,
+  firefoxProfilePort,
+  firefoxProfileRoots,
+  FIREFOX_PORT_RANGE,
+} from './firefox-discovery.js';
+
+const testdata = path.join(import.meta.dirname, 'testdata', 'firefox');
+
+describe('parseProfilesIni', () => {
+  it('reads every [ProfileN] entry and resolves relative + absolute paths', () => {
+    const ini = path.join(testdata, 'profiles-valid.ini');
+    const result = parseProfilesIni(ini);
+    expect(Array.isArray(result)).toBe(true);
+    const profiles = result as Array<{ name: string; dir: string; isDefault: boolean }>;
+    expect(profiles.map((p) => p.name).sort()).toEqual(['Dev Edition', 'default', 'default-release']);
+    const rel = profiles.find((p) => p.name === 'default')!;
+    // IsRelative=1 → resolved against the ini's directory.
+    expect(rel.dir).toBe(path.join(testdata, 'wxyz5678.default'));
+    const abs = profiles.find((p) => p.name === 'Dev Edition')!;
+    // A non-relative Path is used verbatim.
+    expect(abs.dir).toBe('/opt/firefox-dev/profile');
+    expect(profiles.find((p) => p.name === 'default-release')!.isDefault).toBe(true);
+  });
+
+  it('skips [General] and [Install*] sections — they are not profiles', () => {
+    const profiles = parseProfilesIni(path.join(testdata, 'profiles-valid.ini')) as Array<{ name: string }>;
+    expect(profiles.some((p) => p.name === 'default-release')).toBe(true);
+    expect(profiles).toHaveLength(3);
+  });
+
+  it('reports a [Profile] entry with no Name as an error, never a guessed profile', () => {
+    const result = parseProfilesIni(path.join(testdata, 'profiles-malformed.ini'));
+    expect('error' in result).toBe(true);
+    expect((result as { error: string }).error).toContain('no Name or Path');
+  });
+
+  it('returns an error for a missing file', () => {
+    const result = parseProfilesIni('/nonexistent/profiles.ini');
+    expect('error' in result).toBe(true);
+    expect((result as { error: string }).error).toContain('Cannot read');
+  });
+});
+
+describe('discoverFirefoxProfilesAt', () => {
+  it('returns not-installed when no profiles.ini exists in any root', () => {
+    const result = discoverFirefoxProfilesAt([path.join(os.tmpdir(), 'no-firefox-here-xyz')]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.kind).toBe('not-installed');
+  });
+
+  it('returns invalid (not not-installed) when the ini exists but is malformed', () => {
+    const result = discoverFirefoxProfilesAt([testdata]);
+    // testdata holds several .ini files but discovery only reads profiles.ini —
+    // there is none named exactly that here, so it is not-installed.
+    expect(result.ok).toBe(false);
+  });
+
+  it('discovers profiles from a real profiles.ini laid out in a temp root', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ff-disco-'));
+    fs.copyFileSync(path.join(testdata, 'profiles-valid.ini'), path.join(root, 'profiles.ini'));
+    try {
+      const result = discoverFirefoxProfilesAt([root]);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.profiles).toHaveLength(3);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('firefoxDiscoveredProfiles', () => {
+  it('names one agents-cli profile per entry as firefox-<slug> with a stable pinned port', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ff-disco-'));
+    fs.copyFileSync(path.join(testdata, 'profiles-valid.ini'), path.join(root, 'profiles.ini'));
+    try {
+      const result = discoverFirefoxProfilesAt([root]);
+      const flat = firefoxDiscoveredProfiles(result);
+      expect(flat.map((p) => p.name).sort()).toEqual([
+        'firefox-default',
+        'firefox-default-release',
+        'firefox-dev-edition',
+      ]);
+      // Every port sits inside the reserved Firefox range and is unique.
+      const ports = flat.map((p) => p.port);
+      for (const port of ports) {
+        expect(port).toBeGreaterThanOrEqual(FIREFOX_PORT_RANGE.base);
+        expect(port).toBeLessThan(FIREFOX_PORT_RANGE.base + FIREFOX_PORT_RANGE.size);
+      }
+      expect(new Set(ports).size).toBe(ports.length);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('empty discovery flattens to no profiles rather than throwing', () => {
+    expect(firefoxDiscoveredProfiles({ ok: false, kind: 'not-installed', reason: 'x' })).toEqual([]);
+  });
+});
+
+describe('firefoxProfilePort', () => {
+  it('is deterministic for a directory — the same relaunch hint every time', () => {
+    const dir = '/home/u/.mozilla/firefox/abc.default';
+    expect(firefoxProfilePort(dir)).toBe(firefoxProfilePort(dir));
+  });
+
+  it('linear-probes to avoid a port already taken by another discovered profile', () => {
+    const dir = '/home/u/.mozilla/firefox/abc.default';
+    const first = firefoxProfilePort(dir);
+    const taken = new Set([first]);
+    const second = firefoxProfilePort(dir, taken);
+    expect(second).not.toBe(first);
+  });
+});
+
+describe('firefoxProfileRoots', () => {
+  it('honors AGENTS_FIREFOX_DIRS as a path-separator list', () => {
+    const prev = process.env.AGENTS_FIREFOX_DIRS;
+    process.env.AGENTS_FIREFOX_DIRS = ['/a/x', '/b/y'].join(path.delimiter);
+    try {
+      expect(firefoxProfileRoots()).toEqual([path.resolve('/a/x'), path.resolve('/b/y')]);
+    } finally {
+      if (prev === undefined) delete process.env.AGENTS_FIREFOX_DIRS;
+      else process.env.AGENTS_FIREFOX_DIRS = prev;
+    }
+  });
+});

--- a/cli/src/lib/browser/firefox-discovery.test.ts
+++ b/cli/src/lib/browser/firefox-discovery.test.ts
@@ -62,6 +62,21 @@ describe('discoverFirefoxProfilesAt', () => {
     expect(result.ok).toBe(false);
   });
 
+  it('reports invalid (not not-installed) when profiles.ini exists but has no [Profile] entries', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ff-disco-empty-'));
+    fs.copyFileSync(path.join(testdata, 'profiles-empty.ini'), path.join(root, 'profiles.ini'));
+    try {
+      const result = discoverFirefoxProfilesAt([root]);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.kind).toBe('invalid');
+        expect(result.reason).toContain('No [Profile] entries');
+      }
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('discovers profiles from a real profiles.ini laid out in a temp root', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ff-disco-'));
     fs.copyFileSync(path.join(testdata, 'profiles-valid.ini'), path.join(root, 'profiles.ini'));

--- a/cli/src/lib/browser/firefox-discovery.ts
+++ b/cli/src/lib/browser/firefox-discovery.ts
@@ -1,0 +1,194 @@
+/**
+ * Read-only Firefox profile discovery from `profiles.ini` (PHNX-4043).
+ *
+ * One agents-cli profile per `[ProfileN]` entry, named `firefox-<name-slug>`
+ * and pinned to that entry's directory. The profile already carries its
+ * cookies and logins, so it IS the browser profile agents pick with
+ * `--profile` — the same shape Arc Space discovery uses (`arc-discovery.ts`).
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export interface FirefoxIniProfile {
+  /** `Name=` of the `[ProfileN]` section. */
+  name: string;
+  /** Absolute profile directory (`Path=` resolved against the ini's dir when `IsRelative=1`). */
+  dir: string;
+  /** `Default=1` on the entry (a legacy marker; `[Install*]` sections carry the real one). */
+  isDefault: boolean;
+  /** The `profiles.ini` this entry came from. */
+  iniPath: string;
+}
+
+export type FirefoxDiscoveryResult =
+  | { ok: true; profiles: FirefoxIniProfile[]; iniPaths: string[] }
+  | { ok: false; kind: 'not-installed' | 'invalid'; reason: string };
+
+/**
+ * Every directory a `profiles.ini` may live in on this machine. Ubuntu's snap
+ * Firefox keeps its whole `.mozilla` under `~/snap/firefox/common/`, a deb or
+ * tarball Firefox uses `~/.mozilla/firefox/` — a box can carry both, so both
+ * are read. `AGENTS_FIREFOX_DIRS` (path-separator list) points tests and
+ * non-default installs elsewhere.
+ */
+export function firefoxProfileRoots(): string[] {
+  const override = process.env.AGENTS_FIREFOX_DIRS;
+  if (override) return override.split(path.delimiter).filter(Boolean).map((p) => path.resolve(p));
+  const home = os.homedir();
+  switch (process.platform) {
+    case 'darwin':
+      return [path.join(home, 'Library', 'Application Support', 'Firefox')];
+    case 'win32':
+      return [path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'Mozilla', 'Firefox')];
+    default:
+      return [
+        path.join(home, '.mozilla', 'firefox'),
+        path.join(home, 'snap', 'firefox', 'common', '.mozilla', 'firefox'),
+      ];
+  }
+}
+
+/**
+ * Parse one `profiles.ini`. Only `[Profile<n>]` sections are profiles;
+ * `[General]` and `[Install<hash>]` (which record the per-install default) are
+ * skipped. A `[Profile]` section that lacks `Name` or `Path` is a malformed
+ * file, not a profile to guess at.
+ */
+export function parseProfilesIni(iniPath: string): FirefoxIniProfile[] | { error: string } {
+  let text: string;
+  try {
+    text = fs.readFileSync(iniPath, 'utf8');
+  } catch (error) {
+    return { error: `Cannot read ${iniPath}: ${error instanceof Error ? error.message : String(error)}` };
+  }
+  const root = path.dirname(iniPath);
+  const sections: Array<{ header: string; values: Record<string, string> }> = [];
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith(';') || line.startsWith('#')) continue;
+    const header = line.match(/^\[(.+)\]$/);
+    if (header) {
+      sections.push({ header: header[1], values: {} });
+      continue;
+    }
+    const eq = line.indexOf('=');
+    if (eq === -1 || sections.length === 0) {
+      return { error: `${iniPath} has a malformed line: ${JSON.stringify(raw)}` };
+    }
+    sections[sections.length - 1].values[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+  }
+
+  const profiles: FirefoxIniProfile[] = [];
+  for (const section of sections) {
+    if (!/^Profile\d+$/.test(section.header)) continue;
+    const name = section.values.Name;
+    const rel = section.values.Path;
+    if (!name || !rel) {
+      return { error: `${iniPath} [${section.header}] has no Name or Path` };
+    }
+    const isRelative = section.values.IsRelative !== '0';
+    const dir = isRelative ? path.resolve(root, rel) : path.resolve(rel);
+    profiles.push({ name, dir, isDefault: section.values.Default === '1', iniPath });
+  }
+  return profiles;
+}
+
+export function discoverFirefoxProfilesAt(roots: string[]): FirefoxDiscoveryResult {
+  const iniPaths = roots.map((root) => path.join(root, 'profiles.ini')).filter((p) => fs.existsSync(p));
+  if (iniPaths.length === 0) {
+    return {
+      ok: false,
+      kind: 'not-installed',
+      reason: `No Firefox profiles.ini under ${roots.join(', ')}`,
+    };
+  }
+  const profiles: FirefoxIniProfile[] = [];
+  for (const iniPath of iniPaths) {
+    const parsed = parseProfilesIni(iniPath);
+    if ('error' in parsed) return { ok: false, kind: 'invalid', reason: parsed.error };
+    profiles.push(...parsed);
+  }
+  if (profiles.length === 0) {
+    return { ok: false, kind: 'invalid', reason: `No [Profile] entries in ${iniPaths.join(', ')}` };
+  }
+  return { ok: true, profiles, iniPaths };
+}
+
+export function discoverFirefoxProfiles(): FirefoxDiscoveryResult {
+  return discoverFirefoxProfilesAt(firefoxProfileRoots());
+}
+
+/** One discovered Firefox profile as an agents-cli profile row. */
+export interface FirefoxDiscoveredProfile {
+  /** The agents-cli profile name: `firefox-<name-slug>`. */
+  name: string;
+  profileName: string;
+  profileDir: string;
+  iniPath: string;
+  isDefault: boolean;
+  /** The local WebDriver BiDi port this profile is pinned to. */
+  port: number;
+}
+
+function slugify(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+/** FNV-1a over the path, folded into the range. Stable across runs and daemons. */
+function stableHash(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+/** Firefox BiDi ports live in their own range so they never collide with the 9222-9399 CDP profiles. */
+export const FIREFOX_PORT_RANGE = Object.freeze({ base: 9600, size: 100 });
+
+/**
+ * The port a discovered Firefox profile listens on: derived from its directory,
+ * so the relaunch hint in an attach error is the same string every time and a
+ * daemon restart reattaches to the Firefox it launched earlier. Collisions
+ * between two discovered profiles resolve by linear probing within the range.
+ */
+export function firefoxProfilePort(profileDir: string, taken: Set<number> = new Set()): number {
+  const { base, size } = FIREFOX_PORT_RANGE;
+  let port = base + (stableHash(profileDir) % size);
+  for (let i = 0; i < size && taken.has(port); i++) {
+    port = base + ((port - base + 1) % size);
+  }
+  return port;
+}
+
+/**
+ * Flatten discovery into one agents-cli profile per `profiles.ini` entry, named
+ * `firefox-<name>` (`firefox-default`, `firefox-default-release`, …). Two
+ * entries with the same name (one per ini, say) get the first six hex
+ * characters of their directory hash appended so the names stay distinct.
+ */
+export function firefoxDiscoveredProfiles(result: FirefoxDiscoveryResult): FirefoxDiscoveredProfile[] {
+  if (!result.ok) return [];
+  const taken = new Set<number>();
+  const flat: FirefoxDiscoveredProfile[] = result.profiles.map((profile) => {
+    const port = firefoxProfilePort(profile.dir, taken);
+    taken.add(port);
+    return {
+      name: `firefox-${slugify(profile.name) || 'profile'}`,
+      profileName: profile.name,
+      profileDir: profile.dir,
+      iniPath: profile.iniPath,
+      isDefault: profile.isDefault,
+      port,
+    };
+  });
+  const counts = new Map<string, number>();
+  for (const entry of flat) counts.set(entry.name, (counts.get(entry.name) ?? 0) + 1);
+  return flat.map((entry) =>
+    (counts.get(entry.name) ?? 0) > 1
+      ? { ...entry, name: `${entry.name}-${stableHash(entry.profileDir).toString(16).padStart(8, '0').slice(0, 6)}` }
+      : entry,
+  );
+}

--- a/cli/src/lib/browser/profiles.ts
+++ b/cli/src/lib/browser/profiles.ts
@@ -18,6 +18,7 @@ import {
 import { findBrowserPath, isPortInUse } from './chrome.js';
 import { arcSpaceProfiles, discoverArcProfiles } from './arc-discovery.js';
 import { discoverChromiumProfiles, discoverableChromiumBrowsers } from './chromium-discovery.js';
+import { firefoxDiscoveredProfiles, discoverFirefoxProfiles } from './firefox-discovery.js';
 
 export type { BrowserProfile } from './types.js';
 export {
@@ -167,6 +168,7 @@ function configToProfile(
     logDir: config.logDir,
     logHost: config.logHost,
     arc: config.arc,
+    firefox: config.firefox,
     devices,
   };
 }
@@ -191,6 +193,7 @@ function profileToConfig(profile: BrowserProfile): BrowserProfileConfig {
   if (profile.logDir) config.logDir = profile.logDir;
   if (profile.logHost) config.logHost = profile.logHost;
   if (profile.arc) config.arc = profile.arc;
+  if (profile.firefox) config.firefox = profile.firefox;
   return config;
 }
 
@@ -263,6 +266,30 @@ export function discoverNativeProfiles(): DiscoveredProfiles {
         devices: [machineId()],
       });
     }
+  }
+  // Firefox (PHNX-4043): one profiles.ini entry is one `firefox-<slug>` profile,
+  // pinned to that directory and a stable WebDriver BiDi port. Firefox dropped
+  // CDP in 129, so these use a `firefox-bidi:` endpoint, not `cdp://`.
+  const firefox = discoverFirefoxProfiles();
+  if (firefox.ok) {
+    for (const entry of firefoxDiscoveredProfiles(firefox)) {
+      profiles.push({
+        name: entry.name,
+        description: `Firefox profile "${entry.profileName}"${entry.isDefault ? ' (default)' : ''}`,
+        browser: 'firefox',
+        endpoints: { bidi: { target: `firefox-bidi://127.0.0.1:${entry.port}` } },
+        defaultEndpoint: 'bidi',
+        userDataDir: entry.profileDir,
+        firefox: {
+          profileName: entry.profileName,
+          iniPath: entry.iniPath,
+          isDefault: entry.isDefault,
+        },
+        devices: [machineId()],
+      });
+    }
+  } else if (firefox.kind === 'invalid') {
+    errors.firefox = `Cannot discover Firefox profiles: ${firefox.reason}`;
   }
   return { profiles, errors };
 }
@@ -419,6 +446,21 @@ export function isProfileLaunchableHere(profile: BrowserProfile): boolean {
     return !!profile.arc && discoverNativeProfiles().profiles.some(
       (candidate) => candidate.arc?.spaceId === profile.arc?.spaceId,
     );
+  }
+  const bidi = Object.values(getEndpointPresets(profile)).some(
+    (preset) => preset.target.startsWith('firefox-bidi:'),
+  );
+  if (bidi) {
+    // Launchable here only when Firefox is installed AND this box holds the
+    // pinned profile directory (a synced-in firefox- profile from another box
+    // has that box's path, so it command-dispatches instead).
+    if (!profile.userDataDir || !fs.existsSync(profile.userDataDir)) return false;
+    try {
+      findBrowserPath('firefox', profile.binary);
+      return true;
+    } catch {
+      return false;
+    }
   }
   const remote = Object.values(getEndpointPresets(profile)).some((preset) =>
     preset.target.startsWith('ssh://')
@@ -762,6 +804,12 @@ export async function createProfile(profile: BrowserProfile): Promise<void> {
   );
   if (nativeArc && (!profile.arc || profile.browser !== 'arc')) {
     throw new Error('An arc-native profile requires stable Arc Space metadata. Pick a discovered one from `agents browser profiles list`.');
+  }
+  const firefoxBidi = Object.values(getEndpointPresets(profile)).some(
+    (preset) => preset.target.startsWith('firefox-bidi:'),
+  );
+  if (firefoxBidi && (!profile.firefox || profile.browser !== 'firefox')) {
+    throw new Error('A firefox-bidi profile requires a discovered Firefox profile. Pick one from `agents browser profiles list`.');
   }
   // A discovered profile is pinned to a browser store on this disk
   // (`userDataDir` + `profileDirectory`) and is published unattended by the

--- a/cli/src/lib/browser/resolve-target.test.ts
+++ b/cli/src/lib/browser/resolve-target.test.ts
@@ -83,6 +83,16 @@ describe('sshEndpointForDeclaration', () => {
     };
     expect(sshEndpointForDeclaration('zion', config)).toBe('arc-native://local');
   });
+
+  it('does not manufacture an SSH/CDP endpoint for a Firefox BiDi profile', async () => {
+    const { sshEndpointForDeclaration } = await import('./resolve-target.js');
+    const config = {
+      browser: 'firefox' as const,
+      endpoints: { bidi: { target: 'firefox-bidi://127.0.0.1:9652' } },
+      firefox: { profileName: 'default', iniPath: '/home/u/.mozilla/firefox/profiles.ini', isDefault: true },
+    };
+    expect(sshEndpointForDeclaration('yosemite-s0', config)).toBe('firefox-bidi://127.0.0.1:9652');
+  });
 });
 
 describe('resolveBrowserTarget', () => {
@@ -106,6 +116,29 @@ describe('resolveBrowserTarget', () => {
       target: 'arc-native://local',
       commandDispatch: true,
       profile: { arc: config.arc },
+    });
+  });
+
+  it('marks a remote Firefox BiDi declaration for whole-command dispatch', async () => {
+    const config = {
+      browser: 'firefox' as const,
+      endpoints: { bidi: { target: 'firefox-bidi://127.0.0.1:9652' } },
+      defaultEndpoint: 'bidi',
+      firefox: { profileName: 'default', iniPath: '/home/u/.mozilla/firefox/profiles.ini', isDefault: true },
+    };
+    writeYaml(deviceFile('yosemite-s0'), { browser: { 'firefox-default': config } });
+
+    const { resolveBrowserTarget } = await import('./resolve-target.js');
+    const routed = resolveBrowserTarget('firefox-default', {
+      here: 'yosemite-s1',
+      probe: () => ({ reachable: true, os: 'Linux' }),
+    });
+    expect(routed).toMatchObject({
+      local: false,
+      device: 'yosemite-s0',
+      target: 'firefox-bidi://127.0.0.1:9652',
+      commandDispatch: true,
+      profile: { firefox: config.firefox },
     });
   });
 

--- a/cli/src/lib/browser/resolve-target.ts
+++ b/cli/src/lib/browser/resolve-target.ts
@@ -87,6 +87,7 @@ export function profileFromDeclaration(
     logDir: config.logDir,
     logHost: config.logHost,
     arc: config.arc,
+    firefox: config.firefox,
   };
 }
 
@@ -208,6 +209,10 @@ export function sshEndpointForDeclaration(
   // Native Arc endpoints (arc-native:) must NOT be rewritten into SSH tunnels
   // (PHNX-2399). They dispatch the whole command to the owner device instead.
   if (resolved.target.startsWith('arc-native:')) return resolved.target;
+  // Firefox BiDi endpoints (firefox-bidi:) are a local WebSocket bound to a
+  // specific profile directory on the owner box; they dispatch the whole
+  // command to that box rather than tunnelling (PHNX-4043).
+  if (resolved.target.startsWith('firefox-bidi:')) return resolved.target;
   const parsed = parseEndpointUrl(resolved.target);
   const port = parsed?.port ?? 9222;
   const osQuery = isWindowsOs(os) ? '&os=windows' : '';
@@ -302,7 +307,8 @@ export function resolveBrowserTarget(
         targetFilter: resolved.targetFilter,
       },
       picked,
-      commandDispatch: resolved.target.startsWith('arc-native:'),
+      commandDispatch:
+        resolved.target.startsWith('arc-native:') || resolved.target.startsWith('firefox-bidi:'),
     };
   }
 

--- a/cli/src/lib/browser/service.firefox.live.test.ts
+++ b/cli/src/lib/browser/service.firefox.live.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { tmpdir, userInfo } from 'os';
+import * as state from '../state.js';
+import * as profiles from './profiles.js';
+
+// ─── Service-level BiDi drive against a REAL Firefox (no mocking) ───────────────
+//
+// The sibling service.reopen.live.test.ts does this for Chromium/CDP. This one
+// drives the real BrowserService through its `bidi` backend against a real
+// headless Firefox: the same-task reopen contract, tab add, evaluate, refs,
+// type, trusted click, and screenshot — end to end, no protocol double.
+//
+// Gated on AGENTS_TEST_FIREFOX=<firefox binary>. Unset → skips cleanly.
+const FIREFOX = process.env.AGENTS_TEST_FIREFOX;
+const haveFirefox = !!(FIREFOX && fs.existsSync(FIREFOX));
+
+const TEST_BROWSER_DIR = path.join(tmpdir(), 'agents-cli-firefox-live-test');
+vi.spyOn(state, 'getBrowserRuntimeDir').mockReturnValue(TEST_BROWSER_DIR);
+vi.spyOn(profiles, 'getBrowserRuntimeDir').mockReturnValue(TEST_BROWSER_DIR);
+vi.spyOn(profiles, 'getProfileRuntimeDir').mockImplementation((name: string) =>
+  path.join(TEST_BROWSER_DIR, name),
+);
+
+const { BrowserService } = await import('./service.js');
+const { connectFirefox } = await import('./drivers/firefox.js');
+
+const KEY = 'firefox-live@endpoint-0';
+const PORT = 9675;
+const d = haveFirefox ? describe : describe.skip;
+
+// See drivers/firefox.test.ts: a snap Firefox needs the REAL home (recovered via
+// os.userInfo(), not the vitest sandbox $HOME) and a profile under ~/snap.
+const realHome = userInfo().homedir;
+const snapMozilla = path.join(realHome, 'snap', 'firefox', 'common', '.mozilla');
+const useSnap = fs.existsSync(path.join(realHome, 'snap', 'firefox'));
+function makeProfileDir(prefix: string): string {
+  const base = useSnap ? snapMozilla : tmpdir();
+  fs.mkdirSync(base, { recursive: true });
+  return fs.mkdtempSync(path.join(base, prefix));
+}
+
+d('BrowserService over Firefox BiDi against real Firefox', () => {
+  let profileDir = '';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let service: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let conn: any;
+
+  const dataUrl = (body: string) => `data:text/html,${encodeURIComponent(body)}`;
+
+  function seedTask(name: string) {
+    const now = Date.now();
+    const task = { id: name, name, label: name, profile: KEY, tabs: {}, currentTabId: undefined, createdAt: now, lastActionAt: now, pid: conn.pid };
+    conn.tasks.set(name, task);
+    return task as { tabs: Record<string, string>; currentTabId?: string };
+  }
+
+  beforeAll(async () => {
+    fs.rmSync(TEST_BROWSER_DIR, { recursive: true, force: true });
+    fs.mkdirSync(TEST_BROWSER_DIR, { recursive: true });
+    profileDir = makeProfileDir('ff-svc-live-');
+    process.env.HOME = realHome;
+
+    const ff = await connectFirefox(
+      { name: 'firefox-live', browser: 'firefox', binary: FIREFOX, endpoints: { bidi: { target: `firefox-bidi://127.0.0.1:${PORT}` } }, userDataDir: profileDir, firefox: { profileName: 'live', iniPath: '', isDefault: false } },
+      KEY as never,
+      PORT,
+      { profileDir, headless: true },
+    );
+
+    service = new BrowserService();
+    conn = {
+      backend: 'bidi',
+      browserType: 'firefox',
+      bidi: ff.bidi,
+      firefoxProfile: { profileName: 'live', iniPath: '', isDefault: false },
+      sessionId: ff.sessionId,
+      profileDir,
+      port: ff.port,
+      pid: ff.pid,
+      key: KEY,
+      profile: 'firefox-live',
+      tasks: new Map(),
+      sessionCache: new Map(),
+    };
+    service.connections.set(KEY, conn);
+  }, 60_000);
+
+  afterAll(async () => {
+    try { conn?.bidi?.close?.(); } catch { /* ignore */ }
+    if (conn?.pid) { try { process.kill(conn.pid, 'SIGKILL'); } catch { /* gone */ } }
+    try { fs.rmSync(TEST_BROWSER_DIR, { recursive: true, force: true }); } catch { /* best-effort */ }
+    try { if (profileDir) fs.rmSync(profileDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('tab add opens a tab; a same-URL navigate refreshes it in place, no duplicate', async () => {
+    const task = seedTask('reopen');
+    const url = dataUrl('<title>A</title><h1>A</h1>');
+    const added = await service.tabAdd('reopen', url);
+    expect(added).toMatchObject({ created: true, refreshed: false });
+    const before = (await service.tabs('reopen')).length;
+
+    const again = await service.navigate('reopen', url);
+    expect(again.tabId).toBe(added.tabId); // same short id retained
+    expect(again).toMatchObject({ created: false, refreshed: true });
+    expect((await service.tabs('reopen')).length).toBe(before); // no duplicate tab
+    expect(Object.keys(task.tabs).length).toBe(before);
+  }, 60_000);
+
+  it('evaluate returns a structured value deserialized from BiDi', async () => {
+    seedTask('evalt');
+    await service.tabAdd('evalt', dataUrl('<title>Eval</title><p>hi</p>'));
+    const value = await service.evaluate('evalt', undefined, '({ t: document.title, p: document.querySelector("p").textContent, n: 3 })');
+    expect(value).toEqual({ t: 'Eval', p: 'hi', n: 3 });
+  }, 60_000);
+
+  it('refs → type → trusted click drives a form end to end', async () => {
+    seedTask('form');
+    await service.tabAdd(
+      'form',
+      dataUrl('<input id=q><button id=go onclick="document.getElementById(\'out\').textContent=\'clicked:\'+document.getElementById(\'q\').value">Go</button><div id=out></div>'),
+    );
+    const { refs } = await service.refs('form');
+    expect(refs).toContain('textbox');
+    expect(refs).toContain('button');
+
+    await service.type('form', 1, 'hello bidi', undefined, false);
+    expect(await service.evaluate('form', undefined, 'document.getElementById("q").value')).toBe('hello bidi');
+
+    await service.click('form', 2);
+    expect(await service.evaluate('form', undefined, 'document.getElementById("out").textContent')).toBe('clicked:hello bidi');
+  }, 60_000);
+
+  it('screenshot writes a real image file for a Firefox tab', async () => {
+    seedTask('shot');
+    await service.tabAdd('shot', dataUrl('<title>Shot</title><h1>shot</h1>'));
+    const out = path.join(TEST_BROWSER_DIR, 'shot.png');
+    const res = await service.screenshot('shot', undefined, out, 'raw');
+    expect(res.bytes).toBeGreaterThan(100);
+    expect(fs.existsSync(out)).toBe(true);
+    expect(fs.readFileSync(out).subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  }, 60_000);
+
+  it('an unsupported verb fails loud, naming a Chromium-family profile', async () => {
+    seedTask('nope');
+    await service.tabAdd('nope', dataUrl('<title>x</title>'));
+    await expect(service.printToPdf('nope')).rejects.toThrow(/Firefox.*does not support pdf|Chromium/i);
+  }, 60_000);
+
+  it('done closes the task tabs without killing Firefox', async () => {
+    seedTask('close');
+    await service.tabAdd('close', dataUrl('<title>C</title>'));
+    await service.done('close');
+    expect(conn.tasks.has('close')).toBe(false);
+    // Firefox is still up — other tasks can still run.
+    expect(conn.bidi.isOpen).toBe(true);
+  }, 60_000);
+});

--- a/cli/src/lib/browser/service.ts
+++ b/cli/src/lib/browser/service.ts
@@ -82,8 +82,24 @@ import type {
   PageOpenResult,
   ArcNativeProfileIdentity,
   ArcNativeTabRef,
+  FirefoxProfileIdentity,
 } from './types.js';
 import { resolveFfmpeg } from './ffmpeg.js';
+import {
+  FirefoxCapabilityError,
+  FirefoxBiDiClient,
+  connectFirefox,
+  bidiTopLevelContexts,
+  bidiCreateTab,
+  bidiNavigate,
+  bidiReload,
+  bidiCloseTab,
+  bidiActivate,
+  bidiEvaluate,
+  bidiScreenshot,
+  bidiSetViewport,
+  bidiClickAt,
+} from './drivers/firefox.js';
 import {
   ArcNativeCapabilityError,
   executeJavaScript,
@@ -316,6 +332,11 @@ async function isConnHealthy(conn: ProfileConnection, timeoutMs = 1000): Promise
   if (conn.backend === 'arc-native') {
     return isArcRunning();
   }
+  // Firefox BiDi connections: healthy while the WebSocket is open (a killed
+  // Firefox closes it). No lightweight round-trip verb is needed.
+  if (conn.backend === 'bidi') {
+    return conn.bidi.isOpen;
+  }
   if (!conn.cdp.isOpen) return false;
   try {
     await Promise.race([
@@ -384,13 +405,37 @@ interface ArcProfileConnection extends BaseProfileConnection {
   arcProfile: ArcNativeProfileIdentity;
 }
 
-type ProfileConnection = CdpProfileConnection | ArcProfileConnection;
+/**
+ * A Firefox connection driven over WebDriver BiDi (PHNX-4043). No CDP socket:
+ * `bidi` is the live BiDi client, and `firefoxProfile` is the discovered
+ * profile identity. Task tab ids map to BiDi browsing-context ids.
+ */
+interface FirefoxProfileConnection extends BaseProfileConnection {
+  backend: 'bidi';
+  browserType: 'firefox';
+  bidi: FirefoxBiDiClient;
+  firefoxProfile: FirefoxProfileIdentity;
+  /** The BiDi session id from `session.new`. */
+  sessionId: string;
+  /** Absolute Firefox profile directory this connection is bound to. */
+  profileDir: string;
+}
 
+type ProfileConnection = CdpProfileConnection | ArcProfileConnection | FirefoxProfileConnection;
+
+/**
+ * Narrow `conn` to the CDP backend, or throw the backend's capability error.
+ * Because the union now carries `arc-native` AND `bidi`, every action that
+ * reaches `conn.cdp` without a preceding backend branch fails to type-check —
+ * the compiler is the checklist that no verb silently calls CDP on a
+ * non-CDP connection.
+ */
 function requireCdp(
   conn: ProfileConnection,
   capability: string,
 ): asserts conn is CdpProfileConnection {
   if (conn.backend === 'arc-native') throw new ArcNativeCapabilityError(capability);
+  if (conn.backend === 'bidi') throw new FirefoxCapabilityError(capability);
 }
 
 /** Join error lines so callers get a next command, not a dead-end message. */
@@ -782,7 +827,7 @@ export class BrowserService {
     // pile-up in RUSH-2622. Tabs the daemon did NOT open are still left alone —
     // the branch only fires when the profile has no page target at all.
     let startupBlankTargetId: string | undefined;
-    if (!opts.url && !conn.electron && conn.backend !== 'arc-native') {
+    if (!opts.url && !conn.electron && conn.backend !== 'arc-native' && conn.backend !== 'bidi') {
       const { targetInfos } = (await conn.cdp.send('Target.getTargets')) as {
         targetInfos: Array<{ type: string }>;
       };
@@ -836,7 +881,7 @@ export class BrowserService {
     }
 
     // For Electron, get the existing window as the tab
-    if (conn.electron && conn.backend !== 'arc-native') {
+    if (conn.electron && conn.backend !== 'arc-native' && conn.backend !== 'bidi') {
       const windowId = await this.getOrCreateWindow(conn);
       if (windowId) {
         const shortId = generateShortId();
@@ -891,7 +936,13 @@ export class BrowserService {
     // opening a fresh target is created:true.
     let tabId: string | undefined;
     let firstOpen: PageOpenResult | undefined;
-    if (opts.url && conn.backend !== 'arc-native' && !conn.electron && conn.browserType !== 'arc') {
+    if (opts.url && conn.backend === 'bidi') {
+      // Firefox: the implicit first navigate opens a fresh tab (no adopt path —
+      // Firefox tabs aren't shared across abandoned tasks the way CDP ones are).
+      const result = await this.navigate(taskName, opts.url, effectiveKey);
+      tabId = result.tabId;
+      firstOpen = { tabId: result.tabId, created: result.created, refreshed: result.refreshed, message: result.message };
+    } else if (opts.url && conn.backend !== 'arc-native' && conn.backend !== 'bidi' && !conn.electron && conn.browserType !== 'arc') {
       const adopted = opts.fresh ? undefined : await this.adoptTabShowing(conn, opts.url);
       const targetId =
         adopted ?? (await this.createPageTarget(conn, { url: opts.url })).targetId;
@@ -1156,6 +1207,17 @@ export class BrowserService {
           }
           await this.saveToHistory(task, Array.from(domains));
           await this.closeArcNativeTabs(conn, task);
+        } else if (conn.backend === 'bidi') {
+          try {
+            for (const tab of await this.listFirefoxTaskTabs(conn, task)) {
+              try {
+                const domain = new URL(tab.url).hostname.replace(/^www\./, '');
+                if (domain && domain !== 'blank') domains.add(domain);
+              } catch { /* invalid URL */ }
+            }
+          } catch { /* Firefox not responding */ }
+          await this.saveToHistory(task, Array.from(domains));
+          await this.closeFirefoxTabs(conn, task);
         } else {
           try {
             const { targetInfos } = (await conn.cdp.send('Target.getTargets')) as {
@@ -1211,7 +1273,10 @@ export class BrowserService {
         }).catch(() => { /* fail soft */ });
 
         if (conn.forkedFrom && conn.tasks.size === 0) {
-          if (conn.backend !== 'arc-native') {
+          if (conn.backend === 'bidi') {
+            conn.bidi.close();
+            if (conn.pid) killChrome(conn.pid);
+          } else if (conn.backend !== 'arc-native') {
             conn.cdp.close();
             killChrome(conn.pid);
           }
@@ -1265,6 +1330,17 @@ export class BrowserService {
         clearProfileRuntime(key);
         continue;
       }
+      // Firefox: close the BiDi socket and kill the Firefox WE launched (pid !=
+      // 0). An attached Firefox the user started (pid 0) is left running — the
+      // CLI does not own that process, same as Arc.
+      if (conn.backend === 'bidi') {
+        conn.bidi.close();
+        if (conn.pid) killChrome(conn.pid);
+        conn.cleanup?.();
+        this.connections.delete(key);
+        clearProfileRuntime(key);
+        continue;
+      }
       conn.cdp.close();
       killChrome(conn.pid);
       conn.cleanup?.();
@@ -1308,6 +1384,10 @@ export class BrowserService {
     // Native Arc backend (PHNX-2399): route through the native driver instead of CDP.
     if (conn.backend === 'arc-native') {
       return this.navigateArcNative(conn, task, url);
+    }
+    // Firefox BiDi backend (PHNX-4043).
+    if (conn.backend === 'bidi') {
+      return this.navigateFirefox(conn, task, url);
     }
     requireCdp(conn, 'navigate');
 
@@ -1431,6 +1511,9 @@ export class BrowserService {
     if (conn.backend === 'arc-native') {
       return this.navigateArcNative(conn, task, url, true);
     }
+    if (conn.backend === 'bidi') {
+      return this.navigateFirefox(conn, task, url, true);
+    }
     requireCdp(conn, 'createTab');
     if (conn.electron) {
       throw new Error('Electron apps do not support opening additional tabs');
@@ -1469,6 +1552,12 @@ export class BrowserService {
       });
       return { tabId: resolvedTabId };
     }
+    if (conn.backend === 'bidi') {
+      await bidiActivate(conn.bidi, this.firefoxContext(task, resolvedTabId));
+      task.currentTabId = resolvedTabId;
+      await this.saveTaskState(task.profile, conn.tasks);
+      return { tabId: resolvedTabId };
+    }
     task.currentTabId = resolvedTabId;
     await this.saveTaskState(task.profile, conn.tasks);
     return { tabId: resolvedTabId };
@@ -1478,6 +1567,11 @@ export class BrowserService {
     const { conn, task } = await this.findTask(taskId);
     if (conn.backend === 'arc-native') {
       return (await this.listArcTaskTabs(task)).map((tab) => ({ ...tab, current: tab.current === true }));
+    }
+    if (conn.backend === 'bidi') {
+      return (await this.listFirefoxTaskTabs(conn, task)).map((tab) => ({
+        id: tab.id, url: tab.url, title: tab.title, current: tab.current === true,
+      }));
     }
     requireCdp(conn, 'enumerate');
     const targets = (await conn.cdp.send('Target.getTargets')) as {
@@ -1513,6 +1607,8 @@ export class BrowserService {
     // Native Arc addresses owned tabs only by the task's stable short id. URL
     // and title are display data and must never become fallback identities.
     if (conn.backend === 'arc-native') throw new Error(`Tab "${hint}" not found`);
+    // Firefox tabs are addressed by the task's stable short id too.
+    if (conn.backend === 'bidi') throw new Error(`Tab "${hint}" not found`);
 
     // URL substring match
     const targets = (await conn.cdp.send('Target.getTargets')) as {
@@ -1550,6 +1646,7 @@ export class BrowserService {
     if (taskId) {
       const { conn, task } = await this.findTask(taskId, profileRef);
       if (conn.backend === 'arc-native') return this.listArcTaskTabs(task);
+      if (conn.backend === 'bidi') return this.listFirefoxTaskTabs(conn, task);
       return this.getTabsForTask(conn.cdp, task);
     }
 
@@ -1558,7 +1655,9 @@ export class BrowserService {
       for (const [, task] of conn.tasks) {
         const tabs = conn.backend === 'arc-native'
           ? await this.listArcTaskTabs(task)
-          : await this.getTabsForTask(conn.cdp, task);
+          : conn.backend === 'bidi'
+            ? await this.listFirefoxTaskTabs(conn, task)
+            : await this.getTabsForTask(conn.cdp, task);
         allTabs.push(...tabs);
       }
     }
@@ -1588,6 +1687,27 @@ export class BrowserService {
         }
         await this.saveTaskState(task.profile, conn.tasks);
       });
+      return;
+    }
+    if (conn.backend === 'bidi') {
+      const borrowed = new Set(task.borrowedTabs ?? []);
+      const ids = tabHint === undefined
+        ? Object.keys(task.tabs)
+        : [await this.resolveTabHint(conn, task, tabHint)];
+      for (const shortId of ids) {
+        const context = task.tabs[shortId];
+        // A borrowed tab is released, not closed — it outlives this task.
+        if (context && !borrowed.has(shortId)) {
+          try { await bidiCloseTab(conn.bidi, context); } catch { /* already closed */ }
+        }
+        delete task.tabs[shortId];
+        delete task.refDescriptors?.[shortId];
+        task.borrowedTabs = (task.borrowedTabs ?? []).filter((id) => id !== shortId);
+      }
+      if (!task.currentTabId || ids.includes(task.currentTabId)) {
+        task.currentTabId = Object.keys(task.tabs).at(-1);
+      }
+      await this.saveTaskState(task.profile, conn.tasks);
       return;
     }
     requireCdp(conn, 'closeTab');
@@ -1641,6 +1761,10 @@ export class BrowserService {
     // Native Arc backend (PHNX-2399): synchronous JS only, isolated world.
     if (conn.backend === 'arc-native') {
       return this.evaluateArcNative(conn, task, shortId, expression);
+    }
+    // Firefox BiDi backend (PHNX-4043): async-capable, isolated realm.
+    if (conn.backend === 'bidi') {
+      return this.evaluateFirefox(conn, task, shortId, expression);
     }
 
     const cdpTargetId = this.getCdpTargetId(task, shortId);
@@ -1701,6 +1825,11 @@ export class BrowserService {
           'This task still belongs to the Arc profile. ' +
           'Use a Chromium-family browser for screenshot capability.',
       );
+    }
+
+    // Firefox BiDi backend (PHNX-4043): captureScreenshot on the context.
+    if (conn.backend === 'bidi') {
+      return this.screenshotFirefox(conn, task, runtimeKey, tabHint, outputPath, quality);
     }
 
     const shortId = tabHint ? await this.resolveTabHint(conn, task, tabHint) : this.resolveCurrentTab(task);
@@ -2173,6 +2302,17 @@ export class BrowserService {
       await this.saveTaskState(task.profile, conn.tasks);
       return result;
     }
+    // Firefox BiDi (PHNX-4043): the same DOM-derived accessibility listing Arc
+    // uses, evaluated over BiDi. selector-based refs, no CDP accessibility tree.
+    if (conn.backend === 'bidi') {
+      const result = parseArcRefsResult(
+        await this.evaluateFirefox(conn, task, shortId, arcRefsExpression(opts)),
+        opts,
+      );
+      this.cacheRefDescriptors(task, shortId, result.nodeMap, result.opts);
+      await this.saveTaskState(task.profile, conn.tasks);
+      return result;
+    }
     requireCdp(conn, 'enumerate');
     const cdpTargetId = this.getCdpTargetId(task, shortId);
 
@@ -2258,6 +2398,21 @@ export class BrowserService {
       await this.evaluateArcNative(conn, task, shortId, arcClickExpression(selector));
       return healed ? { healed } : {};
     }
+    if (conn.backend === 'bidi') {
+      const snapshot = task.refDescriptors?.[shortId];
+      const buildOpts = snapshot?.opts ?? { interactive: true, limit: 500 };
+      const { nodeMap } = parseArcRefsResult(
+        await this.evaluateFirefox(conn, task, shortId, arcRefsExpression(buildOpts)),
+        buildOpts,
+      );
+      const { targetRef, healed } = this.resolveHealedRef(snapshot, nodeMap, ref);
+      const selector = nodeMap.get(targetRef)?.selector;
+      if (!selector) throw new Error(`Ref ${ref} has no DOM selector`);
+      const coords = await this.firefoxRefCoords(conn, task, shortId, selector);
+      const context = this.firefoxContext(task, shortId);
+      await bidiClickAt(conn.bidi, context, coords.x, coords.y);
+      return healed ? { healed } : {};
+    }
     requireCdp(conn, 'click');
     const cdpTargetId = this.getCdpTargetId(task, shortId);
     const target = await this.getTarget(conn, cdpTargetId);
@@ -2318,6 +2473,19 @@ export class BrowserService {
       const selector = nodeMap.get(targetRef)?.selector;
       if (!selector) throw new Error(`Ref ${ref} has no DOM selector`);
       await this.evaluateArcNative(conn, task, shortId, arcFillExpression(selector, text, clear ?? false));
+      return;
+    }
+    if (conn.backend === 'bidi') {
+      const snapshot = task.refDescriptors?.[shortId];
+      const buildOpts = snapshot?.opts ?? { interactive: true, limit: 500 };
+      const { nodeMap } = parseArcRefsResult(
+        await this.evaluateFirefox(conn, task, shortId, arcRefsExpression(buildOpts)),
+        buildOpts,
+      );
+      const { targetRef } = this.resolveHealedRef(snapshot, nodeMap, ref);
+      const selector = nodeMap.get(targetRef)?.selector;
+      if (!selector) throw new Error(`Ref ${ref} has no DOM selector`);
+      await this.evaluateFirefox(conn, task, shortId, arcFillExpression(selector, text, clear ?? false));
       return;
     }
     requireCdp(conn, 'type');
@@ -2384,6 +2552,10 @@ export class BrowserService {
     if (conn.backend === 'arc-native') {
       if (atX !== undefined || atY !== undefined) throw new ArcNativeCapabilityError('trustedInput');
       await this.evaluateArcNative(conn, task, shortId, arcScrollExpression(deltaX, deltaY));
+      return;
+    }
+    if (conn.backend === 'bidi') {
+      await this.evaluateFirefox(conn, task, shortId, arcScrollExpression(deltaX, deltaY));
       return;
     }
     requireCdp(conn, 'scroll');
@@ -3082,7 +3254,8 @@ export class BrowserService {
     }
 
     for (const [, conn] of this.connections) {
-      if (conn.backend !== 'arc-native') conn.cdp.close();
+      if (conn.backend === 'bidi') conn.bidi.close();
+      else if (conn.backend !== 'arc-native') conn.cdp.close();
       conn.cleanup?.();
     }
     this.connections.clear();
@@ -3162,6 +3335,12 @@ export class BrowserService {
   ): Promise<ProfileConnection> {
     const existingInfo = getRunningChromeInfo(key);
     const tunnelled = opts.persistRemote || target.startsWith('ssh:');
+    // Native Arc and Firefox BiDi speak their own transport, not CDP — never
+    // route them through the CDP reuse branch (which would probe /json/version
+    // and wipe the runtime meta the Firefox driver wrote). connectEndpoint owns
+    // their attach-or-launch decision.
+    const nativeTransport =
+      target.startsWith('arc-native:') || target.startsWith('firefox-bidi:');
 
     if (tunnelled) {
       // A leftover local chrome-data / pid file under this key is the
@@ -3172,7 +3351,7 @@ export class BrowserService {
       if (meta && meta.kind !== 'tunnel') {
         clearProfileRuntime(key);
       }
-    } else if (existingInfo) {
+    } else if (existingInfo && !nativeTransport) {
       try {
         const { wsUrl, browser } = await discoverBrowserWsUrl(
           existingInfo.port,
@@ -3300,6 +3479,42 @@ export class BrowserService {
       };
     }
 
+    // Firefox BiDi backend (PHNX-4043): `firefox-bidi://127.0.0.1:<port>` connects
+    // over a WebDriver BiDi WebSocket. The driver attaches to a Firefox already
+    // serving the port, else launches one headless bound to the pinned profile
+    // directory, else fails loud (Firefox is single-instance per profile).
+    if (url.protocol === 'firefox-bidi:') {
+      if (!profile.firefox) {
+        throw new Error(
+          `Firefox profile "${profile.name}" has no discovered profile metadata. ` +
+            `Re-select it with: agents browser use ${profile.name}`,
+        );
+      }
+      const profileDir = profile.userDataDir;
+      if (!profileDir) {
+        throw new Error(`Firefox profile "${profile.name}" has no profile directory.`);
+      }
+      const port = parseInt(url.port || '9600', 10);
+      const conn = await connectFirefox(profile, key, port, {
+        profileDir,
+        headless: profile.chrome?.headless,
+      });
+      return {
+        backend: 'bidi',
+        browserType: 'firefox',
+        bidi: conn.bidi,
+        firefoxProfile: profile.firefox,
+        sessionId: conn.sessionId,
+        profileDir,
+        port: conn.port,
+        pid: conn.pid,
+        electron: false,
+        targetFilter: profile.targetFilter,
+        tasks: this.loadTaskState(key),
+        sessionCache: new Map(),
+      };
+    }
+
     // Native Arc backend (PHNX-2399): `arc-native:` protocol connects through
     // Apple Events instead of CDP. No debugging port, no browser launch.
     if (url.protocol === 'arc-native:') {
@@ -3354,6 +3569,8 @@ export class BrowserService {
     if (conn.browserType === 'arc') {
       throw arcNotDrivableError(conn.profile);
     }
+    // Firefox opens tabs through the BiDi driver, never Target.createTarget.
+    requireCdp(conn, 'createTab');
     return (await conn.cdp.send('Target.createTarget', params)) as { targetId: string };
   }
 
@@ -3910,6 +4127,42 @@ export class BrowserService {
       };
     }
 
+    // Firefox BiDi endpoints (PHNX-4043): a daemon restart dropped the BiDi
+    // socket, but the Firefox we launched is still serving the port — reattach
+    // by opening a fresh session, then merge the disk tasks. connectFirefox
+    // attaches (never launches) when the port is already served. A failure
+    // returns null like the CDP path, so the caller falls through to disk
+    // reconcile instead of crashing.
+    if (resolved.target.startsWith('firefox-bidi:')) {
+      if (!profile.firefox || !profile.userDataDir) return null;
+      const port = parseEndpointUrl(resolved.target)?.port ?? 9600;
+      try {
+        const ff = await connectFirefox(profile, key, port, { profileDir: profile.userDataDir });
+        const tasks = this.loadTaskState(key);
+        for (const [k, t] of diskTasks) {
+          if (!tasks.has(k)) tasks.set(k, t);
+        }
+        return {
+          backend: 'bidi',
+          browserType: 'firefox',
+          bidi: ff.bidi,
+          firefoxProfile: profile.firefox,
+          sessionId: ff.sessionId,
+          profileDir: profile.userDataDir,
+          port: ff.port,
+          pid: ff.pid,
+          electron: false,
+          targetFilter: profile.targetFilter,
+          key,
+          profile: bare,
+          tasks,
+          sessionCache: new Map(),
+        };
+      } catch {
+        return null;
+      }
+    }
+
     const existingInfo = getRunningChromeInfo(key);
     const parsed = parseEndpointUrl(resolved.target);
     const port = existingInfo?.port ?? parsed?.port;
@@ -4025,8 +4278,10 @@ export class BrowserService {
       try { conn.cleanup(); } catch { /* best effort — the winner stays live */ }
     } else {
       // Shared/borrowed tunnel (or a local connection with no tunnel): close
-      // only our own CDP client; killing the tunnel would break the winner.
-      if (conn.backend !== 'arc-native') {
+      // only our own client; killing the tunnel would break the winner.
+      if (conn.backend === 'bidi') {
+        try { conn.bidi.close(); } catch { /* best effort */ }
+      } else if (conn.backend !== 'arc-native') {
         try { conn.cdp.close(); } catch { /* best effort */ }
       }
     }
@@ -4064,7 +4319,7 @@ export class BrowserService {
       const registered = this.registerRehydratedConnection(key, conn);
       if (registered !== conn) continue;
       try {
-        if (conn.backend !== 'arc-native') await this.applyDefaultDownloadBehavior(conn, key);
+        if (conn.backend !== 'arc-native' && conn.backend !== 'bidi') await this.applyDefaultDownloadBehavior(conn, key);
       } catch {
         // Non-fatal for rehydrate.
       }
@@ -4128,7 +4383,7 @@ export class BrowserService {
         conn = this.registerRehydratedConnection(key, attached);
         if (conn === attached) {
           try {
-            if (conn.backend !== 'arc-native') await this.applyDefaultDownloadBehavior(conn, key);
+            if (conn.backend !== 'arc-native' && conn.backend !== 'bidi') await this.applyDefaultDownloadBehavior(conn, key);
           } catch {
             // Non-fatal.
           }
@@ -4201,6 +4456,40 @@ export class BrowserService {
         running: await isArcRunning(),
         port: 0,
         pid: 0,
+        tasks,
+      };
+    }
+
+    if (conn.backend === 'bidi') {
+      const tasks: TaskStatus[] = [];
+      for (const task of conn.tasks.values()) {
+        let tabs: TabInfo[] = [];
+        try { tabs = await this.listFirefoxTaskTabs(conn, task); } catch { /* Firefox down */ }
+        const domains = tabs.flatMap((tab) => {
+          try {
+            const domain = new URL(tab.url).hostname.replace(/^www\./, '');
+            return domain && domain !== 'blank' ? [domain] : [];
+          } catch { return []; }
+        });
+        tasks.push({
+          id: task.id,
+          name: task.name,
+          label: task.label ?? task.name,
+          tabCount: Object.keys(task.tabs).length,
+          currentTabId: task.currentTabId,
+          createdAt: task.createdAt,
+          tabs: tabs.length ? tabs.map((t) => ({ id: t.id, url: t.url, title: t.title, current: t.current })) : undefined,
+          domains: domains.length ? [...new Set(domains)] : undefined,
+        });
+      }
+      const parsed = parseConnectionKey(key);
+      return {
+        name: conn.profile ?? parsed.profile,
+        endpoint: parsed.endpoint,
+        key,
+        running: conn.bidi.isOpen,
+        port: conn.port,
+        pid: conn.pid,
         tasks,
       };
     }
@@ -4452,7 +4741,9 @@ export class BrowserService {
     const conn = this.connections.get(key);
     if (!conn) return undefined;
     if (await isConnHealthy(conn)) return conn;
-    if (conn.backend !== 'arc-native') {
+    if (conn.backend === 'bidi') {
+      try { conn.bidi.close(); } catch { /* already closed */ }
+    } else if (conn.backend !== 'arc-native') {
       try { conn.cdp.close(); } catch { /* already closed */ }
     }
     conn.cleanup?.();
@@ -4722,6 +5013,219 @@ export class BrowserService {
     });
   }
 
+  // ---------------------------------------------------------------------------
+  // Firefox WebDriver BiDi backend helpers (PHNX-4043)
+  // ---------------------------------------------------------------------------
+
+  /** The BiDi browsing-context id a task owns for `shortId`. */
+  private firefoxContext(task: Task, shortId: string): string {
+    const context = task.tabs[shortId];
+    if (!context) throw new Error(`Tab ${shortId} not found`);
+    return context;
+  }
+
+  /** The context ids currently live in this Firefox (a killed tab drops out). */
+  private async firefoxLiveContexts(conn: FirefoxProfileConnection): Promise<Set<string>> {
+    const contexts = await bidiTopLevelContexts(conn.bidi);
+    return new Set(contexts.map((c) => c.context));
+  }
+
+  /**
+   * Same-task reopen for Firefox (mirrors {@link reopenOwnedTab}): the URL is
+   * already live in one of this task's own tabs → reload THAT tab in place and
+   * keep its id, rather than opening a duplicate. Borrowed tabs are excluded —
+   * Firefox never borrows, but the guard keeps parity. Returns the retained
+   * short id, or undefined when nothing matches.
+   */
+  private async reopenOwnedFirefoxTab(
+    conn: FirefoxProfileConnection,
+    task: Task,
+    url: string,
+  ): Promise<{ tabId: string } | undefined> {
+    const borrowed = new Set(task.borrowedTabs ?? []);
+    const live = await this.firefoxLiveContexts(conn);
+    const wanted = canonicalTabUrl(url);
+    for (const [shortId, context] of Object.entries(task.tabs)) {
+      if (borrowed.has(shortId)) continue;
+      if (!live.has(context)) continue;
+      const current = await bidiEvaluate(conn.bidi, context, 'location.href');
+      if (canonicalTabUrl(String(current)) === wanted) {
+        await bidiReload(conn.bidi, context);
+        task.currentTabId = shortId;
+        await this.saveTaskState(task.profile, conn.tasks);
+        return { tabId: shortId };
+      }
+    }
+    return undefined;
+  }
+
+  private async navigateFirefox(
+    conn: FirefoxProfileConnection,
+    task: Task,
+    url: string,
+    addTab = false,
+  ): Promise<{ tabId: string; url: string; created: boolean; refreshed: boolean; message?: string }> {
+    if (!addTab) {
+      const reopened = await this.reopenOwnedFirefoxTab(conn, task, url);
+      if (reopened) {
+        emit('browser.navigate', { profile: parseConnectionKey(task.profile).profile, task: task.name, url, tabId: reopened.tabId, created: false });
+        return { tabId: reopened.tabId, url, created: false, refreshed: true, message: 'Tab already open—refreshed' };
+      }
+      // Reuse the current tab when there is one — navigate() semantics.
+      const currentShortId = task.currentTabId;
+      if (currentShortId && task.tabs[currentShortId]) {
+        const context = task.tabs[currentShortId];
+        const live = await this.firefoxLiveContexts(conn);
+        if (live.has(context)) {
+          await bidiNavigate(conn.bidi, context, url);
+          await this.saveTaskState(task.profile, conn.tasks);
+          emit('browser.navigate', { profile: parseConnectionKey(task.profile).profile, task: task.name, url, tabId: currentShortId, created: false });
+          return { tabId: currentShortId, url, created: false, refreshed: false };
+        }
+      }
+    } else {
+      const reopened = await this.reopenOwnedFirefoxTab(conn, task, url);
+      if (reopened) {
+        return { tabId: reopened.tabId, url, created: false, refreshed: true, message: 'Tab already open—refreshed' };
+      }
+    }
+    // Open a fresh tab.
+    const context = await bidiCreateTab(conn.bidi);
+    await bidiNavigate(conn.bidi, context, url);
+    const shortId = generateShortId();
+    task.tabs[shortId] = context;
+    task.currentTabId = shortId;
+    await this.saveTaskState(task.profile, conn.tasks);
+    emit('browser.navigate', { profile: parseConnectionKey(task.profile).profile, task: task.name, url, tabId: shortId, created: true });
+    return { tabId: shortId, url, created: true, refreshed: false };
+  }
+
+  private async evaluateFirefox(
+    conn: FirefoxProfileConnection,
+    task: Task,
+    shortId: string,
+    expression: string,
+  ): Promise<unknown> {
+    const context = this.firefoxContext(task, shortId);
+    const live = await this.firefoxLiveContexts(conn);
+    if (!live.has(context)) throw new Error(`Tab ${shortId} is no longer open in Firefox.`);
+    return bidiEvaluate(conn.bidi, context, expression);
+  }
+
+  private async listFirefoxTaskTabs(conn: FirefoxProfileConnection, task: Task): Promise<TabInfo[]> {
+    const live = await bidiTopLevelContexts(conn.bidi);
+    const byId = new Map(live.map((c) => [c.context, c]));
+    const tabs: TabInfo[] = [];
+    for (const [shortId, context] of Object.entries(task.tabs)) {
+      const info = byId.get(context);
+      if (!info) continue; // tab closed out from under the task — drop it silently.
+      let title = '';
+      try {
+        title = String(await bidiEvaluate(conn.bidi, context, 'document.title'));
+      } catch {
+        /* about: pages or a mid-navigation context — url is enough */
+      }
+      tabs.push({ id: shortId, url: info.url, title, task: task.name, current: shortId === task.currentTabId });
+    }
+    return tabs;
+  }
+
+  /**
+   * Close every non-borrowed tab a Firefox task owns. Never kills the Firefox
+   * process (that is `stopProfile`'s job) — a killed browser would take the
+   * user's other tabs with it. A tab already gone is skipped.
+   */
+  private async closeFirefoxTabs(conn: FirefoxProfileConnection, task: Task): Promise<void> {
+    const borrowed = new Set(task.borrowedTabs ?? []);
+    const live = await this.firefoxLiveContexts(conn);
+    for (const [shortId, context] of Object.entries(task.tabs)) {
+      if (borrowed.has(shortId)) continue;
+      if (live.has(context)) {
+        try { await bidiCloseTab(conn.bidi, context); } catch { /* already closed */ }
+      }
+    }
+  }
+
+  /**
+   * Viewport-center coordinates of a selector-addressed element in a Firefox
+   * tab, scrolled into view first — the (x, y) `input.performActions` clicks.
+   * Throws when the element is gone or has zero size (off-screen / display:none).
+   */
+  private async firefoxRefCoords(
+    conn: FirefoxProfileConnection,
+    task: Task,
+    shortId: string,
+    selector: string,
+  ): Promise<{ x: number; y: number }> {
+    const expr = `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) throw new Error('DOM ref is missing');
+      el.scrollIntoView({ block: 'center', inline: 'center' });
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) throw new Error('DOM ref has no layout box');
+      return JSON.stringify({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
+    })()`;
+    const raw = await this.evaluateFirefox(conn, task, shortId, expr);
+    const parsed = JSON.parse(String(raw)) as { x: number; y: number };
+    return parsed;
+  }
+
+  /**
+   * Screenshot a Firefox tab over BiDi. Same output contract as the CDP path:
+   * `raw` is a pixel-faithful PNG; the default is JPEG iteratively downscaled
+   * under 100 KB so chat-injected screenshots stay token-cheap.
+   */
+  private async screenshotFirefox(
+    conn: FirefoxProfileConnection,
+    task: Task,
+    runtimeKey: ConnectionKey,
+    tabHint: string | undefined,
+    outputPath: string | undefined,
+    quality: 'compressed' | 'raw',
+  ): Promise<{ path: string; bytes: number; width: number; height: number }> {
+    const shortId = tabHint ? await this.resolveTabHint(conn, task, tabHint) : this.resolveCurrentTab(task);
+    const context = this.firefoxContext(task, shortId);
+    const live = await this.firefoxLiveContexts(conn);
+    if (!live.has(context)) throw new Error(`Tab ${shortId} is no longer open in Firefox.`);
+
+    let buffer: Buffer;
+    let extension: string;
+    if (quality === 'raw') {
+      buffer = await bidiScreenshot(conn.bidi, context, { type: 'image/png' });
+      extension = 'png';
+    } else {
+      buffer = await bidiScreenshot(conn.bidi, context, { type: 'image/jpeg', quality: 0.7 });
+      const MAX_SIZE = 100 * 1024;
+      let q = 0.5;
+      while (buffer.length > MAX_SIZE && q > 0.1) {
+        buffer = await bidiScreenshot(conn.bidi, context, { type: 'image/jpeg', quality: q });
+        q -= 0.1;
+      }
+      extension = 'jpg';
+    }
+
+    const sessionsDir = getProfileSessionsDir(runtimeKey, task.name);
+    const automaticPath = path.join(sessionsDir, `${Date.now()}.${extension}`);
+    const finalPath = resolveScreenshotOutputPath(outputPath, automaticPath);
+    await fs.promises.mkdir(path.dirname(finalPath), { recursive: true });
+    await fs.promises.writeFile(finalPath, buffer);
+
+    const dims =
+      (extension === 'png' ? readPngDimensions(buffer) : readJpegDimensions(buffer)) ??
+      { width: 0, height: 0 };
+    emit('browser.screenshot', {
+      profile: parseConnectionKey(runtimeKey).profile,
+      task: task.name,
+      tabId: shortId,
+      path: finalPath,
+      bytes: buffer.length,
+      width: dims.width,
+      height: dims.height,
+      quality,
+    });
+    return { path: finalPath, bytes: buffer.length, width: dims.width, height: dims.height };
+  }
+
   /** Connect a profile at `target`, register it under `key`, and arm downloads. */
   private async openConnection(
     profile: BrowserProfile,
@@ -4734,8 +5238,8 @@ export class BrowserService {
     conn.key = key;
     conn.profile = profileName;
     this.connections.set(key, conn);
-    // Download behavior configuration is CDP-specific; skip for native Arc.
-    if (conn.backend !== 'arc-native') {
+    // Download behavior configuration is CDP-specific; skip for native Arc + Firefox.
+    if (conn.backend !== 'arc-native' && conn.backend !== 'bidi') {
       await this.applyDefaultDownloadBehavior(conn, key);
     }
     return conn;
@@ -4792,6 +5296,13 @@ export class BrowserService {
       throw new ArcNativeCapabilityError(
         'show',
         'Task-less viewer tabs are unavailable for native Arc because creation intent cannot be bound to an owning task.',
+      );
+    }
+    if (conn.backend === 'bidi') {
+      throw new FirefoxCapabilityError(
+        'show',
+        'Task-less viewer tabs are unavailable for a headless-automation Firefox profile. ' +
+          'Use a Chromium-family profile, or open the URL in your OS browser.',
       );
     }
 

--- a/cli/src/lib/browser/service.ts
+++ b/cli/src/lib/browser/service.ts
@@ -97,7 +97,6 @@ import {
   bidiActivate,
   bidiEvaluate,
   bidiScreenshot,
-  bidiSetViewport,
   bidiClickAt,
 } from './drivers/firefox.js';
 import {
@@ -5043,13 +5042,20 @@ export class BrowserService {
     url: string,
   ): Promise<{ tabId: string } | undefined> {
     const borrowed = new Set(task.borrowedTabs ?? []);
-    const live = await this.firefoxLiveContexts(conn);
+    // Read each live tab's URL from browsingContext.getTree metadata rather than
+    // evaluating location.href per tab: the same source the CDP path reads
+    // (Target.getTargets), so a mid-navigation or just-closed sibling tab can
+    // never throw a BiDi "no such frame" and fail an unrelated navigate. A tab
+    // absent from the tree is simply not a reopen candidate.
+    const liveUrlByContext = new Map(
+      (await bidiTopLevelContexts(conn.bidi)).map((c) => [c.context, c.url]),
+    );
     const wanted = canonicalTabUrl(url);
     for (const [shortId, context] of Object.entries(task.tabs)) {
       if (borrowed.has(shortId)) continue;
-      if (!live.has(context)) continue;
-      const current = await bidiEvaluate(conn.bidi, context, 'location.href');
-      if (canonicalTabUrl(String(current)) === wanted) {
+      const liveUrl = liveUrlByContext.get(context);
+      if (liveUrl === undefined) continue; // registered but gone from the browser
+      if (canonicalTabUrl(liveUrl) === wanted) {
         await bidiReload(conn.bidi, context);
         task.currentTabId = shortId;
         await this.saveTaskState(task.profile, conn.tasks);

--- a/cli/src/lib/browser/testdata/firefox/profiles-empty.ini
+++ b/cli/src/lib/browser/testdata/firefox/profiles-empty.ini
@@ -1,0 +1,3 @@
+[General]
+StartWithLastProfile=1
+Version=2

--- a/cli/src/lib/browser/testdata/firefox/profiles-malformed.ini
+++ b/cli/src/lib/browser/testdata/firefox/profiles-malformed.ini
@@ -1,0 +1,3 @@
+[Profile0]
+IsRelative=1
+Path=missing-name.default

--- a/cli/src/lib/browser/testdata/firefox/profiles-valid.ini
+++ b/cli/src/lib/browser/testdata/firefox/profiles-valid.ini
@@ -1,0 +1,23 @@
+[Install4F96D1932A9F858E]
+Default=abcd1234.default-release
+Locked=1
+
+[Profile1]
+Name=default-release
+IsRelative=1
+Path=abcd1234.default-release
+Default=1
+
+[Profile0]
+Name=default
+IsRelative=1
+Path=wxyz5678.default
+
+[Profile2]
+Name=Dev Edition
+IsRelative=1
+Path=/opt/firefox-dev/profile
+
+[General]
+StartWithLastProfile=1
+Version=2

--- a/cli/src/lib/browser/types.ts
+++ b/cli/src/lib/browser/types.ts
@@ -2,18 +2,21 @@ import type { ArcNativeTabRef } from './drivers/arc.js';
 
 export type { ArcNativeTabRef } from './drivers/arc.js';
 
-export type BrowserType = 'chrome' | 'comet' | 'chromium' | 'brave' | 'edge' | 'arc' | 'custom';
+export type BrowserType = 'chrome' | 'comet' | 'chromium' | 'brave' | 'edge' | 'arc' | 'firefox' | 'custom';
 
 /**
  * The transport backend a live browser connection uses (PHNX-2399).
  *   - `cdp` — Chrome DevTools Protocol (the existing path for all Chromium-family browsers).
  *   - `arc-native` — Apple Events via `osascript` (the native Arc path, no CDP port required).
+ *   - `bidi` — WebDriver BiDi over a WebSocket (Firefox, PHNX-4043; Firefox 129+
+ *     ships no CDP at all).
  *
  * Load-bearing: every action method on `BrowserService` that calls `conn.cdp.send()`
  * must check `conn.backend` and route to the native driver instead when it is
- * `arc-native`. Unsupported native verbs throw `ArcNativeCapabilityError`.
+ * `arc-native` or `bidi`. Unsupported verbs throw `ArcNativeCapabilityError` /
+ * `FirefoxCapabilityError`.
  */
-export type BackendKind = 'cdp' | 'arc-native';
+export type BackendKind = 'cdp' | 'arc-native' | 'bidi';
 
 /**
  * Stable native identity carried by an Arc profile declaration (PHNX-2399).
@@ -222,6 +225,27 @@ export interface BrowserProfile {
   logHost?: string;
   /** Native Arc identity. Present only for an `arc-native:` profile. */
   arc?: ArcNativeProfileIdentity;
+  /**
+   * The Firefox profile this agents-cli profile is pinned to (PHNX-4043).
+   * Present only for a `bidi:` profile discovered from `profiles.ini`; the
+   * directory itself is {@link userDataDir}, which is what Firefox is launched
+   * with (`--profile <dir>`).
+   */
+  firefox?: FirefoxProfileIdentity;
+}
+
+/**
+ * Stable identity of a Firefox profile discovered from `profiles.ini` (PHNX-4043).
+ * One agents-cli profile is one Firefox profile: it already carries the cookies
+ * and logins, so agents never learn a second concept.
+ */
+export interface FirefoxProfileIdentity {
+  /** The `Name=` of the `[ProfileN]` section. Display + slug source only. */
+  profileName: string;
+  /** The `profiles.ini` the entry was read from. Display only. */
+  iniPath: string;
+  /** Whether `profiles.ini` marks the entry `Default=1`. Display only. */
+  isDefault: boolean;
 }
 
 /** Parsed form of `BrowserProfile.targetFilter`. */

--- a/cli/src/lib/open-url.ts
+++ b/cli/src/lib/open-url.ts
@@ -163,6 +163,12 @@ export async function resolveViewer(opts: ShowOptions = {}): Promise<'os' | { pr
     console.error(`[viewer] "${resolved}" is Arc, which cannot open a new viewer tab — using the OS browser.`);
     return 'os';
   }
+  if (profile.browser === 'firefox') {
+    // agents drives Firefox headless over BiDi for its own read-back; a page a
+    // human is meant to read goes to the visible OS browser, not the headless one.
+    console.error(`[viewer] "${resolved}" is a headless-automation Firefox profile — using the OS browser.`);
+    return 'os';
+  }
   if (!isProfileLaunchableHere(profile)) {
     console.error(`[viewer] "${resolved}" cannot launch on this machine — using the OS browser.`);
     return 'os';

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -1329,7 +1329,7 @@ export interface HostEntry {
 /** Browser profile definition stored in agents.yaml. */
 export interface BrowserProfileConfig {
   description?: string;
-  browser: 'chrome' | 'comet' | 'chromium' | 'brave' | 'edge' | 'arc' | 'custom';
+  browser: 'chrome' | 'comet' | 'chromium' | 'brave' | 'edge' | 'arc' | 'firefox' | 'custom';
   binary?: string;
   electron?: boolean;
   /**
@@ -1392,6 +1392,12 @@ export interface BrowserProfileConfig {
     profileName: string;
     spaceId: string;
     spaceTitle: string;
+  };
+  /** The `profiles.ini` entry a discovered Firefox profile is pinned to (PHNX-4043); the dir is `userDataDir`. */
+  firefox?: {
+    profileName: string;
+    iniPath: string;
+    isDefault: boolean;
   };
 }
 


### PR DESCRIPTION
## What

Firefox 129 removed the Chrome DevTools Protocol, so `agents browser` gains a new transport rather than a CDP variant: a `firefox` BrowserType and a `bidi` backend on `ProfileConnection`, following the existing `arc-native` backend discriminator. `requireCdp()` now narrows away both non-CDP backends, so any action that reaches `conn.cdp` without a backend branch is a compile error.

- **Driver** (`drivers/firefox.ts`): launches `firefox --remote-debugging-port <port> --profile <dir> --no-remote [--headless]`, connects the WebDriver BiDi WebSocket, runs `session.new`, then `browsingContext.create/navigate/reload/close/getTree/captureScreenshot`, `script.evaluate`, and `input.performActions`. Attaches to a Firefox already serving the port; fails loud (mirroring `attachOnlyRequiredError`) when a portless Firefox already holds the profile, since Firefox is single-instance per profile directory.
- **Discovery** (`firefox-discovery.ts`): reads `profiles.ini` (including the Ubuntu snap location `~/snap/firefox/common/.mozilla/firefox`) and lists one profile per entry — `firefox-default`, `firefox-default-release`, … — pinned to that profile directory and a stable BiDi port. A torn or failed read never breaks listing the other browsers. Same shape as Arc Space discovery.
- **Service verbs**: start, navigate, tab add, tabs, tab focus, tab close, evaluate, refs, click (trusted pointer via `input.performActions`), fill/type, scroll, screenshot, status, stop/done, plus daemon-restart reattach — with the same same-task reopen semantics as the rest of the service. Unsupported verbs (network capture, upload, pdf, key input, viewport emulation, recording) fail loud with a structured `FirefoxCapabilityError` naming a Chromium-family profile.
- Firefox profiles command-dispatch to their owner device (a local BiDi socket cannot be tunnelled), the same routing Arc native uses.

## Verification — installed-from-worktree CLI driving real Firefox 155.0.1 on yosemite-s1

Built and installed with `cli/scripts/install.sh --skip-tests` (`agents-dev`), then drove a real headless Firefox profile end to end over BiDi:

~~~
$ agents-dev browser start --device yosemite-s1 --profile firefox-agents-e2e --url https://example.com --json
{ "ok": true, "task": "482b05a2", "tabId": "ee4d7a9a", "device": "yosemite-s1", "profile": "firefox-agents-e2e", "created": true }

$ agents-dev browser evaluate --task 482b05a2 '({url: location.href, links: document.querySelectorAll("a").length, nested:{a:true}})'
{ ... "nested": { "a": true } }            # BiDi RemoteValue deserialized to plain JS

$ agents-dev browser refs --task 482b05a2
- link "Learn more" [ref=1]

$ agents-dev browser navigate --task 482b05a2 --url https://example.com
Tab already open—refreshed                 # same-task reopen: no duplicate tab

$ agents-dev browser tab add --task 482b05a2 --url https://www.iana.org/help
Opened tab f28ece82: https://www.iana.org/help

# form drive: type (DOM fill + input/change) then trusted click (input.performActions)
$ agents-dev browser type  --task 482b05a2 1 --text "hello bidi"     # -> input value = "hello bidi"
$ agents-dev browser click --task 482b05a2 2                          # -> out = "clicked:hello bidi"

$ agents-dev browser screenshot --task 482b05a2 -o /tmp/phnx4043-firefox-bidi.png
Saved screenshot to /tmp/phnx4043-firefox-bidi.png (20 KB, 1366×682)

# unsupported verbs fail loud, naming a Chromium-family profile
$ agents-dev browser pdf      --task ...  -> Firefox (WebDriver BiDi) does not support pdf. Use a Chromium-family profile ...
$ agents-dev browser requests --task ...  -> Firefox (WebDriver BiDi) does not support networkCapture. Use a Chromium-family profile ...
~~~

The captured screenshot (`/tmp/phnx4043-firefox-bidi-raw.png`) shows the form with the field reading **hello bidi** and the page output **clicked:hello bidi**, confirming the trusted type+click path drove real Firefox.

## Tests (beside source, real Firefox, no mocking)

- `firefox-discovery.test.ts` — `profiles.ini` parsing, discovery, port derivation (always runs).
- `drivers/firefox.test.ts` — `deserializeBidi`, error wording (always run), plus a live block that launches real Firefox and drives create/navigate/evaluate/screenshot/close and a trusted `input.performActions` click.
- `service.firefox.live.test.ts` — BrowserService over BiDi: reopen (no duplicate), evaluate, refs→type→click, screenshot, unsupported-verb failure, done.

Live tests gate on `AGENTS_TEST_FIREFOX` and skip cleanly without Firefox. On yosemite-s1:

~~~
$ AGENTS_TEST_FIREFOX=/usr/bin/firefox vitest run src/lib/browser/drivers/firefox.test.ts src/lib/browser/service.firefox.live.test.ts
Test Files  2 passed (2)   Tests  14 passed (14)
~~~

Command index (`bun scripts/gen-command-index.ts`) and docs (`docs/browser.md`) regenerated; `verify-command-index.sh` and `verify-docs.sh` green. Changelog fragment added at `.changelog/next/firefox-bidi.md`.