### PR TITLE
test(secrets): pin the standalone fixture to 0.1.4, matching the install pin

### DIFF
--- a/cli/tests/secrets-standalone.ts
+++ b/cli/tests/secrets-standalone.ts
@@ -30,7 +30,7 @@ import { _resetSecretsClientForTest, keychainUsesFileFallback } from '../src/lib
 import { invalidateClaudeSetupTokenCache } from '../src/lib/claude-account-token.js';
 
 /** The published standalone the suite is pinned to; bump with the protocol. */
-export const STANDALONE_SECRETS_VERSION = '0.1.2';
+export const STANDALONE_SECRETS_VERSION = '0.1.4';
 const LOCK_STALE_MS = 10 * 60 * 1000;
 const LOCK_WAIT_MS = 5 * 60 * 1000;
 


### PR DESCRIPTION
Tracking: [PHNX-4081](https://linear.app/getrush/issue/PHNX-4081) · follow-up from the review on #3613 (merged), which moved `SECRETS_CLI_PACKAGE` to 0.1.4 while `cli/tests/secrets-standalone.ts` still installed 0.1.2 for the real-standalone suite.

One-line change: `STANDALONE_SECRETS_VERSION = '0.1.4'`. secrets-cli 0.1.4 is on npm (`npm view @phnx-labs/secrets-cli version` → 0.1.4, tag v0.1.4 pushed).

## Run

`TZ=UTC node ./node_modules/vitest/vitest.mjs run src/lib/secrets-client.test.ts` in this worktree's `cli/` — capture at `/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/secrets-fixture-pin/.agents/scratch/secrets-client-vitest-0.1.4.log`: 30 passed, 3 failed. The 3 failures (`reports bundleExists=false on a fresh home`, `renames a bundle with its raw items and rotates a key in place`, `writes, reads and deletes a raw keychain item synchronously`, all `NOT_FOUND`) are a headed-macOS artifact: on this laptop the real-standalone block reaches the operator's login keychain (`cli/tests/secrets-standalone.ts` documents that there is no per-test keychain on a headed box), and they fail identically with the constant set back to 0.1.2. In the required check they run and pass: this file is in the `toolchain` ownership group, so the PR ran `suite=cli-full` (run 34712412173) — 1072 files / 15070 tests passed, including those three, against the 0.1.4 fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xknXeypKqMrDBpMqhrJ6P

