### PR TITLE
ci(scope): the CLI install is the typecheck; stop building twice per selected run

### DIFF
--- a/scripts/ci-scope.test.ts
+++ b/scripts/ci-scope.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import {
   IMPACT_BUDGET_SEC,
+  type ImpactPlan,
   canReuseProof,
   changedFilesBetween,
   isVitestWorkerCrashWithZeroFailures,
@@ -20,6 +21,7 @@ import {
   commandForTestFile,
   commandsForPlan,
   companionCandidates,
+  installCommandsForPlan,
   existingCompanions,
   formatGitHubOutputs,
   loadOwnershipManifest,
@@ -857,6 +859,32 @@ describe('commandsForPlan', () => {
       suite: 'selected',
     }, REPO);
     for (const c of batched) expect(c.cmd).not.toContain('--');
+  });
+});
+
+describe('typecheck runs once per selected run (PR #3568)', () => {
+  test('the CLI install is the typecheck: prepare builds with tsc, and the check adds no second build', () => {
+    // Half one: the package's install lifecycle really is a tsc build. If this
+    // ever stops being true the `typecheck` check must run a build again.
+    const pkg = JSON.parse(readFileSync(join(REPO, 'cli', 'package.json'), 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts.prepare).toBe('npm run build');
+    expect(pkg.scripts.build.startsWith('tsc')).toBe(true);
+
+    // Half two: a plan that asks for typecheck installs the CLI (which builds)
+    // and runs no separate build command.
+    const plan = {
+      ...selectImpact({ files: ['cli/src/commands/webhook.ts'], repoRoot: REPO, related: false }),
+      tests: [],
+      checks: ['typecheck'] as ImpactPlan['checks'],
+      suite: 'selected' as const,
+    };
+    const install = installCommandsForPlan(plan, REPO);
+    expect(install.map((c) => c.cmd.join(' '))).toEqual(['bun install --frozen-lockfile']);
+    const cmds = commandsForPlan(plan, REPO);
+    expect(cmds.some((c) => c.cmd.join(' ') === 'bun run build')).toBe(false);
+    expect(cmds.some((c) => c.cmd.includes('tsc'))).toBe(false);
   });
 });
 

--- a/scripts/ci-scope.ts
+++ b/scripts/ci-scope.ts
@@ -823,7 +823,11 @@ export function commandsForPlan(plan: ImpactPlan, repoRoot: string): RunCommand[
   for (const check of plan.checks) {
     switch (check) {
       case 'typecheck':
-        out.push({ cwd: cli, cmd: ['bun', 'run', 'build'] });
+        // Already proven: `bun install` (installCommandsForPlan) runs the CLI's
+        // `prepare` script, which is `npm run build`, which is `tsc`. Running
+        // the build a second time here cost a measured 18s on every selected
+        // run (PR #3568: 126s against a 120s budget, 2113 tests green).
+        // ci-scope.test.ts pins both halves of that invariant.
         break;
       case 'command-index':
         out.push({ cwd: cli, cmd: ['bash', 'scripts/verify-command-index.sh'] });
@@ -862,6 +866,8 @@ export function installCommandsForPlan(plan: ImpactPlan, repoRoot: string): RunC
   const needsCli = plan.suite === 'cli-full'
     || plan.tests.some((t) => t.file.startsWith('cli/'))
     || plan.checks.some((c) => ['typecheck', 'command-index', 'docs', 'binary-smoke', 'sessions-bench'].includes(c));
+  // The CLI install is also the typecheck: its `prepare` script builds with tsc
+  // (see the `typecheck` case in commandsForPlan).
   if (needsCli) out.push({ cwd: join(repoRoot, 'cli'), cmd: ['bun', 'install', '--frozen-lockfile'] });
   if (plan.checks.includes('session-tracker')) {
     out.push({


### PR DESCRIPTION
## What

The required Linux check ran `tsc` twice on every selected run: once inside `bun install --frozen-lockfile` (the CLI's `prepare` script is `npm run build`), and again as the `typecheck` check, which `commandsForPlan` turned into `bun run build`. The second build is pure duplication and cost a measured 18s.

That duplication is what failed PR #3568 (Firefox over WebDriver BiDi) twice with every test green:

```
prepare tsc      14:05:33 -> 14:05:52   (19s)
vitest           14:05:53 -> 14:07:18   (85s, 2113 passed)
second tsc       14:07:20 -> 14:07:38   (18s)
impact ran in 126s (budget 120s, suite selected)
```

## How

`scripts/ci-scope.ts`: the `typecheck` case adds no command; the install remains the build. `scripts/ci-scope.test.ts` pins both halves so the typecheck cannot silently disappear: `cli/package.json` `prepare` must be `npm run build` with a `tsc` build, and a plan carrying `typecheck` must install the CLI and emit no separate build.

No budget was touched. This moves the browser selection from 126s to about 108s under its existing 120s ceiling; the R1 bar (60s) is unchanged and still not met.

## Verification

```
$ bun test scripts/ci-scope.test.ts
 70 pass
 0 fail
```

This PR's own required check is the live measurement of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBUjy12eBa4UKiE8tuaSGA