### PR TITLE
chore(menubar): bump helper floor to 1.2.3

### DIFF
--- a/cli/src/lib/helper-versions.ts
+++ b/cli/src/lib/helper-versions.ts
@@ -51,7 +51,7 @@ export interface HelperRelease {
  * helper release now, off this table entirely.
  */
 export const HELPER_RELEASES: Readonly<Record<HelperName, HelperRelease>> = {
-  menubar: { tagPrefix: 'menubar', floor: '1.2.2' },
+  menubar: { tagPrefix: 'menubar', floor: '1.2.3' },
   'computer-mac': { tagPrefix: 'computer-mac', floor: '1.0.0' },
   // The Windows helper is a bare .exe, not an .app bundle, so it does not share
   // helper-download.ts's zip/codesign/notarize machinery -- but it has the same


### PR DESCRIPTION
This is a RELEASE PR (floor bump only, one line); no feature run applies. The published asset was verified by running it, output recorded at `/private/tmp/claude-501/-Users-muqsit-src-github-com-muqsitnawaz-agi-menu/36c008e6-c3d5-4f1d-8cfd-4afd8c498c95/scratchpad/asset123/verify-1.2.3.txt`.

1.2.3 is published on `menubar/v1.2.3` (phnx-labs/agi-menu PR #25). Bumping the floor is what makes installed CLIs resolve and download it.

Why: on the installed 1.2.2, rows from devices whose CLI predates #3601 carry a `pr` with no status, and the chip read `checks running` on long-merged PRs. 1.2.3 renders such a PR as a plain `PR #n` until the status arrives.

Verified on the published asset, downloaded from the release and run:

```
MenubarHelper.app.zip: OK                      (sha256 sidecar)
CFBundleShortVersionString 1.2.3
origin=Developer ID Application: Muqit Nawaz (2HTP252L87)   (spctl -a -t exec)
$ MENUBAR_ISSUE_TEST=1 MenubarHelper.app/Contents/MacOS/AGI\ Menu   → ALL PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yS7m9XUbLHU8twqKjgr2P
