### PR TITLE
chore(menubar): bump helper floor to 1.1.3

### DIFF
--- a/cli/src/lib/helper-versions.ts
+++ b/cli/src/lib/helper-versions.ts
@@ -51,7 +51,7 @@ export interface HelperRelease {
  * helper release now, off this table entirely.
  */
 export const HELPER_RELEASES: Readonly<Record<HelperName, HelperRelease>> = {
-  menubar: { tagPrefix: 'menubar', floor: '1.1.2' },
+  menubar: { tagPrefix: 'menubar', floor: '1.1.3' },
   'computer-mac': { tagPrefix: 'computer-mac', floor: '1.0.0' },
   // The Windows helper is a bare .exe, not an .app bundle, so it does not share
   // helper-download.ts's zip/codesign/notarize machinery -- but it has the same


### PR DESCRIPTION
1.1.2 crashed on every Sessions row once installed (Bundle.module trap — the agent-logo bundle resolved only from the build machine's path, absent on a user's Mac). 1.1.3 fixes it (resolve from the app + a packaging gate that runs the resource self-test inside the assembled .app before signing) and is published + verified: sha256 match, Developer ID 2HTP252L87, notarized, Gatekeeper-accepted, and the issue-test passes inside the downloaded release .app AND the installed app on the owner's Mac. Bump the floor so installed CLIs pull 1.1.3, not the crashing 1.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fj8xs64boUZTDnwvPL914F