### PR TITLE
fix(test): isolate fleet workspaces and native keyring fixtures

### DIFF
--- a/cli/.changelog/next/PHNX-4075-test-isolation.md
+++ b/cli/.changelog/next/PHNX-4075-test-isolation.md
@@ -1,0 +1,1 @@
+- Fleet test runs use separate temporary workspaces and clean up their own copies. Router account fixtures run only with isolated file-backed secret storage, preserving native keyrings.

--- a/cli/scripts/test.sh
+++ b/cli/scripts/test.sh
@@ -227,7 +227,7 @@ fi
 # shard fan-out can reuse it N times instead of duplicating the rsync/bind/run
 # sequence -- one place to fix, and the shard path cannot drift from the single
 # -device path it is built on.
-ship_and_run() {
+ship_and_run() (
   local device="$1"; shift
   local addr remote_dir extra
   extra="$*"
@@ -240,20 +240,25 @@ ship_and_run() {
   ssh -o BatchMode=yes -o ConnectTimeout=15 "$addr" true 2>/dev/null \
     || die "cannot reach '$device' ($addr) over ssh"
 
-  # Per-device dir so two shards on ONE box (or a stale run) cannot collide.
-  remote_dir="\$HOME/.cache/agents-cli/test-runs/tree"
-  ssh "$addr" "mkdir -p $remote_dir" >/dev/null
-  rsync -az --delete \
+  remote_dir="$(ssh "$addr" 'mkdir -p "$HOME/.cache/agents-cli/test-runs" && mktemp -d "$HOME/.cache/agents-cli/test-runs/run.XXXXXXXX"')" \
+    || die "could not allocate a test workspace on '$device'"
+  [[ "$remote_dir" == /*/test-runs/run.* && "$remote_dir" != *$'\n'* ]] \
+    || die "unexpected test workspace from '$device'"
+  local remote_path
+  printf -v remote_path '%q' "$remote_dir"
+  trap 'ssh -o BatchMode=yes -o ConnectTimeout=15 "$addr" "rm -rf -- $remote_path && test ! -e $remote_path" || gray "Retained test workspace: $device:$remote_dir" >&2' EXIT
+  gray "  workspace: $device:$remote_dir"
+  rsync -az \
     --exclude '.git' --exclude 'node_modules' --exclude 'dist' \
     --exclude '.agents/worktrees' --exclude '.release-attestations' \
-    "$TREE_ROOT/" "$addr:${remote_dir#\$HOME/}/"
-  ssh "$addr" "bash $remote_dir/cli/scripts/bound-repo-root.sh $remote_dir" \
+    "$TREE_ROOT/" "$addr:$remote_path/"
+  ssh "$addr" "bash $remote_path/cli/scripts/bound-repo-root.sh $remote_path" \
     || die "could not give the shipped tree a git repo on '$device'"
-  ssh "$addr" "cd $remote_dir/cli \
+  ssh "$addr" "cd $remote_path/cli \
     && bun install --silent \
     && bun run build >/dev/null \
     && bun run test$(vitest_suffix)${extra:+ $extra}"
-}
+)
 
 case "$MODE" in
   here|here-worker)

--- a/cli/src/commands/route.test.ts
+++ b/cli/src/commands/route.test.ts
@@ -8,13 +8,14 @@ import * as state from '../lib/state.js';
 import { registerRouteCommands } from './route.js';
 import { readRouter, routerExists } from '../lib/routers.js';
 import { addAccount } from '../lib/account-registry.js';
-import { useFreshSecretsHome } from '../../tests/secrets-standalone.js';
+import { standaloneKeychainIsFileBacked, useFreshSecretsHome } from '../../tests/secrets-standalone.js';
 
 let TEST_ROOT: string;
 let USER_DIR: string;
 let PROJECT_DIR: string;
 
 useFreshSecretsHome();
+const fileBacked = await standaloneKeychainIsFileBacked();
 
 beforeEach(() => {
   TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'route-cmd-test-'));
@@ -71,7 +72,7 @@ async function runRoute(args: string[], noun: 'route' | 'routes' = 'route'): Pro
   return { stdout: chunks.join('\n'), exitCode };
 }
 
-describe('agents route add (alias create)', () => {
+describe.skipIf(!fileBacked)('agents route add (alias create)', () => {
   it('writes a router yml with the given harnesses and tiers', async () => {
     const result = await runRoute(['add', 'research', '--harness', 'gemini,kimi', '--tier', 'cheap,default', '--task', 'research']);
     expect(result.exitCode).toBeNull();
@@ -119,7 +120,7 @@ describe('agents route add (alias create)', () => {
   });
 });
 
-describe('agents route allow', () => {
+describe.skipIf(!fileBacked)('agents route allow', () => {
   it('replaces (narrows) a harness model set, preserving existing accounts', async () => {
     await runRoute(['create', 'research', '--harness', 'gemini,kimi', '--tier', 'cheap,default']);
     await runRoute(['link-account', 'research', 'kimi', 'work']);
@@ -151,7 +152,7 @@ describe('agents route allow', () => {
   });
 });
 
-describe('agents route link-account / unlink-account', () => {
+describe.skipIf(!fileBacked)('agents route link-account / unlink-account', () => {
   it('link-account adds an account; unlink-account removes it', async () => {
     await runRoute(['create', 'research', '--harness', 'gemini']);
 
@@ -191,7 +192,7 @@ describe('agents route link-account / unlink-account', () => {
   });
 });
 
-describe('agents route edit verbs refuse a non-user-layer router (layer-shadow safety)', () => {
+describe.skipIf(!fileBacked)('agents route edit verbs refuse a non-user-layer router (layer-shadow safety)', () => {
   function writeProjectRouter(): void {
     fs.mkdirSync(path.join(PROJECT_DIR, 'routers'), { recursive: true });
     fs.writeFileSync(
@@ -233,7 +234,7 @@ describe('agents route edit verbs refuse a non-user-layer router (layer-shadow s
   });
 });
 
-describe('agents route list --json', () => {
+describe.skipIf(!fileBacked)('agents route list --json', () => {
   it('emits one summary object per router', async () => {
     await runRoute(['create', 'zeta', '--harness', 'gemini', '--tier', 'cheap']);
     await runRoute(['create', 'alpha', '--harness', 'kimi,claude', '--tier', 'best']);
@@ -267,7 +268,7 @@ describe('agents route list --json', () => {
   });
 });
 
-describe('agents route view --json (alias show)', () => {
+describe.skipIf(!fileBacked)('agents route view --json (alias show)', () => {
   it('emits the full router object', async () => {
     await runRoute(['add', 'research', '--harness', 'gemini,kimi', '--tier', 'cheap,default', '--task', 'research']);
     await runRoute(['link-account', 'research', 'gemini', 'personal']);
@@ -292,7 +293,7 @@ describe('agents route view --json (alias show)', () => {
   });
 });
 
-describe('agents route rename', () => {
+describe.skipIf(!fileBacked)('agents route rename', () => {
   it('re-keys the stored router, preserving every field', async () => {
     await runRoute(['add', 'research', '--harness', 'gemini,kimi', '--tier', 'cheap,default', '--task', 'research']);
     await runRoute(['link-account', 'research', 'gemini', 'personal']);
@@ -349,7 +350,7 @@ describe('agents route rename', () => {
   });
 });
 
-describe('agents route remove (alias rm)', () => {
+describe.skipIf(!fileBacked)('agents route remove (alias rm)', () => {
   it('removes the router file via the canonical verb', async () => {
     await runRoute(['create', 'research', '--harness', 'gemini']);
     const result = await runRoute(['remove', 'research']);


### PR DESCRIPTION
Tests and release infrastructure only; no UI surface changed.

Concurrent fleet suites previously copied and built into the same remote directory, so one run could overwrite another run's source. Each invocation now allocates its own workspace and cleans only that workspace on exit. Router account fixtures now use the existing file-backed Secrets guard so fixed fixture names cannot reach an operator's native keyring.

Validation against committed head 8583eef98ad823596fa3ee0a4cc174f873eec225: two simultaneous runs on the same worker used distinct workspaces, passed 61 and 30 tests, and each exited 0. The native-keyring check skipped all 30 route tests and exited 0. All three workspace removals were verified after completion. A real SSH failure during cleanup reported the retained directory while preserving successful and failed test exit codes: `requestedExit:0 actualExit:0; requestedExit:7 actualExit:7`. Shell syntax and diff checks pass. Required green CI remains a merge prerequisite.

Found while verifying the Computer extraction release: https://linear.app/getrush/issue/PHNX-4075
