### PR TITLE
fix(release): include session tracking in attested packages

### DIFF
--- a/cli/.changelog/next/PHNX-3940-release-session-tracker.md
+++ b/cli/.changelog/next/PHNX-3940-release-session-tracker.md
@@ -1,0 +1,1 @@
+- Fixed release packages omitting the session-tracking hook. Release qualification now uses the complete CLI build, so installed agents can record the account that owns each native session.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1880,6 +1880,11 @@ path — it runs nightly, not on the release PR, so a release no longer waits on
 Run it on demand via `workflow_dispatch` before a risky release. `--skip-tests`
 skips only the Linux suite run.
 
+**Release attestations package the complete CLI build.** The producer calls
+`scripts/build.sh --clean --skip-tests` after its suite gate. This includes the
+session-tracker installer and hook under `dist/session-tracker/dist/`; plain
+`bun run build` only compiles the CLI and omits those installed resources.
+
 **The attestation producer shards by default.** `release-attestation-produce.sh`
 (the suite run that mints the attestation) now fans the ~13k-test suite across the
 fleet via `test.sh --shard N` instead of pinning one box — the suite is
@@ -1898,7 +1903,8 @@ tree, once for the `chore(release)` commit tree — even though the second diffe
 from the first only by the version bump, the folded changelog, and the
 regenerated command-index. `release-attestation-produce.sh --inherit-suite-from
 <base-attestation.json>` mints the release-tree record from an already-green base
-**without re-running the suite**: it still `bun run build` + `npm pack`s (so the
+**without re-running the suite**: it still runs `scripts/build.sh --clean --skip-tests`
+and `npm pack` (so the
 recorded tarball is the real release tree's, carrying the new version), but the
 expensive suite run is inherited. The soundness gate is
 `release-attestation.sh derive` — it fails **closed** unless the tree diff between

--- a/cli/scripts/packed-tarball.test.ts
+++ b/cli/scripts/packed-tarball.test.ts
@@ -24,9 +24,9 @@ function packedEntries(): string[] {
   // beside today's output, and `npm pack` ships them: this test then fails on a
   // tree that is actually clean (the 1.22.85 attestation run on a shard box).
   // Wiping `dist/` first is not an option either — other tests in the same run
-  // exec `dist/index.js`. So the build goes to a fresh dir, mirroring what
-  // `release-attestation-produce.sh` does (`rm -rf dist` before its build):
-  // the listing proves the checked-out tree, not whatever the box had lying around.
+  // exec `dist/index.js`. Build into a fresh dir to check the CLI allowlist and
+  // secrets exclusion. The release producer's build.sh also bundles the session
+  // tracker; release-attestation-produce.test.ts covers that packaging step.
   const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-pack-'));
   try {
     execFileSync(

--- a/cli/scripts/release-attestation-produce.sh
+++ b/cli/scripts/release-attestation-produce.sh
@@ -347,9 +347,8 @@ else
   gray "Not a macOS signing box -- nothing to do: the tarball ships no helper bundle."
 fi
 
-bold "Building (bun run build)..."
-rm -rf dist
-bun run build || die "build failed for ${SHA:0:12}"
+bold "Building the complete CLI package..."
+scripts/build.sh --clean --skip-tests || die "build failed for ${SHA:0:12}"
 
 bold "Packing the pretested tarball (npm pack)..."
 TGZ_NAME="$(npm pack --silent 2>&1 | tail -1)"

--- a/cli/scripts/release-attestation-produce.test.ts
+++ b/cli/scripts/release-attestation-produce.test.ts
@@ -13,6 +13,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 const TEST_SCRIPT = path.resolve(__dirname, 'test.sh');
+const BUILD_SCRIPT = path.resolve(__dirname, 'build.sh');
 const PRODUCE_SCRIPT = path.resolve(__dirname, 'release-attestation-produce.sh');
 const ATTEST_SCRIPT = path.resolve(__dirname, 'release-attestation.sh');
 const MANIFEST_SCRIPT = path.resolve(__dirname, 'release-manifest.sh');
@@ -85,6 +86,12 @@ function buildFixture(root: string, opts: { failSuite?: boolean; suite?: 'greenW
   // script and not a stub: that is what pins the producer -> test.sh contract.
   fs.copyFileSync(TEST_SCRIPT, path.join(caller, 'cli/scripts/test.sh'));
   fs.chmodSync(path.join(caller, 'cli/scripts/test.sh'), 0o755);
+  fs.copyFileSync(BUILD_SCRIPT, path.join(caller, 'cli/scripts/build.sh'));
+  fs.chmodSync(path.join(caller, 'cli/scripts/build.sh'), 0o755);
+  const tracker = path.join(caller, 'packages/session-tracker');
+  fs.mkdirSync(path.join(tracker, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(tracker, 'package.json'), '{"name":"@agents/session-tracker","scripts":{"build":"tsc"}}\n');
+  fs.copyFileSync(path.resolve(__dirname, '../../packages/session-tracker/src/hook.sh'), path.join(tracker, 'src/hook.sh'));
   fs.copyFileSync(PRODUCE_SCRIPT, path.join(caller, 'cli/scripts/release-attestation-produce.sh'));
   fs.copyFileSync(ATTEST_SCRIPT, path.join(caller, 'cli/scripts/release-attestation.sh'));
   fs.chmodSync(path.join(caller, 'cli/scripts/release-attestation-produce.sh'), 0o755);
@@ -119,7 +126,11 @@ function buildFixture(root: string, opts: { failSuite?: boolean; suite?: 'greenW
       '  echo "RUSH-3007-ENV: producer=${AGENTS_ATTEST_PRODUCER:-<unset>} ci=${CI:-<unset>}"',
       fakeSuiteBody(opts),
       'fi',
-      'if [[ "$1" == "run" && "$2" == "build" ]]; then mkdir -p dist; exit 0; fi',
+      'if [[ "$1" == "run" && "$2" == "build" ]]; then',
+      '  mkdir -p dist',
+      '  if [[ "$PWD" == */packages/session-tracker ]]; then echo "export {};" > dist/install-hook.js; fi',
+      '  exit 0',
+      'fi',
       'echo "fake bun: unhandled args: $*" >&2; exit 1',
       '',
     ].join('\n'),
@@ -130,6 +141,8 @@ function buildFixture(root: string, opts: { failSuite?: boolean; suite?: 'greenW
     [
       '#!/usr/bin/env bash',
       'if [[ "$1" == "pack" ]]; then',
+      '  [[ -f dist/session-tracker/dist/install-hook.js && -f dist/session-tracker/dist/hook.sh ]] || { echo "missing session tracker" >&2; exit 1; }',
+      '  cmp ../packages/session-tracker/src/hook.sh dist/session-tracker/dist/hook.sh || exit 1',
       '  name="phnx-labs-agents-cli-9.9.9.tgz"',
       '  echo "fake-tarball-bytes-$$" > "$name"',
       '  echo "$name"',


### PR DESCRIPTION
Release qualification called the TypeScript-only build, so the attested npm package omitted the session-tracker installer and hook even though the complete build bundled them. The session account-provenance fix in #3624 therefore could not reach a clean installed CLI.

Use the existing complete build before packing, after the unchanged suite gate. The orchestration fixture now refuses packing missing or altered tracker resources. Release docs and notes are current.

Validation: 31/31 release-producer tests passed on yosemite-m4; complete build and isolated npm installation passed. Real packed output includes `package/dist/session-tracker/dist/install-hook.js` and `hook.sh`; the packed installer registered Codex in a disposable home, and two invocations of the packed hook preserved the first account ID and recorded plan mode. Independent Codex Sol approved exact head ed6c7537d9eb7e9f0b572cd0072d530e44765767.

Tracking: https://linear.app/getrush/issue/PHNX-3940

[Captured packed-hook run output](https://gist.githubusercontent.com/muqsitnawaz/95786e3bd5464a4ccb62872e71316f7e/raw/564d5929c6547b4f9ae2ae1e60832e56107f57ae/packed-hook-run.txt). This uses synthetic account metadata and contains no user session material.
