### PR TITLE
Install computer CLI 0.1.1 for compiled Windows compatibility

### DIFF
--- a/cli/src/commands/setup-computer.ts
+++ b/cli/src/commands/setup-computer.ts
@@ -55,8 +55,8 @@ export async function runComputerWizard(): Promise<boolean> {
     resolveComputerBin();
   } catch (error) {
     if (!(error instanceof ComputerClientError) || error.code !== 'COMPUTER_BIN_MISSING') throw error;
-    console.log('Installing @phnx-labs/computer-cli@0.1.0…');
-    const installed = spawnSync('npm', ['install', '-g', '@phnx-labs/computer-cli@0.1.0'], { stdio: 'inherit' });
+    console.log('Installing @phnx-labs/computer-cli@0.1.1…');
+    const installed = spawnSync('npm', ['install', '-g', '@phnx-labs/computer-cli@0.1.1'], { stdio: 'inherit' });
     if (installed.status !== 0) return false;
     try { resolveComputerBin(); }
     catch { console.error('Computer CLI installation did not produce an executable on PATH.'); return false; }


### PR DESCRIPTION
Dependency release update; no visible surface is added. Computer setup now installs @phnx-labs/computer-cli@0.1.1, which corrects compiled Windows asset lookup. The previous 0.1.0 package installed and printed its version on Windows, but status failed while converting an embedded build-host path. Validation: TypeScript build passed. Publication and installed Windows verification of 0.1.1 are required before merge. Tracking: https://linear.app/getrush/issue/PHNX-4075