### PR TITLE
fix(release): select agents executable for Worker checks

### DIFF
--- a/cli/scripts/release.sh
+++ b/cli/scripts/release.sh
@@ -270,7 +270,7 @@ deploy_share_worker() {
     gray "share Worker deploy: skipped (--deploy-worker=off)"
     return 0
   fi
-  local cli=(npx --yes "$PHNX_PKG@$TARGET" --)
+  local cli=(npx --yes --package "$PHNX_PKG@$TARGET" -- agents)
   bold "Deploying the managed share Worker from $PHNX_PKG@$TARGET (mode: $DEPLOY_WORKER)..."
   if [[ "$DEPLOY_WORKER" == "auto" ]]; then
     # Change detection is a pure local render+hash and needs no CF creds; skip the


### PR DESCRIPTION
The post-publish Worker check failed with `could not determine executable to run` because the package exposes multiple executable names. Select `agents` explicitly while retaining the exact published package version.

Verified against published 1.22.104: `npm exec --yes --package=@phnx-labs/agents-cli@1.22.104 -- agents artifacts share update --bundle cloudflare.com --check --update-json` returned `deployNeeded: false`, with matching template and deployed hashes. `bash -n` and `git diff --check` pass. This is release tooling; no visible surface is added.

Tracking: https://linear.app/getrush/issue/PHNX-4075
