### PR TITLE
chore(menubar): helper floor 1.3.0

### DIFF
--- a/cli/src/lib/helper-versions.ts
+++ b/cli/src/lib/helper-versions.ts
@@ -51,7 +51,7 @@ export interface HelperRelease {
  * helper release now, off this table entirely.
  */
 export const HELPER_RELEASES: Readonly<Record<HelperName, HelperRelease>> = {
-  menubar: { tagPrefix: 'menubar', floor: '1.2.3' },
+  menubar: { tagPrefix: 'menubar', floor: '1.3.0' },
   'computer-mac': { tagPrefix: 'computer-mac', floor: '1.0.0' },
   // The Windows helper is a bare .exe, not an .app bundle, so it does not share
   // helper-download.ts's zip/codesign/notarize machinery -- but it has the same


### PR DESCRIPTION
This is a RELEASE PR (floor bump only, one line); no feature run applies. The published asset was verified by running it, output recorded at `/private/tmp/claude-501/-Users-muqsit-src-github-com-muqsitnawaz-agi-menu/1fd83192-3389-4e97-96b3-f8d4df5c3b42/scratchpad/asset130/verify-1.3.0.txt`.

1.3.0 is published on `menubar/v1.3.0` (phnx-labs/agi-menu PR #26, merged 9b2032d). Bumping the floor is what makes installed CLIs resolve and download it; once #3607 ships, the floor is the tested-against record and offline answer and installs resolve upward on their own.

Why: the owner reviewed the running prototype of the agents-cli visual language (one Theme, mono machine values, two-line rows with the real host-app icon and device) and asked for it to be released and installed.

Verified on the published asset, downloaded from the release and run:

```
MenubarHelper.app.zip: OK                      (sha256 sidecar)
CFBundleShortVersionString 1.3.0
CFBundleIdentifier com.phnx-labs.agents-menubar
MenubarHelper.app: accepted · origin=Developer ID Application: Muqit Nawaz (2HTP252L87)   (spctl -a -t exec)
TeamIdentifier=2HTP252L87
$ MENUBAR_ISSUE_TEST=1 … → ALL PASS · MENUBAR_ROWMODEL_TEST=1 … → ALL PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yS7m9XUbLHU8twqKjgr2P
