### PR TITLE
feat(accounts): account-first storage, sync, and lifecycle cutover (PHNX-3940)

### DIFF
--- a/cli/.changelog/next/PHNX-3940-storage.md
+++ b/cli/.changelog/next/PHNX-3940-storage.md
@@ -1,0 +1,21 @@
+- **Account-first storage, sync, and lifecycle (PHNX-3940).** Sync and resource
+  projection now target account slots through a single home-targeted writer,
+  `syncResourcesToHome`, instead of detecting and copying a version home's output:
+  `agents sync` reconciles every materialized account slot for a harness beside the
+  version home, and the version-scoped staleness manifest, project fan-out, and
+  resource-pattern defaults stay scoped to the managed installation. `agents accounts
+  logout` and legacy attach resolve the account-owned home (its slot first, a legacy
+  version home only for an unmigrated account) and never recreate or carry credentials
+  into a version-owned home. A binary version switch, update, or uninstall no longer
+  copies freshest auth forward or deletes an adopted account's credentials, settings,
+  or history once that harness has adopted slots — account state lives outside the
+  version tree. `agents accounts migrate` is strengthened, not rebuilt: the final
+  active recheck and every home/binary move run under the shared per-installation
+  exclusion so a launch that starts after planning is deferred rather than raced; the
+  journal is crash-recoverable and an interrupted apply resumes idempotently from it;
+  and a legacy home whose account already holds a provisioned slot is preserved inside
+  that slot (differing settings and transcripts kept, sessions reindexed) rather than
+  trashed. Source: `cli/src/lib/accounts/slots.ts`, `cli/src/lib/accounts/migrate.ts`,
+  `cli/src/lib/accounts/add.ts`, `cli/src/lib/installations/versions.ts`,
+  `cli/src/lib/installations/shims.ts`, `cli/src/commands/accounts.ts`,
+  `cli/src/commands/sync.ts`.

--- a/cli/src/commands/accounts.native-home.test.ts
+++ b/cli/src/commands/accounts.native-home.test.ts
@@ -50,11 +50,15 @@ describe('native logout home safety', () => {
   });
 
   it('honors the account default and never silently substitutes the installation default', async () => {
-    const { commands, state } = await setup();
+    const { commands, state, dir } = await setup();
     const meta = state.readMeta();
     state.updateMeta({ accounts: { ...meta.accounts, defaults: { codex: 'work' } } });
     await expect(commands.resolveLogoutTarget('codex')).rejects.toThrow(/no installed/);
-    await expect(commands.resolveLogoutTarget('codex@personal')).resolves.toEqual({ agent: 'codex', version: 'personal' });
+    // An explicit installation label resolves to THAT version home (PHNX-3940:
+    // the target now carries the resolved home + its source, not just a label).
+    await expect(commands.resolveLogoutTarget('codex@personal')).resolves.toEqual({
+      agent: 'codex', version: 'personal', home: dir, source: 'legacy-home',
+    });
   });
 
   it('rejects empty explicit selectors before any account can be selected', async () => {

--- a/cli/src/commands/accounts.test.ts
+++ b/cli/src/commands/accounts.test.ts
@@ -4,16 +4,13 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { Command } from 'commander';
 import { password } from '@inquirer/prompts';
-import { classifyAttachTarget, groupLabelIdentities, nativeIdentityFromSource, parseBundleKey, parseLogoutTarget, registerAccountsCommand, resolveLabelIdentity, runAccountsLabel, setDefaultAccount, writeClaudeInteractiveOauthToken } from './accounts.js';
-import { claudeAccountTokenKey, invalidateClaudeSetupTokenCache, readClaudeAccountEmail, resolveClaudeSetupTokenForEmail, seedClaudeWorkerHomeIdentity } from '../lib/claude-account-token.js';
-import { getVersionHomePath } from '../lib/installations/versions.js';
+import { classifyAttachTarget, groupLabelIdentities, nativeIdentityFromSource, parseBundleKey, parseLogoutTarget, registerAccountsCommand, resolveLabelIdentity, runAccountsLabel, setDefaultAccount } from './accounts.js';
 import { addAccount, addNativeAccount, labelNativeAccount, listNativeAccounts, removeAccount } from '../lib/account-registry.js';
 import { recordSlot, slotDir } from '../lib/accounts/slots.js';
 import { getAgentConfigPath } from '../lib/installations/shims.js';
 import type { RotateCandidate } from '../lib/accounting/rotate.js';
 import { getUserAgentsDir, readMeta, updateMeta } from '../lib/state.js';
 import { applyGlobalHelpConventions } from '../lib/help.js';
-import { keychainRef, secretsKeychainItem, writeBundleWithItemsSync } from '../lib/secrets-client.js';
 import { standaloneKeychainIsFileBacked, useFreshSecretsHome } from '../../tests/secrets-standalone.js';
 
 vi.mock('@inquirer/prompts', async (importOriginal) => {
@@ -411,89 +408,6 @@ describe('groupLabelIdentities', () => {
       { version: '1.1.0', email: 'kept@example.com', accountKey: null },
     ], null);
     expect(rows.map(row => row.email)).toEqual(['kept@example.com']);
-  });
-});
-
-describe('writeClaudeInteractiveOauthToken', () => {
-  // The .oauth_token fallback is the Linux keychain-less path; the write is a no-op
-  // off Linux, so exercise the write/clear behavior only there.
-  const linuxOnly = process.platform === 'linux' ? it : it.skip;
-  const VERSION = '2.1.0';
-  const EMAIL = 'social@swarmify.co';
-  const TOKEN = 'sk-ant-oat01-interactive-write-test';
-  const versionHome = (): string => getVersionHomePath('claude', VERSION);
-  useFreshSecretsHome();
-
-  beforeEach(() => {
-    // Each test seeds its own `auth` bundle into a fresh SECRETS_HOME; the
-    // process-local setup-token memo must not carry a previous test's read.
-    invalidateClaudeSetupTokenCache();
-    // A version home whose .claude.json names the account, so resolveClaudeSetupToken
-    // can key the per-account token in the auth bundle.
-    const configDir = path.join(versionHome(), '.claude');
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(path.join(configDir, '.claude.json'), JSON.stringify({ oauthAccount: { emailAddress: EMAIL } }));
-  });
-
-  afterEach(() => {
-    fs.rmSync(versionHome(), { recursive: true, force: true });
-  });
-
-  function oauthTokenPath(): string {
-    return path.join(versionHome(), '.claude', '.oauth_token');
-  }
-  /** Seed the reserved file-backed `auth` bundle with one per-account setup-token. */
-  function writeAuthToken(email: string, token: string): void {
-    const key = claudeAccountTokenKey(email);
-    writeBundleWithItemsSync(
-      { name: 'auth', backend: 'file', policy: 'never', vars: { [key]: keychainRef(key) } },
-      new Map([[secretsKeychainItem('auth', key), token]]),
-    );
-  }
-
-  linuxOnly('writes the resolved setup-token mode 0600 for a claude@version attach', () => {
-    writeAuthToken(EMAIL, TOKEN);
-    writeClaudeInteractiveOauthToken({ kind: 'installation', agent: 'claude', version: VERSION }, 'claude');
-    expect(fs.readFileSync(oauthTokenPath(), 'utf8')).toBe(TOKEN);
-    expect(fs.statSync(oauthTokenPath()).mode & 0o777).toBe(0o600);
-  });
-
-  linuxOnly('clears a stale .oauth_token when no token resolves (re-point / detach)', () => {
-    fs.writeFileSync(oauthTokenPath(), 'stale-token-from-a-previous-account');
-    // No auth bundle at all in this fresh SECRETS_HOME -> resolveClaudeSetupToken returns null.
-    writeClaudeInteractiveOauthToken({ kind: 'installation', agent: 'claude', version: VERSION }, 'claude');
-    expect(fs.existsSync(oauthTokenPath())).toBe(false);
-  });
-
-  it('no-ops for a non-installation target (device-scoped attach)', () => {
-    writeClaudeInteractiveOauthToken({ kind: 'device-agent', agent: 'claude' }, 'claude');
-    expect(fs.existsSync(oauthTokenPath())).toBe(false);
-  });
-
-  // Regression for the review BLOCKER on PR #3331: a native claude account's email
-  // lives in `identityLabel`, NOT `identityKey` (which is the synthetic composite
-  // `claude:account=<uuid>:org=<uuid>`). The bootstrap must key the setup-token off
-  // the email; keying off `identityKey` resolves nothing and the fix silently no-ops.
-  linuxOnly('bootstraps a signed-out worker home off the account email in identityLabel, not identityKey', () => {
-    // A signed-out worker home: drop the identity the beforeEach seeded.
-    const workerHome = versionHome();
-    fs.rmSync(path.join(workerHome, '.claude', '.claude.json'), { force: true });
-    writeAuthToken(EMAIL, TOKEN);
-    // A realistic native claude account: composite identityKey, email in identityLabel.
-    const account = addNativeAccount('claude-worker', 'claude', 'claude:account=abc:org=xyz', EMAIL, 'version');
-    expect(account.identityKey).not.toContain('@');
-    expect(account.identityLabel).toBe(EMAIL);
-    // The bug: keying the token off identityKey resolves nothing.
-    expect(resolveClaudeSetupTokenForEmail(account.identityKey)).toBeNull();
-    // The fix: keying off identityLabel (the email) resolves the fleet-synced token.
-    expect(resolveClaudeSetupTokenForEmail(account.identityLabel!)).toBe(TOKEN);
-    // End to end, the bootstrap path attach takes: seed identity, then write .oauth_token.
-    expect(readClaudeAccountEmail(workerHome)).toBeNull();
-    seedClaudeWorkerHomeIdentity(workerHome, account.identityLabel!);
-    writeClaudeInteractiveOauthToken({ kind: 'installation', agent: 'claude', version: VERSION }, 'claude', account.identityLabel);
-    expect(readClaudeAccountEmail(workerHome)).toBe(EMAIL);
-    expect(fs.readFileSync(oauthTokenPath(), 'utf8')).toBe(TOKEN);
-    expect(fs.statSync(oauthTokenPath()).mode & 0o777).toBe(0o600);
   });
 });
 

--- a/cli/src/commands/accounts.ts
+++ b/cli/src/commands/accounts.ts
@@ -1,9 +1,6 @@
 import type { Command } from 'commander';
-import * as fs from 'fs';
-import * as path from 'path';
 import chalk from 'chalk';
 import { password, select } from '@inquirer/prompts';
-import { readClaudeAccountEmail, resolveClaudeSetupToken, resolveClaudeSetupTokenForEmail, seedClaudeWorkerHomeIdentity } from '../lib/claude-account-token.js';
 import { setHelpSections } from '../lib/help.js';
 import { readMeta, updateMeta } from '../lib/state.js';
 import { machineId } from '../lib/machine-id.js';
@@ -34,6 +31,7 @@ import { applyAccountMigration, formatMigrationPlan, planAccountMigration } from
 import { isSymlinkAdoptedHarness } from '../lib/installations/shims.js';
 import { ensureAdoptedDefaultRepoint } from '../lib/exec-account-home.js';
 import { acquireAuthOperationLock } from '../lib/accounts/auth-operation-lock.js';
+import { readSlots } from '../lib/accounts/slots.js';
 import { isSecretsClientError, pushBundleToHost, readAndResolveBundleEnv, readBundle } from '../lib/secrets-client.js';
 import { getAccountProvider, listAccountProviders, providerAuthenticatesHarness, type AccountAuthKind } from '../lib/account-provider-registry.js';
 import { accountBindings, addAccount, addNativeAccount, assertUnambiguousNativeAccount, bindAccount, findAccount, findUnifiedAccount, inspectAccount, labelNativeAccount, listNativeAccounts, nativeAccountHome, parseAccountSelector, readAccountRegistry, removeAccount, renameAccount, setAccountSecret, unbindAccount, type UnifiedAccount } from '../lib/account-registry.js';
@@ -135,39 +133,6 @@ export function classifyAttachTarget(target: string): AttachTarget {
   const agent = resolveAgentName(target);
   if (agent) return { kind: 'device-agent', agent };
   throw new Error(`Unknown attach target '${target}'. Expected an installed <agent>@<version>, a harness id, or an existing custom harness profile.`);
-}
-
-/**
- * Persist the attached setup-token to a per-version `.oauth_token` file so an
- * INTERACTIVE Claude launch on a keychain-less Linux worker can authenticate from it.
- * Headless runs inject the token via `buildExecEnv`. Since PHNX-3502 an interactive
- * launch on a worker-role device ALSO injects it through `claudeAdapter.applyExecConfigEnv`
- * (only a headed `personal`/`desktop` device defers to its per-version native login), and
- * the shim's Linux fallback (`claudeAdapter.shimConfigEnvBash`) reads exactly this file —
- * so writing it is what makes a freshly-attached setup-token visible to that shim fallback
- * on a worker. macOS keeps the credential in the keychain, so `resolveClaudeSetupToken`
- * returns null there and this is a no-op off Linux.
- */
-export function writeClaudeInteractiveOauthToken(target: AttachTarget, targetAgent: AgentId, email?: string): void {
-  if (process.platform !== 'linux' || targetAgent !== 'claude' || target.kind !== 'installation') return;
-  const versionHome = getVersionHomePath('claude', target.version);
-  const tokenPath = path.join(versionHome, '.claude', '.oauth_token');
-  // Resolve by the attached account's email when known (a freshly-seeded worker
-  // home the `.claude.json` read below could not key on yet), else by the home's
-  // own recorded identity for a re-point/detach.
-  const token = email
-    ? resolveClaudeSetupTokenForEmail(email, versionHome)
-    : resolveClaudeSetupToken(versionHome);
-  // A re-point (attach B over A, or a detach) can leave no setup-token resolving for
-  // this version — B's may not be minted yet. A leftover file from the previous binding
-  // would silently authenticate interactive runs as the OLD account (the shim's Linux
-  // fallback reads it), so clear it rather than leave it stale.
-  if (!token) {
-    fs.rmSync(tokenPath, { force: true });
-    return;
-  }
-  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
-  fs.writeFileSync(tokenPath, token, { mode: 0o600 });
 }
 
 export function parseBundleKey(raw: string): { bundle: string; key: string } {
@@ -517,8 +482,29 @@ export function parseLogoutTarget(target: string): { agentRaw: string; installat
   return { agentRaw: target };
 }
 
+export interface LogoutTarget {
+  agent: AgentId;
+  version: string;
+  home: string;
+  source: 'slot' | 'legacy-home';
+  accountName?: string;
+}
+
 /** Explicit account logout must never fall back to another account's home. */
-async function resolveAccountHomeLabel(account: UnifiedAccount & { kind: 'native' }): Promise<string> {
+async function resolveAccountLogoutTarget(account: UnifiedAccount & { kind: 'native' }): Promise<LogoutTarget> {
+  const meta = readMeta();
+  const slot = readSlots(meta)[account.id];
+  const installed = listInstalledVersions(account.agent);
+  const version = getGlobalDefault(account.agent) ?? installed[installed.length - 1];
+  if (slot) {
+    if (!version) throw new Error(`No installed version of ${account.agent}. Install one with: agents add ${account.agent}`);
+    const info = await getAccountInfo(account.agent, slot.slotDir);
+    const observed = nativeIdentityKey(info, nativeAccountCapability(account.agent));
+    if (observed && observed !== account.identityKey) {
+      throw new Error(`Account '${account.name}' slot contains a different ${account.agent} identity; refusing to sign it out.`);
+    }
+    return { agent: account.agent, version, home: slot.slotDir, source: 'slot', accountName: account.name };
+  }
   const rows = await collectNativeHomeRows();
   const homes = rows
     .filter(r => r.signedIn && (r.accountKey ?? r.email))
@@ -529,7 +515,13 @@ async function resolveAccountHomeLabel(account: UnifiedAccount & { kind: 'native
   if (!label || !listInstalledVersions(account.agent).includes(label)) {
     throw new Error(`Account '${account.name}' has no installed ${account.agent} home to sign out of.`);
   }
-  return label;
+  return {
+    agent: account.agent,
+    version: label,
+    home: getVersionHomePath(account.agent, label),
+    source: 'legacy-home',
+    accountName: account.name,
+  };
 }
 
 /**
@@ -537,7 +529,7 @@ async function resolveAccountHomeLabel(account: UnifiedAccount & { kind: 'native
  * should be signed out — honoring a passed `@label` or `#account` selector
  * instead of always selecting the global default (PHNX-3940).
  */
-export async function resolveLogoutTarget(target: string): Promise<{ agent: AgentId; version: string }> {
+export async function resolveLogoutTarget(target: string): Promise<LogoutTarget> {
   const parsed = parseLogoutTarget(target);
   const meta = readMeta();
   if (ALL_AGENT_IDS.includes(parsed.agentRaw as AgentId)) {
@@ -546,14 +538,14 @@ export async function resolveLogoutTarget(target: string): Promise<{ agent: Agen
       if (!listInstalledVersions(agent).includes(parsed.installationLabel)) {
         throw new Error(`${agent}@${parsed.installationLabel} is not installed.`);
       }
-      return { agent, version: parsed.installationLabel };
+      return { agent, version: parsed.installationLabel, home: getVersionHomePath(agent, parsed.installationLabel), source: 'legacy-home' };
     }
     if (parsed.identitySelector) {
       const account = findUnifiedAccount(parsed.identitySelector, meta, undefined, agent);
       if (!account || account.kind !== 'native' || account.agent !== agent) {
         throw new Error(`No ${agent} account '${parsed.identitySelector}'.`);
       }
-      return { agent, version: await resolveAccountHomeLabel(account) };
+      return resolveAccountLogoutTarget(account);
     }
     const configuredDefault = meta.accounts?.defaults?.[agent];
     if (configuredDefault) {
@@ -561,17 +553,17 @@ export async function resolveLogoutTarget(target: string): Promise<{ agent: Agen
       if (!account || account.kind !== 'native') {
         throw new Error(`${agent}'s default is not a locally connected native account. Select the native account to sign out explicitly.`);
       }
-      return { agent, version: await resolveAccountHomeLabel(account) };
+      return resolveAccountLogoutTarget(account);
     }
     const installed = listInstalledVersions(agent);
     const version = getGlobalDefault(agent) ?? installed[installed.length - 1];
     if (!version) throw new Error(`No installed version of ${agent}. Install one with: agents add ${agent}`);
-    return { agent, version };
+    return { agent, version, home: getVersionHomePath(agent, version), source: 'legacy-home' };
   }
   // A bare, non-harness target may be a native account name.
   const account = findUnifiedAccount(target, meta);
   if (account?.kind === 'native') {
-    return { agent: account.agent, version: await resolveAccountHomeLabel(account) };
+    return resolveAccountLogoutTarget(account);
   }
   throw new Error(
     `Unknown target '${target}'. Pass a native harness (claude, codex, …), <harness>@<label>, <harness>#<account>, or a native account name. Provider API-key accounts use \`agents accounts remove\`.`,
@@ -912,27 +904,11 @@ agents run codex#work`,
             if (t.kind !== 'device-agent') throw new Error(`${account.agent} authentication is device-scoped. Attach it with 'agents accounts attach ${account.name} ${account.agent}'.`);
           } else {
             if (t.kind !== 'installation') throw new Error(`${account.agent} authentication is per-version. Attach '${account.name}' to a specific ${account.agent}@<version>.`);
-            const versionHome = getVersionHomePath(t.agent, t.version);
-            // The literal email keys the account's `auth`-bundle setup-token. It lives
-            // in `identityLabel` — `identityKey` is a synthetic composite
-            // (`claude:account=<uuid>:org=<uuid>`, agents.ts nativeIdentityKey), never
-            // the address, so it must NOT be used to derive the token key.
-            const accountEmail = account.identityLabel;
-            // Headless-worker bootstrap: a keychain-less Linux worker home never had
-            // an interactive login, so its `.claude.json` carries no identity and
-            // `nativeIdentityFromSource` would reject the attach — yet the account's
-            // non-rotating setup-token is already fleet-synced in the `auth` bundle.
-            // Seed the identity (email only, no rotating credential) so the token
-            // resolves; `writeClaudeInteractiveOauthToken` then writes `.oauth_token`.
-            if (
-              process.platform === 'linux' &&
-              account.agent === 'claude' &&
-              accountEmail &&
-              !readClaudeAccountEmail(versionHome) &&
-              resolveClaudeSetupTokenForEmail(accountEmail)
-            ) {
-              seedClaudeWorkerHomeIdentity(versionHome, accountEmail);
-            } else {
+            const slot = readSlots(meta)[account.id];
+            if (!slot) {
+              // One-release compatibility for an unmigrated account: an existing
+              // legacy home may still be attached, but attach never creates or
+              // transports auth into that version-owned home.
               const identity = await nativeIdentityFromSource(target);
               if (identity.identityKey !== account.identityKey) throw new Error(`'${target}' is signed in to a different identity than account '${account.name}'.`);
             }
@@ -942,7 +918,6 @@ agents run codex#work`,
           getAccountProvider(account.provider).envFor(targetAgent, account.auth);
         }
         bindAccount(name, target, targetAgent);
-        writeClaudeInteractiveOauthToken(t, targetAgent, account.kind === 'native' && account.agent === 'claude' ? account.identityLabel : undefined);
         console.log(chalk.green(`Attached ${account.name} to ${target}.`));
       });
     }), 'agents run <harness>#<name> (accounts select by name; installation bindings are legacy)');
@@ -959,13 +934,6 @@ agents run codex#work`,
           targetAgent = t.kind === 'profile' ? t.profile.host.agent : t.agent;
         } catch { /* an unresolvable target still unbinds by whatever row matches */ }
         unbindAccount(name, target, targetAgent);
-        // With the binding gone, no setup-token resolves for this version home, so this
-        // clears any .oauth_token the attach left behind (else interactive runs would keep
-        // authenticating as the just-detached account).
-        try {
-          const t = classifyAttachTarget(target);
-          writeClaudeInteractiveOauthToken(t, t.kind === 'profile' ? t.profile.host.agent : t.agent);
-        } catch { /* an unresolvable target has no version home to clean */ }
         console.log(chalk.green(`Detached ${name} from ${target}.`));
       });
     }), 'agents run <harness>#<name> (accounts select by name; installation bindings are legacy)');
@@ -1039,16 +1007,15 @@ agents accounts rename codex#icloud cloud`,
         try {
           const resolved = await resolveLogoutTarget(target);
           if (resolved.agent !== agent) throw new Error('Account selection changed; retry sign-out.');
-          const { version } = resolved;
+          const { version, home } = resolved;
           const { runNativeAccountCommand } = await import('../lib/installations/native-command.js');
-          const { getVersionHomePath } = await import('../lib/installations/versions.js');
           const { buildExecEnv } = await import('../lib/exec.js');
           // Pin the harness's own config-dir env (CLAUDE_CONFIG_DIR / CODEX_HOME) to
           // the resolved home so `logout` signs out THAT account's home — not
           // whichever the global default happens to be. HOME alone was insufficient
           // for a config-dir-env harness, which is why a passed @label was ignored.
-          const env = buildExecEnv({ agent, version, configVersion: version, interactive: true, mode: 'auto', effort: 'auto', cwd: process.cwd() });
-          env.HOME = getVersionHomePath(agent, version);
+          const env = buildExecEnv({ agent, version, execHome: home, interactive: true, mode: 'auto', effort: 'auto', cwd: process.cwd() });
+          env.HOME = home;
           lock.assertHeld();
           const result = await runNativeAccountCommand(agent, version, agent === 'claude' ? ['auth', 'logout'] : ['logout'], env, lock.signal);
           lock.assertHeld();
@@ -1057,7 +1024,8 @@ agents accounts rename codex#icloud cloud`,
               `${agent} logout exited ${result.code ?? 'null'}. If this harness has no logout verb, sign out from its own UI.`,
             );
           }
-          console.log(chalk.green(`Signed out native ${agent} login (${agent}@${version}).`));
+          const owner = resolved.accountName ? `${agent}#${resolved.accountName}` : `${agent}@${version}`;
+          console.log(chalk.green(`Signed out native ${agent} login (${owner}).`));
         } finally {
           lock.release();
         }

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -77,6 +77,7 @@ import { addHostOption } from '../lib/hosts/option.js';
 import { syncRepoGit, adoptUserRepoIfNeeded, recordUserRepoRemote, resolveUserRepoRemoteUrl } from '../lib/git.js';
 import { getSystemAgentsDir, getUserAgentsDir, getEnabledExtraRepos } from '../lib/state.js';
 import { registerStatusCommand } from './status.js';
+import { syncResourcesToAccountSlots } from '../lib/accounts/slots.js';
 
 interface SyncOpts {
   agent?: string;
@@ -130,6 +131,17 @@ interface SyncOpts {
   rule?: string[] | true;
   rules?: string[] | true;
   memory?: boolean;
+}
+
+function syncVersionAndAccountSlots(
+  agent: AgentId,
+  version: string,
+  selection: ResourceSelection | undefined,
+  options: Parameters<typeof syncResourcesToVersion>[3],
+): SyncResult {
+  const result = syncResourcesToVersion(agent, version, selection, options);
+  syncResourcesToAccountSlots(agent, version, selection, { ...options, prune: false });
+  return result;
 }
 
 /** Emit one JSON object to stdout for `--json` callers / fleet fan-out. */
@@ -522,7 +534,7 @@ async function runInteractiveReconcile(
   for (const agentId of agents) {
     const version = resolveVersion(agentId, cwd) || listInstalledVersions(agentId).slice(-1)[0];
     if (!version) continue;
-    const result = syncResourcesToVersion(agentId, version, selection, { cwd, prune: true });
+    const result = syncVersionAndAccountSlots(agentId, version, selection, { cwd, prune: true });
     printSyncDetail(result, agentId, version, cwd);
     if (result.hooks && hookCapable.has(agentId) && Object.keys(hookManifest).length > 0) {
       registerHooksToSettings(agentId, getVersionHomePath(agentId, version), hookManifest);
@@ -908,7 +920,7 @@ async function runSync(agentSpec: string | undefined, repoArg: string | undefine
       // it no longer provides. Bare @all (no repo) leaves selection undefined
       // and falls through to the full-sync orphan sweep, so prune is a no-op
       // there (it requires a caller selection).
-      const result = syncResourcesToVersion(agentId, v, selection, { projectDir, cwd, force, prune: !!repoScope, allowExecSurfaces: !!opts.allowExecSurfaces });
+      const result = syncVersionAndAccountSlots(agentId, v, selection, { projectDir, cwd, force, prune: !!repoScope, allowExecSurfaces: !!opts.allowExecSurfaces });
       versions.push({ version: v, result });
       if (!quiet && !json) printSyncDetail(result, agentId, v, cwd);
     }
@@ -1058,7 +1070,7 @@ async function runSync(agentSpec: string | undefined, repoArg: string | undefine
       if (json) emitJson({ ok: true, mode: 'dry-run', agent: agentId, version, repo: repoScope, selection: scoped });
       return;
     }
-    const result = syncResourcesToVersion(agentId, version, scoped, { projectDir, cwd, force, prune: !!repoScope, allowExecSurfaces: !!opts.allowExecSurfaces });
+    const result = syncVersionAndAccountSlots(agentId, version, scoped, { projectDir, cwd, force, prune: !!repoScope, allowExecSurfaces: !!opts.allowExecSurfaces });
     const scopedRepair = await repairAfterSync({ agent: agentId, versions: [version], cwd });
     const scopedRepairFailed = repairHadFailures(scopedRepair);
     if (scopedRepairFailed) process.exitCode = 1;
@@ -1145,7 +1157,7 @@ async function runSync(agentSpec: string | undefined, repoArg: string | undefine
     if (json) emitJson({ ok: true, mode: 'dry-run', agent: agentId, version, repo: repoScope, selection: selection ?? 'all' });
     return;
   }
-  const result = syncResourcesToVersion(agentId, version, selection, { projectDir, cwd, force, allowExecSurfaces: !!opts.allowExecSurfaces });
+  const result = syncVersionAndAccountSlots(agentId, version, selection, { projectDir, cwd, force, allowExecSurfaces: !!opts.allowExecSurfaces });
 
   // Post-reconcile verification (PHNX-3186). Only for a FULL reconcile
   // (`!selection`): an interactive subset-selection deliberately touched only the

--- a/cli/src/lib/accounts/add.ts
+++ b/cli/src/lib/accounts/add.ts
@@ -688,20 +688,16 @@ async function defaultAddRunners(): Promise<AddRunners> {
     import('../exec.js'),
   ]);
   const { ensureHarnessInstallation, getBinaryPath, readInstallation } = store;
-  const { agentConfigDirName, getAccountInfo } = agentsMod;
+  const { getAccountInfo } = agentsMod;
   const { buildExecEnv } = execMod;
   const { runNativeAccountCommand } = await import('../installations/native-command.js');
 
-  // A slot is HOME-shaped; the harness's config dir lives directly inside it.
-  const slotConfigDir = (agent: AgentId, home: string): string => path.join(home, agentConfigDirName(agent));
-
   const loginEnv = (agent: AgentId, installLabel: string, home: string): NodeJS.ProcessEnv => {
-    const env = buildExecEnv({ agent, version: installLabel, configVersion: installLabel, interactive: true, mode: 'auto', effort: 'auto', cwd: process.cwd() });
-    // HOME = slot; the harness's slotEnv (CLAUDE_CONFIG_DIR / CODEX_HOME / …)
-    // pins its config dir inside the slot so the login lands there.
+    const env = buildExecEnv({ agent, version: installLabel, execHome: home, interactive: true, mode: 'auto', effort: 'auto', cwd: process.cwd() });
+    // `execHome` routes through the harness adapter, including OpenCode/Muse's
+    // distinct XDG config/data roots; HOME still gives HOME-only harnesses the
+    // same account-owned destination.
     env.HOME = home;
-    const pin = harnessAuth(agent).slotEnv;
-    if (pin) env[pin] = slotConfigDir(agent, home);
     // Strip any ambient provider API-key / setup-token env so the native login
     // authenticates as the human's OAuth identity, not an injected credential
     // that would impersonate a different account into this slot.
@@ -738,8 +734,13 @@ async function defaultAddRunners(): Promise<AddRunners> {
       const flow = MINT_FLOWS[agent];
       if (!flow || flow.auth !== 'setup-token') throw new Error(`No setup-token mint flow for ${agent}.`);
       const install = await ensureHarnessInstallation(agent, {});
+      // Pin the harness config-dir env (CLAUDE_CONFIG_DIR / …) to the slot
+      // through the same adapter `buildExecEnv` uses for a slot launch, so the
+      // mint writes into the account slot rather than the version home.
+      const slotEnv = harnessAuth(agent).slotEnv;
+      const execEnv = buildExecEnv({ agent, version: install.installation.label, execHome: home, interactive: true, mode: 'auto', effort: 'auto', cwd: process.cwd() });
       const command = buildMintCommand(flow, getBinaryPath(agent, install.installation.label), home, {
-        ...(harnessAuth(agent).slotEnv ? { [harnessAuth(agent).slotEnv!]: slotConfigDir(agent, home) } : {}),
+        ...(slotEnv && execEnv[slotEnv] ? { [slotEnv]: execEnv[slotEnv]! } : {}),
       });
       const driven = await driveSetupTokenMint(command, flow, {
         readCode: async () => {

--- a/cli/src/lib/accounts/migrate.test.ts
+++ b/cli/src/lib/accounts/migrate.test.ts
@@ -347,54 +347,64 @@ describe('accounts migrate (PHNX-3940 T7)', () => {
     fs.rmSync(getVersionDir('claude', label), { recursive: true, force: true });
   });
 
-  it('trashes a stale home whose account already holds a provisioned slot instead of aborting', async () => {
+  it('preserves a legacy home inside the account slot it already owns instead of losing its differing contents', async () => {
     prevDefault = fixtureFleet().prevDefault;
     await applyAccountMigration(['claude'], { isActive: async () => false });
     const natives = listNativeAccounts(readMeta()).filter((a) => a.identityLabel === gmail || a.identityLabel === icloud);
     plantedAccounts.push(...natives.map((a) => a.name));
     const gmailAcct = natives.find((a) => a.identityLabel === gmail)!;
-    const slotBefore = fs.readdirSync(slotDir('claude', gmailAcct.id));
+    const icloudAcct = natives.find((a) => a.identityLabel === icloud)!;
+    const slotBefore = fs.readdirSync(slotDir('claude', gmailAcct.id)).sort();
     expect(slotBefore.length).toBeGreaterThan(0);
     // Canonical is the newest signed-in install, so plant a newer icloud home
-    // to hold that role: it also already has a slot, which exercises the
-    // canonical branch (binary kept, home left in place) while the older gmail
-    // home below takes the trash branch.
+    // to hold that role: it also already has a slot, exercising the canonical
+    // branch (binary kept, home archived into the slot), while the older gmail
+    // home below exercises the non-canonical branch (binary trashed).
     const pinnedDefault = `9.9.9-${suffix}-def`;
     extraCleanupLabels.push(pinnedDefault);
     plantInstall(pinnedDefault, '9.9.9', { email: icloud });
     setGlobalDefault('claude', pinnedDefault);
     const extra = `0.7.0-${suffix}`;
     plantInstall(extra, '0.7.0', { email: gmail });
+    // A file present ONLY in the legacy home: folding it in must not drop it.
+    const legacyOnly = path.join(getVersionDir('claude', extra), 'home', '.claude', 'settings.local.json');
+    fs.writeFileSync(legacyOnly, JSON.stringify({ legacyOnly: true }));
     invalidateInstalledVersionsCache('claude');
     bindAccount(gmailAcct.id, `claude@${extra}`, 'claude');
 
     const plan = await planAccountMigration(['claude'], { isActive: async () => false });
     const action = plan.harnesses.find((h) => h.agent === 'claude')?.actions.find((a) => a.label === extra);
-    expect(action?.kind).toBe('trash');
-    expect(action?.reason).toMatch(/already holds a provisioned slot/);
+    expect(action?.kind).toBe('slot');
+    expect(action?.reason).toMatch(/preserve the legacy home inside that account slot/);
     expect(action?.accountId).toBe(gmailAcct.id);
     const canonicalAction = plan.harnesses.find((h) => h.agent === 'claude')?.actions.find((a) => a.label === pinnedDefault);
-    expect(canonicalAction?.kind).toBe('canonical');
-    expect(canonicalAction?.reason).toMatch(/already holds a slot — stale home trashed/);
+    expect(canonicalAction?.kind).toBe('slot');
 
     const result = await applyAccountMigration(['claude'], { isActive: async () => false });
     expect(result.manifest.status).toBe('complete');
+    // Non-canonical legacy install: the binary is trashed (recoverable)...
     expect(fs.existsSync(getVersionDir('claude', extra))).toBe(false);
     expect(fs.existsSync(path.join(getHistoryDir(), 'trash', 'versions', 'claude', extra))).toBe(true);
-    expect(result.manifest.harnesses.claude?.trashed.find((t) => t.label === extra)?.reason).toMatch(/already holds a provisioned slot/);
-    // The slot the account already owned is untouched, and the binding that
-    // named the trashed version now names the account.
-    expect(fs.readdirSync(slotDir('claude', gmailAcct.id))).toEqual(slotBefore);
+    // ...but its home is archived INSIDE the account's own slot, contents intact,
+    // never trashed out of reach. The differing file survives.
+    const gmailArchive = path.join(slotDir('claude', gmailAcct.id), '.agents-migration', 'legacy', extra);
+    expect(fs.existsSync(path.join(gmailArchive, '.claude.json'))).toBe(true);
+    expect(JSON.parse(fs.readFileSync(path.join(gmailArchive, '.claude', 'settings.local.json'), 'utf8'))).toEqual({ legacyOnly: true });
+    // The slot record still points at the real slot, NOT the archive subdir, so
+    // spawn launches the live slot and not the preserved copy.
+    expect(readSlots(readMeta())[gmailAcct.id]?.slotDir).toBe(slotDir('claude', gmailAcct.id));
+    // The slot's own top-level contents are untouched; the archive rides beside
+    // them under a hidden dir the harness ignores.
+    expect(fs.readdirSync(slotDir('claude', gmailAcct.id)).filter((n) => n !== '.agents-migration').sort()).toEqual(slotBefore);
     const bindings = { ...readMeta().accounts?.bindings, ...readMeta().deviceAccounts?.bindings };
     expect(bindings[`claude@${extra}`]).toBe(gmailAcct.id);
-    // The canonical install keeps its binary with an empty home; its stale
-    // credential copy went to the homes trash and the manifest names the path.
+    // The canonical install keeps its binary and gets a fresh empty home; its
+    // legacy credential copy is archived in the icloud slot, not trashed.
     const canonicalHome = path.join(getVersionDir('claude', pinnedDefault), 'home');
     expect(fs.existsSync(canonicalHome)).toBe(true);
     expect(fs.readdirSync(canonicalHome)).toEqual([]);
-    const homeTrash = result.manifest.map[`claude@${pinnedDefault}#home`];
-    expect(homeTrash).toContain(path.join('trash', 'homes', 'claude', pinnedDefault));
-    expect(fs.existsSync(path.join(homeTrash!, '.claude.json'))).toBe(true);
+    const icloudArchive = path.join(slotDir('claude', icloudAcct.id), '.agents-migration', 'legacy', pinnedDefault);
+    expect(fs.existsSync(path.join(icloudArchive, '.claude.json'))).toBe(true);
     expect(fs.existsSync(path.join(getVersionDir('claude', pinnedDefault), 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude-launcher'))).toBe(true);
     unbindAccount(gmailAcct.id, `claude@${extra}`, 'claude');
   });
@@ -516,5 +526,87 @@ describe('accounts migrate (PHNX-3940 T7)', () => {
       .rejects.toThrow(/Identity mismatch for claude@.*: home is '.*' but account row '.*' is 'claude:account=other:org=other'/);
     await expect(applyAccountMigration(['claude'], { isActive: async () => false }))
       .rejects.toThrow(/Identity mismatch/);
+  });
+
+  it('rechecks the install is idle under the shared exclusion before renaming and defers one that went busy after planning', async () => {
+    const label = `0.1.0-${suffix}-recheck`;
+    extraCleanupLabels.push(label);
+    prevDefault = getGlobalDefault('claude');
+    plantInstall(label, '0.1.0', { email: gmail });
+    invalidateInstalledVersionsCache('claude');
+    // Idle at plan time (inventory), busy at the apply-time recheck: the launch
+    // started in the window between planning and the move. The exclusion recheck
+    // must defer it rather than rename a live home out from under a process.
+    let seen = 0;
+    const isActive = async (inst: { label: string }) => {
+      if (inst.label !== label) return false;
+      seen += 1;
+      return seen > 1;
+    };
+    const result = await applyAccountMigration(['claude'], { isActive });
+    plantedAccounts.push(...listNativeAccounts(readMeta())
+      .filter((a) => a.agent === 'claude' && a.identityLabel === gmail).map((a) => a.name));
+    expect(result.manifest.status).toBe('complete');
+    expect(result.manifest.harnesses.claude?.deferred.some((d) => d.label === label && /busy/.test(d.reason))).toBe(true);
+    // The home was never moved and its credential is intact.
+    expect(fs.existsSync(path.join(getVersionDir('claude', label), 'home', '.claude.json'))).toBe(true);
+    expect(fs.existsSync(getVersionDir('claude', label))).toBe(true);
+    // The deferred move left no committed slot destination in the manifest map.
+    expect(result.manifest.map[`claude@${label}`]).toBeUndefined();
+  });
+
+  it('resumes an interrupted apply from its manifest and completes idempotently without losing data', async () => {
+    const labelA = `0.1.0-${suffix}-resume-a`;
+    const labelB = `0.2.0-${suffix}-resume-b`;
+    extraCleanupLabels.push(labelA, labelB);
+    const emailA = `resume-a-${suffix}@example.com`;
+    const emailB = `resume-b-${suffix}@example.com`;
+    prevDefault = getGlobalDefault('claude');
+    plantInstall(labelA, '0.1.0', { email: emailA });
+    plantInstall(labelB, '0.2.0', { email: emailB });
+    invalidateInstalledVersionsCache('claude');
+    const acctA = await registerHomeAccount(labelA, `resume-a-${suffix}`, emailA);
+    const acctB = await registerHomeAccount(labelB, `resume-b-${suffix}`, emailB);
+    // A transcript in A's home whose path the DB indexes, to prove reindex
+    // survives the crash + resume rather than dangling.
+    const resumeSession = `t7-resume-${suffix}`;
+    const sessionFile = path.join(getVersionDir('claude', labelA), 'home', '.claude', 'projects', '-Users-resume', `${suffix}.jsonl`);
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(sessionFile, `${JSON.stringify({ type: 'user', message: { content: 'resume me' } })}\n`);
+    getDB().prepare(`
+      INSERT INTO sessions (id, short_id, agent, timestamp, last_activity, file_path, is_team_origin)
+      VALUES (?, ?, 'claude', ?, ?, ?, 0)
+    `).run(resumeSession, resumeSession.slice(0, 8), new Date().toISOString(), new Date().toISOString(), sessionFile);
+
+    // Crash after the first filesystem move commits: the move is durable but the
+    // journal is still `planned` and the account/session records are not written.
+    let crashed = false;
+    await expect(applyAccountMigration(['claude'], {
+      isActive: async () => false,
+      afterMove: () => { if (!crashed) { crashed = true; throw new Error('injected crash after first move'); } },
+    })).rejects.toThrow(/injected crash/);
+    const manifests = path.join(getHistoryDir(), 'accounts');
+    const planned = fs.readdirSync(manifests).filter((f) => f.startsWith('migration-') && f.endsWith('.json'));
+    expect(planned).toHaveLength(1);
+    expect((JSON.parse(fs.readFileSync(path.join(manifests, planned[0]!), 'utf8')) as { status: string }).status).toBe('planned');
+
+    // Resume: picks up the same journal, re-does nothing already done, finishes.
+    const result = await applyAccountMigration(['claude'], { isActive: async () => false });
+    expect(result.manifest.status).toBe('complete');
+    // Exactly one manifest — the resume reused the pending one, never a second.
+    expect(fs.readdirSync(manifests).filter((f) => f.startsWith('migration-') && f.endsWith('.json'))).toHaveLength(1);
+    for (const acct of [acctA, acctB]) {
+      expect(fs.existsSync(path.join(slotDir('claude', acct.id), '.claude.json'))).toBe(true);
+      expect(fs.existsSync(path.join(slotDir('claude', acct.id), '.claude', '.credentials.json'))).toBe(true);
+    }
+    expect(fs.existsSync(path.join(getVersionDir('claude', labelA), 'home', '.claude.json'))).toBe(false);
+    expect(fs.existsSync(path.join(getVersionDir('claude', labelB), 'home', '.claude.json'))).toBe(false);
+    // No duplicate account rows minted across the two apply passes.
+    expect(listNativeAccounts(readMeta()).filter((a) => a.identityLabel === emailA)).toHaveLength(1);
+    // The transcript followed A's home into its slot and the DB points at it.
+    const row = getDB().prepare(`SELECT file_path FROM sessions WHERE id = ?`).get(resumeSession) as { file_path: string };
+    expect(row.file_path.includes(`${path.sep}accounts${path.sep}claude${path.sep}${acctA.id}${path.sep}`)).toBe(true);
+    expect(fs.existsSync(row.file_path)).toBe(true);
+    getDB().prepare(`DELETE FROM sessions WHERE id = ?`).run(resumeSession);
   });
 });

--- a/cli/src/lib/accounts/migrate.ts
+++ b/cli/src/lib/accounts/migrate.ts
@@ -33,11 +33,11 @@ import {
   listInstalledVersionDirs,
   readInstallation,
   setGlobalDefault,
-  softDeleteVersionDir,
 } from '../installations/versions.js';
 import { removeVersionedAlias } from '../installations/shims.js';
 import { countSessionsWithFilePrefix, reindexMovedSessionPaths } from '../session/db.js';
-import { atomicWriteFileSync } from '../fs-atomic.js';
+import { atomicWriteFileSync, withFileLockAsync } from '../fs-atomic.js';
+import { installationLockTarget, INSTALLATION_LOCK_OPTIONS } from '../installations/installation-lock.js';
 import { getHistoryDir, readMeta, updateMeta } from '../state.js';
 import type { AgentId, DeviceAccountSlot } from '../types.js';
 import { recordSlot, slotDir } from './slots.js';
@@ -113,11 +113,15 @@ export interface AccountMigrationManifest {
   }>;
   /** old `agent@label` → new slot dir (or trash path). */
   map: Record<string, string>;
+  /** Cumulative rows updated while the journal was applied or resumed. */
+  sessionsReindexed?: number;
 }
 
 export interface AccountMigrateDeps {
   isActive?: (installation: { agent: AgentId; label: string }) => Promise<boolean>;
   now?: () => Date;
+  /** Test-only crash injection after a filesystem move has committed. */
+  afterMove?: (move: { agent: AgentId; label: string; from: string; to: string }) => void;
 }
 
 const OPAQUE_LABEL = /^(?:latest|main|acct-[0-9a-f]+|\d+\.\d+.*)$/i;
@@ -274,33 +278,6 @@ function plannedTrashPath(agent: AgentId, label: string): string {
   return path.join(getHistoryDir(), 'trash', 'versions', agent, label, '<stamp>');
 }
 
-/**
- * Where a canonical install's stale `home/` goes when its account already holds
- * a slot: the binary and the (recreated, empty) home stay under `versions/`, so
- * the old home cannot use the versions trash — `agents trash restore` would put a
- * whole install back over a live one. Restoring is a plain move back; the
- * migration manifest records the path under `<agent>@<label>#home`.
- */
-function homeTrashDir(agent: AgentId, label: string): string {
-  return path.join(getHistoryDir(), 'trash', 'homes', agent, label);
-}
-
-function plannedHomeTrashPath(agent: AgentId, label: string): string {
-  return path.join(homeTrashDir(agent, label), '<stamp>');
-}
-
-function trashHome(agent: AgentId, item: InstallationInventory): string {
-  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const dest = path.join(homeTrashDir(agent, item.label), stamp);
-  fs.mkdirSync(path.dirname(dest), { recursive: true, mode: 0o700 });
-  if (!fs.existsSync(item.home)) {
-    throw new Error(`Home ${item.home} is missing; cannot trash it.`);
-  }
-  fs.renameSync(item.home, dest);
-  fs.mkdirSync(item.home, { recursive: true, mode: 0o700 });
-  return dest;
-}
-
 function emptyDir(dir: string): boolean {
   if (!fs.existsSync(dir)) return true;
   try {
@@ -333,6 +310,10 @@ function provisionedSlotExists(agent: AgentId, accountId: string): boolean {
   } catch {
     return false;
   }
+}
+
+function legacyArchiveDir(agent: AgentId, accountId: string, label: string): string {
+  return path.join(slotDir(agent, accountId), '.agents-migration', 'legacy', label);
 }
 
 function takenNames(meta: ReturnType<typeof readMeta>): Set<string> {
@@ -419,38 +400,21 @@ async function planHarness(
       continue;
     }
     if (item.hasCredential && item.accountId && provisionedSlotExists(agent, item.accountId)) {
-      // The account already owns a populated slot on this device, so this
-      // per-version home is a stale copy of a credential the slot now carries.
-      // Routing it to `slot` would only trip `assertSlotAbsent` and abort the
-      // whole apply with nothing done — the state every auth-synced worker was
-      // in. Trash it instead (`agents trash restore` reverses). The canonical
-      // install keeps its binary and ends up with an empty home, exactly as it
-      // does when its home is the one that moves into the slot: two on-disk
-      // copies of one credential is not an end state the migration leaves.
-      if (canonical && item.label === canonical.label) {
-        actions.push({
-          kind: 'canonical',
-          label: item.label,
-          release: item.release,
-          reason: 'canonical install (binary kept); account already holds a slot — stale home trashed, empty home recreated',
-          accountId: item.accountId,
-          identityKey: item.identityKey,
-          email: item.email,
-          sessionCount: item.sessionCount,
-          pathMoves: [{ from: item.home, to: plannedHomeTrashPath(agent, item.label) }],
-        });
-        continue;
-      }
+      const archive = legacyArchiveDir(agent, item.accountId, item.label);
       actions.push({
-        kind: 'trash',
+        kind: 'slot',
         label: item.label,
         release: item.release,
-        reason: 'account already holds a provisioned slot on this device — stale home trashed',
+        reason: 'account already holds a distinct slot — preserve the legacy home inside that account slot',
         accountId: item.accountId,
         identityKey: item.identityKey,
         email: item.email,
+        slotDir: slotDir(agent, item.accountId),
         sessionCount: item.sessionCount,
-        pathMoves: [{ from: item.dir, to: plannedTrashPath(agent, item.label) }],
+        pathMoves: [
+          { from: item.home, to: archive },
+          ...(item.label === canonical?.label ? [] : [{ from: item.dir, to: plannedTrashPath(agent, item.label) }]),
+        ],
       });
       continue;
     }
@@ -611,6 +575,7 @@ function clearHomes(accountIds: string[]): void {
 }
 
 function moveHomeToSlot(item: InstallationInventory, dest: string): void {
+  if (!fs.existsSync(item.home) && fs.existsSync(dest)) return;
   if (fs.existsSync(dest) && !emptyDir(dest)) {
     throw new Error(`Slot already exists for ${item.agent} account at ${dest}.`);
   }
@@ -620,6 +585,52 @@ function moveHomeToSlot(item: InstallationInventory, dest: string): void {
     throw new Error(`Home ${item.home} is missing; cannot move it into a slot.`);
   }
   fs.renameSync(item.home, dest);
+}
+
+function moveDirectoryTo(item: InstallationInventory, source: string, dest: string): void {
+  if (!fs.existsSync(source) && fs.existsSync(dest)) return;
+  if (!fs.existsSync(source)) throw new Error(`${source} is missing; cannot move it to ${dest}.`);
+  if (fs.existsSync(dest)) throw new Error(`${dest} already exists while ${source} is still present.`);
+  fs.mkdirSync(path.dirname(dest), { recursive: true, mode: 0o700 });
+  try {
+    fs.renameSync(source, dest);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'EPERM' && code !== 'EACCES') throw err;
+    fs.cpSync(source, dest, { recursive: true });
+    fs.rmSync(source, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Run one installation-mutating step (home→slot rename, binary trash) under the
+ * SHARED per-installation exclusion, re-checking the install is idle FIRST.
+ *
+ * This is the migration side of the shared installation-lock contract
+ * (`installation-lock.ts`): one lock per `(agent, label)`, its target kept
+ * OUTSIDE the installation dir, every holder agreeing on
+ * `INSTALLATION_LOCK_OPTIONS` (same stale threshold, so none breaks a live npm
+ * install). The contract has two peers that MUST both honor it, or a launch and
+ * a migration race the same home:
+ *   - Launch (the local-account launch path, `agents run`): MUST hold this lock
+ *     through ACTUAL process registration — acquire before spawning and release
+ *     only once the live process is recorded, so the recheck below observes it.
+ *   - Migration (here): MUST hold it for the FINAL active recheck AND the move,
+ *     as one critical section. Planning's `isActive` read is advisory and racy;
+ *     the authoritative decision is this recheck under the lock, immediately
+ *     before the rename. An install that went busy between planning and now is
+ *     deferred, never renamed out from under a running agent.
+ */
+async function withMigrationExclusion<T>(
+  item: InstallationInventory,
+  deps: AccountMigrateDeps,
+  mutate: () => T,
+): Promise<{ deferred: boolean; value?: T }> {
+  return withFileLockAsync(installationLockTarget(item.agent, item.label), async () => {
+    const active = await (deps.isActive ?? defaultIsActive)({ agent: item.agent, label: item.label });
+    if (active) return { deferred: true };
+    return { deferred: false, value: mutate() };
+  }, INSTALLATION_LOCK_OPTIONS);
 }
 
 function recordMovedSlot(agent: AgentId, account: NativeAccount, dest: string): void {
@@ -639,6 +650,40 @@ function persistManifest(manifestPath: string, manifest: AccountMigrationManifes
     manifestPath,
     `${JSON.stringify(manifest, null, 2)}\n`,
     { encoding: 'utf8', mode: 0o600 },
+  );
+}
+
+function pendingManifest(): { manifestPath: string; manifest: AccountMigrationManifest } | null {
+  const dir = path.join(getHistoryDir(), 'accounts');
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir).filter((name) => /^migration-.*\.json$/.test(name)).sort().reverse();
+  } catch {
+    return null;
+  }
+  for (const name of names) {
+    const manifestPath = path.join(dir, name);
+    try {
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as AccountMigrationManifest;
+      if (manifest.schema === ACCOUNT_MIGRATION_SCHEMA && manifest.status === 'planned' && manifest.dryRun === false) {
+        return { manifestPath, manifest };
+      }
+    } catch {
+      // A corrupt journal is not safe to guess through; a later valid journal
+      // can still be resumed, otherwise the next apply creates a fresh plan.
+    }
+  }
+  return null;
+}
+
+function exactTrashPath(manifest: AccountMigrationManifest, item: InstallationInventory): string {
+  return path.join(
+    getHistoryDir(),
+    'trash',
+    'versions',
+    item.agent,
+    item.label,
+    manifest.at.replace(/[:.]/g, '-'),
   );
 }
 
@@ -665,16 +710,16 @@ export async function applyAccountMigration(
   agents: AgentId[] = [...ALL_AGENT_IDS],
   deps: AccountMigrateDeps = {},
 ): Promise<ApplyMigrationResult> {
-  const plan = await planAccountMigration(agents, deps);
+  const pending = pendingManifest();
+  const plan = pending?.manifest.plan ?? await planAccountMigration(agents, deps);
   const now = deps.now ?? (() => new Date());
-  const at = now();
-  const stamp = at.toISOString();
-  const manifestPath = path.join(
+  const stamp = pending?.manifest.at ?? now().toISOString();
+  const manifestPath = pending?.manifestPath ?? path.join(
     getHistoryDir(),
     'accounts',
     `migration-${stamp.replace(/[:.]/g, '-')}.json`,
   );
-  const manifest: AccountMigrationManifest = {
+  const manifest: AccountMigrationManifest = pending?.manifest ?? {
     schema: ACCOUNT_MIGRATION_SCHEMA,
     at: stamp,
     dryRun: false,
@@ -682,10 +727,11 @@ export async function applyAccountMigration(
     plan,
     harnesses: {},
     map: {},
+    sessionsReindexed: 0,
   };
   persistManifest(manifestPath, manifest);
 
-  const remaps: Array<{ from: string; to: string }> = [];
+  let sessionsReindexed = manifest.sessionsReindexed ?? 0;
   const taken = takenNames(readMeta());
 
   for (const h of plan.harnesses) {
@@ -708,27 +754,66 @@ export async function applyAccountMigration(
       const item = byLabel.get(action.label);
       if (!item) throw new Error(`Plan named ${h.agent}@${action.label} but inventory has no such install.`);
       const account = resolveOrRegisterAccount(item, taken);
-      const dest = assertSlotAbsent(h.agent, account.id);
-      moveHomeToSlot(item, dest);
-      recordMovedSlot(h.agent, account, dest);
-      remaps.push({ from: item.home, to: dest });
+      const slotRoot = slotDir(h.agent, account.id);
+      const mapKey = `${h.agent}@${item.label}`;
+      const priorDest = manifest.map[mapKey];
+      const dest = priorDest ?? (provisionedSlotExists(h.agent, account.id)
+        ? legacyArchiveDir(h.agent, account.id, item.label)
+        : assertSlotAbsent(h.agent, account.id));
+      manifest.map[mapKey] = dest;
+      persistManifest(manifestPath, manifest);
+
+      const moved = await withMigrationExclusion(item, deps, () => {
+        if (dest === slotRoot) moveHomeToSlot(item, dest);
+        else moveDirectoryTo(item, item.home, dest);
+      });
+      if (moved.deferred) {
+        if (!entry.deferred.some((row) => row.label === item.label)) {
+          entry.deferred.push({ label: item.label, reason: 'installation became busy before its migration move' });
+        }
+        delete manifest.map[mapKey];
+        persistManifest(manifestPath, manifest);
+        continue;
+      }
+      deps.afterMove?.({ agent: h.agent, label: item.label, from: item.home, to: dest });
+
+      // Only the home that BECAME the account's slot defines its slot record. A
+      // legacy home archived alongside an already-provisioned slot
+      // (dest = legacyArchiveDir) must leave that record pointing at slotRoot —
+      // recording the archive subdir would make spawn launch the preserved copy.
+      if (dest === slotRoot) recordMovedSlot(h.agent, account, dest);
+      sessionsReindexed += reindexMovedSessionPaths([{ from: item.home, to: dest }]);
+      manifest.sessionsReindexed = sessionsReindexed;
       labelToAccount.set(item.label, account.id);
       if (item.identityKey) identityToAccount.set(item.identityKey, account.id);
       movedAccountIds.push(account.id);
-      entry.slots.push({ oldLabel: item.label, accountId: account.id, accountName: account.name, slotDir: dest });
-      manifest.map[`${h.agent}@${item.label}`] = dest;
+      if (!entry.slots.some((row) => row.oldLabel === item.label)) {
+        entry.slots.push({ oldLabel: item.label, accountId: account.id, accountName: account.name, slotDir: slotRoot });
+      }
       persistManifest(manifestPath, manifest);
 
       if (item.label === h.canonical) {
         fs.mkdirSync(item.home, { recursive: true, mode: 0o700 });
       } else {
-        const trashPath = softDeleteVersionDir(h.agent, item.label);
-        if (!trashPath) throw new Error(`Failed to trash binary leftover ${h.agent}@${item.label}.`);
+        const binaryKey = `${mapKey}#binary`;
+        const trashPath = manifest.map[binaryKey] ?? exactTrashPath(manifest, item);
+        manifest.map[binaryKey] = trashPath;
+        persistManifest(manifestPath, manifest);
+        const trashed = await withMigrationExclusion(item, deps, () => moveDirectoryTo(item, item.dir, trashPath));
+        if (trashed.deferred) {
+          if (!entry.deferred.some((row) => row.label === item.label)) {
+            entry.deferred.push({ label: item.label, reason: 'installation became busy before its binary cleanup' });
+          }
+          persistManifest(manifestPath, manifest);
+          continue;
+        }
         removeVersionedAlias(h.agent, item.label);
-        remaps.push({ from: item.dir, to: trashPath });
+        sessionsReindexed += reindexMovedSessionPaths([{ from: item.dir, to: trashPath }]);
+        manifest.sessionsReindexed = sessionsReindexed;
         stillPresent.delete(item.label);
-        entry.trashed.push({ label: item.label, reason: 'binary leftover after home moved to slot', trashPath });
-        manifest.map[`${h.agent}@${item.label}#binary`] = trashPath;
+        if (!entry.trashed.some((row) => row.label === item.label && row.trashPath === trashPath)) {
+          entry.trashed.push({ label: item.label, reason: 'binary leftover after home moved to slot', trashPath });
+        }
         persistManifest(manifestPath, manifest);
       }
     }
@@ -739,28 +824,30 @@ export async function applyAccountMigration(
       if (kept) labelToAccount.set(item.label, kept);
     }
 
-    for (const action of h.actions.filter((a) => a.kind === 'canonical' && a.accountId)) {
-      // Canonical install whose account already holds a slot: hand the stale
-      // home off to the homes trash and leave an empty home behind, mirroring
-      // the slot branch's end state for a canonical home.
-      const item = byLabel.get(action.label);
-      if (!item) throw new Error(`Plan named ${h.agent}@${action.label} but inventory has no such install.`);
-      const trashPath = trashHome(h.agent, item);
-      remaps.push({ from: item.home, to: trashPath });
-      labelToAccount.set(item.label, action.accountId!);
-      movedAccountIds.push(action.accountId!);
-      entry.trashed.push({ label: item.label, reason: 'stale canonical home — account already holds a provisioned slot', trashPath });
-      manifest.map[`${h.agent}@${item.label}#home`] = trashPath;
-      persistManifest(manifestPath, manifest);
-    }
-
     for (const action of trashActions) {
       const item = byLabel.get(action.label);
       if (!item) throw new Error(`Plan named ${h.agent}@${action.label} but inventory has no such install.`);
-      const trashPath = softDeleteVersionDir(h.agent, item.label);
-      if (!trashPath) throw new Error(`Failed to trash ${h.agent}@${item.label}.`);
+      const mapKey = `${h.agent}@${item.label}`;
+      const trashPath = manifest.map[mapKey] ?? exactTrashPath(manifest, item);
+      manifest.map[mapKey] = trashPath;
+      persistManifest(manifestPath, manifest);
+      // Recheck the installation is idle under the shared exclusion before the
+      // rename, so a launch that started after planning defers this trash
+      // instead of racing it. A resumed apply is idempotent: moveDirectoryTo is
+      // a no-op once the dir already moved to the recorded trash path.
+      const trashed = await withMigrationExclusion(item, deps, () => moveDirectoryTo(item, item.dir, trashPath));
+      if (trashed.deferred) {
+        if (!entry.deferred.some((row) => row.label === item.label)) {
+          entry.deferred.push({ label: item.label, reason: 'installation became busy before its trash move' });
+        }
+        delete manifest.map[mapKey];
+        persistManifest(manifestPath, manifest);
+        continue;
+      }
+      deps.afterMove?.({ agent: h.agent, label: item.label, from: item.dir, to: trashPath });
       removeVersionedAlias(h.agent, item.label);
-      remaps.push({ from: item.dir, to: trashPath });
+      sessionsReindexed += reindexMovedSessionPaths([{ from: item.dir, to: trashPath }]);
+      manifest.sessionsReindexed = sessionsReindexed;
       stillPresent.delete(item.label);
       if (action.accountId) {
         // A home trashed because its account already holds a slot: anything
@@ -769,8 +856,9 @@ export async function applyAccountMigration(
         labelToAccount.set(item.label, action.accountId);
         movedAccountIds.push(action.accountId);
       }
-      entry.trashed.push({ label: item.label, reason: action.reason, trashPath });
-      manifest.map[`${h.agent}@${item.label}`] = trashPath;
+      if (!entry.trashed.some((row) => row.label === item.label && row.trashPath === trashPath)) {
+        entry.trashed.push({ label: item.label, reason: action.reason, trashPath });
+      }
       persistManifest(manifestPath, manifest);
     }
 
@@ -780,7 +868,6 @@ export async function applyAccountMigration(
     invalidateInstalledVersionsCache(h.agent);
   }
 
-  const sessionsReindexed = reindexMovedSessionPaths(remaps);
   manifest.status = 'complete';
   persistManifest(manifestPath, manifest);
 

--- a/cli/src/lib/accounts/slots.test.ts
+++ b/cli/src/lib/accounts/slots.test.ts
@@ -3,8 +3,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { addNativeAccount, readSlots, removeAccount } from '../account-registry.js';
 import { getGlobalDefault, getVersionHomePath, listInstalledVersions } from '../installations/store.js';
+import { getVersionDir, invalidateInstalledVersionsCache, removeVersion } from '../installations/versions.js';
+import { loadManifest } from '../staleness/index.js';
 import { getHistoryDir, readMeta, updateMeta } from '../state.js';
-import { ensureSlot, recordSlot, slotDir } from './slots.js';
+import { ensureSlot, recordSlot, slotDir, syncResourcesToAccountSlots } from './slots.js';
 
 describe('slotDir', () => {
   it('is ~/.agents/.history/accounts/<harness>/<accountId>/', () => {
@@ -106,5 +108,79 @@ describe('recordSlot / readSlots device-doc round-trip', () => {
       authMode: 'native',
       verdict: 'unconfigured',
     })).toThrow(/mismatch/);
+  });
+});
+
+describe('syncResourcesToAccountSlots (single home-targeted writer, two accounts one binary)', () => {
+  const suffix = `slotsync-${Date.now().toString(36)}`;
+  const version = '2.1.0';
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const name of created.splice(0)) {
+      try { removeAccount(name); } catch { /* already gone */ }
+    }
+    const claudeAccounts = path.join(getHistoryDir(), 'accounts', 'claude');
+    const codexAccounts = path.join(getHistoryDir(), 'accounts', 'codex');
+    for (const root of [claudeAccounts, codexAccounts]) {
+      if (fs.existsSync(root)) fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reconciles every materialized slot for the harness, skips other harnesses and unmaterialized slots, and never writes version-home staleness metadata into a slot', () => {
+    const a = addNativeAccount(`a-${suffix}`, 'claude', `claude:user=a-${suffix}`, `a-${suffix}@example.com`, 'version');
+    const b = addNativeAccount(`b-${suffix}`, 'claude', `claude:user=b-${suffix}`, `b-${suffix}@example.com`, 'version');
+    const cx = addNativeAccount(`cx-${suffix}`, 'codex', `codex:user=cx-${suffix}`, `cx-${suffix}@example.com`, 'version');
+    const ghost = addNativeAccount(`ghost-${suffix}`, 'claude', `claude:user=ghost-${suffix}`, `ghost-${suffix}@example.com`, 'version');
+    created.push(a.name, b.name, cx.name, ghost.name);
+
+    // a + b have real slot dirs; codex slot is materialized too (must still be
+    // skipped, wrong harness); ghost has a slot RECORD but no dir on disk.
+    recordSlot(a.id, ensureSlot('claude', a.id));
+    recordSlot(b.id, ensureSlot('claude', b.id));
+    recordSlot(cx.id, ensureSlot('codex', cx.id));
+    recordSlot(ghost.id, { accountId: ghost.id, slotDir: slotDir('claude', ghost.id), authMode: 'native', verdict: 'unconfigured' });
+
+    const results = syncResourcesToAccountSlots('claude', version, undefined, { force: true });
+    const targeted = results.map((r) => r.accountId).sort();
+    expect(targeted).toEqual([a.id, b.id].sort());
+    expect(targeted).not.toContain(cx.id);
+    expect(targeted).not.toContain(ghost.id);
+
+    // The slot sync projects resources into the slot home but must NOT write the
+    // version-home `.sync-manifest.json` staleness record — that stays scoped to
+    // the managed installation (the isManagedVersionHome guard).
+    expect(loadManifest('claude', version)).toBeNull();
+    expect(fs.existsSync(path.join(slotDir('claude', a.id), '.sync-manifest.json'))).toBe(false);
+  });
+});
+
+describe('binary lifecycle preserves account slots', () => {
+  it('removeVersion trashes the binary but leaves the account slot intact', () => {
+    const id = `lifecycle-${Date.now().toString(36)}`;
+    const version = `0.0.0-lifecycle-${Date.now().toString(36)}`;
+    const slot = ensureSlot('claude', id);
+    fs.writeFileSync(path.join(slot.slotDir, '.claude.json'), JSON.stringify({ marker: id }));
+    fs.writeFileSync(path.join(slot.slotDir, '.claude', '.credentials.json'), JSON.stringify({ token: id }));
+
+    const vdir = getVersionDir('claude', version);
+    fs.mkdirSync(path.join(vdir, 'node_modules', '.bin'), { recursive: true });
+    fs.writeFileSync(path.join(vdir, 'node_modules', '.bin', 'claude'), '#!/bin/sh\n');
+    fs.writeFileSync(path.join(vdir, 'package.json'), '{}');
+    invalidateInstalledVersionsCache('claude');
+
+    try {
+      expect(removeVersion('claude', version)).toBe(true);
+      // The binary install is gone; the account slot lives outside the version
+      // tree (~/.agents/.history/accounts/…), so it is untouched, credential and all.
+      expect(fs.existsSync(vdir)).toBe(false);
+      expect(JSON.parse(fs.readFileSync(path.join(slot.slotDir, '.claude.json'), 'utf8'))).toEqual({ marker: id });
+      expect(fs.existsSync(path.join(slot.slotDir, '.claude', '.credentials.json'))).toBe(true);
+    } finally {
+      fs.rmSync(slot.slotDir, { recursive: true, force: true });
+      const trash = path.join(getHistoryDir(), 'trash', 'versions', 'claude', version);
+      if (fs.existsSync(trash)) fs.rmSync(trash, { recursive: true, force: true });
+      invalidateInstalledVersionsCache('claude');
+    }
   });
 });

--- a/cli/src/lib/accounts/slots.ts
+++ b/cli/src/lib/accounts/slots.ts
@@ -17,9 +17,9 @@ import { agentConfigDirName } from '../agents.js';
 import { harnessAuth, harnessWorkerIsPerDevice } from '../harness-auth-capabilities.js';
 import { getGlobalDefault, getVersionHomePath, listInstalledVersions } from '../installations/store.js';
 import { carryForwardSettings } from '../settings-manifest.js';
-import { getHistoryDir, updateMeta } from '../state.js';
-import { ALL_RESOURCE_KINDS, getDetector, getWriter, kindToCapability } from '../staleness/registry.js';
-import { supports } from '../capabilities.js';
+import { getHistoryDir, readMeta, updateMeta } from '../state.js';
+import { syncResourcesToHome, type SyncResourcesOptions } from '../installations/versions.js';
+import type { ResourceSelection, SyncResult } from '../installations/versions.js';
 import type { AccountAuthMode, AgentId, DeviceAccountSlot, Meta } from '../types.js';
 import { isAgentId } from '../types.js';
 
@@ -63,20 +63,41 @@ function sourceVersion(harness: AgentId): string | null {
   return getGlobalDefault(harness) ?? listInstalledVersions(harness)[0] ?? null;
 }
 
-function projectResources(harness: AgentId, version: string, destHome: string, fromHome: string): void {
-  const cwd = process.cwd();
-  for (const kind of ALL_RESOURCE_KINDS) {
-    if (!supports(harness, kindToCapability(kind), version).ok) continue;
-    const writer = getWriter(kind, harness);
-    if (!writer) continue;
-    if (kind === 'rules') {
-      writer.write({ version, versionHome: destHome, selection: { preset: 'default' }, cwd });
-      continue;
-    }
-    const names = getDetector(kind, harness)?.list({ version, versionHome: fromHome, cwd }) ?? [];
-    if (names.length === 0) continue;
-    writer.write({ version, versionHome: destHome, selection: names, cwd });
+/** Project resources into one account slot through the installation writer. */
+export function syncResourcesToSlot(
+  harness: AgentId,
+  version: string,
+  home: string,
+  selection?: ResourceSelection,
+  options: SyncResourcesOptions = {},
+): SyncResult {
+  return syncResourcesToHome(harness, version, home, selection, options);
+}
+
+/** Reconcile every materialized account slot for one harness. */
+export function syncResourcesToAccountSlots(
+  harness: AgentId,
+  version: string,
+  selection?: ResourceSelection,
+  options: SyncResourcesOptions = {},
+): Array<{ accountId: string; result: SyncResult }> {
+  const meta = readMeta();
+  const slots = readSlots(meta);
+  const results: Array<{ accountId: string; result: SyncResult }> = [];
+  const accounts = [
+    ...Object.values(meta.accounts?.native ?? {}),
+    ...Object.values(meta.deviceAccounts?.native ?? {}),
+  ];
+  for (const account of accounts) {
+    if (account.agent !== harness) continue;
+    const slot = slots[account.id];
+    if (!slot || !fs.existsSync(slot.slotDir)) continue;
+    results.push({
+      accountId: account.id,
+      result: syncResourcesToSlot(harness, version, slot.slotDir, selection, options),
+    });
   }
+  return results;
 }
 
 /**
@@ -96,7 +117,7 @@ export function ensureSlot(harness: AgentId, accountId: string): DeviceAccountSl
     const fromHome = getVersionHomePath(harness, version);
     if (fs.existsSync(fromHome)) {
       carryForwardSettings(harness, fromHome, dir);
-      projectResources(harness, version, dir, fromHome);
+      syncResourcesToSlot(harness, version, dir, undefined, { force: true });
     }
   }
 

--- a/cli/src/lib/installations/shims.auth-carry.test.ts
+++ b/cli/src/lib/installations/shims.auth-carry.test.ts
@@ -27,6 +27,8 @@ vi.mock('../state.js', async () => {
 
 import { switchConfigSymlink, carryForwardAuthFiles, readAuthFileIdentity } from './shims.js';
 import { getAccountInfo } from '../agents.js';
+import { addNativeAccount, removeAccount } from '../account-registry.js';
+import { recordSlot, slotDir } from '../accounts/slots.js';
 
 const tempDirs: string[] = [];
 
@@ -197,6 +199,32 @@ describe('carryForwardAuthFiles — account-identity guard (RUSH-1764)', () => {
 
     const body = JSON.parse(fs.readFileSync(path.join(destDir, 'antigravity-oauth-token'), 'utf8'));
     expect(body.token.refresh_token).toBe('REFRESH_A'); // account B's newer token was refused
+  });
+
+  it('is a no-op once the harness has adopted an account slot — credentials are account-owned (PHNX-3940)', () => {
+    // With no slot, an empty target is seeded from the freshest source (the
+    // `seeds an EMPTY target` case above). Once this harness owns a materialized
+    // slot, that version-home carry must stop entirely: switching a binary must
+    // never refresh version-owned auth again.
+    const v1 = droidHome('latest');    // a freshest source that WOULD be carried
+    const v2 = droidHome('0.159.1');   // empty target
+    writeDroidCred(v1, { email: 'a@x.com', org_id: 'orgA' }, 2_000_000);
+
+    const acct = addNativeAccount(`carry-gate-${Date.now().toString(36)}`, 'droid', `droid:user=carry-${Date.now().toString(36)}`, 'a@x.com', 'version');
+    try {
+      const dir = slotDir('droid', acct.id);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'auth.json'), '{}');
+      recordSlot(acct.id, { accountId: acct.id, slotDir: dir, authMode: 'per-device', verdict: 'unconfigured' });
+
+      carryForwardAuthFiles('droid', path.join(v2, '.factory'));
+
+      // The empty target stayed empty — the adopted slot short-circuited the carry.
+      expect(fs.existsSync(path.join(v2, '.factory', 'auth.v2.file'))).toBe(false);
+      fs.rmSync(dir, { recursive: true, force: true });
+    } finally {
+      removeAccount(`droid#${acct.name}`);
+    }
   });
 });
 

--- a/cli/src/lib/installations/shims.ts
+++ b/cli/src/lib/installations/shims.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 import { confirm, select } from '@inquirer/prompts';
 import type { AgentId } from '../types.js';
 import { IS_WINDOWS, prependToWindowsUserPath } from '../platform/index.js';
-import { getShimsDir, getVersionsDir, getBackupsDir, getHistoryDir, ensureAgentsDir } from '../state.js';
+import { getShimsDir, getVersionsDir, getBackupsDir, getHistoryDir, ensureAgentsDir, readMeta } from '../state.js';
 export { getShimsDir };
 import { AGENTS, agentConfigDirName, readAuthAccountIdentity } from '../agents.js';
 import { acquireAuthOperationLock } from '../accounts/auth-operation-lock.js';
@@ -1654,6 +1654,18 @@ export function readAuthFileIdentity(agent: AgentId, configDir: string): string 
 
 /** Carry the freshest existing account credential into `toConfigDir` so version switches don't log out file-auth agents. */
 export function carryForwardAuthFiles(agent: AgentId, toConfigDir: string): void {
+  const meta = readMeta();
+  const nativeRows = [
+    ...Object.values(meta.accounts?.native ?? {}),
+    ...Object.values(meta.deviceAccounts?.native ?? {}),
+  ];
+  const slots = meta.deviceAccounts?.slots ?? {};
+  if (nativeRows.some((account) => account.agent === agent && slots[account.id] && fs.existsSync(slots[account.id]!.slotDir))) {
+    // Once this harness has adopted account slots, credentials are account-owned.
+    // Keep the old carry path only for devices whose version homes have not yet
+    // migrated; switching a binary must never refresh version-owned auth again.
+    return;
+  }
   const authFiles = AGENTS[agent].authFiles;
   if (!authFiles || authFiles.length === 0) return;
 

--- a/cli/src/lib/installations/versions.ts
+++ b/cli/src/lib/installations/versions.ts
@@ -2546,13 +2546,37 @@ export function resolveHookSelection(sel: string[] | 'all' | undefined, availabl
   return out;
 }
 
-export function syncResourcesToVersion(agent: AgentId, version: string, selection?: ResourceSelection, options: { projectDir?: string; cwd?: string; force?: boolean; available?: AvailableResources; prune?: boolean; allowExecSurfaces?: boolean } = {}): SyncResult {
+export interface SyncResourcesOptions {
+  projectDir?: string;
+  cwd?: string;
+  force?: boolean;
+  available?: AvailableResources;
+  prune?: boolean;
+  allowExecSurfaces?: boolean;
+}
+
+/**
+ * Reconcile one harness home through the canonical resource writers.
+ *
+ * `version` selects binary capabilities and resource policy; `versionHome` is
+ * the HOME-shaped destination. Account slots deliberately use this same writer
+ * instead of detecting/copying a version home's output. Version-only project
+ * fan-out and staleness metadata stay scoped to the managed installation.
+ */
+export function syncResourcesToHome(
+  agent: AgentId,
+  version: string,
+  versionHome: string,
+  selection?: ResourceSelection,
+  options: SyncResourcesOptions = {},
+): SyncResult {
   if (isAgentHardDeprecated(agent)) {
     return { commands: false, skills: false, hooks: false, memory: [], permissions: false, mcp: [], subagents: [], plugins: [], workflows: [], projectSkipped: [], pruned: { commands: [], skills: [] }, declined: [] };
   }
 
   const agentConfig = AGENTS[agent];
-  const versionHome = getVersionHomePath(agent, version);
+  const managedVersionHome = getVersionHomePath(agent, version);
+  const isManagedVersionHome = path.resolve(versionHome) === path.resolve(managedVersionHome);
   const agentDir = path.join(versionHome, agentConfigDirName(agent));
   fs.mkdirSync(agentDir, { recursive: true });
   // Capture whether the caller passed a selection. The pattern-expansion
@@ -2571,7 +2595,7 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
 
   // Project-layer fan-out always runs — even on the early guard hit — so the
   // `projectSkipped` contract is preserved for callers (RUSH-2320 #4).
-  if (projectAgentsDir) {
+  if (isManagedVersionHome && projectAgentsDir) {
     result.projectSkipped = syncProjectResourcesToAgent(agent, version, projectAgentsDir).skipped;
   }
 
@@ -2580,7 +2604,7 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   // staleness guard, because the hook is registered in the harness's native
   // config (not in the version-home resource tree the manifest tracks).
   if (supports(agent, 'hooks', version).ok) {
-    const trackerResult = installSessionTrackerHookSync(agent, version);
+    const trackerResult = installSessionTrackerHookSync(agent, version, versionHome);
     if (!trackerResult.installed && trackerResult.error) {
       console.warn(`agents: SessionStart hook not installed for ${agent}@${version}: ${trackerResult.error}`);
     }
@@ -2601,7 +2625,7 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   // version resource patterns, so skipping ensureVersionResourcePatterns on
   // the hit path is safe in practice but is not byte-identical to the old
   // order (that call always wrote missing pattern defaults).
-  if (!userPassedSelection && !options.force) {
+  if (isManagedVersionHome && !userPassedSelection && !options.force) {
     const manifest = loadManifest(agent, version);
     if (manifest && !isStale(manifest, agent, version, cwd)) {
       return { ...result };
@@ -2614,7 +2638,7 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
 
   // Write default resource selection patterns for this version (idempotent —
   // only sets fields that aren't already present, preserving user edits).
-  {
+  if (isManagedVersionHome) {
     const extraAliases = extraRepos.map(e => e.alias);
     const noProject = defaultPatterns(extraAliases, false);
     ensureVersionResourcePatterns(agent, version, {
@@ -3103,7 +3127,7 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   // and only when they are gone from ALL source layers — so a user-authored
   // file the sync never placed, or a same-named resource still provided by
   // another layer, is never removed. No manifest → fail loud (delete nothing).
-  if (options.prune && userPassedSelection) {
+  if (isManagedVersionHome && options.prune && userPassedSelection) {
     const previousManifest = loadManifest(agent, version);
     const outcome = pruneRemovedResources({
       agent,
@@ -3131,7 +3155,7 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   // one-off override, so the resulting state matches what the manifest
   // records as the synced set. Carry forward still-fresh fingerprints from
   // the previous manifest so we do not re-hash an unchanged tree (RUSH-2320 #3).
-  if (!userPassedSelection) {
+  if (isManagedVersionHome && !userPassedSelection) {
     const previous = loadManifest(agent, version);
     const manifest = buildSyncManifest(agent, version, cwd, previous);
     manifest.writtenCommands = writtenCommands;
@@ -3141,6 +3165,15 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   }
 
   return result;
+}
+
+export function syncResourcesToVersion(
+  agent: AgentId,
+  version: string,
+  selection?: ResourceSelection,
+  options: SyncResourcesOptions = {},
+): SyncResult {
+  return syncResourcesToHome(agent, version, getVersionHomePath(agent, version), selection, options);
 }
 
 


### PR DESCRIPTION
**Account-first storage, sync, and lifecycle cutover (PHNX-3940).** feat — the storage/lifecycle track of the account-first plan (audit PR #3569). Recovery of a stalled writer: the seven uncommitted files were adopted, finished (they did not compile), corrected, and covered with tests.

Parent Codex owns integration/review/merge. Sibling tracks (launch #3577, consumer) edit disjoint modules.

## What changed
- **`cli/src/lib/installations/versions.ts`** — extract `syncResourcesToHome(agent, version, home)` as the single home-targeted writer; `syncResourcesToVersion` delegates to it. Version-only side effects (project fan-out, `.sync-manifest.json` staleness record, resource-pattern defaults, prune) are gated by `isManagedVersionHome`, so a slot sync never writes version-scoped metadata.
- **`cli/src/lib/accounts/slots.ts`** — `syncResourcesToSlot` / `syncResourcesToAccountSlots` project resources into each materialized account slot through that one writer instead of detecting-and-copying a version home's output (audit slots.ts:62). Slot-record shape is **unchanged**.
- **`cli/src/commands/sync.ts`** — `syncVersionAndAccountSlots` reconciles the version home and every account slot together at each caller (523/911/1061/1148).
- **`cli/src/commands/accounts.ts`** — logout resolves the account-owned home (`LogoutTarget`: slot first, a legacy version home only for an unmigrated account; accounts.ts:1044); attach no longer recreates or transports auth into a version-owned home and `writeClaudeInteractiveOauthToken` is removed (accounts.ts:914). The slot `.oauth_token` writer (`writeClaudeSlotOauthToken`, `claude-account-token.ts`) is the account-first replacement; existing version-home token files are left untouched for bounded compatibility.
- **`cli/src/lib/accounts/add.ts`** — login and setup-token mint pin the harness config-dir env through the same adapter `buildExecEnv` uses for a slot launch (fixes the leftover `slotConfigDir` reference the adopted diff didn't finish).
- **`cli/src/lib/installations/shims.ts`** — `carryForwardAuthFiles` is a no-op once the harness has adopted a slot on disk, so a binary switch/update (`switchConfigToVersion`) never refreshes version-owned auth again (audit shims.ts:1655/1741).
- **`cli/src/lib/accounts/migrate.ts`** — strengthened, not rebuilt: the final active recheck **and** every home/binary move run under the shared per-installation exclusion (`installation-lock.ts`), deferring an install that went busy after planning (audit 225-vs-712 race); the journal is crash-recoverable and an interrupted apply resumes idempotently from its manifest; a legacy home whose account already holds a provisioned slot is **preserved inside that slot** (differing settings/transcripts kept, sessions reindexed) rather than trashed, and the slot record keeps pointing at the real slot, not the archive. Also completed the adopted-but-uncompiled refactor (removed the dead `canonical`-with-accountId path + `remaps`, consolidated the session-reindex accumulator, dropped orphaned helpers).
- **tests** — real temporary filesystems, no mocks: two-accounts/one-binary sync isolation + no version-manifest leak into a slot, binary-lifecycle slot survival, logout home resolution, active-recheck deferral, interrupted-then-resumed migration with no data loss, preserved distinct legacy history, and the adopted-slot carry-forward no-op. Existing tests updated to the new logout shape and the preserve-in-slot migration behavior; the removed `writeClaudeInteractiveOauthToken` block was deleted (its live slot replacement is covered in `claude-account-token.test.ts`).
- **`cli/.changelog/next/PHNX-3940-storage.md`** — release note.

### Shared installation-lock contract (for the launch track)
Documented in `withMigrationExclusion` (`migrate.ts`): one lock per `(agent, label)` from `installation-lock.ts` with shared `INSTALLATION_LOCK_OPTIONS`. Launch MUST hold it through actual process registration; migration MUST hold it for the final active recheck **and** the move as one critical section.

## Verification
`bun` vitest on `yosemite-m5`, real filesystems:
- `tsc --noEmit`: clean.
- `migrate.test.ts` 16 · `slots.test.ts` 8 · `add.test.ts` · `accounts.test.ts` · `accounts.native-home.test.ts` · `accounts-render.test.ts` · `sync.test.ts` · `shims.auth-carry.test.ts` 16 · `gen-changelog.test.ts` 5 → **164 passed** together.
- Regression sweep of the managed-home writer (`__tests__/versions.test.ts`, `installations/versions.test.ts`, `drift-sync`, `reconcile-and-repair`, `staleness/prune`, `doctor-diff`, `sync-restore-deleted`) → **134 passed**.

No live migration was run and no OAuth tokens were copied (secrets never printed), per the recovery constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
