### PR TITLE
chore(release): 1.22.105

### DIFF
--- a/cli/.changelog/1.22.105.md
+++ b/cli/.changelog/1.22.105.md
@@ -1,0 +1,9 @@
+- Computer setup installs standalone Computer CLI 0.1.2, whose application code is obfuscated before compilation to increase inspection effort. Agents continues to provide permissions and session tracking through its adapter.
+
+- Fleet test runs use separate temporary workspaces and clean up their own copies. Router account fixtures run only with isolated file-backed secret storage, preserving native keyrings.
+
+- **Device picker module for `agents run <agent>@` (PHNX-4083).** New
+  `run-device-picker` command module builds the fleet device menu entirely from
+  on-disk state — the device registry, the cached fleet stats, configured roles
+  and descriptions, and the fleet-synced account catalog — with zero SSH, zero
+  network, and no re-probing of stale rows. Source: `src/commands/run-device-picker.ts`.

--- a/cli/.changelog/next/PHNX-4075-computer-hardening.md
+++ b/cli/.changelog/next/PHNX-4075-computer-hardening.md
@@ -1,1 +1,0 @@
-- Computer setup installs standalone Computer CLI 0.1.2, whose application code is obfuscated before compilation to increase inspection effort. Agents continues to provide permissions and session tracking through its adapter.

--- a/cli/.changelog/next/PHNX-4075-test-isolation.md
+++ b/cli/.changelog/next/PHNX-4075-test-isolation.md
@@ -1,1 +1,0 @@
-- Fleet test runs use separate temporary workspaces and clean up their own copies. Router account fixtures run only with isolated file-backed secret storage, preserving native keyrings.

--- a/cli/.changelog/next/PHNX-4083-device-picker.md
+++ b/cli/.changelog/next/PHNX-4083-device-picker.md
@@ -1,5 +1,0 @@
-- **Device picker module for `agents run <agent>@` (PHNX-4083).** New
-  `run-device-picker` command module builds the fleet device menu entirely from
-  on-disk state — the device registry, the cached fleet stats, configured roles
-  and descriptions, and the fleet-synced account catalog — with zero SSH, zero
-  network, and no re-probing of stale rows. Source: `src/commands/run-device-picker.ts`.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.22.105
+
+- Computer setup installs standalone Computer CLI 0.1.2, whose application code is obfuscated before compilation to increase inspection effort. Agents continues to provide permissions and session tracking through its adapter.
+
+- Fleet test runs use separate temporary workspaces and clean up their own copies. Router account fixtures run only with isolated file-backed secret storage, preserving native keyrings.
+
+- **Device picker module for `agents run <agent>@` (PHNX-4083).** New
+  `run-device-picker` command module builds the fleet device menu entirely from
+  on-disk state — the device registry, the cached fleet stats, configured roles
+  and descriptions, and the fleet-synced account catalog — with zero SSH, zero
+  network, and no re-probing of stale rows. Source: `src/commands/run-device-picker.ts`.
+
 ## 1.22.104
 
 - **Interactive Claude runs on a worker fail loud instead of dropping to the login screen (PHNX-3502 sibling).** `agents run claude --interactive --device auto/<worker>` whose selected account had no synced setup-token used to fall through to Claude Code's "Select login method" screen — an interactive OAuth on a headless box that never persists, so Anthropic re-prompted on the next run (the repeated re-login loop). The run is now refused before spawn with the real fix (pin a live account with `agents run claude#<name>`, set the fleet default with `agents accounts default claude <name>`, or mint the account's token on a headed box with `agents accounts login claude#<name>`). Headless runs are unchanged (they already fail loud with a 401), and headed boxes still show their normal native-login prompt. Source: `cli/src/lib/harness/adapters/claude.ts`, `cli/src/lib/exec.ts`.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.22.104",
+  "version": "1.22.105",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release PR: metadata and packaging only; no UI surface changed.

Release Agents 1.22.105 with three changes already merged into main:

- Computer setup installs standalone Computer CLI 0.1.2, which obfuscates application code before compilation. Agents retains permission handling and session tracking through its adapter.
- Fleet tests use a separate workspace per invocation; router account fixtures run only against isolated file-backed secret storage, protecting native keyrings.
- The PHNX-4083 device-picker module builds the fleet menu from on-disk registry, cached stats, roles, descriptions, and account catalog without network probes.

This PR changes only the package version and canonical changelog metadata against main commit 333da33070fdb316ddceb67cd01c761cc16c0e55. All three queued notes are folded into 1.22.105; command-index regeneration produces no diff.

Validation: exact metadata comparison and git diff --check pass. Fresh four-shard full-suite validation starts from this merged main commit using isolated remote workspaces and workers verified to use file-backed secret storage. Results are pending; no previous suite result is reused as proof for this release. Canonical attestation derivation, required green CI, and registry-installed verification remain release gates.

The setup pin and test-isolation fixes landed through #3623 and #3626. Device-picker work is tracked by PHNX-4083. Computer CLI 0.1.2 publication and installed verification remain prerequisites. Tracking: https://linear.app/getrush/issue/PHNX-4075
