### PR TITLE
fix(accounts): refresh session tracker in account homes

### DIFF
--- a/cli/.changelog/next/PHNX-3940-account-slot-tracker.md
+++ b/cli/.changelog/next/PHNX-3940-account-slot-tracker.md
@@ -1,1 +1,1 @@
-- Account sync now refreshes the native session-tracking hook in every account home, replacing stale registrations from previous CLI installations so new sessions retain their account identity.
+- Account sync now refreshes the native session-tracking hook in every account home, replacing stale registrations from previous CLI installations so new sessions retain their account identity. Codex tracker installation also refreshes hook trust so headless runs can execute the registered hook.

--- a/cli/.changelog/next/PHNX-3940-account-slot-tracker.md
+++ b/cli/.changelog/next/PHNX-3940-account-slot-tracker.md
@@ -1,0 +1,1 @@
+- Account sync now refreshes the native session-tracking hook in every account home, replacing stale registrations from previous CLI installations so new sessions retain their account identity.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1886,6 +1886,8 @@ session-tracker installer and hook under `dist/session-tracker/dist/`; plain
 `bun run build` only compiles the CLI and omits those installed resources.
 Account resource projection also invokes that installer for each account home,
 so both slot creation and later sync replace registrations from older CLI installs.
+Both tracker bridges refresh Codex hook trust after registration using the same
+config writer as ordinary hooks; invalid TOML is reported and preserved.
 
 **The attestation producer shards by default.** `release-attestation-produce.sh`
 (the suite run that mints the attestation) now fans the ~13k-test suite across the

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1884,6 +1884,8 @@ skips only the Linux suite run.
 `scripts/build.sh --clean --skip-tests` after its suite gate. This includes the
 session-tracker installer and hook under `dist/session-tracker/dist/`; plain
 `bun run build` only compiles the CLI and omits those installed resources.
+Account resource projection also invokes that installer for each account home,
+so both slot creation and later sync replace registrations from older CLI installs.
 
 **The attestation producer shards by default.** `release-attestation-produce.sh`
 (the suite run that mints the attestation) now fans the ~13k-test suite across the

--- a/cli/src/lib/accounts/slots.test.ts
+++ b/cli/src/lib/accounts/slots.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -6,6 +8,14 @@ import { addNativeAccount, readSlots, removeAccount } from '../account-registry.
 import { getGlobalDefault, getVersionHomePath, listInstalledVersions } from '../installations/store.js';
 import { getHistoryDir, readMeta, updateMeta } from '../state.js';
 import { ensureSlot, projectAccountSlots, recordSlot, slotDir } from './slots.js';
+
+beforeAll(() => {
+  const tracker = path.resolve(__dirname, '../../../../packages/session-tracker');
+  execFileSync('bun', ['install', '--frozen-lockfile', '--ignore-scripts'], { cwd: tracker, stdio: 'pipe' });
+  execFileSync('bun', ['run', 'build'], { cwd: tracker, stdio: 'pipe' });
+  fs.copyFileSync(path.join(tracker, 'src/hook.sh'), path.join(tracker, 'dist/hook.sh'));
+  fs.chmodSync(path.join(tracker, 'dist/hook.sh'), 0o755);
+}, 60_000);
 
 describe('slotDir', () => {
   it('is ~/.agents/.history/accounts/<harness>/<accountId>/', () => {
@@ -191,6 +201,53 @@ describe('projectAccountSlots (PHNX-3940: slots follow the version home)', () =>
       expect(projectAccountSlots('claude').some((p) => p.accountId === created.id)).toBe(false);
     } finally {
       removeAccount('gone');
+    }
+  });
+
+  it('registers the tracker in new Codex slots and replaces stale registrations during sync', () => {
+    const fromHome = getVersionHomePath('codex', VERSION);
+    const previousDefault = readMeta().agents?.codex;
+    fs.mkdirSync(path.join(fromHome, '.codex'), { recursive: true });
+    updateMeta((m) => ({ ...m, agents: { ...m.agents, codex: VERSION } }));
+    const created = addNativeAccount('tracker', 'codex', 'codex:account=slot-tracker', 'tracker@example.com', VERSION);
+    const slot = ensureSlot('codex', created.id);
+    recordSlot(created.id, slot);
+    const hooksFile = path.join(slot.slotDir, '.codex', 'hooks.json');
+    const sessionId = randomUUID();
+    const sidecar = path.join(getHistoryDir(), 'by-session', `${sessionId}.json`);
+    const commands = (): string[] => JSON.parse(fs.readFileSync(hooksFile, 'utf8')).hooks.SessionStart
+      .flatMap((group: { hooks: { command: string }[] }) => group.hooks.map((hook) => hook.command));
+    try {
+      expect(commands().filter((command) => command.includes('session-tracker'))).toHaveLength(1);
+      const old = '/obsolete/session-tracker/dist/hook.sh codex';
+      const unrelated = 'echo unrelated-user-hook';
+      fs.writeFileSync(hooksFile, JSON.stringify({ hooks: { SessionStart: [{ matcher: '', hooks: [
+        { type: 'command', command: old }, { type: 'command', command: unrelated },
+      ] }] } }));
+      const credentials = path.join(slot.slotDir, '.codex', 'auth.json');
+      const credentialBytes = '{"fixture":"account-local credential sentinel"}\n';
+      fs.writeFileSync(credentials, credentialBytes);
+      for (let pass = 0; pass < 2; pass++) {
+        projectAccountSlots('codex');
+        const registered = commands();
+        expect(registered).not.toContain(old);
+        expect(registered).toContain(unrelated);
+        expect(registered.filter((command) => command.includes('session-tracker'))).toHaveLength(1);
+        expect(fs.readFileSync(credentials, 'utf8')).toBe(credentialBytes);
+      }
+      const command = commands().find((value) => value.includes('session-tracker'))!;
+      execFileSync('sh', ['-c', command], {
+        cwd: slot.slotDir,
+        input: JSON.stringify({ session_id: sessionId, cwd: slot.slotDir }),
+        env: { ...process.env, HOME: slot.slotDir, AGENTS_HISTORY_DIR: getHistoryDir(), AGENTS_RUN_ACCOUNT_ID: created.id },
+      });
+      expect(JSON.parse(fs.readFileSync(sidecar, 'utf8')).accountId).toBe(created.id);
+    } finally {
+      fs.rmSync(sidecar, { force: true });
+      removeAccount('tracker');
+      fs.rmSync(slot.slotDir, { recursive: true, force: true });
+      fs.rmSync(fromHome, { recursive: true, force: true });
+      updateMeta((m) => ({ ...m, agents: { ...m.agents, codex: previousDefault } }));
     }
   });
 });

--- a/cli/src/lib/accounts/slots.test.ts
+++ b/cli/src/lib/accounts/slots.test.ts
@@ -4,8 +4,10 @@ import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as TOML from 'smol-toml';
 import { addNativeAccount, readSlots, removeAccount } from '../account-registry.js';
 import { getGlobalDefault, getVersionHomePath, listInstalledVersions } from '../installations/store.js';
+import { computeCodexHookTrustHash } from '../hooks/install.js';
 import { getHistoryDir, readMeta, updateMeta } from '../state.js';
 import { ensureSlot, projectAccountSlots, recordSlot, slotDir } from './slots.js';
 
@@ -227,6 +229,15 @@ describe('projectAccountSlots (PHNX-3940: slots follow the version home)', () =>
       const credentials = path.join(slot.slotDir, '.codex', 'auth.json');
       const credentialBytes = '{"fixture":"account-local credential sentinel"}\n';
       fs.writeFileSync(credentials, credentialBytes);
+      const configPath = path.join(slot.slotDir, '.codex', 'config.toml');
+      const trackerKey = `${hooksFile}:session_start:0:1`;
+      fs.writeFileSync(configPath, TOML.stringify({
+        model: 'fixture-model', features: { hooks: false },
+        hooks: { state: {
+          [trackerKey]: { enabled: false, trusted_hash: 'old-tracker-hash' },
+          'unrelated-state': { enabled: false, trusted_hash: 'unrelated-hash' },
+        } },
+      }));
       for (let pass = 0; pass < 2; pass++) {
         projectAccountSlots('codex');
         const registered = commands();
@@ -234,6 +245,21 @@ describe('projectAccountSlots (PHNX-3940: slots follow the version home)', () =>
         expect(registered).toContain(unrelated);
         expect(registered.filter((command) => command.includes('session-tracker'))).toHaveLength(1);
         expect(fs.readFileSync(credentials, 'utf8')).toBe(credentialBytes);
+        const config = TOML.parse(fs.readFileSync(configPath, 'utf8')) as {
+          model: string; features: { hooks: boolean }; hooks: { state: Record<string, { trusted_hash: string; enabled?: boolean }> };
+        };
+        expect(config.features.hooks).toBe(true);
+        expect(config.model).toBe('fixture-model');
+        expect(config.hooks.state[trackerKey].enabled).toBe(false);
+        expect(config.hooks.state['unrelated-state']).toEqual({ enabled: false, trusted_hash: 'unrelated-hash' });
+        const groups = JSON.parse(fs.readFileSync(hooksFile, 'utf8')).hooks.SessionStart;
+        groups.forEach((group: { matcher?: string; hooks: { command: string; timeout: number }[] }, groupIndex: number) => {
+          group.hooks.forEach((hook, hookIndex) => {
+            if (!hook.command.includes('session-tracker')) return;
+            expect(config.hooks.state[`${hooksFile}:session_start:${groupIndex}:${hookIndex}`].trusted_hash)
+              .toBe(computeCodexHookTrustHash('session_start', hook.command, hook.timeout, group.matcher));
+          });
+        });
       }
       const command = commands().find((value) => value.includes('session-tracker'))!;
       execFileSync('sh', ['-c', command], {

--- a/cli/src/lib/accounts/slots.ts
+++ b/cli/src/lib/accounts/slots.ts
@@ -15,6 +15,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { agentConfigDirName } from '../agents.js';
 import { harnessAuth, harnessWorkerIsPerDevice } from '../harness-auth-capabilities.js';
+import { installSessionTrackerHookSync } from '../hooks/install.js';
 import { getGlobalDefault, getVersionHomePath, listInstalledVersions } from '../installations/store.js';
 import { carryForwardSettings } from '../settings-manifest.js';
 import { getHistoryDir, readMeta, updateMeta } from '../state.js';
@@ -76,6 +77,12 @@ function projectResources(harness: AgentId, version: string, destHome: string, f
     const names = getDetector(kind, harness)?.list({ version, versionHome: fromHome, cwd }) ?? [];
     if (names.length === 0) continue;
     writer.write({ version, versionHome: destHome, selection: names, cwd });
+  }
+  if (supports(harness, 'hooks', version).ok) {
+    const tracker = installSessionTrackerHookSync(harness, version, destHome);
+    if (!tracker.installed && tracker.error) {
+      console.warn(`agents: SessionStart hook not installed for ${harness} account home ${destHome}: ${tracker.error}`);
+    }
   }
 }
 

--- a/cli/src/lib/hooks/install.ts
+++ b/cli/src/lib/hooks/install.ts
@@ -2613,6 +2613,77 @@ export function pruneVersionHomeHookEntriesFromSettings(
   return removed;
 }
 
+function trustCodexHooks(hooksPath: string): void {
+  const configPath = path.join(path.dirname(hooksPath), 'config.toml');
+  const hooksFile = JSON.parse(fs.readFileSync(hooksPath, 'utf-8')) as CodexHooksFile;
+  let tomlConfig: Record<string, unknown> = {};
+  if (fs.existsSync(configPath)) {
+    tomlConfig = TOML.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+  }
+
+  if (!tomlConfig.features || typeof tomlConfig.features !== 'object') {
+    tomlConfig.features = {};
+  }
+  // Codex 0.116+ feature flag is `hooks` (the legacy `codex_hooks` name is
+  // an unrecognized key that triggers a deprecation error and is ignored).
+  const features = tomlConfig.features as Record<string, unknown>;
+  delete features.codex_hooks;
+  features.hooks = true;
+
+  // Pre-trust hooks. The [hooks.state] key is keyed by the hooks.json path
+  // exactly as Codex resolves it (the absolute CODEX_HOME path), the
+  // snake_case event label, and the per-event group/handler indices — which
+  // must match Codex's parse order, so we iterate the just-written
+  // hooksFile structure in array order.
+  if (!tomlConfig.hooks || typeof tomlConfig.hooks !== 'object') {
+    tomlConfig.hooks = {};
+  }
+  const hooksTable = tomlConfig.hooks as Record<string, unknown>;
+  const existingState =
+    hooksTable.state && typeof hooksTable.state === 'object'
+      ? (hooksTable.state as Record<string, { enabled?: boolean; trusted_hash?: string }>)
+      : {};
+  const hookState: Record<string, { enabled?: boolean; trusted_hash?: string }> = {};
+
+  for (const [event, eventGroups] of Object.entries(hooksFile.hooks)) {
+    const eventKeyLabel = CODEX_EVENT_KEY_LABELS[event];
+    if (!eventKeyLabel) continue;
+    eventGroups.forEach((group, groupIdx) => {
+      if (!group.hooks) return;
+      group.hooks.forEach((handler, handlerIdx) => {
+        if (handler.type !== 'command') return;
+        const key = `${hooksPath}:${eventKeyLabel}:${groupIdx}:${handlerIdx}`;
+        const trustedHash = computeCodexHookTrustHash(
+          eventKeyLabel,
+          handler.command,
+          handler.timeout,
+          group.matcher
+        );
+        // Preserve a user's explicit `enabled = false` for this exact hook;
+        // only (re)write the trust hash.
+        const prior = existingState[key];
+        const entry: { enabled?: boolean; trusted_hash?: string } = { trusted_hash: trustedHash };
+        if (prior && prior.enabled === false) {
+          entry.enabled = false;
+        }
+        hookState[key] = entry;
+      });
+    });
+  }
+
+  // Carry forward trust state for any hooks we did not (re)register this
+  // pass — e.g. user-added hooks under a different command path.
+  for (const [key, entry] of Object.entries(existingState)) {
+    if (!(key in hookState)) {
+      hookState[key] = entry;
+    }
+  }
+
+  hooksTable.state = hookState;
+
+  fs.writeFileSync(configPath, TOML.stringify(tomlConfig as Parameters<typeof TOML.stringify>[0]), 'utf-8');
+}
+
 function registerHooksForCodex(
   versionHome: string,
   manifest: Record<string, ManifestHook>,
@@ -2624,7 +2695,6 @@ function registerHooksForCodex(
 
   const configDir = path.join(versionHome, '.codex');
   const hooksPath = path.join(configDir, 'hooks.json');
-  const configPath = path.join(configDir, 'config.toml');
 
   // Read existing hooks.json — must have top-level "hooks" wrapper key
   let hooksFile: CodexHooksFile = { hooks: {} };
@@ -2751,74 +2821,7 @@ function registerHooksForCodex(
   // them, so an untrusted hook is silently dropped. We compute the same
   // trust hash Codex would and persist it under [hooks.state].
   try {
-    let tomlConfig: Record<string, unknown> = {};
-    if (fs.existsSync(configPath)) {
-      try {
-        tomlConfig = TOML.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
-      } catch { /* start fresh if corrupt */ }
-    }
-
-    if (!tomlConfig.features || typeof tomlConfig.features !== 'object') {
-      tomlConfig.features = {};
-    }
-    // Codex 0.116+ feature flag is `hooks` (the legacy `codex_hooks` name is
-    // an unrecognized key that triggers a deprecation error and is ignored).
-    const features = tomlConfig.features as Record<string, unknown>;
-    delete features.codex_hooks;
-    features.hooks = true;
-
-    // Pre-trust hooks. The [hooks.state] key is keyed by the hooks.json path
-    // exactly as Codex resolves it (the absolute CODEX_HOME path), the
-    // snake_case event label, and the per-event group/handler indices — which
-    // must match Codex's parse order, so we iterate the just-written
-    // hooksFile structure in array order.
-    if (!tomlConfig.hooks || typeof tomlConfig.hooks !== 'object') {
-      tomlConfig.hooks = {};
-    }
-    const hooksTable = tomlConfig.hooks as Record<string, unknown>;
-    const existingState =
-      hooksTable.state && typeof hooksTable.state === 'object'
-        ? (hooksTable.state as Record<string, { enabled?: boolean; trusted_hash?: string }>)
-        : {};
-    const hookState: Record<string, { enabled?: boolean; trusted_hash?: string }> = {};
-
-    for (const [event, eventGroups] of Object.entries(hooksFile.hooks)) {
-      const eventKeyLabel = CODEX_EVENT_KEY_LABELS[event];
-      if (!eventKeyLabel) continue;
-      eventGroups.forEach((group, groupIdx) => {
-        if (!group.hooks) return;
-        group.hooks.forEach((handler, handlerIdx) => {
-          if (handler.type !== 'command') return;
-          const key = `${hooksPath}:${eventKeyLabel}:${groupIdx}:${handlerIdx}`;
-          const trustedHash = computeCodexHookTrustHash(
-            eventKeyLabel,
-            handler.command,
-            handler.timeout,
-            group.matcher
-          );
-          // Preserve a user's explicit `enabled = false` for this exact hook;
-          // only (re)write the trust hash.
-          const prior = existingState[key];
-          const entry: { enabled?: boolean; trusted_hash?: string } = { trusted_hash: trustedHash };
-          if (prior && prior.enabled === false) {
-            entry.enabled = false;
-          }
-          hookState[key] = entry;
-        });
-      });
-    }
-
-    // Carry forward trust state for any hooks we did not (re)register this
-    // pass — e.g. user-added hooks under a different command path.
-    for (const [key, entry] of Object.entries(existingState)) {
-      if (!(key in hookState)) {
-        hookState[key] = entry;
-      }
-    }
-
-    hooksTable.state = hookState;
-
-    fs.writeFileSync(configPath, TOML.stringify(tomlConfig as Parameters<typeof TOML.stringify>[0]), 'utf-8');
+    trustCodexHooks(hooksPath);
   } catch (err) {
     errors.push(`Failed to update config.toml: ${(err as Error).message}`);
   }
@@ -3810,11 +3813,13 @@ export async function installSessionTrackerHook(
   if (!invocation) {
     return { installed: false, error: 'session-tracker not built and tsx is unavailable' };
   }
+  const env = sessionTrackerInstallEnv(agent, version, home);
   try {
     await execFileAsync(invocation.command, invocation.args, {
-      env: sessionTrackerInstallEnv(agent, version, home),
+      env,
       encoding: 'utf8',
     });
+    if (agent === 'codex') trustCodexHooks(path.join(env.HOME ?? os.homedir(), '.codex', 'hooks.json'));
     return { installed: true };
   } catch (err) {
     return { installed: false, error: installFailureMessage(err) };
@@ -3856,12 +3861,14 @@ export function installSessionTrackerHookSync(
   if (!invocation) {
     return { installed: false, error: 'session-tracker not built and tsx is unavailable' };
   }
+  const env = sessionTrackerInstallEnv(agent, version, home);
   try {
     execFileSync(invocation.command, invocation.args, {
-      env: sessionTrackerInstallEnv(agent, version, home),
+      env,
       stdio: ['ignore', 'pipe', 'pipe'],
       encoding: 'utf8',
     });
+    if (agent === 'codex') trustCodexHooks(path.join(env.HOME ?? os.homedir(), '.codex', 'hooks.json'));
     return { installed: true };
   } catch (err) {
     return { installed: false, error: installFailureMessage(err) };


### PR DESCRIPTION
An account home could keep its SessionStart tracker pointed at an older CLI installation even after `agents sync codex --hook --yes` refreshed the managed home. New native sessions then missed their originating account ID, undermining account-based resume routing.

The shared account resource projection now invokes the existing tracker installer for new slots and subsequent sync. Both tracker bridges also refresh Codex hook trust through the same config writer used by ordinary hooks. Obsolete registrations are replaced while unrelated hooks, config, account credentials, and explicit disabled state are preserved. Parse and installation failures are reported rather than claiming a working installation.

Validation: the canonical fleet run passed 33/33 tests. The regression uses the real installer and hook, checks Codex's exact trust key/hash and the saved account ID, and covers repeated sync and preserved user state. [Captured test output](https://gist.github.com/muqsitnawaz/23ddf8583ef5863813d7ea3176a2b50c). The final tree's release attestation is running across four fleet workers.

Follow-up to #3624 and #3628. Tracking: PHNX-3940.
