### PR TITLE
chore(menubar): bump helper floor to 1.1.4

### DIFF
--- a/cli/src/lib/helper-versions.ts
+++ b/cli/src/lib/helper-versions.ts
@@ -51,7 +51,7 @@ export interface HelperRelease {
  * helper release now, off this table entirely.
  */
 export const HELPER_RELEASES: Readonly<Record<HelperName, HelperRelease>> = {
-  menubar: { tagPrefix: 'menubar', floor: '1.1.3' },
+  menubar: { tagPrefix: 'menubar', floor: '1.1.4' },
   'computer-mac': { tagPrefix: 'computer-mac', floor: '1.0.0' },
   // The Windows helper is a bare .exe, not an .app bundle, so it does not share
   // helper-download.ts's zip/codesign/notarize machinery -- but it has the same


### PR DESCRIPTION
1.1.4 is published on `menubar/v1.1.4` (phnx-labs/agi-menu PR #16 + #18, source tag v1.1.4). Bumping the floor is what makes installed CLIs resolve and download it.

Why: the owner's review of 1.1.3 on a screen recording — translucent khaki popover over light windows, light-mode tab fill under dark-mode text, agent logos invisible on brand-colored tiles, every row titled by its project twice, rows reflowing under the cursor on every refresh and click. All five fixed in 1.1.4, plus an offscreen popover capture mode so chrome changes are inspected as pixels.

Verified on the published asset, downloaded from the release:

```
MenubarHelper.app.zip: OK                      (sha256 sidecar)
CFBundleShortVersionString 1.1.4
Identifier=com.phnx-labs.agents-menubar
Authority=Developer ID Application: Muqit Nawaz (2HTP252L87)
$ MENUBAR_ISSUE_TEST=1 MenubarHelper.app/Contents/MacOS/AGI\ Menu
  PASS  inside a .app the resource bundle resolves from Contents/Resources, not a build path
$ MENUBAR_POPOVER_CAPTURE=cap MenubarHelper.app/Contents/MacOS/AGI\ Menu   → 8 captures, opaque surface, navy tab, logo on neutral tile
```

Note: 1.22.99 shipped with floor 1.1.2 (the crashing helper); the 1.1.3 floor bump (#3591) and this one are not in any published CLI yet. A CLI release follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UK6PqhaXuVCNuGZXT7aigg
