### PR TITLE
chore(menubar): bump helper floor to 1.2.1

### DIFF
--- a/cli/src/lib/helper-versions.ts
+++ b/cli/src/lib/helper-versions.ts
@@ -51,7 +51,7 @@ export interface HelperRelease {
  * helper release now, off this table entirely.
  */
 export const HELPER_RELEASES: Readonly<Record<HelperName, HelperRelease>> = {
-  menubar: { tagPrefix: 'menubar', floor: '1.1.4' },
+  menubar: { tagPrefix: 'menubar', floor: '1.2.1' },
   'computer-mac': { tagPrefix: 'computer-mac', floor: '1.0.0' },
   // The Windows helper is a bare .exe, not an .app bundle, so it does not share
   // helper-download.ts's zip/codesign/notarize machinery -- but it has the same


### PR DESCRIPTION
1.2.1 is published on `menubar/v1.2.1` (phnx-labs/agi-menu PR #23, source tag v1.2.1, release run 34600548912). Bumping the floor is what makes installed CLIs resolve and download it. 1.2.0 was never floored here (its pin only existed in a hand-edited installed dist), so this bump carries both.

Why: the owner's review of 1.2.0 on a screen recording — the header and tab bar sat higher on Home than on the other tabs (Home laid out 585 pt wide in a 570 pt popover), the popover never resized after its first open (`preferredContentSize` came from `view.fittingSize`, which reports the frame NSPopover already gave the view), and every agent without a Linear ticket landed in one Unticketed bucket because `~/…` project paths were expanded against this Mac's home and never matched a worker's `/home/…`. All three fixed in 1.2.1; agents now group by project, then repository, then Unticketed.

Verified on the published asset, downloaded from the release:

```
MenubarHelper.app.zip: OK                      (sha256 sidecar)
CFBundleShortVersionString 1.2.1
Identifier=com.phnx-labs.agents-menubar
TeamIdentifier=2HTP252L87
origin=Developer ID Application: Muqit Nawaz (2HTP252L87)   (spctl -a -t exec)
$ MENUBAR_ISSUE_TEST=1 MenubarHelper.app/Contents/MacOS/AGI\ Menu
  PASS  inside a .app the resource bundle resolves from Contents/Resources, not a build path
  ALL PASS
$ MENUBAR_POPOVER_CAPTURE=cap MenubarHelper.app/Contents/MacOS/AGI\ Menu
  home 570x395 · sessions 570x266 · inbox 570x191 · projects 570x411 · settings 570x694 (+ light)
```

Every tab renders at the popover's 570 pt width; heights differ per tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yS7m9XUbLHU8twqKjgr2P
