### PR TITLE
chore(menubar): bump helper floor to 1.2.2

### DIFF
--- a/cli/src/lib/helper-versions.ts
+++ b/cli/src/lib/helper-versions.ts
@@ -51,7 +51,7 @@ export interface HelperRelease {
  * helper release now, off this table entirely.
  */
 export const HELPER_RELEASES: Readonly<Record<HelperName, HelperRelease>> = {
-  menubar: { tagPrefix: 'menubar', floor: '1.2.1' },
+  menubar: { tagPrefix: 'menubar', floor: '1.2.2' },
   'computer-mac': { tagPrefix: 'computer-mac', floor: '1.0.0' },
   // The Windows helper is a bare .exe, not an .app bundle, so it does not share
   // helper-download.ts's zip/codesign/notarize machinery -- but it has the same


### PR DESCRIPTION
This is a RELEASE PR (floor bump only, one line); no feature run applies. The published asset was verified by running it, output recorded at `/private/tmp/claude-501/-Users-muqsit-src-github-com-muqsitnawaz-agi-menu/36c008e6-c3d5-4f1d-8cfd-4afd8c498c95/scratchpad/asset122/verify-1.2.2.txt`.

1.2.2 is published on `menubar/v1.2.2` (phnx-labs/agi-menu PR #24, source tag v1.2.2). Bumping the floor is what makes installed CLIs resolve and download it.

Why: owner review of 1.2.1 — rows read `14d 22h` for sessions whose tmux pane was opened two weeks ago, and PR chips looked the same open, merged or failing. 1.2.2 shows the CLI's transcript span as the duration, idle only from a real `lastActivityMs` (which #3601 now backfills from the index), and colors the PR chip from the status #3601 attaches to feed rows: merged green, open amber, failing red.

Verified on the published asset, downloaded from the release and run:

```
MenubarHelper.app.zip: OK                      (sha256 sidecar)
CFBundleShortVersionString 1.2.2
origin=Developer ID Application: Muqit Nawaz (2HTP252L87)   (spctl -a -t exec)
$ MENUBAR_ISSUE_TEST=1 MenubarHelper.app/Contents/MacOS/AGI\ Menu   → ALL PASS
```

Installed on zion via `agents menubar setup`: `agents menubar doctor` reports installed 1.2.2, running, pid matches the on-disk bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yS7m9XUbLHU8twqKjgr2P
