### PR TITLE
test(browser): the reopen counter page reports its own document's loads, not the origin's (PHNX-2399)

### DIFF
--- a/cli/src/lib/browser/service.reopen.ipc.live.test.ts
+++ b/cli/src/lib/browser/service.reopen.ipc.live.test.ts
@@ -104,6 +104,16 @@ d('same-task reopen over the real IPC socket + real Chromium (PHNX-2399)', () =>
     return targetInfos.filter((t) => t.type === 'page');
   };
   const targetsForUrl = async (url: string) => (await pageTargets()).filter((t) => t.url === url);
+  // Right after a Page.reload the target briefly reports no url, so a count taken
+  // at that instant reads 0. Wait for the url to be reported again before counting.
+  const settledTargetsForUrl = async (url: string) => {
+    for (let i = 0; i < 80; i++) {
+      const hits = await targetsForUrl(url);
+      if (hits.length > 0) return hits;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    return targetsForUrl(url);
+  };
 
   beforeAll(async () => {
     fs.rmSync(TEST_HOME, { recursive: true, force: true });
@@ -168,13 +178,15 @@ d('same-task reopen over the real IPC socket + real Chromium (PHNX-2399)', () =>
     expect(first.created).toBe(true);
     expect(first.refreshed).toBe(false);
     expect(await targetsForUrl(urlFor('P'))).toHaveLength(1); // exactly one open — no double execution
+    const before = (await pageTargets()).length;
 
     const again = await ipcCall(socketPath, { action: 'navigate', url: urlFor('P'), profile: PROFILE, sessionId: 'ipc-s1', launchId: 'ipc-l1', actor: 'tester' });
     expect(again.ok).toBe(true);
     expect(again.refreshed).toBe(true);
     expect(again.tabId).toBe(first.tabId); // SAME tab id
     expect(String(again.message)).toContain('Tab already open—refreshed');
-    expect(await targetsForUrl(urlFor('P'))).toHaveLength(1); // still one target
+    expect(await settledTargetsForUrl(urlFor('P'))).toHaveLength(1); // still one target
+    expect((await pageTargets()).length).toBe(before); // the refresh opened nothing
   }, 40_000);
 
   it('two INDEPENDENT socket connections adding one URL create ONE target, same id', async () => {

--- a/cli/src/lib/browser/service.reopen.ipc.live.test.ts
+++ b/cli/src/lib/browser/service.reopen.ipc.live.test.ts
@@ -261,10 +261,10 @@ d('same-task reopen over the real IPC socket + real Chromium (PHNX-2399)', () =>
       .toBe(persisted[task].tabs[String(opened.tabId)]);
   }, 40_000);
 
-  // Read a tab's persisted load counter, waiting until the page's own script ran.
+  // Read the document's own load count, waiting until the page's own script ran.
   const waitLoads = async (task: string, tabId: string, name: string) => {
     for (let i = 0; i < 80; i++) {
-      const v = await service.evaluate(task, tabId, `localStorage.getItem('loads-${name}')`);
+      const v = await service.evaluate(task, tabId, 'window.__loads ?? null');
       if (v != null) return String(v);
       await new Promise((r) => setTimeout(r, 50));
     }
@@ -284,7 +284,7 @@ d('same-task reopen over the real IPC socket + real Chromium (PHNX-2399)', () =>
     expect(s2.created).not.toBe(true);
     expect(String(s2.message ?? '')).toContain('Reused existing task');
     // No Page.reload happened, so the counter did not advance.
-    expect(await service.evaluate(task, String(s1.tabId), "localStorage.getItem('loads-N')")).toBe(before);
+    expect(await service.evaluate(task, String(s1.tabId), 'String(window.__loads)')).toBe(before);
   }, 40_000);
 
   it('a named retry to a DIFFERENT url reuses the task but is NOT a refresh', async () => {

--- a/cli/src/lib/browser/service.reopen.live.test.ts
+++ b/cli/src/lib/browser/service.reopen.live.test.ts
@@ -68,8 +68,10 @@ d('same-task page reopen against real Chromium (PHNX-2399)', () => {
     }
     throw new Error(`page ${name} never reached loads=${wantLoads ?? 'any'}`);
   };
-  const loadsOf = (task: string, tabId: string, name: string) =>
-    service.evaluate(task, tabId, `localStorage.getItem('loads-${name}')`);
+  // The document's OWN load count. localStorage would read the per-origin key,
+  // which another tab showing the same page also bumps.
+  const loadsOf = (task: string, tabId: string) =>
+    service.evaluate(task, tabId, 'String(window.__loads)');
 
   function seedTask(name: string) {
     const now = Date.now();
@@ -174,11 +176,11 @@ d('same-task page reopen against real Chromium (PHNX-2399)', () => {
     expect((await pageTargets()).length).toBe(before); // no extra target
 
     await settle('reopentask', a.tabId, 'A', 2); // the reopen really reloaded A
-    expect(await loadsOf('reopentask', a.tabId, 'A')).toBe('2');
+    expect(await loadsOf('reopentask', a.tabId)).toBe('2');
     // A genuinely reloaded → its in-document sentinel is gone.
     expect(await service.evaluate('reopentask', a.tabId, 'window.__sentinel ?? null')).toBeNull();
     // B never reloaded → its sentinel and load count survive, id unchanged.
-    expect(await loadsOf('reopentask', b.tabId, 'B')).toBe('1');
+    expect(await loadsOf('reopentask', b.tabId)).toBe('1');
     expect(await service.evaluate('reopentask', b.tabId, 'window.__sentinel ?? null')).toBe('B-doc-1');
     expect(task.tabs[b.tabId]).toBe(targetIdB);
   }, 40_000);
@@ -239,6 +241,6 @@ d('same-task page reopen against real Chromium (PHNX-2399)', () => {
     // in-document sentinel, load counter still 1 (no Page.reload ran on it).
     expect(task.tabs[a.tabId]).toBe(aTargetId);
     expect(await service.evaluate('borrowtask', a.tabId, 'window.__sentinel ?? null')).toBe('E-borrowed-doc');
-    expect(await loadsOf('borrowtask', a.tabId, 'E')).toBe('1');
+    expect(await loadsOf('borrowtask', a.tabId)).toBe('1');
   }, 40_000);
 });

--- a/cli/src/lib/browser/testdata/reopen-counter.html
+++ b/cli/src/lib/browser/testdata/reopen-counter.html
@@ -4,8 +4,11 @@
     <!--
       Load-counter page for the same-task reopen live test (PHNX-2399). Its key is
       the `?p=<name>` query param, so ONE file serves distinct pages (A/B/C/D) that
-      each count their own loads in localStorage — a real Page.reload of the SAME
-      tab bumps the count, and a fresh in-document `window.__sentinel` proves the
+      each count their own loads. localStorage carries the count across reloads and
+      is per ORIGIN, so every tab showing the same page shares it; `window.__loads`
+      is the count THIS document was loaded with, so a test that must prove one tab
+      was left alone reads that, not the shared key. A real Page.reload of the SAME
+      tab bumps both, and a fresh in-document `window.__sentinel` proves the
       document was genuinely reloaded rather than reported refreshed on stale state.
     -->
     <meta charset="utf-8" />
@@ -15,6 +18,7 @@
       var n = Number(localStorage.getItem(key) || '0') + 1;
       localStorage.setItem(key, String(n));
       document.title = name + ' loads=' + n;
+      window.__loads = n;
       window.__sentinel = undefined; // reset on every document load
     </script>
   </head>


### PR DESCRIPTION
## What

The BORROWED-tab reopen case in `service.reopen.live.test.ts` failed against real Chromium with `expected '2' to be '1'` at line 242, on unmodified main (baseline: https://github.com/phnx-labs/agi-cli/pull/3571#issuecomment-5620523831). The reopen logic was doing the right thing: it opened a second owned tab at URL E instead of reloading the borrowed one, and the borrowed document's `window.__sentinel` survived, which the assertion one line earlier proves.

The test then read the borrowed tab's load count from `localStorage.getItem('loads-E')`. localStorage is per origin, so the second E tab bumped the same key. The assertion was reading the origin's count and calling it the tab's.

## How

`reopen-counter.html` also exposes `window.__loads`, the count the current document was loaded with. `loadsOf` in `service.reopen.live.test.ts` and `waitLoads` plus its final assertion in `service.reopen.ipc.live.test.ts` read that instead of the shared key. localStorage still carries the count across reloads, so the "reopen reloads THAT tab" case still sees 2 after a real `Page.reload`.

Test files and testdata only. No product code changes.

## Verification

Same box and binary as the baseline (yosemite-s1, `AGENTS_TEST_CHROME=/snap/bin/chromium`), both live files at this commit. Output posted below once the run finishes.

Tracking: PHNX-2399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015npdH2bcSko9pSFhbaApD2
