### PR TITLE
chore(menubar): bump helper floor to 1.1.2

### DIFF
--- a/cli/src/lib/helper-versions.ts
+++ b/cli/src/lib/helper-versions.ts
@@ -51,7 +51,7 @@ export interface HelperRelease {
  * helper release now, off this table entirely.
  */
 export const HELPER_RELEASES: Readonly<Record<HelperName, HelperRelease>> = {
-  menubar: { tagPrefix: 'menubar', floor: '1.1.1' },
+  menubar: { tagPrefix: 'menubar', floor: '1.1.2' },
   'computer-mac': { tagPrefix: 'computer-mac', floor: '1.0.0' },
   // The Windows helper is a bare .exe, not an .app bundle, so it does not share
   // helper-download.ts's zip/codesign/notarize machinery -- but it has the same


### PR DESCRIPTION
Points installed CLIs at the just-published menubar/v1.1.2 helper.

Verified the published asset before bumping: sha256 matches the sidecar, signed Developer ID Application: Muqit Nawaz (2HTP252L87), bundle id com.phnx-labs.agents-menubar, notarized + Gatekeeper-accepted (source=Notarized Developer ID).

Round-2 owner review (I1-I8) shipped in agi-menu: non-blocking popover open, real agent logos + device glyph + working duration, stable headline, Sessions grouping with an Inbox tab, and the in-place session preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fj8xs64boUZTDnwvPL914F